### PR TITLE
Update desktop 1.3.2 release notes

### DIFF
--- a/packages/changelog/content/1.3.2.md
+++ b/packages/changelog/content/1.3.2.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-07-20"
-summary: "Anarlog 1.3.2 protects Google Calendar data from remote AI and polishes sharing, the menu bar, and in-app notifications."
+summary: "Anarlog 1.3.2 protects Google Calendar data from remote AI and improves calendar sync, encrypted recovery, sharing, and AI-assisted editing."
 ---
 
 ## Google Calendar privacy
@@ -8,8 +8,18 @@ summary: "Anarlog 1.3.2 protects Google Calendar data from remote AI and polishe
 - Block remote language models while Google Calendar data is present on your device, with a direct option to configure on-device AI instead
 - Keep calendar-derived names, event titles, attendees, and speaker hints out of remote transcription requests
 
-## Sharing and polish
+## Calendar and sync reliability
+
+- Keep connected calendars syncing on schedule without overlapping or stalling, and remove disconnected account data immediately
+- Recover encrypted sync histories more reliably after throttling or interrupted backfills
+
+## Sharing and AI review
 
 - Open sharing in a compact panel anchored to the note toolbar, with a simpler icon control and clear Pro upgrade guidance
+- Copy share links reliably without reverting the access level you just selected
+- Review complete AI summary rewrites in a diff before applying them
+
+## Everyday polish
+
 - Scan upcoming meetings more easily from a cleaner menu bar agenda that shows compact event titles before their start times
 - Close in-app notifications without the button being clipped at the edge


### PR DESCRIPTION
Refresh the stable changelog with the final user-facing reliability, sharing, and AI review improvements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no application or infrastructure changes.
> 
> **Overview**
> Updates the **1.3.2** stable changelog so it matches the final user-facing scope of the release.
> 
> The front-matter **summary** now calls out calendar sync, encrypted recovery, sharing, and AI-assisted editing alongside Google Calendar privacy. Content is reorganized into **Calendar and sync reliability**, **Sharing and AI review**, and **Everyday polish**, with new bullets for sync scheduling, disconnected-account cleanup, encrypted history recovery, reliable share-link copy, and diff review before applying AI summary rewrites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a72ea0904cd7fa16609e5b02de59aae722eeca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->