### PR TITLE
fix(oauth): verify Microsoft publisher domain

### DIFF
--- a/apps/web/public/.well-known/microsoft-identity-association.json
+++ b/apps/web/public/.well-known/microsoft-identity-association.json
@@ -2,6 +2,9 @@
   "associatedApplications": [
     {
       "applicationId": "22bc6342-cd6a-4784-8d66-3242113fe7fb"
+    },
+    {
+      "applicationId": "3d7c41ea-a814-489f-9d57-9a4bbe780ddb"
     }
   ]
 }


### PR DESCRIPTION
Add the new Entra application ID to the public Microsoft identity association so publisher-domain verification survives future production deploys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static public JSON only; no runtime auth or application logic changes.
> 
> **Overview**
> Registers a **second Microsoft Entra application** (`3d7c41ea-a814-489f-9d57-9a4bbe780ddb`) in `apps/web/public/.well-known/microsoft-identity-association.json` alongside the existing app ID, so Microsoft can associate both apps with the site’s publisher domain during OAuth setup.
> 
> This keeps **publisher-domain verification** valid after production deploys when using the new Entra application.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c4838fd0a51a5648ea5d74999bc3c7e15c50c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->