### PR TITLE
fix(toast): show delete undo countdown

### DIFF
--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
@@ -78,6 +78,20 @@ describe("UndoDeleteToast", () => {
       }),
     );
     expect(mocks.message.mock.calls[0][1]).not.toHaveProperty("cancel");
+    expect(mocks.message.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        description: expect.objectContaining({
+          props: expect.objectContaining({
+            className: expect.stringContaining("undo-delete-toast-gauge"),
+            style: expect.objectContaining({
+              "--undo-delete-duration": "5000ms",
+              "--undo-delete-progress": 1,
+            }),
+          }),
+        }),
+        descriptionClassName: expect.stringContaining("bottom-0"),
+      }),
+    );
 
     view.unmount();
     expect(mocks.dismiss).toHaveBeenCalledWith("undo-delete:session-1");

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
@@ -1,12 +1,12 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
+import { type CSSProperties, useCallback, useMemo } from "react";
 
 import { sonnerToast } from "@hypr/ui/components/ui/toast";
 
 import { restoreDeletedSession } from "~/session/queries";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { useTabs } from "~/store/zustand/tabs";
-import { useUndoDelete } from "~/store/zustand/undo-delete";
+import { UNDO_TIMEOUT_MS, useUndoDelete } from "~/store/zustand/undo-delete";
 
 type ToastGroup = {
   key: string;
@@ -115,6 +115,11 @@ function UndoDeleteSonnerToast({ group }: { group: ToastGroup }) {
   const label = group.isBatch
     ? `${group.sessionIds.length} ${noteLabel} deleted`
     : `${title} deleted`;
+  const remainingDuration = Math.max(
+    0,
+    group.addedAt + UNDO_TIMEOUT_MS - Date.now(),
+  );
+  const progress = remainingDuration / UNDO_TIMEOUT_MS;
 
   useMountEffect(() => {
     const toastId = `undo-delete:${group.key}`;
@@ -122,6 +127,20 @@ function UndoDeleteSonnerToast({ group }: { group: ToastGroup }) {
     sonnerToast.message(label, {
       id: toastId,
       duration: Infinity,
+      description: (
+        <span
+          aria-hidden="true"
+          className="undo-delete-toast-gauge bg-primary block h-full w-full"
+          style={
+            {
+              "--undo-delete-duration": `${remainingDuration}ms`,
+              "--undo-delete-progress": progress,
+            } as CSSProperties
+          }
+        />
+      ),
+      descriptionClassName:
+        "bg-muted absolute inset-x-0 bottom-0 h-1 overflow-hidden",
       action: {
         label: "Undo",
         onClick: () => restoreGroup(group),

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -7,6 +7,19 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+.undo-delete-toast-gauge {
+  animation: undo-delete-toast-gauge var(--undo-delete-duration) linear
+    forwards;
+  transform: scaleX(var(--undo-delete-progress));
+  transform-origin: left;
+}
+
+@keyframes undo-delete-toast-gauge {
+  to {
+    transform: scaleX(0);
+  }
+}
+
 @source "../../node_modules/streamdown/dist/index.js";
 @source "../../../../packages/changelog/src";
 @source "../../../../packages/editor/src";


### PR DESCRIPTION
Add a bottom-edge gauge that drains with the five-second undo window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic toast UI only; undo behavior and timeouts are unchanged.
> 
> **Overview**
> Undo-delete Sonner toasts now show a **bottom progress bar** that drains in sync with the existing five-second undo timeout (`UNDO_TIMEOUT_MS`).
> 
> The toast passes a `description` element with CSS variables `--undo-delete-duration` and `--undo-delete-progress` (derived from `group.addedAt` and remaining time), plus `descriptionClassName` to pin a thin muted track at the bottom. **globals.css** adds `.undo-delete-toast-gauge` with a linear `scaleX` animation from the current progress down to zero.
> 
> Tests assert the gauge markup and style props on single-delete toasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a28d2f7135f89131746e480eccda103ab0385ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->