### PR TITLE
feat(sharing): add conflict-safe snapshot mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ dependencies = [
  "transcribe-proxy",
  "url",
  "utoipa",
+ "wiremock",
 ]
 
 [[package]]

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -46,3 +46,6 @@ jsonwebtoken = { workspace = true }
 sentry = { workspace = true, features = ["tower", "tower-axum-matched-path", "tracing"] }
 tower = { workspace = true }
 utoipa = { workspace = true }
+
+[dev-dependencies]
+wiremock = { workspace = true }

--- a/apps/api/openapi.gen.json
+++ b/apps/api/openapi.gen.json
@@ -2747,8 +2747,75 @@
           "403": {
             "description": "Anarlog Pro or share-manager access required"
           },
+          "409": {
+            "description": "Shared note changed since the supplied base revision"
+          },
           "413": {
             "description": "Shared-note snapshot is too large"
+          },
+          "502": {
+            "description": "Shared-note service unavailable"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/sync/shares/{share_id}/web-edit": {
+      "put": {
+        "tags": [
+          "sync"
+        ],
+        "operationId": "edit_session_share_snapshot",
+        "parameters": [
+          {
+            "name": "share_id",
+            "in": "path",
+            "description": "Session share ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublishSessionShareSnapshotRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Shared-note edit saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublishedSessionShareSnapshot"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or unsupported shared-note edit"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Explicit Editor access required"
+          },
+          "409": {
+            "description": "Shared note changed since the supplied base revision"
+          },
+          "413": {
+            "description": "Shared-note edit is too large"
           },
           "502": {
             "description": "Shared-note service unavailable"
@@ -3778,6 +3845,36 @@
             "type": "string"
           }
         }
+      },
+      "CasSessionShareSnapshotRequest": {
+        "type": "object",
+        "required": [
+          "baseRevision",
+          "mutationId",
+          "title",
+          "body",
+          "attachmentIds"
+        ],
+        "properties": {
+          "attachmentIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "baseRevision": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "body": {},
+          "mutationId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       },
       "CharTask": {
         "type": "string",
@@ -6324,6 +6421,29 @@
           }
         }
       },
+      "LegacySessionShareSnapshotRequest": {
+        "type": "object",
+        "required": [
+          "title",
+          "body"
+        ],
+        "properties": {
+          "attachmentIds": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "body": {},
+          "title": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "LinearListTeamsRequest": {
         "type": "object",
         "required": [
@@ -7491,27 +7611,14 @@
         }
       },
       "PublishSessionShareSnapshotRequest": {
-        "type": "object",
-        "required": [
-          "title",
-          "body"
-        ],
-        "properties": {
-          "attachmentIds": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CasSessionShareSnapshotRequest"
           },
-          "body": {},
-          "title": {
-            "type": "string"
+          {
+            "$ref": "#/components/schemas/LegacySessionShareSnapshotRequest"
           }
-        },
-        "additionalProperties": false
+        ]
       },
       "PublishedSessionShareSnapshot": {
         "type": "object",
@@ -7522,9 +7629,15 @@
           "title",
           "body",
           "attachments",
+          "webEditable",
+          "accessVersion",
           "publishedAt"
         ],
         "properties": {
+          "accessVersion": {
+            "type": "integer",
+            "format": "int64"
+          },
           "attachments": {
             "type": "array",
             "items": {
@@ -7548,6 +7661,9 @@
           },
           "title": {
             "type": "string"
+          },
+          "webEditable": {
+            "type": "boolean"
           }
         }
       },

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -77,6 +77,35 @@ fn request_client_address(request: &Request<Body>) -> Option<String> {
     forwarded_header_value(request.headers(), "x-forwarded-for")
 }
 
+fn build_sync_routes(
+    state: hypr_api_sync::AppState,
+    rate_limit_state: rate_limit::RateLimitState,
+    auth_state: AuthState,
+) -> Router {
+    let pro_routes = hypr_api_sync::pro_router(state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            rate_limit_state.clone(),
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let web_edit_routes = hypr_api_sync::web_edit_router(state)
+        .route_layer(middleware::from_fn_with_state(
+            rate_limit_state,
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state,
+            auth::require_auth,
+        ));
+
+    pro_routes.merge(web_edit_routes)
+}
+
 async fn app() -> Router {
     let env = env();
 
@@ -207,16 +236,11 @@ async fn app() -> Router {
         ));
 
     let sync_routes = match sync_config {
-        Some(config) => hypr_api_sync::router(hypr_api_sync::AppState::new(config))
-            .route_layer(middleware::from_fn_with_state(
-                sync_rate_limit,
-                rate_limit::rate_limit,
-            ))
-            .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-            .route_layer(middleware::from_fn_with_state(
-                auth_state.clone().with_required_entitlement("hyprnote_pro"),
-                auth::require_auth,
-            )),
+        Some(config) => build_sync_routes(
+            hypr_api_sync::AppState::new(config),
+            sync_rate_limit,
+            auth_state.clone(),
+        ),
         None => Router::new(),
     };
     let shared_notes_state = hypr_api_sync::SharedNotesState::new(shared_notes_config);
@@ -685,4 +709,172 @@ fn build_honeycomb_trace_url(
         .append_pair("trace_start_ts", trace_start_ts.as_str());
 
     Some(url.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request, StatusCode, header},
+    };
+    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    use super::*;
+
+    const TEST_KEY_ID: &str = "sync-composition-test";
+    const TEST_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\n\
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgWTFfCGljY6aw3Hrt\n\
+kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
+950IxEzvw/x5BMEINRMrXLBJhqzO9Bm+d6JbqA21YQmd1Kt4RzLJR1W+\n\
+-----END PRIVATE KEY-----";
+
+    fn non_pro_token() -> String {
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(TEST_KEY_ID.to_string());
+        let expires_at = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3_600;
+
+        encode(
+            &header,
+            &json!({
+                "sub": "editor-user",
+                "aud": "authenticated",
+                "exp": expires_at,
+                "entitlements": []
+            }),
+            &EncodingKey::from_ec_pem(TEST_PRIVATE_KEY.as_bytes()).unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn test_sync_rate_limit() -> rate_limit::RateLimitState {
+        let quota = || {
+            governor::Quota::with_period(Duration::from_secs(1))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(10).unwrap())
+        };
+        rate_limit::RateLimitState::builder()
+            .pro(quota())
+            .free(quota())
+            .build()
+    }
+
+    fn test_sync_state(server: &MockServer) -> hypr_api_sync::AppState {
+        let config = hypr_api_sync::SyncConfig::new(
+            "https://test.sqlite.cloud",
+            "issuer-key",
+            "database-id",
+            server.uri(),
+            "anon-key",
+            "service-role-key",
+        )
+        .unwrap()
+        .with_token_ttl_seconds(60)
+        .unwrap();
+        hypr_api_sync::AppState::new(config)
+    }
+
+    async fn response_bytes(response: axum::response::Response) -> Vec<u8> {
+        to_bytes(response.into_body(), 16 * 1024)
+            .await
+            .unwrap()
+            .to_vec()
+    }
+
+    #[tokio::test]
+    async fn sync_composition_allows_non_pro_web_edits_but_keeps_other_routes_pro_only() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/auth/v1/.well-known/jwks.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "keys": [{
+                    "kty": "EC",
+                    "use": "sig",
+                    "crv": "P-256",
+                    "kid": TEST_KEY_ID,
+                    "x": "w7JAoU_gJbZJvV-zCOvU9yFJq0FNC_edCMRM78P8eQQ",
+                    "y": "wQg1EytcsEmGrM70Gb53oluoDbVhCZ3Uq3hHMslHVb4",
+                    "alg": "ES256"
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/edit_session_share_snapshot_cas"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+                "code": "42501",
+                "message": "editor access required"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let app = Router::new().nest(
+            "/sync",
+            build_sync_routes(
+                test_sync_state(&server),
+                test_sync_rate_limit(),
+                AuthState::new(&server.uri()),
+            ),
+        );
+        let token = non_pro_token();
+        let web_edit_response = app
+            .clone()
+            .oneshot(
+                Request::put("/sync/shares/11111111-1111-4111-8111-111111111111/web-edit")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "baseRevision": 1,
+                            "mutationId": "22222222-2222-4222-8222-222222222222",
+                            "title": "Title",
+                            "body": {
+                                "type": "doc",
+                                "content": [{ "type": "paragraph" }]
+                            },
+                            "attachmentIds": []
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(web_edit_response.status(), StatusCode::FORBIDDEN);
+        let web_edit_body: Value =
+            serde_json::from_slice(&response_bytes(web_edit_response).await).unwrap();
+        assert_eq!(
+            web_edit_body["error"]["code"],
+            "shared_note_publication_forbidden"
+        );
+
+        let token_response = app
+            .oneshot(
+                Request::post("/sync/token")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(token_response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            response_bytes(token_response).await,
+            b"subscription_required"
+        );
+        server.verify().await;
+    }
 }

--- a/crates/api-sync/src/error.rs
+++ b/crates/api-sync/src/error.rs
@@ -32,6 +32,9 @@ pub enum SyncError {
     #[error("Shared note publication is not permitted")]
     SnapshotPublicationForbidden,
 
+    #[error("Shared note changed")]
+    SnapshotChanged,
+
     #[error("Shared note service is unavailable")]
     SnapshotServiceUnavailable,
 
@@ -129,6 +132,12 @@ impl IntoResponse for SyncError {
                 StatusCode::FORBIDDEN,
                 "shared_note_publication_forbidden",
                 "Shared note publication is not permitted".to_string(),
+            ),
+            Self::SnapshotChanged => (
+                StatusCode::CONFLICT,
+                "snapshot_conflict",
+                "Shared note changed; update Anarlog and reload before publishing again"
+                    .to_string(),
             ),
             Self::SnapshotServiceUnavailable => (
                 StatusCode::BAD_GATEWAY,

--- a/crates/api-sync/src/lib.rs
+++ b/crates/api-sync/src/lib.rs
@@ -7,7 +7,7 @@ mod state;
 
 pub use config::{SharedNotesConfig, SyncConfig, SyncEnv};
 pub use error::{Result, SyncError};
-pub use routes::{openapi, router};
+pub use routes::{openapi, pro_router, web_edit_router};
 pub use shared_notes::{
     SharedNotesState, authenticated_router as authenticated_shared_notes_router,
     openapi as shared_notes_openapi, router as shared_notes_router,

--- a/crates/api-sync/src/routes/mod.rs
+++ b/crates/api-sync/src/routes/mod.rs
@@ -3,7 +3,8 @@ use std::collections::HashSet;
 use axum::{
     Extension, Json, Router,
     extract::{DefaultBodyLimit, Path, State},
-    http::{HeaderMap, HeaderValue, header},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
     routing::{post, put},
 };
 use chrono::{SecondsFormat, TimeDelta, Utc};
@@ -31,7 +32,7 @@ const MAX_TOKEN_WORKSPACES: usize = 128;
 const MAX_TOKEN_ATTRIBUTES_BYTES: usize = 8 * 1024;
 const SNAPSHOT_PUBLISH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const MAX_SNAPSHOT_REQUEST_BYTES: usize = MAX_SNAPSHOT_BODY_BYTES + 16 * 1024;
-const MAX_SNAPSHOT_RESPONSE_BYTES: u64 = (MAX_SNAPSHOT_BODY_BYTES + 16 * 1024) as u64;
+const MAX_SNAPSHOT_RESPONSE_BYTES: usize = MAX_SNAPSHOT_BODY_BYTES + 256 * 1024;
 const CLOUDSYNC_ENCRYPTION_VERSION: u8 = 2;
 const E2EE_KEY_ID_HEADER: &str = "x-anarlog-e2ee-key-id";
 
@@ -151,8 +152,25 @@ struct WorkspaceRow {
 }
 
 #[derive(Deserialize, utoipa::ToSchema)]
+#[serde(untagged)]
+pub enum PublishSessionShareSnapshotRequest {
+    Cas(CasSessionShareSnapshotRequest),
+    Legacy(LegacySessionShareSnapshotRequest),
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct PublishSessionShareSnapshotRequest {
+pub struct CasSessionShareSnapshotRequest {
+    base_revision: i64,
+    mutation_id: String,
+    title: String,
+    body: Value,
+    attachment_ids: Vec<String>,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LegacySessionShareSnapshotRequest {
     title: String,
     body: Value,
     attachment_ids: Option<Vec<String>>,
@@ -177,11 +195,36 @@ pub struct PublishedSessionShareSnapshot {
     title: String,
     body: Value,
     attachments: Vec<SharedNoteAttachment>,
+    web_editable: bool,
+    access_version: i64,
     published_at: String,
 }
 
 #[derive(Serialize)]
-struct PublishSnapshotRpcRequest<'a> {
+struct PublishSnapshotCasRpcRequest<'a> {
+    p_share_id: &'a str,
+    p_actor_user_id: &'a str,
+    p_expected_content_revision: i64,
+    p_mutation_id: &'a str,
+    p_title: &'a str,
+    p_body_json: &'a Value,
+    p_attachment_ids: &'a [String],
+    p_web_editable: bool,
+}
+
+#[derive(Serialize)]
+struct EditSnapshotCasRpcRequest<'a> {
+    p_share_id: &'a str,
+    p_actor_user_id: &'a str,
+    p_expected_content_revision: i64,
+    p_mutation_id: &'a str,
+    p_title: &'a str,
+    p_body_json: &'a Value,
+    p_attachment_ids: &'a [String],
+}
+
+#[derive(Serialize)]
+struct LegacyPublishSnapshotRpcRequest<'a> {
     p_share_id: &'a str,
     p_actor_user_id: &'a str,
     p_title: &'a str,
@@ -190,7 +233,7 @@ struct PublishSnapshotRpcRequest<'a> {
 }
 
 #[derive(Deserialize)]
-struct PublishedSnapshotRow {
+struct LegacyPublishedSnapshotRow {
     share_id: String,
     schema_version: i16,
     content_revision: i64,
@@ -198,6 +241,39 @@ struct PublishedSnapshotRow {
     body_json: Value,
     attachments_json: Vec<SharedNoteAttachment>,
     published_at: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyPublishedSessionShareSnapshot {
+    share_id: String,
+    schema_version: i16,
+    content_revision: i64,
+    title: String,
+    body: Value,
+    attachments: Vec<SharedNoteAttachment>,
+    published_at: String,
+}
+
+#[derive(Deserialize)]
+struct PublishedSnapshotRow {
+    outcome: String,
+    share_id: String,
+    schema_version: i16,
+    content_revision: i64,
+    title: String,
+    body_json: Value,
+    attachments_json: Vec<SharedNoteAttachment>,
+    web_editable: bool,
+    access_version: i64,
+    published_at: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SnapshotConflictResponse {
+    code: &'static str,
+    snapshot: PublishedSessionShareSnapshot,
 }
 
 #[derive(Deserialize)]
@@ -210,7 +286,8 @@ struct PostgrestError {
     paths(
         create_credentials,
         claim_e2ee_identity,
-        publish_session_share_snapshot
+        publish_session_share_snapshot,
+        edit_session_share_snapshot
     ),
     components(schemas(
         CloudsyncCredentialResponse,
@@ -220,6 +297,8 @@ struct PostgrestError {
         E2eeIdentity,
         LegacyCloudsyncCredentials,
         PublishSessionShareSnapshotRequest,
+        CasSessionShareSnapshotRequest,
+        LegacySessionShareSnapshotRequest,
         PublishedSessionShareSnapshot,
         SharedNoteAttachment
     ))
@@ -234,7 +313,7 @@ pub fn openapi() -> utoipa::openapi::OpenApi {
     openapi
 }
 
-pub fn router(state: AppState) -> Router {
+pub fn pro_router(state: AppState) -> Router {
     Router::new()
         .route("/token", post(create_credentials))
         .route("/e2ee/identity", put(claim_e2ee_identity))
@@ -246,6 +325,16 @@ pub fn router(state: AppState) -> Router {
         )
         .merge(attachment_backups::router())
         .merge(shared_attachments::router())
+        .with_state(state)
+}
+
+pub fn web_edit_router(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/shares/{share_id}/web-edit",
+            put(edit_session_share_snapshot)
+                .layer(DefaultBodyLimit::max(MAX_SNAPSHOT_REQUEST_BYTES)),
+        )
         .with_state(state)
 }
 
@@ -290,6 +379,7 @@ async fn claim_e2ee_identity(
         (status = 400, description = "Invalid shared-note snapshot"),
         (status = 401, description = "Authentication required"),
         (status = 403, description = "Anarlog Pro or share-manager access required"),
+        (status = 409, description = "Shared note changed since the supplied base revision"),
         (status = 413, description = "Shared-note snapshot is too large"),
         (status = 502, description = "Shared-note service unavailable")
     )
@@ -298,40 +388,42 @@ async fn publish_session_share_snapshot(
     Extension(auth): Extension<AuthContext>,
     State(state): State<AppState>,
     Path(share_id): Path<String>,
-    Json(request): Json<PublishSessionShareSnapshotRequest>,
-) -> Result<(
-    [(header::HeaderName, HeaderValue); 1],
-    Json<PublishedSessionShareSnapshot>,
-)> {
+    Json(payload): Json<Value>,
+) -> Result<Response> {
     if !auth.claims.is_pro() {
         return Err(SyncError::ProPlanRequired);
     }
 
-    let share_id = Uuid::parse_str(&share_id)
-        .map_err(|_| SyncError::BadRequest("Shared note ID is invalid".to_string()))?
-        .to_string();
-    let title = sanitize_title(&request.title)?;
-    let mut attachment_ids = HashSet::new();
-    if let Some(requested_attachment_ids) = &request.attachment_ids {
-        if requested_attachment_ids.len() > 64 {
-            return Err(SyncError::BadRequest(
-                "Shared note has too many attachments".to_string(),
-            ));
+    let request = serde_json::from_value::<PublishSessionShareSnapshotRequest>(payload)
+        .map_err(|_| SyncError::BadRequest("Shared note snapshot is invalid".to_string()))?;
+    match request {
+        PublishSessionShareSnapshotRequest::Legacy(request) => {
+            publish_legacy_session_share_snapshot(&state, &auth.claims.sub, &share_id, &request)
+                .await
         }
-        for attachment_id in requested_attachment_ids {
-            let uuid = Uuid::parse_str(attachment_id).map_err(|_| {
-                SyncError::BadRequest("Shared attachment ID is invalid".to_string())
-            })?;
-            if uuid.to_string() != *attachment_id
-                || uuid.get_version() != Some(uuid::Version::Random)
-                || !attachment_ids.insert(attachment_id.clone())
-            {
-                return Err(SyncError::BadRequest(
-                    "Shared attachment ID is invalid".to_string(),
-                ));
-            }
+        PublishSessionShareSnapshotRequest::Cas(request) => {
+            mutate_session_share_snapshot(
+                &state,
+                &auth.claims.sub,
+                &share_id,
+                request,
+                SnapshotMutationKind::DesktopPublish,
+            )
+            .await
         }
     }
+}
+
+async fn publish_legacy_session_share_snapshot(
+    state: &AppState,
+    actor_user_id: &str,
+    share_id: &str,
+    request: &LegacySessionShareSnapshotRequest,
+) -> Result<Response> {
+    let share_id = canonical_random_uuid(share_id, "Shared note ID")?;
+    let title = sanitize_title(&request.title)?;
+    let requested_attachment_ids = request.attachment_ids.as_deref();
+    let attachment_ids = validate_attachment_ids(requested_attachment_ids.unwrap_or_default())?;
     let body = sanitize_document_with_attachments(&request.body, &attachment_ids)?;
 
     let response = state
@@ -343,44 +435,45 @@ async fn publish_session_share_snapshot(
         .header("apikey", &state.config.supabase_service_role_key)
         .bearer_auth(&state.config.supabase_service_role_key)
         .timeout(SNAPSHOT_PUBLISH_TIMEOUT)
-        .json(&PublishSnapshotRpcRequest {
+        .json(&LegacyPublishSnapshotRpcRequest {
             p_share_id: &share_id,
-            p_actor_user_id: &auth.claims.sub,
+            p_actor_user_id: actor_user_id,
             p_title: &title,
             p_body_json: &body,
-            p_attachment_ids: request.attachment_ids.as_deref(),
+            p_attachment_ids: requested_attachment_ids,
         })
         .send()
         .await
         .map_err(|error| {
-            tracing::warn!(%error, "Supabase shared-note publication request failed");
+            tracing::warn!(%error, "Supabase legacy shared-note publication request failed");
             SyncError::SnapshotServiceUnavailable
         })?;
     let status = response.status();
     if response
         .content_length()
-        .is_some_and(|length| length > MAX_SNAPSHOT_RESPONSE_BYTES)
+        .is_some_and(|length| length > MAX_SNAPSHOT_RESPONSE_BYTES as u64)
     {
-        tracing::warn!(%status, "Supabase shared-note publication response was too large");
+        tracing::warn!(%status, "Supabase legacy shared-note publication response was too large");
         return Err(SyncError::SnapshotServiceUnavailable);
     }
     let bytes = response.bytes().await.map_err(|error| {
-        tracing::warn!(%error, "Supabase shared-note publication response could not be read");
+        tracing::warn!(%error, "Supabase legacy shared-note publication response could not be read");
         SyncError::SnapshotServiceUnavailable
     })?;
-    if bytes.len() as u64 > MAX_SNAPSHOT_RESPONSE_BYTES {
-        tracing::warn!(%status, "Supabase shared-note publication response was too large");
+    if bytes.len() > MAX_SNAPSHOT_RESPONSE_BYTES {
+        tracing::warn!(%status, "Supabase legacy shared-note publication response was too large");
         return Err(SyncError::SnapshotServiceUnavailable);
     }
     if !status.is_success() {
         let code = serde_json::from_slice::<PostgrestError>(&bytes)
             .ok()
             .map(|error| error.code);
-        tracing::warn!(%status, ?code, "Supabase shared-note publication was rejected");
+        tracing::warn!(%status, ?code, "Supabase legacy shared-note publication was rejected");
         return match (status, code.as_deref()) {
             (HttpStatusCode::UNAUTHORIZED | HttpStatusCode::FORBIDDEN, _) | (_, Some("42501")) => {
                 Err(SyncError::SnapshotPublicationForbidden)
             }
+            (_, Some("23514")) => Err(SyncError::SnapshotChanged),
             (_, Some("22023")) => Err(SyncError::BadRequest(
                 "Shared note snapshot is invalid".to_string(),
             )),
@@ -389,14 +482,14 @@ async fn publish_session_share_snapshot(
     }
 
     let mut rows =
-        serde_json::from_slice::<Vec<PublishedSnapshotRow>>(&bytes).map_err(|error| {
-            tracing::warn!(%error, "Supabase shared-note publication response was invalid");
+        serde_json::from_slice::<Vec<LegacyPublishedSnapshotRow>>(&bytes).map_err(|error| {
+            tracing::warn!(%error, "Supabase legacy shared-note publication response was invalid");
             SyncError::SnapshotServiceUnavailable
         })?;
     if rows.len() != 1 {
         tracing::warn!(
             row_count = rows.len(),
-            "Supabase shared-note publication returned an invalid row count"
+            "Supabase legacy shared-note publication returned an invalid row count"
         );
         return Err(SyncError::SnapshotServiceUnavailable);
     }
@@ -406,17 +499,16 @@ async fn publish_session_share_snapshot(
         || row.content_revision < 1
         || row.title != title
         || row.body_json != body
-        || validate_shared_attachments(&row.attachments_json, request.attachment_ids.as_deref())
-            .is_err()
+        || validate_shared_attachments(&row.attachments_json, requested_attachment_ids).is_err()
         || chrono::DateTime::parse_from_rfc3339(&row.published_at).is_err()
     {
-        tracing::warn!("Supabase shared-note publication response failed validation");
+        tracing::warn!("Supabase legacy shared-note publication response failed validation");
         return Err(SyncError::SnapshotServiceUnavailable);
     }
 
     Ok((
         [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
-        Json(PublishedSessionShareSnapshot {
+        Json(LegacyPublishedSessionShareSnapshot {
             share_id: row.share_id,
             schema_version: row.schema_version,
             content_revision: row.content_revision,
@@ -425,7 +517,263 @@ async fn publish_session_share_snapshot(
             attachments: row.attachments_json,
             published_at: row.published_at,
         }),
-    ))
+    )
+        .into_response())
+}
+
+#[utoipa::path(
+    put,
+    path = "/shares/{share_id}/web-edit",
+    tag = "sync",
+    params(("share_id" = String, Path, description = "Session share ID")),
+    request_body = PublishSessionShareSnapshotRequest,
+    responses(
+        (status = 200, description = "Shared-note edit saved", body = PublishedSessionShareSnapshot),
+        (status = 400, description = "Invalid or unsupported shared-note edit"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Explicit Editor access required"),
+        (status = 409, description = "Shared note changed since the supplied base revision"),
+        (status = 413, description = "Shared-note edit is too large"),
+        (status = 502, description = "Shared-note service unavailable")
+    )
+)]
+async fn edit_session_share_snapshot(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Path(share_id): Path<String>,
+    Json(payload): Json<Value>,
+) -> Result<Response> {
+    let request = serde_json::from_value::<CasSessionShareSnapshotRequest>(payload)
+        .map_err(|_| SyncError::BadRequest("Shared note edit is invalid".to_string()))?;
+    mutate_session_share_snapshot(
+        &state,
+        &auth.claims.sub,
+        &share_id,
+        request,
+        SnapshotMutationKind::WebEdit,
+    )
+    .await
+}
+
+#[derive(Clone, Copy)]
+enum SnapshotMutationKind {
+    DesktopPublish,
+    WebEdit,
+}
+
+async fn mutate_session_share_snapshot(
+    state: &AppState,
+    actor_user_id: &str,
+    share_id: &str,
+    request: CasSessionShareSnapshotRequest,
+    kind: SnapshotMutationKind,
+) -> Result<Response> {
+    let share_id = canonical_random_uuid(share_id, "Shared note ID")?;
+    let base_revision = request.base_revision;
+    let mutation_id = canonical_random_uuid(&request.mutation_id, "Mutation ID")?;
+    let minimum_revision = match kind {
+        SnapshotMutationKind::DesktopPublish => 0,
+        SnapshotMutationKind::WebEdit => 1,
+    };
+    if base_revision < minimum_revision || base_revision == i64::MAX {
+        return Err(SyncError::BadRequest(
+            "Shared note base revision is invalid".to_string(),
+        ));
+    }
+    let title = sanitize_title(&request.title)?;
+    let requested_attachment_ids = request.attachment_ids.as_slice();
+    let attachment_ids = validate_attachment_ids(requested_attachment_ids)?;
+    let body = sanitize_document_with_attachments(&request.body, &attachment_ids)?;
+    let web_editable = body == request.body;
+    if matches!(kind, SnapshotMutationKind::WebEdit) && !web_editable {
+        return Err(SyncError::BadRequest(
+            "Shared note edit contains unsupported content".to_string(),
+        ));
+    }
+
+    let rpc_name = match kind {
+        SnapshotMutationKind::DesktopPublish => "publish_session_share_snapshot_cas",
+        SnapshotMutationKind::WebEdit => "edit_session_share_snapshot_cas",
+    };
+    let builder = state
+        .client
+        .post(format!(
+            "{}/rest/v1/rpc/{rpc_name}",
+            state.config.supabase_url
+        ))
+        .header("apikey", &state.config.supabase_service_role_key)
+        .bearer_auth(&state.config.supabase_service_role_key)
+        .timeout(SNAPSHOT_PUBLISH_TIMEOUT);
+    let builder = match kind {
+        SnapshotMutationKind::DesktopPublish => builder.json(&PublishSnapshotCasRpcRequest {
+            p_share_id: &share_id,
+            p_actor_user_id: actor_user_id,
+            p_expected_content_revision: base_revision,
+            p_mutation_id: &mutation_id,
+            p_title: &title,
+            p_body_json: &body,
+            p_attachment_ids: requested_attachment_ids,
+            p_web_editable: web_editable,
+        }),
+        SnapshotMutationKind::WebEdit => builder.json(&EditSnapshotCasRpcRequest {
+            p_share_id: &share_id,
+            p_actor_user_id: actor_user_id,
+            p_expected_content_revision: base_revision,
+            p_mutation_id: &mutation_id,
+            p_title: &title,
+            p_body_json: &body,
+            p_attachment_ids: requested_attachment_ids,
+        }),
+    };
+    let mut response = builder.send().await.map_err(|error| {
+        tracing::warn!(%error, rpc_name, "Supabase shared-note mutation request failed");
+        SyncError::SnapshotServiceUnavailable
+    })?;
+    let status = response.status();
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_SNAPSHOT_RESPONSE_BYTES as u64)
+    {
+        tracing::warn!(%status, rpc_name, "Supabase shared-note mutation response was too large");
+        return Err(SyncError::SnapshotServiceUnavailable);
+    }
+
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        tracing::warn!(%error, rpc_name, "Supabase shared-note mutation response could not be read");
+        SyncError::SnapshotServiceUnavailable
+    })? {
+        if bytes.len().saturating_add(chunk.len()) > MAX_SNAPSHOT_RESPONSE_BYTES {
+            tracing::warn!(%status, rpc_name, "Supabase shared-note mutation response was too large");
+            return Err(SyncError::SnapshotServiceUnavailable);
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    if !status.is_success() {
+        let code = serde_json::from_slice::<PostgrestError>(&bytes)
+            .ok()
+            .map(|error| error.code);
+        tracing::warn!(%status, ?code, rpc_name, "Supabase shared-note mutation was rejected");
+        return match (status, code.as_deref()) {
+            (HttpStatusCode::UNAUTHORIZED | HttpStatusCode::FORBIDDEN, _) | (_, Some("42501")) => {
+                Err(SyncError::SnapshotPublicationForbidden)
+            }
+            (_, Some("40001")) => Err(SyncError::SnapshotChanged),
+            (_, Some("22023" | "55000")) => Err(SyncError::BadRequest(
+                "Shared note snapshot is invalid".to_string(),
+            )),
+            _ => Err(SyncError::SnapshotServiceUnavailable),
+        };
+    }
+
+    let mut rows =
+        serde_json::from_slice::<Vec<PublishedSnapshotRow>>(&bytes).map_err(|error| {
+            tracing::warn!(%error, rpc_name, "Supabase shared-note mutation response was invalid");
+            SyncError::SnapshotServiceUnavailable
+        })?;
+    if rows.len() != 1 {
+        tracing::warn!(
+            row_count = rows.len(),
+            "Supabase shared-note mutation returned an invalid row count"
+        );
+        return Err(SyncError::SnapshotServiceUnavailable);
+    }
+    let row = rows.pop().expect("row count was checked");
+    if !matches!(row.outcome.as_str(), "applied" | "replayed" | "conflict")
+        || row.share_id != share_id
+        || row.schema_version != 1
+        || row.content_revision < 1
+        || (row.outcome == "conflict" && row.content_revision == base_revision)
+        || (row.outcome != "conflict" && row.content_revision != base_revision + 1)
+        || row.access_version < 1
+        || chrono::DateTime::parse_from_rfc3339(&row.published_at).is_err()
+    {
+        tracing::warn!(
+            rpc_name,
+            "Supabase shared-note mutation response failed validation"
+        );
+        return Err(SyncError::SnapshotServiceUnavailable);
+    }
+    let expected_ids = (row.outcome != "conflict").then_some(requested_attachment_ids);
+    if validate_shared_attachments(&row.attachments_json, expected_ids).is_err()
+        || validate_snapshot_document(&row.body_json, &row.attachments_json).is_err()
+        || !sanitize_title(&row.title).is_ok_and(|title| title == row.title)
+        || (row.outcome != "conflict" && (row.title != title || row.body_json != body))
+        || (matches!(kind, SnapshotMutationKind::WebEdit)
+            && row.outcome != "conflict"
+            && !row.web_editable)
+    {
+        tracing::warn!(
+            rpc_name,
+            "Supabase shared-note mutation payload failed validation"
+        );
+        return Err(SyncError::SnapshotServiceUnavailable);
+    }
+
+    let outcome = row.outcome;
+    let snapshot = PublishedSessionShareSnapshot {
+        share_id: row.share_id,
+        schema_version: row.schema_version,
+        content_revision: row.content_revision,
+        title: row.title,
+        body: row.body_json,
+        attachments: row.attachments_json,
+        web_editable: row.web_editable,
+        access_version: row.access_version,
+        published_at: row.published_at,
+    };
+    let headers = [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))];
+    if outcome == "conflict" {
+        return Ok((
+            StatusCode::CONFLICT,
+            headers,
+            Json(SnapshotConflictResponse {
+                code: "snapshot_conflict",
+                snapshot,
+            }),
+        )
+            .into_response());
+    }
+    Ok((headers, Json(snapshot)).into_response())
+}
+
+fn canonical_random_uuid(value: &str, label: &str) -> Result<String> {
+    let uuid =
+        Uuid::parse_str(value).map_err(|_| SyncError::BadRequest(format!("{label} is invalid")))?;
+    if uuid.to_string() != value || uuid.get_version() != Some(uuid::Version::Random) {
+        return Err(SyncError::BadRequest(format!("{label} is invalid")));
+    }
+    Ok(value.to_string())
+}
+
+fn validate_attachment_ids(values: &[String]) -> Result<HashSet<String>> {
+    if values.len() > 64 {
+        return Err(SyncError::BadRequest(
+            "Shared note has too many attachments".to_string(),
+        ));
+    }
+    let mut ids = HashSet::new();
+    for value in values {
+        canonical_random_uuid(value, "Shared attachment ID")?;
+        if !ids.insert(value.clone()) {
+            return Err(SyncError::BadRequest(
+                "Shared attachment ID is invalid".to_string(),
+            ));
+        }
+    }
+    Ok(ids)
+}
+
+fn validate_snapshot_document(body: &Value, attachments: &[SharedNoteAttachment]) -> Result<()> {
+    let ids = attachments
+        .iter()
+        .map(|attachment| attachment.id.clone())
+        .collect::<HashSet<_>>();
+    let sanitized = sanitize_document_with_attachments(body, &ids)?;
+    if sanitized != *body {
+        return Err(SyncError::SnapshotServiceUnavailable);
+    }
+    Ok(())
 }
 
 pub(crate) fn validate_shared_attachments(
@@ -864,7 +1212,7 @@ mod tests {
         protocol_mode: CloudsyncProtocolMode,
         legacy_database_id: Option<&str>,
     ) -> Router {
-        router(AppState::new(SyncConfig {
+        let state = AppState::new(SyncConfig {
             project_url: server.uri(),
             token_issuer_api_key: api_key.to_string(),
             database_id: "database-id".to_string(),
@@ -874,21 +1222,23 @@ mod tests {
             supabase_url: server.uri(),
             supabase_anon_key: "anon-key".to_string(),
             supabase_service_role_key: "service-role-key".to_string(),
-        }))
-        .layer(Extension(AuthContext {
-            token: "supabase-token".to_string(),
-            claims: Claims {
-                sub: "user-123".to_string(),
-                email: None,
-                entitlements: entitlements
-                    .iter()
-                    .map(|entitlement| (*entitlement).to_string())
-                    .collect(),
-                subscription_status: None,
-                trial_end: None,
-                has_payment_method: None,
-            },
-        }))
+        });
+        pro_router(state.clone())
+            .merge(web_edit_router(state))
+            .layer(Extension(AuthContext {
+                token: "supabase-token".to_string(),
+                claims: Claims {
+                    sub: "user-123".to_string(),
+                    email: None,
+                    entitlements: entitlements
+                        .iter()
+                        .map(|entitlement| (*entitlement).to_string())
+                        .collect(),
+                    subscription_status: None,
+                    trial_end: None,
+                    has_payment_method: None,
+                },
+            }))
     }
 
     fn personal_workspace(id: &str) -> Value {
@@ -1430,6 +1780,7 @@ mod tests {
     async fn publishes_only_the_sanitized_snapshot_as_the_authenticated_actor() {
         let server = MockServer::start().await;
         let share_id = "11111111-1111-4111-8111-111111111111";
+        let mutation_id = "22222222-2222-4222-8222-222222222222";
         let sanitized_body = json!({
             "type": "doc",
             "content": [
@@ -1447,25 +1798,29 @@ mod tests {
             ]
         });
         Mock::given(method("POST"))
-            .and(path(
-                "/rest/v1/rpc/publish_session_share_snapshot_with_attachments",
-            ))
+            .and(path("/rest/v1/rpc/publish_session_share_snapshot_cas"))
             .and(header("apikey", "service-role-key"))
             .and(header("authorization", "Bearer service-role-key"))
             .and(body_partial_json(json!({
                 "p_share_id": share_id,
                 "p_actor_user_id": "user-123",
+                "p_expected_content_revision": 1,
+                "p_mutation_id": mutation_id,
                 "p_title": "Quarterly plan",
                 "p_body_json": sanitized_body,
-                "p_attachment_ids": null
+                "p_attachment_ids": [],
+                "p_web_editable": false
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "outcome": "applied",
                 "share_id": share_id,
                 "schema_version": 1,
                 "content_revision": 2,
                 "title": "Quarterly plan",
                 "body_json": sanitized_body,
                 "attachments_json": [],
+                "web_editable": false,
+                "access_version": 4,
                 "published_at": "2026-07-16T10:00:00Z"
             }])))
             .expect(1)
@@ -1504,6 +1859,8 @@ mod tests {
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(Body::from(
                         json!({
+                            "baseRevision": 1,
+                            "mutationId": mutation_id,
                             "title": "  Quarterly plan  ",
                             "body": {
                                 "type": "doc",
@@ -1531,7 +1888,8 @@ mod tests {
                                         }
                                     }
                                 ]
-                            }
+                            },
+                            "attachmentIds": []
                         })
                         .to_string(),
                     ))
@@ -1548,6 +1906,8 @@ mod tests {
         assert_eq!(body["contentRevision"], 2);
         assert_eq!(body["title"], "Quarterly plan");
         assert_eq!(body["body"], sanitized_body);
+        assert_eq!(body["webEditable"], false);
+        assert_eq!(body["accessVersion"], 4);
 
         let requests = server.received_requests().await.unwrap();
         let published = String::from_utf8(requests[0].body.clone()).unwrap();
@@ -1575,6 +1935,93 @@ mod tests {
             .unwrap();
 
         assert_eq!(explicit_empty_response.status(), StatusCode::OK);
+        let legacy_body = response_json(explicit_empty_response).await;
+        let legacy_object = legacy_body.as_object().unwrap();
+        assert_eq!(legacy_object.len(), 7);
+        for key in [
+            "shareId",
+            "schemaVersion",
+            "contentRevision",
+            "title",
+            "body",
+            "attachments",
+            "publishedAt",
+        ] {
+            assert!(legacy_object.contains_key(key));
+        }
+        assert!(!legacy_object.contains_key("webEditable"));
+        assert!(!legacy_object.contains_key("accessVersion"));
+    }
+
+    #[tokio::test]
+    async fn publishes_lossless_attachment_snapshots_as_web_editable() {
+        let server = MockServer::start().await;
+        let share_id = "11111111-1111-4111-8111-111111111111";
+        let mutation_id = "22222222-2222-4222-8222-222222222222";
+        let attachment_id = "33333333-3333-4333-8333-333333333333";
+        let body = json!({
+            "type": "doc",
+            "content": [{
+                "type": "image",
+                "attrs": { "sharedAttachmentId": attachment_id }
+            }]
+        });
+        let attachment = json!({
+            "id": attachment_id,
+            "filename": "diagram.png",
+            "contentType": "image/png",
+            "sizeBytes": 1024,
+            "sha256": "a".repeat(64)
+        });
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/publish_session_share_snapshot_cas"))
+            .and(body_partial_json(json!({
+                "p_share_id": share_id,
+                "p_actor_user_id": "user-123",
+                "p_expected_content_revision": 1,
+                "p_mutation_id": mutation_id,
+                "p_title": "Diagram",
+                "p_body_json": body,
+                "p_attachment_ids": [attachment_id],
+                "p_web_editable": true
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "outcome": "applied",
+                "share_id": share_id,
+                "schema_version": 1,
+                "content_revision": 2,
+                "title": "Diagram",
+                "body_json": body,
+                "attachments_json": [attachment],
+                "web_editable": true,
+                "access_version": 4,
+                "published_at": "2026-07-17T10:00:00Z"
+            }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, "issuer-key", &["hyprnote_pro"])
+            .oneshot(
+                Request::put(format!("/shares/{share_id}/snapshot"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "baseRevision": 1,
+                            "mutationId": mutation_id,
+                            "title": "Diagram",
+                            "body": body,
+                            "attachmentIds": [attachment_id]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_json(response).await["webEditable"], true);
     }
 
     #[tokio::test]
@@ -1582,11 +2029,46 @@ mod tests {
         let cases = [
             (
                 "/shares/not-a-uuid/snapshot".to_string(),
-                json!({ "title": "Title", "body": { "type": "doc" } }),
+                json!({
+                    "baseRevision": 1,
+                    "mutationId": "22222222-2222-4222-8222-222222222222",
+                    "title": "Title",
+                    "body": { "type": "doc" }
+                }),
             ),
             (
                 "/shares/11111111-1111-4111-8111-111111111111/snapshot".to_string(),
-                json!({ "title": "Title", "body": { "type": "paragraph" } }),
+                json!({
+                    "baseRevision": 1,
+                    "mutationId": "22222222-2222-4222-8222-222222222222",
+                    "title": "Title",
+                    "body": { "type": "paragraph" }
+                }),
+            ),
+            (
+                "/shares/11111111-1111-4111-8111-111111111111/snapshot".to_string(),
+                json!({
+                    "baseRevision": 1,
+                    "title": "Title",
+                    "body": { "type": "doc" }
+                }),
+            ),
+            (
+                "/shares/11111111-1111-4111-8111-111111111111/snapshot".to_string(),
+                json!({
+                    "mutationId": "22222222-2222-4222-8222-222222222222",
+                    "title": "Title",
+                    "body": { "type": "doc" }
+                }),
+            ),
+            (
+                "/shares/11111111-1111-4111-8111-111111111111/snapshot".to_string(),
+                json!({
+                    "baseRevision": null,
+                    "mutationId": null,
+                    "title": "Title",
+                    "body": { "type": "doc" }
+                }),
             ),
         ];
 
@@ -1608,6 +2090,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejects_missing_or_null_cas_attachment_manifests_before_calling_supabase() {
+        let cases = [
+            json!({
+                "baseRevision": 1,
+                "mutationId": "22222222-2222-4222-8222-222222222222",
+                "title": "Title",
+                "body": { "type": "doc", "content": [{ "type": "paragraph" }] }
+            }),
+            json!({
+                "baseRevision": 1,
+                "mutationId": "22222222-2222-4222-8222-222222222222",
+                "title": "Title",
+                "body": { "type": "doc", "content": [{ "type": "paragraph" }] },
+                "attachmentIds": null
+            }),
+        ];
+
+        for payload in cases {
+            let server = MockServer::start().await;
+            let response = test_router(&server, "issuer-key", &["hyprnote_pro"])
+                .oneshot(
+                    Request::put("/shares/11111111-1111-4111-8111-111111111111/snapshot")
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(payload.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert!(server.received_requests().await.unwrap().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_legacy_publication_after_cas_cutover_to_a_redacted_conflict() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/rest/v1/rpc/publish_session_share_snapshot_with_attachments",
+            ))
+            .respond_with(ResponseTemplate::new(409).set_body_json(json!({
+                "code": "23514",
+                "message": "session_share_snapshots_last_mutation_check secret detail"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, "issuer-key", &["hyprnote_pro"])
+            .oneshot(
+                Request::put("/shares/11111111-1111-4111-8111-111111111111/snapshot")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "title": "Legacy",
+                            "body": { "type": "doc", "content": [{ "type": "paragraph" }] },
+                            "attachmentIds": []
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await.to_string();
+        assert!(body.contains("snapshot_conflict"));
+        assert!(!body.contains("last_mutation"));
+        assert!(!body.contains("secret detail"));
+    }
+
+    #[tokio::test]
     async fn rejects_snapshot_publication_without_pro_entitlement() {
         let server = MockServer::start().await;
         let response = test_router(&server, "issuer-key", &[])
@@ -1615,7 +2171,14 @@ mod tests {
                 Request::put("/shares/11111111-1111-4111-8111-111111111111/snapshot")
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(Body::from(
-                        json!({ "title": "Title", "body": { "type": "doc" } }).to_string(),
+                        json!({
+                            "baseRevision": 1,
+                            "mutationId": "22222222-2222-4222-8222-222222222222",
+                            "title": "Title",
+                            "body": { "type": "doc" },
+                            "attachmentIds": []
+                        })
+                        .to_string(),
                     ))
                     .unwrap(),
             )
@@ -1634,9 +2197,7 @@ mod tests {
     async fn maps_manager_denial_without_leaking_supabase_details() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path(
-                "/rest/v1/rpc/publish_session_share_snapshot_with_attachments",
-            ))
+            .and(path("/rest/v1/rpc/publish_session_share_snapshot_cas"))
             .respond_with(ResponseTemplate::new(403).set_body_json(json!({
                 "code": "42501",
                 "message": "secret database detail"
@@ -1649,7 +2210,14 @@ mod tests {
                 Request::put("/shares/11111111-1111-4111-8111-111111111111/snapshot")
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(Body::from(
-                        json!({ "title": "Title", "body": { "type": "doc" } }).to_string(),
+                        json!({
+                            "baseRevision": 1,
+                            "mutationId": "22222222-2222-4222-8222-222222222222",
+                            "title": "Title",
+                            "body": { "type": "doc" },
+                            "attachmentIds": []
+                        })
+                        .to_string(),
                     ))
                     .unwrap(),
             )
@@ -1660,6 +2228,397 @@ mod tests {
         let body = response_json(response).await.to_string();
         assert!(body.contains("shared_note_publication_forbidden"));
         assert!(!body.contains("secret database detail"));
+        assert!(!body.contains("service-role-key"));
+    }
+
+    #[tokio::test]
+    async fn maps_missing_snapshot_cas_conflicts_without_leaking_database_details() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/publish_session_share_snapshot_cas"))
+            .respond_with(ResponseTemplate::new(409).set_body_json(json!({
+                "code": "40001",
+                "message": "missing snapshot secret database detail"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, "issuer-key", &["hyprnote_pro"])
+            .oneshot(
+                Request::put("/shares/11111111-1111-4111-8111-111111111111/snapshot")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "baseRevision": 1,
+                            "mutationId": "22222222-2222-4222-8222-222222222222",
+                            "title": "Title",
+                            "body": { "type": "doc", "content": [{ "type": "paragraph" }] },
+                            "attachmentIds": []
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "snapshot_conflict");
+        let body = body.to_string();
+        assert!(!body.contains("missing snapshot"));
+        assert!(!body.contains("secret database detail"));
+        assert!(!body.contains("service-role-key"));
+    }
+
+    #[tokio::test]
+    async fn saves_an_explicit_editor_web_edit_without_a_pro_entitlement() {
+        let server = MockServer::start().await;
+        let share_id = "11111111-1111-4111-8111-111111111111";
+        let mutation_id = "22222222-2222-4222-8222-222222222222";
+        let body = json!({
+            "type": "doc",
+            "content": [{
+                "type": "heading",
+                "attrs": { "level": 1 },
+                "content": [{ "type": "text", "text": "Edited note" }]
+            }]
+        });
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/edit_session_share_snapshot_cas"))
+            .and(header("apikey", "service-role-key"))
+            .and(header("authorization", "Bearer service-role-key"))
+            .and(body_partial_json(json!({
+                "p_share_id": share_id,
+                "p_actor_user_id": "user-123",
+                "p_expected_content_revision": 3,
+                "p_mutation_id": mutation_id,
+                "p_title": "Edited note",
+                "p_body_json": body,
+                "p_attachment_ids": []
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "outcome": "applied",
+                "share_id": share_id,
+                "schema_version": 1,
+                "content_revision": 4,
+                "title": "Edited note",
+                "body_json": body,
+                "attachments_json": [],
+                "web_editable": true,
+                "access_version": 7,
+                "published_at": "2026-07-17T10:00:00Z"
+            }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, "issuer-key", &[])
+            .oneshot(
+                Request::put(format!("/shares/{share_id}/web-edit"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "baseRevision": 3,
+                            "mutationId": mutation_id,
+                            "title": "Edited note",
+                            "body": body,
+                            "attachmentIds": []
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        let response = response_json(response).await;
+        assert_eq!(response["contentRevision"], 4);
+        assert_eq!(response["webEditable"], true);
+        assert_eq!(response["accessVersion"], 7);
+    }
+
+    #[tokio::test]
+    async fn saves_web_edits_that_preserve_the_attachment_manifest() {
+        let server = MockServer::start().await;
+        let share_id = "11111111-1111-4111-8111-111111111111";
+        let mutation_id = "22222222-2222-4222-8222-222222222222";
+        let attachment_id = "33333333-3333-4333-8333-333333333333";
+        let body = json!({
+            "type": "doc",
+            "content": [{
+                "type": "fileAttachment",
+                "attrs": { "sharedAttachmentId": attachment_id }
+            }]
+        });
+        let attachment = json!({
+            "id": attachment_id,
+            "filename": "notes.pdf",
+            "contentType": "application/pdf",
+            "sizeBytes": 2048,
+            "sha256": "b".repeat(64)
+        });
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/edit_session_share_snapshot_cas"))
+            .and(body_partial_json(json!({
+                "p_share_id": share_id,
+                "p_actor_user_id": "user-123",
+                "p_expected_content_revision": 3,
+                "p_mutation_id": mutation_id,
+                "p_title": "Edited note",
+                "p_body_json": body,
+                "p_attachment_ids": [attachment_id]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "outcome": "applied",
+                "share_id": share_id,
+                "schema_version": 1,
+                "content_revision": 4,
+                "title": "Edited note",
+                "body_json": body,
+                "attachments_json": [attachment],
+                "web_editable": true,
+                "access_version": 7,
+                "published_at": "2026-07-17T10:00:00Z"
+            }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, "issuer-key", &[])
+            .oneshot(
+                Request::put(format!("/shares/{share_id}/web-edit"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "baseRevision": 3,
+                            "mutationId": mutation_id,
+                            "title": "Edited note",
+                            "body": body,
+                            "attachmentIds": [attachment_id]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_json(response).await["webEditable"], true);
+    }
+
+    #[tokio::test]
+    async fn rejects_an_oversized_chunked_snapshot_mutation_response() {
+        let server = MockServer::start().await;
+        let share_id = "11111111-1111-4111-8111-111111111111";
+        let mutation_id = "22222222-2222-4222-8222-222222222222";
+        let body = json!({
+            "type": "doc",
+            "content": [{ "type": "paragraph" }]
+        });
+        let upstream_body = json!([{
+            "outcome": "applied",
+            "share_id": share_id,
+            "schema_version": 1,
+            "content_revision": 2,
+            "title": "Title",
+            "body_json": body,
+            "attachments_json": [],
+            "web_editable": true,
+            "access_version": 1,
+            "published_at": "2026-07-17T10:00:00Z",
+            "padding": "x".repeat(MAX_SNAPSHOT_RESPONSE_BYTES)
+        }])
+        .to_string();
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/edit_session_share_snapshot_cas"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("transfer-encoding", "chunked")
+                    .set_body_raw(upstream_body, "application/json"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, "issuer-key", &[])
+            .oneshot(
+                Request::put(format!("/shares/{share_id}/web-edit"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "baseRevision": 1,
+                            "mutationId": mutation_id,
+                            "title": "Title",
+                            "body": body,
+                            "attachmentIds": []
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            response_json(response).await["error"]["code"],
+            "shared_note_service_unavailable"
+        );
+    }
+
+    #[tokio::test]
+    async fn maps_a_stale_web_edit_to_a_redacted_conflict_snapshot() {
+        let server = MockServer::start().await;
+        let share_id = "11111111-1111-4111-8111-111111111111";
+        let mutation_id = "22222222-2222-4222-8222-222222222222";
+        let draft = json!({
+            "type": "doc",
+            "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Draft" }] }]
+        });
+        let current = json!({
+            "type": "doc",
+            "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Current" }] }]
+        });
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/edit_session_share_snapshot_cas"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "outcome": "conflict",
+                "share_id": share_id,
+                "schema_version": 1,
+                "content_revision": 5,
+                "title": "Current",
+                "body_json": current,
+                "attachments_json": [],
+                "web_editable": true,
+                "access_version": 9,
+                "published_at": "2026-07-17T10:05:00Z"
+            }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, "issuer-key", &[])
+            .oneshot(
+                Request::put(format!("/shares/{share_id}/web-edit"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "baseRevision": 4,
+                            "mutationId": mutation_id,
+                            "title": "Draft",
+                            "body": draft,
+                            "attachmentIds": []
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        let response = response_json(response).await;
+        assert_eq!(response["code"], "snapshot_conflict");
+        assert_eq!(response["snapshot"]["contentRevision"], 5);
+        assert_eq!(response["snapshot"]["body"], current);
+    }
+
+    #[tokio::test]
+    async fn rejects_legacy_payloads_on_the_web_edit_route() {
+        let server = MockServer::start().await;
+        let response = test_router(&server, "issuer-key", &[])
+            .oneshot(
+                Request::put("/shares/11111111-1111-4111-8111-111111111111/web-edit")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "title": "Legacy",
+                            "body": { "type": "doc", "content": [{ "type": "paragraph" }] },
+                            "attachmentIds": []
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn rejects_a_lossy_web_edit_before_calling_supabase() {
+        let server = MockServer::start().await;
+        let response = test_router(&server, "issuer-key", &[])
+            .oneshot(
+                Request::put(
+                    "/shares/11111111-1111-4111-8111-111111111111/web-edit",
+                )
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "baseRevision": 1,
+                        "mutationId": "22222222-2222-4222-8222-222222222222",
+                        "title": "Unsupported",
+                        "body": {
+                            "type": "doc",
+                            "content": [{ "type": "privateNode", "attrs": { "secret": "value" } }]
+                        },
+                        "attachmentIds": []
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn maps_revoked_editor_denial_without_leaking_database_details() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/edit_session_share_snapshot_cas"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+                "code": "42501",
+                "message": "revoked editor secret detail"
+            })))
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, "issuer-key", &[])
+            .oneshot(
+                Request::put("/shares/11111111-1111-4111-8111-111111111111/web-edit")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "baseRevision": 1,
+                            "mutationId": "22222222-2222-4222-8222-222222222222",
+                            "title": "Title",
+                            "body": { "type": "doc", "content": [{ "type": "paragraph" }] },
+                            "attachmentIds": []
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = response_json(response).await.to_string();
+        assert!(body.contains("shared_note_publication_forbidden"));
+        assert!(!body.contains("revoked editor secret detail"));
         assert!(!body.contains("service-role-key"));
     }
 }

--- a/supabase/migrations/20260718140000_session_share_web_editing.sql
+++ b/supabase/migrations/20260718140000_session_share_web_editing.sql
@@ -1,0 +1,1019 @@
+ALTER TABLE public.session_share_snapshots
+  ADD COLUMN web_editable boolean NOT NULL DEFAULT false,
+  ADD COLUMN last_mutation_id uuid,
+  ADD COLUMN last_mutation_base_revision bigint,
+  ADD COLUMN last_mutation_fingerprint bytea,
+  ADD CONSTRAINT session_share_snapshots_last_mutation_check CHECK (
+    (
+      last_mutation_id IS NULL
+      AND last_mutation_base_revision IS NULL
+      AND last_mutation_fingerprint IS NULL
+    )
+    OR (
+      last_mutation_id IS NOT NULL
+      AND last_mutation_base_revision IS NOT NULL
+      AND last_mutation_base_revision >= 0
+      AND last_mutation_base_revision = content_revision - 1
+      AND last_mutation_fingerprint IS NOT NULL
+      AND octet_length(last_mutation_fingerprint) = 32
+    )
+  );
+
+CREATE TABLE public.session_share_pending_web_edits (
+  share_id uuid PRIMARY KEY
+    REFERENCES public.session_shares(id) ON DELETE CASCADE,
+  base_content_revision bigint NOT NULL,
+  base_title text NOT NULL,
+  base_body_json jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT session_share_pending_web_edits_revision_check CHECK (
+    base_content_revision > 0
+  ),
+  CONSTRAINT session_share_pending_web_edits_title_check CHECK (
+    base_title = btrim(base_title)
+    AND octet_length(base_title) <= 4096
+  ),
+  CONSTRAINT session_share_pending_web_edits_body_check CHECK (
+    jsonb_typeof(base_body_json) = 'object'
+    AND base_body_json ->> 'type' = 'doc'
+    AND octet_length(base_body_json::text) <= 2097152
+  ),
+  CONSTRAINT session_share_pending_web_edits_time_check CHECK (
+    updated_at >= created_at
+  )
+);
+
+ALTER TABLE public.session_share_pending_web_edits ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.session_share_pending_web_edits
+  FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.session_share_pending_web_edits TO service_role;
+
+CREATE POLICY session_share_pending_web_edits_service_all
+  ON public.session_share_pending_web_edits
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE OR REPLACE FUNCTION private.require_session_share_editor(
+  p_share_id uuid,
+  p_actor_user_id uuid
+)
+RETURNS TABLE (
+  manage_access boolean,
+  access_version bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_share public.session_shares%ROWTYPE;
+  v_manage_access boolean;
+  v_has_editor_grant boolean;
+BEGIN
+  IF p_share_id IS NULL OR p_actor_user_id IS NULL THEN
+    RAISE EXCEPTION 'session snapshot edit not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM 1
+  FROM auth.users AS actor
+  WHERE actor.id = p_actor_user_id
+    AND actor.email_confirmed_at IS NOT NULL
+    AND COALESCE(actor.is_anonymous, false) = false
+    AND NOT EXISTS (
+      SELECT 1
+      FROM private.account_deletion_jobs AS deletion
+      WHERE deletion.owner_user_id = actor.id
+    );
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session snapshot edit not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT share.*
+  INTO v_share
+  FROM public.session_shares AS share
+  JOIN public.workspaces AS workspace
+    ON workspace.id = share.workspace_id
+  WHERE share.id = p_share_id
+    AND share.deleted_at IS NULL
+    AND workspace.deleted_at IS NULL
+  FOR UPDATE OF share;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session snapshot edit not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.workspace_memberships AS membership
+    WHERE membership.workspace_id = v_share.workspace_id
+      AND membership.user_id = p_actor_user_id
+      AND membership.role IN ('owner', 'admin')
+      AND membership.deleted_at IS NULL
+  )
+  INTO v_manage_access;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.session_access_grants AS access_grant
+    WHERE access_grant.share_id = v_share.id
+      AND access_grant.grantee_user_id = p_actor_user_id
+      AND access_grant.capability = 'editor'
+      AND access_grant.revoked_at IS NULL
+  )
+  INTO v_has_editor_grant;
+
+  IF NOT v_manage_access AND NOT v_has_editor_grant THEN
+    RAISE EXCEPTION 'session snapshot edit not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY SELECT v_manage_access, v_share.access_version;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.apply_session_share_snapshot_cas(
+  p_share_id uuid,
+  p_actor_user_id uuid,
+  p_expected_content_revision bigint,
+  p_mutation_id uuid,
+  p_title text,
+  p_body_json jsonb,
+  p_attachment_ids uuid[],
+  p_web_editable boolean,
+  p_is_web_edit boolean
+)
+RETURNS TABLE (
+  outcome text,
+  share_id uuid,
+  schema_version smallint,
+  content_revision bigint,
+  title text,
+  body_json jsonb,
+  attachments_json jsonb,
+  web_editable boolean,
+  access_version bigint,
+  published_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_title text := btrim(p_title);
+  v_attachment_ids uuid[] := COALESCE(p_attachment_ids, ARRAY[]::uuid[]);
+  v_existing_attachment_ids uuid[] := ARRAY[]::uuid[];
+  v_retired_ids uuid[] := ARRAY[]::uuid[];
+  v_fingerprint bytea;
+  v_snapshot public.session_share_snapshots%ROWTYPE;
+  v_had_snapshot boolean;
+  v_access_version bigint;
+BEGIN
+  IF p_share_id IS NULL
+    OR p_actor_user_id IS NULL
+    OR p_expected_content_revision IS NULL
+    OR p_expected_content_revision < 0
+    OR p_mutation_id IS NULL
+    OR v_title IS NULL
+    OR octet_length(v_title) > 4096
+    OR p_body_json IS NULL
+    OR jsonb_typeof(p_body_json) <> 'object'
+    OR p_body_json ->> 'type' <> 'doc'
+    OR octet_length(p_body_json::text) > 2097152
+    OR cardinality(v_attachment_ids) > 64
+    OR EXISTS (
+      SELECT 1
+      FROM unnest(v_attachment_ids) AS requested(id)
+      WHERE requested.id IS NULL
+    )
+    OR cardinality(v_attachment_ids) <> (
+      SELECT count(DISTINCT requested.id)
+      FROM unnest(v_attachment_ids) AS requested(id)
+    )
+    OR p_web_editable IS NULL
+    OR p_is_web_edit IS NULL
+  THEN
+    RAISE EXCEPTION 'invalid session share snapshot mutation'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT share.access_version
+  INTO v_access_version
+  FROM public.session_shares AS share
+  JOIN public.workspaces AS workspace
+    ON workspace.id = share.workspace_id
+  WHERE share.id = p_share_id
+    AND share.deleted_at IS NULL
+    AND workspace.deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session snapshot edit not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  v_fingerprint := extensions.digest(
+    convert_to(
+      jsonb_build_object(
+        'attachmentIds', to_jsonb(v_attachment_ids),
+        'body', p_body_json,
+        'isWebEdit', p_is_web_edit,
+        'title', v_title,
+        'webEditable', p_web_editable
+      )::text,
+      'UTF8'
+    ),
+    'sha256'
+  );
+
+  SELECT snapshot.*
+  INTO v_snapshot
+  FROM public.session_share_snapshots AS snapshot
+  WHERE snapshot.share_id = p_share_id
+  FOR UPDATE;
+  v_had_snapshot := FOUND;
+
+  IF v_had_snapshot AND v_snapshot.last_mutation_id = p_mutation_id THEN
+    IF v_snapshot.published_by_user_id = p_actor_user_id
+      AND v_snapshot.last_mutation_base_revision = p_expected_content_revision
+      AND v_snapshot.last_mutation_fingerprint = v_fingerprint
+    THEN
+      RETURN QUERY SELECT
+        'replayed'::text,
+        v_snapshot.share_id,
+        v_snapshot.schema_version,
+        v_snapshot.content_revision,
+        v_snapshot.title,
+        v_snapshot.body_json,
+        private.session_share_attachment_manifest(v_snapshot.share_id),
+        v_snapshot.web_editable,
+        v_access_version,
+        v_snapshot.published_at;
+      RETURN;
+    END IF;
+
+    RAISE EXCEPTION 'session share mutation id is invalid'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT v_had_snapshot AND p_expected_content_revision > 0 THEN
+    RAISE EXCEPTION 'session share snapshot is unavailable'
+      USING ERRCODE = '40001';
+  END IF;
+
+  IF COALESCE(v_snapshot.content_revision, 0)
+    <> p_expected_content_revision
+  THEN
+    RETURN QUERY SELECT
+      'conflict'::text,
+      p_share_id,
+      v_snapshot.schema_version,
+      v_snapshot.content_revision,
+      v_snapshot.title,
+      v_snapshot.body_json,
+      private.session_share_attachment_manifest(p_share_id),
+      v_snapshot.web_editable,
+      v_access_version,
+      v_snapshot.published_at;
+    RETURN;
+  END IF;
+
+  SELECT COALESCE(
+    array_agg(binding.attachment_id ORDER BY binding.position),
+    ARRAY[]::uuid[]
+  )
+  INTO v_existing_attachment_ids
+  FROM public.session_share_snapshot_attachments AS binding
+  WHERE binding.share_id = p_share_id;
+
+  IF p_is_web_edit
+    AND v_attachment_ids IS DISTINCT FROM v_existing_attachment_ids
+  THEN
+    RAISE EXCEPTION 'web snapshot attachments must be preserved'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM 1
+  FROM public.session_share_attachment_objects AS attachment
+  WHERE attachment.id = ANY(v_attachment_ids)
+  ORDER BY attachment.id
+  FOR UPDATE;
+
+  IF cardinality(v_attachment_ids) <> (
+    SELECT count(*)
+    FROM public.session_share_attachment_objects AS attachment
+    WHERE attachment.id = ANY(v_attachment_ids)
+      AND attachment.share_id = p_share_id
+      AND attachment.state = 'ready'
+      AND attachment.sha256 IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'shared snapshot attachment is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  SELECT COALESCE(
+    array_agg(existing.id ORDER BY existing.id),
+    ARRAY[]::uuid[]
+  )
+  INTO v_retired_ids
+  FROM unnest(v_existing_attachment_ids) AS existing(id)
+  WHERE NOT (existing.id = ANY(v_attachment_ids));
+
+  IF p_is_web_edit THEN
+    IF NOT v_had_snapshot OR NOT v_snapshot.web_editable THEN
+      RAISE EXCEPTION 'session snapshot edit not permitted'
+        USING ERRCODE = '42501';
+    END IF;
+
+    INSERT INTO public.session_share_pending_web_edits (
+      share_id,
+      base_content_revision,
+      base_title,
+      base_body_json,
+      created_at,
+      updated_at
+    ) VALUES (
+      p_share_id,
+      v_snapshot.content_revision,
+      v_snapshot.title,
+      v_snapshot.body_json,
+      v_now,
+      v_now
+    )
+    ON CONFLICT ON CONSTRAINT session_share_pending_web_edits_pkey
+    DO UPDATE SET updated_at = excluded.updated_at;
+  END IF;
+
+  IF v_had_snapshot THEN
+    UPDATE public.session_share_snapshots AS target_snapshot
+    SET
+      schema_version = 1,
+      content_revision = target_snapshot.content_revision + 1,
+      title = v_title,
+      body_json = p_body_json,
+      published_by_user_id = p_actor_user_id,
+      published_at = v_now,
+      updated_at = v_now,
+      web_editable = p_web_editable,
+      last_mutation_id = p_mutation_id,
+      last_mutation_base_revision = p_expected_content_revision,
+      last_mutation_fingerprint = v_fingerprint
+    WHERE target_snapshot.share_id = p_share_id
+    RETURNING * INTO v_snapshot;
+  ELSE
+    INSERT INTO public.session_share_snapshots (
+      share_id,
+      schema_version,
+      content_revision,
+      title,
+      body_json,
+      published_by_user_id,
+      published_at,
+      updated_at,
+      web_editable,
+      last_mutation_id,
+      last_mutation_base_revision,
+      last_mutation_fingerprint
+    ) VALUES (
+      p_share_id,
+      1,
+      1,
+      v_title,
+      p_body_json,
+      p_actor_user_id,
+      v_now,
+      v_now,
+      p_web_editable,
+      p_mutation_id,
+      p_expected_content_revision,
+      v_fingerprint
+    )
+    RETURNING * INTO v_snapshot;
+  END IF;
+
+  DELETE FROM public.session_share_snapshot_attachments AS binding
+  WHERE binding.share_id = p_share_id;
+
+  INSERT INTO public.session_share_snapshot_attachments (
+    share_id,
+    attachment_id,
+    position,
+    created_at
+  )
+  SELECT
+    p_share_id,
+    requested.id,
+    (requested.ordinality - 1)::smallint,
+    v_now
+  FROM unnest(v_attachment_ids) WITH ORDINALITY AS requested(id, ordinality);
+
+  UPDATE public.session_share_attachment_objects AS attachment
+  SET
+    state = 'deleting',
+    deletion_requested_at = COALESCE(attachment.deletion_requested_at, v_now),
+    gc_lease_id = NULL,
+    gc_lease_expires_at = NULL,
+    updated_at = v_now
+  WHERE attachment.id = ANY(v_retired_ids)
+    AND attachment.share_id = p_share_id
+    AND attachment.state <> 'deleting';
+
+  IF NOT p_is_web_edit THEN
+    DELETE FROM public.session_share_pending_web_edits AS pending
+    WHERE pending.share_id = p_share_id;
+  END IF;
+
+  PERFORM private.write_session_access_event(
+    p_share_id,
+    'snapshot_published',
+    p_actor_user_id,
+    NULL,
+    p_mutation_id,
+    CASE
+      WHEN v_snapshot.content_revision > 1
+        THEN (v_snapshot.content_revision - 1)::text
+      ELSE NULL
+    END,
+    v_snapshot.content_revision::text
+  );
+
+  RETURN QUERY SELECT
+    'applied'::text,
+    v_snapshot.share_id,
+    v_snapshot.schema_version,
+    v_snapshot.content_revision,
+    v_snapshot.title,
+    v_snapshot.body_json,
+    private.session_share_attachment_manifest(v_snapshot.share_id),
+    v_snapshot.web_editable,
+    v_access_version,
+    v_snapshot.published_at;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.publish_session_share_snapshot_cas(
+  p_share_id uuid,
+  p_actor_user_id uuid,
+  p_expected_content_revision bigint,
+  p_mutation_id uuid,
+  p_title text,
+  p_body_json jsonb,
+  p_attachment_ids uuid[],
+  p_web_editable boolean
+)
+RETURNS TABLE (
+  outcome text,
+  share_id uuid,
+  schema_version smallint,
+  content_revision bigint,
+  title text,
+  body_json jsonb,
+  attachments_json jsonb,
+  web_editable boolean,
+  access_version bigint,
+  published_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_session_share_attachment_manager(
+    p_share_id,
+    p_actor_user_id
+  );
+
+  RETURN QUERY
+  SELECT *
+  FROM private.apply_session_share_snapshot_cas(
+    p_share_id,
+    p_actor_user_id,
+    p_expected_content_revision,
+    p_mutation_id,
+    p_title,
+    p_body_json,
+    p_attachment_ids,
+    p_web_editable,
+    false
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.edit_session_share_snapshot_cas(
+  p_share_id uuid,
+  p_actor_user_id uuid,
+  p_expected_content_revision bigint,
+  p_mutation_id uuid,
+  p_title text,
+  p_body_json jsonb,
+  p_attachment_ids uuid[]
+)
+RETURNS TABLE (
+  outcome text,
+  share_id uuid,
+  schema_version smallint,
+  content_revision bigint,
+  title text,
+  body_json jsonb,
+  attachments_json jsonb,
+  web_editable boolean,
+  access_version bigint,
+  published_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_web_editable boolean;
+BEGIN
+  PERFORM 1
+  FROM private.require_session_share_editor(
+    p_share_id,
+    p_actor_user_id
+  );
+
+  SELECT snapshot.web_editable
+  INTO v_web_editable
+  FROM public.session_share_snapshots AS snapshot
+  WHERE snapshot.share_id = p_share_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR NOT v_web_editable THEN
+    RAISE EXCEPTION 'session snapshot edit not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT *
+  FROM private.apply_session_share_snapshot_cas(
+    p_share_id,
+    p_actor_user_id,
+    p_expected_content_revision,
+    p_mutation_id,
+    p_title,
+    p_body_json,
+    p_attachment_ids,
+    true,
+    true
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.read_my_session_share_snapshot_v2(
+  p_share_id uuid
+)
+RETURNS TABLE (
+  share_id uuid,
+  workspace_id uuid,
+  session_id text,
+  schema_version smallint,
+  content_revision bigint,
+  title text,
+  body_json jsonb,
+  attachments_json jsonb,
+  web_editable boolean,
+  capability text,
+  manage_access boolean,
+  access_version bigint,
+  published_at timestamptz,
+  web_edit_base_content_revision bigint,
+  web_edit_base_title text,
+  web_edit_base_body_json jsonb,
+  pending_created_at timestamptz,
+  pending_updated_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    access.share_id,
+    access.workspace_id,
+    access.session_id,
+    snapshot.schema_version,
+    snapshot.content_revision,
+    snapshot.title,
+    snapshot.body_json,
+    private.session_share_attachment_manifest(snapshot.share_id),
+    snapshot.web_editable,
+    access.capability,
+    access.manage_access,
+    access.access_version,
+    snapshot.published_at,
+    CASE WHEN access.manage_access
+      THEN pending.base_content_revision
+      ELSE NULL::bigint
+    END,
+    CASE WHEN access.manage_access
+      THEN pending.base_title
+      ELSE NULL::text
+    END,
+    CASE WHEN access.manage_access
+      THEN pending.base_body_json
+      ELSE NULL::jsonb
+    END,
+    CASE WHEN access.manage_access
+      THEN pending.created_at
+      ELSE NULL::timestamptz
+    END,
+    CASE WHEN access.manage_access
+      THEN pending.updated_at
+      ELSE NULL::timestamptz
+    END
+  FROM private.resolve_my_session_access(p_share_id) AS access
+  JOIN public.session_share_snapshots AS snapshot
+    ON snapshot.share_id = access.share_id
+  LEFT JOIN public.session_share_pending_web_edits AS pending
+    ON pending.share_id = snapshot.share_id;
+$$;
+
+CREATE OR REPLACE FUNCTION private.list_my_session_share_snapshot_page_v2(
+  p_after_share_id uuid,
+  p_limit integer
+)
+RETURNS TABLE (
+  share_id uuid,
+  workspace_id uuid,
+  session_id text,
+  schema_version smallint,
+  content_revision bigint,
+  title text,
+  body_json jsonb,
+  attachments_json jsonb,
+  web_editable boolean,
+  capability text,
+  manage_access boolean,
+  access_version bigint,
+  published_at timestamptz,
+  web_edit_base_content_revision bigint,
+  web_edit_base_title text,
+  web_edit_base_body_json jsonb,
+  pending_created_at timestamptz,
+  pending_updated_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_limit IS NULL OR p_limit < 1 OR p_limit > 8 THEN
+    RAISE EXCEPTION 'invalid session share snapshot page limit'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  WITH access_page AS MATERIALIZED (
+    SELECT access.*
+    FROM private.list_my_accessible_sessions() AS access
+    WHERE (p_after_share_id IS NULL OR access.share_id > p_after_share_id)
+      AND EXISTS (
+        SELECT 1
+        FROM public.session_share_snapshots AS available_snapshot
+        WHERE available_snapshot.share_id = access.share_id
+      )
+    ORDER BY access.share_id
+    LIMIT p_limit
+  )
+  SELECT
+    access.share_id,
+    access.workspace_id,
+    access.session_id,
+    snapshot.schema_version,
+    snapshot.content_revision,
+    snapshot.title,
+    snapshot.body_json,
+    private.session_share_attachment_manifest(snapshot.share_id),
+    snapshot.web_editable,
+    access.capability,
+    access.manage_access,
+    access.access_version,
+    snapshot.published_at,
+    CASE WHEN access.manage_access
+      THEN pending.base_content_revision
+      ELSE NULL::bigint
+    END,
+    CASE WHEN access.manage_access
+      THEN pending.base_title
+      ELSE NULL::text
+    END,
+    CASE WHEN access.manage_access
+      THEN pending.base_body_json
+      ELSE NULL::jsonb
+    END,
+    CASE WHEN access.manage_access
+      THEN pending.created_at
+      ELSE NULL::timestamptz
+    END,
+    CASE WHEN access.manage_access
+      THEN pending.updated_at
+      ELSE NULL::timestamptz
+    END
+  FROM access_page AS access
+  JOIN public.session_share_snapshots AS snapshot
+    ON snapshot.share_id = access.share_id
+  LEFT JOIN public.session_share_pending_web_edits AS pending
+    ON pending.share_id = snapshot.share_id
+  ORDER BY access.share_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.acknowledge_session_share_web_edits(
+  p_share_id uuid,
+  p_expected_content_revision bigint
+)
+RETURNS TABLE (
+  share_id uuid,
+  acknowledged_content_revision bigint,
+  was_pending boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_content_revision bigint;
+  v_was_pending boolean;
+BEGIN
+  IF p_expected_content_revision IS NULL
+    OR p_expected_content_revision <= 0
+  THEN
+    RAISE EXCEPTION 'invalid web edit acknowledgement'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM private.require_session_share_manager(p_share_id);
+
+  SELECT snapshot.content_revision
+  INTO v_content_revision
+  FROM public.session_share_snapshots AS snapshot
+  WHERE snapshot.share_id = p_share_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_content_revision <> p_expected_content_revision THEN
+    RAISE EXCEPTION 'web edit acknowledgement conflicts'
+      USING ERRCODE = '40001';
+  END IF;
+
+  DELETE FROM public.session_share_pending_web_edits AS pending
+  WHERE pending.share_id = p_share_id;
+  v_was_pending := FOUND;
+
+  RETURN QUERY SELECT p_share_id, v_content_revision, v_was_pending;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.publish_session_share_snapshot_cas(
+  p_share_id uuid,
+  p_actor_user_id uuid,
+  p_expected_content_revision bigint,
+  p_mutation_id uuid,
+  p_title text,
+  p_body_json jsonb,
+  p_attachment_ids uuid[],
+  p_web_editable boolean
+)
+RETURNS TABLE (
+  outcome text,
+  share_id uuid,
+  schema_version smallint,
+  content_revision bigint,
+  title text,
+  body_json jsonb,
+  attachments_json jsonb,
+  web_editable boolean,
+  access_version bigint,
+  published_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.publish_session_share_snapshot_cas(
+    p_share_id,
+    p_actor_user_id,
+    p_expected_content_revision,
+    p_mutation_id,
+    p_title,
+    p_body_json,
+    p_attachment_ids,
+    p_web_editable
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.edit_session_share_snapshot_cas(
+  p_share_id uuid,
+  p_actor_user_id uuid,
+  p_expected_content_revision bigint,
+  p_mutation_id uuid,
+  p_title text,
+  p_body_json jsonb,
+  p_attachment_ids uuid[]
+)
+RETURNS TABLE (
+  outcome text,
+  share_id uuid,
+  schema_version smallint,
+  content_revision bigint,
+  title text,
+  body_json jsonb,
+  attachments_json jsonb,
+  web_editable boolean,
+  access_version bigint,
+  published_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.edit_session_share_snapshot_cas(
+    p_share_id,
+    p_actor_user_id,
+    p_expected_content_revision,
+    p_mutation_id,
+    p_title,
+    p_body_json,
+    p_attachment_ids
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.read_my_session_share_snapshot_v2(
+  p_share_id uuid
+)
+RETURNS TABLE (
+  share_id uuid,
+  workspace_id uuid,
+  session_id text,
+  schema_version smallint,
+  content_revision bigint,
+  title text,
+  body_json jsonb,
+  attachments_json jsonb,
+  web_editable boolean,
+  capability text,
+  manage_access boolean,
+  access_version bigint,
+  published_at timestamptz,
+  web_edit_base_content_revision bigint,
+  web_edit_base_title text,
+  web_edit_base_body_json jsonb,
+  pending_created_at timestamptz,
+  pending_updated_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.read_my_session_share_snapshot_v2(p_share_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_my_session_share_snapshot_page_v2(
+  p_after_share_id uuid DEFAULT NULL,
+  p_limit integer DEFAULT 8
+)
+RETURNS TABLE (
+  share_id uuid,
+  workspace_id uuid,
+  session_id text,
+  schema_version smallint,
+  content_revision bigint,
+  title text,
+  body_json jsonb,
+  attachments_json jsonb,
+  web_editable boolean,
+  capability text,
+  manage_access boolean,
+  access_version bigint,
+  published_at timestamptz,
+  web_edit_base_content_revision bigint,
+  web_edit_base_title text,
+  web_edit_base_body_json jsonb,
+  pending_created_at timestamptz,
+  pending_updated_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.list_my_session_share_snapshot_page_v2(
+    p_after_share_id,
+    p_limit
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.acknowledge_session_share_web_edits(
+  p_share_id uuid,
+  p_expected_content_revision bigint
+)
+RETURNS TABLE (
+  share_id uuid,
+  acknowledged_content_revision bigint,
+  was_pending boolean
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.acknowledge_session_share_web_edits(
+    p_share_id,
+    p_expected_content_revision
+  );
+$$;
+
+REVOKE ALL ON FUNCTION private.require_session_share_editor(uuid, uuid)
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION private.apply_session_share_snapshot_cas(
+  uuid, uuid, bigint, uuid, text, jsonb, uuid[], boolean, boolean
+) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION private.publish_session_share_snapshot_cas(
+  uuid, uuid, bigint, uuid, text, jsonb, uuid[], boolean
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.edit_session_share_snapshot_cas(
+  uuid, uuid, bigint, uuid, text, jsonb, uuid[]
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.read_my_session_share_snapshot_v2(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.list_my_session_share_snapshot_page_v2(uuid, integer)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.acknowledge_session_share_web_edits(uuid, bigint)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION private.publish_session_share_snapshot_cas(
+  uuid, uuid, bigint, uuid, text, jsonb, uuid[], boolean
+) TO service_role;
+GRANT EXECUTE ON FUNCTION private.edit_session_share_snapshot_cas(
+  uuid, uuid, bigint, uuid, text, jsonb, uuid[]
+) TO service_role;
+GRANT EXECUTE ON FUNCTION private.read_my_session_share_snapshot_v2(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.list_my_session_share_snapshot_page_v2(
+  uuid,
+  integer
+)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.acknowledge_session_share_web_edits(
+  uuid,
+  bigint
+) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.publish_session_share_snapshot_cas(
+  uuid, uuid, bigint, uuid, text, jsonb, uuid[], boolean
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.edit_session_share_snapshot_cas(
+  uuid, uuid, bigint, uuid, text, jsonb, uuid[]
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.read_my_session_share_snapshot_v2(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_my_session_share_snapshot_page_v2(
+  uuid,
+  integer
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.acknowledge_session_share_web_edits(uuid, bigint)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.publish_session_share_snapshot_cas(
+  uuid, uuid, bigint, uuid, text, jsonb, uuid[], boolean
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.edit_session_share_snapshot_cas(
+  uuid, uuid, bigint, uuid, text, jsonb, uuid[]
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.read_my_session_share_snapshot_v2(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_my_session_share_snapshot_page_v2(
+  uuid,
+  integer
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.acknowledge_session_share_web_edits(
+  uuid,
+  bigint
+) TO authenticated;
+
+COMMENT ON FUNCTION public.publish_session_share_snapshot(
+  uuid,
+  uuid,
+  text,
+  jsonb
+) IS 'Legacy service-only writer for pre-CAS clients; unavailable after a snapshot enters CAS mode.';
+COMMENT ON FUNCTION public.publish_session_share_snapshot_with_attachments(
+  uuid,
+  uuid,
+  text,
+  jsonb,
+  uuid[]
+) IS 'Legacy service-only writer for pre-CAS clients; unavailable after a snapshot enters CAS mode.';

--- a/supabase/tests/024-session-share-web-editing.sql
+++ b/supabase/tests/024-session-share-web-editing.sql
@@ -1,0 +1,1460 @@
+begin;
+select plan(62);
+
+select tests.create_supabase_user('webedit_owner', 'webedit-owner@example.com');
+select tests.create_supabase_user('webedit_manager', 'webedit-manager@example.com');
+select tests.create_supabase_user('webedit_editor', 'webedit-editor@example.com');
+select tests.create_supabase_user('webedit_viewer', 'webedit-viewer@example.com');
+select tests.create_supabase_user('webedit_commenter', 'webedit-commenter@example.com');
+select tests.create_supabase_user('webedit_revoked', 'webedit-revoked@example.com');
+select tests.create_supabase_user('webedit_other', 'webedit-other@example.com');
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('webedit_owner'),
+  tests.get_supabase_uid('webedit_manager'),
+  tests.get_supabase_uid('webedit_editor'),
+  tests.get_supabase_uid('webedit_viewer'),
+  tests.get_supabase_uid('webedit_commenter'),
+  tests.get_supabase_uid('webedit_revoked'),
+  tests.get_supabase_uid('webedit_other')
+);
+
+insert into auth.users (
+  id,
+  raw_user_meta_data,
+  raw_app_meta_data,
+  is_anonymous,
+  created_at,
+  updated_at
+) values (
+  '30000000-0000-4000-8000-000000000001',
+  '{"test_identifier":"webedit_anonymous"}'::jsonb,
+  '{}'::jsonb,
+  true,
+  now(),
+  now()
+);
+
+select tests.authenticate_as_service_role();
+
+insert into public.workspaces (
+  id,
+  owner_user_id,
+  kind,
+  name
+) values (
+  '20000000-0000-4000-8000-000000000001',
+  tests.get_supabase_uid('webedit_owner'),
+  'shared',
+  'Web editing workspace'
+);
+
+insert into public.workspace_memberships (
+  workspace_id,
+  user_id,
+  role
+) values
+  (
+    '20000000-0000-4000-8000-000000000001',
+    tests.get_supabase_uid('webedit_owner'),
+    'owner'
+  ),
+  (
+    '20000000-0000-4000-8000-000000000001',
+    tests.get_supabase_uid('webedit_manager'),
+    'admin'
+  );
+
+insert into public.session_shares (
+  id,
+  workspace_id,
+  session_id,
+  created_by_user_id,
+  general_scope
+) values
+  (
+    '20000000-0000-4000-8000-000000000101',
+    '20000000-0000-4000-8000-000000000001',
+    'web-edit-main',
+    tests.get_supabase_uid('webedit_owner'),
+    'link'
+  ),
+  (
+    '20000000-0000-4000-8000-000000000102',
+    '20000000-0000-4000-8000-000000000001',
+    'web-edit-bootstrap',
+    tests.get_supabase_uid('webedit_owner'),
+    'restricted'
+  ),
+  (
+    '20000000-0000-4000-8000-000000000120',
+    '20000000-0000-4000-8000-000000000001',
+    'web-edit-legacy',
+    tests.get_supabase_uid('webedit_owner'),
+    'restricted'
+  );
+
+insert into public.session_share_links (
+  id,
+  share_id,
+  token_hash,
+  created_by_user_id
+) values (
+  '20000000-0000-4000-8000-000000000111',
+  '20000000-0000-4000-8000-000000000101',
+  extensions.digest(repeat('l', 43), 'sha256'),
+  tests.get_supabase_uid('webedit_owner')
+);
+
+insert into public.session_share_snapshots (
+  share_id,
+  content_revision,
+  title,
+  body_json,
+  published_by_user_id,
+  web_editable
+) values (
+  '20000000-0000-4000-8000-000000000101',
+  5,
+  'Base title',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Base body"}]}]}'::jsonb,
+  tests.get_supabase_uid('webedit_owner'),
+  true
+);
+
+insert into public.session_share_attachment_objects (
+  id,
+  share_id,
+  owner_user_id,
+  attachment_ref,
+  version_ref,
+  object_key,
+  filename,
+  content_type,
+  size_bytes,
+  sha256,
+  state,
+  reservation_expires_at,
+  cleanup_not_before,
+  finalized_at,
+  created_at,
+  updated_at
+) values
+  (
+    '20000000-0000-4000-8000-000000000201',
+    '20000000-0000-4000-8000-000000000101',
+    tests.get_supabase_uid('webedit_owner'),
+    repeat('a', 43),
+    repeat('b', 43),
+    tests.get_supabase_uid('webedit_owner')::text
+      || '/20000000-0000-4000-8000-000000000101/'
+      || '20000000-0000-4000-8000-000000000201.sna1',
+    'one.png',
+    'image/png',
+    10,
+    repeat('a', 64),
+    'ready',
+    now() + interval '15 minutes',
+    now() + interval '2 days',
+    now(),
+    now(),
+    now()
+  ),
+  (
+    '20000000-0000-4000-8000-000000000202',
+    '20000000-0000-4000-8000-000000000101',
+    tests.get_supabase_uid('webedit_owner'),
+    repeat('c', 43),
+    repeat('d', 43),
+    tests.get_supabase_uid('webedit_owner')::text
+      || '/20000000-0000-4000-8000-000000000101/'
+      || '20000000-0000-4000-8000-000000000202.sna1',
+    'two.png',
+    'image/png',
+    20,
+    repeat('b', 64),
+    'ready',
+    now() + interval '15 minutes',
+    now() + interval '2 days',
+    now(),
+    now(),
+    now()
+  );
+
+insert into public.session_share_snapshot_attachments (
+  share_id,
+  attachment_id,
+  position
+) values (
+  '20000000-0000-4000-8000-000000000101',
+  '20000000-0000-4000-8000-000000000201',
+  0
+);
+
+insert into public.session_access_grants (
+  share_id,
+  grantee_user_id,
+  capability,
+  granted_by_user_id,
+  revoked_by_user_id,
+  revoked_at
+) values
+  (
+    '20000000-0000-4000-8000-000000000101',
+    tests.get_supabase_uid('webedit_editor'),
+    'editor',
+    tests.get_supabase_uid('webedit_owner'),
+    null,
+    null
+  ),
+  (
+    '20000000-0000-4000-8000-000000000101',
+    tests.get_supabase_uid('webedit_viewer'),
+    'viewer',
+    tests.get_supabase_uid('webedit_owner'),
+    null,
+    null
+  ),
+  (
+    '20000000-0000-4000-8000-000000000101',
+    tests.get_supabase_uid('webedit_commenter'),
+    'commenter',
+    tests.get_supabase_uid('webedit_owner'),
+    null,
+    null
+  ),
+  (
+    '20000000-0000-4000-8000-000000000101',
+    tests.get_supabase_uid('webedit_revoked'),
+    'editor',
+    tests.get_supabase_uid('webedit_owner'),
+    tests.get_supabase_uid('webedit_owner'),
+    now()
+  ),
+  (
+    '20000000-0000-4000-8000-000000000102',
+    tests.get_supabase_uid('webedit_editor'),
+    'editor',
+    tests.get_supabase_uid('webedit_owner'),
+    null,
+    null
+  );
+
+select tests.clear_authentication();
+reset role;
+
+select ok(
+  (
+    select count(*) = 4
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'session_share_snapshots'
+      and column_name in (
+        'web_editable',
+        'last_mutation_id',
+        'last_mutation_base_revision',
+        'last_mutation_fingerprint'
+      )
+  )
+    and exists (
+      select 1
+      from pg_constraint
+      where conrelid = 'public.session_share_snapshots'::regclass
+        and conname = 'session_share_snapshots_last_mutation_check'
+    ),
+  'Snapshots carry web-edit and idempotency state'
+);
+
+select ok(
+  (
+    select class.relrowsecurity
+    from pg_class as class
+    join pg_namespace as namespace
+      on namespace.oid = class.relnamespace
+    where namespace.nspname = 'public'
+      and class.relname = 'session_share_pending_web_edits'
+  ),
+  'Pending web edit state has row-level security enabled'
+);
+
+select ok(
+  not exists (
+    select 1
+    from information_schema.table_privileges as privilege
+    where privilege.table_schema = 'public'
+      and privilege.table_name = 'session_share_pending_web_edits'
+      and privilege.grantee in ('PUBLIC', 'anon', 'authenticated')
+  )
+    and has_table_privilege(
+      'service_role',
+      'public.session_share_pending_web_edits',
+      'SELECT, INSERT, UPDATE, DELETE'
+    ),
+  'Pending web edit state is closed to clients'
+);
+
+select ok(
+  (
+    select count(*) = 5
+    from pg_constraint
+    where conrelid = 'public.session_share_pending_web_edits'::regclass
+      and conname in (
+        'session_share_pending_web_edits_pkey',
+        'session_share_pending_web_edits_share_id_fkey',
+        'session_share_pending_web_edits_revision_check',
+        'session_share_pending_web_edits_title_check',
+        'session_share_pending_web_edits_body_check'
+      )
+  )
+    and exists (
+      select 1
+      from pg_constraint
+      where conrelid = 'public.session_share_pending_web_edits'::regclass
+        and conname = 'session_share_pending_web_edits_share_id_fkey'
+        and confdeltype = 'c'
+    ),
+  'Pending web edits are bounded to one constrained row per live share'
+);
+
+select ok(
+  (
+    select count(*) = 5
+      and bool_and(not proc.prosecdef)
+      and bool_and(
+        'search_path=""' = any(coalesce(proc.proconfig, array[]::text[]))
+      )
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'public'
+      and proc.proname in (
+        'publish_session_share_snapshot_cas',
+        'edit_session_share_snapshot_cas',
+        'read_my_session_share_snapshot_v2',
+        'list_my_session_share_snapshot_page_v2',
+        'acknowledge_session_share_web_edits'
+      )
+  ),
+  'Public web editing wrappers are hardened security invokers'
+);
+
+select ok(
+  (
+    select count(*) = 7
+      and bool_and(proc.prosecdef)
+      and bool_and(
+        'search_path=""' = any(coalesce(proc.proconfig, array[]::text[]))
+      )
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'private'
+      and proc.proname in (
+        'require_session_share_editor',
+        'apply_session_share_snapshot_cas',
+        'publish_session_share_snapshot_cas',
+        'edit_session_share_snapshot_cas',
+        'read_my_session_share_snapshot_v2',
+        'list_my_session_share_snapshot_page_v2',
+        'acknowledge_session_share_web_edits'
+      )
+  ),
+  'Private web editing functions are hardened security definers'
+);
+
+select ok(
+  (
+    select count(*) = 2
+      and bool_and(has_function_privilege('service_role', proc.oid, 'EXECUTE'))
+      and bool_and(not has_function_privilege('anon', proc.oid, 'EXECUTE'))
+      and bool_and(not has_function_privilege('authenticated', proc.oid, 'EXECUTE'))
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'public'
+      and proc.proname in (
+        'publish_session_share_snapshot_cas',
+        'edit_session_share_snapshot_cas'
+      )
+  ),
+  'Only service code can call explicit-actor snapshot mutations'
+);
+
+select ok(
+  (
+    select count(*) = 3
+      and bool_and(has_function_privilege('authenticated', proc.oid, 'EXECUTE'))
+      and bool_and(not has_function_privilege('anon', proc.oid, 'EXECUTE'))
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'public'
+      and proc.proname in (
+        'read_my_session_share_snapshot_v2',
+        'list_my_session_share_snapshot_page_v2',
+        'acknowledge_session_share_web_edits'
+      )
+  ),
+  'Authenticated clients can only read and acknowledge through actorless wrappers'
+);
+
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    'private.apply_session_share_snapshot_cas(uuid,uuid,bigint,uuid,text,jsonb,uuid[],boolean,boolean)',
+    'EXECUTE'
+  )
+    and not has_function_privilege(
+      'service_role',
+      'private.apply_session_share_snapshot_cas(uuid,uuid,bigint,uuid,text,jsonb,uuid[],boolean,boolean)',
+      'EXECUTE'
+    ),
+  'The unauthenticated mutation core is not directly executable'
+);
+
+select ok(
+  obj_description(
+    'public.publish_session_share_snapshot(uuid,uuid,text,jsonb)'::regprocedure,
+    'pg_proc'
+  ) ilike 'Legacy service-only writer%'
+    and obj_description(
+      'public.publish_session_share_snapshot_with_attachments(uuid,uuid,text,jsonb,uuid[])'::regprocedure,
+      'pg_proc'
+    ) ilike 'Legacy service-only writer%'
+    and not has_function_privilege(
+      'authenticated',
+      'public.publish_session_share_snapshot(uuid,uuid,text,jsonb)',
+      'EXECUTE'
+    ),
+  'Legacy writers are marked for runtime retirement and remain client-inaccessible'
+);
+
+select tests.authenticate_as_service_role();
+
+insert into public.session_shares (
+  id,
+  workspace_id,
+  session_id,
+  created_by_user_id,
+  general_scope
+)
+select
+  (
+    '20000000-0000-4000-8000-'
+    || lpad(page_number::text, 12, '0')
+  )::uuid,
+  '20000000-0000-4000-8000-000000000001'::uuid,
+  'web-edit-page-' || page_number,
+  tests.get_supabase_uid('webedit_owner'),
+  'restricted'
+from generate_series(103, 111) as page(page_number);
+
+insert into public.session_share_snapshots (
+  share_id,
+  content_revision,
+  title,
+  body_json,
+  published_by_user_id,
+  web_editable
+)
+select
+  (
+    '20000000-0000-4000-8000-'
+    || lpad(page_number::text, 12, '0')
+  )::uuid,
+  1,
+  'Page ' || page_number,
+  '{"type":"doc"}'::jsonb,
+  tests.get_supabase_uid('webedit_owner'),
+  true
+from generate_series(103, 111) as page(page_number);
+
+select tests.authenticate_as('webedit_owner');
+
+select throws_ok(
+  $$select count(*) from public.session_share_pending_web_edits$$,
+  '42501',
+  'permission denied for table session_share_pending_web_edits',
+  'Authenticated clients cannot read pending web edit rows directly'
+);
+
+select tests.clear_authentication();
+set local role anon;
+
+select throws_ok(
+  $$
+    select *
+    from public.publish_session_share_snapshot_cas(
+      '20000000-0000-4000-8000-000000000101',
+      '20000000-0000-4000-8000-000000000001',
+      5,
+      '20000000-0000-4000-8000-000000001000',
+      'Blocked',
+      '{"type":"doc"}'::jsonb,
+      array['20000000-0000-4000-8000-000000000201'::uuid],
+      true
+    )
+  $$,
+  '42501',
+  'permission denied for function publish_session_share_snapshot_cas',
+  'Anonymous callers cannot invoke service snapshot mutations'
+);
+
+reset role;
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  format(
+    $sql$
+      select content_revision, title
+      from public.publish_session_share_snapshot(
+        '20000000-0000-4000-8000-000000000120',
+        %L::uuid,
+        'Legacy one',
+        '{"type":"doc"}'::jsonb
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_manager')
+  ),
+  $$values (1::bigint, 'Legacy one'::text)$$,
+  'A pre-CAS legacy client can create a snapshot'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select content_revision, title
+      from public.publish_session_share_snapshot(
+        '20000000-0000-4000-8000-000000000120',
+        %L::uuid,
+        'Legacy two',
+        '{"type":"doc","content":[{"type":"paragraph"}]}'::jsonb
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_manager')
+  ),
+  $$values (2::bigint, 'Legacy two'::text)$$,
+  'A pre-CAS legacy client can update its snapshot'
+);
+
+select results_eq(
+  $$
+    select
+      web_editable,
+      last_mutation_id is null,
+      last_mutation_base_revision is null,
+      last_mutation_fingerprint is null
+    from public.session_share_snapshots
+    where share_id = '20000000-0000-4000-8000-000000000120'
+  $$,
+  $$values (false, true, true, true)$$,
+  'Legacy writes stay view-only and do not enter CAS mode'
+);
+
+delete from public.session_shares
+where id = '20000000-0000-4000-8000-000000000120';
+
+select throws_ok(
+  $$
+    update public.session_share_snapshots
+    set
+      last_mutation_id = '20000000-0000-4000-8000-000000001099',
+      last_mutation_base_revision = null,
+      last_mutation_fingerprint = decode(repeat('ab', 32), 'hex')
+    where share_id = '20000000-0000-4000-8000-000000000101'
+  $$,
+  '23514',
+  'new row for relation "session_share_snapshots" violates check constraint "session_share_snapshots_last_mutation_check"',
+  'Snapshot mutation state rejects a missing base revision'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        5,
+        '20000000-0000-4000-8000-000000001001',
+        'Viewer edit',
+        '{"type":"doc"}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_viewer')
+  ),
+  '42501',
+  'session snapshot edit not permitted',
+  'A named Viewer cannot edit snapshots'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        5,
+        '20000000-0000-4000-8000-000000001002',
+        'Commenter edit',
+        '{"type":"doc"}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_commenter')
+  ),
+  '42501',
+  'session snapshot edit not permitted',
+  'A named Commenter cannot edit snapshots'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        5,
+        '20000000-0000-4000-8000-000000001003',
+        'Revoked edit',
+        '{"type":"doc"}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_revoked')
+  ),
+  '42501',
+  'session snapshot edit not permitted',
+  'A revoked Editor cannot edit snapshots'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        5,
+        '20000000-0000-4000-8000-000000001004',
+        'Link edit',
+        '{"type":"doc"}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_other')
+  ),
+  '42501',
+  'session snapshot edit not permitted',
+  'Bearer-link viewing does not grant edit access'
+);
+
+update public.session_shares
+set general_scope = 'public'
+where id = '20000000-0000-4000-8000-000000000101';
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        5,
+        '20000000-0000-4000-8000-000000001005',
+        'Public edit',
+        '{"type":"doc"}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_other')
+  ),
+  '42501',
+  'session snapshot edit not permitted',
+  'Public viewing does not grant edit access'
+);
+
+select throws_ok(
+  $$
+    select * from public.edit_session_share_snapshot_cas(
+      '20000000-0000-4000-8000-000000000101',
+      '30000000-0000-4000-8000-000000000001',
+      5,
+      '20000000-0000-4000-8000-000000001006',
+      'Anonymous edit',
+      '{"type":"doc"}'::jsonb,
+      array['20000000-0000-4000-8000-000000000201'::uuid]
+    )
+  $$,
+  '42501',
+  'session snapshot edit not permitted',
+  'An anonymous account cannot edit snapshots'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.publish_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000102',
+        %L::uuid,
+        0,
+        '20000000-0000-4000-8000-000000001007',
+        'Editor bootstrap',
+        '{"type":"doc"}'::jsonb,
+        array[]::uuid[],
+        true
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_editor')
+  ),
+  '42501',
+  'session attachment operation not permitted',
+  'An Editor cannot use the manager publication path'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000102',
+        %L::uuid,
+        0,
+        '20000000-0000-4000-8000-000000001008',
+        'Editor bootstrap',
+        '{"type":"doc"}'::jsonb,
+        array[]::uuid[]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_editor')
+  ),
+  '42501',
+  'session snapshot edit not permitted',
+  'An Editor cannot bootstrap a missing snapshot'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.publish_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000102',
+        %L::uuid,
+        1,
+        '20000000-0000-4000-8000-000000001019',
+        'Missing manager base',
+        '{"type":"doc"}'::jsonb,
+        array[]::uuid[],
+        false
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_manager')
+  ),
+  '40001',
+  'session share snapshot is unavailable',
+  'A nonzero manager base cannot target a missing snapshot'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select outcome, content_revision, title, web_editable
+      from public.publish_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000102',
+        %L::uuid,
+        0,
+        '20000000-0000-4000-8000-000000001009',
+        'Manager bootstrap',
+        '{"type":"doc","content":[{"type":"paragraph"}]}'::jsonb,
+        array[]::uuid[],
+        false
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_manager')
+  ),
+  $$values ('applied'::text, 1::bigint, 'Manager bootstrap'::text, false)$$,
+  'A manager can bootstrap a snapshot without a Pro entitlement'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select outcome, content_revision
+      from public.publish_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000102',
+        %L::uuid,
+        0,
+        '20000000-0000-4000-8000-000000001009',
+        'Manager bootstrap',
+        '{"type":"doc","content":[{"type":"paragraph"}]}'::jsonb,
+        array[]::uuid[],
+        false
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_manager')
+  ),
+  $$values ('replayed'::text, 1::bigint)$$,
+  'An exact bootstrap retry is replayed idempotently'
+);
+
+select results_eq(
+  $$
+    select count(*), max(new_value)
+    from public.session_access_events
+    where share_id = '20000000-0000-4000-8000-000000000102'
+      and event_type = 'snapshot_published'
+  $$,
+  $$values (1::bigint, '1'::text)$$,
+  'Bootstrap replay does not add a revision or audit event'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.publish_session_share_snapshot(
+        '20000000-0000-4000-8000-000000000102',
+        %L::uuid,
+        'Legacy overwrite',
+        '{"type":"doc"}'::jsonb
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_manager')
+  ),
+  '23514',
+  'new row for relation "session_share_snapshots" violates check constraint "session_share_snapshots_last_mutation_check"',
+  'A stale legacy writer cannot advance a snapshot after CAS cutover'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select outcome, content_revision, title
+      from public.publish_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000102',
+        %L::uuid,
+        0,
+        '20000000-0000-4000-8000-000000001010',
+        'Stale bootstrap',
+        '{"type":"doc"}'::jsonb,
+        array[]::uuid[],
+        true
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_manager')
+  ),
+  $$values ('conflict'::text, 1::bigint, 'Manager bootstrap'::text)$$,
+  'A second bootstrap mutation conflicts with the committed snapshot'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select
+        outcome,
+        content_revision,
+        title,
+        jsonb_array_length(attachments_json),
+        attachments_json -> 0 ->> 'id',
+        web_editable
+      from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        5,
+        '20000000-0000-4000-8000-000000001011',
+        'Web revision six',
+        '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Web six"}]}]}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_editor')
+  ),
+  $$
+    values (
+      'applied'::text,
+      6::bigint,
+      'Web revision six'::text,
+      1,
+      '20000000-0000-4000-8000-000000000201'::text,
+      true
+    )
+  $$,
+  'An explicit Editor applies a web edit and preserves attachments without Pro'
+);
+
+select results_eq(
+  $$
+    select
+      base_content_revision,
+      base_title,
+      base_content_revision < snapshot.content_revision,
+      pending.created_at = pending.updated_at
+    from public.session_share_pending_web_edits as pending
+    join public.session_share_snapshots as snapshot
+      on snapshot.share_id = pending.share_id
+    where pending.share_id = '20000000-0000-4000-8000-000000000101'
+  $$,
+  $$values (5::bigint, 'Base title'::text, true, true)$$,
+  'The first web edit captures a bounded base older than the current snapshot'
+);
+
+select results_eq(
+  $$
+    select
+      count(*),
+      max(related_entity_id::text)::uuid,
+      max(previous_value),
+      max(new_value)
+    from public.session_access_events
+    where share_id = '20000000-0000-4000-8000-000000000101'
+      and event_type = 'snapshot_published'
+  $$,
+  $$
+    values (
+      1::bigint,
+      '20000000-0000-4000-8000-000000001011'::uuid,
+      '5'::text,
+      '6'::text
+    )
+  $$,
+  'An applied web edit writes exactly one revision audit event'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select outcome, content_revision
+      from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        5,
+        '20000000-0000-4000-8000-000000001011',
+        'Web revision six',
+        '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Web six"}]}]}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_editor')
+  ),
+  $$values ('replayed'::text, 6::bigint)$$,
+  'An exact web retry is replayed idempotently'
+);
+
+select results_eq(
+  $$
+    select
+      snapshot.content_revision,
+      count(event.id),
+      bool_and(pending.created_at = pending.updated_at)
+    from public.session_share_snapshots as snapshot
+    join public.session_share_pending_web_edits as pending
+      on pending.share_id = snapshot.share_id
+    left join public.session_access_events as event
+      on event.share_id = snapshot.share_id
+      and event.event_type = 'snapshot_published'
+    where snapshot.share_id = '20000000-0000-4000-8000-000000000101'
+    group by snapshot.content_revision
+  $$,
+  $$values (6::bigint, 1::bigint, true)$$,
+  'A replay has no snapshot, pending-base, or audit side effects'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        5,
+        '20000000-0000-4000-8000-000000001011',
+        'Mutation reuse',
+        '{"type":"doc"}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_editor')
+  ),
+  '22023',
+  'session share mutation id is invalid',
+  'A mutation ID cannot be reused with different content'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        6,
+        '20000000-0000-4000-8000-000000001012',
+        'Drop attachment',
+        '{"type":"doc"}'::jsonb,
+        array[]::uuid[]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_editor')
+  ),
+  '22023',
+  'web snapshot attachments must be preserved',
+  'Web edits cannot change the ordered attachment manifest'
+);
+
+select results_eq(
+  $$
+    select
+      snapshot.content_revision,
+      pending.base_content_revision,
+      count(binding.attachment_id),
+      min(attachment.state),
+      count(event.id)
+    from public.session_share_snapshots as snapshot
+    join public.session_share_pending_web_edits as pending
+      on pending.share_id = snapshot.share_id
+    join public.session_share_snapshot_attachments as binding
+      on binding.share_id = snapshot.share_id
+    join public.session_share_attachment_objects as attachment
+      on attachment.id = binding.attachment_id
+    left join public.session_access_events as event
+      on event.share_id = snapshot.share_id
+      and event.event_type = 'snapshot_published'
+    where snapshot.share_id = '20000000-0000-4000-8000-000000000101'
+    group by snapshot.content_revision, pending.base_content_revision
+  $$,
+  $$values (6::bigint, 5::bigint, 1::bigint, 'ready'::text, 1::bigint)$$,
+  'Rejected mutations leave snapshot, pending base, attachments, and audit intact'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select outcome, content_revision, title
+      from public.publish_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        5,
+        '20000000-0000-4000-8000-000000001013',
+        'Stale desktop',
+        '{"type":"doc"}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid],
+        true
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_manager')
+  ),
+  $$values ('conflict'::text, 6::bigint, 'Web revision six'::text)$$,
+  'A stale desktop publish conflicts after a web edit'
+);
+
+select results_eq(
+  $$
+    select snapshot.content_revision, pending.base_content_revision, count(event.id)
+    from public.session_share_snapshots as snapshot
+    join public.session_share_pending_web_edits as pending
+      on pending.share_id = snapshot.share_id
+    left join public.session_access_events as event
+      on event.share_id = snapshot.share_id
+      and event.event_type = 'snapshot_published'
+    where snapshot.share_id = '20000000-0000-4000-8000-000000000101'
+    group by snapshot.content_revision, pending.base_content_revision
+  $$,
+  $$values (6::bigint, 5::bigint, 1::bigint)$$,
+  'A stale desktop conflict has no side effects'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select outcome, content_revision, title, web_editable
+      from public.publish_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        6,
+        '20000000-0000-4000-8000-000000001014',
+        'Desktop revision seven',
+        '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Desktop seven"}]}]}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid],
+        true
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_manager')
+  ),
+  $$values ('applied'::text, 7::bigint, 'Desktop revision seven'::text, true)$$,
+  'A manager applies the reconciled desktop revision without Pro'
+);
+
+select results_eq(
+  $$
+    select
+      count(pending.share_id),
+      count(event.id),
+      max(event.new_value)
+    from public.session_share_snapshots as snapshot
+    left join public.session_share_pending_web_edits as pending
+      on pending.share_id = snapshot.share_id
+    left join public.session_access_events as event
+      on event.share_id = snapshot.share_id
+      and event.event_type = 'snapshot_published'
+    where snapshot.share_id = '20000000-0000-4000-8000-000000000101'
+  $$,
+  $$values (0::bigint, 2::bigint, '7'::text)$$,
+  'An applied manager publish clears pending web edits and audits once'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select outcome, content_revision, title
+      from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        6,
+        '20000000-0000-4000-8000-000000001015',
+        'Stale web',
+        '{"type":"doc"}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_editor')
+  ),
+  $$values ('conflict'::text, 7::bigint, 'Desktop revision seven'::text)$$,
+  'A stale web save conflicts after a desktop publish'
+);
+
+select results_eq(
+  $$
+    select snapshot.content_revision, count(pending.share_id), count(event.id)
+    from public.session_share_snapshots as snapshot
+    left join public.session_share_pending_web_edits as pending
+      on pending.share_id = snapshot.share_id
+    left join public.session_access_events as event
+      on event.share_id = snapshot.share_id
+      and event.event_type = 'snapshot_published'
+    where snapshot.share_id = '20000000-0000-4000-8000-000000000101'
+    group by snapshot.content_revision
+  $$,
+  $$values (7::bigint, 0::bigint, 2::bigint)$$,
+  'A stale web conflict has no snapshot, pending, or audit side effects'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select outcome, content_revision
+      from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        7,
+        '20000000-0000-4000-8000-000000001016',
+        'Web revision eight',
+        '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Web eight"}]}]}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_editor')
+  ),
+  $$values ('applied'::text, 8::bigint)$$,
+  'An Editor can start a new pending web-edit sequence'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select outcome, content_revision
+      from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        8,
+        '20000000-0000-4000-8000-000000001017',
+        'Web revision nine',
+        '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Web nine"}]}]}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_manager')
+  ),
+  $$values ('applied'::text, 9::bigint)$$,
+  'A manager also has effective Editor access on the web path'
+);
+
+select results_eq(
+  $$
+    select
+      pending.base_content_revision,
+      pending.base_title,
+      pending.base_content_revision < snapshot.content_revision,
+      pending.updated_at >= pending.created_at
+    from public.session_share_pending_web_edits as pending
+    join public.session_share_snapshots as snapshot
+      on snapshot.share_id = pending.share_id
+    where pending.share_id = '20000000-0000-4000-8000-000000000101'
+  $$,
+  $$values (7::bigint, 'Desktop revision seven'::text, true, true)$$,
+  'Later web edits collapse into the first pending base'
+);
+
+select tests.authenticate_as('webedit_owner');
+
+select results_eq(
+  $$
+    select
+      content_revision,
+      web_edit_base_content_revision,
+      web_edit_base_title,
+      web_edit_base_content_revision < content_revision,
+      jsonb_array_length(attachments_json),
+      manage_access
+    from public.read_my_session_share_snapshot_v2(
+      '20000000-0000-4000-8000-000000000101'
+    )
+  $$,
+  $$
+    values (
+      9::bigint,
+      7::bigint,
+      'Desktop revision seven'::text,
+      true,
+      1,
+      true
+    )
+  $$,
+  'A manager reads the current snapshot and pending reconciliation base'
+);
+
+select tests.authenticate_as('webedit_editor');
+
+select results_eq(
+  $$
+    select
+      content_revision,
+      web_editable,
+      capability,
+      manage_access,
+      web_edit_base_content_revision is null,
+      web_edit_base_title is null,
+      web_edit_base_body_json is null,
+      pending_created_at is null,
+      pending_updated_at is null
+    from public.read_my_session_share_snapshot_v2(
+      '20000000-0000-4000-8000-000000000101'
+    )
+  $$,
+  $$values (9::bigint, true, 'editor'::text, false, true, true, true, true, true)$$,
+  'Non-managing Editors cannot read the pending manager reconciliation base'
+);
+
+select tests.authenticate_as_service_role();
+
+delete from public.session_share_snapshots
+where share_id = '20000000-0000-4000-8000-000000000102';
+
+select tests.authenticate_as('webedit_owner');
+
+select throws_ok(
+  $$
+    select *
+    from public.list_my_session_share_snapshot_page_v2(null, 9)
+  $$,
+  '22023',
+  'invalid session share snapshot page limit',
+  'The public v2 feed rejects page sizes above the response bound'
+);
+
+select throws_ok(
+  $$
+    select *
+    from private.list_my_session_share_snapshot_page_v2(null, 9)
+  $$,
+  '22023',
+  'invalid session share snapshot page limit',
+  'The private v2 feed rejects page sizes above the response bound'
+);
+
+select results_eq(
+  $$
+    select content_revision, web_edit_base_content_revision, web_edit_base_title
+    from public.list_my_session_share_snapshot_page_v2(null, 8)
+    where share_id = '20000000-0000-4000-8000-000000000101'
+  $$,
+  $$values (9::bigint, 7::bigint, 'Desktop revision seven'::text)$$,
+  'The paginated v2 feed carries the manager reconciliation base'
+);
+
+select results_eq(
+  $$
+    select share_id
+    from public.list_my_session_share_snapshot_page_v2(null, 8)
+  $$,
+  $$
+    values
+      ('20000000-0000-4000-8000-000000000101'::uuid),
+      ('20000000-0000-4000-8000-000000000103'::uuid),
+      ('20000000-0000-4000-8000-000000000104'::uuid),
+      ('20000000-0000-4000-8000-000000000105'::uuid),
+      ('20000000-0000-4000-8000-000000000106'::uuid),
+      ('20000000-0000-4000-8000-000000000107'::uuid),
+      ('20000000-0000-4000-8000-000000000108'::uuid),
+      ('20000000-0000-4000-8000-000000000109'::uuid)
+  $$,
+  'An accessible share without a snapshot does not shorten the first v2 page'
+);
+
+select results_eq(
+  $$
+    select share_id
+    from public.list_my_session_share_snapshot_page_v2(
+      '20000000-0000-4000-8000-000000000109',
+      8
+    )
+  $$,
+  $$
+    values
+      ('20000000-0000-4000-8000-000000000110'::uuid),
+      ('20000000-0000-4000-8000-000000000111'::uuid)
+  $$,
+  'The next v2 page starts after the last returned snapshot-backed share'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.acknowledge_session_share_web_edits(
+      '20000000-0000-4000-8000-000000000101',
+      8
+    )
+  $$,
+  '40001',
+  'web edit acknowledgement conflicts',
+  'A stale manager acknowledgement cannot clear pending web edits'
+);
+
+select results_eq(
+  $$
+    select share_id, acknowledged_content_revision, was_pending
+    from public.acknowledge_session_share_web_edits(
+      '20000000-0000-4000-8000-000000000101',
+      9
+    )
+  $$,
+  $$
+    values (
+      '20000000-0000-4000-8000-000000000101'::uuid,
+      9::bigint,
+      true
+    )
+  $$,
+  'A current manager acknowledgement clears the pending base without editing content'
+);
+
+select results_eq(
+  $$
+    select acknowledged_content_revision, was_pending
+    from public.acknowledge_session_share_web_edits(
+      '20000000-0000-4000-8000-000000000101',
+      9
+    )
+  $$,
+  $$values (9::bigint, false)$$,
+  'A repeated current acknowledgement is idempotent'
+);
+
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  $$
+    select access_version
+    from public.session_shares
+    where id = '20000000-0000-4000-8000-000000000101'
+  $$,
+  $$values (1::bigint)$$,
+  'Content revisions do not change the access-version epoch'
+);
+
+insert into private.account_deletion_jobs (owner_user_id)
+values (tests.get_supabase_uid('webedit_editor'));
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        9,
+        '20000000-0000-4000-8000-000000001020',
+        'Deletion pending',
+        '{"type":"doc"}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_editor')
+  ),
+  '42501',
+  'session snapshot edit not permitted',
+  'A deletion-pending Editor cannot mutate a shared note'
+);
+
+delete from private.account_deletion_jobs
+where owner_user_id = tests.get_supabase_uid('webedit_editor');
+
+update public.session_access_grants
+set
+  revoked_by_user_id = tests.get_supabase_uid('webedit_owner'),
+  revoked_at = now(),
+  updated_at = now()
+where share_id = '20000000-0000-4000-8000-000000000101'
+  and grantee_user_id = tests.get_supabase_uid('webedit_editor');
+
+update public.session_shares
+set
+  access_version = access_version + 1,
+  updated_at = now()
+where id = '20000000-0000-4000-8000-000000000101';
+
+select throws_ok(
+  format(
+    $sql$
+      select * from public.edit_session_share_snapshot_cas(
+        '20000000-0000-4000-8000-000000000101',
+        %L::uuid,
+        9,
+        '20000000-0000-4000-8000-000000001018',
+        'Revoked after editing',
+        '{"type":"doc"}'::jsonb,
+        array['20000000-0000-4000-8000-000000000201'::uuid]
+      )
+    $sql$,
+    tests.get_supabase_uid('webedit_editor')
+  ),
+  '42501',
+  'session snapshot edit not permitted',
+  'An active Editor loses write access immediately after revocation'
+);
+
+select results_eq(
+  $$
+    select count(*), min(previous_value), max(new_value)
+    from public.session_access_events
+    where share_id = '20000000-0000-4000-8000-000000000101'
+      and event_type = 'snapshot_published'
+  $$,
+  $$values (4::bigint, '5'::text, '9'::text)$$,
+  'Only four applied main-share writes produced audit events'
+);
+
+select tests.authenticate_as('webedit_owner');
+
+select results_eq(
+  $$
+    select
+      content_revision,
+      access_version,
+      jsonb_array_length(attachments_json),
+      web_edit_base_content_revision is null,
+      web_edit_base_title is null,
+      web_edit_base_body_json is null
+    from public.read_my_session_share_snapshot_v2(
+      '20000000-0000-4000-8000-000000000101'
+    )
+  $$,
+  $$values (9::bigint, 2::bigint, 1, true, true, true)$$,
+  'Acknowledgement leaves the latest attachment-bearing snapshot and clears only pending state'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- add strict compare-and-swap snapshot mutation endpoints for authenticated web editors
- require complete attachment manifests for CAS writes while preserving legacy omission compatibility
- reject deletion-pending editors and return redacted missing/stale revision conflicts
- wire the API surface and generated OpenAPI contract

## Validation
- cargo test -p api-sync (84 passed)
- cargo test -p api (12 passed)
- Supabase collaboration and web-editing migrations reset cleanly
- pgTAP setup + session-share web-editing suite (63 passed)
- pnpm exec dprint check (clean)

Dependency: #6102 is merged; this PR is directly based on `main`.

