### PR TITLE
fix(sharing): tolerate missing personal workspace projection

### DIFF
--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -681,7 +681,10 @@ async function activateCloudsync(
       console.warn("[cloudsync] local sync suspension failed");
     }
 
-    console.warn("[cloudsync] local sync configuration failed; retrying");
+    console.warn(
+      "[cloudsync] local sync configuration failed; retrying",
+      error,
+    );
     scheduleExchange(
       session,
       activeGeneration,

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -380,6 +380,7 @@ describe("SessionShareButton", () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
   });
 
   it("starts sign-in before attempting to share for a signed-out user", () => {
@@ -443,6 +444,9 @@ describe("SessionShareButton", () => {
   });
 
   it("bootstraps an existing share after its first snapshot publish failed", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);
     mocks.createOrReuseSessionShare
       .mockResolvedValueOnce({
@@ -469,6 +473,10 @@ describe("SessionShareButton", () => {
       expect(mocks.toastError).toHaveBeenCalledWith(
         "Could not prepare this note for sharing.",
       ),
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "[session-sharing] could not prepare note",
+      expect.objectContaining({ message: "connection lost" }),
     );
     expect(screen.queryByRole("dialog")).toBeNull();
 

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -331,7 +331,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
       });
       setDialogIdentity(identity);
     },
-    onError: (_error, variables) => {
+    onError: (error, variables) => {
       if (latestAuthRef.current.session?.user.id !== variables.ownerUserId) {
         return;
       }
@@ -339,6 +339,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
         billing.upgradeToPro();
         return;
       }
+      console.error("[session-sharing] could not prepare note", error);
       sonnerToast.error("Could not prepare this note for sharing.");
     },
   });

--- a/apps/desktop/src/session-sharing/source.test.ts
+++ b/apps/desktop/src/session-sharing/source.test.ts
@@ -114,6 +114,39 @@ describe("loadSessionShareSource", () => {
     );
   });
 
+  it("uses the bound personal workspace while its local projection is missing", async () => {
+    mocks.execute.mockResolvedValue([
+      sourceRow({
+        personal_workspace_available: 0,
+        assigned_workspace_kind: null,
+        assigned_workspace_role: null,
+        binding_json: JSON.stringify({
+          workspace_id: ACCOUNT_ID,
+          account_user_id: ACCOUNT_ID,
+        }),
+      }),
+    ]);
+
+    await expect(
+      loadSessionShareSource("session-1", ACCOUNT_ID),
+    ).resolves.toMatchObject({ workspaceId: ACCOUNT_ID });
+  });
+
+  it("rejects an unprojected personal workspace without an account binding", async () => {
+    mocks.execute.mockResolvedValue([
+      sourceRow({
+        personal_workspace_available: 0,
+        assigned_workspace_kind: null,
+        assigned_workspace_role: null,
+        binding_json: null,
+      }),
+    ]);
+
+    await expect(
+      loadSessionShareSource("session-1", ACCOUNT_ID),
+    ).rejects.toThrow("personal workspace is unavailable");
+  });
+
   it.each(["owner", "admin"])(
     "allows an active shared-workspace %s to share the note",
     async (role) => {

--- a/apps/desktop/src/session-sharing/source.ts
+++ b/apps/desktop/src/session-sharing/source.ts
@@ -208,6 +208,16 @@ function resolveSourceWorkspace(
     ) {
       return accountUserId;
     }
+    if (
+      !row.assigned_workspace_kind &&
+      isLegacyWorkspaceBinding(
+        assignedWorkspaceId,
+        row.binding_json,
+        accountUserId,
+      )
+    ) {
+      return accountUserId;
+    }
     throw new Error("The personal workspace is unavailable for sharing");
   }
 


### PR DESCRIPTION
Allow sharing flows to proceed when the personal workspace projection is missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow workspace-resolution change with new unit/UI tests; no auth or API contract changes.
> 
> **Overview**
> **Sharing** can proceed when the local personal workspace row is not projected yet, as long as the session is on the account workspace and `cloudsync_workspace_binding` still points at that personal workspace. Without that binding, sharing still fails with “personal workspace is unavailable.”
> 
> **Diagnostics:** share preparation logs `[session-sharing] could not prepare note` on failure; cloudsync retry logs include the configuration error. Tests cover the new workspace cases and mock cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f54560fa9af392146a94819582306aed4752d5c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->