### PR TITLE
fix(e2ee): enforce append-only witness grants

### DIFF
--- a/supabase/migrations/20260718150000_e2ee_witness_append_only_privileges.sql
+++ b/supabase/migrations/20260718150000_e2ee_witness_append_only_privileges.sql
@@ -1,0 +1,7 @@
+REVOKE ALL ON TABLE public.e2ee_freshness_events FROM service_role;
+GRANT SELECT, INSERT ON TABLE public.e2ee_freshness_events TO service_role;
+
+REVOKE ALL ON SEQUENCE public.e2ee_freshness_events_sequence_seq
+  FROM service_role;
+GRANT USAGE, SELECT ON SEQUENCE public.e2ee_freshness_events_sequence_seq
+  TO service_role;


### PR DESCRIPTION
## Summary
- revoke Supabase default table and sequence privileges from `service_role`
- re-grant only the SELECT/INSERT and sequence access required by the freshness witness
- keep the encrypted witness append-only for API traffic

## Validation
- fresh local Supabase reset applied every migration
- E2EE freshness witness pgTAP suite: 15/15 passed
- full Supabase pgTAP suite: 866/866 passed
- local privilege probe confirms SELECT/INSERT allowed and UPDATE/DELETE denied
- exact-head CI, formatting, lint, database tests, and Bugbot passed

