### PR TITLE
fix/calendar-auth-session

### DIFF
--- a/apps/desktop/src/calendar/components/context.test.tsx
+++ b/apps/desktop/src/calendar/components/context.test.tsx
@@ -1,0 +1,107 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { createManager } from "tinytick";
+import { Provider as TinyTickProvider } from "tinytick/ui-react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { SyncProvider, useSync } from "./context";
+
+import { CALENDAR_SYNC_TASK_ID } from "~/services/calendar";
+
+function StatusHarness() {
+  const { scheduleSync, status } = useSync();
+
+  return (
+    <button type="button" onClick={scheduleSync}>
+      {status}
+    </button>
+  );
+}
+
+describe("SyncProvider", () => {
+  const managers: ReturnType<typeof createManager>[] = [];
+
+  afterEach(() => {
+    cleanup();
+    for (const manager of managers) {
+      manager.stop(true);
+    }
+    managers.length = 0;
+    vi.useRealTimers();
+  });
+
+  test("keeps a newly scheduled sync in the scheduled state", () => {
+    const manager = createManager();
+    managers.push(manager);
+    manager.setTask(CALENDAR_SYNC_TASK_ID, async () => undefined);
+
+    render(
+      <TinyTickProvider manager={manager}>
+        <SyncProvider>
+          <StatusHarness />
+        </SyncProvider>
+      </TinyTickProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "idle" }));
+
+    expect(screen.getByRole("button", { name: "scheduled" })).toBeDefined();
+  });
+
+  test("reflects a calendar sync scheduled outside the provider", () => {
+    const manager = createManager();
+    managers.push(manager);
+    manager.setTask(CALENDAR_SYNC_TASK_ID, async () => undefined);
+    manager.scheduleTaskRun(CALENDAR_SYNC_TASK_ID);
+
+    render(
+      <TinyTickProvider manager={manager}>
+        <SyncProvider>
+          <StatusHarness />
+        </SyncProvider>
+      </TinyTickProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: "scheduled" })).toBeDefined();
+  });
+
+  test("moves from scheduled to syncing to idle", async () => {
+    vi.useFakeTimers();
+    const manager = createManager();
+    managers.push(manager);
+    let finishTask = () => {};
+    manager.setTask(
+      CALENDAR_SYNC_TASK_ID,
+      async () =>
+        await new Promise<void>((resolve) => {
+          finishTask = resolve;
+        }),
+    );
+
+    render(
+      <TinyTickProvider manager={manager}>
+        <SyncProvider>
+          <StatusHarness />
+        </SyncProvider>
+      </TinyTickProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "idle" }));
+    expect(screen.getByRole("button", { name: "scheduled" })).toBeDefined();
+
+    manager.start();
+    await act(async () => await vi.advanceTimersByTimeAsync(100));
+    expect(screen.getByRole("button", { name: "syncing" })).toBeDefined();
+
+    await act(async () => {
+      finishTask();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("button", { name: "idle" })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/calendar/components/context.tsx
+++ b/apps/desktop/src/calendar/components/context.tsx
@@ -2,20 +2,22 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useRef,
   useState,
 } from "react";
 import {
-  useScheduleTaskRunCallback,
-  useTaskRunRunning,
+  useManager,
+  useRunningTaskRunIds,
+  useScheduledTaskRunIds,
 } from "tinytick/ui-react";
 
 import {
   type CalendarSyncRange,
   CALENDAR_SYNC_TASK_ID,
+  scheduleCalendarSync,
   syncCalendarEventsForRange,
 } from "~/services/calendar";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 export const TOGGLE_SYNC_DEBOUNCE_MS = 5000;
 
@@ -33,51 +35,45 @@ interface SyncContextValue {
 const SyncContext = createContext<SyncContextValue | null>(null);
 
 export function SyncProvider({ children }: { children: React.ReactNode }) {
-  const scheduleEventSync = useScheduleTaskRunCallback(
-    CALENDAR_SYNC_TASK_ID,
-    undefined,
-    0,
-  );
+  const manager = useManager();
+  const scheduledTaskRunIds = useScheduledTaskRunIds() ?? [];
+  const runningTaskRunIds = useRunningTaskRunIds() ?? [];
   const toggleSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const [pendingTaskRunId, setPendingTaskRunId] = useState<string | null>(null);
   const [isDebouncing, setIsDebouncing] = useState(false);
   const [rangeSyncCount, setRangeSyncCount] = useState(0);
 
-  const isTaskRunning = useTaskRunRunning(pendingTaskRunId ?? "");
-  const isSyncing = pendingTaskRunId !== null && isTaskRunning === true;
+  const isCalendarTaskRun = (taskRunId: string) =>
+    manager?.getTaskRunInfo(taskRunId)?.taskId === CALENDAR_SYNC_TASK_ID;
+  const isScheduled = scheduledTaskRunIds.some(isCalendarTaskRun);
+  const isSyncing = runningTaskRunIds.some(isCalendarTaskRun);
   const isRangeSyncing = rangeSyncCount > 0;
-  const canSync = true;
+  const canSync = manager !== undefined;
 
   const status: SyncStatus =
     isSyncing || isRangeSyncing
       ? "syncing"
-      : isDebouncing
+      : isDebouncing || isScheduled
         ? "scheduled"
         : "idle";
 
-  useEffect(() => {
-    if (pendingTaskRunId && isTaskRunning === false) {
-      setPendingTaskRunId(null);
+  const scheduleSync = useCallback(() => {
+    if (manager) {
+      scheduleCalendarSync(manager);
     }
-  }, [pendingTaskRunId, isTaskRunning]);
+  }, [manager]);
 
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       if (toggleSyncTimeoutRef.current) {
         clearTimeout(toggleSyncTimeoutRef.current);
-        scheduleEventSync();
+        if (manager) {
+          scheduleCalendarSync(manager);
+        }
       }
     };
-  }, [scheduleEventSync]);
-
-  const scheduleSync = useCallback(() => {
-    const taskRunId = scheduleEventSync();
-    if (taskRunId) {
-      setPendingTaskRunId(taskRunId);
-    }
-  }, [scheduleEventSync]);
+  });
 
   const scheduleDebouncedSync = useCallback(() => {
     if (toggleSyncTimeoutRef.current) {

--- a/apps/desktop/src/services/calendar/ctx.test.ts
+++ b/apps/desktop/src/services/calendar/ctx.test.ts
@@ -136,4 +136,19 @@ describe("calendar sync context", () => {
       successfulConnections: [{ connectionId: "conn-ok", calendars: [] }],
     });
   });
+
+  test("does not write calendar inventory after cancellation", async () => {
+    const abortController = new AbortController();
+    pluginCalendar.listCalendars.mockImplementation(async () => {
+      abortController.abort();
+      return { status: "success", data: [] };
+    });
+
+    await syncCalendars(
+      [{ provider: "google", connection_ids: ["conn-work"] }],
+      abortController.signal,
+    );
+
+    expect(storage.applyCalendarInventory).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/services/calendar/ctx.test.ts
+++ b/apps/desktop/src/services/calendar/ctx.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const pluginCalendar = vi.hoisted(() => ({
+  listConnectionIds: vi.fn(),
   listCalendars: vi.fn(),
 }));
 
@@ -11,13 +12,14 @@ const storage = vi.hoisted(() => ({
 
 vi.mock("@hypr/plugin-calendar", () => ({
   commands: {
+    listConnectionIds: pluginCalendar.listConnectionIds,
     listCalendars: pluginCalendar.listCalendars,
   },
 }));
 
 vi.mock("./storage", () => storage);
 
-import { createCtx, syncCalendars } from "./ctx";
+import { createCtx, getProviderConnections, syncCalendars } from "./ctx";
 
 describe("calendar sync context", () => {
   beforeEach(() => {
@@ -64,6 +66,17 @@ describe("calendar sync context", () => {
 
     expect(ctx.from).toBe(range.from);
     expect(ctx.to).toBe(range.to);
+  });
+
+  test("surfaces connection discovery errors", async () => {
+    pluginCalendar.listConnectionIds.mockResolvedValue({
+      status: "error",
+      error: "auth session could not be parsed",
+    });
+
+    await expect(getProviderConnections()).rejects.toThrow(
+      "Failed to discover calendar connections: auth session could not be parsed",
+    );
   });
 
   test("keeps overlapping calendar ids isolated by connection", async () => {

--- a/apps/desktop/src/services/calendar/ctx.ts
+++ b/apps/desktop/src/services/calendar/ctx.ts
@@ -59,22 +59,29 @@ export async function getProviderConnections(): Promise<
 
 export async function syncCalendars(
   providerConnections: ProviderConnectionIds[],
+  signal?: AbortSignal,
 ): Promise<void> {
   for (const { provider, connection_ids } of providerConnections) {
+    if (signal?.aborted) return;
+
     const successfulConnections: Array<{
       connectionId: string;
       calendars: CalendarListItem[];
     }> = [];
 
     for (const connectionId of connection_ids) {
+      if (signal?.aborted) return;
+
       const result = await calendarCommands.listCalendars(
         provider,
         connectionId,
       );
+      if (signal?.aborted) return;
       if (result.status === "error") continue;
       successfulConnections.push({ connectionId, calendars: result.data });
     }
 
+    if (signal?.aborted) return;
     await applyCalendarInventory({
       provider,
       requestedConnectionIds: connection_ids,

--- a/apps/desktop/src/services/calendar/ctx.ts
+++ b/apps/desktop/src/services/calendar/ctx.ts
@@ -51,7 +51,9 @@ export async function getProviderConnections(): Promise<
   ProviderConnectionIds[]
 > {
   const result = await calendarCommands.listConnectionIds();
-  if (result.status === "error") return [];
+  if (result.status === "error") {
+    throw new Error(`Failed to discover calendar connections: ${result.error}`);
+  }
   return result.data;
 }
 

--- a/apps/desktop/src/services/calendar/index.test.ts
+++ b/apps/desktop/src/services/calendar/index.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createManager } from "tinytick";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const ctxMocks = vi.hoisted(() => ({
   createCtx: vi.fn(),
@@ -42,7 +43,10 @@ vi.mock("~/db/write-queue", () => ({
 }));
 
 import {
+  CALENDAR_SYNC_TASK_ID,
   removeDisconnectedCalendarConnection,
+  scheduleCalendarSync,
+  syncCalendarEvents,
   syncCalendarEventsForRange,
 } from ".";
 
@@ -54,6 +58,8 @@ const ctx = {
   calendarIds: new Set(["cal-1"]),
   calendarTrackingIdToId: new Map([["primary", "cal-1"]]),
 };
+
+const managers: ReturnType<typeof createManager>[] = [];
 
 describe("syncCalendarEventsForRange", () => {
   beforeEach(() => {
@@ -89,6 +95,14 @@ describe("syncCalendarEventsForRange", () => {
     storageMocks.tombstoneCalendarConnection.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    for (const manager of managers) {
+      manager.stop(true);
+    }
+    managers.length = 0;
+    vi.useRealTimers();
+  });
+
   test("removes the exact disconnected calendar connection", async () => {
     await removeDisconnectedCalendarConnection(
       "google-calendar",
@@ -116,6 +130,72 @@ describe("syncCalendarEventsForRange", () => {
 
     expect(ctxMocks.getProviderConnections).not.toHaveBeenCalled();
     expect(fetchMocks.fetchIncomingEvents).not.toHaveBeenCalled();
+  });
+
+  test("does not start a scheduled sync when already aborted", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await syncCalendarEvents({ signal: abortController.signal });
+
+    expect(ctxMocks.getProviderConnections).not.toHaveBeenCalled();
+  });
+
+  test("reuses an active scheduled calendar sync", () => {
+    const manager = createManager();
+    managers.push(manager);
+    manager.setTask(CALENDAR_SYNC_TASK_ID, async () => undefined);
+
+    const firstTaskRunId = scheduleCalendarSync(manager);
+    const secondTaskRunId = scheduleCalendarSync(manager);
+
+    expect(firstTaskRunId).toBeDefined();
+    expect(secondTaskRunId).toBe(firstTaskRunId);
+  });
+
+  test("reuses a running calendar sync", async () => {
+    vi.useFakeTimers();
+    const manager = createManager();
+    managers.push(manager);
+    manager.setTask(
+      CALENDAR_SYNC_TASK_ID,
+      async (_arg, signal) =>
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+    );
+    manager.start();
+
+    const firstTaskRunId = scheduleCalendarSync(manager);
+    await vi.advanceTimersByTimeAsync(100);
+    const secondTaskRunId = scheduleCalendarSync(manager);
+
+    expect(manager.getRunningTaskRunIds()).toContain(firstTaskRunId);
+    expect(secondTaskRunId).toBe(firstTaskRunId);
+  });
+
+  test("can schedule a new calendar sync after a timeout", async () => {
+    const manager = createManager();
+    managers.push(manager);
+    manager.setTask(
+      CALENDAR_SYNC_TASK_ID,
+      async (_arg, signal) =>
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+      undefined,
+      { maxDuration: 50 },
+    );
+    manager.start();
+
+    const timedOutTaskRunId = scheduleCalendarSync(manager);
+    if (!timedOutTaskRunId) throw new Error("Failed to schedule calendar sync");
+    await manager.untilTaskRunDone(timedOutTaskRunId);
+    const nextTaskRunId = scheduleCalendarSync(manager);
+
+    expect(manager.getTaskRunInfo(timedOutTaskRunId)).toBeUndefined();
+    expect(nextTaskRunId).toBeDefined();
+    expect(nextTaskRunId).not.toBe(timedOutTaskRunId);
   });
 
   test("does not write fetched events after aborting a range sync", async () => {

--- a/apps/desktop/src/services/calendar/index.ts
+++ b/apps/desktop/src/services/calendar/index.ts
@@ -1,3 +1,5 @@
+import type { Manager } from "tinytick";
+
 import type { CalendarProviderType } from "@hypr/plugin-calendar";
 
 import {
@@ -32,13 +34,27 @@ type CalendarSyncOptions = {
   signal?: AbortSignal;
 };
 
-export function syncCalendarEvents(): Promise<void> {
+export function syncCalendarEvents(
+  options: CalendarSyncOptions = {},
+): Promise<void> {
   return enqueueDatabaseWrite("calendar-sync", async () => {
     await Promise.all([
       new Promise((resolve) => setTimeout(resolve, 250)),
-      run(),
+      run(undefined, options),
     ]);
   });
+}
+
+export function scheduleCalendarSync(manager: Manager): string | undefined {
+  const activeTaskRunId = [
+    ...manager.getScheduledTaskRunIds(),
+    ...manager.getRunningTaskRunIds(),
+  ].find(
+    (taskRunId) =>
+      manager.getTaskRunInfo(taskRunId)?.taskId === CALENDAR_SYNC_TASK_ID,
+  );
+
+  return activeTaskRunId ?? manager.scheduleTaskRun(CALENDAR_SYNC_TASK_ID);
 }
 
 export function syncCalendarEventsForRange(
@@ -75,7 +91,7 @@ async function run(
   const providerConnections = await getProviderConnections();
   if (isAborted(options.signal)) return;
 
-  await syncCalendars(providerConnections);
+  await syncCalendars(providerConnections, options.signal);
   if (isAborted(options.signal)) return;
 
   for (const { provider, connection_ids } of providerConnections) {

--- a/apps/desktop/src/services/task-manager.tsx
+++ b/apps/desktop/src/services/task-manager.tsx
@@ -1,10 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
-import {
-  useScheduleTaskRun,
-  useScheduleTaskRunCallback,
-  useSetTask,
-} from "tinytick/ui-react";
+import { useRef } from "react";
+import { useManager, useScheduleTaskRun, useSetTask } from "tinytick/ui-react";
 
 import { events as appleCalendarEvents } from "@hypr/plugin-calendar";
 
@@ -14,7 +10,11 @@ import {
   cleanupExpiredAudio,
   normalizeAudioRetention,
 } from "./audio-retention";
-import { CALENDAR_SYNC_TASK_ID, syncCalendarEvents } from "./calendar";
+import {
+  CALENDAR_SYNC_TASK_ID,
+  scheduleCalendarSync,
+  syncCalendarEvents,
+} from "./calendar";
 import {
   checkEventNotifications,
   EVENT_NOTIFICATION_INTERVAL,
@@ -23,11 +23,14 @@ import {
 } from "./event-notification";
 
 import { useConfigValue } from "~/shared/config";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 const CALENDAR_SYNC_INTERVAL = 60 * 1000; // 60 sec
+const CALENDAR_SYNC_MAX_DURATION = 120 * 1000; // 2 min
 
 export function TaskManager() {
   const queryClient = useQueryClient();
+  const manager = useManager();
 
   const notificationEvent = useConfigValue("notification_event");
   const audioRetention = normalizeAudioRetention(
@@ -35,29 +38,55 @@ export function TaskManager() {
   );
   const notifiedEventsRef = useRef<NotifiedEventsMap>(new Map());
 
-  useSetTask(CALENDAR_SYNC_TASK_ID, async () => {
-    await syncCalendarEvents();
-  }, []);
-
-  useScheduleTaskRun(CALENDAR_SYNC_TASK_ID, undefined, 0, {
-    repeatDelay: CALENDAR_SYNC_INTERVAL,
-  });
-
-  const scheduleCalendarSync = useScheduleTaskRunCallback(
+  useSetTask(
     CALENDAR_SYNC_TASK_ID,
+    async (_arg, signal) => {
+      await syncCalendarEvents({ signal });
+    },
+    [],
     undefined,
-    0,
+    { maxDuration: CALENDAR_SYNC_MAX_DURATION },
   );
 
-  useEffect(() => {
+  useMountEffect(() => {
+    if (!manager) return;
+
+    let timeoutId: number | undefined;
+    const clearNextSync = () => {
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
+    const scheduleNextSync = () => {
+      clearNextSync();
+      timeoutId = window.setTimeout(() => {
+        timeoutId = undefined;
+        scheduleCalendarSync(manager);
+      }, CALENDAR_SYNC_INTERVAL);
+    };
+    const taskRunListenerId = manager.addTaskRunRunningListener(
+      CALENDAR_SYNC_TASK_ID,
+      null,
+      (_manager, _taskId, _taskRunId, running) => {
+        if (running === undefined) {
+          scheduleNextSync();
+        } else {
+          clearNextSync();
+        }
+      },
+    );
     const unlisten = appleCalendarEvents.calendarChangedEvent.listen(() => {
-      scheduleCalendarSync();
+      scheduleCalendarSync(manager);
     });
+    scheduleCalendarSync(manager);
 
     return () => {
+      clearNextSync();
+      manager.delListener(taskRunListenerId);
       unlisten.then((fn) => fn());
     };
-  }, [scheduleCalendarSync]);
+  });
 
   useSetTask(EVENT_NOTIFICATION_TASK_ID, async () => {
     await checkEventNotifications(notificationEvent, notifiedEventsRef.current);

--- a/crates/calendar/src/fetch.rs
+++ b/crates/calendar/src/fetch.rs
@@ -1,8 +1,13 @@
+use std::time::Duration;
+
 use hypr_calendar_interface::EventFilter;
 use hypr_google_calendar::{CalendarListEntry as GoogleCalendar, Event as GoogleEvent};
 use hypr_outlook_calendar::{Calendar as OutlookCalendar, Event as OutlookEvent};
 
 use crate::error::Error;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub async fn list_all_connection_ids(
     api_base_url: &str,
@@ -32,6 +37,8 @@ fn make_client(api_base_url: &str, access_token: &str) -> Result<hypr_api_client
     headers.insert(reqwest::header::AUTHORIZATION, auth_value);
     let http = reqwest::Client::builder()
         .default_headers(headers)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
         .build()?;
     Ok(hypr_api_client::Client::new_with_client(api_base_url, http))
 }

--- a/crates/supabase-auth/src/session.rs
+++ b/crates/supabase-auth/src/session.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use serde_json::{Map, Value};
+use serde::{Deserialize, Deserializer, de};
+use serde_json::{Map, Number, Value};
 
 #[cfg(feature = "client")]
 use std::collections::HashMap;
@@ -12,7 +13,7 @@ pub struct Session {
     pub refresh_token: Option<String>,
     #[serde(default)]
     pub token_type: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_optional_seconds")]
     pub expires_in: Option<u64>,
     #[serde(default)]
     pub expires_at: Option<u64>,
@@ -20,6 +21,30 @@ pub struct Session {
     pub user: Option<SessionUser>,
     #[serde(flatten)]
     pub extra: Map<String, Value>,
+}
+
+fn deserialize_optional_seconds<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(number) = Option::<Number>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+
+    if let Some(seconds) = number.as_u64() {
+        return Ok(Some(seconds));
+    }
+
+    let seconds = number
+        .as_f64()
+        .filter(|seconds| seconds.is_finite() && *seconds >= 0.0)
+        .ok_or_else(|| de::Error::custom("expires_in must be a non-negative number"))?;
+
+    if seconds >= u64::MAX as f64 {
+        return Err(de::Error::custom("expires_in is too large"));
+    }
+
+    Ok(Some(seconds.floor() as u64))
 }
 
 impl Session {
@@ -189,6 +214,19 @@ mod tests {
         assert_eq!(session.refresh_token.as_deref(), Some("refresh123"));
         assert_eq!(session.token_type, "bearer");
         assert_eq!(session.expires_at, Some(9999999999));
+    }
+
+    #[test]
+    fn floors_fractional_expires_in() {
+        let session: Session = serde_json::from_str(
+            r#"{
+                "access_token": "tok",
+                "expires_in": 3585.936000108719
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(session.expires_in, Some(3585));
     }
 
     #[cfg(feature = "client")]

--- a/plugins/calendar/src/commands.rs
+++ b/plugins/calendar/src/commands.rs
@@ -20,7 +20,10 @@ pub async fn is_provider_enabled<R: tauri::Runtime>(
     provider: CalendarProviderType,
 ) -> Result<bool, Error> {
     let config = app.state::<crate::PluginConfig>();
-    let token = access_token(&app);
+    let token = match provider {
+        CalendarProviderType::Apple => None,
+        _ => access_token(&app)?,
+    };
     let apple = is_apple_authorized(&app).await?;
     hypr_calendar::is_provider_enabled(&config.api_base_url, token.as_deref(), apple, provider)
         .await
@@ -33,7 +36,7 @@ pub async fn list_connection_ids<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
 ) -> Result<Vec<hypr_calendar::ProviderConnectionIds>, Error> {
     let config = app.state::<crate::PluginConfig>();
-    let token = access_token(&app);
+    let token = access_token(&app)?;
     let apple = is_apple_authorized(&app).await?;
     hypr_calendar::list_connection_ids(&config.api_base_url, token.as_deref(), apple)
         .await
@@ -49,7 +52,7 @@ pub async fn list_calendars<R: tauri::Runtime>(
 ) -> Result<Vec<CalendarListItem>, Error> {
     let config = app.state::<crate::PluginConfig>();
     let token = match provider {
-        CalendarProviderType::Apple => access_token(&app).unwrap_or_default(),
+        CalendarProviderType::Apple => String::new(),
         _ => require_access_token(&app)?,
     };
     hypr_calendar::list_calendars(&config.api_base_url, &token, provider, &connection_id)
@@ -67,7 +70,7 @@ pub async fn list_events<R: tauri::Runtime>(
 ) -> Result<Vec<CalendarEvent>, Error> {
     let config = app.state::<crate::PluginConfig>();
     let token = match provider {
-        CalendarProviderType::Apple => access_token(&app).unwrap_or_default(),
+        CalendarProviderType::Apple => String::new(),
         _ => require_access_token(&app)?,
     };
     hypr_calendar::list_events(
@@ -106,12 +109,14 @@ pub fn parse_meeting_link(text: String) -> Option<String> {
     hypr_calendar::parse_meeting_link(&text)
 }
 
-fn access_token<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> Option<String> {
-    app.access_token().ok().flatten().filter(|t| !t.is_empty())
+fn access_token<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> Result<Option<String>, Error> {
+    app.access_token()
+        .map(|token| token.filter(|token| !token.is_empty()))
+        .map_err(|error| Error::Auth(error.to_string()))
 }
 
 fn require_access_token<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> Result<String, Error> {
-    let token = app.access_token().map_err(|e| Error::Auth(e.to_string()))?;
+    let token = access_token(app)?;
     match token {
         Some(t) if !t.is_empty() => Ok(t),
         _ => Err(hypr_calendar::Error::NotAuthenticated.into()),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication error propagation, session deserialization, and calendar sync scheduling/writes; behavior changes are intentional but affect a core sync path.
> 
> **Overview**
> Fixes calendar sync failing or misbehaving when auth sessions are malformed, when syncs overlap, or when work is cancelled mid-flight.
> 
> **Auth and plugin layer:** Supabase `Session` now accepts fractional `expires_in` values (floored to whole seconds), addressing parse failures like “auth session could not be parsed.” Calendar Tauri commands propagate auth read errors instead of treating them as “no token,” and Apple calendar paths no longer depend on a bearer token. HTTP clients used for calendar API calls get connect (10s) and request (30s) timeouts.
> 
> **Sync pipeline:** `getProviderConnections` throws on connection-discovery errors instead of returning an empty list. Calendar inventory sync and the main sync `run` path honor `AbortSignal` and skip writes after abort. `scheduleCalendarSync` deduplicates against already scheduled or running `calendarSync` task runs.
> 
> **Scheduling and UI:** `TaskManager` runs calendar sync with a task abort signal and 2-minute max duration, replaces tinytick `repeatDelay` with a listener-driven 60s reschedule after each run, and triggers sync on Apple calendar change events. `SyncProvider` derives idle / scheduled / syncing from the tinytick manager’s scheduled and running runs (including syncs started elsewhere) instead of tracking a single pending task run id.
> 
> Tests cover sync status transitions, scheduling reuse, abort behavior, and connection discovery errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 678b494f4dd7f5a429137bae1f01851f6edcf709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->