### PR TITLE
fix(onboarding): space welcome note sections

### DIFF
--- a/apps/desktop/src/onboarding/welcome-note.constants.ts
+++ b/apps/desktop/src/onboarding/welcome-note.constants.ts
@@ -1,0 +1,2 @@
+export const WELCOME_NOTE_DEMO_URL = "https://anarlog.so/onboarding-demo/";
+export const WELCOME_NOTE_TRACKING_ID = "anarlog-onboarding-demo-v1";

--- a/apps/desktop/src/onboarding/welcome-note.test.ts
+++ b/apps/desktop/src/onboarding/welcome-note.test.ts
@@ -52,6 +52,12 @@ it("creates a prerecorded demo note with normal meeting metadata", async () => {
   expect(event.tracking_id).toBe("anarlog-onboarding-demo-v1");
   expect(initial.raw_md).toContain("prerecorded demo meeting");
   expect(initial.raw_md).toContain("Join & record");
+
+  const note = JSON.parse(initial.raw_md);
+  expect(note.content).toHaveLength(7);
+  expect(note.content[1]).toEqual({ type: "paragraph" });
+  expect(note.content[3]).toEqual({ type: "paragraph" });
+  expect(note.content[5]).toEqual({ type: "paragraph" });
 });
 
 it("guards empty event metadata before reading its tracking ID", async () => {

--- a/apps/desktop/src/onboarding/welcome-note.ts
+++ b/apps/desktop/src/onboarding/welcome-note.ts
@@ -2,18 +2,23 @@ import { md2json } from "@hypr/editor/markdown";
 import type { SessionEvent } from "@hypr/store";
 
 import { liveQueryClient } from "~/db";
+import {
+  WELCOME_NOTE_DEMO_URL,
+  WELCOME_NOTE_TRACKING_ID,
+} from "~/onboarding/welcome-note.constants";
 import { createSession } from "~/session/queries";
 import { DEFAULT_USER_ID } from "~/shared/utils";
 
-const DEMO_URL = "https://anarlog.so/onboarding-demo/";
 const PENDING_WELCOME_SESSION_KEY = "anarlog.pending-welcome-session";
-const TRACKING_ID = "anarlog-onboarding-demo-v1";
 
 const WELCOME_NOTE = `Welcome to Anarlog 👋
 
+
 This note is a quick way to see how Anarlog works.
 
+
 Click **Join & record** in the top-right corner. It will open a private, prerecorded demo meeting, so you don't have to worry about your camera or microphone. Anarlog will listen, transcribe the conversation, and turn it into notes just like a real meeting.
+
 
 When the video ends, come back here to review the transcript and notes.`;
 
@@ -55,20 +60,20 @@ async function findOrCreateWelcomeSession(): Promise<string> {
       ORDER BY created_at, id
       LIMIT 1
     `,
-    [TRACKING_ID],
+    [WELCOME_NOTE_TRACKING_ID],
   );
   if (rows[0]) return rows[0].id;
 
   const now = new Date().toISOString();
   const event: SessionEvent = {
-    tracking_id: TRACKING_ID,
+    tracking_id: WELCOME_NOTE_TRACKING_ID,
     calendar_id: "",
     title: "Welcome to Anarlog",
     started_at: now,
     ended_at: "",
     is_all_day: false,
     has_recurrence_rules: false,
-    meeting_link: DEMO_URL,
+    meeting_link: WELCOME_NOTE_DEMO_URL,
     description: "A private, prerecorded introduction to Anarlog.",
   };
 

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -447,6 +447,28 @@ describe("OuterHeader", () => {
     expect(mocks.startListening).toHaveBeenCalledTimes(1);
   });
 
+  it("shows the Anarlog logo for the welcome note meeting", () => {
+    mocks.sessionEvents = {
+      "session-1": {
+        tracking_id: "anarlog-onboarding-demo-v1",
+        meeting_link: "https://anarlog.so/onboarding-demo/",
+      },
+    };
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+      />,
+    );
+
+    const joinButton = screen.getByRole("button", { name: "Join & record" });
+    const logo = joinButton.querySelector("img");
+
+    expect(logo?.getAttribute("src")).toBe("/assets/anarlog-icon.png");
+    expect(logo?.getAttribute("alt")).toBe("");
+  });
+
   it("shows the meeting countdown to the left of the header action", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-05T09:55:30.000Z"));

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -17,6 +17,7 @@ import { OverflowButton } from "./overflow";
 import { useAudioPlayer } from "~/audio-player";
 import { useNow } from "~/calendar/hooks";
 import { useShell } from "~/contexts/shell";
+import { WELCOME_NOTE_TRACKING_ID } from "~/onboarding/welcome-note.constants";
 import { SessionShareButton } from "~/session-sharing";
 import { useEventCountdown } from "~/session/hooks/useEventCountdown";
 import {
@@ -129,7 +130,11 @@ function HeaderMeetingActionPill({
   sessionMode,
 }: {
   sessionId: string;
-  event: { ended_at?: string; meeting_link?: string } | null;
+  event: {
+    ended_at?: string;
+    meeting_link?: string;
+    tracking_id?: string;
+  } | null;
   now: Date;
   sessionMode: string;
 }) {
@@ -215,7 +220,12 @@ function HeaderMeetingActionPill({
       return {
         label: t`Join & record`,
         title: t`Join meeting and record`,
-        icon: remote ? getMeetingDisplay(remote.type).icon : undefined,
+        icon:
+          event?.tracking_id === WELCOME_NOTE_TRACKING_ID ? (
+            <img src="/assets/anarlog-icon.png" alt="" className="size-4" />
+          ) : remote ? (
+            getMeetingDisplay(remote.type).icon
+          ) : undefined,
         onClick: () => {
           void openerCommands.openUrl(meetingLink, null);
           start();


### PR DESCRIPTION
Improve generated welcome-note spacing and keep outer-header behavior covered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding copy/layout and a small header UI branch keyed on tracking_id; no auth, data, or recording pipeline changes.
> 
> **Overview**
> **Welcome note spacing and shared constants** — The onboarding welcome markdown now inserts blank lines between sections so `md2json` produces extra empty paragraph nodes for clearer layout. Demo URL and tracking ID move into `welcome-note.constants.ts` for reuse.
> 
> **Session header** — For sessions whose event `tracking_id` matches the onboarding demo, the **Join & record** pill shows the Anarlog app icon instead of a generic remote-meeting provider icon. Tests cover the spaced note structure and the welcome-note header icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ffaaf87bbfc628138a67c353c9a40bb6fe1c59f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->