### PR TITLE
Simplify auth and callback page chrome

### DIFF
--- a/apps/web/src/components/auth-shell.tsx
+++ b/apps/web/src/components/auth-shell.tsx
@@ -26,12 +26,6 @@ export const authSecondaryButtonClassName = cn([
 export const authNoticeClassName =
   "rounded-xl border border-[#e5ddcf] bg-[#f7f4ef] p-4 text-center";
 
-const authPromises = [
-  "Bot-free meeting capture",
-  "Fully offline notes",
-  "On-device or bring-your-own-key AI",
-];
-
 export function AuthShell({
   title,
   description,
@@ -55,19 +49,6 @@ export function AuthShell({
                 private meetings.
               </mark>
             </h2>
-            <p className="mt-7 max-w-xl text-lg leading-8 text-[#4f4940]">
-              Jot notes during the call. Anarlog turns them into an editable
-              summary while your work stays in your hands.
-            </p>
-
-            <ul className="mt-9 grid gap-3 text-sm text-[#4f4940]">
-              {authPromises.map((promise) => (
-                <li key={promise} className="flex items-center gap-3">
-                  <span className="size-1.5 rounded-full bg-[#d1a321]" />
-                  {promise}
-                </li>
-              ))}
-            </ul>
           </section>
 
           <section className="mx-auto w-full max-w-[440px] overflow-hidden rounded-[24px] border border-[#e5ddcf] bg-white shadow-[0_24px_80px_rgba(24,22,19,0.10)]">
@@ -86,13 +67,6 @@ export function AuthShell({
             <div className="p-6 sm:p-8">{children}</div>
           </section>
         </div>
-
-        <footer className="flex min-h-16 items-center justify-between gap-4 border-t border-[#ede7dc] py-5 text-xs text-[#8b8174]">
-          <span>Open source. Local-first. Yours.</span>
-          <span className="hidden sm:inline">
-            Your notes should survive us.
-          </span>
-        </footer>
       </div>
     </main>
   );

--- a/apps/web/src/routes/_view/callback/integration.tsx
+++ b/apps/web/src/routes/_view/callback/integration.tsx
@@ -4,8 +4,12 @@ import { CheckIcon, CopyIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
-import { cn } from "@hypr/utils";
-
+import {
+  AuthShell,
+  authNoticeClassName,
+  authPrimaryButtonClassName,
+  authSecondaryButtonClassName,
+} from "@/components/auth-shell";
 import { flowSearchSchema } from "@/functions/desktop-flow";
 
 const commonSearch = {
@@ -106,64 +110,53 @@ function Component() {
 
   if (search.flow === "desktop") {
     return (
-      <div className="flex min-h-screen items-center justify-center p-6">
-        <div className="flex w-full max-w-md flex-col gap-8 text-center">
+      <AuthShell
+        title={isSuccess ? "You’re connected" : "Connection didn’t work"}
+        description={
+          isSuccess
+            ? "Return to Anarlog to keep going."
+            : "Something went wrong while connecting."
+        }
+      >
+        {isSuccess ? (
           <div className="flex flex-col gap-3">
-            <h1 className="font-sans text-3xl tracking-tight text-stone-700">
-              {isSuccess ? "Connection successful" : "Connection failed"}
-            </h1>
-            <p className="text-neutral-600">
-              {isSuccess
-                ? "Click the button below to return to the app"
-                : "Something went wrong during the connection"}
-            </p>
-          </div>
+            <button
+              onClick={handleDeeplink}
+              className={authPrimaryButtonClassName}
+            >
+              Open Anarlog
+            </button>
 
-          {isSuccess && (
-            <div className="flex flex-col gap-4">
-              <button
-                onClick={handleDeeplink}
-                className={cn([
-                  "flex h-12 w-full cursor-pointer items-center justify-center text-base font-medium transition-all",
-                  "rounded-full bg-linear-to-t from-stone-600 to-stone-500 text-white shadow-md hover:scale-[102%] hover:shadow-lg active:scale-[98%]",
-                ])}
-              >
-                Open Anarlog
-              </button>
-
+            <div className="rounded-xl border border-[#e5ddcf] bg-[#fbfaf7] p-4 text-center">
+              <p className="mb-3 text-sm leading-6 text-[#756b5d]">
+                Button not working? Copy the link instead
+              </p>
               <button
                 onClick={handleCopy}
-                className={cn([
-                  "flex w-full cursor-pointer flex-col items-center gap-3 p-4 text-left transition-all",
-                  "rounded-lg border border-stone-100 bg-stone-50 hover:bg-stone-100 active:scale-[99%]",
-                ])}
+                className={authSecondaryButtonClassName}
               >
-                <p className="text-sm text-stone-500">
-                  Button not working? Copy the link instead
-                </p>
-                <span
-                  className={cn([
-                    "flex h-10 w-full items-center justify-center gap-2 text-sm font-medium",
-                    "rounded-full bg-linear-to-t from-neutral-200 to-neutral-100 text-neutral-900 shadow-xs",
-                  ])}
-                >
-                  {copied ? (
-                    <>
-                      <CheckIcon className="size-4" />
-                      Copied!
-                    </>
-                  ) : (
-                    <>
-                      <CopyIcon className="size-4" />
-                      Copy URL
-                    </>
-                  )}
-                </span>
+                {copied ? (
+                  <>
+                    <CheckIcon className="size-4" />
+                    Copied!
+                  </>
+                ) : (
+                  <>
+                    <CopyIcon className="size-4" />
+                    Copy URL
+                  </>
+                )}
               </button>
             </div>
-          )}
-        </div>
-      </div>
+          </div>
+        ) : (
+          <div className={authNoticeClassName}>
+            <p className="text-sm font-medium text-[#4f4940]">
+              Close this window and try again from Anarlog.
+            </p>
+          </div>
+        )}
+      </AuthShell>
     );
   }
 


### PR DESCRIPTION
Summary:
- remove supporting marketing copy and the footer from the shared auth shell
- align the desktop integration callback with the auth page styles and tone
- preserve automatic deep-link and copy-link fallback behavior

Testing:
- pnpm -F @hypr/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to auth/callback pages; no auth, routing, or deeplink logic changes.
> 
> **Overview**
> **Trims shared auth layout chrome** and **moves the desktop integration OAuth callback onto the same `AuthShell` and tokenized button/notice styles** as other auth flows.
> 
> `AuthShell` drops the left-column marketing paragraph, feature bullet list, and page footer; the headline block (“Stay present… / private meetings”) and card layout stay. The integration callback no longer uses a one-off centered stone-themed page—it wraps content in `AuthShell` with updated success/failure titles and copy, `authPrimaryButtonClassName` / `authSecondaryButtonClassName` for Open Anarlog and copy-link, and an `authNoticeClassName` block on failure. Deep-link auto-redirect, manual open, and clipboard fallback behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ce648c588e055b9d1ddde77aaf5d6a3c0b34c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->