### PR TITLE
Make chat history placement adaptive

### DIFF
--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -33,18 +33,21 @@ vi.mock("@hypr/ui/components/ui/dropdown-menu", () => ({
     avoidCollisions,
     children,
     className,
+    collisionPadding,
     side,
     sideOffset,
   }: {
     avoidCollisions?: boolean;
     children: ReactNode;
     className?: string;
+    collisionPadding?: number;
     side?: string;
     sideOffset?: number;
   }) => (
     <div
       className={className}
       data-avoid-collisions={String(avoidCollisions)}
+      data-collision-padding={collisionPadding}
       data-side={side}
       data-side-offset={sideOffset}
       data-testid="chat-history-menu"
@@ -113,10 +116,11 @@ describe("ChatToolbarControls", () => {
     expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
   });
 
-  it("keeps the history menu below the trigger and scrolls inside the panel", () => {
+  it("opens floating chat history to the right and adapts to viewport collisions", () => {
     render(
       <ChatToolbarControls
         currentChatGroupId={undefined}
+        layout="floating"
         onNewChat={vi.fn()}
         onOpenRightPanel={vi.fn()}
         onSelectChat={vi.fn()}
@@ -127,13 +131,34 @@ describe("ChatToolbarControls", () => {
     const menu = screen.getByTestId("chat-history-menu");
     const panel = screen.getByTestId("chat-history-panel");
 
-    expect(menu.dataset.side).toBe("bottom");
+    expect(menu.dataset.side).toBe("right");
     expect(menu.dataset.sideOffset).toBe("4");
-    expect(menu.dataset.avoidCollisions).toBe("false");
+    expect(menu.dataset.avoidCollisions).toBe("true");
+    expect(menu.dataset.collisionPadding).toBe("8");
     expect(menu.className).toContain("w-72");
-    expect(menu.className).toContain("max-w-[calc(100vw-2rem)]");
-    expect(panel.className).toContain("max-h-80");
-    expect(panel.className).toContain("overflow-y-auto");
+    expect(menu.className).toContain(
+      "max-w-[var(--radix-dropdown-menu-content-available-width)]",
+    );
+    expect(menu.className).toContain(
+      "max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))]",
+    );
+    expect(menu.className).toContain("overflow-y-auto");
+    expect(panel.className).not.toContain("overflow-y-auto");
+  });
+
+  it("keeps right-panel chat history below the trigger", () => {
+    render(
+      <ChatToolbarControls
+        currentChatGroupId={undefined}
+        layout="right-panel"
+        onNewChat={vi.fn()}
+        onOpenFloating={vi.fn()}
+        onSelectChat={vi.fn()}
+        surface="light"
+      />,
+    );
+
+    expect(screen.getByTestId("chat-history-menu").dataset.side).toBe("bottom");
   });
 
   it("renders dark toolbar action buttons as circles without tooltips", () => {

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -54,6 +54,7 @@ export function ChatToolbarControls({
       <div className="flex min-w-0 flex-1 items-center gap-1">
         <ChatGroups
           currentChatGroupId={currentChatGroupId}
+          layout={layout}
           onSelectChat={onSelectChat}
           surface={surface}
         />
@@ -144,10 +145,12 @@ function ChatActionButton({
 
 function ChatGroups({
   currentChatGroupId,
+  layout,
   onSelectChat,
   surface = "light",
 }: {
   currentChatGroupId: string | undefined;
+  layout: "floating" | "right-panel";
   onSelectChat: (chatGroupId: string) => void;
   surface?: "light" | "dark";
 }) {
@@ -189,12 +192,13 @@ function ChatGroups({
       <DropdownMenuContent
         variant="app"
         align="start"
-        side="bottom"
+        side={layout === "floating" ? "right" : "bottom"}
         sideOffset={4}
-        avoidCollisions={false}
-        className="w-72 max-w-[calc(100vw-2rem)]"
+        avoidCollisions
+        collisionPadding={8}
+        className="max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))] w-72 max-w-[var(--radix-dropdown-menu-content-available-width)] overflow-y-auto"
       >
-        <AppFloatingPanel className="max-h-80 overflow-y-auto p-1.5">
+        <AppFloatingPanel className="p-1.5">
           <div className="px-2 py-1.5">
             <h4 className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
               Recent Chats


### PR DESCRIPTION
Open floating history beside its trigger and clamp the menu to available viewport space.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only dropdown positioning and styling in the desktop chat toolbar, with no auth, data, or API changes.
> 
> **Overview**
> **Chat history dropdown placement now depends on toolbar layout.** In the **floating** chat surface, the recent-chats menu opens to the **right** of the trigger instead of below it. In the **right-panel** layout it still opens **below** the trigger.
> 
> **Viewport-aware sizing** replaces fixed `calc(100vw)` / inner-panel scroll limits: collision avoidance is enabled with padding, and the menu’s max width/height use Radix’s available-space CSS variables with scrolling on the menu content rather than on the inner floating panel.
> 
> Tests were split/updated to assert floating vs right-panel `side`, collision props, and the new overflow classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f33353c98e024c7093618316889cede58a2dd08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->