### PR TITLE
Refresh Otter.ai alternatives guide

### DIFF
--- a/apps/web/content/articles/otter-ai-alternatives.mdx
+++ b/apps/web/content/articles/otter-ai-alternatives.mdx
@@ -1,472 +1,300 @@
 ---
-meta_title: "14 Best Otter.ai Alternatives & Competitors in 2026"
-meta_description: "Discover 14 Otter AI alternatives that solve privacy, language, and accuracy issues. Compare features and pricing to find your perfect meeting assistant."
+meta_title: "6 Best Otter.ai Alternatives in 2026"
+meta_description: "Compare six Otter.ai alternatives by capture method, privacy, platform, integrations, and ownership to find the best fit for your meeting workflow."
 author: "John Jeong"
 category: "Comparisons"
-date: "2025-08-11"
+date: "2026-07-19"
 ---
 
-While [Otter.ai](/blog/otter-ai-review/) has established itself as a popular meeting transcription tool, teams that prioritize data privacy and security often find it unsuitable for their needs.
+Most Otter.ai alternative lists start with an outdated assumption: Otter always sends a bot into your meeting.
 
-If you need better accuracy, offline capabilities, or want to keep sensitive conversations off cloud servers, several alternatives are worth evaluating.
+That is no longer accurate. Otter still offers its visible Notetaker, but it also has Mac and Windows desktop apps that record device audio without a bot. Its Chrome extension provides another bot-free path for browser meetings.
 
-This guide reviews 14 Otter AI alternatives, from zero-lock-in open-source solutions to enterprise platforms with advanced analytics.
+The useful question is no longer simply, “Which app avoids a bot?”
 
-## Quick comparison: top Otter AI alternatives
+It is: **Which capture method, storage model, and meeting workflow do you want to depend on?**
 
-| Tool         | Best For                | Starting Price (monthly)                                           | Key Advantage                                     |
-| ------------ | ----------------------- | ------------------------------------------------------------------ | ------------------------------------------------- |
-| Anarlog     | Zero lock-in, complete control | Free forever (local + BYOK). Managed cloud $25/month. | Open source. Plain markdown files. Your choice of AI. |
-| Fireflies.ai | Team collaboration      | $18/user/month                                                     | 69+ languages supported                           |
-| Rev          | High accuracy needs     | Pay-per-use: $0.25/min                                             | Human + AI transcription                          |
-| Fathom       | Sales teams             | $19/user/month                                                     | CRM integrations                                  |
-| Notta        | Multilingual teams      | $13.49/user/month                                                  | 58 languages supported                            |
-| MeetGeek     | Analytics focus         | $19/user/month                                                     | Advanced meeting insights                         |
-| Tactiq       | Chrome users            | $12/user/month                                                     | Browser extension                                 |
-| Dialpad      | Communication platforms | $27/user/month                                                     | Unified communications                            |
-| Avoma        | Revenue teams           | $29/user/month                                                     | Conversation intelligence                         |
-| Grain        | Video-first teams       | $19/user/month                                                     | Video highlights                                  |
-| Sembly AI    | Workflow Integration    | $15/user/month                                                     | AI task extraction                                |
-| Descript     | Content creators        | $24/user/month                                                     | Audio/video editing                               |
-| Jamie AI     | Bot-free EU teams       | €24/user/month                                                     | GDPR compliance & offline capability              |
-| tl;dv        | Video-first teams       | $29/user/month                                                     | Unlimited video recordings & clips                |
+## The short answer
 
-## How we selected these alternatives
+- **Choose Anarlog** if you want bot-free capture, local transcription, and meeting notes stored as files you control.
+- **Choose Granola** if you want a polished, collaborative AI notepad without a visible meeting bot.
+- **Choose Fireflies** if integrations, CRM automation, and post-meeting workflows matter most.
+- **Choose Tactiq** if you primarily want a live transcript inside browser-based meetings.
+- **Choose Notta** if multilingual transcription and cross-device capture are the priority.
+- **Choose Meetily** if you want an open-source, local setup and are comfortable operating more of the stack yourself.
+- **Stay with Otter** if unattended meeting attendance and a centralized, searchable archive matter more than local ownership.
 
-We analyzed hundreds of user reviews on G2, Capterra, and Reddit, [conducted hands-on testing of leading AI notetakers](/blog/best-ai-meeting-assistant-for-taking-notes), and identified the most frequently cited limitations driving teams to seek alternatives.
+There is no universally best Otter alternative. The best choice depends on what should happen before, during, and after the meeting.
 
-The most common pain points we found include:
+## Otter is no longer a bot-only notetaker
 
