### PR TITLE
fix(desktop): route release builds through Cargo

### DIFF
--- a/apps/desktop/scripts/dev-runner.mjs
+++ b/apps/desktop/scripts/dev-runner.mjs
@@ -13,9 +13,9 @@ if (!command) {
   process.exit(1);
 }
 
-if (command === "run") {
+if (command === "run" || command === "build") {
   const cargoArgs = [];
-  if (process.platform === "darwin") {
+  if (command === "run" && process.platform === "darwin") {
     cargoArgs.push(
       "--config",
       `target.'cfg(target_os = "macos")'.runner = [${JSON.stringify(scriptPath)}]`,


### PR DESCRIPTION
## Summary

- Proxy Tauri `build` invocations to Cargo instead of treating `build` as an application binary.
- Keep macOS ad-hoc signing and the custom Cargo runner limited to launched dev binaries.

## Why

The staging release workflow reached the Tauri build, then `dev-runner.mjs` attempted to execute a nonexistent program named `build`. The same path would block the stable 1.3.0 release.

## Verification

- `pnpm exec dprint fmt apps/desktop/scripts/dev-runner.mjs`
- `node --check apps/desktop/scripts/dev-runner.mjs`
- Cargo build and run proxy help invocations
- `pnpm -F desktop typecheck`
- Signed staging workflow 29641871919 passed at `20516827e22577c4932ad4252145a30141d94966`; the downloaded arm64 DMG passed checksum, stapler, Gatekeeper, codesign, and bundle-identity verification.
- Installing that artifact exposed a separate legacy attachment migration checksum mismatch, repaired in #6137.

