### PR TITLE
fix(stt): hide live badges from model options

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -715,7 +715,7 @@ function ModelSelectItem({
       />
       <div className="flex shrink-0 items-center gap-2 text-[11px]">
         <LocalModelBackendBadge model={model.id} />
-        <ModelModeBadge mode={model.mode} />
+        {model.mode !== "realtime" && <ModelModeBadge mode={model.mode} />}
         {!model.isDownloaded && sizeLabel && (
           <span className="text-muted-foreground font-mono">{sizeLabel}</span>
         )}


### PR DESCRIPTION
Hide live-only badges from speech-to-text model option rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in STT settings UI with no behavior or selection logic changes.
> 
> **Overview**
> STT model **dropdown rows** no longer show the **Live** `ModelModeBadge` when `model.mode` is `realtime`; **After recording** badges still appear for batch models.
> 
> The selected-model trigger (`ModelSelectedValue`) is unchanged and still shows the mode badge for the current choice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58384282e2b36fbad9959f68cfff37a747fbb9c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->