### PR TITLE
fix(oauth): keep Google data off remote AI

### DIFF
--- a/apps/desktop/src/ai/data-boundary.test.ts
+++ b/apps/desktop/src/ai/data-boundary.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  canSendCalendarDerivedSttHints,
+  isOnDeviceLlmConnection,
+  isOnDeviceLiveSttConnection,
+  isOnDeviceSttTarget,
+  resolveGoogleCalendarLlmBoundary,
+} from "./data-boundary";
+
+describe("Google Calendar AI data boundary", () => {
+  it.each([
+    ["ollama", "http://127.0.0.1:11434/v1"],
+    ["ollama", "http://localhost:11434/v1"],
+    ["lmstudio", "http://[::1]:1234/v1"],
+  ])("allows %s on a loopback endpoint", (providerId, baseUrl) => {
+    expect(isOnDeviceLlmConnection({ providerId, baseUrl })).toBe(true);
+    expect(
+      resolveGoogleCalendarLlmBoundary({
+        googleCalendarDataState: "present",
+        providerId,
+        baseUrl,
+      }),
+    ).toBe("allowed");
+  });
+
+  it.each([
+    ["hyprnote", "http://localhost:3011/llm"],
+    ["openrouter", "https://openrouter.ai/api/v1"],
+    ["openai", "https://api.openai.com/v1"],
+    ["custom", "http://localhost:9000/v1"],
+    ["ollama", "https://models.example.com/v1"],
+    ["lmstudio", "http://localhost.evil.example/v1"],
+    ["ollama", "not-a-url"],
+  ])("treats %s at %s as off-device", (providerId, baseUrl) => {
+    expect(isOnDeviceLlmConnection({ providerId, baseUrl })).toBe(false);
+    expect(
+      resolveGoogleCalendarLlmBoundary({
+        googleCalendarDataState: "present",
+        providerId,
+        baseUrl,
+      }),
+    ).toBe("blocked");
+  });
+
+  it("fails closed while the local Google data check is unresolved", () => {
+    expect(
+      resolveGoogleCalendarLlmBoundary({
+        googleCalendarDataState: "loading",
+        providerId: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+    ).toBe("checking");
+    expect(
+      resolveGoogleCalendarLlmBoundary({
+        googleCalendarDataState: "error",
+        providerId: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+    ).toBe("check_failed");
+  });
+
+  it("allows off-device models only when Google data is conclusively absent", () => {
+    expect(
+      resolveGoogleCalendarLlmBoundary({
+        googleCalendarDataState: "absent",
+        providerId: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+    ).toBe("allowed");
+  });
+
+  it("recognizes only known local transcription targets", () => {
+    expect(
+      isOnDeviceSttTarget({ provider: "soniqo", baseUrl: "soniqo://local" }),
+    ).toBe(true);
+    expect(
+      isOnDeviceSttTarget({
+        provider: "am",
+        baseUrl: "http://127.0.0.1:8080",
+      }),
+    ).toBe(true);
+    expect(
+      isOnDeviceSttTarget({
+        provider: "hyprnote",
+        baseUrl: "http://localhost:3011/stt",
+      }),
+    ).toBe(false);
+    expect(
+      isOnDeviceSttTarget({
+        provider: "deepgram",
+        baseUrl: "https://api.deepgram.com",
+      }),
+    ).toBe(false);
+  });
+
+  it("validates the resolved endpoint for live local STT", () => {
+    expect(
+      isOnDeviceLiveSttConnection({
+        isLocalModel: true,
+        baseUrl: "http://127.0.0.1:8080",
+      }),
+    ).toBe(true);
+    expect(
+      isOnDeviceLiveSttConnection({
+        isLocalModel: true,
+        baseUrl: "https://remote.example.com",
+      }),
+    ).toBe(false);
+    expect(
+      isOnDeviceLiveSttConnection({
+        isLocalModel: true,
+        baseUrl: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("rechecks Google data immediately before off-device STT", async () => {
+    await expect(
+      canSendCalendarDerivedSttHints({
+        targetIsOnDevice: false,
+        googleCalendarDataState: "absent",
+        checkHasGoogleCalendarData: async () => true,
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      canSendCalendarDerivedSttHints({
+        targetIsOnDevice: false,
+        googleCalendarDataState: "absent",
+        checkHasGoogleCalendarData: async () => false,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("fails closed when the request-time STT data check fails", async () => {
+    await expect(
+      canSendCalendarDerivedSttHints({
+        targetIsOnDevice: false,
+        googleCalendarDataState: "absent",
+        checkHasGoogleCalendarData: async () => {
+          throw new Error("database unavailable");
+        },
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("does not query Google data for on-device STT", async () => {
+    const checkHasGoogleCalendarData = vi.fn(async () => true);
+
+    await expect(
+      canSendCalendarDerivedSttHints({
+        targetIsOnDevice: true,
+        googleCalendarDataState: "present",
+        checkHasGoogleCalendarData,
+      }),
+    ).resolves.toBe(true);
+    expect(checkHasGoogleCalendarData).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/ai/data-boundary.ts
+++ b/apps/desktop/src/ai/data-boundary.ts
@@ -1,0 +1,119 @@
+export type GoogleCalendarDataState =
+  | "loading"
+  | "error"
+  | "present"
+  | "absent";
+
+export type GoogleCalendarLlmBoundary =
+  | "allowed"
+  | "checking"
+  | "check_failed"
+  | "blocked";
+
+const LOCAL_LLM_PROVIDERS = new Set(["lmstudio", "ollama"]);
+
+export function isOnDeviceLlmConnection({
+  providerId,
+  baseUrl,
+}: {
+  providerId: string;
+  baseUrl: string;
+}): boolean {
+  if (!LOCAL_LLM_PROVIDERS.has(providerId)) {
+    return false;
+  }
+
+  return isLoopbackHttpUrl(baseUrl);
+}
+
+export function resolveGoogleCalendarLlmBoundary({
+  googleCalendarDataState,
+  providerId,
+  baseUrl,
+}: {
+  googleCalendarDataState: GoogleCalendarDataState;
+  providerId: string;
+  baseUrl: string;
+}): GoogleCalendarLlmBoundary {
+  if (isOnDeviceLlmConnection({ providerId, baseUrl })) {
+    return "allowed";
+  }
+
+  switch (googleCalendarDataState) {
+    case "absent":
+      return "allowed";
+    case "loading":
+      return "checking";
+    case "error":
+      return "check_failed";
+    case "present":
+      return "blocked";
+  }
+}
+
+export function isOnDeviceSttTarget({
+  provider,
+  baseUrl,
+}: {
+  provider: string;
+  baseUrl: string;
+}): boolean {
+  if (provider === "hyprnote") {
+    return false;
+  }
+
+  if (provider !== "soniqo" && provider !== "am") {
+    return false;
+  }
+
+  return baseUrl === "soniqo://local" || isLoopbackHttpUrl(baseUrl);
+}
+
+export function isOnDeviceLiveSttConnection({
+  isLocalModel,
+  baseUrl,
+}: {
+  isLocalModel: boolean;
+  baseUrl: string | undefined;
+}): boolean {
+  return isLocalModel && !!baseUrl && isLoopbackHttpUrl(baseUrl);
+}
+
+export async function canSendCalendarDerivedSttHints({
+  targetIsOnDevice,
+  googleCalendarDataState,
+  checkHasGoogleCalendarData,
+}: {
+  targetIsOnDevice: boolean;
+  googleCalendarDataState: GoogleCalendarDataState;
+  checkHasGoogleCalendarData: () => Promise<boolean>;
+}): Promise<boolean> {
+  if (targetIsOnDevice) {
+    return true;
+  }
+
+  if (googleCalendarDataState !== "absent") {
+    return false;
+  }
+
+  try {
+    return !(await checkHasGoogleCalendarData());
+  } catch {
+    return false;
+  }
+}
+
+export function isLoopbackHttpUrl(baseUrl: string): boolean {
+  try {
+    const url = new URL(baseUrl);
+    const hostname = url.hostname.toLowerCase();
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      (hostname === "localhost" ||
+        hostname === "127.0.0.1" ||
+        hostname === "[::1]")
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/desktop/src/ai/google-calendar-boundary-fetch.test.ts
+++ b/apps/desktop/src/ai/google-calendar-boundary-fetch.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createGoogleCalendarBoundaryFetch,
+  GoogleCalendarRemoteAiBlockedError,
+} from "./google-calendar-boundary-fetch";
+
+describe("Google Calendar request-time AI boundary", () => {
+  it("blocks before an off-device request is sent", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const boundaryFetch = createGoogleCalendarBoundaryFetch(
+      fetchImpl,
+      async () => true,
+    );
+
+    await expect(boundaryFetch("https://model.example.com")).rejects.toThrow(
+      GoogleCalendarRemoteAiBlockedError,
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("sends the request only after Google data is conclusively absent", async () => {
+    const response = new Response(null, { status: 204 });
+    const fetchImpl = vi.fn<typeof fetch>(async () => response);
+    const boundaryFetch = createGoogleCalendarBoundaryFetch(
+      fetchImpl,
+      async () => false,
+    );
+
+    await expect(boundaryFetch("https://model.example.com")).resolves.toBe(
+      response,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when the local data check fails", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const boundaryFetch = createGoogleCalendarBoundaryFetch(
+      fetchImpl,
+      async () => {
+        throw new Error("database unavailable");
+      },
+    );
+
+    await expect(boundaryFetch("https://model.example.com")).rejects.toThrow(
+      "database unavailable",
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/ai/google-calendar-boundary-fetch.ts
+++ b/apps/desktop/src/ai/google-calendar-boundary-fetch.ts
@@ -1,0 +1,22 @@
+import { hasGoogleCalendarData } from "./google-calendar-data";
+
+export class GoogleCalendarRemoteAiBlockedError extends Error {
+  constructor() {
+    super(
+      "Remote AI is disabled while Google Calendar data remains on this device.",
+    );
+    this.name = "GoogleCalendarRemoteAiBlockedError";
+  }
+}
+
+export function createGoogleCalendarBoundaryFetch(
+  fetchImpl: typeof fetch,
+  checkHasGoogleCalendarData: () => Promise<boolean> = hasGoogleCalendarData,
+): typeof fetch {
+  return async (input, init) => {
+    if (await checkHasGoogleCalendarData()) {
+      throw new GoogleCalendarRemoteAiBlockedError();
+    }
+    return fetchImpl(input, init);
+  };
+}

--- a/apps/desktop/src/ai/google-calendar-data.test.ts
+++ b/apps/desktop/src/ai/google-calendar-data.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  GOOGLE_CALENDAR_DATA_SQL,
+  type GoogleCalendarDataSqlRow,
+} from "./google-calendar-data";
+
+describe("Google Calendar data query", () => {
+  let database: DatabaseSync;
+
+  beforeEach(() => {
+    database = new DatabaseSync(":memory:");
+    database.exec(`
+      CREATE TABLE calendars (
+        id TEXT NOT NULL DEFAULT '',
+        provider TEXT NOT NULL DEFAULT '',
+        deleted_at TEXT
+      );
+      CREATE TABLE events (
+        id TEXT NOT NULL DEFAULT '',
+        tracking_id_event TEXT NOT NULL DEFAULT '',
+        calendar_id TEXT NOT NULL DEFAULT '',
+        provider TEXT NOT NULL DEFAULT '',
+        deleted_at TEXT
+      );
+      CREATE TABLE sessions (
+        event_id TEXT NOT NULL DEFAULT '',
+        external_event_id TEXT NOT NULL DEFAULT '',
+        external_provider TEXT NOT NULL DEFAULT '',
+        event_json TEXT NOT NULL DEFAULT '',
+        deleted_at TEXT
+      );
+    `);
+  });
+
+  afterEach(() => {
+    database.close();
+  });
+
+  function hasGoogleCalendarData(): boolean {
+    const row = database
+      .prepare(GOOGLE_CALENDAR_DATA_SQL)
+      .get() as GoogleCalendarDataSqlRow;
+    return Boolean(row.has_google_calendar_data);
+  }
+
+  it("returns false without calendar-derived data", () => {
+    expect(hasGoogleCalendarData()).toBe(false);
+  });
+
+  it("includes live and tombstoned Google provider rows", () => {
+    database.exec(`
+      INSERT INTO calendars (provider) VALUES ('google');
+    `);
+    expect(hasGoogleCalendarData()).toBe(true);
+
+    database.exec("DELETE FROM calendars;");
+    database.exec(`
+      INSERT INTO events (id, provider, deleted_at)
+      VALUES ('event-1', 'google-calendar', '2026-07-20T00:00:00Z');
+    `);
+    expect(hasGoogleCalendarData()).toBe(true);
+
+    database.exec("DELETE FROM events;");
+    database.exec(`
+      INSERT INTO sessions (external_provider, deleted_at)
+      VALUES ('google', '2026-07-20T00:00:00Z');
+    `);
+    expect(hasGoogleCalendarData()).toBe(true);
+  });
+
+  it("fails closed for legacy event-backed sessions without provenance", () => {
+    database.exec(`
+      INSERT INTO sessions (event_json)
+      VALUES ('{"tracking_id":"event-1","calendar_id":"calendar-1","title":"Imported calendar event"}');
+    `);
+
+    expect(hasGoogleCalendarData()).toBe(true);
+  });
+
+  it("does not classify the local welcome event as Google data", () => {
+    database.exec(`
+      INSERT INTO sessions (event_json)
+      VALUES ('{"tracking_id":"anarlog-onboarding-demo-v1","calendar_id":"","title":"Welcome to Anarlog"}');
+    `);
+
+    expect(hasGoogleCalendarData()).toBe(false);
+  });
+
+  it("does not classify a legacy session linked to a known Outlook event as Google data", () => {
+    database.exec(`
+      INSERT INTO events (id, tracking_id_event, provider)
+      VALUES ('event-1', 'outlook-1', 'outlook');
+      INSERT INTO sessions (event_id, external_event_id, event_json)
+      VALUES ('event-1', 'outlook-1', '{"title":"Outlook event"}');
+    `);
+
+    expect(hasGoogleCalendarData()).toBe(false);
+  });
+
+  it("does not classify an orphaned session linked to a known Outlook calendar as Google data", () => {
+    database.exec(`
+      INSERT INTO calendars (id, provider)
+      VALUES ('outlook-calendar-1', 'outlook');
+      INSERT INTO sessions (event_json)
+      VALUES ('{"calendar_id":"outlook-calendar-1","title":"Outlook event"}');
+    `);
+
+    expect(hasGoogleCalendarData()).toBe(false);
+  });
+
+  it("fails closed when an external event ID lacks calendar-scoped provenance", () => {
+    database.exec(`
+      INSERT INTO events (tracking_id_event, calendar_id, provider)
+      VALUES ('event-1', 'outlook-calendar-1', 'outlook');
+      INSERT INTO sessions (external_event_id, event_json)
+      VALUES ('event-1', '{"title":"Imported event"}');
+    `);
+
+    expect(hasGoogleCalendarData()).toBe(true);
+  });
+});

--- a/apps/desktop/src/ai/google-calendar-data.ts
+++ b/apps/desktop/src/ai/google-calendar-data.ts
@@ -1,0 +1,83 @@
+import { liveQueryClient } from "~/db";
+
+export type GoogleCalendarDataSqlRow = {
+  has_google_calendar_data: boolean | number;
+};
+
+export const GOOGLE_CALENDAR_DATA_SQL = `
+  SELECT (
+    EXISTS (
+      SELECT 1
+      FROM calendars
+      WHERE provider IN ('google', 'google-calendar')
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM events
+      WHERE provider IN ('google', 'google-calendar')
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM sessions AS session
+      WHERE session.external_provider IN ('google', 'google-calendar')
+        OR (
+          session.external_provider = ''
+          AND (
+            session.event_id <> ''
+            OR session.external_event_id <> ''
+            OR (
+              LOWER(TRIM(session.event_json)) NOT IN ('', '{}', 'null')
+              AND NOT (
+                json_valid(session.event_json)
+                AND json_extract(session.event_json, '$.tracking_id') = 'anarlog-onboarding-demo-v1'
+              )
+            )
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM events AS linked_non_google_event
+            WHERE (
+              (
+                session.event_id <> ''
+                AND linked_non_google_event.id = session.event_id
+              )
+              OR (
+                session.external_event_id <> ''
+                AND json_valid(session.event_json)
+                AND COALESCE(json_extract(session.event_json, '$.calendar_id'), '') <> ''
+                AND linked_non_google_event.tracking_id_event = session.external_event_id
+                AND linked_non_google_event.calendar_id = json_extract(session.event_json, '$.calendar_id')
+              )
+            )
+            AND linked_non_google_event.provider IN ('apple', 'outlook')
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM calendars AS linked_non_google_calendar
+            WHERE json_valid(session.event_json)
+              AND COALESCE(json_extract(session.event_json, '$.calendar_id'), '') <> ''
+              AND linked_non_google_calendar.id = json_extract(session.event_json, '$.calendar_id')
+              AND linked_non_google_calendar.provider IN ('apple', 'outlook')
+          )
+        )
+    )
+  ) AS has_google_calendar_data
+`;
+
+export function mapGoogleCalendarDataRows(
+  rows: GoogleCalendarDataSqlRow[],
+): boolean {
+  const row = rows[0];
+  if (!row) {
+    throw new Error("Google Calendar data boundary query returned no result");
+  }
+  return Boolean(row.has_google_calendar_data);
+}
+
+export async function hasGoogleCalendarData(): Promise<boolean> {
+  const rows = await liveQueryClient.execute<GoogleCalendarDataSqlRow>(
+    GOOGLE_CALENDAR_DATA_SQL,
+    [],
+  );
+  return mapGoogleCalendarDataRows(rows);
+}

--- a/apps/desktop/src/ai/hooks/useGoogleCalendarDataState.test.ts
+++ b/apps/desktop/src/ai/hooks/useGoogleCalendarDataState.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { GOOGLE_CALENDAR_DATA_SQL } from "../google-calendar-data";
+import { getGoogleCalendarDataState } from "./useGoogleCalendarDataState";
+
+describe("Google Calendar data state", () => {
+  it("keeps tombstoned local data inside the boundary", () => {
+    expect(GOOGLE_CALENDAR_DATA_SQL).not.toContain("deleted_at");
+    expect(GOOGLE_CALENDAR_DATA_SQL).toContain("FROM calendars");
+    expect(GOOGLE_CALENDAR_DATA_SQL).toContain("FROM events");
+    expect(GOOGLE_CALENDAR_DATA_SQL).toContain("FROM sessions");
+  });
+
+  it("maps a conclusive query result", () => {
+    expect(
+      getGoogleCalendarDataState({
+        data: true,
+        isLoading: false,
+        error: null,
+      }),
+    ).toBe("present");
+    expect(
+      getGoogleCalendarDataState({
+        data: false,
+        isLoading: false,
+        error: null,
+      }),
+    ).toBe("absent");
+  });
+
+  it("fails closed on loading and errors", () => {
+    expect(
+      getGoogleCalendarDataState({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      }),
+    ).toBe("loading");
+    expect(
+      getGoogleCalendarDataState({
+        data: false,
+        isLoading: false,
+        error: new Error("database unavailable"),
+      }),
+    ).toBe("error");
+  });
+});

--- a/apps/desktop/src/ai/hooks/useGoogleCalendarDataState.ts
+++ b/apps/desktop/src/ai/hooks/useGoogleCalendarDataState.ts
@@ -1,0 +1,35 @@
+import type { GoogleCalendarDataState } from "../data-boundary";
+import {
+  GOOGLE_CALENDAR_DATA_SQL,
+  mapGoogleCalendarDataRows,
+  type GoogleCalendarDataSqlRow,
+} from "../google-calendar-data";
+
+import { useLiveQuery } from "~/db";
+
+export function getGoogleCalendarDataState({
+  data,
+  isLoading,
+  error,
+}: {
+  data: boolean | undefined;
+  isLoading: boolean;
+  error: Error | null;
+}): GoogleCalendarDataState {
+  if (error) {
+    return "error";
+  }
+  if (isLoading || data === undefined) {
+    return "loading";
+  }
+  return data ? "present" : "absent";
+}
+
+export function useGoogleCalendarDataState(): GoogleCalendarDataState {
+  const query = useLiveQuery<GoogleCalendarDataSqlRow, boolean>({
+    sql: GOOGLE_CALENDAR_DATA_SQL,
+    mapRows: mapGoogleCalendarDataRows,
+  });
+
+  return getGoogleCalendarDataState(query);
+}

--- a/apps/desktop/src/ai/hooks/useLLMConnection.ts
+++ b/apps/desktop/src/ai/hooks/useLLMConnection.ts
@@ -12,7 +12,13 @@ import type { CharTask } from "@hypr/api-client";
 import type { AIProviderStorage } from "@hypr/store";
 
 import { createAuthFetch } from "../auth-fetch";
+import {
+  isOnDeviceLlmConnection,
+  resolveGoogleCalendarLlmBoundary,
+} from "../data-boundary";
+import { createGoogleCalendarBoundaryFetch } from "../google-calendar-boundary-fetch";
 import { createTracedFetch, tracedFetch } from "../traced-fetch";
+import { useGoogleCalendarDataState } from "./useGoogleCalendarDataState";
 
 import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
@@ -37,9 +43,21 @@ type LLMConnectionInfo = {
 export type LLMConnectionStatus =
   | { status: "pending"; reason: "missing_provider" }
   | { status: "pending"; reason: "missing_model"; providerId: ProviderId }
+  | {
+      status: "pending";
+      reason: "checking_google_calendar_data";
+      providerId: ProviderId;
+    }
   | { status: "error"; reason: "provider_not_found"; providerId: string }
   | { status: "error"; reason: "unauthenticated"; providerId: "hyprnote" }
   | { status: "error"; reason: "not_pro"; providerId: "hyprnote" }
+  | {
+      status: "error";
+      reason:
+        | "google_calendar_data_check_failed"
+        | "google_calendar_remote_ai_blocked";
+      providerId: ProviderId;
+    }
   | {
       status: "error";
       reason: "missing_config";
@@ -80,6 +98,7 @@ export const useLanguageModel = (task?: CharTask): LanguageModelV3 | null => {
 export const useLLMConnection = (): LLMConnectionResult => {
   const auth = useAuth();
   const billing = useBillingAccess();
+  const googleCalendarDataState = useGoogleCalendarDataState();
 
   const { current_llm_provider, current_llm_model } = useConfigValues([
     "current_llm_provider",
@@ -97,10 +116,12 @@ export const useLLMConnection = (): LLMConnectionResult => {
         providerConfig,
         session: auth?.session,
         isPaid: billing.isPaid,
+        googleCalendarDataState,
       }),
     [
       auth,
       billing.isPaid,
+      googleCalendarDataState,
       current_llm_model,
       current_llm_provider,
       providerConfig,
@@ -119,6 +140,7 @@ const resolveLLMConnection = (params: {
   providerConfig: AIProviderStorage | undefined;
   session: { access_token: string } | null | undefined;
   isPaid: boolean;
+  googleCalendarDataState: ReturnType<typeof useGoogleCalendarDataState>;
 }): LLMConnectionResult => {
   const {
     providerId: rawProviderId,
@@ -126,6 +148,7 @@ const resolveLLMConnection = (params: {
     providerConfig,
     session,
     isPaid,
+    googleCalendarDataState,
   } = params;
 
   if (!rawProviderId) {
@@ -201,6 +224,42 @@ const resolveLLMConnection = (params: {
     }
   }
 
+  const boundary = resolveGoogleCalendarLlmBoundary({
+    googleCalendarDataState,
+    providerId,
+    baseUrl,
+  });
+  if (boundary === "checking") {
+    return {
+      conn: null,
+      status: {
+        status: "pending",
+        reason: "checking_google_calendar_data",
+        providerId,
+      },
+    };
+  }
+  if (boundary === "check_failed") {
+    return {
+      conn: null,
+      status: {
+        status: "error",
+        reason: "google_calendar_data_check_failed",
+        providerId,
+      },
+    };
+  }
+  if (boundary === "blocked") {
+    return {
+      conn: null,
+      status: {
+        status: "error",
+        reason: "google_calendar_remote_ai_blocked",
+        providerId,
+      },
+    };
+  }
+
   if (providerId === "hyprnote" && session) {
     return {
       conn: {
@@ -236,10 +295,17 @@ const createLanguageModel = (
   task?: CharTask,
   hostedFetch?: typeof fetch,
 ): LanguageModelV3 => {
+  const providerFetch = isOnDeviceLlmConnection(conn)
+    ? tauriFetch
+    : createGoogleCalendarBoundaryFetch(tauriFetch);
+
   switch (conn.providerId) {
     case "hyprnote": {
+      const fetchImpl = createGoogleCalendarBoundaryFetch(
+        hostedFetch ?? (task ? createTracedFetch(task) : tracedFetch),
+      );
       const provider = createOpenRouter({
-        fetch: hostedFetch ?? (task ? createTracedFetch(task) : tracedFetch),
+        fetch: fetchImpl,
         baseURL: conn.baseUrl,
         apiKey: conn.apiKey,
       });
@@ -248,7 +314,7 @@ const createLanguageModel = (
 
     case "anthropic": {
       const provider = createAnthropic({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         apiKey: conn.apiKey,
         headers: {
           "anthropic-version": "2023-06-01",
@@ -260,7 +326,7 @@ const createLanguageModel = (
 
     case "google_generative_ai": {
       const provider = createGoogleGenerativeAI({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         baseURL: conn.baseUrl,
         apiKey: conn.apiKey,
       });
@@ -269,7 +335,7 @@ const createLanguageModel = (
 
     case "openrouter": {
       const provider = createOpenRouter({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         apiKey: conn.apiKey,
       });
       return wrapWithThinkingMiddleware(provider.chat(conn.modelId));
@@ -277,7 +343,7 @@ const createLanguageModel = (
 
     case "openai": {
       const provider = createOpenAI({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         baseURL: conn.baseUrl,
         apiKey: conn.apiKey,
       });
@@ -286,7 +352,7 @@ const createLanguageModel = (
 
     case "azure_openai": {
       const provider = createAzure({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         baseURL: conn.baseUrl,
         apiKey: conn.apiKey,
       });
@@ -295,7 +361,7 @@ const createLanguageModel = (
 
     case "azure_ai": {
       const provider = createOpenAICompatible({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         name: "azure_ai",
         baseURL: conn.baseUrl,
         apiKey: conn.apiKey,
@@ -309,7 +375,7 @@ const createLanguageModel = (
       const ollamaFetch: typeof fetch = async (input, init) => {
         const headers = new Headers(init?.headers);
         headers.set("Origin", ollamaOrigin);
-        return tauriFetch(input as RequestInfo | URL, {
+        return providerFetch(input as RequestInfo | URL, {
           ...init,
           headers,
         });
@@ -324,7 +390,7 @@ const createLanguageModel = (
 
     default: {
       const config: Parameters<typeof createOpenAICompatible>[0] = {
-        fetch: tauriFetch,
+        fetch: providerFetch,
         name: conn.providerId,
         baseURL: conn.baseUrl,
       };

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -1,5 +1,5 @@
 import { Chat, useChat } from "@ai-sdk/react";
-import type { ChatStatus, ChatTransport, LanguageModel, ToolSet } from "ai";
+import type { ChatStatus, ChatTransport, ToolSet } from "ai";
 import {
   type ReactNode,
   useCallback,
@@ -57,7 +57,6 @@ interface ChatSessionProps {
   sessionId: string;
   chatGroupId?: string;
   currentSessionId?: string;
-  modelOverride?: LanguageModel;
   extraTools?: ToolSet;
   systemPromptOverride?: string;
   unstyled?: boolean;
@@ -85,7 +84,6 @@ export function ChatSession({
   sessionId,
   chatGroupId,
   currentSessionId,
-  modelOverride,
   extraTools,
   systemPromptOverride,
   unstyled = false,
@@ -125,7 +123,6 @@ export function ChatSession({
   }, [sessionId, chatGroupId]);
 
   const { transport, isSystemPromptReady } = useTransport(
-    modelOverride,
     extraTools,
     systemPromptOverride,
     ownerUserId || undefined,

--- a/apps/desktop/src/chat/transport/use-transport.ts
+++ b/apps/desktop/src/chat/transport/use-transport.ts
@@ -1,4 +1,4 @@
-import type { LanguageModel, ToolSet } from "ai";
+import type { ToolSet } from "ai";
 import { useEffect, useMemo, useState } from "react";
 
 import { commands as templateCommands } from "@hypr/plugin-template";
@@ -80,14 +80,12 @@ async function renderOrganizationContext(
 }
 
 export function useTransport(
-  modelOverride?: LanguageModel,
   extraTools?: ToolSet,
   systemPromptOverride?: string,
   userId?: string,
 ) {
   const registry = useToolRegistry();
-  const configuredModel = useLanguageModel("chat");
-  const model = modelOverride ?? configuredModel;
+  const model = useLanguageModel("chat");
   const language = useConfigValue("ai_language") || "en";
   const [systemPrompt, setSystemPrompt] = useState<string | undefined>();
 

--- a/apps/desktop/src/session/components/note-input/enhanced/google-calendar-ai-boundary-error.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/google-calendar-ai-boundary-error.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const openNew = vi.hoisted(() => vi.fn());
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: (selector: (state: { openNew: typeof openNew }) => unknown) =>
+    selector({ openNew }),
+}));
+
+import { GoogleCalendarAiBoundaryError } from "./google-calendar-ai-boundary-error";
+
+describe("GoogleCalendarAiBoundaryError", () => {
+  afterEach(() => {
+    cleanup();
+    openNew.mockReset();
+  });
+
+  it("offers on-device AI when Google data blocks remote models", () => {
+    render(<GoogleCalendarAiBoundaryError checkFailed={false} />);
+
+    expect(
+      screen.getByText("Use on-device AI for Google Calendar notes"),
+    ).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Choose on-device AI" }),
+    );
+    expect(openNew).toHaveBeenCalledWith({
+      type: "settings",
+      state: { tab: "intelligence" },
+    });
+  });
+
+  it("fails closed when the local data check fails", () => {
+    render(<GoogleCalendarAiBoundaryError checkFailed />);
+
+    expect(screen.getByText("AI is temporarily unavailable")).not.toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/apps/desktop/src/session/components/note-input/enhanced/google-calendar-ai-boundary-error.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/google-calendar-ai-boundary-error.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@hypr/ui/components/ui/button";
+
+import { useTabs } from "~/store/zustand/tabs";
+
+export function GoogleCalendarAiBoundaryError({
+  checkFailed,
+}: {
+  checkFailed: boolean;
+}) {
+  const openNew = useTabs((state) => state.openNew);
+
+  return (
+    <div
+      role="alert"
+      className="flex h-full min-h-[400px] flex-col items-center justify-center px-6"
+    >
+      <div className="mb-6 flex max-w-md flex-col gap-2 text-center">
+        <p className="text-base font-medium">
+          {checkFailed
+            ? "AI is temporarily unavailable"
+            : "Use on-device AI for Google Calendar notes"}
+        </p>
+        <p className="text-muted-foreground text-sm leading-relaxed">
+          {checkFailed
+            ? "Anarlog could not verify the local calendar data boundary. Restart the app and try again."
+            : "To keep Google Calendar data on your device, Anarlog disables hosted and remote AI while that data is present. Choose Ollama or LM Studio to process notes locally."}
+        </p>
+      </div>
+      {!checkFailed && (
+        <Button
+          variant="outline"
+          className="shadow-none"
+          onClick={() =>
+            openNew({ type: "settings", state: { tab: "intelligence" } })
+          }
+        >
+          Choose on-device AI
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -69,6 +69,10 @@ vi.mock("./config-error", () => ({
   ConfigError: () => <div>Config error</div>,
 }));
 
+vi.mock("./google-calendar-ai-boundary-error", () => ({
+  GoogleCalendarAiBoundaryError: () => <div>Google Calendar AI boundary</div>,
+}));
+
 vi.mock("./editor", () => ({
   EnhancedEditor: ({
     content,
@@ -375,6 +379,19 @@ describe("Enhanced", () => {
 
     expect(screen.getByText("Config error")).not.toBeNull();
     expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("shows the Google Calendar boundary instead of generic AI setup", () => {
+    hoisted.llmStatus = {
+      status: "error",
+      reason: "google_calendar_remote_ai_blocked",
+      providerId: "hyprnote",
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByText("Google Calendar AI boundary")).not.toBeNull();
+    expect(screen.queryByText("Config error")).toBeNull();
   });
 
   it("shows config errors for missing provider setup", () => {

--- a/apps/desktop/src/session/components/note-input/enhanced/index.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.tsx
@@ -6,6 +6,7 @@ import type { NoteEditorRef } from "@hypr/editor/note";
 import { ConfigError } from "./config-error";
 import { EnhancedEditor } from "./editor";
 import { EnhanceError } from "./enhance-error";
+import { GoogleCalendarAiBoundaryError } from "./google-calendar-ai-boundary-error";
 import { StreamingView } from "./streaming";
 
 import { useAITaskTask } from "~/ai/hooks";
@@ -71,6 +72,20 @@ export const Enhanced = forwardRef<
     const isConfigError = shouldShowEmptySummaryConfigError(llmStatus);
 
     if (status === "idle" && isConfigError && !hasContent) {
+      if (
+        llmStatus.status === "error" &&
+        (llmStatus.reason === "google_calendar_data_check_failed" ||
+          llmStatus.reason === "google_calendar_remote_ai_blocked")
+      ) {
+        return (
+          <GoogleCalendarAiBoundaryError
+            checkFailed={
+              llmStatus.reason === "google_calendar_data_check_failed"
+            }
+          />
+        );
+      }
+
       return <ConfigError />;
     }
 

--- a/apps/desktop/src/session/enhance-config.ts
+++ b/apps/desktop/src/session/enhance-config.ts
@@ -14,6 +14,8 @@ export function shouldShowEmptySummaryConfigError(status: LLMConnectionStatus) {
   return (
     status.reason === "unauthenticated" ||
     status.reason === "not_pro" ||
-    status.reason === "missing_config"
+    status.reason === "missing_config" ||
+    status.reason === "google_calendar_data_check_failed" ||
+    status.reason === "google_calendar_remote_ai_blocked"
   );
 }

--- a/apps/desktop/src/stt/useKeywords.test.ts
+++ b/apps/desktop/src/stt/useKeywords.test.ts
@@ -170,6 +170,7 @@ describe("getSessionKeywords", () => {
       getSessionKeywords({
         sessionId: "session-1",
         dictionaryTerms: ["Anarlog"],
+        allowCalendarDerivedHints: true,
       }),
     ).resolves.toEqual(expect.arrayContaining(["Anarlog", "Launch"]));
   });
@@ -200,17 +201,82 @@ describe("getSessionKeywords", () => {
     const result = await getSessionKeywords({
       sessionId: "session-1",
       dictionaryTerms: ["Anarlog"],
+      allowCalendarDerivedHints: true,
     });
 
     expect(result.slice(0, 3)).toEqual(["Alice Kim", "Mina Park", "Anarlog"]);
     expect(result).toEqual(expect.arrayContaining(["Launch"]));
     expect(result).not.toContain("John Jeong");
   });
+
+  it("withholds calendar event and attendee hints from off-device STT", async () => {
+    execute.mockResolvedValue([
+      {
+        raw_md: "Remember #UserMemo",
+        title: "GoogleOnlyTitle",
+        event_json: JSON.stringify({
+          title: "GoogleOnlyEvent",
+          description: "GoogleOnlyDescription",
+          location: "GoogleOnlyLocation",
+        }),
+        participant_names_json: JSON.stringify(["GoogleOnlyParticipant"]),
+        event_participants_json: JSON.stringify([
+          { name: "GoogleOnlyAttendee" },
+        ]),
+      },
+    ]);
+
+    const result = await getSessionKeywords({
+      sessionId: "session-google",
+      dictionaryTerms: ["UserDictionary"],
+      allowCalendarDerivedHints: false,
+    });
+
+    expect(result).toEqual(
+      expect.arrayContaining(["UserMemo", "UserDictionary"]),
+    );
+    expect(result.join(" ")).not.toContain("GoogleOnly");
+  });
+
+  it("retains Google hints for explicitly on-device STT", async () => {
+    execute.mockResolvedValue([
+      {
+        raw_md: "",
+        title: "GoogleLocalTitle",
+        event_json: "",
+        participant_names_json: JSON.stringify(["Google Local Participant"]),
+        event_participants_json: "[]",
+      },
+    ]);
+
+    await expect(
+      getSessionKeywords({
+        sessionId: "session-google",
+        dictionaryTerms: [],
+        allowCalendarDerivedHints: true,
+      }),
+    ).resolves.toEqual(
+      expect.arrayContaining(["Google Local Participant", "GoogleLocalTitle"]),
+    );
+  });
+
+  it("returns dictionary-only hints when session provenance is unresolved", async () => {
+    execute.mockResolvedValue([]);
+
+    await expect(
+      getSessionKeywords({
+        sessionId: "missing-session",
+        dictionaryTerms: ["UserDictionary"],
+        allowCalendarDerivedHints: false,
+      }),
+    ).resolves.toEqual(["UserDictionary"]);
+  });
 });
 
 describe("buildKeywords", () => {
   it("dedupes higher-priority hints and caps the result", () => {
     const result = buildKeywords({
+      allowCalendarDerivedHints: true,
       rawMd: "",
       title: "",
       eventJson: "",

--- a/apps/desktop/src/stt/useKeywords.ts
+++ b/apps/desktop/src/stt/useKeywords.ts
@@ -18,7 +18,10 @@ import { normalizeKeywordList } from "~/stt/keywords";
 
 const MAX_TRANSCRIPTION_HINTS = 50;
 
-export function useKeywords(sessionId: string) {
+export function useKeywords(
+  sessionId: string,
+  allowCalendarDerivedHints: boolean,
+) {
   const session = useSession(sessionId);
   const participants = useSessionParticipants(sessionId);
   const eventParticipants = useSessionEventParticipants(sessionId);
@@ -27,6 +30,7 @@ export function useKeywords(sessionId: string) {
   return useMemo(
     () =>
       buildKeywords({
+        allowCalendarDerivedHints,
         rawMd: session?.raw_md,
         title: session?.title,
         eventJson: session?.event_json,
@@ -42,7 +46,13 @@ export function useKeywords(sessionId: string) {
         ),
         dictionaryTerms,
       }),
-    [dictionaryTerms, eventParticipants, participants, session],
+    [
+      allowCalendarDerivedHints,
+      dictionaryTerms,
+      eventParticipants,
+      participants,
+      session,
+    ],
   );
 }
 
@@ -57,9 +67,11 @@ type KeywordSnapshotSqlRow = {
 export async function getSessionKeywords({
   sessionId,
   dictionaryTerms,
+  allowCalendarDerivedHints,
 }: {
   sessionId: string;
   dictionaryTerms: string[];
+  allowCalendarDerivedHints: boolean;
 }): Promise<string[]> {
   const [snapshot] = await liveQueryClient.execute<KeywordSnapshotSqlRow>(
     `
@@ -116,6 +128,7 @@ export async function getSessionKeywords({
   );
 
   return buildKeywords({
+    allowCalendarDerivedHints,
     rawMd: snapshot?.raw_md,
     title: snapshot?.title,
     eventJson: snapshot?.event_json,
@@ -128,6 +141,7 @@ export async function getSessionKeywords({
 }
 
 export function buildKeywords({
+  allowCalendarDerivedHints,
   rawMd,
   title,
   eventJson,
@@ -135,6 +149,7 @@ export function buildKeywords({
   eventParticipantTerms = [],
   dictionaryTerms,
 }: {
+  allowCalendarDerivedHints: boolean;
   rawMd: unknown;
   title: unknown;
   eventJson: unknown;
@@ -144,8 +159,8 @@ export function buildKeywords({
 }) {
   const sourceText = buildKeywordSourceText({
     rawMd,
-    title,
-    eventJson,
+    title: allowCalendarDerivedHints ? title : "",
+    eventJson: allowCalendarDerivedHints ? eventJson : "",
   });
   const { keywords, keyphrases } =
     sourceText.length > 0
@@ -153,8 +168,8 @@ export function buildKeywords({
       : { keywords: [], keyphrases: [] };
 
   return normalizeKeywordList([
-    ...sessionParticipantTerms,
-    ...eventParticipantTerms,
+    ...(allowCalendarDerivedHints ? sessionParticipantTerms : []),
+    ...(allowCalendarDerivedHints ? eventParticipantTerms : []),
     ...dictionaryTerms,
     ...keywords,
     ...keyphrases,

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import { getSessionKeywords } from "./useKeywords";
 import {
   canRunBatchTranscription,
   getBatchFallbackTarget,
@@ -15,6 +16,8 @@ const {
   useSessionMock,
   useSessionParticipantsMock,
   useSTTConnectionMock,
+  useGoogleCalendarDataStateMock,
+  hasGoogleCalendarDataMock,
   useAuthMock,
   useBillingAccessMock,
   useConfigValueMock,
@@ -30,6 +33,8 @@ const {
   useSessionMock: vi.fn(),
   useSessionParticipantsMock: vi.fn(),
   useSTTConnectionMock: vi.fn(),
+  useGoogleCalendarDataStateMock: vi.fn(),
+  hasGoogleCalendarDataMock: vi.fn(),
   useAuthMock: vi.fn(),
   useBillingAccessMock: vi.fn(),
   useConfigValueMock: vi.fn(),
@@ -52,6 +57,14 @@ vi.mock("./useKeywords", () => ({
 
 vi.mock("./useSTTConnection", () => ({
   useSTTConnection: useSTTConnectionMock,
+}));
+
+vi.mock("~/ai/hooks/useGoogleCalendarDataState", () => ({
+  useGoogleCalendarDataState: useGoogleCalendarDataStateMock,
+}));
+
+vi.mock("~/ai/google-calendar-data", () => ({
+  hasGoogleCalendarData: hasGoogleCalendarDataMock,
 }));
 
 vi.mock("@hypr/ui/components/ui/toast", () => ({
@@ -231,6 +244,8 @@ describe("useRunBatch", () => {
         apiKey: "test-key",
       },
     });
+    useGoogleCalendarDataStateMock.mockReturnValue("absent");
+    hasGoogleCalendarDataMock.mockResolvedValue(false);
     useAuthMock.mockReturnValue({
       session: {
         access_token: "paid-token",
@@ -353,6 +368,146 @@ describe("useRunBatch", () => {
       }),
       expect.any(Object),
     );
+  });
+
+  test("withholds Google attendee speaker hints from off-device batch STT", async () => {
+    useSessionMock.mockReturnValue({
+      id: "session-1",
+      user_id: "user-1",
+      raw_md: "Existing memo",
+    });
+    useGoogleCalendarDataStateMock.mockReturnValue("present");
+    useSessionParticipantsMock.mockReturnValue([
+      {
+        source: "auto",
+        humanId: "google-attendee-human",
+      },
+    ]);
+    startTranscriptionMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav", {
+        numSpeakers: 4,
+        minSpeakers: 2,
+        maxSpeakers: 6,
+      });
+    });
+
+    expect(startTranscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        num_speakers: undefined,
+        min_speakers: undefined,
+        max_speakers: undefined,
+      }),
+      expect.any(Object),
+    );
+    expect(getSessionKeywords).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      dictionaryTerms: [],
+      allowCalendarDerivedHints: false,
+    });
+  });
+
+  test("rechecks Google data before starting off-device batch STT", async () => {
+    useSessionParticipantsMock.mockReturnValue([
+      { source: "auto", humanId: "google-attendee-human" },
+    ]);
+    hasGoogleCalendarDataMock.mockResolvedValue(true);
+    vi.mocked(getSessionKeywords).mockImplementation(
+      async ({ allowCalendarDerivedHints }) =>
+        allowCalendarDerivedHints ? ["Google event"] : ["safe note"],
+    );
+    startTranscriptionMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav", { numSpeakers: 4 });
+    });
+
+    expect(getSessionKeywords).toHaveBeenNthCalledWith(1, {
+      sessionId: "session-1",
+      dictionaryTerms: [],
+      allowCalendarDerivedHints: true,
+    });
+    expect(getSessionKeywords).toHaveBeenNthCalledWith(2, {
+      sessionId: "session-1",
+      dictionaryTerms: [],
+      allowCalendarDerivedHints: false,
+    });
+    expect(startTranscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keywords: ["safe note"],
+        num_speakers: undefined,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  test("redacts batch hints when the request-time check fails", async () => {
+    hasGoogleCalendarDataMock.mockRejectedValue(new Error("database offline"));
+    startTranscriptionMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav", {
+        minSpeakers: 2,
+        maxSpeakers: 5,
+      });
+    });
+
+    expect(getSessionKeywords).toHaveBeenLastCalledWith({
+      sessionId: "session-1",
+      dictionaryTerms: [],
+      allowCalendarDerivedHints: false,
+    });
+    expect(startTranscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        min_speakers: undefined,
+        max_speakers: undefined,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  test("retains Google speaker hints for on-device batch STT", async () => {
+    useSessionMock.mockReturnValue({
+      id: "session-1",
+      user_id: "user-1",
+      raw_md: "Existing memo",
+    });
+    useGoogleCalendarDataStateMock.mockReturnValue("present");
+    useSessionParticipantsMock.mockReturnValue([
+      { source: "auto", humanId: "google-attendee-human" },
+    ]);
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "hyprnote",
+        model: "soniqo-parakeet-batch",
+        baseUrl: "soniqo://local",
+        apiKey: "",
+      },
+    });
+    startTranscriptionMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav");
+    });
+
+    expect(startTranscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ num_speakers: 2 }),
+      expect.any(Object),
+    );
+    expect(getSessionKeywords).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      dictionaryTerms: [],
+      allowCalendarDerivedHints: true,
+    });
   });
 
   test("falls back to local Soniqo when the selected provider is not batch-capable", async () => {

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -7,6 +7,12 @@ import { useListener } from "./contexts";
 import { getSessionKeywords } from "./useKeywords";
 import { useSTTConnection } from "./useSTTConnection";
 
+import {
+  canSendCalendarDerivedSttHints,
+  isOnDeviceSttTarget,
+} from "~/ai/data-boundary";
+import { hasGoogleCalendarData } from "~/ai/google-calendar-data";
+import { useGoogleCalendarDataState } from "~/ai/hooks/useGoogleCalendarDataState";
 import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
 import { env } from "~/env";
@@ -30,7 +36,6 @@ type RunOptions = {
   model?: string;
   baseUrl?: string;
   apiKey?: string;
-  keywords?: string[];
   languages?: string[];
   numSpeakers?: number;
   minSpeakers?: number;
@@ -170,6 +175,7 @@ export const useRunBatch = (sessionId: string) => {
 
   const startTranscription = useListener((state) => state.startTranscription);
   const { conn } = useSTTConnection();
+  const googleCalendarDataState = useGoogleCalendarDataState();
   const auth = useAuth();
   const billing = useBillingAccess();
   const aiLanguage = useConfigValue("ai_language");
@@ -236,14 +242,20 @@ export const useRunBatch = (sessionId: string) => {
 
       const createdAt = new Date().toISOString();
       const memoMd = session?.raw_md ?? "";
-      const keywords =
-        options?.keywords ??
-        (await getSessionKeywords({
-          sessionId,
-          dictionaryTerms,
-        }));
+      const targetIsOnDevice = isOnDeviceSttTarget({
+        provider: target.provider,
+        baseUrl: target.baseUrl,
+      });
+      const allowCalendarDerivedHintsAtSnapshot =
+        targetIsOnDevice || googleCalendarDataState === "absent";
+      let keywords = await getSessionKeywords({
+        sessionId,
+        dictionaryTerms,
+        allowCalendarDerivedHints: allowCalendarDerivedHintsAtSnapshot,
+      });
       let transcriptId: string | null = null;
       const inferredNumSpeakers =
+        allowCalendarDerivedHintsAtSnapshot &&
         options?.numSpeakers === undefined &&
         options?.minSpeakers === undefined &&
         options?.maxSpeakers === undefined
@@ -349,6 +361,19 @@ export const useRunBatch = (sessionId: string) => {
           }
         });
 
+      const allowCalendarDerivedHints = await canSendCalendarDerivedSttHints({
+        targetIsOnDevice,
+        googleCalendarDataState,
+        checkHasGoogleCalendarData: hasGoogleCalendarData,
+      });
+      if (allowCalendarDerivedHintsAtSnapshot && !allowCalendarDerivedHints) {
+        keywords = await getSessionKeywords({
+          sessionId,
+          dictionaryTerms,
+          allowCalendarDerivedHints: false,
+        });
+      }
+
       const params: TranscriptionParams = {
         session_id: sessionId,
         provider: target.provider,
@@ -358,9 +383,15 @@ export const useRunBatch = (sessionId: string) => {
         api_key: target.apiKey,
         keywords,
         languages,
-        num_speakers: options?.numSpeakers ?? inferredNumSpeakers,
-        min_speakers: options?.minSpeakers,
-        max_speakers: options?.maxSpeakers,
+        num_speakers: allowCalendarDerivedHints
+          ? (options?.numSpeakers ?? inferredNumSpeakers)
+          : undefined,
+        min_speakers: allowCalendarDerivedHints
+          ? options?.minSpeakers
+          : undefined,
+        max_speakers: allowCalendarDerivedHints
+          ? options?.maxSpeakers
+          : undefined,
       };
 
       try {
@@ -380,6 +411,7 @@ export const useRunBatch = (sessionId: string) => {
       audioRetention,
       billing.isPaid,
       dictionaryTerms,
+      googleCalendarDataState,
       session,
       participants,
       spokenLanguages,

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -26,6 +26,8 @@ const {
   softDeleteTranscriptMock,
   useConfigValueMock,
   useSTTConnectionMock,
+  useGoogleCalendarDataStateMock,
+  hasGoogleCalendarDataMock,
   isSupportedLanguagesLiveMock,
   leftSidebarExpanded,
   setLeftSidebarExpandedMock,
@@ -52,6 +54,8 @@ const {
   softDeleteTranscriptMock: vi.fn(),
   useConfigValueMock: vi.fn(),
   useSTTConnectionMock: vi.fn(),
+  useGoogleCalendarDataStateMock: vi.fn(),
+  hasGoogleCalendarDataMock: vi.fn(),
   isSupportedLanguagesLiveMock: vi.fn(),
   leftSidebarExpanded: { value: true },
   setLeftSidebarExpandedMock: vi.fn(),
@@ -107,6 +111,14 @@ vi.mock("./useRunBatch", () => ({
 
 vi.mock("./useSTTConnection", () => ({
   useSTTConnection: useSTTConnectionMock,
+}));
+
+vi.mock("~/ai/hooks/useGoogleCalendarDataState", () => ({
+  useGoogleCalendarDataState: useGoogleCalendarDataStateMock,
+}));
+
+vi.mock("~/ai/google-calendar-data", () => ({
+  hasGoogleCalendarData: hasGoogleCalendarDataMock,
 }));
 
 vi.mock("~/services/enhancer", () => ({
@@ -271,7 +283,10 @@ describe("useStartListening", () => {
         baseUrl: "http://localhost:8080",
         apiKey: "",
       },
+      isLocalModel: true,
     });
+    useGoogleCalendarDataStateMock.mockReturnValue("absent");
+    hasGoogleCalendarDataMock.mockResolvedValue(false);
     startMock.mockResolvedValue(true);
     runBatchMock.mockResolvedValue(undefined);
     isSupportedLanguagesLiveMock.mockResolvedValue({
@@ -356,6 +371,141 @@ describe("useStartListening", () => {
     expect(startMock.mock.calls[0]?.[0]).toMatchObject({
       keywords: ["launch"],
     });
+    expect(getSessionKeywords).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      dictionaryTerms: [],
+      allowCalendarDerivedHints: true,
+    });
+  });
+
+  test("withholds Google attendee speaker hints from off-device STT", async () => {
+    useSessionMock.mockReturnValue({
+      id: "session-1",
+      user_id: "user-1",
+      raw_md: "Existing memo",
+    });
+    useGoogleCalendarDataStateMock.mockReturnValue("present");
+    useSessionParticipantHumanIdsMock.mockReturnValue([
+      "google-attendee-human",
+    ]);
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "deepgram",
+        model: "nova-3-general",
+        baseUrl: "https://api.deepgram.com/v1/listen",
+        apiKey: "test-key",
+      },
+      isLocalModel: false,
+    });
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(startMock.mock.calls[0]?.[0]).toMatchObject({
+      participant_human_ids: [],
+    });
+    expect(getSessionKeywords).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      dictionaryTerms: [],
+      allowCalendarDerivedHints: false,
+    });
+  });
+
+  test("rechecks Google data before starting off-device STT", async () => {
+    useSessionParticipantHumanIdsMock.mockReturnValue(["google-attendee"]);
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "deepgram",
+        model: "nova-3-general",
+        baseUrl: "https://api.deepgram.com/v1/listen",
+        apiKey: "test-key",
+      },
+      isLocalModel: false,
+    });
+    hasGoogleCalendarDataMock.mockResolvedValue(true);
+    vi.mocked(getSessionKeywords).mockImplementation(
+      async ({ allowCalendarDerivedHints }) =>
+        allowCalendarDerivedHints ? ["Google event"] : ["safe note"],
+    );
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(getSessionKeywords).toHaveBeenNthCalledWith(1, {
+      sessionId: "session-1",
+      dictionaryTerms: [],
+      allowCalendarDerivedHints: true,
+    });
+    expect(getSessionKeywords).toHaveBeenNthCalledWith(2, {
+      sessionId: "session-1",
+      dictionaryTerms: [],
+      allowCalendarDerivedHints: false,
+    });
+    expect(startMock.mock.calls[0]?.[0]).toMatchObject({
+      keywords: ["safe note"],
+      participant_human_ids: [],
+    });
+  });
+
+  test("redacts off-device STT hints when the request-time check fails", async () => {
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "deepgram",
+        model: "nova-3-general",
+        baseUrl: "https://api.deepgram.com/v1/listen",
+        apiKey: "test-key",
+      },
+      isLocalModel: false,
+    });
+    hasGoogleCalendarDataMock.mockRejectedValue(new Error("database offline"));
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(getSessionKeywords).toHaveBeenLastCalledWith({
+      sessionId: "session-1",
+      dictionaryTerms: [],
+      allowCalendarDerivedHints: false,
+    });
+    expect(startMock.mock.calls[0]?.[0]).toMatchObject({
+      participant_human_ids: [],
+    });
+  });
+
+  test("does not trust a local model label with a remote endpoint", async () => {
+    useGoogleCalendarDataStateMock.mockReturnValue("present");
+    useSessionParticipantHumanIdsMock.mockReturnValue(["google-attendee"]);
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "hyprnote",
+        model: "soniqo-parakeet-streaming",
+        baseUrl: "https://remote.example.com/stt",
+        apiKey: "test-key",
+      },
+      isLocalModel: true,
+    });
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(startMock.mock.calls[0]?.[0]).toMatchObject({
+      participant_human_ids: [],
+    });
+    expect(getSessionKeywords).toHaveBeenCalledWith(
+      expect.objectContaining({ allowCalendarDerivedHints: false }),
+    );
   });
 
   test("runs batch transcription after record-only capture stops", async () => {

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -14,6 +14,12 @@ import {
 } from "./useRunBatch";
 import { useSTTConnection } from "./useSTTConnection";
 
+import {
+  canSendCalendarDerivedSttHints,
+  isOnDeviceLiveSttConnection,
+} from "~/ai/data-boundary";
+import { hasGoogleCalendarData } from "~/ai/google-calendar-data";
+import { useGoogleCalendarDataState } from "~/ai/hooks/useGoogleCalendarDataState";
 import { useShell } from "~/contexts/shell";
 import {
   deleteProcessedAudioForRetention,
@@ -267,7 +273,8 @@ export function useStartListening(sessionId: string) {
   );
 
   const start = useListener((state) => state.start);
-  const { conn } = useSTTConnection();
+  const { conn, isLocalModel } = useSTTConnection();
+  const googleCalendarDataState = useGoogleCalendarDataState();
   const runBatch = useRunBatch(sessionId);
   const { leftsidebar } = useShell();
   const setLeftSidebarExpanded = leftsidebar.setExpanded;
@@ -297,9 +304,16 @@ export function useStartListening(sessionId: string) {
         console.error("[listener] failed to persist transcript", error);
       });
     };
-    const keywords = await getSessionKeywords({
+    const targetIsOnDevice = isOnDeviceLiveSttConnection({
+      isLocalModel,
+      baseUrl: conn?.baseUrl,
+    });
+    const allowCalendarDerivedHintsAtSnapshot =
+      targetIsOnDevice || googleCalendarDataState === "absent";
+    let keywords = await getSessionKeywords({
       sessionId,
       dictionaryTerms,
+      allowCalendarDerivedHints: allowCalendarDerivedHintsAtSnapshot,
     });
 
     const onStopped: OnStoppedCallback = async (_sessionId, details) => {
@@ -392,7 +406,18 @@ export function useStartListening(sessionId: string) {
       model: conn?.model,
       languages,
     });
-
+    const allowCalendarDerivedHints = await canSendCalendarDerivedSttHints({
+      targetIsOnDevice,
+      googleCalendarDataState,
+      checkHasGoogleCalendarData: hasGoogleCalendarData,
+    });
+    if (allowCalendarDerivedHintsAtSnapshot && !allowCalendarDerivedHints) {
+      keywords = await getSessionKeywords({
+        sessionId,
+        dictionaryTerms,
+        allowCalendarDerivedHints: false,
+      });
+    }
     const started = await start(
       {
         session_id: sessionId,
@@ -403,7 +428,9 @@ export function useStartListening(sessionId: string) {
         api_key: conn?.apiKey ?? "",
         keywords,
         transcription_mode: liveTranscriptionConfig.transcriptionMode,
-        participant_human_ids: participantHumanIds,
+        participant_human_ids: allowCalendarDerivedHints
+          ? participantHumanIds
+          : [],
         self_human_id: session?.user_id || null,
       },
       {
@@ -453,7 +480,9 @@ export function useStartListening(sessionId: string) {
     conn,
     dictionaryTerms,
     getSessionMode,
+    googleCalendarDataState,
     hadTranscriptBeforeStart,
+    isLocalModel,
     participantHumanIds,
     session,
     sessionId,

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -4,44 +4,46 @@ import { vi } from "vitest";
 
 Object.defineProperty(globalThis.crypto, "randomUUID", { value: randomUUID });
 
-Object.defineProperty(globalThis.window, "__TAURI_INTERNALS__", {
-  value: {
-    metadata: {
-      currentWindow: {
-        label: "main",
+if (typeof globalThis.window !== "undefined") {
+  Object.defineProperty(globalThis.window, "__TAURI_INTERNALS__", {
+    value: {
+      metadata: {
+        currentWindow: {
+          label: "main",
+        },
+        currentWebview: {
+          label: "main",
+        },
       },
-      currentWebview: {
-        label: "main",
-      },
+      transformCallback: vi.fn((callback: unknown) => {
+        const callbackId = Math.trunc(Math.random() * Number.MAX_SAFE_INTEGER);
+        Object.assign(globalThis.window, {
+          [`_${callbackId}`]: callback,
+        });
+
+        return callbackId;
+      }),
+      unregisterCallback: vi.fn((callbackId: number) => {
+        delete (globalThis.window as unknown as Record<string, unknown>)[
+          `_${callbackId}`
+        ];
+      }),
+      invoke: vi.fn((command: string) =>
+        Promise.resolve(command === "plugin:event|listen" ? 0 : null),
+      ),
     },
-    transformCallback: vi.fn((callback: unknown) => {
-      const callbackId = Math.trunc(Math.random() * Number.MAX_SAFE_INTEGER);
-      Object.assign(globalThis.window, {
-        [`_${callbackId}`]: callback,
-      });
+    writable: true,
+    configurable: true,
+  });
 
-      return callbackId;
-    }),
-    unregisterCallback: vi.fn((callbackId: number) => {
-      delete (globalThis.window as unknown as Record<string, unknown>)[
-        `_${callbackId}`
-      ];
-    }),
-    invoke: vi.fn((command: string) =>
-      Promise.resolve(command === "plugin:event|listen" ? 0 : null),
-    ),
-  },
-  writable: true,
-  configurable: true,
-});
-
-Object.defineProperty(globalThis.window, "__TAURI_EVENT_PLUGIN_INTERNALS__", {
-  value: {
-    unregisterListener: vi.fn(),
-  },
-  writable: true,
-  configurable: true,
-});
+  Object.defineProperty(globalThis.window, "__TAURI_EVENT_PLUGIN_INTERNALS__", {
+    value: {
+      unregisterListener: vi.fn(),
+    },
+    writable: true,
+    configurable: true,
+  });
+}
 
 vi.mock("@tauri-apps/api/path", () => ({
   resolveResource: vi.fn((path: string) =>

--- a/apps/web/content/legal/privacy.mdx
+++ b/apps/web/content/legal/privacy.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2026-07-17"
+date: "2026-07-20"
 title: "Privacy Policy"
 summary: "How we collect, use, and protect your personal information"
 ---
@@ -43,7 +43,9 @@ If you connect Google Calendar or Microsoft Outlook Calendar, we use the Google 
 - **Event Information:** Event IDs, titles, descriptions, locations, meeting links, start and end times, time zones, recurrence metadata, organizer details, and attendee details such as names, email addresses, and RSVP status
 - **Connection Information:** Provider connection IDs, connection status, and the Google or Microsoft account identity associated with the connection
 
-We use connected calendar data to display calendars and upcoming events and to support the personal notes and memos you create for those events. Calendar API responses pass through Nango's encrypted API proxy before reaching Anarlog. We do not use connected calendar data for advertising, marketing personalization, sale to data brokers, or training generalized AI models. The use of information received from Google Workspace APIs adheres to the [Google Workspace API User Data and Developer Policy](https://developers.google.com/workspace/workspace-api-user-data-developer-policy), including the Limited Use requirements.
+We use connected calendar data to display calendars and upcoming events and to support the personal notes and memos you create for those events. Calendar API responses pass through Nango's encrypted API proxy before reaching Anarlog. We do not use connected calendar data for advertising, marketing personalization, sale to data brokers, or training generalized AI models.
+
+Information received from Google Workspace APIs is not sent to hosted or third-party AI model or speech-to-text providers. While Google Calendar data remains on a device, Anarlog disables hosted and remote AI processing; you may use an on-device model such as Ollama or LM Studio instead. The use of information received from Google Workspace APIs adheres to the [Google Workspace API User Data and Developer Policy](https://developers.google.com/workspace/workspace-api-user-data-developer-policy), including the Limited Use requirements.
 
 ## 4. How We Use Your Information
 

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -144,6 +144,13 @@ export function ConnectFlow() {
             associated with that note can be included in the content you choose
             to sync or share.
           </p>
+          {isGoogleCalendar && (
+            <p>
+              Google Calendar data is not sent to hosted AI or cloud
+              transcription providers. While that data remains on your device,
+              hosted and remote AI is disabled; on-device AI remains available.
+            </p>
+          )}
           <p>
             Read our{" "}
             <a className="underline" href="/privacy">

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -22,6 +22,8 @@ The destination depends on the feature you choose:
 
 Anarlog Cloud, your own API-key providers, and local providers are separate choices. Review the provider's own retention and training policies before sending sensitive content.
 
+Google Calendar data is not sent to hosted or third-party AI or transcription providers. While Google Calendar data remains on your device, hosted and remote Intelligence features are disabled. You can still use Ollama or LM Studio on your device, and cloud transcription continues without calendar-derived titles, event details, attendees, or speaker hints.
+
 ## Keep a meeting fully local
 
 1. Select an on-device model under **Settings → Transcription**.


### PR DESCRIPTION
Block off-device AI requests when Google Calendar data is present, redact cloud STT hints, and align the consent and privacy disclosures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches auth-adjacent AI routing, request-time fetch gating, and STT payload redaction for Google user data—incorrect classification could block legitimate AI or leak calendar metadata to cloud providers.
> 
> **Overview**
> Adds a **Google Calendar data boundary** so hosted and remote AI cannot run while local Google-linked calendar data exists, in line with Workspace API Limited Use expectations.
> 
> **LLM:** A SQLite probe (`hasGoogleCalendarData`) drives connection status (`checking`, blocked, check failed). Off-device providers are rejected at resolve time; remote `fetch` is wrapped to re-check the DB and throw before any request. Loopback **Ollama/LM Studio** stays allowed.
> 
> **STT:** Live and batch transcription strip calendar-derived keywords, titles, attendees, and speaker hints when the target is off-device; a request-time DB recheck can downgrade hints if Google data appears. On-device STT (loopback/`soniqo://local`) keeps full hints.
> 
> **UX & docs:** Empty enhanced-note flows show `GoogleCalendarAiBoundaryError` (on-device AI CTA) instead of generic config errors. Chat drops `modelOverride` so the configured model always respects the boundary. Privacy policy, data-and-privacy doc, and Google connect flow disclose the restriction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d77879507fe3337306c8b4c5168cb0a9526808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->