### PR TITLE
Harden shared note Open Graph rendering

### DIFF
--- a/apps/web/src/lib/og-image.test.ts
+++ b/apps/web/src/lib/og-image.test.ts
@@ -2,7 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import sharp from "sharp";
 
-import { renderSharedNoteOgImage } from "./og-image.ts";
+import { createSharedNoteOgSvg, renderSharedNoteOgImage } from "./og-image.ts";
+
+test("normalizes shared note metadata", () => {
+  const svg = createSharedNoteOgSvg({
+    title: "   ",
+    publishedAt: "2026-07-02T23:30:00Z",
+  });
+
+  assert.match(svg, />Shared note<\/text>/);
+  assert.match(svg, /Published July 2, 2026/);
+});
 
 test("renders a large social image for a shared note", async () => {
   const response = await renderSharedNoteOgImage({

--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -75,6 +75,7 @@ function formatDate(date: string | undefined) {
   return parsed.toLocaleDateString("en-US", {
     month: "long",
     day: "numeric",
+    timeZone: "UTC",
     year: "numeric",
   });
 }
@@ -122,8 +123,8 @@ function createBlogOgSvg(input: BlogOgImageInput) {
 </svg>`;
 }
 
-function createSharedNoteOgSvg(input: SharedNoteOgImageInput) {
-  const normalizedTitle = clampText(input.title || "Shared note", 110);
+export function createSharedNoteOgSvg(input: SharedNoteOgImageInput) {
+  const normalizedTitle = clampText(input.title, 110) || "Shared note";
   const titleFontSize = normalizedTitle.length > 72 ? 62 : 72;
   const title = wrapText(
     normalizedTitle,

--- a/apps/web/src/routes/api/og/share/public/$publicSlug.ts
+++ b/apps/web/src/routes/api/og/share/public/$publicSlug.ts
@@ -15,7 +15,8 @@ export const Route = createFileRoute("/api/og/share/public/$publicSlug")({
         if (!publicSlug.success) return notFound();
 
         const result = await fetchPublicSharedNoteResult(publicSlug.data);
-        if (result.status !== "ready") return notFound();
+        if (result.status === "unavailable") return notFound();
+        if (result.status === "error") return serviceUnavailable();
 
         return renderSharedNoteOgImage({
           title: result.snapshot.title || "Shared note",
@@ -31,6 +32,13 @@ export const Route = createFileRoute("/api/og/share/public/$publicSlug")({
 function notFound() {
   return new Response("Not found", {
     status: 404,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+function serviceUnavailable() {
+  return new Response("Unable to load shared note", {
+    status: 503,
     headers: { "Cache-Control": "no-store" },
   });
 }


### PR DESCRIPTION
Handle blank titles, render publication dates in UTC, and return a service error when the shared-note backend is unavailable. Includes focused Open Graph regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small OG rendering and HTTP status mapping changes with no auth or data-model impact; main effect is clearer errors and stable date display for crawlers.
> 
> **Overview**
> Hardens **shared-note Open Graph** behavior so social previews are consistent and the OG API distinguishes missing notes from backend failures.
> 
> **SVG/metadata:** `createSharedNoteOgSvg` is exported for testing. Blank or whitespace-only titles now fall back to **"Shared note"** after clamp/trim (instead of treating empty input differently). Publication dates on OG images use **`timeZone: "UTC"`** in `formatDate`, so late-evening ISO timestamps don’t shift to the wrong calendar day in local time.
> 
> **OG route:** `GET /api/og/share/public/$publicSlug` maps `fetchPublicSharedNoteResult` **`unavailable`** → 404 and **`error`** → **503** with `Cache-Control: no-store`, instead of treating every non-ready result as 404.
> 
> **Tests:** Adds a focused unit test that whitespace titles render as "Shared note" and UTC dates show as expected (e.g. July 2, 2026 for `2026-07-02T23:30:00Z`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8bd8f76ff3eb24a5048e9e9094f547bfd8088db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->