### PR TITLE
Make E2EE witness backfills reliable

### DIFF
--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -80,12 +80,23 @@ fn request_client_address(request: &Request<Body>) -> Option<String> {
 fn build_sync_routes(
     state: hypr_api_sync::AppState,
     rate_limit_state: rate_limit::RateLimitState,
+    witness_rate_limit_state: rate_limit::RateLimitState,
     auth_state: AuthState,
 ) -> Router {
     let pro_routes = hypr_api_sync::pro_router(state.clone())
         .route_layer(middleware::from_fn_with_state(
             rate_limit_state.clone(),
             rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let witness_routes = hypr_api_sync::e2ee_witness_router(state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            witness_rate_limit_state,
+            rate_limit::wait_for_rate_limit,
         ))
         .route_layer(middleware::from_fn(auth::sentry_and_analytics))
         .route_layer(middleware::from_fn_with_state(
@@ -103,7 +114,7 @@ fn build_sync_routes(
             auth::require_auth,
         ));
 
-    pro_routes.merge(web_edit_routes)
+    pro_routes.merge(witness_routes).merge(web_edit_routes)
 }
 
 async fn app() -> Router {
@@ -149,6 +160,18 @@ async fn app() -> Router {
         )
         .free(
             governor::Quota::with_period(Duration::from_secs(30))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(20).unwrap()),
+        )
+        .build();
+    let e2ee_witness_rate_limit = rate_limit::RateLimitState::builder()
+        .pro(
+            governor::Quota::with_period(Duration::from_millis(100))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(20).unwrap()),
+        )
+        .free(
+            governor::Quota::with_period(Duration::from_millis(100))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(20).unwrap()),
         )
@@ -239,6 +262,7 @@ async fn app() -> Router {
         Some(config) => build_sync_routes(
             hypr_api_sync::AppState::new(config),
             sync_rate_limit,
+            e2ee_witness_rate_limit,
             auth_state.clone(),
         ),
         None => Router::new(),
@@ -824,6 +848,7 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
             build_sync_routes(
                 test_sync_state(&server),
                 test_sync_rate_limit(),
+                test_sync_rate_limit(),
                 AuthState::new(&server.uri()),
             ),
         );
@@ -861,6 +886,7 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
         );
 
         let token_response = app
