### PR TITLE
fix(summary): skip trivial transcript generation

### DIFF
--- a/apps/desktop/src/services/enhancer/eligibility.ts
+++ b/apps/desktop/src/services/enhancer/eligibility.ts
@@ -1,3 +1,8 @@
+import {
+  countTranscriptWordCharacters,
+  MIN_TRANSCRIPT_CHARACTERS_FOR_SUMMARY,
+} from "./summary-length";
+
 export const MIN_WORDS_FOR_ENHANCEMENT = 5;
 
 export function countTranscriptWords(
@@ -10,25 +15,48 @@ export function countTranscriptWords(
 }
 
 type EligibilityResult =
-  | { eligible: true; wordCount: number }
-  | { eligible: false; reason: string; wordCount: number };
+  | { eligible: true; characterCount: number; wordCount: number }
+  | {
+      eligible: false;
+      characterCount: number;
+      reason: string;
+      wordCount: number;
+    };
 
 export function getEligibility(
-  transcripts: ReadonlyArray<{ words: readonly unknown[] }>,
+  transcripts: ReadonlyArray<{
+    words: ReadonlyArray<{ text?: unknown }>;
+  }>,
 ): EligibilityResult {
   if (transcripts.length === 0) {
-    return { eligible: false, reason: "No transcript recorded", wordCount: 0 };
+    return {
+      eligible: false,
+      reason: "No transcript recorded",
+      characterCount: 0,
+      wordCount: 0,
+    };
   }
 
   const wordCount = countTranscriptWords(transcripts);
+  const characterCount = countTranscriptWordCharacters(transcripts);
 
   if (wordCount < MIN_WORDS_FOR_ENHANCEMENT) {
     return {
       eligible: false,
       reason: `Not enough words recorded (${wordCount}/${MIN_WORDS_FOR_ENHANCEMENT} minimum)`,
+      characterCount,
       wordCount,
     };
   }
 
-  return { eligible: true, wordCount };
+  if (characterCount < MIN_TRANSCRIPT_CHARACTERS_FOR_SUMMARY) {
+    return {
+      eligible: false,
+      reason: `Transcript too short to summarize (${characterCount}/${MIN_TRANSCRIPT_CHARACTERS_FOR_SUMMARY} characters minimum)`,
+      characterCount,
+      wordCount,
+    };
+  }
+
+  return { eligible: true, characterCount, wordCount };
 }

--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -343,9 +343,17 @@ describe("EnhancerService", () => {
       wordCount: 4,
     });
     snapshot = createSnapshot({ wordCount: 5 });
+    await expect(service.checkEligibility("session-1")).resolves.toMatchObject({
+      eligible: false,
+      characterCount: 24,
+      reason: "Transcript too short to summarize (24/160 characters minimum)",
+      wordCount: 5,
+    });
+    snapshot = createSnapshot({ wordCount: 40 });
     await expect(service.checkEligibility("session-1")).resolves.toEqual({
       eligible: true,
-      wordCount: 5,
+      characterCount: 199,
+      wordCount: 40,
     });
   });
 