-### 1. Privacy and data control concerns
+Otter’s Notetaker can automatically join scheduled Zoom, Google Meet, and Microsoft Teams calls. It appears as a guest participant and can attend even when you are absent. Otter explicitly states that this participant cannot be anonymous. That visibility is part of the design, not a hidden implementation detail. [Otter Notetaker overview](https://help.otter.ai/hc/en-us/articles/4425393298327-Otter-Notetaker-Overview)
 
-[Otter.ai's privacy policy](https://otter.ai/privacy-policy) indicates they transfer data across international borders to partners and service providers, subjecting conversations to different privacy laws and regulatory frameworks depending on where those partners operate.
+<Image src="/api/assets/blog/library/products/otter/notetaker/2026-07-17-notetaker-overview.png" alt="Otter Notetaker joining a calendar meeting as a visible guest and producing a transcript" />
 
-This creates compliance complexity: organizations must ensure adherence to privacy regulations across multiple countries rather than maintaining local control.
+*Otter’s official Notetaker overview shows the calendar, visible guest, and transcript workflow. Source: [Otter](https://help.otter.ai/hc/en-us/articles/4425393298327-Otter-Notetaker-Overview).*
 
-Otter also shares data with third-party vendors and uses customer conversations for AI model training, even when de-identified.
+Otter now also offers two bot-free paths:
 
-Also read about [Otter AI's recent class-action lawsuit and privacy concerns](/blog/is-otter-ai-safe).
+- Its [desktop app](https://help.otter.ai/hc/en-us/articles/35973988280215-Otter-Desktop-App-Mac-Windows) captures audio directly from Mac or Windows.
+- Its [Chrome extension](https://help.otter.ai/hc/en-us/articles/1500001857021-Otter-Chrome-extension) records supported browser meetings without sending the Notetaker.
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-1.webp" alt="Otter AI's Privacy Concerns"/>
+That means “I do not want a bot” is no longer, by itself, a reason to leave Otter. A stronger reason would be that you want local files, offline processing, a browser-first transcript, deeper automation, stronger multilingual support, or an open-source stack.
 
-### 2. Bot dependence and intrusiveness
+If privacy is the central concern, examine the entire data flow rather than the participant list. Our detailed guide to [whether Otter.ai is safe](/blog/is-otter-ai-safe/) covers the questions worth asking about access, retention, and storage.
 
-Otter.ai requires meeting bots to join Zoom, Teams, or Google Meet calls to record and transcribe. Many users find this intrusive—especially in client-facing meetings where an unfamiliar "bot participant" suddenly appears.
+## Otter alternatives compared by workflow
 
-Bot-based assistants also create compliance hurdles in finance and healthcare, where explicit participant consent is mandatory.
+| Tool | Capture model | Visible bot? | Default meeting record | Can attend without you? | Best fit |
+| --- | --- | --- | --- | --- | --- |
+| **Anarlog** | Device audio and local transcription | No | Local files | No | Ownership, privacy, and offline work |
+| **Granola** | Device audio paired with personal notes | No | Granola workspace | No | Collaborative AI-enhanced notes |
+| **Fireflies** | Meeting bot or desktop capture | Depends | Fireflies workspace | Yes, with Notetaker | Integrations and automation |
+| **Tactiq** | Browser extension and meeting captions | No | Tactiq workspace and exports | No | Live browser transcripts |
+| **Notta** | App, browser, file import, and meeting workflows | Depends | Notta workspace | Depends on capture method | Multilingual and cross-device use |
+| **Meetily** | Local device capture | No | Local or self-managed data | No | Open-source and self-hosted workflows |
+| **Otter** | Notetaker, desktop app, or Chrome extension | Depends | Otter workspace | Yes, with Notetaker | Unattended attendance and searchable archives |
 
-If your team prefers an invisible approach that runs locally or integrates directly into your workflow, see [our guide on bot-free AI meeting assistants](/blog/bot-free-ai-meeting-assistants).
+Pricing changes too frequently to be a reliable differentiator in a long-lived comparison. Test current plans against your real monthly meeting hours, import requirements, team size, and export needs before choosing.
 
-### 3. Restrictive free plan limitations
+## 1. Anarlog: best for local files and user-owned meeting memory
 
-The free plan caps usage at 300 minutes per month, 30 minutes per meeting, and allows only 3 lifetime file uploads.
+[Anarlog](/) is an open-source, local-first meeting notetaker for people who do not want their meeting history trapped inside another proprietary dashboard.
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-2.webp" alt="otter ai free plan restriction"/>
-Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-9860718)
+It captures meeting audio from your device without joining the call as a participant. Transcription can run locally, and your audio, transcripts, and notes remain available as files on your computer. You can use local models, connect your own AI provider, or use Anarlog’s hosted AI depending on the workflow you want.
 
-### 4. Language support gaps
+<Image src="/api/assets/blog/library/products/anarlog/desktop/2026-07-17-meeting-note.png" alt="Anarlog desktop meeting note with a live transcript, personal notes, and local meeting controls" />
 
-[International teams](https://cybernews.com/ai-tools/otter-ai-review/) report significant limitations with Otter AI's support for only English, Spanish, and French, compared to competitors offering 40+ languages. Global organizations with diverse linguistic needs find this restrictive.
+That difference becomes more important after the meeting. A local, file-based record can participate in the rest of your knowledge system: folders, search tools, scripts, backups, editors, and coding agents. You are not limited to whatever integrations the notetaker vendor decides to maintain.
 
-### 5. Internet dependency
+**Choose Anarlog when:**
 
-Teams working in locations with poor connectivity or needing offline capabilities find Otter AI's requirement for stable internet connection for live transcription limiting.
+- you want bot-free capture;
+- meetings may contain sensitive customer, hiring, legal, or founder conversations;
+- you want transcription to keep working offline;
+- Markdown files and open formats are preferable to a closed meeting database;
+- you want control over which AI model processes your notes.
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-3.webp" alt="does otter ai work offline"/>
-Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-10454595)
+**Consider the tradeoffs:**
 
-### 6. Cost escalation for teams
+- The current download experience is centered on macOS.
+- A device-based notetaker cannot attend a meeting when your computer is absent.
+- Local models require storage and computing resources.
+- Local ownership also means taking responsibility for your own backup workflow.
 
-Advanced features are locked behind higher-tier subscriptions. Organizations with heavy usage requirements report costs escalating quickly.
+For a deeper explanation of the architecture, see our guide to [local AI meeting notes](/blog/local-ai-meeting-notes/).
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-4.webp" alt="otter ai cost"/>
-Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-10454595)
+## 2. Granola: best for a polished collaborative notepad
 
-### 7. Accuracy and speaker identification issues
+Granola is built around a useful premise: people should still take notes during a meeting, while AI fills in the details around them.
 
-Speaker identification accuracy issues become problematic in multi-speaker environments where precise attribution is critical for follow-up actions and accountability.
+It captures computer audio without adding a bot to the participant list. Your own notes become the starting point for a more complete meeting document, and Granola adds collaborative workspaces, templates, chat, and cross-meeting analysis. Its current product supports desktop, mobile, virtual, and in-person workflows. [Granola product overview](https://www.granola.ai/)
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-5.webp" alt="otter ai accuracy issues"/>
-Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-10454595)
+<Image src="/api/assets/blog/library/products/granola/notepad/2026-07-19-meeting-note.jpg" alt="Granola note beside a six-person video call with the background recording indicator active" />
 
-## The 14 best Otter.ai alternatives
+*Granola’s first-party product image shows its notepad working beside a call without another participant in the meeting. Source: [Granola](https://www.granola.ai/).*
 
-### 1. Anarlog - Best for Zero Lock-in and Complete Control
+This makes Granola a good fit for product teams, investors, researchers, recruiters, and founders who want to remain actively involved in note-taking rather than delegate the whole record to an automated transcript.
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-6.webp" alt="Anarlog"/>
+**Choose Granola when:**
 
-#### How it compares to Otter AI:
+- the team wants polished notes with little setup;
+- no-bot capture matters, but local storage is not required;
+- human notes should guide what the AI emphasizes;
+- collaboration inside a shared workspace is valuable.
 
-[Anarlog](/) is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack.
+**Consider the tradeoffs:**
 
-The interface resembles Apple Notes, and everything is stored as plain markdown files on your device—not in proprietary databases. No bots joining your calls, no vendor lock-in.
+- “No bot” and “private by default” do not mean the same thing as local-first storage.
+- Your meeting archive remains organized around Granola’s workspace.
+- It is less suitable when unattended meeting attendance is essential.
 
-Launch a meeting and the AI assistant transcribes speech in real-time. When the meeting ends, it presents a structured summary with key decisions, action items, and discussion themes automatically extracted.
+Anarlog and Granola both avoid a visible meeting participant. The main distinction is what happens to the record afterward: a managed collaborative workspace versus files owned by the user.
 
-You choose your AI stack: use the managed cloud service, bring your own API keys (OpenAI, Deepgram, Anthropic), or run local models via Ollama. Otter AI locks you into their cloud with no way to switch.
+## 3. Fireflies: best for integrations and workflow automation
 
-You trade Otter's real-time collaboration features for zero lock-in, true file ownership, and complete control over your workflow. Your notes work with any tool—Obsidian, Notion, VS Code—because they're just markdown files.
+Fireflies is strongest when the transcript is the beginning of an automated business process.
 
-#### Key advantages over Otter AI:
+Its Notetaker can join calls, produce transcripts and summaries, and feed meeting data into downstream systems. Fireflies also documents a bot-free desktop app that captures system audio on Mac and Windows. In that mode, it produces a transcript and summary but does not save a separate audio or video recording. [Fireflies bot-free desktop guide](https://guide.fireflies.ai/articles/6666374717-how-to-record-meetings-without-a-bot-on-the-fireflies-desktop-app)
 
-- Zero lock-in vs. platform dependency
-- Plain markdown files vs. proprietary database
-- Your choice of AI stack vs. vendor-locked cloud processing
-- Open source vs. closed source
-- Bot-free recording vs. meeting bot intrusion
-- Free forever for local transcription and BYOK vs. limited 300 minutes/month
+<Image src="/api/assets/blog/library/products/fireflies/meeting-summary/2026-07-17-refine-summary.png" alt="Fireflies meeting summary with controls to refine, expand, and regenerate the summary" />
 
-#### Trade-offs:
+*The current Fireflies summary interface. Source: [Fireflies](https://guide.fireflies.ai/articles/9547055509-Fireflies-AI-Meeting-Summaries%3A-View%2C-Customise%2C-Expand%2C-Regenerate).*
 
-- Currently macOS only vs. Otter AI's cross-platform availability
-- No real-time collaboration vs. Otter AI's team features
-- Performance depends on local hardware vs. cloud processing power
+The platform’s integration model is the main reason to choose it. Its Zapier integration can route meeting summaries, action items, and other outputs into CRMs, project tools, spreadsheets, and communication systems. [Fireflies Zapier guide](https://guide.fireflies.ai/articles/8908189165-how-to-integrate-zapier-with-fireflies)
 
-### 2. Fireflies - best for global team collaboration
+**Choose Fireflies when:**
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-7.webp" alt="fireflies"/>
+- sales or customer-success workflows depend on meeting data;
+- CRM logging should happen automatically;
+- a team needs both bot-based and bot-free capture options;
+- integrations matter more than local artifact ownership.
 
-#### How it compares to Otter AI:
+**Consider the tradeoffs:**
 
-[Fireflies](https://fireflies.ai/) addresses Otter.ai's language limitations. Otter AI supports only 3 languages, making it unsuitable for global organizations. Fireflies offers 69+ languages while also providing the advanced conversation intelligence that Otter AI lacks.
+- The privacy and social experience changes depending on which capture method you use.
+- Bot-free desktop capture has different artifacts from the Notetaker workflow.
+- More automation usually means more systems can receive meeting-derived data.
 
-Both tools use meeting bots, which may concern people preferring less intrusive AI assistants.
+Before connecting a meeting assistant to several downstream services, map where transcripts, summaries, and action items will be copied.
 
-#### Key advantages over Otter AI:
+## 4. Tactiq: best for browser-based live transcription
 
-- 69+ languages vs. 3 languages
-- Advanced conversation intelligence vs. basic summaries
-- Stronger CRM integrations vs. limited third-party connections
-- Automated workflows vs. manual post-meeting tasks
-- Sentiment analysis capabilities vs. text-only insights
+Tactiq is a browser extension designed around live transcription. Instead of introducing another attendee, it uses the meeting experience already visible in your browser.
 
-#### Trade-offs:
+For Microsoft Teams, Tactiq’s current documentation requires the web version and a supported Chromium browser. It starts displaying the transcript when the meeting begins, without adding a bot. [Tactiq for Microsoft Teams](https://help.tactiq.io/en/articles/9560779-how-to-use-tactiq-with-microsoft-teams)
 
-- Meeting bots can be intrusive (similar to Otter AI)
-- Higher complexity vs. Otter's simplicity
-- Requires more setup vs. Otter's plug-and-play approach
+<Image src="/api/assets/blog/library/products/tactiq/microsoft-teams/tactiq-2026-07-17-live-transcript.png" alt="Microsoft Teams web meeting with the Tactiq Live Transcript panel open beside the call" />
 
-### 3. Rev - best for human + AI transcription
+*Tactiq’s official Teams demonstration shows its Live Transcript panel beside the web meeting. Source: [Tactiq](https://help.tactiq.io/en/articles/9560779-how-to-use-tactiq-with-microsoft-teams).*
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-8.webp" alt="rev"/>
+Its Zoom workflow is similarly browser-oriented. That simplicity is appealing if the primary goal is to follow the transcript during the meeting, highlight decisions, and generate notes afterward. [Tactiq for Zoom](https://help.tactiq.io/en/articles/9530151-how-to-use-tactiq-with-zoom)
 
-#### How it compares to Otter AI:
+**Choose Tactiq when:**
 
-[Rev](https://www.rev.com/) solves Otter AI's accuracy limitations. While Otter relies solely on AI transcription with 85% accuracy, Rev offers both AI (96%+) and human transcription (99% accuracy) options.
+- most meetings happen in a supported browser;
+- a visible live transcript is more useful than unattended attendance;
+- the team wants a lightweight extension instead of another desktop app;
+- extracting highlights and actions matters more than maintaining a complete audio archive.
 
-This matters for legal, healthcare, and journalism professionals who cannot tolerate transcription errors from Otter's AI-only approach.
+**Consider the tradeoffs:**
 
-#### Key advantages over Otter AI:
+- The browser and meeting platform become dependencies.
+- Desktop-client meetings may require changing how you join.
+- Browser caption availability and platform changes can affect capture.
 
-- Dual transcription options (AI + human) vs. AI-only
-- 99% human accuracy vs. 85% AI accuracy
-- Professional compliance (HIPAA, SOC 2, GDPR) vs. basic security
-- Pay-per-use flexibility vs. subscription-only
-- Specialized industry focus vs. general business meetings
+Tactiq is less of a general meeting database and more of an efficient transcription layer for browser meetings.
 
-#### Trade-offs:
+## 5. Notta: best for multilingual and cross-device capture
 
-- Higher cost for premium accuracy vs. Otter's affordable plans
-- Human transcription turnaround time vs. real-time processing
-- Complex feature set vs. Otter's user-friendly interface
+Notta is the strongest multilingual option in this shortlist.
 
-### 4. Tactiq - best Chrome extension
+Its current documentation lists 58 monolingual transcription languages, along with separate bilingual transcription and translation capabilities. Language availability differs by feature, so verify the exact language pair and workflow you need rather than relying on the headline number. [Notta language support](https://support.notta.ai/hc/en-us/articles/4403155631131-What-languages-does-Notta-support)
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-9.webp" alt="tactiq"/>
+<Image src="/api/assets/blog/library/products/notta/ai-brain/2026-07-19-notta-brain.webp" alt="Notta Brain interface for asking questions across meeting files and generating images or slides" />
 
-#### How it compares to Otter AI:
+*Notta Brain turns meeting material into questions and deliverables inside the Notta workspace. Source: [Notta](https://www.notta.ai/en).*
 
-[Tactiq](https://tactiq.io/) works directly in your browser rather than as a separate app.
+Notta supports online meetings, in-person recording, and imported media. That makes it useful for teams whose “meeting notes” also include interviews, lectures, field recordings, or conversations captured across several devices.
 
-This browser-first design eliminates the need to download additional software like Otter AI requires, but creates dependency on Chrome that limits flexibility.
+**Choose Notta when:**
 
-The privacy philosophy differs significantly—Tactiq transcribes without storing audio files, addressing privacy concerns some users have with Otter's comprehensive recording approach.
+- meetings regularly switch between languages;
+- mobile and desktop capture are both important;
+- imported recordings are a major part of the workflow;
+- translation and multilingual search outweigh local processing.
 
-This privacy-focused design means sacrificing Otter's ability to playback meetings or share recordings with absent team members.
+**Consider the tradeoffs:**
 
-#### Key advantages over Otter AI:
+- Capture behavior differs between app, browser, import, and meeting workflows.
+- The meeting record is organized inside a vendor-hosted workspace.
+- Accuracy still varies by language, accent, microphone quality, and domain vocabulary.
 
-- Browser integration vs. separate app requirement
-- 60+ languages vs. 3 languages
-- Custom AI workflows vs. standard templates
-- No audio storage (privacy) vs. full recording
-- Advanced search filtering vs. basic search
+Run a test using your real language mix. A broad language list is useful, but accuracy on the specific conversations you hold is what matters.
 
-#### Trade-offs:
+## 6. Meetily: best for an open-source, self-managed setup
 
-- Chrome dependency vs. Otter AI's platform flexibility
-- Limited free plan vs. Otter's generous free tier
-- Accuracy issues with accents vs. Otter's speaker recognition
-- No offline capability vs. Otter's mobile app offline features
+Meetily is an open-source, local-first notetaker for users who want visibility into the software and control over deployment.
 
-### 5. Fathom - best free-to-enterprise alternative
+Its community project supports real-time transcription, AI summaries, and local processing across macOS, Windows, and Linux. The source is publicly available, which makes it possible to inspect, modify, and operate more of the stack yourself. [Meetily on GitHub](https://github.com/Zackriya-Solutions/meetily)
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-10.webp" alt="fathom"/>
+<Image src="/api/assets/blog/library/products/meetily/meeting-summary/2026-07-19-summary.png" alt="Meetily interface showing a timestamped transcript beside a generated summary, key decisions, and action items" />
 
-#### How it compares to Otter AI:
+*Meetily’s official repository screenshot shows the transcript and generated meeting record side by side. Source: [Meetily](https://github.com/Zackriya-Solutions/meetily/blob/main/docs/summary.png).*
 
-[Fathom](https://www.fathom.ai/) directly challenges Otter AI's freemium limitations. While Otter AI restricts free users to 300 minutes monthly and basic features, Fathom provides unlimited recording, transcription, and AI summaries at no cost.
+That makes Meetily particularly relevant to technical teams, self-hosters, and Windows or Linux users who want a local alternative.
 
-In its "Teams Edition," Fathom offers conversation intelligence features typically found in expensive tools like Gong. Otter AI remains focused on basic meeting documentation.
+**Choose Meetily when:**
 
-#### Key advantages over Otter AI:
+- open-source code is a requirement;
+- you need Windows or Linux support;
+- local processing is more important than a fully managed experience;
+- your team is comfortable troubleshooting models, hardware, and deployment.
 
-- Unlimited free features vs. 300-minute monthly cap
-- Instant processing vs. standard processing time
-- Sales conversation intelligence vs. basic transcription
-- Deal tracking and coaching vs. simple meeting notes
-- CRM sync automation vs. manual export
+**Consider the tradeoffs:**
 
-#### Trade-offs:
+- Self-managed software asks more from the user.
+- Local model performance depends on the machine.
+- Setup, updates, and operational polish may matter as much as the feature list.
 
-- Sales-focused features vs. Otter AI's general meeting focus
-- Team features require paid plans vs. Otter's collaborative free tier
-- Less brand recognition vs. Otter's established market presence
+Anarlog and Meetily share a local-first philosophy. The practical choice comes down to platform support, desired product polish, and how much of the stack you want to operate yourself.
 
-### 6. Notta - best for multilingual teams
+## When staying with Otter makes more sense
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-11.webp" alt="notta"/>
+Switching tools is not automatically an improvement.
 
-#### How it compares to Otter AI:
+Otter remains a strong choice when:
 
-[Notta](https://www.notta.ai/) solves Otter's language support limitation.
+- the Notetaker must attend a scheduled meeting without you;
+- the team already relies on a central Otter workspace;
+- conversations need to be searchable across many meetings;
+- participants are comfortable with a visible recording assistant;
+- changing the capture workflow would create more friction than it removes.
 
-Otter's three-language restriction makes it unsuitable for international organizations, while Notta supports 58 languages with real-time translation capabilities.
+Otter also now supports transcription in English, Spanish, French, German, Japanese, and Chinese according to its current pricing page. That is broader than older comparisons suggest, though still narrower than a multilingual specialist such as Notta. [Otter pricing and feature matrix](https://otter.ai/pricing)
 
-The trade-off involves ecosystem maturity—Otter AI offers more established integrations and collaborative features, while Notta focuses on superior multilingual accuracy.
+Do not switch because a comparison page says another product has more features. Switch when the alternative provides a meaningfully better data model, capture experience, platform fit, or post-meeting workflow.
 
-#### Key advantages over Otter AI:
+## How to test an Otter alternative
 
-- 58 languages vs. 3 languages
-- Real-time translation vs. single-language transcription
-- 98.86% accuracy vs. lower reported accuracy
-- Global team collaboration vs. English-speaking team focus
-- Cross-platform mobile apps vs. limited mobile functionality
+Use the same representative meeting with every serious candidate. A short product demo is not enough.
 
-#### Trade-offs:
+### 1. Test the real capture environment
 
-- Some billing issues reported vs. Otter's stable billing
-- Advanced features require paid plans vs. Otter's feature-rich free tier
-- Less integration ecosystem vs. Otter's established partnerships
+Use the conferencing app, browser, headphones, microphone, and operating system you normally rely on.
 
-### 7. MeetGeek - best for automated meeting workflows
+Confirm what happens when another person shares audio, you use headphones, the network drops, speakers interrupt one another, someone joins from a noisy room, or the meeting changes languages.
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-12.webp" alt="meetgeek"/>
+### 2. Inspect the raw transcript
 
-#### How it compares to Otter AI:
+Do not evaluate only the polished summary. Check speaker attribution, names and technical vocabulary, timestamps, missing sentences, overlapping speech, and how easily errors can be corrected.
 
-[MeetGeek](https://meetgeek.ai/) goes beyond Otter's basic transcription and summary by automatically understanding meeting context.
+### 3. Trace the meeting record
 
-Otter AI treats every meeting the same way. MeetGeek intelligently detects whether you're in a sales call, HR interview, or team standup, then applies appropriate templates and workflows.
+Ask where each artifact exists: raw audio, transcript, summary, personal notes, chat history, search indexes, and exports sent to connected tools.
 
-This contextual intelligence means less manual post-meeting work compared to Otter's generic output, though it requires more initial setup and learning to fully utilize advanced automation features.
+A bot-free interface can still send the meeting record to a cloud service. Conversely, a visible bot may operate within a well-defined organizational policy. The capture method is only one part of the privacy model.
 
-#### Key advantages over Otter AI:
+### 4. Reproduce the post-meeting workflow
 
-- Context-aware AI that understands different meeting types
-- Automated workflow distribution to relevant stakeholders
-- 100+ performance KPIs with coaching insights
-- Chrome recorder operates without platform restrictions
-- Intelligent meeting organization and knowledge base creation
+Turn the transcript into decisions, tasks, a customer follow-up, a project update, or searchable background for the next meeting.
 
-#### Trade-offs:
+If extracting [meeting action items](/blog/meeting-action-items/) still requires copying between several tools, the notetaker has only solved part of the problem.
 
-- Steeper learning curve vs. Otter's simplicity
-- Complex feature set may overwhelm basic users
-- Higher-tier plans needed for advanced automation
+### 5. Test export and exit
 
-### 8. Dialpad - best unified communications
+Export several meetings before committing to a product.
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-13.webp" alt="dialpad"/>
+Check whether the export preserves headings, speakers, timestamps, links, action items, and attachments. A meeting archive becomes more valuable over time, so the cost of leaving matters from the first day.
 
-#### How it compares to Otter AI:
+## Frequently asked questions
 
-[Dialpad](https://www.dialpad.com/) positions transcription as part of a complete business communications platform. Otter AI focuses solely on meeting documentation.
+### Does Otter.ai have a bot-free mode?
 
-Dialpad users get unified voice, video, messaging, and contact center capabilities alongside transcription, but pay significantly more than Otter's meeting-focused pricing.
+Yes. Otter’s Mac and Windows desktop apps can capture device audio without sending a bot into the meeting. Its Chrome extension also provides bot-free browser recording. Otter’s separate Notetaker remains a visible participant and is the option designed for unattended attendance.
 
-For organizations already using multiple communication tools, Dialpad consolidates functionality that Otter AI cannot provide, though it may be overkill for teams only needing meeting transcription.
+### What is the best private alternative to Otter.ai?
 
-#### Key advantages over Otter AI:
+For users who want local files, bot-free capture, and on-device transcription, Anarlog is the strongest fit in this comparison. Meetily is another local, open-source option, especially for Windows and Linux users.
 
-- Complete communications platform integration
-- Real-time sentiment analysis during calls
-- Business phone system connectivity
-- Contact center capabilities with transcription
-- Unified platform approach eliminates tool switching
+Privacy still depends on configuration. A local application connected to a hosted AI provider is not the same as a completely offline setup.
 
-#### Trade-offs:
+### Which Otter alternative is best for multiple languages?
 
-- Higher cost structure vs. meeting-focused pricing
-- Complex setup vs. plug-and-play simplicity
-- Communication platform lock-in vs. standalone flexibility
+Notta has the broadest documented language coverage among the tools compared here. Test the exact language, accent, vocabulary, and translation direction you need before adopting it.
 
-### 9. Avoma - best for revenue teams
+### Can a bot-free notetaker attend without me?
 
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-14.webp" alt="avoma"/>
+Generally, no. Device-based capture requires the device to be present and recording. If unattended attendance is essential, Otter’s Notetaker or another bot-based workflow is a better fit.
 
-#### How it compares to Otter AI:
+### Is a bot-free meeting assistant automatically safer?
 
-[Avoma](https://www.avoma.com/) transforms meeting transcripts into revenue intelligence. Otter.ai stops at basic documentation.
+No. Bot-free describes how audio is captured, not where it is processed or stored. Review retention, model-provider access, connected integrations, administrative controls, and deletion behavior as well. Our guide to [AI meeting notes without a bot](/blog/ai-meeting-notes-without-bot/) explains the distinction.
 
-Otter AI provides generic summaries. Avoma automatically identifies objections, tracks deal progression, and generates sales coaching insights. This makes Avoma invaluable for revenue teams frustrated with Otter's inability to connect meeting content to business outcomes, though the specialized focus and higher pricing make it less suitable for general meeting documentation needs.
+## Choose the meeting record you want to keep
 
-#### Key advantages over Otter AI:
+Otter is useful when you want a meeting assistant that can attend calls, centralize conversations, and make them searchable.
 
-- Revenue-focused conversation intelligence
-- Automatic objection and topic identification
-- Sales performance metrics and coaching
-- Deal risk assessment capabilities
-- Custom conversation scorecards for sales processes
+Anarlog starts from a different premise: the meeting record should remain part of your own files and knowledge system.
 
-#### Trade-offs:
-
-- Significantly higher pricing vs. affordable plans
-- Sales-specialized features vs. general meeting utility
-- Complex feature set vs. straightforward transcription
-
-### 10. Grain - best for video highlights
-
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-15.webp" alt="grain"/>
-
-#### How it compares to Otter AI:
-
-[Grain](https://grain.com/) prioritizes video content creation over text transcription, making it ideal for teams who need to share meeting clips rather than read summaries.
-
-Otter AI focuses on searchable text and collaborative editing. Grain excels at creating shareable video highlights with timestamps for visual learners and content creators.
-
-This video-first approach trades some of Otter's text analysis capabilities for superior visual meeting documentation and clip sharing.
-
-#### Key advantages over Otter AI:
-
-- Video highlight creation and clip sharing
-- Timestamp-based video navigation
-- Visual meeting documentation approach
-- Collaborative video editing features
-- Content creation workflow optimization
-
-#### Trade-offs:
-
-- Limited text transcription features vs. comprehensive text analysis
-- Video storage requirements vs. lightweight text approach
-- No mobile app vs. cross-platform accessibility
-
-### 11. Sembly AI - best for task management
-
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-16.webp" alt="sembly ai"/>
-
-#### How it compares to Otter AI:
-
-Otter AI focuses primarily on transcription and basic note-taking. [Sembly AI](https://www.sembly.ai/) positions itself as a comprehensive meeting intelligence platform.
-
-Sembly analyzes deeper, creating structured insights, action items, and complex artifacts like project plans and requirements documents. Otter AI excels at accurate transcription but lacks Sembly's advanced document generation.
-
-#### Key advantages over Otter AI:
-
-- AI Artifacts generation (project plans, requirements, reports)
-- Multi-meeting trend analysis and insights across conversations
-- Advanced action item extraction with assignees and due dates
-- Enterprise-grade security (SOC 2 Type II, GDPR compliance)
-- Role-based meeting insights tailored to specific job functions and goals
-- Comprehensive CRM and project management integrations
-- Team analytics and workspace management features
-- 45+ language support with international data residency options
-
-#### Trade-offs:
-
-- Steeper learning curve vs. straightforward transcription interface
-- Enterprise focus vs. broader consumer appeal
-- Complex feature set vs. simple, intuitive note-taking experience
-
-### 12. Descript - best for content creators
-
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-17.webp" alt="descript"/>
-
-#### How it compares to Otter AI:
-
-[Descript](https://www.descript.com/) combines transcription with comprehensive audio and video editing tools. Otter focuses purely on meeting documentation. Descript works better for podcast creators, video producers, and content teams who need to edit their recordings, not just transcribe them.
-
-This expanded functionality comes with complexity and higher pricing that exceeds what most teams need for simple meeting notes—an area where Otter AI's focused approach provides better value.
-
-#### Key advantages over Otter AI:
-
-- Text-based audio and video editing capabilities
-- Collaborative content creation workspace
-- Screen recording with transcription integration
-- Professional content creator workflow tools
-- Multi-format export and publishing options
-
-#### Trade-offs:
-
-- Content creation focus vs. meeting-specific features
-- Higher complexity and learning curve vs. simple transcription
-- Premium pricing vs. meeting-focused affordability
-
-### 13. Jamie AI - best bot-free European alternative
-
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-18.webp" alt="jamie ai"/>
-
-#### How it compares to Otter AI:
-
-[Jamie AI](https://www.meetjamie.ai/) addresses privacy and compliance concerns that European organizations have with US-based tools like Otter AI.
-
-Otter processes data in the cloud and uses meeting bots that can feel intrusive. Jamie operates without bots and stores all data within EU servers in Frankfurt with strict GDPR compliance.
-
-Jamie works both online and offline, making it ideal for in-person meetings or areas with poor connectivity. Otter AI requires stable internet.
-
-The key trade-off is real-time collaboration—Otter AI offers live editing and team features, while Jamie focuses on post-meeting processing and individual productivity.
-
-#### Key advantages over Otter AI:
-
-- Complete bot-free operation vs. intrusive meeting bots
-- EU data hosting with GDPR compliance vs. international data transfers
-- Offline functionality for in-person meetings vs. internet dependency
-- Advanced accent recognition for 20+ languages vs. limited language support
-- Privacy-first approach with automatic audio deletion vs. cloud storage
-
-#### Trade-offs:
-
-- Post-meeting processing vs. real-time transcription
-- Individual focus vs. team collaboration features
-- Limited integrations vs. established ecosystem partnerships
-
-### 14. tl;dv - best video-first meeting assistant
-
-<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-19.webp" alt="tl;dv"/>
-
-#### How it compares to Otter AI:
-
-Otter only offers video recording on Enterprise plans. [tl;dv](https://tldv.io/) provides unlimited video recordings, transcriptions, and automated notes for free.
-
-tl;dv excels at creating video clips directly from transcripts and timestamped highlights. Otter AI requires users to upgrade to expensive enterprise tiers for basic video functionality.
-
-Otter offers better transcript editing capabilities and mobile functionality that tl;dv currently lacks.
-
-#### Key advantages over Otter AI:
-
-- Unlimited video recordings and transcripts on free plan vs. Enterprise-only video
-- Video clip creation directly from transcripts vs. no video editing
-- Advanced search filtering by deal stage, meeting type, attendance vs. basic search
-- 30+ language support with dialect recognition vs. 3 languages
-- Unlimited concurrent meeting recordings vs. 3-meeting limitation
-
-#### Trade-offs:
-
-- Limited mobile functionality vs. comprehensive mobile apps
-- Internet dependency for optimal performance vs. offline mobile recording
-- Less transcript editing capability vs. full transcript modification
-- Desktop-focused approach vs. cross-platform accessibility
-
-## Why Anarlog stands out
-
-While each alternative has strengths, **Anarlog** offers a unique value proposition: **zero lock-in and complete control**.
-
-✅ **Zero lock-in** - Plain markdown files, open source, portable format that works with any tool
-✅ **Complete control** - Choose your AI stack: managed cloud, bring your own keys, or run fully local
-✅ **True ownership** - Your files live on your device, not in someone's database
-✅ **Simple but powerful** - Complete control without complexity
-✅ **Cost-effective** - No recurring fees for basic functionality
-
-Whether you're an engineer who wants files over apps, a privacy-conscious professional in regulated industries, or someone whose company has banned cloud tools like Otter—Anarlog gives you ownership at the foundational level.
-
-**Ready to take control?** [Download Anarlog](/download) and experience meeting notes with zero lock-in.
+If you want bot-free capture, local transcription, open-source software, and notes that remain available outside a proprietary meeting database, [download Anarlog for macOS](/download).


### PR DESCRIPTION
Refresh Otter.ai alternatives guide

- Rebuild the comparison around capture method, ownership, and workflow fit.
- Correct Otter's current bot-free capabilities.
- Add seven verified first-party product visuals through the blog media proxy.

Checks:
- dprint check
- web typecheck
- content collections and client/SSR compile
- production asset proxy: 7/7 HTTP 200

Local prerender requires production environment variables supplied by deployment CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/content-only MDX changes with no application logic; main risk is SEO/title mismatch for inbound links expecting “14 alternatives.”
> 
> **Overview**
> Replaces the **14-tool** Otter.ai alternatives article with a **six-alternative** guide (Anarlog, Granola, Fireflies, Tactiq, Notta, Meetily) plus when to stay on Otter. SEO metadata moves from “14 Best … in 2026” to **“6 Best …”** with a new description and **date `2026-07-19`**.
> 
> The narrative shifts from “avoid the bot” to **capture method, where the meeting record lives, and post-meeting workflow**. Otter is updated to note **desktop and Chrome bot-free capture** alongside the visible Notetaker, with a **workflow comparison table** (bot visibility, unattended attendance, default record location).
> 
> Product write-ups are restructured around **when to choose / tradeoffs** instead of long feature-vs-Otter lists; **pricing tables and the old selection-criteria section** are dropped in favor of advising readers to validate current plans. **Seven first-party product images** are wired through `/api/assets/blog/library/...` (replacing older `/api/assets/blog/otter-ai-alternatives/*.webp` assets). New **evaluation checklist**, **FAQ**, and a shorter closing CTA round out the piece.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17e5f8b17f91f40abf50d7875512c11d438d057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->