### PR TITLE
fix(sharing): make access revalidation authoritative

### DIFF
--- a/apps/web/src/components/shared-note-editable-viewer.tsx
+++ b/apps/web/src/components/shared-note-editable-viewer.tsx
@@ -11,7 +11,10 @@ import {
   getSharedNoteReadOnlySnapshot,
   getSharedNoteWebEditPreparationMessage,
   hasUnsupportedSharedNoteEditorNode,
+  resolveSharedNoteViewerAuthorization,
   shouldRenderSharedNoteUnavailable,
+  syncSharedNoteViewerAuthorization,
+  type SharedNoteViewerAuthorization,
 } from "@/lib/shared-note-editing";
 import type {
   AuthenticatedSharedNote,
@@ -43,43 +46,43 @@ export function SharedNoteEditableViewer({
   collaboration?: React.ReactNode;
   fallbackAccessLabel?: string;
   fallbackSnapshot?: SharedNoteSnapshot | null;
-  onAccessChanged?: () => void;
+  onAccessChanged?: () => Promise<AuthenticatedSharedNote | null>;
   resolveAttachment?: SharedAttachmentResolver;
   revokedBehavior: "read-only" | "unavailable";
   snapshot: SharedNoteSnapshot;
 }) {
   const [snapshot, setSnapshot] = useState(initialSnapshot);
-  const [activeAuthenticatedNote, setActiveAuthenticatedNote] =
-    useState(authenticatedNote);
+  const [authorization, setAuthorization] =
+    useState<SharedNoteViewerAuthorization>({
+      note: authenticatedNote,
+      state: "ready",
+    });
   const [source, setSource] = useState({
     authenticatedNote,
     snapshot: initialSnapshot,
   });
   const [isEditing, setIsEditing] = useState(false);
-  const [accessRevoked, setAccessRevoked] = useState(false);
-  const [requiresSignIn, setRequiresSignIn] = useState(false);
 
   if (
     !isEditing &&
     (source.snapshot !== initialSnapshot ||
       source.authenticatedNote !== authenticatedNote)
   ) {
-    const priorAccessVersion = source.authenticatedNote?.accessVersion ?? 0;
     setSource({ authenticatedNote, snapshot: initialSnapshot });
     setSnapshot((current) =>
       initialSnapshot.contentRevision >= current.contentRevision
         ? initialSnapshot
         : current,
     );
-    setActiveAuthenticatedNote(authenticatedNote);
-    if (authenticatedNote) {
-      setRequiresSignIn(false);
-      if (authenticatedNote.accessVersion > priorAccessVersion) {
-        setAccessRevoked(false);
-      }
+    if (authorization.state !== "sign_in_required") {
+      setAuthorization((current) =>
+        syncSharedNoteViewerAuthorization(current, authenticatedNote),
+      );
     }
   }
 
+  const accessRevoked = authorization.state === "access_changed";
+  const requiresSignIn = authorization.state === "sign_in_required";
   const readOnlySnapshot = getSharedNoteReadOnlySnapshot(
     snapshot,
     fallbackSnapshot,
@@ -90,11 +93,11 @@ export function SharedNoteEditableViewer({
     activeSnapshot.body,
   );
   const canEdit =
-    !accessRevoked &&
-    canEditSharedNoteOnWeb(activeAuthenticatedNote) &&
+    authorization.state === "ready" &&
+    canEditSharedNoteOnWeb(authorization.note) &&
     !hasUnsupportedContent;
   const preparationMessage = getSharedNoteWebEditPreparationMessage(
-    accessRevoked ? null : activeAuthenticatedNote,
+    authorization.state === "ready" ? authorization.note : null,
     hasUnsupportedContent,
   );
 
@@ -167,11 +170,27 @@ export function SharedNoteEditableViewer({
               }}
               onUnavailable={(reason) => {
                 if (reason === "access_changed") {
-                  setAccessRevoked(true);
-                  onAccessChanged?.();
+                  setAuthorization((current) => ({
+                    ...current,
+                    state: "access_changed",
+                  }));
+                  const refresh = onAccessChanged?.();
+                  if (refresh) {
+                    void refresh
+                      .then((note) => {
+                        setAuthorization((current) =>
+                          current.state === "sign_in_required"
+                            ? current
+                            : resolveSharedNoteViewerAuthorization(note),
+                        );
+                      })
+                      .catch(() => {});
+                  }
                 } else {
-                  setRequiresSignIn(true);
-                  setActiveAuthenticatedNote(null);
+                  setAuthorization({
+                    note: null,
+                    state: "sign_in_required",
+                  });
                 }
                 setIsEditing(false);
               }}
@@ -200,17 +219,17 @@ export function SharedNoteEditableViewer({
   function applyEditedSnapshot(edited: SharedNoteWebEditSnapshot) {
     setSource({ authenticatedNote, snapshot: initialSnapshot });
     setSnapshot(edited.snapshot);
-    setRequiresSignIn(false);
-    setActiveAuthenticatedNote((note) =>
-      note
+    setAuthorization((current) => ({
+      state: "ready",
+      note: current.note
         ? {
-            ...note,
+            ...current.note,
             accessVersion: edited.accessVersion,
             snapshot: edited.snapshot,
             webEditable: edited.webEditable,
           }
-        : note,
-    );
+        : null,
+    }));
   }
 }
 

--- a/apps/web/src/lib/shared-note-editing.test.ts
+++ b/apps/web/src/lib/shared-note-editing.test.ts
@@ -10,10 +10,16 @@ import {
   getSharedNoteReadOnlySnapshot,
   getSharedNoteWebEditPreparationMessage,
   hasUnsupportedSharedNoteEditorNode,
+  resolveSharedNoteViewerAuthorization,
   reuseSharedNoteMutationIdForUnchangedDraft,
   shouldRenderSharedNoteUnavailable,
+  syncSharedNoteViewerAuthorization,
 } from "./shared-note-editing.ts";
-import type { SharedNoteDocument, SharedNoteSnapshot } from "./shared-notes.ts";
+import type {
+  AuthenticatedSharedNote,
+  SharedNoteDocument,
+  SharedNoteSnapshot,
+} from "./shared-notes.ts";
 
 const BODY: SharedNoteDocument = {
   type: "doc",
@@ -43,6 +49,35 @@ test("allows web editing only for an authenticated editable editor", () => {
   assert.equal(
     canEditSharedNoteOnWeb({ capability: "editor", webEditable: true }),
     true,
+  );
+});
+
+test("keeps sign-in expiry sticky across stale authenticated prop updates", () => {
+  const expired = {
+    note: null,
+    state: "sign_in_required" as const,
+  };
+  const staleAuthenticatedNote = authenticatedEditor(3);
+
+  assert.equal(
+    syncSharedNoteViewerAuthorization(expired, staleAuthenticatedNote),
+    expired,
+  );
+});
+
+test("restores confirmed edit access without requiring a version increase", () => {
+  const refreshed = authenticatedEditor(3);
+
+  assert.deepEqual(resolveSharedNoteViewerAuthorization(refreshed), {
+    note: refreshed,
+    state: "ready",
+  });
+  assert.equal(
+    resolveSharedNoteViewerAuthorization({
+      ...refreshed,
+      capability: "viewer",
+    }).state,
+    "access_changed",
   );
 });
 
@@ -148,6 +183,16 @@ function sharedNoteSnapshot(contentRevision: number): SharedNoteSnapshot {
     body: BODY,
     attachments: [],
     publishedAt: "2026-07-17T12:00:00Z",
+  };
+}
+
+function authenticatedEditor(accessVersion: number): AuthenticatedSharedNote {
+  return {
+    snapshot: sharedNoteSnapshot(7),
+    capability: "editor",
+    manageAccess: false,
+    accessVersion,
+    webEditable: true,
   };
 }
 

--- a/apps/web/src/lib/shared-note-editing.test.ts
+++ b/apps/web/src/lib/shared-note-editing.test.ts
@@ -79,6 +79,13 @@ test("restores confirmed edit access without requiring a version increase", () =
     }).state,
     "access_changed",
   );
+  assert.equal(
+    resolveSharedNoteViewerAuthorization({
+      ...refreshed,
+      webEditable: false,
+    }).state,
+    "ready",
+  );
 });
 
 test("shows the preparation message only to authenticated editors", () => {

--- a/apps/web/src/lib/shared-note-editing.ts
+++ b/apps/web/src/lib/shared-note-editing.ts
@@ -17,10 +17,31 @@ export type SharedNoteWebEditInput = {
   attachmentIds: string[];
 };
 
+export type SharedNoteViewerAuthorization = {
+  note: AuthenticatedSharedNote | null;
+  state: "ready" | "access_changed" | "sign_in_required";
+};
+
 export function canEditSharedNoteOnWeb(
   note: Pick<AuthenticatedSharedNote, "capability" | "webEditable"> | null,
 ) {
   return note?.capability === "editor" && note.webEditable;
+}
+
+export function syncSharedNoteViewerAuthorization(
+  current: SharedNoteViewerAuthorization,
+  note: AuthenticatedSharedNote | null,
+): SharedNoteViewerAuthorization {
+  return current.state === "sign_in_required" ? current : { ...current, note };
+}
+
+export function resolveSharedNoteViewerAuthorization(
+  note: AuthenticatedSharedNote | null,
+): SharedNoteViewerAuthorization {
+  return {
+    note,
+    state: canEditSharedNoteOnWeb(note) ? "ready" : "access_changed",
+  };
 }
 
 export function getSharedNoteWebEditPreparationMessage(

--- a/apps/web/src/lib/shared-note-editing.ts
+++ b/apps/web/src/lib/shared-note-editing.ts
@@ -40,7 +40,7 @@ export function resolveSharedNoteViewerAuthorization(
 ): SharedNoteViewerAuthorization {
   return {
     note,
-    state: canEditSharedNoteOnWeb(note) ? "ready" : "access_changed",
+    state: note?.capability === "editor" ? "ready" : "access_changed",
   };
 }
 

--- a/apps/web/src/routes/share/$shareId.tsx
+++ b/apps/web/src/routes/share/$shareId.tsx
@@ -90,8 +90,12 @@ function Component() {
       authenticatedNote={note}
       fallbackAccessLabel="Shared note · View only"
       fallbackSnapshot={note.snapshot}
-      onAccessChanged={() => {
-        void router.invalidate();
+      onAccessChanged={async () => {
+        await router.invalidate();
+        const refreshed = await readAuthenticatedSharedNote({
+          data: note.snapshot.shareId,
+        });
+        return refreshed.status === "ready" ? refreshed.note : null;
       }}
       resolveAttachment={resolveAttachment}
       revokedBehavior="read-only"

--- a/apps/web/src/routes/share/link/$shareId.tsx
+++ b/apps/web/src/routes/share/link/$shareId.tsx
@@ -189,9 +189,15 @@ function LinkSharedNoteClient({
           : "Shared note · View only"
       }
       fallbackSnapshot={fallbackSnapshot}
-      onAccessChanged={() => {
-        void authenticatedQuery.refetch();
-        if (hasToken) void snapshotQuery.refetch();
+      onAccessChanged={async () => {
+        const [refreshed] = await Promise.all([
+          authenticatedQuery.refetch(),
+          hasToken ? snapshotQuery.refetch() : Promise.resolve(null),
+        ]);
+        return refreshed.status === "success" &&
+          refreshed.data.status === "ready"
+          ? refreshed.data.note
+          : null;
       }}
       resolveAttachment={resolveAttachment}
       revokedBehavior="read-only"

--- a/apps/web/src/routes/share/public/$publicSlug.tsx
+++ b/apps/web/src/routes/share/public/$publicSlug.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute, useRouter } from "@tanstack/react-router";
 import { useCallback } from "react";
 
-import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import { PublicSharedNoteActions } from "@/components/shared-note-actions";
 import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
+import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import { SharedNoteEditableViewer } from "@/components/shared-note-editable-viewer";
 import {
   SharedNoteLoading,
@@ -16,16 +16,13 @@ import {
   readAuthenticatedSharedNote,
   readPublicSharedNote,
 } from "@/functions/shared-notes";
+import { prepareShareRoutePrivacy } from "@/lib/share-route-privacy";
+import { fetchPublicSharedAttachmentDownload } from "@/lib/shared-note-api";
 import {
   formatAuthenticatedSharedNoteAccessLabel,
   shouldUseAuthenticatedSharedNoteAccessLabel,
 } from "@/lib/shared-note-collaboration";
-import {
-  getPublicShareHead,
-  publicShareHeaders,
-} from "@/lib/shared-note-meta";
-import { prepareShareRoutePrivacy } from "@/lib/share-route-privacy";
-import { fetchPublicSharedAttachmentDownload } from "@/lib/shared-note-api";
+import { getPublicShareHead, publicShareHeaders } from "@/lib/shared-note-meta";
 import {
   buildSharedNoteWebPath,
   publicShareSlugSchema,
@@ -63,9 +60,7 @@ export const Route = createFileRoute("/share/public/$publicSlug")({
   head: ({ loaderData, params }) =>
     getPublicShareHead(
       params.publicSlug,
-      loaderData?.result.status === "ready"
-        ? loaderData.result.snapshot
-        : null,
+      loaderData?.result.status === "ready" ? loaderData.result.snapshot : null,
     ),
   headers: () => publicShareHeaders,
   pendingComponent: SharedNoteLoading,
@@ -78,18 +73,16 @@ function Component() {
   const { publicSlug } = Route.useParams();
   const { scheme } = Route.useSearch();
   const authenticatedNote =
-    authenticatedResult?.status === "ready"
-      ? authenticatedResult.note
-      : null;
+    authenticatedResult?.status === "ready" ? authenticatedResult.note : null;
   const resolveAttachment = useCallback<SharedAttachmentResolver>(
     async (attachment, signal) => {
       if (authenticatedNote) {
         const download = await createAuthenticatedSharedAttachmentDownload({
-            data: {
-              shareId: authenticatedNote.snapshot.shareId,
-              attachmentId: attachment.id,
-            },
-          });
+          data: {
+            shareId: authenticatedNote.snapshot.shareId,
+            attachmentId: attachment.id,
+          },
+        });
         if (download) return download;
       }
       return fetchPublicSharedAttachmentDownload(
@@ -121,8 +114,12 @@ function Component() {
       authenticatedNote={authenticatedNote}
       fallbackAccessLabel="Public note · View only"
       fallbackSnapshot={result.snapshot}
-      onAccessChanged={() => {
-        void router.invalidate();
+      onAccessChanged={async () => {
+        await router.invalidate();
+        const refreshed = await readAuthenticatedSharedNote({
+          data: snapshot.shareId,
+        });
+        return refreshed.status === "ready" ? refreshed.note : null;
       }}
       resolveAttachment={resolveAttachment}
       revokedBehavior="read-only"


### PR DESCRIPTION
## Summary
- keep an expired web-edit session signed out across stale loader or query updates
- revalidate access through a fresh authenticated read on private, link, and public routes
- restore editing when the server confirms editor access even if the access version is unchanged
- preserve the preparation notice for valid editors whose note is not yet web-editable
- remain read-only when revalidation fails, downgrades, or returns no authenticated note

## Safety
- sign-in-required wins over stale props and in-flight access refreshes
- editing remains disabled until an authoritative refresh confirms editor capability and web-editability
- null, downgraded, errored, and rejected refreshes stay read-only
- public and capability fallbacks remain same-share and revision-safe

## Validation
- `pnpm -F @hypr/web test` (85 tests)
- `pnpm -F @hypr/web typecheck`
- `pnpm exec dprint check`
- independent state/race review: pass, no blockers
- exact-head CI and Bugbot: green, all review threads resolved

Follow-up for two late review findings on #6130.