### PR TITLE
fix(api): include trial policy in release image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 COPY Cargo.toml Cargo.lock ./
 RUN sed -i '/^members = \[/,/^\]/c\members = ["apps/api", "crates/*"]' Cargo.toml
 COPY crates crates
+COPY packages/pricing/src/trial-policy.json packages/pricing/src/trial-policy.json
 COPY apps/api apps/api
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \


### PR DESCRIPTION
## Summary
- copy the shared Pro trial policy into the API Docker build context before the final Rust build
- preserve the existing cargo-chef cache boundaries
- unblock API 0.0.58 without changing runtime behavior

## Validation
- reproduced API CD run 29640208503 failing at `include_str!`
- `docker build --progress=plain -f apps/api/Dockerfile --build-arg APP_VERSION=0.0.58 -t anarlog-api:release-test .`
- final `cargo build --release -p api` and runtime image export succeeded
- exact-head API CI, formatting, lint, Bugbot, and the full Docker build passed

