### PR TITLE
Reduce inactive tab padding

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -385,10 +385,14 @@ describe("Header", () => {
     expect(memoTab.className).toContain("dark:bg-accent");
     expect(memoTab.className).toContain("dark:shadow-none");
     expect(summaryTab.className).toContain("h-[26px]");
+    expect(summaryTab.className).toContain("px-2");
+    expect(summaryTab.className).not.toContain("min-w-10");
     expect(summaryTab.className).toContain("dark:hover:bg-accent/80");
     expect(summaryTab.querySelector("svg")).not.toBeNull();
     expect(summaryTab.querySelectorAll("svg")).toHaveLength(1);
     expect(transcriptTab.querySelector("svg")).not.toBeNull();
+    expect(transcriptTab.className).toContain("px-2");
+    expect(transcriptTab.className).not.toContain("min-w-10");
     expect(summaryTab.textContent).toBe("");
     expect(transcriptTab.textContent).toBe("");
     expect(summaryTab.getAttribute("title")).toBe(

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -117,8 +117,8 @@ function IconHeaderView({
         isActive,
         size,
         cn([
-          "min-w-10 px-2",
-          isActive ? "max-w-40 gap-1.5" : null,
+          "px-2",
+          isActive ? "max-w-40 min-w-10 gap-1.5" : null,
           hoverLabel
             ? "after:hidden after:min-w-0 after:truncate after:text-xs after:font-medium after:content-[attr(data-hover-label)] hover:after:block"
             : null,
@@ -422,7 +422,7 @@ function HeaderViewEnhancedInactive({
       aria-label={viewTitle}
       onClick={onClick}
       title={templateTooltip}
-      className={iconHeaderViewClassName(false, "tray", "min-w-10 px-2")}
+      className={iconHeaderViewClassName(false, "tray", "px-2")}
     >
       {isGenerating ? (
         <Spinner size={16} className="shrink-0" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only layout tweak in the session header with no logic or data changes.
> 
> **Overview**
> **Inactive** summary and transcript tabs in the session note header view switcher no longer use `min-w-10`, so icon-only tabs take less horizontal space in the tray.
> 
> `min-w-10` is now applied only when a tab is **active** (along with `max-w-40` and gap for the label). Inactive enhanced summary buttons keep `px-2` only. Tests in `header.test.tsx` assert inactive summary/transcript tabs include `px-2` and exclude `min-w-10`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b09dab50771208c78ca0b12224f24b8f09558a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->