### PR TITLE
Refine the tray menu layout

### DIFF
--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -305,19 +305,17 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
             }
         }
 
-        if !agenda.is_empty() {
-            menu.append(&PredefinedMenuItem::separator(app)?)?;
-        }
-
-        menu.append(&TrayVersion::build(app)?)?;
+        menu.append(&TrayShowEvents::build(app)?)?;
         menu.append(&PredefinedMenuItem::separator(app)?)?;
+
         menu.append(&TrayOpen::build(app)?)?;
         menu.append(&TrayStart::build_with_disabled(
             app,
             START_DISABLED.load(Ordering::SeqCst),
         )?)?;
-        menu.append(&TrayShowEvents::build(app)?)?;
+        menu.append(&TraySettings::build(app)?)?;
         menu.append(&PredefinedMenuItem::separator(app)?)?;
+        menu.append(&TrayVersion::build(app)?)?;
         menu.append(&TrayCheckUpdate::build(app)?)?;
         menu.append(&PredefinedMenuItem::separator(app)?)?;
         menu.append(&TrayQuit::build(app)?)?;

--- a/plugins/tray/src/schedule.rs
+++ b/plugins/tray/src/schedule.rs
@@ -1,4 +1,5 @@
 const DISPLAY_HORIZON_MS: f64 = 24.0 * 60.0 * 60.0 * 1000.0;
+const MAX_AGENDA_LABEL_CHARS: usize = 24;
 const MAX_MENU_BAR_LABEL_CHARS: usize = 30;
 
 #[derive(Debug, Clone, serde::Deserialize, specta::Type, PartialEq)]
@@ -46,11 +47,11 @@ pub fn agenda_sections(
             });
         }
 
-        sections.last_mut().unwrap().events.push(format!(
-            "{}  {}",
-            event.time_label,
-            compact_agenda_title(&event.title)
-        ));
+        sections
+            .last_mut()
+            .unwrap()
+            .events
+            .push(compact_agenda_label(event));
     }
 
     sections
@@ -143,26 +144,17 @@ fn compact_title(title: &str, max_chars: usize) -> String {
     format!("{}…", title.chars().take(max_chars - 1).collect::<String>())
 }
 
-fn compact_agenda_title(title: &str) -> String {
-    const MAX_AGENDA_TITLE_CHARS: usize = 32;
-    let title = title.split_whitespace().collect::<Vec<_>>().join(" ");
-    let title = if title.is_empty() {
-        "Untitled event".to_string()
-    } else {
-        title
-    };
+fn compact_agenda_label(event: &TrayScheduleEvent) -> String {
+    let start_time = event
+        .time_label
+        .split('–')
+        .next()
+        .unwrap_or_default()
+        .trim();
+    let suffix = format!(" · {start_time}");
+    let title_limit = MAX_AGENDA_LABEL_CHARS.saturating_sub(suffix.chars().count());
 
-    if title.chars().count() <= MAX_AGENDA_TITLE_CHARS {
-        return title;
-    }
-
-    format!(
-        "{}…",
-        title
-            .chars()
-            .take(MAX_AGENDA_TITLE_CHARS - 1)
-            .collect::<String>()
-    )
+    format!("{}{suffix}", compact_title(&event.title, title_limit))
 }
 
 fn duration_label(diff_ms: f64) -> String {
@@ -289,17 +281,29 @@ mod tests {
             vec![
                 TrayAgendaSection {
                     label: "Today".to_string(),
-                    events: vec!["9:00 AM – 9:30 AM  Active".to_string()],
+                    events: vec!["Active · 9:00 AM".to_string()],
                 },
                 TrayAgendaSection {
                     label: "Tomorrow".to_string(),
                     events: vec![
-                        "9:00 AM – 9:30 AM  Next".to_string(),
-                        "9:00 AM – 9:30 AM  Tomorrow one".to_string(),
+                        "Next · 9:00 AM".to_string(),
+                        "Tomorrow one · 9:00 AM".to_string(),
                     ],
                 },
             ]
         );
+    }
+
+    #[test]
+    fn keeps_agenda_labels_compact() {
+        let label = compact_agenda_label(&event(
+            "Sprint retrospective and planning",
+            1_000_000.0,
+            None,
+        ));
+
+        assert_eq!(label, "Sprint retros… · 9:00 AM");
+        assert_eq!(label.chars().count(), MAX_AGENDA_LABEL_CHARS);
     }
 
     #[test]


### PR DESCRIPTION
- Reorder tray controls into clearer agenda, app, update, and quit groups.
- Show compact agenda labels with the event title followed by its start time.
- Keep long event labels bounded and covered by tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tray UI and label formatting only; behavior is covered by updated unit tests with no auth or data-path changes.
> 
> **Overview**
> **Tray menu** items are regrouped: **Show Events** sits directly under the agenda, then **Open / Start / Settings**, then **Version / Check for updates**, then **Quit**. The old trailing separator and version block right after the agenda are removed.
> 
> **Agenda rows** no longer use `time range + title`. They use **`title · start time`** (start parsed from `time_label`), with a **24-character** cap via shared `compact_title` logic. Tests and expectations are updated for the new format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da61589ac9f5b441e0bed53dbfad1a80ab7db645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->