### PR TITLE
feat(sharing): add conflict-safe web editing

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@honeycombio/opentelemetry-web": "^1.3.0",
     "@hypr/api-client": "workspace:*",
     "@hypr/changelog": "workspace:^",
+    "@hypr/editor": "workspace:*",
     "@hypr/pricing": "workspace:^",
     "@hypr/supabase": "workspace:*",
     "@hypr/ui": "workspace:*",

--- a/apps/web/src/components/shared-note-editable-viewer.tsx
+++ b/apps/web/src/components/shared-note-editable-viewer.tsx
@@ -1,0 +1,218 @@
+import { lazy, Suspense, useState } from "react";
+
+import type { SharedAttachmentResolver } from "@/components/shared-note-document";
+import {
+  sharedSecondaryButtonClassName,
+  SharedNoteUnavailable,
+  SharedNoteViewer,
+} from "@/components/shared-note-viewer";
+import {
+  canEditSharedNoteOnWeb,
+  getSharedNoteWebEditPreparationMessage,
+  hasUnsupportedSharedNoteEditorNode,
+  shouldRenderSharedNoteUnavailable,
+} from "@/lib/shared-note-editing";
+import type {
+  AuthenticatedSharedNote,
+  SharedNoteSnapshot,
+  SharedNoteWebEditSnapshot,
+} from "@/lib/shared-notes";
+
+const SharedNoteEditorSurface = lazy(() =>
+  import("@/components/shared-note-editor-surface").then((module) => ({
+    default: module.SharedNoteEditorSurface,
+  })),
+);
+
+export function SharedNoteEditableViewer({
+  accessLabel,
+  actions,
+  authenticatedNote,
+  collaboration,
+  fallbackAccessLabel,
+  fallbackSnapshot,
+  onAccessChanged,
+  resolveAttachment,
+  revokedBehavior,
+  snapshot: initialSnapshot,
+}: {
+  accessLabel: string;
+  actions?: React.ReactNode;
+  authenticatedNote: AuthenticatedSharedNote | null;
+  collaboration?: React.ReactNode;
+  fallbackAccessLabel?: string;
+  fallbackSnapshot?: SharedNoteSnapshot | null;
+  onAccessChanged?: () => void;
+  resolveAttachment?: SharedAttachmentResolver;
+  revokedBehavior: "read-only" | "unavailable";
+  snapshot: SharedNoteSnapshot;
+}) {
+  const [snapshot, setSnapshot] = useState(initialSnapshot);
+  const [activeAuthenticatedNote, setActiveAuthenticatedNote] =
+    useState(authenticatedNote);
+  const [source, setSource] = useState({
+    authenticatedNote,
+    snapshot: initialSnapshot,
+  });
+  const [isEditing, setIsEditing] = useState(false);
+  const [accessRevoked, setAccessRevoked] = useState(false);
+  const [requiresSignIn, setRequiresSignIn] = useState(false);
+
+  if (
+    !isEditing &&
+    (source.snapshot !== initialSnapshot ||
+      source.authenticatedNote !== authenticatedNote)
+  ) {
+    const priorAccessVersion = source.authenticatedNote?.accessVersion ?? 0;
+    setSource({ authenticatedNote, snapshot: initialSnapshot });
+    setSnapshot((current) =>
+      initialSnapshot.contentRevision >= current.contentRevision
+        ? initialSnapshot
+        : current,
+    );
+    setActiveAuthenticatedNote(authenticatedNote);
+    if (authenticatedNote) {
+      setRequiresSignIn(false);
+      if (authenticatedNote.accessVersion > priorAccessVersion) {
+        setAccessRevoked(false);
+      }
+    }
+  }
+
+  const activeSnapshot =
+    accessRevoked && fallbackSnapshot ? fallbackSnapshot : snapshot;
+  const hasUnsupportedContent = hasUnsupportedSharedNoteEditorNode(
+    activeSnapshot.body,
+  );
+  const canEdit =
+    !accessRevoked &&
+    canEditSharedNoteOnWeb(activeAuthenticatedNote) &&
+    !hasUnsupportedContent;
+  const preparationMessage = getSharedNoteWebEditPreparationMessage(
+    accessRevoked ? null : activeAuthenticatedNote,
+    hasUnsupportedContent,
+  );
+
+  if (
+    shouldRenderSharedNoteUnavailable({
+      accessRevoked,
+      hasFallbackSnapshot: Boolean(fallbackSnapshot),
+      revokedBehavior,
+    })
+  ) {
+    return <SharedNoteUnavailable />;
+  }
+
+  const preparationNotice = preparationMessage ? (
+    <SharedNoteEditNotice>{preparationMessage}</SharedNoteEditNotice>
+  ) : null;
+  const accessNotice = accessRevoked ? (
+    <SharedNoteEditNotice>
+      Your editing access changed. The view-only shared note is still available.
+    </SharedNoteEditNotice>
+  ) : null;
+  const signInNotice = requiresSignIn ? (
+    <SharedNoteEditNotice>
+      Your session expired.{" "}
+      <a className="underline underline-offset-4" href="/auth/?flow=web">
+        Sign in again
+      </a>{" "}
+      to continue editing.
+    </SharedNoteEditNotice>
+  ) : null;
+
+  return (
+    <SharedNoteViewer
+      accessLabel={
+        accessRevoked
+          ? (fallbackAccessLabel ?? "Shared note · View only")
+          : requiresSignIn
+            ? "Shared note · Sign in required"
+            : accessLabel
+      }
+      actions={actions}
+      collaboration={
+        accessRevoked || requiresSignIn ? undefined : collaboration
+      }
+      documentContent={
+        isEditing ? (
+          <Suspense
+            fallback={
+              <p className="text-color-muted py-10 text-center text-sm">
+                Loading editor…
+              </p>
+            }
+          >
+            <SharedNoteEditorSurface
+              key={`${activeSnapshot.shareId}:${activeSnapshot.contentRevision}`}
+              snapshot={activeSnapshot}
+              onCancel={() => setIsEditing(false)}
+              onReloadLatest={(edited) => {
+                applyEditedSnapshot(edited);
+                if (
+                  !edited.webEditable ||
+                  hasUnsupportedSharedNoteEditorNode(edited.snapshot.body)
+                ) {
+                  setIsEditing(false);
+                }
+              }}
+              onSaved={(edited) => {
+                applyEditedSnapshot(edited);
+                setIsEditing(false);
+              }}
+              onUnavailable={(reason) => {
+                if (reason === "access_changed") {
+                  setAccessRevoked(true);
+                  onAccessChanged?.();
+                } else {
+                  setRequiresSignIn(true);
+                  setActiveAuthenticatedNote(null);
+                }
+                setIsEditing(false);
+              }}
+            />
+          </Suspense>
+        ) : undefined
+      }
+      headerActions={
+        canEdit && !isEditing ? (
+          <button
+            type="button"
+            className={sharedSecondaryButtonClassName}
+            onClick={() => setIsEditing(true)}
+          >
+            Edit
+          </button>
+        ) : undefined
+      }
+      notice={accessNotice ?? signInNotice ?? preparationNotice}
+      resolveAttachment={resolveAttachment}
+      showTitle={!isEditing}
+      snapshot={activeSnapshot}
+    />
+  );
+
+  function applyEditedSnapshot(edited: SharedNoteWebEditSnapshot) {
+    setSource({ authenticatedNote, snapshot: initialSnapshot });
+    setSnapshot(edited.snapshot);
+    setRequiresSignIn(false);
+    setActiveAuthenticatedNote((note) =>
+      note
+        ? {
+            ...note,
+            accessVersion: edited.accessVersion,
+            snapshot: edited.snapshot,
+            webEditable: edited.webEditable,
+          }
+        : note,
+    );
+  }
+}
+
+function SharedNoteEditNotice({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="border-color-subtle bg-surface-subtle mb-6 rounded-2xl border px-4 py-3 text-sm leading-6">
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/shared-note-editable-viewer.tsx
+++ b/apps/web/src/components/shared-note-editable-viewer.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/shared-note-viewer";
 import {
   canEditSharedNoteOnWeb,
+  getSharedNoteReadOnlySnapshot,
   getSharedNoteWebEditPreparationMessage,
   hasUnsupportedSharedNoteEditorNode,
   shouldRenderSharedNoteUnavailable,
@@ -79,8 +80,12 @@ export function SharedNoteEditableViewer({
     }
   }
 
+  const readOnlySnapshot = getSharedNoteReadOnlySnapshot(
+    snapshot,
+    fallbackSnapshot,
+  );
   const activeSnapshot =
-    accessRevoked && fallbackSnapshot ? fallbackSnapshot : snapshot;
+    accessRevoked && readOnlySnapshot ? readOnlySnapshot : snapshot;
   const hasUnsupportedContent = hasUnsupportedSharedNoteEditorNode(
     activeSnapshot.body,
   );
@@ -96,7 +101,7 @@ export function SharedNoteEditableViewer({
   if (
     shouldRenderSharedNoteUnavailable({
       accessRevoked,
-      hasFallbackSnapshot: Boolean(fallbackSnapshot),
+      hasFallbackSnapshot: Boolean(readOnlySnapshot),
       revokedBehavior,
     })
   ) {

--- a/apps/web/src/components/shared-note-editor-surface.tsx
+++ b/apps/web/src/components/shared-note-editor-surface.tsx
@@ -1,0 +1,405 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+  AlertCircleIcon,
+  FileIcon,
+  ImageIcon,
+  LoaderCircleIcon,
+  PaperclipIcon,
+} from "lucide-react";
+import {
+  type ComponentProps,
+  createContext,
+  forwardRef,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  NoteEditor,
+  type NoteEditorProps,
+  type NoteEditorRef,
+  schema,
+} from "@hypr/editor/note";
+
+import {
+  sharedPrimaryButtonClassName,
+  sharedSecondaryButtonClassName,
+} from "@/components/shared-note-viewer";
+import { editAuthenticatedSharedNote } from "@/functions/shared-notes";
+import {
+  buildSharedNoteWebEditInput,
+  canonicalizeSharedNoteWebDraft,
+  ensureSharedNoteEditorTitle,
+  hasUnsupportedSharedNoteEditorNode,
+  reuseSharedNoteMutationIdForUnchangedDraft,
+  type SharedNoteWebEditInput,
+} from "@/lib/shared-note-editing";
+import type {
+  SharedNoteAttachment,
+  SharedNoteDocument,
+  SharedNoteNode,
+  SharedNoteSnapshot,
+  SharedNoteWebEditSnapshot,
+} from "@/lib/shared-notes";
+
+type EditorNodeView = NonNullable<NoteEditorProps["extraNodeViews"]>[string];
+type EditorNodeViewProps = ComponentProps<EditorNodeView>;
+
+const SharedEditorAttachmentsContext = createContext<
+  ReadonlyMap<string, SharedNoteAttachment>
+>(new Map());
+
+export function SharedNoteEditorSurface({
+  onCancel,
+  onReloadLatest,
+  onSaved,
+  onUnavailable,
+  snapshot,
+}: {
+  onCancel: () => void;
+  onReloadLatest: (edited: SharedNoteWebEditSnapshot) => void;
+  onSaved: (edited: SharedNoteWebEditSnapshot) => void;
+  onUnavailable: (reason: "access_changed" | "sign_in_required") => void;
+  snapshot: SharedNoteSnapshot;
+}) {
+  const editorRef = useRef<NoteEditorRef>(null);
+  const [clientError, setClientError] = useState<string | null>(null);
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const attachmentById = useMemo(
+    () =>
+      new Map(
+        snapshot.attachments.map((attachment) => [attachment.id, attachment]),
+      ),
+    [snapshot.attachments],
+  );
+  const { initialContent, initialContentIsValid } = useMemo(() => {
+    const content = ensureSharedNoteEditorTitle(snapshot.body, snapshot.title);
+    return {
+      initialContent: content,
+      initialContentIsValid:
+        !hasUnsupportedSharedNoteEditorNode(content) &&
+        isCanonicalEditorDocument(content),
+    };
+  }, [snapshot]);
+  const mutation = useMutation({
+    mutationFn: (input: SharedNoteWebEditInput) =>
+      editAuthenticatedSharedNote({ data: input }),
+    onSuccess: (result) => {
+      if (result.status === "ready") onSaved(result);
+    },
+  });
+
+  if (!initialContentIsValid) {
+    return (
+      <EditorMessage
+        description="This note uses content the web editor can’t safely preserve yet. You can still view it here or edit it in the Anarlog app."
+        onCancel={onCancel}
+        title="This note isn’t ready for web editing"
+      />
+    );
+  }
+
+  const conflict = mutation.data?.status === "conflict" ? mutation.data : null;
+  const hasServerError = mutation.isError || mutation.data?.status === "error";
+  const availabilityIssue =
+    mutation.data?.status === "sign_in_required"
+      ? "sign_in_required"
+      : mutation.data?.status === "unavailable"
+        ? "access_changed"
+        : null;
+
+  const save = () => {
+    const view = editorRef.current?.view;
+    if (!view) return;
+    const body = view.state.doc.toJSON() as SharedNoteDocument;
+    const canonicalBody = canonicalizeSharedNoteWebDraft(
+      body,
+      snapshot.attachments.map(({ id }) => id),
+    );
+    if (
+      hasUnsupportedSharedNoteEditorNode(body) ||
+      !canonicalBody ||
+      !isCanonicalEditorDocument(canonicalBody)
+    ) {
+      setClientError(
+        "This edit includes content the web editor can’t safely save yet.",
+      );
+      return;
+    }
+
+    setClientError(null);
+    const input = buildSharedNoteWebEditInput({
+      body: canonicalBody,
+      mutationId: crypto.randomUUID(),
+      snapshot,
+    });
+    mutation.mutate(
+      reuseSharedNoteMutationIdForUnchangedDraft(
+        input,
+        hasServerError ? mutation.variables : undefined,
+      ),
+    );
+  };
+
+  return (
+    <div className="shared-note-web-editor">
+      {conflict && (
+        <div
+          className="border-color-subtle bg-surface-subtle mb-5 rounded-2xl border p-4"
+          role="alert"
+        >
+          <p className="text-color font-mono text-sm font-medium">
+            This note changed elsewhere.
+          </p>
+          <p className="text-color-muted mt-1 text-sm leading-6">
+            Reload the latest version before making more edits.
+          </p>
+          {confirmDiscard ? (
+            <div className="mt-3">
+              <p className="text-color-muted text-sm leading-6">
+                Reloading will discard this draft. Copy anything you want to
+                keep first.
+              </p>
+              <div className="mt-3 flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  className="text-color font-mono text-sm underline underline-offset-4"
+                  onClick={() => setConfirmDiscard(false)}
+                >
+                  Keep draft
+                </button>
+                <button
+                  type="button"
+                  className="font-mono text-sm text-red-700 underline underline-offset-4"
+                  onClick={() => onReloadLatest(conflict)}
+                >
+                  Discard draft and reload
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="text-color mt-3 font-mono text-sm underline underline-offset-4"
+              onClick={() => setConfirmDiscard(true)}
+            >
+              Reload latest
+            </button>
+          )}
+        </div>
+      )}
+      {(clientError || hasServerError) && (
+        <div
+          className="mb-5 flex gap-3 rounded-2xl border border-red-200 bg-red-50 p-4 text-red-900"
+          role="alert"
+        >
+          <AlertCircleIcon className="mt-0.5 size-4 shrink-0" aria-hidden />
+          <p className="text-sm leading-6">
+            {clientError ??
+              "We couldn’t save this edit. Your draft is still here."}
+          </p>
+        </div>
+      )}
+      {availabilityIssue && (
+        <div
+          className="mb-5 flex gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-amber-950"
+          role="alert"
+        >
+          <AlertCircleIcon className="mt-0.5 size-4 shrink-0" aria-hidden />
+          <p className="text-sm leading-6">
+            {availabilityIssue === "sign_in_required"
+              ? "Your session expired. Your draft is still here and can be copied before you leave the editor and sign in again."
+              : "Your editing access changed. Your draft is still here and can be copied before you leave the editor."}
+          </p>
+        </div>
+      )}
+
+      {snapshot.attachments.length > 0 && (
+        <div className="border-color-subtle bg-surface-subtle text-color-muted mb-5 flex items-start gap-3 rounded-xl border px-4 py-3 text-sm leading-6">
+          <PaperclipIcon className="mt-1 size-4 shrink-0" aria-hidden />
+          <span>
+            {snapshot.attachments.length}{" "}
+            {snapshot.attachments.length === 1 ? "attachment" : "attachments"}
+            {" will stay included with this note."}
+          </span>
+        </div>
+      )}
+
+      <SharedEditorAttachmentsContext.Provider value={attachmentById}>
+        <NoteEditor
+          ref={editorRef}
+          className="min-h-80 outline-hidden"
+          extraNodeViews={lockedAttachmentNodeViews}
+          initialContent={initialContent}
+          handleChange={() => {
+            setClientError(null);
+            if (hasServerError && !mutation.isPending) mutation.reset();
+          }}
+          readOnly={
+            mutation.isPending ||
+            conflict !== null ||
+            availabilityIssue !== null
+          }
+          showFormatToolbar={false}
+          showSlashCommand={false}
+        />
+      </SharedEditorAttachmentsContext.Provider>
+
+      <div className="border-color-subtle mt-7 flex flex-wrap justify-end gap-3 border-t pt-5">
+        <button
+          type="button"
+          className={sharedSecondaryButtonClassName}
+          disabled={mutation.isPending}
+          onClick={() => {
+            if (availabilityIssue) {
+              onUnavailable(availabilityIssue);
+            } else {
+              onCancel();
+            }
+          }}
+        >
+          {availabilityIssue ? "Leave editor" : "Cancel"}
+        </button>
+        <button
+          type="button"
+          className={sharedPrimaryButtonClassName}
+          disabled={
+            mutation.isPending ||
+            conflict !== null ||
+            availabilityIssue !== null
+          }
+          onClick={save}
+        >
+          {mutation.isPending && (
+            <LoaderCircleIcon
+              className="mr-2 size-4 animate-spin"
+              aria-hidden
+            />
+          )}
+          {mutation.isPending
+            ? "Saving…"
+            : hasServerError
+              ? "Try again"
+              : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const LockedSharedAttachmentView = forwardRef<
+  HTMLDivElement,
+  EditorNodeViewProps
+>(function LockedSharedAttachmentView({ nodeProps, ...htmlAttrs }, ref) {
+  const attachments = useContext(SharedEditorAttachmentsContext);
+  const sharedAttachmentId = nodeProps.node.attrs.sharedAttachmentId;
+  const attachment =
+    typeof sharedAttachmentId === "string"
+      ? attachments.get(sharedAttachmentId)
+      : undefined;
+  const isImage = nodeProps.node.type.name === "image";
+  const Icon = isImage ? ImageIcon : FileIcon;
+
+  return (
+    <div
+      ref={ref}
+      {...htmlAttrs}
+      contentEditable={false}
+      suppressContentEditableWarning
+      className="border-color-subtle bg-surface-subtle my-3 flex items-center gap-3 rounded-xl border px-4 py-3"
+    >
+      <div className="bg-surface flex size-10 shrink-0 items-center justify-center rounded-lg">
+        <Icon className="text-color-muted size-5" aria-hidden />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-color truncate text-sm font-medium">
+          {attachment?.filename ?? "Attachment unavailable"}
+        </p>
+        <p className="text-color-muted mt-0.5 text-xs">
+          {attachment
+            ? `${formatFileSize(attachment.sizeBytes)} · Included with shared note`
+            : "Included attachment"}
+        </p>
+      </div>
+    </div>
+  );
+});
+
+const lockedAttachmentNodeViews = {
+  fileAttachment: LockedSharedAttachmentView,
+  image: LockedSharedAttachmentView,
+};
+
+function EditorMessage({
+  description,
+  onCancel,
+  title,
+}: {
+  description: string;
+  onCancel: () => void;
+  title: string;
+}) {
+  return (
+    <div className="border-color-subtle bg-surface-subtle rounded-2xl border p-5">
+      <h2 className="text-color font-mono text-base font-medium">{title}</h2>
+      <p className="text-color-muted mt-2 text-sm leading-6">{description}</p>
+      <div className="mt-4">
+        <button
+          type="button"
+          className={sharedSecondaryButtonClassName}
+          onClick={onCancel}
+        >
+          Back to note
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function isCanonicalEditorDocument(document: SharedNoteDocument) {
+  const stack: SharedNoteNode[] = [document];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) continue;
+    const nodeType = schema.nodes[node.type];
+    if (
+      !nodeType ||
+      hasUnknownAttributes(node.attrs, nodeType.spec.attrs ?? {})
+    ) {
+      return false;
+    }
+
+    for (const mark of node.marks ?? []) {
+      const markType = schema.marks[mark.type];
+      if (
+        !markType ||
+        hasUnknownAttributes(mark.attrs, markType.spec.attrs ?? {})
+      ) {
+        return false;
+      }
+    }
+    if (node.content) stack.push(...node.content);
+  }
+
+  try {
+    schema.nodeFromJSON(document).check();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasUnknownAttributes(
+  attrs: Record<string, unknown> | undefined,
+  allowed: Record<string, unknown>,
+) {
+  return Object.keys(attrs ?? {}).some((key) => !(key in allowed));
+}
+
+function formatFileSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/web/src/components/shared-note-viewer.tsx
+++ b/apps/web/src/components/shared-note-viewer.tsx
@@ -35,13 +35,21 @@ export function SharedNoteViewer({
   accessLabel,
   actions,
   collaboration,
+  documentContent,
+  headerActions,
+  notice,
   resolveAttachment,
+  showTitle = true,
   snapshot,
 }: {
   accessLabel: string;
   actions?: React.ReactNode;
   collaboration?: React.ReactNode;
+  documentContent?: React.ReactNode;
+  headerActions?: React.ReactNode;
+  notice?: React.ReactNode;
   resolveAttachment?: SharedAttachmentResolver;
+  showTitle?: boolean;
   snapshot: SharedNoteSnapshot;
 }) {
   const body = withoutDuplicateLeadingTitle(snapshot.body, snapshot.title);
@@ -50,25 +58,33 @@ export function SharedNoteViewer({
     <SharedNoteShell>
       <article className="surface border-color-subtle overflow-hidden rounded-3xl border shadow-sm">
         <header className="border-color-subtle border-b px-6 py-7 sm:px-10 sm:py-10">
-          <div className="text-color-muted flex items-center gap-2 text-sm">
-            <UsersRoundIcon className="size-4" aria-hidden="true" />
-            <span>{accessLabel}</span>
-            <span aria-hidden="true">·</span>
-            <time dateTime={snapshot.publishedAt}>
-              {formatPublishedAt(snapshot.publishedAt)}
-            </time>
+          <div className="flex items-start justify-between gap-4">
+            <div className="text-color-muted flex min-w-0 flex-wrap items-center gap-2 text-sm">
+              <UsersRoundIcon className="size-4" aria-hidden="true" />
+              <span>{accessLabel}</span>
+              <span aria-hidden="true">·</span>
+              <time dateTime={snapshot.publishedAt}>
+                {formatPublishedAt(snapshot.publishedAt)}
+              </time>
+            </div>
+            {headerActions}
           </div>
-          <h1 className="text-color mt-5 font-mono text-3xl font-medium text-balance sm:text-4xl">
-            {snapshot.title || "Untitled note"}
-          </h1>
+          {showTitle && (
+            <h1 className="text-color mt-5 font-mono text-3xl font-medium text-balance sm:text-4xl">
+              {snapshot.title || "Untitled note"}
+            </h1>
+          )}
         </header>
 
         <div className="px-6 py-7 sm:px-10 sm:py-10">
-          <SharedNoteDocument
-            attachments={snapshot.attachments}
-            document={body}
-            resolveAttachment={resolveAttachment}
-          />
+          {notice}
+          {documentContent ?? (
+            <SharedNoteDocument
+              attachments={snapshot.attachments}
+              document={body}
+              resolveAttachment={resolveAttachment}
+            />
+          )}
         </div>
       </article>
 

--- a/apps/web/src/functions/shared-notes.ts
+++ b/apps/web/src/functions/shared-notes.ts
@@ -12,12 +12,17 @@ import {
   MAX_SHARED_NOTE_COMMENT_BYTES,
   validateSharedNoteCommentBody,
 } from "@/lib/shared-note-collaboration";
+import { deriveSharedNoteEditorTitle } from "@/lib/shared-note-editing";
 import {
   type AuthenticatedSharedNote,
+  handoffRequestIdSchema,
   parseSessionAccessRequestState,
   parseSessionInvitationState,
   parseSessionShareAccessPage,
   parseAuthenticatedSharedNote,
+  parseSharedNoteDocument,
+  parseSharedNoteWebEditConflict,
+  parseSharedNoteWebEditSnapshot,
   parseSharedNoteComment,
   parseSharedNoteCommentPage,
   parseSharedNoteAttachmentDownload,
@@ -28,10 +33,18 @@ import {
   shareIdSchema,
   type SharedNoteComment,
   type SharedNoteCommentPage,
+  type SharedNoteWebEditSnapshot,
 } from "@/lib/shared-notes";
 
 export type AuthenticatedSharedNoteReadResult =
   | { status: "ready"; note: AuthenticatedSharedNote }
+  | { status: "unavailable" }
+  | { status: "error" };
+
+export type SharedNoteWebEditResult =
+  | ({ status: "ready" } & SharedNoteWebEditSnapshot)
+  | ({ status: "conflict" } & SharedNoteWebEditSnapshot)
+  | { status: "sign_in_required" }
   | { status: "unavailable" }
   | { status: "error" };
 
@@ -41,6 +54,23 @@ const attachmentDownloadInputSchema = z
     attachmentId: shareIdSchema,
   })
   .strict();
+
+const sharedNoteWebEditInputSchema = z
+  .object({
+    shareId: shareIdSchema,
+    baseRevision: z.number().int().positive().safe(),
+    mutationId: handoffRequestIdSchema,
+    title: z.string().trim().max(4096),
+    body: z.unknown(),
+    attachmentIds: z.array(handoffRequestIdSchema).max(64),
+  })
+  .strict()
+  .refine(
+    ({ attachmentIds }) => new Set(attachmentIds).size === attachmentIds.length,
+    { path: ["attachmentIds"] },
+  );
+
+const MAX_WEB_EDIT_RESPONSE_BYTES = 2_250_000;
 
 const sharedNoteCommentInputSchema = z
   .object({
@@ -165,7 +195,7 @@ export const readAuthenticatedSharedNote = createServerFn({ method: "GET" })
 
       const supabase = getSupabaseServerClient();
       const { data, error } = await supabase.rpc(
-        "read_my_session_share_snapshot_with_attachments",
+        "read_my_session_share_snapshot_v2",
         { p_share_id: shareId },
       );
       if (error || !Array.isArray(data)) {
@@ -535,6 +565,107 @@ export const createAuthenticatedSharedAttachmentDownload = createServerFn({
     }
   });
 
+export const editAuthenticatedSharedNote = createServerFn({ method: "POST" })
+  .inputValidator(sharedNoteWebEditInputSchema)
+  .handler(async ({ data: input }): Promise<SharedNoteWebEditResult> => {
+    setPrivateShareResponseHeaders();
+
+    let body;
+    try {
+      body = parseSharedNoteDocument(input.body);
+    } catch {
+      return { status: "error" };
+    }
+
+    const first = body.content?.[0];
+    if (
+      new TextEncoder().encode(input.title).byteLength > 4096 ||
+      first?.type !== "heading" ||
+      (first.attrs?.level ?? 1) !== 1 ||
+      deriveSharedNoteEditorTitle(body) !== input.title
+    ) {
+      return { status: "error" };
+    }
+
+    const supabase = getSupabaseServerClient();
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+    if (!accessToken) return { status: "sign_in_required" };
+
+    try {
+      const response = await fetch(
+        new URL(
+          `/sync/shares/${encodeURIComponent(input.shareId)}/web-edit`,
+          apiBaseUrl(),
+        ),
+        {
+          method: "PUT",
+          body: JSON.stringify({
+            baseRevision: input.baseRevision,
+            mutationId: input.mutationId,
+            title: input.title,
+            body,
+            attachmentIds: input.attachmentIds,
+          }),
+          cache: "no-store",
+          credentials: "omit",
+          headers: {
+            Accept: "application/json",
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+          redirect: "error",
+          referrerPolicy: "no-referrer",
+        },
+      );
+
+      if (response.status === 401) {
+        return { status: "sign_in_required" };
+      }
+      if (response.status === 403 || response.status === 404) {
+        return { status: "unavailable" };
+      }
+      if (
+        !response.headers
+          .get("content-type")
+          ?.toLowerCase()
+          .startsWith("application/json")
+      ) {
+        return { status: "error" };
+      }
+
+      const responseBody = await readBoundedJson(
+        response,
+        MAX_WEB_EDIT_RESPONSE_BYTES,
+      );
+      if (responseBody === null) return { status: "error" };
+
+      if (response.status === 409) {
+        const edited = parseSharedNoteWebEditConflict(responseBody);
+        return edited.snapshot.shareId === input.shareId &&
+          edited.snapshot.contentRevision > input.baseRevision
+          ? { status: "conflict", ...edited }
+          : { status: "error" };
+      }
+      if (!response.ok) return { status: "error" };
+
+      const edited = parseSharedNoteWebEditSnapshot(responseBody);
+      if (
+        edited.snapshot.shareId !== input.shareId ||
+        edited.snapshot.contentRevision <= input.baseRevision ||
+        !sameOrderedIds(
+          edited.snapshot.attachments.map(({ id }) => id),
+          input.attachmentIds,
+        )
+      ) {
+        return { status: "error" };
+      }
+      return { status: "ready", ...edited };
+    } catch {
+      return { status: "error" };
+    }
+  });
+
 function setPrivateShareResponseHeaders() {
   setResponseHeader("Cache-Control", "private, no-store");
   setResponseHeader("Referrer-Policy", "no-referrer");
@@ -577,4 +708,29 @@ function apiBaseUrl() {
   return env.VITE_API_URL.endsWith("/")
     ? env.VITE_API_URL
     : `${env.VITE_API_URL}/`;
+}
+
+async function readBoundedJson(response: Response, maxBytes: number) {
+  const contentLength = response.headers.get("content-length");
+  if (
+    contentLength &&
+    (!/^\d+$/.test(contentLength) || Number(contentLength) > maxBytes)
+  ) {
+    return null;
+  }
+
+  const text = await response.text();
+  if (new TextEncoder().encode(text).byteLength > maxBytes) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function sameOrderedIds(left: string[], right: string[]) {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
 }

--- a/apps/web/src/lib/shared-note-editing.test.ts
+++ b/apps/web/src/lib/shared-note-editing.test.ts
@@ -1,0 +1,348 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildSharedNoteWebEditInput,
+  canEditSharedNoteOnWeb,
+  canonicalizeSharedNoteWebDraft,
+  deriveSharedNoteEditorTitle,
+  ensureSharedNoteEditorTitle,
+  getSharedNoteWebEditPreparationMessage,
+  hasUnsupportedSharedNoteEditorNode,
+  reuseSharedNoteMutationIdForUnchangedDraft,
+  shouldRenderSharedNoteUnavailable,
+} from "./shared-note-editing.ts";
+import type { SharedNoteDocument, SharedNoteSnapshot } from "./shared-notes.ts";
+
+const BODY: SharedNoteDocument = {
+  type: "doc",
+  content: [
+    {
+      type: "heading",
+      attrs: { level: 1 },
+      content: [{ type: "text", text: "  Weekly sync  " }],
+    },
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Decisions and next steps." }],
+    },
+  ],
+};
+
+test("allows web editing only for an authenticated editable editor", () => {
+  assert.equal(canEditSharedNoteOnWeb(null), false);
+  assert.equal(
+    canEditSharedNoteOnWeb({ capability: "viewer", webEditable: true }),
+    false,
+  );
+  assert.equal(
+    canEditSharedNoteOnWeb({ capability: "editor", webEditable: false }),
+    false,
+  );
+  assert.equal(
+    canEditSharedNoteOnWeb({ capability: "editor", webEditable: true }),
+    true,
+  );
+});
+
+test("shows the preparation message only to authenticated editors", () => {
+  assert.equal(
+    getSharedNoteWebEditPreparationMessage(
+      { capability: "viewer", webEditable: false },
+      false,
+    ),
+    null,
+  );
+  assert.match(
+    getSharedNoteWebEditPreparationMessage(
+      { capability: "editor", webEditable: false },
+      false,
+    ) ?? "",
+    /needs to be prepared/i,
+  );
+  assert.match(
+    getSharedNoteWebEditPreparationMessage(
+      { capability: "editor", webEditable: true },
+      true,
+    ) ?? "",
+    /needs to be prepared/i,
+  );
+  assert.equal(
+    getSharedNoteWebEditPreparationMessage(
+      { capability: "editor", webEditable: true },
+      false,
+    ),
+    null,
+  );
+});
+
+test("keeps a read-only fallback visible while changed access is refreshed", () => {
+  assert.equal(
+    shouldRenderSharedNoteUnavailable({
+      accessRevoked: true,
+      hasFallbackSnapshot: true,
+      revokedBehavior: "read-only",
+    }),
+    false,
+  );
+  assert.equal(
+    shouldRenderSharedNoteUnavailable({
+      accessRevoked: true,
+      hasFallbackSnapshot: false,
+      revokedBehavior: "read-only",
+    }),
+    true,
+  );
+  assert.equal(
+    shouldRenderSharedNoteUnavailable({
+      accessRevoked: true,
+      hasFallbackSnapshot: true,
+      revokedBehavior: "unavailable",
+    }),
+    true,
+  );
+});
+
+test("keeps or restores the canonical leading title heading", () => {
+  assert.equal(ensureSharedNoteEditorTitle(BODY, "Weekly sync"), BODY);
+
+  const bodyWithoutTitle: SharedNoteDocument = {
+    type: "doc",
+    content: [{ type: "paragraph" }],
+  };
+  const prepared = ensureSharedNoteEditorTitle(bodyWithoutTitle, "Weekly sync");
+  assert.deepEqual(prepared.content?.[0], {
+    type: "heading",
+    attrs: { level: 1 },
+    content: [{ type: "text", text: "Weekly sync" }],
+  });
+  assert.equal(prepared.content?.[1], bodyWithoutTitle.content?.[0]);
+});
+
+test("builds a revision-safe payload from the live canonical document", () => {
+  const snapshot: SharedNoteSnapshot = {
+    shareId: "00000000-0000-4000-8000-000000000001",
+    schemaVersion: 1,
+    contentRevision: 7,
+    title: "Old title",
+    body: BODY,
+    attachments: [
+      {
+        id: "00000000-0000-4000-8000-000000000003",
+        filename: "first.txt",
+        contentType: "text/plain",
+        sizeBytes: 1,
+        sha256: "a".repeat(64),
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000002",
+        filename: "second.txt",
+        contentType: "text/plain",
+        sizeBytes: 1,
+        sha256: "b".repeat(64),
+      },
+    ],
+    publishedAt: "2026-07-17T12:00:00Z",
+  };
+  const mutationId = "00000000-0000-4000-8000-000000000004";
+  const input = buildSharedNoteWebEditInput({
+    body: BODY,
+    mutationId,
+    snapshot,
+  });
+
+  assert.equal(deriveSharedNoteEditorTitle(BODY), "Weekly sync");
+  assert.equal(input.baseRevision, 7);
+  assert.equal(input.mutationId, mutationId);
+  assert.equal(input.title, "Weekly sync");
+  assert.equal(input.body, BODY);
+  assert.deepEqual(input.attachmentIds, [
+    "00000000-0000-4000-8000-000000000003",
+    "00000000-0000-4000-8000-000000000002",
+  ]);
+});
+
+test("allows shared attachments but keeps clips blocked at any depth", () => {
+  assert.equal(hasUnsupportedSharedNoteEditorNode(BODY), false);
+  assert.equal(
+    hasUnsupportedSharedNoteEditorNode({
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "image",
+              attrs: { sharedAttachmentId: "attachment" },
+            },
+            {
+              type: "fileAttachment",
+              attrs: { sharedAttachmentId: "attachment" },
+            },
+          ],
+        },
+      ],
+    }),
+    false,
+  );
+  assert.equal(
+    hasUnsupportedSharedNoteEditorNode({
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [{ type: "clip" }],
+        },
+      ],
+    }),
+    true,
+  );
+});
+
+test("canonicalizes nested attachment nodes without mutating the draft", () => {
+  const draft: SharedNoteDocument = {
+    type: "doc",
+    attrs: { source: "web" },
+    content: [
+      {
+        type: "blockquote",
+        attrs: { cite: "https://example.com" },
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Diagram" }],
+          },
+          {
+            type: "image",
+            attrs: {
+              sharedAttachmentId: "attachment-image",
+              src: "blob:private-image",
+              alt: "Diagram",
+              editorWidth: 640,
+            },
+            marks: [{ type: "link", attrs: { href: "https://example.com" } }],
+          },
+          {
+            type: "fileAttachment",
+            attrs: {
+              sharedAttachmentId: "attachment-file",
+              src: "blob:private-file",
+              path: "/private/report.pdf",
+              filename: "report.pdf",
+            },
+          },
+        ],
+      },
+    ],
+  };
+  const original = structuredClone(draft);
+
+  assert.deepEqual(
+    canonicalizeSharedNoteWebDraft(draft, [
+      "attachment-image",
+      "attachment-file",
+    ]),
+    {
+      type: "doc",
+      attrs: { source: "web" },
+      content: [
+        {
+          type: "blockquote",
+          attrs: { cite: "https://example.com" },
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Diagram" }],
+            },
+            {
+              type: "image",
+              attrs: { sharedAttachmentId: "attachment-image" },
+            },
+            {
+              type: "fileAttachment",
+              attrs: { sharedAttachmentId: "attachment-file" },
+            },
+          ],
+        },
+      ],
+    },
+  );
+  assert.deepEqual(draft, original);
+});
+
+test("rejects attachment nodes with missing or foreign manifest IDs", () => {
+  assert.equal(
+    canonicalizeSharedNoteWebDraft(
+      {
+        type: "doc",
+        content: [{ type: "image", attrs: { src: "blob:private" } }],
+      },
+      ["attachment-image"],
+    ),
+    null,
+  );
+  assert.equal(
+    canonicalizeSharedNoteWebDraft(
+      {
+        type: "doc",
+        content: [
+          {
+            type: "fileAttachment",
+            attrs: { sharedAttachmentId: "attachment-foreign" },
+          },
+        ],
+      },
+      ["attachment-file"],
+    ),
+    null,
+  );
+  assert.equal(
+    canonicalizeSharedNoteWebDraft(
+      { type: "doc", content: [{ type: "clip", attrs: { src: "private" } }] },
+      [],
+    ),
+    null,
+  );
+});
+
+test("reuses a failed mutation only while the live draft is unchanged", () => {
+  const snapshot: SharedNoteSnapshot = {
+    shareId: "00000000-0000-4000-8000-000000000001",
+    schemaVersion: 1,
+    contentRevision: 7,
+    title: "Weekly sync",
+    body: BODY,
+    attachments: [],
+    publishedAt: "2026-07-17T12:00:00Z",
+  };
+  const previous = buildSharedNoteWebEditInput({
+    body: BODY,
+    mutationId: "00000000-0000-4000-8000-000000000004",
+    snapshot,
+  });
+  const unchanged = buildSharedNoteWebEditInput({
+    body: structuredClone(BODY),
+    mutationId: "00000000-0000-4000-8000-000000000005",
+    snapshot,
+  });
+  const changed = buildSharedNoteWebEditInput({
+    body: {
+      ...BODY,
+      content: [
+        ...(BODY.content ?? []),
+        { type: "paragraph", content: [{ type: "text", text: "New" }] },
+      ],
+    },
+    mutationId: "00000000-0000-4000-8000-000000000006",
+    snapshot,
+  });
+
+  assert.equal(
+    reuseSharedNoteMutationIdForUnchangedDraft(unchanged, previous).mutationId,
+    previous.mutationId,
+  );
+  assert.equal(
+    reuseSharedNoteMutationIdForUnchangedDraft(changed, previous).mutationId,
+    changed.mutationId,
+  );
+});

--- a/apps/web/src/lib/shared-note-editing.test.ts
+++ b/apps/web/src/lib/shared-note-editing.test.ts
@@ -7,6 +7,7 @@ import {
   canonicalizeSharedNoteWebDraft,
   deriveSharedNoteEditorTitle,
   ensureSharedNoteEditorTitle,
+  getSharedNoteReadOnlySnapshot,
   getSharedNoteWebEditPreparationMessage,
   hasUnsupportedSharedNoteEditorNode,
   reuseSharedNoteMutationIdForUnchangedDraft,
@@ -103,6 +104,25 @@ test("keeps a read-only fallback visible while changed access is refreshed", () 
   );
 });
 
+test("keeps the newest same-note snapshot when editing access changes", () => {
+  const current = sharedNoteSnapshot(8);
+  const staleFallback = sharedNoteSnapshot(7);
+  const newerFallback = sharedNoteSnapshot(9);
+
+  assert.equal(getSharedNoteReadOnlySnapshot(current, staleFallback), current);
+  assert.equal(
+    getSharedNoteReadOnlySnapshot(current, newerFallback),
+    newerFallback,
+  );
+  assert.equal(
+    getSharedNoteReadOnlySnapshot(current, {
+      ...newerFallback,
+      shareId: "00000000-0000-4000-8000-000000000099",
+    }),
+    null,
+  );
+});
+
 test("keeps or restores the canonical leading title heading", () => {
   assert.equal(ensureSharedNoteEditorTitle(BODY, "Weekly sync"), BODY);
 
@@ -118,6 +138,18 @@ test("keeps or restores the canonical leading title heading", () => {
   });
   assert.equal(prepared.content?.[1], bodyWithoutTitle.content?.[0]);
 });
+
+function sharedNoteSnapshot(contentRevision: number): SharedNoteSnapshot {
+  return {
+    shareId: "00000000-0000-4000-8000-000000000001",
+    schemaVersion: 1,
+    contentRevision,
+    title: "Weekly sync",
+    body: BODY,
+    attachments: [],
+    publishedAt: "2026-07-17T12:00:00Z",
+  };
+}
 
 test("builds a revision-safe payload from the live canonical document", () => {
   const snapshot: SharedNoteSnapshot = {

--- a/apps/web/src/lib/shared-note-editing.ts
+++ b/apps/web/src/lib/shared-note-editing.ts
@@ -1,0 +1,186 @@
+import type {
+  AuthenticatedSharedNote,
+  SharedNoteDocument,
+  SharedNoteNode,
+  SharedNoteSnapshot,
+} from "./shared-notes";
+
+const UNSUPPORTED_WEB_EDITOR_NODES = new Set(["clip"]);
+const SHARED_ATTACHMENT_NODES = new Set(["fileAttachment", "image"]);
+
+export type SharedNoteWebEditInput = {
+  shareId: string;
+  baseRevision: number;
+  mutationId: string;
+  title: string;
+  body: SharedNoteDocument;
+  attachmentIds: string[];
+};
+
+export function canEditSharedNoteOnWeb(
+  note: Pick<AuthenticatedSharedNote, "capability" | "webEditable"> | null,
+) {
+  return note?.capability === "editor" && note.webEditable;
+}
+
+export function getSharedNoteWebEditPreparationMessage(
+  note: Pick<AuthenticatedSharedNote, "capability" | "webEditable"> | null,
+  hasUnsupportedContent: boolean,
+) {
+  if (
+    note?.capability !== "editor" ||
+    (note.webEditable && !hasUnsupportedContent)
+  ) {
+    return null;
+  }
+  return "This note needs to be prepared before it can be edited on the web. You can still edit it in the Anarlog app.";
+}
+
+export function shouldRenderSharedNoteUnavailable({
+  accessRevoked,
+  hasFallbackSnapshot,
+  revokedBehavior,
+}: {
+  accessRevoked: boolean;
+  hasFallbackSnapshot: boolean;
+  revokedBehavior: "read-only" | "unavailable";
+}) {
+  return (
+    accessRevoked && (revokedBehavior === "unavailable" || !hasFallbackSnapshot)
+  );
+}
+
+export function hasUnsupportedSharedNoteEditorNode(
+  document: SharedNoteDocument,
+) {
+  const stack: SharedNoteNode[] = [document];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) continue;
+    if (UNSUPPORTED_WEB_EDITOR_NODES.has(node.type)) return true;
+    if (node.content) stack.push(...node.content);
+  }
+  return false;
+}
+
+export function canonicalizeSharedNoteWebDraft(
+  document: SharedNoteDocument,
+  attachmentIds: readonly string[],
+): SharedNoteDocument | null {
+  const canonical = canonicalizeSharedNoteWebDraftNode(
+    document,
+    new Set(attachmentIds),
+  );
+  return canonical?.type === "doc" ? (canonical as SharedNoteDocument) : null;
+}
+
+export function ensureSharedNoteEditorTitle(
+  document: SharedNoteDocument,
+  title: string,
+): SharedNoteDocument {
+  if (isTitleHeading(document.content?.[0])) return document;
+
+  const heading: SharedNoteNode = {
+    type: "heading",
+    attrs: { level: 1 },
+    ...(title ? { content: [{ type: "text", text: title }] } : {}),
+  };
+  return {
+    ...document,
+    content: [heading, ...(document.content ?? [])],
+  };
+}
+
+export function deriveSharedNoteEditorTitle(document: SharedNoteDocument) {
+  const first = document.content?.[0];
+  return isTitleHeading(first) ? getInlineText(first).trim() : "";
+}
+
+export function buildSharedNoteWebEditInput({
+  body,
+  mutationId,
+  snapshot,
+}: {
+  body: SharedNoteDocument;
+  mutationId: string;
+  snapshot: SharedNoteSnapshot;
+}): SharedNoteWebEditInput {
+  return {
+    shareId: snapshot.shareId,
+    baseRevision: snapshot.contentRevision,
+    mutationId,
+    title: deriveSharedNoteEditorTitle(body),
+    body,
+    attachmentIds: snapshot.attachments.map(({ id }) => id),
+  };
+}
+
+export function reuseSharedNoteMutationIdForUnchangedDraft(
+  input: SharedNoteWebEditInput,
+  previousInput: SharedNoteWebEditInput | undefined,
+) {
+  if (!previousInput || !sameSharedNoteDraft(input, previousInput)) {
+    return input;
+  }
+  return { ...input, mutationId: previousInput.mutationId };
+}
+
+function sameSharedNoteDraft(
+  left: SharedNoteWebEditInput,
+  right: SharedNoteWebEditInput,
+) {
+  return (
+    left.shareId === right.shareId &&
+    left.baseRevision === right.baseRevision &&
+    left.title === right.title &&
+    left.attachmentIds.length === right.attachmentIds.length &&
+    left.attachmentIds.every(
+      (id, index) => id === right.attachmentIds[index],
+    ) &&
+    JSON.stringify(left.body) === JSON.stringify(right.body)
+  );
+}
+
+function isTitleHeading(
+  node: SharedNoteNode | undefined,
+): node is SharedNoteNode {
+  return node?.type === "heading" && (node.attrs?.level ?? 1) === 1;
+}
+
+function getInlineText(node: SharedNoteNode): string {
+  if (node.type === "text") return node.text ?? "";
+  return node.content?.map(getInlineText).join("") ?? "";
+}
+
+function canonicalizeSharedNoteWebDraftNode(
+  node: SharedNoteNode,
+  attachmentIds: ReadonlySet<string>,
+): SharedNoteNode | null {
+  if (UNSUPPORTED_WEB_EDITOR_NODES.has(node.type)) return null;
+
+  if (SHARED_ATTACHMENT_NODES.has(node.type)) {
+    const sharedAttachmentId = node.attrs?.sharedAttachmentId;
+    if (
+      typeof sharedAttachmentId !== "string" ||
+      !attachmentIds.has(sharedAttachmentId)
+    ) {
+      return null;
+    }
+    return {
+      type: node.type,
+      attrs: { sharedAttachmentId },
+    };
+  }
+
+  if (!node.content) return node;
+
+  const content: SharedNoteNode[] = [];
+  for (const child of node.content) {
+    const canonical = canonicalizeSharedNoteWebDraftNode(child, attachmentIds);
+    if (!canonical) return null;
+    content.push(canonical);
+  }
+  return content.every((child, index) => child === node.content?.[index])
+    ? node
+    : { ...node, content };
+}

--- a/apps/web/src/lib/shared-note-editing.ts
+++ b/apps/web/src/lib/shared-note-editing.ts
@@ -50,6 +50,18 @@ export function shouldRenderSharedNoteUnavailable({
   );
 }
 
+export function getSharedNoteReadOnlySnapshot(
+  current: SharedNoteSnapshot,
+  fallback: SharedNoteSnapshot | null | undefined,
+): SharedNoteSnapshot | null {
+  if (!fallback || fallback.shareId !== current.shareId) {
+    return null;
+  }
+  return fallback.contentRevision > current.contentRevision
+    ? fallback
+    : current;
+}
+
 export function hasUnsupportedSharedNoteEditorNode(
   document: SharedNoteDocument,
 ) {

--- a/apps/web/src/lib/shared-note-route-state.test.ts
+++ b/apps/web/src/lib/shared-note-route-state.test.ts
@@ -3,8 +3,10 @@ import test from "node:test";
 
 import {
   getInvitationRouteFailure,
+  getLinkSharedNoteFallbackSnapshot,
   getLinkSharedNoteRouteGate,
 } from "./shared-note-route-state.ts";
+import type { SharedNoteSnapshot } from "./shared-notes.ts";
 
 test("keeps failed invitation acceptance retryable", () => {
   assert.equal(
@@ -65,3 +67,35 @@ test("authenticated access outranks continuation failures", () => {
     "continuation-error",
   );
 });
+
+test("link access provides an authenticated fallback without a token", () => {
+  const authenticatedSnapshot = sharedNoteSnapshot(7);
+  const linkSnapshot = sharedNoteSnapshot(6);
+
+  assert.equal(
+    getLinkSharedNoteFallbackSnapshot({
+      authenticatedSnapshot,
+      linkSnapshot: null,
+    }),
+    authenticatedSnapshot,
+  );
+  assert.equal(
+    getLinkSharedNoteFallbackSnapshot({
+      authenticatedSnapshot,
+      linkSnapshot,
+    }),
+    linkSnapshot,
+  );
+});
+
+function sharedNoteSnapshot(contentRevision: number): SharedNoteSnapshot {
+  return {
+    shareId: "00000000-0000-4000-8000-000000000001",
+    schemaVersion: 1,
+    contentRevision,
+    title: "Weekly sync",
+    body: { type: "doc" },
+    attachments: [],
+    publishedAt: "2026-07-17T12:00:00Z",
+  };
+}

--- a/apps/web/src/lib/shared-note-route-state.ts
+++ b/apps/web/src/lib/shared-note-route-state.ts
@@ -1,3 +1,5 @@
+import type { SharedNoteSnapshot } from "./shared-notes";
+
 export function getInvitationRouteFailure({
   acceptanceFailed,
   inspectionFailed,
@@ -39,4 +41,14 @@ export function getLinkSharedNoteRouteGate({
     return "loading";
   }
   return null;
+}
+
+export function getLinkSharedNoteFallbackSnapshot({
+  authenticatedSnapshot,
+  linkSnapshot,
+}: {
+  authenticatedSnapshot: SharedNoteSnapshot | null;
+  linkSnapshot: SharedNoteSnapshot | null;
+}): SharedNoteSnapshot | null {
+  return linkSnapshot ?? authenticatedSnapshot;
 }

--- a/apps/web/src/lib/shared-notes.test.ts
+++ b/apps/web/src/lib/shared-notes.test.ts
@@ -17,6 +17,8 @@ import {
   parseSharedNoteAttachmentDownload,
   parseSharedNoteComment,
   parseSharedNoteCommentPage,
+  parseSharedNoteWebEditConflict,
+  parseSharedNoteWebEditSnapshot,
   withoutDuplicateLeadingTitle,
 } from "./shared-notes.ts";
 
@@ -85,6 +87,52 @@ test("parses the exact public gateway DTO", () => {
   assert.throws(() =>
     parseGatewaySharedNote({ snapshot: { shareId: snapshot.shareId } }),
   );
+  assert.throws(() =>
+    parseGatewaySharedNote({
+      ...snapshot,
+      accessVersion: 4,
+      webEditable: true,
+    }),
+  );
+});
+
+test("parses the exact web-edit snapshot without weakening public reads", () => {
+  const response = {
+    shareId: "00000000-0000-4000-8000-000000000001",
+    schemaVersion: 1,
+    contentRevision: 3,
+    title: "Weekly sync",
+    body: BODY,
+    attachments: [],
+    publishedAt: "2026-07-17T12:00:00Z",
+    accessVersion: 8,
+    webEditable: true,
+  };
+  const edited = parseSharedNoteWebEditSnapshot(response);
+
+  assert.equal(edited.snapshot.contentRevision, 3);
+  assert.equal(edited.accessVersion, 8);
+  assert.equal(edited.webEditable, true);
+  assert.throws(() =>
+    parseSharedNoteWebEditSnapshot({
+      ...edited.snapshot,
+      webEditable: true,
+    }),
+  );
+  assert.deepEqual(
+    parseSharedNoteWebEditConflict({
+      code: "snapshot_conflict",
+      snapshot: response,
+    }),
+    edited,
+  );
+  assert.throws(() =>
+    parseSharedNoteWebEditConflict({
+      code: "snapshot_conflict",
+      snapshot: response,
+      internalReason: "do not expose",
+    }),
+  );
 });
 
 test("maps authenticated snake-case RPC rows without internal identifiers", () => {
@@ -100,12 +148,14 @@ test("maps authenticated snake-case RPC rows without internal identifiers", () =
     capability: "commenter",
     manage_access: true,
     access_version: 7,
+    web_editable: false,
     published_at: "2026-07-17T12:00:00Z",
   });
 
   assert.equal(result.capability, "commenter");
   assert.equal(result.manageAccess, true);
   assert.equal(result.accessVersion, 7);
+  assert.equal(result.webEditable, false);
   assert.equal("workspaceId" in result.snapshot, false);
   assert.equal("sessionId" in result.snapshot, false);
   assert.throws(() =>
@@ -130,6 +180,7 @@ test("maps authenticated snake-case RPC rows without internal identifiers", () =
       capability: "commenter",
       manage_access: true,
       access_version: 0,
+      web_editable: false,
       published_at: "2026-07-17T12:00:00Z",
     }),
   );

--- a/apps/web/src/lib/shared-notes.ts
+++ b/apps/web/src/lib/shared-notes.ts
@@ -76,6 +76,12 @@ export type SharedNoteSnapshot = {
   publishedAt: string;
 };
 
+export type SharedNoteWebEditSnapshot = {
+  snapshot: SharedNoteSnapshot;
+  accessVersion: number;
+  webEditable: boolean;
+};
+
 export type SharedNoteAttachment = {
   id: string;
   filename: string;
@@ -94,6 +100,7 @@ export type AuthenticatedSharedNote = {
   capability: SharedNoteCapability;
   manageAccess: boolean;
   accessVersion: number;
+  webEditable: boolean;
 };
 
 export type SharedNoteComment = {
@@ -205,7 +212,7 @@ const gatewaySnapshotSchema = z
   .object({
     shareId: shareIdSchema,
     schemaVersion: z.literal(1),
-    contentRevision: z.number().int().positive(),
+    contentRevision: z.number().int().positive().safe(),
     title: z.string(),
     body: z.unknown(),
     attachments: z.array(z.unknown()).max(64),
@@ -213,17 +220,32 @@ const gatewaySnapshotSchema = z
   })
   .strict();
 
+const webEditSnapshotSchema = gatewaySnapshotSchema
+  .extend({
+    accessVersion: z.number().int().positive().safe(),
+    webEditable: z.boolean(),
+  })
+  .strict();
+
+const webEditConflictResponseSchema = z
+  .object({
+    code: z.literal("snapshot_conflict"),
+    snapshot: z.unknown(),
+  })
+  .strict();
+
 const authenticatedSnapshotRowSchema = z
   .object({
     share_id: shareIdSchema,
     schema_version: z.literal(1),
-    content_revision: z.number().int().positive(),
+    content_revision: z.number().int().positive().safe(),
     title: z.string(),
     body_json: z.unknown(),
     attachments_json: z.array(z.unknown()).max(64),
     capability: z.enum(["viewer", "commenter", "editor"]),
     manage_access: z.boolean(),
     access_version: z.number().int().positive().safe(),
+    web_editable: z.boolean(),
     published_at: z.string(),
   })
   .passthrough();
@@ -347,6 +369,25 @@ export function parseGatewaySharedNote(value: unknown): SharedNoteSnapshot {
   };
 }
 
+export function parseSharedNoteWebEditSnapshot(
+  value: unknown,
+): SharedNoteWebEditSnapshot {
+  const parsed = webEditSnapshotSchema.parse(value);
+  const { accessVersion, webEditable, ...snapshot } = parsed;
+  return {
+    accessVersion,
+    webEditable,
+    snapshot: parseGatewaySharedNote(snapshot),
+  };
+}
+
+export function parseSharedNoteWebEditConflict(
+  value: unknown,
+): SharedNoteWebEditSnapshot {
+  const parsed = webEditConflictResponseSchema.parse(value);
+  return parseSharedNoteWebEditSnapshot(parsed.snapshot);
+}
+
 export function parseAuthenticatedSharedNote(
   value: unknown,
 ): AuthenticatedSharedNote {
@@ -355,6 +396,7 @@ export function parseAuthenticatedSharedNote(
     capability: parsed.capability,
     manageAccess: parsed.manage_access,
     accessVersion: parsed.access_version,
+    webEditable: parsed.web_editable,
     snapshot: {
       shareId: parsed.share_id,
       schemaVersion: parsed.schema_version,

--- a/apps/web/src/routes/share/$shareId.tsx
+++ b/apps/web/src/routes/share/$shareId.tsx
@@ -1,14 +1,14 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import { AccountSharedNoteActions } from "@/components/shared-note-actions";
 import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
+import { SharedNoteEditableViewer } from "@/components/shared-note-editable-viewer";
 import {
   SharedNoteLoading,
   SharedNoteTransientError,
   SharedNoteUnavailable,
-  SharedNoteViewer,
 } from "@/components/shared-note-viewer";
 import { fetchUser } from "@/functions/auth";
 import {
@@ -61,6 +61,7 @@ export const Route = createFileRoute("/share/$shareId")({
 });
 
 function Component() {
+  const router = useRouter();
   const { result } = Route.useLoaderData();
   const { user } = Route.useRouteContext();
   const { scheme } = Route.useSearch();
@@ -83,9 +84,17 @@ function Component() {
   }
 
   return (
-    <SharedNoteViewer
+    <SharedNoteEditableViewer
+      key={note.snapshot.shareId}
       snapshot={note.snapshot}
+      authenticatedNote={note}
+      fallbackAccessLabel="Shared note · View only"
+      fallbackSnapshot={note.snapshot}
+      onAccessChanged={() => {
+        void router.invalidate();
+      }}
       resolveAttachment={resolveAttachment}
+      revokedBehavior="read-only"
       accessLabel={formatAuthenticatedSharedNoteAccessLabel(note)}
       collaboration={
         <SharedNoteCollaboration

--- a/apps/web/src/routes/share/link/$shareId.tsx
+++ b/apps/web/src/routes/share/link/$shareId.tsx
@@ -30,7 +30,10 @@ import {
   getPrivateShareHead,
   privateShareHeaders,
 } from "@/lib/shared-note-meta";
-import { getLinkSharedNoteRouteGate } from "@/lib/shared-note-route-state";
+import {
+  getLinkSharedNoteFallbackSnapshot,
+  getLinkSharedNoteRouteGate,
+} from "@/lib/shared-note-route-state";
 import {
   buildSharedNoteWebPath,
   sharedNoteDesktopSchemeSchema,
@@ -170,14 +173,26 @@ function LinkSharedNoteClient({
   if (!snapshot) {
     return <SharedNoteUnavailable />;
   }
+  const fallbackSnapshot = getLinkSharedNoteFallbackSnapshot({
+    authenticatedSnapshot: authenticatedNote?.snapshot ?? null,
+    linkSnapshot,
+  });
 
   return (
     <SharedNoteEditableViewer
       key={snapshot.shareId}
       snapshot={snapshot}
       authenticatedNote={authenticatedNote}
-      fallbackAccessLabel="Anyone with the link · View only"
-      fallbackSnapshot={linkSnapshot}
+      fallbackAccessLabel={
+        linkSnapshot
+          ? "Anyone with the link · View only"
+          : "Shared note · View only"
+      }
+      fallbackSnapshot={fallbackSnapshot}
+      onAccessChanged={() => {
+        void authenticatedQuery.refetch();
+        if (hasToken) void snapshotQuery.refetch();
+      }}
       resolveAttachment={resolveAttachment}
       revokedBehavior="read-only"
       accessLabel={

--- a/apps/web/src/routes/share/link/$shareId.tsx
+++ b/apps/web/src/routes/share/link/$shareId.tsx
@@ -6,11 +6,11 @@ import { useShareRouteContinuation } from "@/components/share-route-continuation
 import { LinkSharedNoteActions } from "@/components/shared-note-actions";
 import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
+import { SharedNoteEditableViewer } from "@/components/shared-note-editable-viewer";
 import {
   SharedNoteLoading,
   SharedNoteTransientError,
   SharedNoteUnavailable,
-  SharedNoteViewer,
 } from "@/components/shared-note-viewer";
 import { fetchUser } from "@/functions/auth";
 import {
@@ -103,14 +103,15 @@ function LinkSharedNoteClient({
       ? authenticatedQuery.data.note
       : null;
   const resolveAttachment = useCallback<SharedAttachmentResolver>(
-    (attachment, signal) => {
+    async (attachment, signal) => {
       if (authenticatedNote) {
-        return createAuthenticatedSharedAttachmentDownload({
+        const download = await createAuthenticatedSharedAttachmentDownload({
           data: {
             shareId: authenticatedNote.snapshot.shareId,
             attachmentId: attachment.id,
           },
         });
+        if (download) return download;
       }
       return continuation.token
         ? fetchLinkSharedAttachmentDownload(
@@ -171,9 +172,14 @@ function LinkSharedNoteClient({
   }
 
   return (
-    <SharedNoteViewer
+    <SharedNoteEditableViewer
+      key={snapshot.shareId}
       snapshot={snapshot}
+      authenticatedNote={authenticatedNote}
+      fallbackAccessLabel="Anyone with the link · View only"
+      fallbackSnapshot={linkSnapshot}
       resolveAttachment={resolveAttachment}
+      revokedBehavior="read-only"
       accessLabel={
         authenticatedNote &&
         shouldUseAuthenticatedSharedNoteAccessLabel(authenticatedNote)

--- a/apps/web/src/routes/share/public/$publicSlug.tsx
+++ b/apps/web/src/routes/share/public/$publicSlug.tsx
@@ -4,11 +4,11 @@ import { useCallback } from "react";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import { PublicSharedNoteActions } from "@/components/shared-note-actions";
 import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
+import { SharedNoteEditableViewer } from "@/components/shared-note-editable-viewer";
 import {
   SharedNoteLoading,
   SharedNoteTransientError,
   SharedNoteUnavailable,
-  SharedNoteViewer,
 } from "@/components/shared-note-viewer";
 import { fetchUser } from "@/functions/auth";
 import {
@@ -81,19 +81,22 @@ function Component() {
       ? authenticatedResult.note
       : null;
   const resolveAttachment = useCallback<SharedAttachmentResolver>(
-    (attachment, signal) =>
-      authenticatedNote
-        ? createAuthenticatedSharedAttachmentDownload({
+    async (attachment, signal) => {
+      if (authenticatedNote) {
+        const download = await createAuthenticatedSharedAttachmentDownload({
             data: {
               shareId: authenticatedNote.snapshot.shareId,
               attachmentId: attachment.id,
             },
-          })
-        : fetchPublicSharedAttachmentDownload(
-            publicSlug,
-            attachment.id,
-            signal,
-          ),
+          });
+        if (download) return download;
+      }
+      return fetchPublicSharedAttachmentDownload(
+        publicSlug,
+        attachment.id,
+        signal,
+      );
+    },
     [authenticatedNote, publicSlug],
   );
   if (result.status === "error") {
@@ -111,9 +114,14 @@ function Component() {
       : "Public note · View only";
 
   return (
-    <SharedNoteViewer
+    <SharedNoteEditableViewer
+      key={snapshot.shareId}
       snapshot={snapshot}
+      authenticatedNote={authenticatedNote}
+      fallbackAccessLabel="Public note · View only"
+      fallbackSnapshot={result.snapshot}
       resolveAttachment={resolveAttachment}
+      revokedBehavior="read-only"
       accessLabel={accessLabel}
       collaboration={
         <SharedNoteCollaboration

--- a/apps/web/src/routes/share/public/$publicSlug.tsx
+++ b/apps/web/src/routes/share/public/$publicSlug.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
@@ -73,6 +73,7 @@ export const Route = createFileRoute("/share/public/$publicSlug")({
 });
 
 function Component() {
+  const router = useRouter();
   const { authenticatedResult, result, user } = Route.useLoaderData();
   const { publicSlug } = Route.useParams();
   const { scheme } = Route.useSearch();
@@ -120,6 +121,9 @@ function Component() {
       authenticatedNote={authenticatedNote}
       fallbackAccessLabel="Public note · View only"
       fallbackSnapshot={result.snapshot}
+      onAccessChanged={() => {
+        void router.invalidate();
+      }}
       resolveAttachment={resolveAttachment}
       revokedBehavior="read-only"
       accessLabel={accessLabel}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4,6 +4,7 @@
 @import "../../../packages/ui/src/styles/scroll-fade.css";
 
 @source "../../../packages/changelog/src";
+@source "../../../packages/editor/src";
 @source "../../../packages/ui/src";
 
 @theme {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,9 @@ importers:
       '@hypr/changelog':
         specifier: workspace:^
         version: link:../../packages/changelog
+      '@hypr/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
       '@hypr/pricing':
         specifier: workspace:^
         version: link:../../packages/pricing


### PR DESCRIPTION
## Summary
- let authenticated invited editors edit shared notes in the browser while public and link-only access stays view-only
- keep drafts local until a revision-safe compare-and-swap save succeeds and surface recoverable conflicts instead of overwriting newer revisions
- preserve image and file attachments with the exact ordered manifest while stripping desktop-only attachment metadata before publish
- render shared attachments as locked metadata cards in the web editor and continue to block unsupported audio clip nodes
- revalidate access after permission changes while preserving the newest authorized read-only snapshot

## Safety
- attachment nodes must reference an ID in the immutable server manifest; missing or foreign IDs fail closed
- browser saves cannot add, replace, or reorder attachment bytes
- failed saves remain retryable only while the live draft is unchanged
- public and capability-link viewers never inherit edit permission
- authenticated no-token link routes use a temporary read-only fallback, then refetch to distinguish downgrade from full revocation
- access-loss fallback accepts only the same share and never regresses a successfully saved content revision

## Validation
- `pnpm -F @hypr/web test` (83 tests)
- `pnpm -F @hypr/web typecheck`
- `pnpm exec dprint check`
- production client and server bundles compiled locally; prerender requires deployment-only database, Supabase, Stripe, Loops, and Vite environment values
- independent attachment-contract review: pass, no merge blockers
- all Bugbot access-loss findings fixed with route-state and revision-selection regressions

#6129 is merged. This PR is rebased directly onto current `main`.

