### PR TITLE
Explain Google Calendar access on the homepage

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -478,6 +478,11 @@ function PricingSection() {
           Start with local meeting notes for free. Upgrade when you want hosted
           transcription, AI, sync, and sharing.
         </p>
+        <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-[#756b5d]">
+          Google Calendar access is read-only. It lets Anarlog show upcoming
+          events and associate them with your personal notes; Anarlog cannot
+          create, edit, or delete calendar events.
+        </p>
       </div>
 
       <div className="relative left-1/2 mt-8 grid w-screen max-w-[760px] -translate-x-1/2 grid-cols-1 gap-4 px-5 text-left md:grid-cols-2 md:px-8">


### PR DESCRIPTION
Add a concise homepage disclosure describing why Anarlog requests Google Calendar access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only marketing change with no auth, API, or data-handling logic.
> 
> **Overview**
> Adds a short **privacy disclosure** in the homepage **Simple pricing** section (`PricingSection` in `index.tsx`), directly under the existing pricing intro copy.
> 
> The new paragraph states that Google Calendar access is **read-only**, used to show upcoming events and link them to personal notes, and that Anarlog **cannot** create, edit, or delete calendar events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693be7dbcd57ef84d79e404ef240d78c1268d3de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->