### PR TITLE
chore(release): add 1.3.2 changelog

### DIFF
--- a/packages/changelog/content/1.3.2.md
+++ b/packages/changelog/content/1.3.2.md
@@ -1,0 +1,15 @@
+---
+date: "2026-07-20"
+summary: "Anarlog 1.3.2 protects Google Calendar data from remote AI and polishes sharing, the menu bar, and in-app notifications."
+---
+
+## Google Calendar privacy
+
+- Block remote language models while Google Calendar data is present on your device, with a direct option to configure on-device AI instead
+- Keep calendar-derived names, event titles, attendees, and speaker hints out of remote transcription requests
+
+## Sharing and polish
+
+- Open sharing in a compact panel anchored to the note toolbar, with a simpler icon control and clear Pro upgrade guidance
+- Scan upcoming meetings more easily from a cleaner menu bar agenda that shows compact event titles before their start times
+- Close in-app notifications without the button being clipped at the edge


### PR DESCRIPTION
Document Google Calendar privacy protections and sharing, menu bar, and notification polish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or application code impact.
> 
> **Overview**
> Adds **`packages/changelog/content/1.3.2.md`** for the Anarlog 1.3.2 release, using the same frontmatter (`date`, `summary`) and sectioned bullet format as prior entries (e.g. 1.3.1).
> 
> The entry documents **Google Calendar privacy** (blocking remote LLMs when calendar data is on-device, excluding calendar-derived fields from remote transcription) and **sharing / UI polish** (toolbar-anchored share panel with Pro guidance, cleaner menu bar agenda, fixed in-app notification close button clipping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b91a52d5b0e669ad0357e5ed4f9cd832579aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->