### PR TITLE
fix(auth): restore Stripe-linked sign-in

### DIFF
--- a/supabase/migrations/20260718150001_grant_auth_hook_customer_access.sql
+++ b/supabase/migrations/20260718150001_grant_auth_hook_customer_access.sql
@@ -1,0 +1,3 @@
+GRANT SELECT (id, invoice_settings, default_source)
+ON TABLE stripe.customers
+TO supabase_auth_admin;

--- a/supabase/tests/003-auth-custom-access-token-hook.sql
+++ b/supabase/tests/003-auth-custom-access-token-hook.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(13);
+select plan(14);
 
 select tests.create_supabase_user('pro', 'pro@example.com');
 select tests.create_supabase_user('free', 'free@example.com');
@@ -38,6 +38,15 @@ select results_eq(
   $$select has_table_privilege('supabase_auth_admin', 'stripe.subscriptions', 'SELECT')$$,
   array[true],
   'supabase_auth_admin has SELECT privilege on stripe.subscriptions'
+);
+
+select results_eq(
+  $$
+  select bool_and(has_column_privilege('supabase_auth_admin', 'stripe.customers', column_name, 'SELECT'))
+  from unnest(array['id', 'invoice_settings', 'default_source']) as required_columns(column_name)
+  $$,
+  array[true],
+  'supabase_auth_admin can read the stripe customer columns used by the auth hook'
 );
 
 select results_eq(


### PR DESCRIPTION
Grant the auth hook least-privilege access to customer payment fields and cover the permission contract in pgTAP.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow DB grant and test coverage only; no application logic changes.
> 
> **Overview**
> **Grants `supabase_auth_admin` column-level `SELECT` on `stripe.customers`** for `id`, `invoice_settings`, and `default_source` so `custom_access_token_hook` can read payment-method data during sign-in without failing on missing privileges.
> 
> **Adds a pgTAP assertion** that those three columns are readable by the auth admin role, and bumps the test plan count to 14.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec0bf049231d78942869298c8649b6758b505b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->