### PR TITLE
Keep share-link scope changes after copying

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -82,6 +82,7 @@
     "@tanstack/react-router": "^1.168.19",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-autostart": "^2.5.1",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-http": "^2.5.8",
     "@tauri-apps/plugin-os": "^2.3.2",

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -56,6 +56,7 @@
     "notify:default",
     "tantivy:default",
     "clipboard-manager:allow-write-image",
+    "clipboard-manager:allow-write-text",
     "shell:allow-open",
     "misc:default",
     "fs-sync:default",

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -72,6 +72,14 @@ vi.mock("@hypr/plugin-opener2", () => ({
   commands: { openUrl: mocks.openUrl },
 }));
 
+vi.mock("@tauri-apps/api/core", () => ({
+  isTauri: () => true,
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: mocks.clipboardWriteText,
+}));
+
 vi.mock("~/shared-notes/cache", () => ({
   loadManagedSharedNoteForSession: mocks.loadManagedSharedNoteForSession,
   upsertDurableSharedNoteCache: mocks.upsertDurableSharedNoteCache,
@@ -364,10 +372,6 @@ describe("SessionShareButton", () => {
         publicSlug: PUBLIC_SLUG,
         accessVersion: 2,
       };
-    });
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText: mocks.clipboardWriteText },
     });
   });
 

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -1,6 +1,8 @@
 import { Trans } from "@lingui/react/macro";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { isTauri } from "@tauri-apps/api/core";
+import { writeText as writeClipboardText } from "@tauri-apps/plugin-clipboard-manager";
 import {
   AlertTriangleIcon,
   CheckIcon,
@@ -1810,6 +1812,10 @@ function requireManagementContext(
 }
 
 async function copyText(value: string) {
+  if (isTauri()) {
+    await writeClipboardText(value);
+    return;
+  }
   await navigator.clipboard.writeText(value);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       '@tauri-apps/plugin-autostart':
         specifier: ^2.5.1
         version: 2.5.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.0
         version: 2.7.0
@@ -7398,6 +7401,9 @@ packages:
 
   '@tauri-apps/plugin-autostart@2.5.1':
     resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-dialog@2.7.0':
     resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
@@ -22043,6 +22049,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
 
   '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
     dependencies:
       '@tauri-apps/api': 2.10.1
 


### PR DESCRIPTION
Use the native Tauri clipboard for delayed share-link copies and grant the text-write capability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to clipboard plumbing for share UI copies; no auth or sharing API logic changes beyond more reliable copy on desktop.
> 
> **Overview**
> Share invite and bearer link copies in the desktop app now go through **Tauri’s clipboard manager** when `isTauri()` is true, instead of `navigator.clipboard`. That targets copy steps that run **after async work** (publish, rotate link, create invitation), where the web API was unreliable and could leave general access in a bad state when copy failed.
> 
> Adds `@tauri-apps/plugin-clipboard-manager` and grants **`clipboard-manager:allow-write-text`** alongside the existing image write permission. **`copyText`** in session sharing is the single entry point for these copies; non-Tauri builds still use the browser API.
> 
> Tests mock `isTauri` and `writeText` from the plugin and drop the `navigator.clipboard` override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b81e65c642472d7139024da06bf802d1ed27dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->