@@ -363,7 +371,7 @@ describe("EnhancerService", () => {
   });
 
   it("deduplicates eligible auto-enhance requests", async () => {
-    snapshot = createSnapshot({ wordCount: 5 });
+    snapshot = createSnapshot({ wordCount: 40 });
     const ai = createMockAITaskStore();
     const service = new EnhancerService(createDeps({ aiTaskStore: ai.store }));
 
@@ -374,7 +382,7 @@ describe("EnhancerService", () => {
   });
 
   it("emits no-model and started auto-enhance outcomes", async () => {
-    snapshot = createSnapshot({ wordCount: 5 });
+    snapshot = createSnapshot({ wordCount: 40 });
     const noModelService = new EnhancerService(
       createDeps({ getModel: () => null }),
     );

--- a/apps/desktop/src/services/enhancer/summary-length.test.ts
+++ b/apps/desktop/src/services/enhancer/summary-length.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  constrainSummaryLength,
+  countNormalizedCharacters,
+  countTranscriptWordCharacters,
+  getSummaryLengthPolicy,
+} from "./summary-length";
+
+describe("summary length policy", () => {
+  it("counts transcript characters across languages without relying on spaces", () => {
+    expect(
+      countTranscriptWordCharacters([
+        { words: [{ text: "이번" }, { text: "회의는" }, { text: "짧음" }] },
+      ]),
+    ).toBe(9);
+  });
+
+  it("caps short transcripts at two sections and sizes the output budget", () => {
+    const policy = getSummaryLengthPolicy([
+      {
+        startedAt: null,
+        endedAt: null,
+        segments: [{ speaker: "John", text: "a".repeat(200) }],
+      },
+    ]);
+
+    expect(policy).toEqual({
+      transcriptCharacters: 200,
+      maxCharacters: 200,
+      maxSections: 2,
+    });
+  });
+
+  it("keeps long transcripts on the normal section limit", () => {
+    const policy = getSummaryLengthPolicy([
+      {
+        startedAt: null,
+        endedAt: null,
+        segments: [{ speaker: "John", text: "a".repeat(10_000) }],
+      },
+    ]);
+
+    expect(policy).toMatchObject({
+      transcriptCharacters: 10_000,
+      maxCharacters: 10_000,
+      maxSections: null,
+    });
+  });
+
+  it("keeps no more than two sections or the transcript character count", () => {
+    const markdown = `# First
+
+- ${"a".repeat(100)}
+
+# Second
+
+- ${"b".repeat(100)}
+
+# Third
+
+- ${"c".repeat(100)}`;
+    const result = constrainSummaryLength(markdown, {
+      transcriptCharacters: 160,
+      maxCharacters: 160,
+      maxSections: 2,
+    });
+
+    expect(result).toContain("# First");
+    expect(result).toContain("# Second");
+    expect(result).not.toContain("# Third");
+    expect(countNormalizedCharacters(result)).toBeLessThanOrEqual(160);
+  });
+});

--- a/apps/desktop/src/services/enhancer/summary-length.ts
+++ b/apps/desktop/src/services/enhancer/summary-length.ts
@@ -1,0 +1,136 @@
+import type { Transcript } from "@hypr/plugin-template";
+
+export const MIN_TRANSCRIPT_CHARACTERS_FOR_SUMMARY = 160;
+export const SHORT_TRANSCRIPT_CHARACTER_LIMIT = 1_200;
+
+export type SummaryLengthPolicy = {
+  maxCharacters: number;
+  maxSections: number | null;
+  transcriptCharacters: number;
+};
+
+export function countNormalizedCharacters(text: string): number {
+  return Array.from(text.replace(/\s+/gu, " ").trim()).length;
+}
+
+export function countTranscriptWordCharacters(
+  transcripts: ReadonlyArray<{
+    words: ReadonlyArray<{ text?: unknown }>;
+  }>,
+): number {
+  return countNormalizedCharacters(
+    transcripts
+      .flatMap((transcript) => transcript.words)
+      .map((word) => (typeof word.text === "string" ? word.text : ""))
+      .filter(Boolean)
+      .join(" "),
+  );
+}
+
+export function getSummaryLengthPolicy(
+  transcripts: readonly Transcript[],
+): SummaryLengthPolicy | null {
+  const transcriptCharacters = countNormalizedCharacters(
+    transcripts
+      .flatMap((transcript) => transcript.segments)
+      .map((segment) => segment.text)
+      .filter(Boolean)
+      .join(" "),
+  );
+
+  if (transcriptCharacters === 0) {
+    return null;
+  }
+
+  return {
+    transcriptCharacters,
+    maxCharacters: transcriptCharacters,
+    maxSections:
+      transcriptCharacters < SHORT_TRANSCRIPT_CHARACTER_LIMIT ? 2 : null,
+  };
+}
+
+export function constrainSummaryLength(
+  markdown: string,
+  policy: SummaryLengthPolicy | null,
+): string {
+  if (!policy) {
+    return markdown.trim();
+  }
+
+  const sectionLimited = limitSections(markdown, policy.maxSections);
+  if (countNormalizedCharacters(sectionLimited) <= policy.maxCharacters) {
+    return sectionLimited;
+  }
+
+  const keptLines: string[] = [];
+  for (const line of sectionLimited.split("\n")) {
+    const candidate = [...keptLines, line].join("\n").trim();
+    if (countNormalizedCharacters(candidate) <= policy.maxCharacters) {
+      keptLines.push(line);
+      continue;
+    }
+
+    const truncatedLine = truncateLineToFit(
+      keptLines,
+      line,
+      policy.maxCharacters,
+    );
+    if (truncatedLine) {
+      keptLines.push(truncatedLine);
+    }
+    break;
+  }
+
+  return keptLines.join("\n").trim();
+}
+
+function limitSections(markdown: string, maxSections: number | null): string {
+  if (!maxSections) {
+    return markdown.trim();
+  }
+
+  let sectionCount = 0;
+  const keptLines: string[] = [];
+  for (const line of markdown.trim().split("\n")) {
+    if (/^#\s+\S/.test(line)) {
+      sectionCount += 1;
+      if (sectionCount > maxSections) {
+        break;
+      }
+    }
+    keptLines.push(line);
+  }
+
+  return keptLines.join("\n").trim();
+}
+
+function truncateLineToFit(
+  keptLines: string[],
+  line: string,
+  maxCharacters: number,
+): string {
+  const characters = Array.from(line);
+  let low = 0;
+  let high = characters.length;
+
+  while (low < high) {
+    const midpoint = Math.ceil((low + high) / 2);
+    const candidate = [...keptLines, characters.slice(0, midpoint).join("")]
+      .join("\n")
+      .trim();
+    if (countNormalizedCharacters(candidate) <= maxCharacters) {
+      low = midpoint;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+
+  let truncated = characters.slice(0, low).join("").trimEnd();
+  const lastSpace = truncated.lastIndexOf(" ");
+  if (lastSpace >= Math.floor(truncated.length * 0.6)) {
+    truncated = truncated.slice(0, lastSpace);
+  }
+
+  return truncated.replace(/[,:;\-–—]+$/u, "").trimEnd();
+}

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
@@ -181,6 +181,49 @@ describe("enhanceSuccess.onSuccess", () => {
     );
   });
 
+  it("persists a short summary and tags within the transcript length and section cap", async () => {
+    mocks.loadSessionContentSnapshot.mockResolvedValue(
+      createSnapshot("Meeting title"),
+    );
+    const transformedArgs = createTransformedArgs();
+    transformedArgs.preMeetingMemo = "Follow up with #launch";
+    transformedArgs.transcripts = [
+      {
+        startedAt: null,
+        endedAt: null,
+        segments: [{ speaker: "John", text: "x".repeat(160) }],
+      },
+    ];
+
+    await enhanceSuccess.onSuccess?.(
+      createParams({
+        text: `# First
+
+- ${"a".repeat(100)}
+
+# Second
+
+- ${"b".repeat(100)}
+
+# Third
+
+- ${"c".repeat(100)}`,
+        transformedArgs,
+      }),
+    );
+
+    const content =
+      mocks.persistGeneratedEnhancedNote.mock.calls[0][0].note.nextContent;
+    const markdown = json2md(JSON.parse(content)).trim();
+    expect(markdown).toContain("# First");
+    expect(markdown).toContain("# Second");
+    expect(markdown).not.toContain("# Third");
+    expect(markdown).toContain("#launch");
+    expect(
+      Array.from(markdown.replace(/\s+/gu, " ")).length,
+    ).toBeLessThanOrEqual(160);
+  });
+
   it("does not claim success when the guarded SQLite write fails", async () => {
     mocks.persistGeneratedEnhancedNote.mockRejectedValueOnce(
       new Error("stale summary"),

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
@@ -10,6 +10,11 @@ import {
   persistGeneratedTitle,
 } from "./title-success";
 
+import {
+  constrainSummaryLength,
+  countNormalizedCharacters,
+  getSummaryLengthPolicy,
+} from "~/services/enhancer/summary-length";
 import { persistGeneratedEnhancedNote } from "~/session/content-mutations";
 import { loadSessionContentSnapshot } from "~/session/content-queries";
 import { ensureMarkdownFirstLineTitle } from "~/session/title-content";
@@ -24,12 +29,14 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = async ({
   getTaskState,
   signal,
 }) => {
-  if (!text) {
+  const lengthPolicy = getSummaryLengthPolicy(transformedArgs.transcripts);
+  const constrainedText = constrainSummaryLength(text, lengthPolicy);
+  if (!constrainedText) {
     return;
   }
 
-  const tagNames = extractEnhanceTagNames(text, transformedArgs);
-  const textWithTags = appendTagLineToMarkdown(text, tagNames);
+  const tagNames = extractEnhanceTagNames(constrainedText, transformedArgs);
+  const textWithTags = appendTagLineToMarkdown(constrainedText, tagNames);
   const initialSnapshot = await loadSessionContentSnapshot(args.sessionId);
   if (!initialSnapshot) {
     throw new Error(`Session ${args.sessionId} no longer exists`);
@@ -86,7 +93,28 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = async ({
     shouldPersistGeneratedTitle = true;
   }
 
-  const titledText = ensureMarkdownFirstLineTitle(textWithTags, trimmedTitle);
+  const titledText = ensureMarkdownFirstLineTitle(
+    constrainedText,
+    trimmedTitle,
+  );
+  const tagLine = appendTagLineToMarkdown("", tagNames);
+  const reservedTagCharacters = tagLine
+    ? countNormalizedCharacters(tagLine) + 1
+    : 0;
+  const persistableBody = constrainSummaryLength(
+    titledText,
+    lengthPolicy
+      ? {
+          ...lengthPolicy,
+          maxCharacters: Math.max(
+            0,
+            lengthPolicy.maxCharacters - reservedTagCharacters,
+          ),
+          maxSections: null,
+        }
+      : null,
+  );
+  const persistableText = appendTagLineToMarkdown(persistableBody, tagNames);
   await persistGeneratedEnhancedNote({
     sessionId: args.sessionId,
     ownerUserId: snapshot.ownerUserId,
@@ -94,7 +122,7 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = async ({
       id: note.id,
       currentContent: note.content,
       currentContentFormat: note.contentFormat,
-      nextContent: JSON.stringify(md2json(titledText)),
+      nextContent: JSON.stringify(md2json(persistableText)),
     },
     tagNames,
   });


### PR DESCRIPTION
Reject undersized transcripts before auto-summary and cap short summaries to the source length and two sections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-enhance gating and persisted summary content in the enhancer pipeline; covered by new unit tests but affects user-visible notes.
> 
> **Overview**
> Auto-enhance now requires **at least 160 normalized transcript characters** (in addition to the existing word minimum), with eligibility results including `characterCount` and a clear skip reason when the transcript is too short.
> 
> A new **`summary-length`** helper drives post-generation limits: for transcripts under ~1,200 characters, persisted summaries are capped at **two markdown sections** and **no more characters than the source transcript** (with tag lines reserved in the budget). `enhance-success` applies this trimming before SQLite persistence so short meetings cannot produce oversized summaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cfadd5099a3d7d50c990ce370c4c8bf05e44cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->