+            .clone()
             .oneshot(
                 Request::post("/sync/token")
                     .header(header::AUTHORIZATION, format!("Bearer {token}"))
@@ -873,6 +899,22 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
         assert_eq!(token_response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
             response_bytes(token_response).await,
+            b"subscription_required"
+        );
+
+        let witness_response = app
+            .oneshot(
+                Request::get("/sync/e2ee/witness/editor-user")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(witness_response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            response_bytes(witness_response).await,
             b"subscription_required"
         );
         server.verify().await;

--- a/apps/api/src/rate_limit.rs
+++ b/apps/api/src/rate_limit.rs
@@ -27,6 +27,7 @@ type IpKeyedLimiter = RateLimiter<u16, DefaultKeyedStateStore<u16>, DefaultClock
 const IP_RATE_LIMIT_CLEANUP_EVERY: usize = 1024;
 const IP_RATE_LIMIT_BUCKETS: u64 = 4096;
 const UNKNOWN_CLIENT_IP_BUCKET: u16 = IP_RATE_LIMIT_BUCKETS as u16;
+const MAX_RATE_LIMIT_QUEUE_WAIT: std::time::Duration = std::time::Duration::from_secs(1);
 
 #[derive(Clone)]
 pub struct IpRateLimitState {
@@ -101,6 +102,15 @@ impl RateLimitState {
             .check_key(&auth.claims.sub)
             .map_err(|not_until| not_until.wait_time_from(DefaultClock::default().now()))
     }
+
+    async fn wait(&self, auth: &AuthContext) {
+        let limiter = if auth.claims.is_paid() {
+            &self.limiter_pro
+        } else {
+            &self.limiter_free
+        };
+        limiter.until_key_ready(&auth.claims.sub).await;
+    }
 }
 
 pub struct RateLimitStateBuilder {
@@ -151,6 +161,28 @@ pub async fn rate_limit(
     }
 
     Ok(next.run(request).await)
+}
+
+pub async fn wait_for_rate_limit(
+    axum::extract::State(state): axum::extract::State<RateLimitState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if !cfg!(debug_assertions)
+        && let Some(auth) = request.extensions().get::<AuthContext>()
+        && tokio::time::timeout(MAX_RATE_LIMIT_QUEUE_WAIT, state.wait(auth))
+            .await
+            .is_err()
+    {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            [("retry-after", "1"), ("cache-control", "no-store")],
+            "rate limit exceeded",
+        )
+            .into_response();
+    }
+
+    next.run(request).await
 }
 
 pub async fn rate_limit_by_ip(

--- a/crates/api-sync/src/lib.rs
+++ b/crates/api-sync/src/lib.rs
@@ -7,7 +7,7 @@ mod state;
 
 pub use config::{SharedNotesConfig, SyncConfig, SyncEnv};
 pub use error::{Result, SyncError};
-pub use routes::{openapi, pro_router, web_edit_router};
+pub use routes::{e2ee_witness_router, openapi, pro_router, web_edit_router};
 pub use shared_notes::{
     SharedNotesState, authenticated_router as authenticated_shared_notes_router,
     openapi as shared_notes_openapi, router as shared_notes_router,

--- a/crates/api-sync/src/routes/e2ee_witness.rs
+++ b/crates/api-sync/src/routes/e2ee_witness.rs
@@ -13,11 +13,13 @@ use uuid::Uuid;
 use crate::error::{Result, SyncError};
 use crate::state::AppState;
 
-const MAX_EVENTS_PER_BATCH: usize = 16;
+const MAX_EVENTS_PER_BATCH: usize = 64;
 const MAX_EVENT_BYTES: usize = 16 * 1024 * 1024;
 const MAX_WITNESS_REQUEST_BYTES: usize = 64 * 1024 * 1024;
 const MAX_WITNESS_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
-const WITNESS_PAGE_SIZE: i32 = 3;
+const MAX_WITNESS_PAGE_BYTES: i32 = 48 * 1024 * 1024;
+const WITNESS_PAGE_SIZE: i32 = 1024;
+const LEGACY_WITNESS_PAGE_SIZE: i32 = 3;
 const WITNESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 #[derive(Clone, Debug, Deserialize, Serialize, utoipa::ToSchema)]
@@ -87,6 +89,16 @@ struct PublishRpcEvent<'a> {
 
 #[derive(Serialize)]
 struct ReadRpcRequest<'a> {
+    p_actor_user_id: &'a str,
+    p_workspace_id: &'a str,
+    p_after_sequence: i64,
+    p_through_sequence: Option<i64>,
+    p_limit: i32,
+    p_max_bytes: i32,
+}
+
+#[derive(Serialize)]
+struct LegacyReadRpcRequest<'a> {
     p_actor_user_id: &'a str,
     p_workspace_id: &'a str,
     p_after_sequence: i64,
@@ -176,26 +188,14 @@ async fn read_e2ee_witness(
         .map(i64::try_from)
         .transpose()
         .map_err(|_| SyncError::BadRequest("E2EE witness cursor is invalid".to_string()))?;
-    let response = state
-        .client
-        .post(format!(
-            "{}/rest/v1/rpc/read_e2ee_freshness_page",
-            state.config.supabase_url
-        ))
-        .header("apikey", &state.config.supabase_service_role_key)
-        .bearer_auth(&state.config.supabase_service_role_key)
-        .timeout(WITNESS_TIMEOUT)
-        .json(&ReadRpcRequest {
-            p_actor_user_id: &auth.claims.sub,
-            p_workspace_id: &workspace_id,
-            p_after_sequence: after_sequence,
-            p_through_sequence: through_sequence,
-            p_limit: WITNESS_PAGE_SIZE,
-        })
-        .send()
-        .await
-        .map_err(|error| witness_transport_error(error, "read"))?;
-    let (status, bytes) = read_bounded_response(response, "read").await?;
+    let (status, bytes) = read_witness_page(
+        &state,
+        &auth.claims.sub,
+        &workspace_id,
+        after_sequence,
+        through_sequence,
+    )
+    .await?;
     if !status.is_success() {
         return Err(map_postgrest_error(status, &bytes));
     }
@@ -208,6 +208,60 @@ async fn read_e2ee_witness(
         [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
         Json(page),
     ))
+}
+
+async fn read_witness_page(
+    state: &AppState,
+    actor_user_id: &str,
+    workspace_id: &str,
+    after_sequence: i64,
+    through_sequence: Option<i64>,
+) -> Result<(HttpStatusCode, Vec<u8>)> {
+    let response = state
+        .client
+        .post(format!(
+            "{}/rest/v1/rpc/read_e2ee_freshness_page_v2",
+            state.config.supabase_url
+        ))
+        .header("apikey", &state.config.supabase_service_role_key)
+        .bearer_auth(&state.config.supabase_service_role_key)
+        .timeout(WITNESS_TIMEOUT)
+        .json(&ReadRpcRequest {
+            p_actor_user_id: actor_user_id,
+            p_workspace_id: workspace_id,
+            p_after_sequence: after_sequence,
+            p_through_sequence: through_sequence,
+            p_limit: WITNESS_PAGE_SIZE,
+            p_max_bytes: MAX_WITNESS_PAGE_BYTES,
+        })
+        .send()
+        .await
+        .map_err(|error| witness_transport_error(error, "read"))?;
+    let result = read_bounded_response(response, "read").await?;
+    if !is_missing_v2_rpc(result.0, &result.1) {
+        return Ok(result);
+    }
+
+    let response = state
+        .client
+        .post(format!(
+            "{}/rest/v1/rpc/read_e2ee_freshness_page",
+            state.config.supabase_url
+        ))
+        .header("apikey", &state.config.supabase_service_role_key)
+        .bearer_auth(&state.config.supabase_service_role_key)
+        .timeout(WITNESS_TIMEOUT)
+        .json(&LegacyReadRpcRequest {
+            p_actor_user_id: actor_user_id,
+            p_workspace_id: workspace_id,
+            p_after_sequence: after_sequence,
+            p_through_sequence: through_sequence,
+            p_limit: LEGACY_WITNESS_PAGE_SIZE,
+        })
+        .send()
+        .await
+        .map_err(|error| witness_transport_error(error, "read"))?;
+    read_bounded_response(response, "read").await
 }
 
 #[utoipa::path(
@@ -450,6 +504,12 @@ fn map_postgrest_error(status: HttpStatusCode, bytes: &[u8]) -> SyncError {
     }
 }
 
+fn is_missing_v2_rpc(status: HttpStatusCode, bytes: &[u8]) -> bool {
+    status == HttpStatusCode::NOT_FOUND
+        && serde_json::from_slice::<PostgrestError>(bytes)
+            .is_ok_and(|error| error.code == "PGRST202")
+}
+
 fn is_blinded_id(value: &str) -> bool {
     value.len() == 43
         && value
@@ -527,14 +587,15 @@ mod tests {
         let server = MockServer::start().await;
         let payload = "opaque";
         Mock::given(method("POST"))
-            .and(path("/rest/v1/rpc/read_e2ee_freshness_page"))
+            .and(path("/rest/v1/rpc/read_e2ee_freshness_page_v2"))
             .and(request_header("apikey", "service-role-key"))
             .and(request_header("authorization", "Bearer service-role-key"))
             .and(body_partial_json(json!({
                 "p_actor_user_id": OWNER,
                 "p_workspace_id": OWNER,
                 "p_after_sequence": 0,
-                "p_limit": 3
+                "p_limit": 1024,
+                "p_max_bytes": 50331648
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
                 "initialized_at": "2026-07-17T00:00:00Z",
@@ -560,6 +621,53 @@ mod tests {
         let body = response_json(response).await;
         assert_eq!(body["headSequence"], 1);
         assert_eq!(body["events"][0]["recordId"], RECORD_ID);
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_legacy_witness_pages_during_database_rollout() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/read_e2ee_freshness_page_v2"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+                "code": "PGRST202",
+                "message": "function is not in the schema cache"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/read_e2ee_freshness_page"))
+            .and(body_partial_json(json!({
+                "p_actor_user_id": OWNER,
+                "p_workspace_id": OWNER,
+                "p_after_sequence": 0,
+                "p_limit": 3
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "initialized_at": "2026-07-17T00:00:00Z",
+                "head_sequence": 0,
+                "through_sequence": 0,
+                "event_sequence": null,
+                "record_id": null,
+                "payload_hash": null,
+                "payload": null
+            }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server)
+            .oneshot(request(
+                Method::GET,
+                &format!("/e2ee/witness/{OWNER}?afterSequence=0"),
+                None,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_json(response).await["events"], json!([]));
+        server.verify().await;
     }
 
     #[tokio::test]
@@ -602,6 +710,29 @@ mod tests {
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response_json(response).await["headSequence"], 1);
+    }
+
+    #[test]
+    fn accepts_the_database_publish_batch_limit() {
+        let event = E2eeWitnessEvent {
+            record_id: RECORD_ID.to_string(),
+            payload_hash: PAYLOAD_HASH.to_string(),
+            payload: "opaque".to_string(),
+        };
+        assert!(
+            validate_publish_request(&PublishE2eeWitnessRequest {
+                initialize: false,
+                events: vec![event.clone(); 64],
+            })
+            .is_ok()
+        );
+        assert!(
+            validate_publish_request(&PublishE2eeWitnessRequest {
+                initialize: false,
+                events: vec![event; 65],
+            })
+            .is_err()
+        );
     }
 
     #[tokio::test]

--- a/crates/api-sync/src/routes/mod.rs
+++ b/crates/api-sync/src/routes/mod.rs
@@ -317,7 +317,6 @@ pub fn pro_router(state: AppState) -> Router {
     Router::new()
         .route("/token", post(create_credentials))
         .route("/e2ee/identity", put(claim_e2ee_identity))
-        .merge(e2ee_witness::router())
         .route(
             "/shares/{share_id}/snapshot",
             put(publish_session_share_snapshot)
@@ -326,6 +325,10 @@ pub fn pro_router(state: AppState) -> Router {
         .merge(attachment_backups::router())
         .merge(shared_attachments::router())
         .with_state(state)
+}
+
+pub fn e2ee_witness_router(state: AppState) -> Router {
+    e2ee_witness::router().with_state(state)
 }
 
 pub fn web_edit_router(state: AppState) -> Router {

--- a/plugins/db/Cargo.toml
+++ b/plugins/db/Cargo.toml
@@ -31,7 +31,7 @@ tauri = { workspace = true, features = ["test"] }
 tauri-plugin-store2 = { workspace = true }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 

--- a/plugins/db/src/e2ee_witness.rs
+++ b/plugins/db/src/e2ee_witness.rs
@@ -7,7 +7,10 @@ const MAX_EVENTS_PER_BATCH: usize = 16;
 const MAX_EVENT_BYTES: usize = 16 * 1024 * 1024;
 const MAX_BATCH_BYTES: usize = 48 * 1024 * 1024;
 const MAX_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
-const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+const MAX_RATE_LIMIT_RETRIES: usize = 3;
+const DEFAULT_RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(30);
+const MAX_RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
 #[derive(Clone)]
 pub(crate) struct E2eeWitnessClient {
@@ -160,6 +163,9 @@ impl E2eeWitnessClient {
                 .await
                 .map_err(replica_error)?;
             let after = page.next_after_sequence;
+            hypr_db_app::advance_e2ee_witness_cursor(pool, &self.workspace_id, after)
+                .await
+                .map_err(replica_error)?;
             if after == through {
                 break;
             }
@@ -169,10 +175,7 @@ impl E2eeWitnessClient {
             page = self.read_page(after, Some(through)).await?;
             self.validate_page(&page, after, Some(through))?;
         }
-
-        hypr_db_app::advance_e2ee_witness_cursor(pool, &self.workspace_id, through)
-            .await
-            .map_err(replica_error)
+        Ok(())
     }
 
     async fn publish_pending(
@@ -212,23 +215,23 @@ impl E2eeWitnessClient {
             }
             let batch = &uploads[start..end];
             let response = self
-                .client
-                .post(self.endpoint.clone())
-                .bearer_auth(&self.access_token)
-                .json(&PublishRequest {
-                    initialize: initialize && start == 0,
-                    events: batch
-                        .iter()
-                        .map(|upload| PublishEvent {
-                            record_id: &upload.record_id,
-                            payload_hash: &upload.payload_hash,
-                            payload: &upload.payload,
+                .send_with_rate_limit_retry(|| {
+                    self.client
+                        .post(self.endpoint.clone())
+                        .bearer_auth(&self.access_token)
+                        .json(&PublishRequest {
+                            initialize: initialize && start == 0,
+                            events: batch
+                                .iter()
+                                .map(|upload| PublishEvent {
+                                    record_id: &upload.record_id,
+                                    payload_hash: &upload.payload_hash,
+                                    payload: &upload.payload,
+                                })
+                                .collect(),
                         })
-                        .collect(),
                 })
-                .send()
-                .await
-                .map_err(transport_error)?;
+                .await?;
             let status = response.status();
             let bytes = read_bounded(response).await?;
             if !status.is_success() {
@@ -250,15 +253,19 @@ impl E2eeWitnessClient {
     }
 
     async fn read_page(&self, after: u64, through: Option<u64>) -> io::Result<ReadPage> {
-        let mut request = self
-            .client
-            .get(self.endpoint.clone())
-            .bearer_auth(&self.access_token)
-            .query(&[("afterSequence", after)]);
-        if let Some(through) = through {
-            request = request.query(&[("throughSequence", through)]);
-        }
-        let response = request.send().await.map_err(transport_error)?;
+        let response = self
+            .send_with_rate_limit_retry(|| {
+                let mut request = self
+                    .client
+                    .get(self.endpoint.clone())
+                    .bearer_auth(&self.access_token)
+                    .query(&[("afterSequence", after)]);
+                if let Some(through) = through {
+                    request = request.query(&[("throughSequence", through)]);
+                }
+                request
+            })
+            .await?;
         let status = response.status();
         let bytes = read_bounded(response).await?;
         if !status.is_success() {
@@ -268,6 +275,25 @@ impl E2eeWitnessClient {
         }
         serde_json::from_slice(&bytes)
             .map_err(|_| invalid_data("E2EE witness read response is invalid"))
+    }
+
+    async fn send_with_rate_limit_retry(
+        &self,
+        request: impl Fn() -> reqwest::RequestBuilder,
+    ) -> io::Result<reqwest::Response> {
+        let mut retries = 0;
+        loop {
+            let response = request().send().await.map_err(transport_error)?;
+            if response.status() != reqwest::StatusCode::TOO_MANY_REQUESTS
+                || retries == MAX_RATE_LIMIT_RETRIES
+            {
+                return Ok(response);
+            }
+            let delay = retry_after_delay(response.headers());
+            read_bounded(response).await?;
+            tokio::time::sleep(delay).await;
+            retries += 1;
+        }
     }
 
     fn validate_page(
@@ -345,4 +371,253 @@ fn invalid_data(message: &'static str) -> io::Error {
 
 fn rollback_error() -> io::Error {
     io::Error::other("E2EE freshness witness rollback was detected")
+}
+
+fn retry_after_delay(headers: &reqwest::header::HeaderMap) -> std::time::Duration {
+    let seconds = headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+    match seconds {
+        None => DEFAULT_RETRY_AFTER,
+        Some(0) => std::time::Duration::ZERO,
+        Some(seconds) => std::time::Duration::from_secs(seconds)
+            .saturating_add(std::time::Duration::from_secs(1))
+            .min(MAX_RETRY_AFTER),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, Request, Respond, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct RateLimitedOnce {
+        requests: Arc<AtomicUsize>,
+    }
+
+    impl Respond for RateLimitedOnce {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            if self.requests.fetch_add(1, Ordering::Relaxed) == 0 {
+                return ResponseTemplate::new(429).insert_header("retry-after", "0");
+            }
+            ResponseTemplate::new(200).set_body_json(json!({
+                "initialized": true,
+                "initializedAt": "2026-07-17T00:00:00Z",
+                "headSequence": 0,
+                "throughSequence": 0,
+                "nextAfterSequence": 0,
+                "events": [],
+            }))
+        }
+    }
+
+    #[derive(Clone)]
+    struct InterruptedPage {
+        events: Vec<serde_json::Value>,
+        requests: Arc<AtomicUsize>,
+        after_sequences: Arc<Mutex<Vec<u64>>>,
+    }
+
+    impl Respond for InterruptedPage {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let after = request
+                .url
+                .query_pairs()
+                .find_map(|(key, value)| (key == "afterSequence").then(|| value.parse().unwrap()))
+                .unwrap_or(0);
+            self.after_sequences.lock().unwrap().push(after);
+            match self.requests.fetch_add(1, Ordering::Relaxed) {
+                0 => witness_page(&self.events[..3], 4, 4),
+                1 => ResponseTemplate::new(500),
+                _ => witness_page(&self.events[3..], 4, 4),
+            }
+        }
+    }
+
+    fn witness_page(
+        events: &[serde_json::Value],
+        head_sequence: u64,
+        through_sequence: u64,
+    ) -> ResponseTemplate {
+        let next_after_sequence = events
+            .last()
+            .and_then(|event| event["sequence"].as_u64())
+            .unwrap_or(through_sequence);
+        ResponseTemplate::new(200).set_body_json(json!({
+            "initialized": true,
+            "initializedAt": "2026-07-17T00:00:00Z",
+            "headSequence": head_sequence,
+            "throughSequence": through_sequence,
+            "nextAfterSequence": next_after_sequence,
+            "events": events,
+        }))
+    }
+
+    #[tokio::test]
+    async fn retries_a_rate_limited_witness_read() {
+        let server = MockServer::start().await;
+        let responder = RateLimitedOnce::default();
+        Mock::given(method("GET"))
+            .and(path("/sync/e2ee/witness/user-a"))
+            .respond_with(responder.clone())
+            .expect(2)
+            .mount(&server)
+            .await;
+        let client = E2eeWitnessClient::new(
+            crate::CloudsyncE2eeWitness {
+                endpoint: format!("{}/sync/e2ee/witness/user-a", server.uri()),
+                access_token: "access-token".to_string(),
+            },
+            "user-a",
+        )
+        .unwrap();
+
+        let page = client.read_page(0, None).await.unwrap();
+
+        assert_eq!(page.head_sequence, 0);
+        assert_eq!(responder.requests.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn stops_retrying_a_persistently_rate_limited_read() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sync/e2ee/witness/user-a"))
+            .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0"))
+            .expect(4)
+            .mount(&server)
+            .await;
+        let client = E2eeWitnessClient::new(
+            crate::CloudsyncE2eeWitness {
+                endpoint: format!("{}/sync/e2ee/witness/user-a", server.uri()),
+                access_token: "access-token".to_string(),
+            },
+            "user-a",
+        )
+        .unwrap();
+
+        let error = client
+            .read_page(0, None)
+            .await
+            .err()
+            .expect("persistent throttling should fail");
+
+        assert!(error.to_string().contains("429 Too Many Requests"));
+    }
+
+    #[tokio::test]
+    async fn resumes_refresh_from_the_last_authenticated_page() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = hypr_db_core::Db::open(hypr_db_core::DbOpenOptions {
+            storage: hypr_db_core::DbStorage::Local(&dir.path().join("app.db")),
+            cloudsync_enabled: false,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(1),
+        })
+        .await
+        .unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
+        sqlx::query(
+            "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+             VALUES ('session', 'user-a', 'user-a', 'Session')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        let recovery_key = hypr_e2ee::RecoveryKey::parse(
+            "anarlog-e2ee-v1:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc",
+        )
+        .unwrap();
+        let key = recovery_key.workspace_key("user-a").unwrap();
+        hypr_db_app::encrypt_e2ee_replica_changes(
+            db.pool(),
+            &HashMap::from([("user-a".to_string(), key.clone())]),
+        )
+        .await
+        .unwrap();
+        let uploads = hypr_db_app::pending_e2ee_witness_uploads(db.pool(), "user-a", &key)
+            .await
+            .unwrap();
+        assert!(uploads.len() >= 4);
+        let events = uploads
+            .iter()
+            .take(4)
+            .enumerate()
+            .map(|(index, upload)| {
+                json!({
+                    "sequence": index + 1,
+                    "recordId": upload.record_id,
+                    "payloadHash": upload.payload_hash,
+                    "payload": upload.payload,
+                })
+            })
+            .collect::<Vec<_>>();
+        let server = MockServer::start().await;
+        let responder = InterruptedPage {
+            events,
+            requests: Arc::new(AtomicUsize::new(0)),
+            after_sequences: Arc::new(Mutex::new(Vec::new())),
+        };
+        Mock::given(method("GET"))
+            .and(path("/sync/e2ee/witness/user-a"))
+            .respond_with(responder.clone())
+            .expect(3)
+            .mount(&server)
+            .await;
+        let client = E2eeWitnessClient::new(
+            crate::CloudsyncE2eeWitness {
+                endpoint: format!("{}/sync/e2ee/witness/user-a", server.uri()),
+                access_token: "access-token".to_string(),
+            },
+            "user-a",
+        )
+        .unwrap();
+
+        assert!(client.refresh(db.pool(), &key).await.is_err());
+        assert_eq!(
+            hypr_db_app::e2ee_witness_cursor(db.pool(), "user-a")
+                .await
+                .unwrap(),
+            3
+        );
+
+        client.refresh(db.pool(), &key).await.unwrap();
+
+        assert_eq!(
+            hypr_db_app::e2ee_witness_cursor(db.pool(), "user-a")
+                .await
+                .unwrap(),
+            4
+        );
+        assert_eq!(*responder.after_sequences.lock().unwrap(), vec![0, 3, 3]);
+    }
+
+    #[test]
+    fn retry_after_delays_are_bounded_and_allow_immediate_test_retries() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        assert_eq!(retry_after_delay(&headers), DEFAULT_RETRY_AFTER);
+
+        headers.insert(reqwest::header::RETRY_AFTER, "0".parse().unwrap());
+        assert!(retry_after_delay(&headers).is_zero());
+
+        headers.insert(reqwest::header::RETRY_AFTER, "later".parse().unwrap());
+        assert_eq!(retry_after_delay(&headers), DEFAULT_RETRY_AFTER);
+
+        headers.insert(reqwest::header::RETRY_AFTER, "120".parse().unwrap());
+        assert_eq!(retry_after_delay(&headers), MAX_RETRY_AFTER);
+    }
 }

--- a/supabase/migrations/20260720090000_e2ee_witness_backfill_pages.sql
+++ b/supabase/migrations/20260720090000_e2ee_witness_backfill_pages.sql
@@ -1,0 +1,150 @@
+CREATE OR REPLACE FUNCTION public.read_e2ee_freshness_page_v2(
+  p_actor_user_id uuid,
+  p_workspace_id uuid,
+  p_after_sequence bigint,
+  p_through_sequence bigint,
+  p_limit integer,
+  p_max_bytes integer
+)
+RETURNS TABLE (
+  initialized_at timestamptz,
+  head_sequence bigint,
+  through_sequence bigint,
+  event_sequence bigint,
+  record_id text,
+  payload_hash text,
+  payload text
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_initialized_at timestamptz;
+  v_head_sequence bigint;
+  v_through_sequence bigint;
+BEGIN
+  IF p_actor_user_id IS NULL
+    OR p_workspace_id IS NULL
+    OR p_after_sequence IS NULL
+    OR p_after_sequence < 0
+    OR p_limit IS NULL
+    OR p_limit NOT BETWEEN 1 AND 1024
+    OR p_max_bytes IS NULL
+    OR p_max_bytes NOT BETWEEN 1 AND 50331648
+  THEN
+    RAISE EXCEPTION 'E2EE freshness page is invalid' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT workspace.e2ee_freshness_initialized_at
+  INTO v_initialized_at
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = p_workspace_id
+    AND workspace.id = p_actor_user_id
+    AND workspace.owner_user_id = p_actor_user_id
+    AND workspace.kind = 'personal'
+    AND workspace.deleted_at IS NULL
+    AND workspace.e2ee_key_id IS NOT NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'E2EE freshness read is not permitted' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT COALESCE(MAX(event.sequence), 0)::bigint
+  INTO v_head_sequence
+  FROM public.e2ee_freshness_events AS event
+  WHERE event.workspace_id = p_workspace_id;
+
+  v_through_sequence := COALESCE(p_through_sequence, v_head_sequence);
+  IF v_through_sequence < p_after_sequence OR v_through_sequence > v_head_sequence THEN
+    RAISE EXCEPTION 'E2EE freshness page is invalid' USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    v_initialized_at,
+    v_head_sequence,
+    v_through_sequence,
+    event.sequence,
+    event.record_id,
+    event.payload_hash,
+    event.payload
+  FROM (SELECT 1) AS singleton
+  LEFT JOIN LATERAL (
+    -- Fetch one row at a time so oversized ciphertext tails are never materialized.
+    WITH RECURSIVE bounded AS (
+      SELECT
+        source.sequence,
+        source.record_id,
+        source.payload_hash,
+        source.payload,
+        1 AS event_count,
+        (
+          octet_length(source.record_id)
+            + octet_length(source.payload_hash)
+            + octet_length(source.payload)
+            + 256
+        )::bigint AS cumulative_bytes
+      FROM LATERAL (
+        SELECT candidate.sequence, candidate.record_id, candidate.payload_hash, candidate.payload
+        FROM public.e2ee_freshness_events AS candidate
+        WHERE candidate.workspace_id = p_workspace_id
+          AND candidate.sequence > p_after_sequence
+          AND candidate.sequence <= v_through_sequence
+        ORDER BY candidate.sequence
+        LIMIT 1
+      ) AS source
+
+      UNION ALL
+
+      SELECT
+        source.sequence,
+        source.record_id,
+        source.payload_hash,
+        source.payload,
+        bounded.event_count + 1,
+        bounded.cumulative_bytes
+          + octet_length(source.record_id)
+          + octet_length(source.payload_hash)
+          + octet_length(source.payload)
+          + 256
+      FROM bounded
+      CROSS JOIN LATERAL (
+        SELECT candidate.sequence, candidate.record_id, candidate.payload_hash, candidate.payload
+        FROM public.e2ee_freshness_events AS candidate
+        WHERE candidate.workspace_id = p_workspace_id
+          AND candidate.sequence > bounded.sequence
+          AND candidate.sequence <= v_through_sequence
+        ORDER BY candidate.sequence
+        LIMIT 1
+      ) AS source
+      WHERE bounded.event_count < p_limit
+        AND bounded.cumulative_bytes
+          + octet_length(source.record_id)
+          + octet_length(source.payload_hash)
+          + octet_length(source.payload)
+          + 256 <= p_max_bytes
+    )
+    SELECT bounded.sequence, bounded.record_id, bounded.payload_hash, bounded.payload
+    FROM bounded
+    ORDER BY bounded.sequence
+  ) AS event ON true;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.read_e2ee_freshness_page_v2(
+  uuid,
+  uuid,
+  bigint,
+  bigint,
+  integer,
+  integer
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.read_e2ee_freshness_page_v2(
+  uuid,
+  uuid,
+  bigint,
+  bigint,
+  integer,
+  integer
+) TO service_role;

--- a/supabase/tests/021-e2ee-freshness-witness.sql
+++ b/supabase/tests/021-e2ee-freshness-witness.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(15);
+select plan(18);
 
 select tests.create_supabase_user('witness_owner', 'witness-owner@example.com');
 select tests.create_supabase_user('witness_other', 'witness-other@example.com');
@@ -39,6 +39,16 @@ select ok(
     and has_function_privilege(
       'service_role',
       'public.read_e2ee_freshness_page(uuid, uuid, bigint, bigint, integer)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'public.read_e2ee_freshness_page_v2(uuid, uuid, bigint, bigint, integer, integer)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.read_e2ee_freshness_page_v2(uuid, uuid, bigint, bigint, integer, integer)',
       'EXECUTE'
     ),
   'Only trusted service code can use witness functions'
@@ -156,6 +166,88 @@ select results_eq(
     cross join witness_head as head
   $$,
   'Witness pages return the exact immutable ciphertext event'
+);
+
+create temporary table witness_bulk_event as
+select
+  ordinal,
+  rtrim(
+    translate(
+      encode(extensions.digest('record-' || ordinal::text, 'sha256'), 'base64'),
+      '+/',
+      '-_'
+    ),
+    '='
+  )::text as record_id,
+  payload,
+  rtrim(
+    translate(encode(extensions.digest(payload, 'sha256'), 'base64'), '+/', '-_'),
+    '='
+  )::text as payload_hash
+from (
+  select ordinal, format('{"version":1,"ciphertext":"opaque-%s"}', ordinal)::text as payload
+  from generate_series(1, 64) as series(ordinal)
+) as generated;
+
+select lives_ok(
+  format(
+    $$
+      select *
+      from public.publish_e2ee_freshness_events(
+        %L,
+        %L,
+        false,
+        (
+          select jsonb_agg(
+            jsonb_build_object(
+              'record_id', record_id,
+              'payload_hash', payload_hash,
+              'payload', payload
+            )
+            order by ordinal
+          )
+          from witness_bulk_event
+        )
+      )
+    $$,
+    tests.get_supabase_uid('witness_owner'),
+    tests.get_supabase_uid('witness_owner')
+  ),
+  'The witness accepts the existing maximum publish batch'
+);
+
+select is(
+  (
+    select count(*)
+    from public.read_e2ee_freshness_page_v2(
+      tests.get_supabase_uid('witness_owner'),
+      tests.get_supabase_uid('witness_owner'),
+      0,
+      null,
+      1024,
+      50331648
+    )
+    where event_sequence is not null
+  ),
+  65::bigint,
+  'Backfill pages can return more than the legacy 64-event limit'
+);
+
+select is(
+  (
+    select count(*)
+    from public.read_e2ee_freshness_page_v2(
+      tests.get_supabase_uid('witness_owner'),
+      tests.get_supabase_uid('witness_owner'),
+      0,
+      null,
+      1024,
+      500
+    )
+    where event_sequence is not null
+  ),
+  1::bigint,
+  'Backfill pages stop before exceeding their response byte budget'
 );
 
 select throws_ok(


### PR DESCRIPTION
Resume authenticated pages and bound witness backfill traffic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches E2EE sync witness paths, new DB RPC rollout with legacy fallback, and cursor semantics on partial refresh failure—important for data consistency but well-tested.
> 
> **Overview**
> Improves **E2EE freshness witness backfills** so large histories can be pulled in fewer, size-bounded pages and clients can survive throttling or mid-refresh failures without redoing work.
> 
> The API **splits witness routes** from the general sync pro router and applies a **dedicated, aggressive rate limit** that **waits** for quota (up to ~1s) instead of failing immediately. Witness reads prefer a new Supabase RPC **`read_e2ee_freshness_page_v2`** with much larger page limits (up to 1024 events / 48MB) and **fall back** to the legacy RPC when v2 is not deployed. Publish validation now allows **64 events per batch** (aligned with the DB).
> 
> The desktop **`E2eeWitnessClient`** advances the local witness **cursor after each merged page** (not only at the end), retries **429** responses with bounded `Retry-After` handling, and uses a longer request timeout. A new migration adds the v2 read function with **byte-budgeted** paging so oversized ciphertext tails are not fully materialized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d554c7c4faa46eab1d7ec45d6abf942fda5d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->