### PR TITLE
Add dynamic Open Graph images for public notes

### DIFF
--- a/apps/web/src/lib/og-image.test.ts
+++ b/apps/web/src/lib/og-image.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import sharp from "sharp";
+
+import { renderSharedNoteOgImage } from "./og-image.ts";
+
+test("renders a large social image for a shared note", async () => {
+  const response = await renderSharedNoteOgImage({
+    title: "Sprint retro & planning",
+    description:
+      "A concise recap of decisions, action items, and what the team is doing next.",
+    publishedAt: "2026-07-03T12:00:00Z",
+  });
+  const image = sharp(Buffer.from(await response.arrayBuffer()));
+  const metadata = await image.metadata();
+
+  assert.equal(response.headers.get("Content-Type"), "image/png");
+  assert.equal(
+    response.headers.get("Cache-Control"),
+    "public, max-age=0, s-maxage=60",
+  );
+  assert.equal(metadata.format, "png");
+  assert.equal(metadata.width, 1200);
+  assert.equal(metadata.height, 630);
+});

--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -4,12 +4,19 @@ const OG_WIDTH = 1200;
 const OG_HEIGHT = 630;
 const CACHE_CONTROL =
   "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800";
+const SHARED_NOTE_CACHE_CONTROL = "public, max-age=0, s-maxage=60";
 
 type BlogOgImageInput = {
   title: string;
   description?: string;
   date?: string;
   author?: string;
+};
+
+type SharedNoteOgImageInput = {
+  title: string;
+  description?: string;
+  publishedAt?: string;
 };
 
 function clampText(value: string | undefined, maxLength: number) {
@@ -115,14 +122,83 @@ function createBlogOgSvg(input: BlogOgImageInput) {
 </svg>`;
 }
 
-export async function renderBlogOgImage(input: BlogOgImageInput) {
-  const svg = createBlogOgSvg(input);
+function createSharedNoteOgSvg(input: SharedNoteOgImageInput) {
+  const normalizedTitle = clampText(input.title || "Shared note", 110);
+  const titleFontSize = normalizedTitle.length > 72 ? 62 : 72;
+  const title = wrapText(
+    normalizedTitle,
+    normalizedTitle.length > 72 ? 30 : 27,
+    3,
+  );
+  const description = wrapText(clampText(input.description, 190), 59, 2);
+  const titleStartY = title.length === 1 ? 265 : title.length === 2 ? 226 : 192;
+  const descriptionStartY = titleStartY + title.length * 76 + 22;
+  const date = formatDate(input.publishedAt);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="${OG_WIDTH}" height="${OG_HEIGHT}" viewBox="0 0 ${OG_WIDTH} ${OG_HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="background" x1="44" y1="26" x2="1150" y2="608" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#fff7dd"/>
+      <stop offset="0.52" stop-color="#f4efe6"/>
+      <stop offset="1" stop-color="#ece6dc"/>
+    </linearGradient>
+    <filter id="shadow" x="28" y="24" width="1144" height="594" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#4f412d" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <rect width="${OG_WIDTH}" height="${OG_HEIGHT}" fill="url(#background)"/>
+  <circle cx="1090" cy="74" r="164" fill="#ffe09d" fill-opacity="0.55"/>
+  <circle cx="72" cy="584" r="154" fill="#ffffff" fill-opacity="0.55"/>
+  <rect x="58" y="46" width="1084" height="538" rx="30" fill="#fffefa" filter="url(#shadow)"/>
+  <rect x="58" y="46" width="12" height="538" rx="6" fill="#e0b83d"/>
+  <path d="M112 142 H1088" stroke="#e8e0d4" stroke-width="2"/>
+  <g>
+    <rect x="108" y="82" width="42" height="42" rx="12" fill="#181613"/>
+    <path d="M119 108 C124 94 135 94 139 108 C135 103 124 103 119 108 Z" fill="#ffe09d"/>
+    <circle cx="129" cy="110" r="3" fill="#ffe09d"/>
+    <text x="166" y="113" fill="#181613" font-family="Arial, Helvetica, sans-serif" font-size="30" font-weight="700">Anarlog</text>
+  </g>
+  <g>
+    <rect x="914" y="83" width="174" height="40" rx="20" fill="#f4efe6"/>
+    <circle cx="941" cy="103" r="5" fill="#d1a321"/>
+    <text x="958" y="111" fill="#756b5d" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="700" letter-spacing="1.2">PUBLIC NOTE</text>
+  </g>
+  ${title
+    .map(
+      (line, index) =>
+        `<text x="110" y="${titleStartY + index * 76}" fill="#181613" font-family="Georgia, 'Times New Roman', serif" font-size="${titleFontSize}" font-weight="700">${escapeXml(line)}</text>`,
+    )
+    .join("")}
+  ${description
+    .map(
+      (line, index) =>
+        `<text x="114" y="${descriptionStartY + index * 39}" fill="#57534e" font-family="Arial, Helvetica, sans-serif" font-size="29" font-weight="500">${escapeXml(line)}</text>`,
+    )
+    .join("")}
+  <path d="M112 501 H1088" stroke="#e8e0d4" stroke-width="2"/>
+  <g fill="#756b5d" font-family="Arial, Helvetica, sans-serif" font-size="23" font-weight="600">
+    <text x="112" y="548">${escapeXml(date ? `Published ${date}` : "Shared note")}</text>
+    <text x="1088" y="548" text-anchor="end">Read on anarlog.so</text>
+  </g>
+</svg>`;
+}
+
+async function renderOgImage(svg: string, cacheControl: string) {
   const png = await sharp(Buffer.from(svg)).png().toBuffer();
 
   return new Response(new Uint8Array(png), {
     headers: {
-      "Cache-Control": CACHE_CONTROL,
+      "Cache-Control": cacheControl,
       "Content-Type": "image/png",
     },
   });
+}
+
+export async function renderBlogOgImage(input: BlogOgImageInput) {
+  return renderOgImage(createBlogOgSvg(input), CACHE_CONTROL);
+}
+
+export async function renderSharedNoteOgImage(input: SharedNoteOgImageInput) {
+  return renderOgImage(createSharedNoteOgSvg(input), SHARED_NOTE_CACHE_CONTROL);
 }

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -10,6 +10,10 @@ export function getBlogOgImageUrl(slug: string) {
   return `${ANARLOG_SITE_URL}/api/og/blog/${encodeURIComponent(slug)}`;
 }
 
+export function getPublicSharedNoteOgImageUrl(publicSlug: string) {
+  return `${ANARLOG_SITE_URL}/api/og/share/public/${encodeURIComponent(publicSlug)}`;
+}
+
 type StructuredDataNode = Record<string, unknown>;
 
 export function getStructuredDataGraph(nodes: StructuredDataNode[]) {

--- a/apps/web/src/lib/shared-note-meta.test.ts
+++ b/apps/web/src/lib/shared-note-meta.test.ts
@@ -60,6 +60,20 @@ test("available public notes receive canonical indexable metadata", () => {
       (meta) => meta.name === "robots" && meta.content === "index, follow",
     ),
   );
+  assert.ok(
+    head.meta.some(
+      (meta) =>
+        meta.property === "og:image" &&
+        meta.content ===
+          "https://anarlog.so/api/og/share/public/s_0123456789abcdef0123456789abcdef",
+    ),
+  );
+  assert.ok(
+    head.meta.some(
+      (meta) =>
+        meta.name === "twitter:card" && meta.content === "summary_large_image",
+    ),
+  );
 });
 
 test("unavailable public routes fail closed to private metadata", () => {

--- a/apps/web/src/lib/shared-note-meta.ts
+++ b/apps/web/src/lib/shared-note-meta.ts
@@ -1,4 +1,4 @@
-import { ANARLOG_SITE_URL } from "./seo.ts";
+import { ANARLOG_SITE_URL, getPublicSharedNoteOgImageUrl } from "./seo.ts";
 import {
   getSharedNoteDescription,
   type SharedNoteSnapshot,
@@ -42,6 +42,7 @@ export function getPublicShareHead(
     getSharedNoteDescription(snapshot.body) ||
     "A public note shared with Anarlog.";
   const url = `${ANARLOG_SITE_URL}/share/public/${publicSlug}/`;
+  const imageUrl = getPublicSharedNoteOgImageUrl(publicSlug);
 
   return {
     links: [{ rel: "canonical", href: url }],
@@ -55,9 +56,16 @@ export function getPublicShareHead(
       { property: "og:title", content: title },
       { property: "og:description", content: description },
       { property: "og:url", content: url },
-      { name: "twitter:card", content: "summary" },
+      { property: "og:image", content: imageUrl },
+      { property: "og:image:type", content: "image/png" },
+      { property: "og:image:width", content: "1200" },
+      { property: "og:image:height", content: "630" },
+      { property: "og:image:alt", content: `Preview of ${title}` },
+      { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:title", content: title },
       { name: "twitter:description", content: description },
+      { name: "twitter:image", content: imageUrl },
+      { name: "twitter:image:alt", content: `Preview of ${title}` },
     ],
   };
 }

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -75,6 +75,7 @@ import { Route as ApiAdminContentDeleteRouteImport } from './routes/api/admin/co
 import { Route as ApiAdminContentCreateRouteImport } from './routes/api/admin/content/create'
 import { Route as ApiAdminContentAuditRouteImport } from './routes/api/admin/content/audit'
 import { Route as ApiAdminBlogUploadImageRouteImport } from './routes/api/admin/blog/upload-image'
+import { Route as ApiOgSharePublicPublicSlugRouteImport } from './routes/api/og/share/public/$publicSlug'
 
 const UpdatePasswordRoute = UpdatePasswordRouteImport.update({
   id: '/update-password',
@@ -412,6 +413,12 @@ const ApiAdminBlogUploadImageRoute = ApiAdminBlogUploadImageRouteImport.update({
   path: '/api/admin/blog/upload-image',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiOgSharePublicPublicSlugRoute =
+  ApiOgSharePublicPublicSlugRouteImport.update({
+    id: '/api/og/share/public/$publicSlug',
+    path: '/api/og/share/public/$publicSlug',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -479,6 +486,7 @@ export interface FileRoutesByFullPath {
   '/api/admin/stars/pipeline': typeof ApiAdminStarsPipelineRoute
   '/api/admin/stars/research': typeof ApiAdminStarsResearchRoute
   '/api/og/blog/$slug': typeof ApiOgBlogSlugRoute
+  '/api/og/share/public/$publicSlug': typeof ApiOgSharePublicPublicSlugRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -545,6 +553,7 @@ export interface FileRoutesByTo {
   '/api/admin/stars/pipeline': typeof ApiAdminStarsPipelineRoute
   '/api/admin/stars/research': typeof ApiAdminStarsResearchRoute
   '/api/og/blog/$slug': typeof ApiOgBlogSlugRoute
+  '/api/og/share/public/$publicSlug': typeof ApiOgSharePublicPublicSlugRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -614,6 +623,7 @@ export interface FileRoutesById {
   '/api/admin/stars/pipeline': typeof ApiAdminStarsPipelineRoute
   '/api/admin/stars/research': typeof ApiAdminStarsResearchRoute
   '/api/og/blog/$slug': typeof ApiOgBlogSlugRoute
+  '/api/og/share/public/$publicSlug': typeof ApiOgSharePublicPublicSlugRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -683,6 +693,7 @@ export interface FileRouteTypes {
     | '/api/admin/stars/pipeline'
     | '/api/admin/stars/research'
     | '/api/og/blog/$slug'
+    | '/api/og/share/public/$publicSlug'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -749,6 +760,7 @@ export interface FileRouteTypes {
     | '/api/admin/stars/pipeline'
     | '/api/admin/stars/research'
     | '/api/og/blog/$slug'
+    | '/api/og/share/public/$publicSlug'
   id:
     | '__root__'
     | '/'
@@ -817,6 +829,7 @@ export interface FileRouteTypes {
     | '/api/admin/stars/pipeline'
     | '/api/admin/stars/research'
     | '/api/og/blog/$slug'
+    | '/api/og/share/public/$publicSlug'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -873,6 +886,7 @@ export interface RootRouteChildren {
   ApiAdminStarsPipelineRoute: typeof ApiAdminStarsPipelineRoute
   ApiAdminStarsResearchRoute: typeof ApiAdminStarsResearchRoute
   ApiOgBlogSlugRoute: typeof ApiOgBlogSlugRoute
+  ApiOgSharePublicPublicSlugRoute: typeof ApiOgSharePublicPublicSlugRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1339,6 +1353,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAdminBlogUploadImageRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/og/share/public/$publicSlug': {
+      id: '/api/og/share/public/$publicSlug'
+      path: '/api/og/share/public/$publicSlug'
+      fullPath: '/api/og/share/public/$publicSlug'
+      preLoaderRoute: typeof ApiOgSharePublicPublicSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -1442,6 +1463,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAdminStarsPipelineRoute: ApiAdminStarsPipelineRoute,
   ApiAdminStarsResearchRoute: ApiAdminStarsResearchRoute,
   ApiOgBlogSlugRoute: ApiOgBlogSlugRoute,
+  ApiOgSharePublicPublicSlugRoute: ApiOgSharePublicPublicSlugRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/api/og/share/public/$publicSlug.ts
+++ b/apps/web/src/routes/api/og/share/public/$publicSlug.ts
@@ -1,0 +1,36 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { fetchPublicSharedNoteResult } from "@/lib/shared-note-api";
+import { renderSharedNoteOgImage } from "@/lib/og-image";
+import {
+  getSharedNoteDescription,
+  publicShareSlugSchema,
+} from "@/lib/shared-notes";
+
+export const Route = createFileRoute("/api/og/share/public/$publicSlug")({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        const publicSlug = publicShareSlugSchema.safeParse(params.publicSlug);
+        if (!publicSlug.success) return notFound();
+
+        const result = await fetchPublicSharedNoteResult(publicSlug.data);
+        if (result.status !== "ready") return notFound();
+
+        return renderSharedNoteOgImage({
+          title: result.snapshot.title || "Shared note",
+          description:
+            getSharedNoteDescription(result.snapshot.body) || undefined,
+          publishedAt: result.snapshot.publishedAt,
+        });
+      },
+    },
+  },
+});
+
+function notFound() {
+  return new Response("Not found", {
+    status: 404,
+    headers: { "Cache-Control": "no-store" },
+  });
+}


### PR DESCRIPTION
Generate share-specific social previews from public note metadata and cover the output with focused tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Follows the existing blog OG pattern and only serves images for notes already exposed as public; invalid or unavailable slugs return 404 with no-store.
> 
> **Overview**
> Adds **dynamic 1200×630 PNG previews** for public note links, wired into social/SEO metadata so shares use `summary_large_image` instead of a generic card.
> 
> A new **`GET /api/og/share/public/$publicSlug`** handler validates the slug, loads the public snapshot (404 when invalid or not ready), and renders title, description, and publish date via **`renderSharedNoteOgImage`**. Blog rendering is refactored through a shared **`renderOgImage`** helper; shared-note images use a **shorter CDN cache** (`s-maxage=60`) than blog OG images.
> 
> **`getPublicShareHead`** now emits `og:image` / Twitter image tags (with dimensions and alt) pointing at **`getPublicSharedNoteOgImageUrl`**. Coverage includes an OG render test and updated public-share meta assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e5243e69af61a013ddc151ddb4451cd15783fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->