### PR TITLE
fix(ui): prevent toast close button clipping

### DIFF
--- a/packages/ui/src/components/ui/toast.tsx
+++ b/packages/ui/src/components/ui/toast.tsx
@@ -21,7 +21,7 @@ const Toaster = ({
     toastOptions={{
       classNames: {
         toast:
-          "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border group-[.toaster]:border-border group-[.toaster]:shadow-md group-[.toaster]:rounded-xl group-[.toaster]:overflow-clip group-[.toaster]:w-[300px] group-[.toaster]:p-3.5 group-[.toaster]:gap-3",
+          "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border group-[.toaster]:border-border group-[.toaster]:shadow-md group-[.toaster]:rounded-xl group-[.toaster]:overflow-visible group-[.toaster]:w-[300px] group-[.toaster]:p-3.5 group-[.toaster]:gap-3",
         description: "group-[.toast]:text-muted-foreground",
         actionButton:
           "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",


### PR DESCRIPTION
## Summary

- allow toast content to overflow its rounded container
- keep the close button fully visible at the toast edge

## Testing

- not run (PR creation only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on the toast wrapper; visual-only with no auth, data, or API impact.
> 
> **Overview**
> Fixes toast close buttons being cut off at the rounded edges by changing the toast container from **`overflow-clip`** to **`overflow-visible`** in the shared `Toaster` Sonner wrapper (`packages/ui/src/components/ui/toast.tsx`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3e53025ed794d91c31ad625b190bbbdf6e97260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->