### PR TITLE
fix(sharing): show share action in every note view

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -280,21 +280,25 @@ describe("OuterHeader", () => {
     expect(titleSlot?.className).toContain("justify-center");
   });
 
-  it("shows sharing only for the canonical raw note", () => {
+  it.each([
+    ["summary", { type: "enhanced", id: "summary-1" }],
+    ["memos", { type: "raw" }],
+    ["transcript", { type: "transcript" }],
+  ])("shows sharing from the %s view", (_label, currentView) => {
     render(
       <OuterHeader
         sessionId="session-1"
-        currentView={{ type: "enhanced", id: "summary-1" } as EditorView}
-        title={<span>Summary title</span>}
+        currentView={currentView as EditorView}
+        title={<span>Session title</span>}
       />,
     );
 
-    const title = screen.getByText("Summary title");
+    const title = screen.getByText("Session title");
     const titleSlot = title.parentElement?.parentElement;
 
-    expect(mocks.shareSessionIds).toEqual([]);
-    expect(screen.queryByRole("button", { name: "Share" })).toBeNull();
-    expect(titleSlot?.className).toContain("right-[70px]");
+    expect(mocks.shareSessionIds).toEqual(["session-1"]);
+    expect(screen.getByRole("button", { name: "Share" })).not.toBeNull();
+    expect(titleSlot?.className).toContain("right-[140px]");
   });
 
   it("keeps sidebar header controls hidden while the sidebar is expanded", () => {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -51,7 +51,6 @@ export function OuterHeader({
   const showSidebarTimelineHeaderGutter =
     !standaloneWindow && !leftsidebar.expanded;
   const showExpandedSidebarTimelineHeader = leftsidebar.expanded;
-  const showShareAction = currentView.type === "raw";
 
   return (
     <div
@@ -68,7 +67,7 @@ export function OuterHeader({
           className={cn([
             "pointer-events-none absolute inset-y-0 flex items-center",
             centerTitle && "justify-center",
-            showShareAction ? "right-[140px]" : "right-[70px]",
+            "right-[140px]",
             standaloneWindow
               ? "left-[76px]"
               : showSidebarTimelineHeaderGutter
@@ -91,7 +90,7 @@ export function OuterHeader({
         className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1"
       >
         <HeaderMeetingControl sessionId={sessionId} sessionMode={sessionMode} />
-        {showShareAction ? <SessionShareButton sessionId={sessionId} /> : null}
+        <SessionShareButton sessionId={sessionId} />
         <OverflowButton
           standaloneWindow={standaloneWindow}
           sessionId={sessionId}


### PR DESCRIPTION
Expose the share action consistently across note views.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI behavior change in the session header with no auth or data-path changes; main effect is consistent share affordance across editor tabs.
> 
> **Overview**
> **Share is no longer limited to the raw/memos note view** in `OuterHeader`. The `currentView.type === "raw"` gate is removed so `SessionShareButton` always renders for the session.
> 
> The title area **always reserves the wider right gutter** (`right-[140px]`) that fits the share control, instead of switching to `right-[70px]` on non-raw views.
> 
> Tests now use **`it.each`** to assert the Share button and share gutter on **summary (enhanced), memos (raw), and transcript** views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e0c63eca527e12776718728a1c8d42a93d51c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->