### PR TITLE
fix(desktop): remove replacement audio retranscription

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -22,7 +22,6 @@ type CapturedMenuItem =
 const hoisted = vi.hoisted(() => ({
   enhance: vi.fn(),
   regenerateTranscript: vi.fn(),
-  uploadAudio: vi.fn(),
   startListening: vi.fn(),
   stopListening: vi.fn(),
   stopTranscription: vi.fn(),
@@ -195,10 +194,6 @@ vi.mock("~/session/queries", () => ({
 
 vi.mock("~/session/components/note-input/transcript/actions", () => ({
   useRegenerateTranscript: () => hoisted.regenerateTranscript,
-}));
-
-vi.mock("~/stt/useUploadFile", () => ({
-  useUploadFile: () => ({ uploadAudio: hoisted.uploadAudio }),
 }));
 
 vi.mock("~/session/components/note-input/transcript/export-data", () => ({
@@ -567,7 +562,7 @@ describe("Header", () => {
     expect(hoisted.transcriptRenderDataCalls).toBe(1);
   });
 
-  it("offers audio upload for re-transcription when recording is missing", () => {
+  it("does not offer re-transcription when recording is missing", () => {
     hoisted.audioExists = false;
     const editorTabs: EditorView[] = [
       { type: "enhanced", id: "note-1" },
@@ -588,18 +583,7 @@ describe("Header", () => {
 
     expect(
       menu.map((item) => ("text" in item ? item.text : "separator")),
-    ).toEqual(["Copy", "Upload audio to re-transcribe"]);
-
-    menu
-      .find(
-        (item): item is Extract<CapturedMenuItem, { id: string }> =>
-          "id" in item && item.id === "regenerate-transcript-session-1",
-      )
-      ?.action();
-
-    expect(hoisted.uploadAudio).toHaveBeenCalledWith({
-      preserveSessionDate: true,
-    });
+    ).toEqual(["Copy"]);
   });
 
   it.each(["active", "finalizing", "running_batch"])(
@@ -629,12 +613,9 @@ describe("Header", () => {
     },
   );
 
-  it.each([
-    ["no stored transcript", { hasTranscript: false }],
-    ["audio lookup is pending or failed", { audioExistsResolved: false }],
-  ])("hides replacement upload when %s", (_label, state) => {
-    hoisted.audioExists = false;
-    Object.assign(hoisted, state);
+  it("hides re-transcription while the audio lookup is pending", () => {
+    hoisted.audioExists = true;
+    hoisted.audioExistsResolved = false;
 
     render(
       <Header
@@ -653,7 +634,7 @@ describe("Header", () => {
       findContextMenu("copy-transcript-session-1").map((item) =>
         "text" in item ? item.text : "separator",
       ),
-    ).toEqual(["Copy"]);
+    ).toEqual(["Copy", "Delete recording"]);
   });
 
   it("replaces the current enhanced note when changing templates", async () => {

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -34,10 +34,7 @@ import {
   formatTranscriptExportSegments,
 } from "~/session/components/note-input/transcript/export-data";
 import { useSessionTranscriptRenderData } from "~/session/components/note-input/transcript/render-request-hooks";
-import {
-  useCanShowTranscript,
-  useHasTranscript,
-} from "~/session/components/shared";
+import { useCanShowTranscript } from "~/session/components/shared";
 import { useEnsureDefaultSummary } from "~/session/hooks/useEnhancedNotes";
 import {
   deleteEnhancedNote,
@@ -54,7 +51,6 @@ import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
-import { useUploadFile } from "~/stt/useUploadFile";
 import {
   filterWebTemplatesAgainstUserTemplates,
   DEFAULT_TEMPLATE_ICON,
@@ -750,7 +746,6 @@ function HeaderViewTranscriptActive({
   };
 }) {
   const regenerate = useRegenerateTranscript(sessionId);
-  const { uploadAudio } = useUploadFile(sessionId);
   const { request: transcriptExportRequest } =
     useSessionTranscriptRenderData(sessionId);
   const {
@@ -759,7 +754,6 @@ function HeaderViewTranscriptActive({
     deleteRecording,
     isDeletingRecording,
   } = AudioPlayer.useAudioPlayer();
-  const hasTranscript = useHasTranscript(sessionId);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const canCopyTranscript = Boolean(transcriptExportRequest);
   const handleCopyTranscript = useCallback(async () => {
@@ -800,20 +794,12 @@ function HeaderViewTranscriptActive({
       },
     ];
 
-    if (
-      audioExistsResolved &&
-      sessionMode === "inactive" &&
-      (audioExists || hasTranscript)
-    ) {
+    if (audioExistsResolved && sessionMode === "inactive" && audioExists) {
       items.push({
         id: `regenerate-transcript-${sessionId}`,
-        text: audioExists ? "Re-transcribe" : "Upload audio to re-transcribe",
+        text: "Re-transcribe",
         action: () => {
-          if (audioExists) {
-            void regenerate();
-          } else {
-            uploadAudio({ preserveSessionDate: true });
-          }
+          void regenerate();
         },
       });
     }
@@ -834,12 +820,10 @@ function HeaderViewTranscriptActive({
     canCopyTranscript,
     handleCopyTranscript,
     handleDeleteRecording,
-    hasTranscript,
     isDeletingRecording,
     regenerate,
     sessionMode,
     sessionId,
-    uploadAudio,
   ]);
   const showContextMenu = useNativeContextMenu(contextMenu);
 

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -171,7 +171,7 @@ describe("OverflowButton", () => {
     expect(uploadTranscriptMock).toHaveBeenCalledTimes(1);
   });
 
-  it("offers audio upload for re-transcription when recording is missing", () => {
+  it("does not offer re-transcription when recording is missing", () => {
     render(
       <OverflowButton
         sessionId="session-1"
@@ -183,18 +183,15 @@ describe("OverflowButton", () => {
     expect(
       screen.queryByRole("button", { name: "Upload transcript" }),
     ).toBeNull();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Upload audio to re-transcribe" }),
-    );
+    expect(screen.queryByRole("button", { name: "Re-transcribe" })).toBeNull();
     expect(
       screen.getByRole("button", { name: "Resume listening" }),
     ).not.toBeNull();
-    expect(uploadAudioMock).toHaveBeenCalledWith({
-      preserveSessionDate: true,
-    });
+    expect(uploadAudioMock).not.toHaveBeenCalled();
   });
 
-  it("hides replacement upload until the audio lookup succeeds", () => {
+  it("hides re-transcription until the audio lookup succeeds", () => {
+    audioExists.value = true;
     audioExistsResolved.value = false;
 
     render(
@@ -204,9 +201,7 @@ describe("OverflowButton", () => {
       />,
     );
 
-    expect(
-      screen.queryByRole("button", { name: "Upload audio to re-transcribe" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Re-transcribe" })).toBeNull();
   });
 
   it("hides initial upload actions until the audio lookup succeeds", () => {
@@ -229,6 +224,7 @@ describe("OverflowButton", () => {
   it.each(["active", "finalizing", "running_batch"])(
     "hides re-transcription actions while the session is %s",
     (sessionMode) => {
+      audioExists.value = true;
       useListenerMock.mockImplementation((selector) =>
         selector({
           getSessionMode: () => sessionMode,
@@ -244,7 +240,7 @@ describe("OverflowButton", () => {
 
       expect(
         screen.queryByRole("button", {
-          name: "Upload audio to re-transcribe",
+          name: "Re-transcribe",
         }),
       ).toBeNull();
     },

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -66,9 +66,7 @@ export function OverflowButton({
     sessionMode === "active" || sessionMode === "finalizing";
   const showListeningAction = allowListening;
   const showRetranscribeAction =
-    audioExistsResolved &&
-    sessionMode === "inactive" &&
-    (audioExists || hasTranscript);
+    audioExistsResolved && sessionMode === "inactive" && audioExists;
   const showUploadActions =
     audioExistsResolved &&
     !audioExists &&
@@ -97,11 +95,7 @@ export function OverflowButton({
   };
   const handleRetranscribe = () => {
     setOpen(false);
-    if (audioExists) {
-      void regenerateTranscript();
-    } else {
-      uploadAudio({ preserveSessionDate: true });
-    }
+    void regenerateTranscript();
   };
   const handleOpenFloatingPanel = () => {
     setOpen(false);
@@ -152,11 +146,7 @@ export function OverflowButton({
                 className="cursor-pointer"
               >
                 <RefreshCwIcon />
-                <span>
-                  {audioExists
-                    ? "Re-transcribe"
-                    : "Upload audio to re-transcribe"}
-                </span>
+                <span>Re-transcribe</span>
               </DropdownMenuItem>
             )}
             {showUploadActions && (

--- a/apps/desktop/src/stt/useUploadFile.test.tsx
+++ b/apps/desktop/src/stt/useUploadFile.test.tsx
@@ -169,20 +169,6 @@ describe("useUploadFile", () => {
     );
   });
 
-  test("preserves the session date when replacement audio is selected", async () => {
-    const { result } = renderHook(() => useUploadFile("session-1"), {
-      wrapper: createWrapper(),
-    });
-
-    act(() => {
-      result.current.uploadAudio({ preserveSessionDate: true });
-    });
-
-    await waitFor(() => expect(runBatchMock).toHaveBeenCalled());
-    expect(audioSourceMetadataMock).not.toHaveBeenCalled();
-    expect(updateSessionMock).not.toHaveBeenCalled();
-  });
-
   test("infers the session date for an ordinary audio upload", async () => {
     const { result } = renderHook(() => useUploadFile("session-1"), {
       wrapper: createWrapper(),

--- a/apps/desktop/src/stt/useUploadFile.ts
+++ b/apps/desktop/src/stt/useUploadFile.ts
@@ -256,11 +256,7 @@ export function useUploadFile(sessionId: string) {
   );
 
   const processFile = useCallback(
-    (
-      filePath: string,
-      kind: "audio" | "transcript",
-      options?: { preserveSessionDate?: boolean },
-    ) => {
+    (filePath: string, kind: "audio" | "transcript") => {
       const normalizedPath = filePath.toLowerCase();
 
       if (kind === "transcript") {
@@ -337,10 +333,7 @@ export function useUploadFile(sessionId: string) {
           importWithProgress(() =>
             fsSyncCommands.audioImport(sessionId, filePath),
           ),
-        () =>
-          options?.preserveSessionDate
-            ? Promise.resolve()
-            : applyEstimatedAudioNoteDate(filePath),
+        () => applyEstimatedAudioNoteDate(filePath),
       );
     },
     [
@@ -388,10 +381,7 @@ export function useUploadFile(sessionId: string) {
   );
 
   const selectAndUpload = useCallback(
-    (
-      kind: "audio" | "transcript",
-      options?: { preserveSessionDate?: boolean },
-    ) => {
+    (kind: "audio" | "transcript") => {
       const filters =
         kind === "audio"
           ? [{ name: "Audio", extensions: AUDIO_EXTENSIONS }]
@@ -416,7 +406,7 @@ export function useUploadFile(sessionId: string) {
         .then((selection) => {
           const path = Array.isArray(selection) ? selection[0] : selection;
           if (path) {
-            processFile(path, kind, options);
+            processFile(path, kind);
           }
         })
         .catch((error) => {
@@ -427,8 +417,7 @@ export function useUploadFile(sessionId: string) {
   );
 
   const uploadAudio = useCallback(
-    (options?: { preserveSessionDate?: boolean }) =>
-      selectAndUpload("audio", options),
+    () => selectAndUpload("audio"),
     [selectAndUpload],
   );
   const uploadTranscript = useCallback(

--- a/packages/changelog/content/1.3.0.md
+++ b/packages/changelog/content/1.3.0.md
@@ -24,4 +24,3 @@ CloudSync now encrypts note data before it leaves your device. Store the recover
 - Recover incomplete legacy imports without discarding duplicate notes or orphaned transcripts
 - Preserve sign-in and shared-note links when Anarlog is launched or already running
 - Restore persisted appearance and notification choices reliably during startup
-- Upload replacement audio when you want to re-transcribe a note whose local recording is no longer available


### PR DESCRIPTION
Remove retranscription for replacement audio uploads and update the desktop changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UX and API simplification in desktop session menus and upload hooks; no auth or server changes, with behavior covered by updated unit tests.
> 
> **Overview**
> **Removes the “upload replacement audio to re-transcribe” path** when a note has a transcript but no local recording. Session overflow and transcript header menus now show **Re-transcribe** only when `audioExists` is true and the session is inactive; they no longer fall back to **Upload audio to re-transcribe** or call `uploadAudio({ preserveSessionDate: true })`.
> 
> `useUploadFile` drops the `preserveSessionDate` option on `uploadAudio` / `processFile`, so ordinary uploads always infer session date from file metadata again. Tests and the 1.3.0 changelog are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d66740720bcff2031f33fbe67229fe8e18eff04a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->