### PR TITLE
fix(desktop): recover missing audio for re-transcription

### DIFF
--- a/apps/desktop/src/audio-player/provider.tsx
+++ b/apps/desktop/src/audio-player/provider.tsx
@@ -77,6 +77,7 @@ interface AudioPlayerContextValue {
   stop: () => void;
   seek: (sec: number) => void;
   audioExists: boolean;
+  audioExistsResolved: boolean;
   playbackRate: number;
   setPlaybackRate: (rate: number) => void;
   deleteRecording: () => Promise<void>;
@@ -98,7 +99,7 @@ export function useAudioTime(): TimeSnapshot {
   return useSyncExternalStore(timeStore.subscribe, timeStore.getSnapshot);
 }
 
-export function useAudioExists(sessionId: string): boolean {
+function useAudioExistence(sessionId: string) {
   const audioExists = useQuery({
     queryKey: ["audio", sessionId, "exist"],
     queryFn: () => fsSyncCommands.audioExist(sessionId),
@@ -110,7 +111,14 @@ export function useAudioExists(sessionId: string): boolean {
     },
   });
 
-  return audioExists.data ?? false;
+  return {
+    audioExists: audioExists.data ?? false,
+    audioExistsResolved: audioExists.isSuccess,
+  };
+}
+
+export function useAudioExists(sessionId: string): boolean {
+  return useAudioExistence(sessionId).audioExists;
 }
 
 export function AudioPlayerProvider({
@@ -130,7 +138,8 @@ export function AudioPlayerProvider({
   const [playbackRate, setPlaybackRateState] = useState(1);
   const timeStoreRef = useRef(new TimeStore());
   const stopRequestedRef = useRef(false);
-  const audioExistsValue = useAudioExists(sessionId);
+  const { audioExists: audioExistsValue, audioExistsResolved } =
+    useAudioExistence(sessionId);
 
   const registerContainer = useCallback((el: HTMLDivElement | null) => {
     setContainer((prev) => (prev === el ? prev : el));
@@ -349,6 +358,7 @@ export function AudioPlayerProvider({
       stop,
       seek,
       audioExists: audioExistsValue,
+      audioExistsResolved,
       playbackRate,
       setPlaybackRate,
       deleteRecording: deleteRecordingMutation.mutateAsync,
@@ -364,6 +374,7 @@ export function AudioPlayerProvider({
       stop,
       seek,
       audioExistsValue,
+      audioExistsResolved,
       playbackRate,
       setPlaybackRate,
       deleteRecordingMutation.mutateAsync,

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -30,6 +30,7 @@ const hoisted = vi.hoisted(() => ({
   deleteRecording: vi.fn(),
   activeTemplateTitle: "Customer Call",
   audioExists: true,
+  audioExistsResolved: true,
   hasTranscript: true,
   liveSegments: [] as unknown[],
   liveSessionId: null as string | null,
@@ -134,6 +135,7 @@ vi.mock("@hypr/ui/components/ui/dancing-sticks", () => ({
 vi.mock("~/audio-player", () => ({
   useAudioPlayer: () => ({
     audioExists: hoisted.audioExists,
+    audioExistsResolved: hoisted.audioExistsResolved,
     deleteRecording: hoisted.deleteRecording,
     isDeletingRecording: hoisted.isDeletingRecording,
   }),
@@ -320,6 +322,7 @@ describe("Header", () => {
     hoisted.deleteRecording.mockReset();
     hoisted.activeTemplateTitle = "Customer Call";
     hoisted.audioExists = true;
+    hoisted.audioExistsResolved = true;
     hoisted.hasTranscript = true;
     hoisted.liveSegments = [];
     hoisted.liveSessionId = null;
@@ -597,6 +600,60 @@ describe("Header", () => {
     expect(hoisted.uploadAudio).toHaveBeenCalledWith({
       preserveSessionDate: true,
     });
+  });
+
+  it.each(["active", "finalizing", "running_batch"])(
+    "hides re-transcription actions while the session is %s",
+    (sessionMode) => {
+      hoisted.audioExists = false;
+      hoisted.sessionMode = sessionMode;
+
+      render(
+        <Header
+          sessionId="session-1"
+          editorTabs={[
+            { type: "enhanced", id: "note-1" },
+            { type: "raw" },
+            { type: "transcript" },
+          ]}
+          currentTab={{ type: "transcript" }}
+          handleTabChange={vi.fn()}
+        />,
+      );
+
+      expect(
+        findContextMenu("copy-transcript-session-1").map((item) =>
+          "text" in item ? item.text : "separator",
+        ),
+      ).toEqual(["Copy"]);
+    },
+  );
+
+  it.each([
+    ["no stored transcript", { hasTranscript: false }],
+    ["audio lookup is pending or failed", { audioExistsResolved: false }],
+  ])("hides replacement upload when %s", (_label, state) => {
+    hoisted.audioExists = false;
+    Object.assign(hoisted, state);
+
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={[
+          { type: "enhanced", id: "note-1" },
+          { type: "raw" },
+          { type: "transcript" },
+        ]}
+        currentTab={{ type: "transcript" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      findContextMenu("copy-transcript-session-1").map((item) =>
+        "text" in item ? item.text : "separator",
+      ),
+    ).toEqual(["Copy"]);
   });
 
   it("replaces the current enhanced note when changing templates", async () => {

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -22,6 +22,7 @@ type CapturedMenuItem =
 const hoisted = vi.hoisted(() => ({
   enhance: vi.fn(),
   regenerateTranscript: vi.fn(),
+  uploadAudio: vi.fn(),
   startListening: vi.fn(),
   stopListening: vi.fn(),
   stopTranscription: vi.fn(),
@@ -192,6 +193,10 @@ vi.mock("~/session/queries", () => ({
 
 vi.mock("~/session/components/note-input/transcript/actions", () => ({
   useRegenerateTranscript: () => hoisted.regenerateTranscript,
+}));
+
+vi.mock("~/stt/useUploadFile", () => ({
+  useUploadFile: () => ({ uploadAudio: hoisted.uploadAudio }),
 }));
 
 vi.mock("~/session/components/note-input/transcript/export-data", () => ({
@@ -559,7 +564,7 @@ describe("Header", () => {
     expect(hoisted.transcriptRenderDataCalls).toBe(1);
   });
 
-  it("omits transcript recording actions when recording is missing", () => {
+  it("offers audio upload for re-transcription when recording is missing", () => {
     hoisted.audioExists = false;
     const editorTabs: EditorView[] = [
       { type: "enhanced", id: "note-1" },
@@ -580,7 +585,18 @@ describe("Header", () => {
 
     expect(
       menu.map((item) => ("text" in item ? item.text : "separator")),
-    ).toEqual(["Copy"]);
+    ).toEqual(["Copy", "Upload audio to re-transcribe"]);
+
+    menu
+      .find(
+        (item): item is Extract<CapturedMenuItem, { id: string }> =>
+          "id" in item && item.id === "regenerate-transcript-session-1",
+      )
+      ?.action();
+
+    expect(hoisted.uploadAudio).toHaveBeenCalledWith({
+      preserveSessionDate: true,
+    });
   });
 
   it("replaces the current enhanced note when changing templates", async () => {

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -34,7 +34,10 @@ import {
   formatTranscriptExportSegments,
 } from "~/session/components/note-input/transcript/export-data";
 import { useSessionTranscriptRenderData } from "~/session/components/note-input/transcript/render-request-hooks";
-import { useCanShowTranscript } from "~/session/components/shared";
+import {
+  useCanShowTranscript,
+  useHasTranscript,
+} from "~/session/components/shared";
 import { useEnsureDefaultSummary } from "~/session/hooks/useEnhancedNotes";
 import {
   deleteEnhancedNote,
@@ -750,8 +753,14 @@ function HeaderViewTranscriptActive({
   const { uploadAudio } = useUploadFile(sessionId);
   const { request: transcriptExportRequest } =
     useSessionTranscriptRenderData(sessionId);
-  const { audioExists, deleteRecording, isDeletingRecording } =
-    AudioPlayer.useAudioPlayer();
+  const {
+    audioExists,
+    audioExistsResolved,
+    deleteRecording,
+    isDeletingRecording,
+  } = AudioPlayer.useAudioPlayer();
+  const hasTranscript = useHasTranscript(sessionId);
+  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const canCopyTranscript = Boolean(transcriptExportRequest);
   const handleCopyTranscript = useCallback(async () => {
     if (!transcriptExportRequest) {
@@ -791,17 +800,23 @@ function HeaderViewTranscriptActive({
       },
     ];
 
-    items.push({
-      id: `regenerate-transcript-${sessionId}`,
-      text: audioExists ? "Re-transcribe" : "Upload audio to re-transcribe",
-      action: () => {
-        if (audioExists) {
-          void regenerate();
-        } else {
-          uploadAudio({ preserveSessionDate: true });
-        }
-      },
-    });
+    if (
+      audioExistsResolved &&
+      sessionMode === "inactive" &&
+      (audioExists || hasTranscript)
+    ) {
+      items.push({
+        id: `regenerate-transcript-${sessionId}`,
+        text: audioExists ? "Re-transcribe" : "Upload audio to re-transcribe",
+        action: () => {
+          if (audioExists) {
+            void regenerate();
+          } else {
+            uploadAudio({ preserveSessionDate: true });
+          }
+        },
+      });
+    }
 
     if (audioExists) {
       items.push({
@@ -815,11 +830,14 @@ function HeaderViewTranscriptActive({
     return items;
   }, [
     audioExists,
+    audioExistsResolved,
     canCopyTranscript,
     handleCopyTranscript,
     handleDeleteRecording,
+    hasTranscript,
     isDeletingRecording,
     regenerate,
+    sessionMode,
     sessionId,
     uploadAudio,
   ]);

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -51,6 +51,7 @@ import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
+import { useUploadFile } from "~/stt/useUploadFile";
 import {
   filterWebTemplatesAgainstUserTemplates,
   DEFAULT_TEMPLATE_ICON,
@@ -746,6 +747,7 @@ function HeaderViewTranscriptActive({
   };
 }) {
   const regenerate = useRegenerateTranscript(sessionId);
+  const { uploadAudio } = useUploadFile(sessionId);
   const { request: transcriptExportRequest } =
     useSessionTranscriptRenderData(sessionId);
   const { audioExists, deleteRecording, isDeletingRecording } =
@@ -789,14 +791,19 @@ function HeaderViewTranscriptActive({
       },
     ];
 
-    if (audioExists) {
-      items.push({
-        id: `regenerate-transcript-${sessionId}`,
-        text: "Re-transcribe",
-        action: () => {
+    items.push({
+      id: `regenerate-transcript-${sessionId}`,
+      text: audioExists ? "Re-transcribe" : "Upload audio to re-transcribe",
+      action: () => {
+        if (audioExists) {
           void regenerate();
-        },
-      });
+        } else {
+          uploadAudio({ preserveSessionDate: true });
+        }
+      },
+    });
+
+    if (audioExists) {
       items.push({
         id: `delete-recording-${sessionId}`,
         text: "Delete recording",
@@ -814,6 +821,7 @@ function HeaderViewTranscriptActive({
     isDeletingRecording,
     regenerate,
     sessionId,
+    uploadAudio,
   ]);
   const showContextMenu = useNativeContextMenu(contextMenu);
 

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -165,7 +165,7 @@ describe("OverflowButton", () => {
     expect(uploadTranscriptMock).toHaveBeenCalledTimes(1);
   });
 
-  it("hides upload actions when the session already has a transcript", () => {
+  it("offers audio upload for re-transcription when recording is missing", () => {
     render(
       <OverflowButton
         sessionId="session-1"
@@ -177,12 +177,21 @@ describe("OverflowButton", () => {
     expect(
       screen.queryByRole("button", { name: "Upload transcript" }),
     ).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Upload audio to re-transcribe" }),
+    );
     expect(
       screen.getByRole("button", { name: "Resume listening" }),
     ).not.toBeNull();
+    expect(uploadAudioMock).toHaveBeenCalledWith({
+      preserveSessionDate: true,
+    });
   });
 
   it("renders one separator when meeting actions are disabled", () => {
+    useHasTranscriptMock.mockReturnValue(false);
+    currentNoteContent.value = "Existing content";
+
     const { container } = render(
       <OverflowButton
         allowListening={false}

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -17,6 +17,7 @@ const {
   uploadTranscriptMock,
   regenerateTranscriptMock,
   audioExists,
+  audioExistsResolved,
   currentNoteContent,
   exportModalMock,
   useHasTranscriptMock,
@@ -28,6 +29,7 @@ const {
   uploadTranscriptMock: vi.fn(),
   regenerateTranscriptMock: vi.fn(),
   audioExists: { value: false },
+  audioExistsResolved: { value: true },
   currentNoteContent: { value: "" },
   exportModalMock: vi.fn(
     (_props: { open: boolean; onOpenChange: (open: boolean) => void }) => null,
@@ -96,7 +98,10 @@ vi.mock("~/meeting-float/host", () => ({
 }));
 
 vi.mock("~/audio-player", () => ({
-  useAudioPlayer: () => ({ audioExists: audioExists.value }),
+  useAudioPlayer: () => ({
+    audioExists: audioExists.value,
+    audioExistsResolved: audioExistsResolved.value,
+  }),
 }));
 
 vi.mock("~/session/components/note-input/transcript/actions", () => ({
@@ -137,6 +142,7 @@ describe("OverflowButton", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     audioExists.value = false;
+    audioExistsResolved.value = true;
     currentNoteContent.value = "";
     useHasTranscriptMock.mockReturnValue(true);
     useConfigValueMock.mockReturnValue(false);
@@ -187,6 +193,62 @@ describe("OverflowButton", () => {
       preserveSessionDate: true,
     });
   });
+
+  it("hides replacement upload until the audio lookup succeeds", () => {
+    audioExistsResolved.value = false;
+
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Upload audio to re-transcribe" }),
+    ).toBeNull();
+  });
+
+  it("hides initial upload actions until the audio lookup succeeds", () => {
+    audioExistsResolved.value = false;
+    useHasTranscriptMock.mockReturnValue(false);
+
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Upload audio" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Upload transcript" }),
+    ).toBeNull();
+  });
+
+  it.each(["active", "finalizing", "running_batch"])(
+    "hides re-transcription actions while the session is %s",
+    (sessionMode) => {
+      useListenerMock.mockImplementation((selector) =>
+        selector({
+          getSessionMode: () => sessionMode,
+        }),
+      );
+
+      render(
+        <OverflowButton
+          sessionId="session-1"
+          currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+        />,
+      );
+
+      expect(
+        screen.queryByRole("button", {
+          name: "Upload audio to re-transcribe",
+        }),
+      ).toBeNull();
+    },
+  );
 
   it("renders one separator when meeting actions are disabled", () => {
     useHasTranscriptMock.mockReturnValue(false);

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -66,7 +66,8 @@ export function OverflowButton({
     sessionMode === "active" || sessionMode === "finalizing";
   const isRetranscribing = sessionMode === "running_batch";
   const showListeningAction = allowListening;
-  const showRetranscribeAction = audioExists && !isMeetingInProgress;
+  const showRetranscribeAction =
+    (audioExists || hasTranscript) && !isMeetingInProgress;
   const showUploadActions =
     !audioExists &&
     !hasTranscript &&
@@ -94,7 +95,11 @@ export function OverflowButton({
   };
   const handleRetranscribe = () => {
     setOpen(false);
-    void regenerateTranscript();
+    if (audioExists) {
+      void regenerateTranscript();
+    } else {
+      uploadAudio({ preserveSessionDate: true });
+    }
   };
   const handleOpenFloatingPanel = () => {
     setOpen(false);
@@ -146,7 +151,11 @@ export function OverflowButton({
                 className="cursor-pointer"
               >
                 <RefreshCwIcon />
-                <span>Re-transcribe</span>
+                <span>
+                  {audioExists
+                    ? "Re-transcribe"
+                    : "Upload audio to re-transcribe"}
+                </span>
               </DropdownMenuItem>
             )}
             {showUploadActions && (

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -57,18 +57,20 @@ export function OverflowButton({
     sessionId,
     currentView,
   );
-  const { audioExists } = useAudioPlayer();
+  const { audioExists, audioExistsResolved } = useAudioPlayer();
   const { uploadAudio, uploadTranscript } = useUploadFile(sessionId);
   const regenerateTranscript = useRegenerateTranscript(sessionId);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
   const isMeetingInProgress =
     sessionMode === "active" || sessionMode === "finalizing";
-  const isRetranscribing = sessionMode === "running_batch";
   const showListeningAction = allowListening;
   const showRetranscribeAction =
-    (audioExists || hasTranscript) && !isMeetingInProgress;
+    audioExistsResolved &&
+    sessionMode === "inactive" &&
+    (audioExists || hasTranscript);
   const showUploadActions =
+    audioExistsResolved &&
     !audioExists &&
     !hasTranscript &&
     !currentNoteHasContent &&
@@ -147,7 +149,6 @@ export function OverflowButton({
             {showRetranscribeAction && (
               <DropdownMenuItem
                 onClick={handleRetranscribe}
-                disabled={isRetranscribing}
                 className="cursor-pointer"
               >
                 <RefreshCwIcon />

--- a/apps/desktop/src/stt/useUploadFile.test.tsx
+++ b/apps/desktop/src/stt/useUploadFile.test.tsx
@@ -6,9 +6,12 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { isAudioUploadFile, useUploadFile } from "./useUploadFile";
 
 const {
+  audioSourceMetadataMock,
   audioImportDataMock,
   audioImportMock,
   audioImportListenMock,
+  downloadDirMock,
+  selectFileMock,
   parseSubtitleMock,
   createTranscriptMock,
   enhanceMock,
@@ -23,9 +26,12 @@ const {
   useTabsMock,
   updateSessionTabStateMock,
 } = vi.hoisted(() => ({
+  audioSourceMetadataMock: vi.fn(),
   audioImportDataMock: vi.fn(),
   audioImportMock: vi.fn(),
   audioImportListenMock: vi.fn(),
+  downloadDirMock: vi.fn(),
+  selectFileMock: vi.fn(),
   parseSubtitleMock: vi.fn(),
   createTranscriptMock: vi.fn(),
   enhanceMock: vi.fn(),
@@ -42,7 +48,7 @@ const {
 }));
 
 vi.mock("@tauri-apps/api/path", () => ({
-  downloadDir: vi.fn(),
+  downloadDir: downloadDirMock,
   resolveResource: vi.fn((path: string) =>
     Promise.resolve(`/resources/${path}`),
   ),
@@ -50,14 +56,14 @@ vi.mock("@tauri-apps/api/path", () => ({
 }));
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
-  open: vi.fn(),
+  open: selectFileMock,
 }));
 
 vi.mock("@hypr/plugin-fs-sync", () => ({
   commands: {
     audioImport: audioImportMock,
     audioImportData: audioImportDataMock,
-    audioSourceMetadata: vi.fn(),
+    audioSourceMetadata: audioSourceMetadataMock,
   },
   events: {
     audioImportEvent: {
@@ -129,7 +135,21 @@ describe("useUploadFile", () => {
       status: "ok",
       data: "/vault/sessions/session-1/audio.wav",
     });
+    audioImportMock.mockResolvedValue({
+      status: "ok",
+      data: "/vault/sessions/session-1/audio.wav",
+    });
     audioImportListenMock.mockResolvedValue(vi.fn());
+    audioSourceMetadataMock.mockResolvedValue({
+      status: "ok",
+      data: {
+        createdAt: "2026-03-26T12:00:00.000Z",
+        modifiedAt: null,
+        durationMs: 30_000,
+      },
+    });
+    downloadDirMock.mockResolvedValue("/downloads");
+    selectFileMock.mockResolvedValue("/tmp/replacement.wav");
     catalogLocalSessionAudioMock.mockResolvedValue(undefined);
     runBatchMock.mockResolvedValue(undefined);
     createTranscriptMock.mockResolvedValue(undefined);
@@ -146,6 +166,39 @@ describe("useUploadFile", () => {
         tabs: [],
         updateSessionTabState: updateSessionTabStateMock,
       }),
+    );
+  });
+
+  test("preserves the session date when replacement audio is selected", async () => {
+    const { result } = renderHook(() => useUploadFile("session-1"), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.uploadAudio({ preserveSessionDate: true });
+    });
+
+    await waitFor(() => expect(runBatchMock).toHaveBeenCalled());
+    expect(audioSourceMetadataMock).not.toHaveBeenCalled();
+    expect(updateSessionMock).not.toHaveBeenCalled();
+  });
+
+  test("infers the session date for an ordinary audio upload", async () => {
+    const { result } = renderHook(() => useUploadFile("session-1"), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.uploadAudio();
+    });
+
+    await waitFor(() => {
+      expect(updateSessionMock).toHaveBeenCalledWith({
+        created_at: "2026-03-26T11:59:30.000Z",
+      });
+    });
+    expect(audioSourceMetadataMock).toHaveBeenCalledWith(
+      "/tmp/replacement.wav",
     );
   });
 

--- a/apps/desktop/src/stt/useUploadFile.ts
+++ b/apps/desktop/src/stt/useUploadFile.ts
@@ -256,7 +256,11 @@ export function useUploadFile(sessionId: string) {
   );
 
   const processFile = useCallback(
-    (filePath: string, kind: "audio" | "transcript") => {
+    (
+      filePath: string,
+      kind: "audio" | "transcript",
+      options?: { preserveSessionDate?: boolean },
+    ) => {
       const normalizedPath = filePath.toLowerCase();
 
       if (kind === "transcript") {
@@ -333,7 +337,10 @@ export function useUploadFile(sessionId: string) {
           importWithProgress(() =>
             fsSyncCommands.audioImport(sessionId, filePath),
           ),
-        () => applyEstimatedAudioNoteDate(filePath),
+        () =>
+          options?.preserveSessionDate
+            ? Promise.resolve()
+            : applyEstimatedAudioNoteDate(filePath),
       );
     },
     [
@@ -381,7 +388,10 @@ export function useUploadFile(sessionId: string) {
   );
 
   const selectAndUpload = useCallback(
-    (kind: "audio" | "transcript") => {
+    (
+      kind: "audio" | "transcript",
+      options?: { preserveSessionDate?: boolean },
+    ) => {
       const filters =
         kind === "audio"
           ? [{ name: "Audio", extensions: AUDIO_EXTENSIONS }]
@@ -406,7 +416,7 @@ export function useUploadFile(sessionId: string) {
         .then((selection) => {
           const path = Array.isArray(selection) ? selection[0] : selection;
           if (path) {
-            processFile(path, kind);
+            processFile(path, kind, options);
           }
         })
         .catch((error) => {
@@ -417,7 +427,8 @@ export function useUploadFile(sessionId: string) {
   );
 
   const uploadAudio = useCallback(
-    () => selectAndUpload("audio"),
+    (options?: { preserveSessionDate?: boolean }) =>
+      selectAndUpload("audio", options),
     [selectAndUpload],
   );
   const uploadTranscript = useCallback(


### PR DESCRIPTION
## Summary
- offer replacement-audio upload when a transcript exists but its local recording is missing
- route both transcript action surfaces through the normal batch-transcription flow after the user selects a replacement file
- preserve the existing note date during replacement while keeping metadata-based date inference for ordinary first-time audio imports
- keep uploaded and recorded audio under the same user-selected retention policy

## Safety
- replacement upload appears only after audio absence is confirmed, a stored transcript exists, and the session is inactive
- loading or failed audio lookups never expose replacement or initial upload actions
- picker cancellation and invalid files leave the session unchanged
- replacement import preserves `sessions.created_at`, preventing notes from silently moving in the timeline
- the implementation does not add a permanent-retention exemption or new attachment metadata

## Validation
- focused retranscription and audio-state suites: 3 files, 58 tests
- full desktop suite: 247 files, 1,836 tests
- `pnpm -F @hypr/desktop typecheck`
- `pnpm -F @hypr/desktop i18n:check`
- `pnpm exec dprint check` on all changed files
- independent post-fix review: pass, both prior safety blockers closed

#6130 and #6132 are merged. This PR is rebased directly onto current `main`.

