### PR TITLE
Make note sharing resilient and immediate

### DIFF
--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -79,13 +79,24 @@ fn request_client_address(request: &Request<Body>) -> Option<String> {
 
 fn build_sync_routes(
     state: hypr_api_sync::AppState,
-    rate_limit_state: rate_limit::RateLimitState,
+    cloudsync_rate_limit_state: rate_limit::RateLimitState,
+    session_share_rate_limit_state: rate_limit::RateLimitState,
     witness_rate_limit_state: rate_limit::RateLimitState,
     auth_state: AuthState,
 ) -> Router {
-    let pro_routes = hypr_api_sync::pro_router(state.clone())
+    let cloudsync_routes = hypr_api_sync::cloudsync_router(state.clone())
         .route_layer(middleware::from_fn_with_state(
-            rate_limit_state.clone(),
+            cloudsync_rate_limit_state,
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let session_share_routes = hypr_api_sync::session_share_router(state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            session_share_rate_limit_state.clone(),
             rate_limit::rate_limit,
         ))
         .route_layer(middleware::from_fn(auth::sentry_and_analytics))
@@ -105,7 +116,7 @@ fn build_sync_routes(
         ));
     let web_edit_routes = hypr_api_sync::web_edit_router(state)
         .route_layer(middleware::from_fn_with_state(
-            rate_limit_state,
+            session_share_rate_limit_state,
             rate_limit::rate_limit,
         ))
         .route_layer(middleware::from_fn(auth::sentry_and_analytics))
@@ -114,7 +125,10 @@ fn build_sync_routes(
             auth::require_auth,
         ));
 
-    pro_routes.merge(witness_routes).merge(web_edit_routes)
+    cloudsync_routes
+        .merge(session_share_routes)
+        .merge(witness_routes)
+        .merge(web_edit_routes)
 }
 
 async fn app() -> Router {
@@ -152,18 +166,19 @@ async fn app() -> Router {
                 .allow_burst(NonZeroU32::new(5).unwrap()),
         )
         .build();
-    let sync_rate_limit = rate_limit::RateLimitState::builder()
-        .pro(
+    let build_sync_rate_limit = || {
+        let quota = || {
             governor::Quota::with_period(Duration::from_secs(30))
                 .unwrap()
-                .allow_burst(NonZeroU32::new(20).unwrap()),
-        )
-        .free(
-            governor::Quota::with_period(Duration::from_secs(30))
-                .unwrap()
-                .allow_burst(NonZeroU32::new(20).unwrap()),
-        )
-        .build();
+                .allow_burst(NonZeroU32::new(20).unwrap())
+        };
+        rate_limit::RateLimitState::builder()
+            .pro(quota())
+            .free(quota())
+            .build()
+    };
+    let cloudsync_rate_limit = build_sync_rate_limit();
+    let session_share_rate_limit = build_sync_rate_limit();
     let e2ee_witness_rate_limit = rate_limit::RateLimitState::builder()
         .pro(
             governor::Quota::with_period(Duration::from_millis(100))
@@ -261,7 +276,8 @@ async fn app() -> Router {
     let sync_routes = match sync_config {
         Some(config) => build_sync_routes(
             hypr_api_sync::AppState::new(config),
-            sync_rate_limit,
+            cloudsync_rate_limit,
+            session_share_rate_limit,
             e2ee_witness_rate_limit,
             auth_state.clone(),
         ),
@@ -758,7 +774,7 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
 950IxEzvw/x5BMEINRMrXLBJhqzO9Bm+d6JbqA21YQmd1Kt4RzLJR1W+\n\
 -----END PRIVATE KEY-----";
 
-    fn non_pro_token() -> String {
+    fn token_with_entitlements(entitlements: &[&str]) -> String {
         let mut header = Header::new(Algorithm::ES256);
         header.kid = Some(TEST_KEY_ID.to_string());
         let expires_at = SystemTime::now()
@@ -773,22 +789,27 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
                 "sub": "editor-user",
                 "aud": "authenticated",
                 "exp": expires_at,
-                "entitlements": []
+                "entitlements": entitlements
             }),
             &EncodingKey::from_ec_pem(TEST_PRIVATE_KEY.as_bytes()).unwrap(),
         )
         .unwrap()
     }
 
-    fn test_sync_rate_limit() -> rate_limit::RateLimitState {
+    fn non_pro_token() -> String {
+        token_with_entitlements(&[])
+    }
+
+    fn test_sync_rate_limit(burst: u32) -> rate_limit::RateLimitState {
         let quota = || {
             governor::Quota::with_period(Duration::from_secs(1))
                 .unwrap()
-                .allow_burst(NonZeroU32::new(10).unwrap())
+                .allow_burst(NonZeroU32::new(burst).unwrap())
         };
         rate_limit::RateLimitState::builder()
             .pro(quota())
             .free(quota())
+            .enforce_in_debug()
             .build()
     }
 
@@ -847,8 +868,9 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
             "/sync",
             build_sync_routes(
                 test_sync_state(&server),
-                test_sync_rate_limit(),
-                test_sync_rate_limit(),
+                test_sync_rate_limit(10),
+                test_sync_rate_limit(10),
+                test_sync_rate_limit(10),
                 AuthState::new(&server.uri()),
             ),
         );
@@ -916,6 +938,97 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
         assert_eq!(
             response_bytes(witness_response).await,
             b"subscription_required"
+        );
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn sync_composition_keeps_sharing_available_when_cloudsync_is_rate_limited() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/auth/v1/.well-known/jwks.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "keys": [{
+                    "kty": "EC",
+                    "use": "sig",
+                    "crv": "P-256",
+                    "kid": TEST_KEY_ID,
+                    "x": "w7JAoU_gJbZJvV-zCOvU9yFJq0FNC_edCMRM78P8eQQ",
+                    "y": "wQg1EytcsEmGrM70Gb53oluoDbVhCZ3Uq3hHMslHVb4",
+                    "alg": "ES256"
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/publish_session_share_snapshot_cas"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+                "code": "42501",
+                "message": "share manager access required"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let app = Router::new().nest(
+            "/sync",
+            build_sync_routes(
+                test_sync_state(&server),
+                test_sync_rate_limit(1),
+                test_sync_rate_limit(1),
+                test_sync_rate_limit(1),
+                AuthState::new(&server.uri()),
+            ),
+        );
+        let token = token_with_entitlements(&["hyprnote_pro"]);
+        let cloudsync_request = || {
+            Request::post("/sync/token")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap()
+        };
+
+        let first_cloudsync_response = app.clone().oneshot(cloudsync_request()).await.unwrap();
+        assert_eq!(
+            first_cloudsync_response.status(),
+            StatusCode::UPGRADE_REQUIRED
+        );
+        let second_cloudsync_response = app.clone().oneshot(cloudsync_request()).await.unwrap();
+        assert_eq!(
+            second_cloudsync_response.status(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+
+        let share_response = app
+            .oneshot(
+                Request::put("/sync/shares/11111111-1111-4111-8111-111111111111/snapshot")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "baseRevision": 0,
+                            "mutationId": "22222222-2222-4222-8222-222222222222",
+                            "title": "Title",
+                            "body": {
+                                "type": "doc",
+                                "content": [{ "type": "paragraph" }]
+                            },
+                            "attachmentIds": []
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(share_response.status(), StatusCode::FORBIDDEN);
+        let share_body: Value =
+            serde_json::from_slice(&response_bytes(share_response).await).unwrap();
+        assert_eq!(
+            share_body["error"]["code"],
+            "shared_note_publication_forbidden"
         );
         server.verify().await;
     }

--- a/apps/api/src/rate_limit.rs
+++ b/apps/api/src/rate_limit.rs
@@ -82,6 +82,7 @@ impl IpRateLimitState {
 pub struct RateLimitState {
     limiter_pro: Arc<KeyedLimiter>,
     limiter_free: Arc<KeyedLimiter>,
+    enforce_in_debug: bool,
 }
 
 impl RateLimitState {
@@ -89,6 +90,7 @@ impl RateLimitState {
         RateLimitStateBuilder {
             pro: None,
             free: None,
+            enforce_in_debug: false,
         }
     }
 
@@ -116,6 +118,7 @@ impl RateLimitState {
 pub struct RateLimitStateBuilder {
     pro: Option<Quota>,
     free: Option<Quota>,
+    enforce_in_debug: bool,
 }
 
 impl RateLimitStateBuilder {
@@ -129,12 +132,19 @@ impl RateLimitStateBuilder {
         self
     }
 
+    #[cfg(test)]
+    pub fn enforce_in_debug(mut self) -> Self {
+        self.enforce_in_debug = true;
+        self
+    }
+
     pub fn build(self) -> RateLimitState {
         RateLimitState {
             limiter_pro: Arc::new(RateLimiter::keyed(self.pro.expect("pro quota is required"))),
             limiter_free: Arc::new(RateLimiter::keyed(
                 self.free.expect("free quota is required"),
             )),
+            enforce_in_debug: self.enforce_in_debug,
         }
     }
 }
@@ -144,7 +154,7 @@ pub async fn rate_limit(
     request: Request,
     next: Next,
 ) -> Result<Response, Response> {
-    if cfg!(debug_assertions) {
+    if cfg!(debug_assertions) && !state.enforce_in_debug {
         return Ok(next.run(request).await);
     }
 

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1131,6 +1131,27 @@ describe("SessionShareButton", () => {
     ).not.toBeNull();
   });
 
+  it("abandons a billing wait when the account changes", async () => {
+    mocks.billing.isReady = false;
+    const view = renderShareButtonView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
+    expect(screen.queryByTestId("share-popover")).not.toBeNull();
+
+    mocks.auth.session = createSession(OTHER_USER_ID);
+    view.rerender();
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+
+    mocks.auth.session = createSession();
+    mocks.billing.isReady = true;
+    view.rerender();
+
+    await act(async () => {});
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+    expect(mocks.loadSessionShareSource).not.toHaveBeenCalled();
+    expect(mocks.publishSessionShareSnapshot).not.toHaveBeenCalled();
+  });
+
   it("does not resurface an abandoned preparation when the account returns", async () => {
     let resolveSource!: (source: {
       sessionId: string;

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1131,6 +1131,29 @@ describe("SessionShareButton", () => {
     ).not.toBeNull();
   });
 
+  it("does not resurface a dismissed upgrade prompt when the account returns", async () => {
+    mocks.billing.isPaid = false;
+    mocks.loadManagedSharedNoteForSession.mockResolvedValueOnce(null);
+    const view = renderShareButtonView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
+    expect(
+      await screen.findByRole("heading", { name: "Share notes with others" }),
+    ).not.toBeNull();
+
+    mocks.auth.session = createSession(OTHER_USER_ID);
+    view.rerender();
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+
+    mocks.auth.session = createSession();
+    view.rerender();
+
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+    expect(
+      screen.queryByRole("heading", { name: "Share notes with others" }),
+    ).toBeNull();
+  });
+
   it("abandons a billing wait when the account changes", async () => {
     mocks.billing.isReady = false;
     const view = renderShareButtonView();

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1039,6 +1039,98 @@ describe("SessionShareButton", () => {
     expect(mocks.toastError).not.toHaveBeenCalled();
   });
 
+  it("stays silent when a note-switch remount aborts preparation", async () => {
+    let resolveSource!: (source: {
+      sessionId: string;
+      workspaceId: string;
+      title: string;
+      body: { type: "doc"; content: never[] };
+    }) => void;
+    mocks.loadSessionShareSource.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSource = resolve;
+      }),
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const element = (sessionId: string) => (
+      <QueryClientProvider client={queryClient}>
+        <SessionShareButton key={sessionId} sessionId={sessionId} />
+      </QueryClientProvider>
+    );
+    const view = render(element("session-1"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
+    await waitFor(() =>
+      expect(mocks.loadSessionShareSource).toHaveBeenCalledWith(
+        "session-1",
+        USER_ID,
+      ),
+    );
+
+    view.rerender(element("session-2"));
+    await act(async () => {
+      resolveSource({
+        sessionId: "session-1",
+        workspaceId: WORKSPACE_ID,
+        title: "Planning",
+        body: { type: "doc", content: [] },
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("button", { name: "Share note" })
+          .querySelector(".animate-spin"),
+      ).toBeNull(),
+    );
+    expect(mocks.createOrReuseSessionShare).not.toHaveBeenCalled();
+    expect(mocks.publishSessionShareSnapshot).not.toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("shows the loading state when retrying preparation for a free account", async () => {
+    mocks.billing.isPaid = false;
+    mocks.getSessionShareManagement.mockRejectedValueOnce(
+      new Error("management unavailable"),
+    );
+    renderShareButtonView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
+    expect(
+      await screen.findByText("Access settings could not be loaded."),
+    ).not.toBeNull();
+
+    let resolveManaged!: (value: unknown) => void;
+    mocks.loadManagedSharedNoteForSession.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveManaged = resolve;
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(screen.getByText("Loading access…")).not.toBeNull();
+    expect(
+      screen.queryByText("Access settings could not be loaded."),
+    ).toBeNull();
+
+    await act(async () => {
+      resolveManaged({
+        shareId: SHARE_ID,
+        workspaceId: WORKSPACE_ID,
+        sessionId: "session-1",
+      });
+    });
+    expect(
+      await screen.findByRole("heading", { name: "People with access" }),
+    ).not.toBeNull();
+  });
+
   it("publishes before rotating a bearer link and keeps the token out of query keys", async () => {
     mocks.management = defaultManagement({
       generalScope: "link",

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1131,6 +1131,80 @@ describe("SessionShareButton", () => {
     ).not.toBeNull();
   });
 
+  it("does not resurface an abandoned preparation when the account returns", async () => {
+    let resolveSource!: (source: {
+      sessionId: string;
+      workspaceId: string;
+      title: string;
+      body: { type: "doc"; content: never[] };
+    }) => void;
+    mocks.loadSessionShareSource.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSource = resolve;
+      }),
+    );
+    const view = renderShareButtonView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
+    await waitFor(() =>
+      expect(mocks.loadSessionShareSource).toHaveBeenCalledOnce(),
+    );
+
+    mocks.auth.session = createSession(OTHER_USER_ID);
+    view.rerender();
+    await act(async () => {
+      resolveSource({
+        sessionId: "session-1",
+        workspaceId: WORKSPACE_ID,
+        title: "Planning",
+        body: { type: "doc", content: [] },
+      });
+    });
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+
+    mocks.auth.session = createSession();
+    view.rerender();
+
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+    expect(
+      screen.queryByText("Access settings could not be loaded."),
+    ).toBeNull();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("does not resurface an abandoned free-share check when the account returns", async () => {
+    mocks.billing.isPaid = false;
+    let resolveManaged!: (value: unknown) => void;
+    mocks.loadManagedSharedNoteForSession.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveManaged = resolve;
+      }),
+    );
+    const view = renderShareButtonView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
+    await waitFor(() =>
+      expect(mocks.loadManagedSharedNoteForSession).toHaveBeenCalledOnce(),
+    );
+
+    mocks.auth.session = createSession(OTHER_USER_ID);
+    view.rerender();
+    await act(async () => {
+      resolveManaged({
+        shareId: SHARE_ID,
+        workspaceId: WORKSPACE_ID,
+        sessionId: "session-1",
+      });
+    });
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+
+    mocks.auth.session = createSession();
+    view.rerender();
+
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+    expect(screen.queryByText("Loading access…")).toBeNull();
+  });
+
   it("publishes before rotating a bearer link and keeps the token out of query keys", async () => {
     mocks.management = defaultManagement({
       generalScope: "link",

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -7,6 +7,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -227,25 +228,37 @@ function renderShareButton() {
   return renderShareButtonView().queryClient;
 }
 
-function renderShareButtonView() {
+function renderShareButtonView(
+  initialSessionId = "session-1",
+  strictMode = false,
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  const element = () => (
-    <QueryClientProvider client={queryClient}>
-      <SessionShareButton sessionId="session-1" />
-    </QueryClientProvider>
-  );
+  let currentSessionId = initialSessionId;
+  const element = () => {
+    const content = (
+      <QueryClientProvider client={queryClient}>
+        <SessionShareButton sessionId={currentSessionId} />
+      </QueryClientProvider>
+    );
+    return strictMode ? <StrictMode>{content}</StrictMode> : content;
+  };
   const view = render(element());
   return {
     queryClient,
-    rerender: () => view.rerender(element()),
+    rerender: (sessionId = currentSessionId) => {
+      currentSessionId = sessionId;
+      view.rerender(element());
+    },
   };
 }
 
 async function openSharePopover() {
   fireEvent.click(screen.getByRole("button", { name: "Share note" }));
-  await screen.findByRole("heading", { name: "Share note" });
+  await screen.findByText(
+    "Attachments stay private unless you explicitly include them in this shared note.",
+  );
 }
 
 describe("SessionShareButton", () => {
@@ -297,10 +310,10 @@ describe("SessionShareButton", () => {
       baselineSourceHash: "a".repeat(64),
       status: "clean",
     });
-    mocks.loadSessionShareSource.mockImplementation(async () => {
+    mocks.loadSessionShareSource.mockImplementation(async (sessionId) => {
       mocks.events.push("load");
       return {
-        sessionId: "session-1",
+        sessionId,
         workspaceId: WORKSPACE_ID,
         title: "Planning",
         body: { type: "doc", content: [] },
@@ -382,6 +395,7 @@ describe("SessionShareButton", () => {
 
   it("starts sign-in before attempting to share for a signed-out user", () => {
     mocks.auth.session = null;
+    mocks.billing.isReady = false;
     renderShareButton();
 
     fireEvent.click(screen.getByRole("button", { name: "Share note" }));
@@ -416,17 +430,45 @@ describe("SessionShareButton", () => {
     expect(mocks.billing.upgradeToPro).toHaveBeenCalledOnce();
   });
 
-  it("keeps the share button enabled while billing access loads", () => {
-    mocks.billing.isReady = false;
-    renderShareButton();
+  it("closes a free-plan upgrade state when the account changes", async () => {
+    mocks.billing.isPaid = false;
+    mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);
+    const view = renderShareButtonView();
 
+    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
     expect(
-      (
-        screen.getByRole("button", {
-          name: "Share note",
-        }) as HTMLButtonElement
-      ).disabled,
-    ).toBe(false);
+      await screen.findByRole("heading", { name: "Share notes with others" }),
+    ).not.toBeNull();
+
+    mocks.auth.session = createSession(OTHER_USER_ID);
+    view.rerender();
+
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+  });
+
+  it("opens immediately and continues after billing access loads", async () => {
+    mocks.billing.isReady = false;
+    const view = renderShareButtonView("session-1", true);
+
+    const trigger = screen.getByRole("button", { name: "Share note" });
+    expect((trigger as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(trigger);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Loading access…")).not.toBeNull();
+    expect(mocks.loadSessionShareSource).not.toHaveBeenCalled();
+
+    mocks.billing.isReady = true;
+    view.rerender();
+
+    await screen.findByText(
+      "Attachments stay private unless you explicitly include them in this shared note.",
+    );
+    expect(mocks.loadSessionShareSource).toHaveBeenCalledWith(
+      "session-1",
+      USER_ID,
+    );
+    expect(mocks.loadSessionShareSource).toHaveBeenCalledOnce();
   });
 
   it("opens sharing as a popover anchored to the toolbar button", async () => {
@@ -518,12 +560,16 @@ describe("SessionShareButton", () => {
       "[session-sharing] could not prepare note",
       expect.objectContaining({ message: "connection lost" }),
     );
-    expect(screen.queryByTestId("share-popover")).toBeNull();
+    expect(screen.getByTestId("share-popover")).not.toBeNull();
+    expect(
+      await screen.findByText("Access settings could not be loaded."),
+    ).not.toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
-    await screen.findByRole("heading", { name: "Share note" });
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await waitFor(() =>
+      expect(mocks.publishSessionShareSnapshot).toHaveBeenCalledTimes(2),
+    );
 
-    expect(mocks.publishSessionShareSnapshot).toHaveBeenCalledTimes(2);
     expect(mocks.publishSessionShareSnapshot.mock.calls[0]![0].mutationId).toBe(
       mocks.publishSessionShareSnapshot.mock.calls[1]![0].mutationId,
     );
@@ -896,7 +942,7 @@ describe("SessionShareButton", () => {
     expect(mocks.events.slice(0, 3)).toEqual(["load", "publish", "cloud-off"]);
   });
 
-  it("abandons initial share preparation when the active account changes", async () => {
+  it("opens immediately and abandons preparation when the account changes", async () => {
     let resolveSource!: (source: {
       sessionId: string;
       workspaceId: string;
@@ -910,7 +956,14 @@ describe("SessionShareButton", () => {
     );
     const view = renderShareButtonView();
 
-    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
+    const trigger = screen.getByRole("button", { name: "Share note" });
+    fireEvent.click(trigger);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(
+      await screen.findByRole("heading", { name: "Share note" }),
+    ).not.toBeNull();
+    expect(screen.getByText("Loading access…")).not.toBeNull();
     await waitFor(() =>
       expect(mocks.loadSessionShareSource).toHaveBeenCalledOnce(),
     );
@@ -938,6 +991,52 @@ describe("SessionShareButton", () => {
     expect(mocks.createOrReuseSessionShare).not.toHaveBeenCalled();
     expect(mocks.publishSessionShareSnapshot).not.toHaveBeenCalled();
     expect(screen.queryByTestId("share-popover")).toBeNull();
+  });
+
+  it("abandons preparation when the active note changes", async () => {
+    let resolveSource!: (source: {
+      sessionId: string;
+      workspaceId: string;
+      title: string;
+      body: { type: "doc"; content: never[] };
+    }) => void;
+    mocks.loadSessionShareSource.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSource = resolve;
+      }),
+    );
+    const view = renderShareButtonView();
+
+    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
+    await waitFor(() =>
+      expect(mocks.loadSessionShareSource).toHaveBeenCalledWith(
+        "session-1",
+        USER_ID,
+      ),
+    );
+
+    view.rerender("session-2");
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+
+    await act(async () => {
+      resolveSource({
+        sessionId: "session-1",
+        workspaceId: WORKSPACE_ID,
+        title: "Planning",
+        body: { type: "doc", content: [] },
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("button", { name: "Share note" })
+          .querySelector(".animate-spin"),
+      ).toBeNull(),
+    );
+    expect(mocks.createOrReuseSessionShare).not.toHaveBeenCalled();
+    expect(mocks.publishSessionShareSnapshot).not.toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
   });
 
   it("publishes before rotating a bearer link and keeps the token out of query keys", async () => {

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -242,6 +242,17 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
   const [upgradePromptIdentity, setUpgradePromptIdentity] =
     useState<SharePreparationIdentity | null>(null);
   const sharePanelPendingRef = useRef(false);
+  const clearAbandonedSharePreparation = (
+    identity: SharePreparationIdentity,
+  ) => {
+    setSharePreparationIdentity((current) =>
+      current &&
+      current.ownerUserId === identity.ownerUserId &&
+      current.sessionId === identity.sessionId
+        ? null
+        : current,
+    );
+  };
   const accountUserId = auth.session?.user.id ?? null;
   const activeSharePanelIdentity =
     sharePanelIdentity?.ownerUserId === accountUserId &&
@@ -379,6 +390,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
         latestAuthRef.current.session?.user.id !== identity.ownerUserId ||
         latestSessionIdRef.current !== identity.sessionId
       ) {
+        clearAbandonedSharePreparation(identity);
         return;
       }
       queryClient.setQueryData(
@@ -398,6 +410,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
           variables.identity.ownerUserId ||
         latestSessionIdRef.current !== variables.identity.sessionId
       ) {
+        clearAbandonedSharePreparation(variables.identity);
         return;
       }
       console.error("[session-sharing] could not prepare note", error);
@@ -412,6 +425,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
         latestAuthRef.current.session?.user.id !== identity.ownerUserId ||
         latestSessionIdRef.current !== identity.sessionId
       ) {
+        clearAbandonedSharePreparation(identity);
         return;
       }
       if (!managedShare) {
@@ -426,6 +440,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
         latestAuthRef.current.session?.user.id !== identity.ownerUserId ||
         latestSessionIdRef.current !== identity.sessionId
       ) {
+        clearAbandonedSharePreparation(identity);
         return;
       }
       sonnerToast.error("Could not check this note's sharing status.");
@@ -478,6 +493,8 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
   };
 
   const startSharePreparation = (identity: SharePreparationIdentity) => {
+    initializeMutation.reset();
+    freeShareMutation.reset();
     setSharePreparationIdentity(identity);
     if (!billing.isReady) {
       setWaitingForBilling(true);

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -265,6 +265,13 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     setSharePreparationIdentity(null);
     setWaitingForBilling(false);
   }
+  if (
+    upgradePromptIdentity &&
+    (upgradePromptIdentity.ownerUserId !== accountUserId ||
+      upgradePromptIdentity.sessionId !== sessionId)
+  ) {
+    setUpgradePromptIdentity(null);
+  }
   const activeSharePanelIdentity =
     sharePanelIdentity?.ownerUserId === accountUserId &&
     sharePanelIdentity.sessionId === sessionId

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -98,6 +98,7 @@ import {
   upsertDurableSharedNoteCache,
   useDurableSharedNote,
 } from "~/shared-notes/cache";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { getScheme } from "~/shared/utils";
 
 type SharePanelData = {
@@ -105,8 +106,12 @@ type SharePanelData = {
   access: SessionShareAccessEntry[];
 };
 
-type SharePanelIdentity = {
+type SharePreparationIdentity = {
   ownerUserId: string;
+  sessionId: string;
+};
+
+type SharePanelIdentity = SharePreparationIdentity & {
   shareId: string;
 };
 
@@ -177,6 +182,8 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
   const auth = useAuth();
   const latestAuthRef = useRef(auth);
   latestAuthRef.current = auth;
+  const latestSessionIdRef = useRef(sessionId);
+  latestSessionIdRef.current = sessionId;
   const prepareControllersRef = useRef(new Set<AbortController>());
   const shareButtonLifecycleRef = useCallback(
     (node: HTMLButtonElement | null) => {
@@ -200,12 +207,15 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     }
   };
   const requireActivePrepareContext = (
-    ownerUserId: string,
+    identity: SharePreparationIdentity,
     signal: AbortSignal,
   ) => {
     if (signal.aborted) throw new ShareManagementError();
     const context = requireManagementContext(latestAuthRef.current);
-    if (context.session.user.id !== ownerUserId) {
+    if (
+      context.session.user.id !== identity.ownerUserId ||
+      latestSessionIdRef.current !== identity.sessionId
+    ) {
       throw new ShareManagementError();
     }
     return { ...context, signal };
@@ -214,17 +224,34 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
   const queryClient = useQueryClient();
   const [sharePanelIdentity, setSharePanelIdentity] =
     useState<SharePanelIdentity | null>(null);
-  const [upgradePromptOpen, setUpgradePromptOpen] = useState(false);
+  const [sharePreparationIdentity, setSharePreparationIdentity] =
+    useState<SharePreparationIdentity | null>(null);
+  const [waitingForBilling, setWaitingForBilling] = useState(false);
+  const [upgradePromptIdentity, setUpgradePromptIdentity] =
+    useState<SharePreparationIdentity | null>(null);
   const sharePanelPendingRef = useRef(false);
   const accountUserId = auth.session?.user.id ?? null;
   const activeSharePanelIdentity =
-    sharePanelIdentity?.ownerUserId === accountUserId
+    sharePanelIdentity?.ownerUserId === accountUserId &&
+    sharePanelIdentity.sessionId === sessionId
       ? sharePanelIdentity
       : null;
+  const activeSharePreparationIdentity =
+    sharePreparationIdentity?.ownerUserId === accountUserId &&
+    sharePreparationIdentity.sessionId === sessionId
+      ? sharePreparationIdentity
+      : null;
+  const activeUpgradePromptIdentity =
+    upgradePromptIdentity?.ownerUserId === accountUserId &&
+    upgradePromptIdentity.sessionId === sessionId
+      ? upgradePromptIdentity
+      : null;
   const showUpgradePrompt =
-    upgradePromptOpen && billing.isReady && !billing.isPaid;
+    Boolean(activeUpgradePromptIdentity) && billing.isReady && !billing.isPaid;
   const sharePopoverOpen =
-    showUpgradePrompt || Boolean(activeSharePanelIdentity);
+    showUpgradePrompt ||
+    Boolean(activeSharePanelIdentity) ||
+    Boolean(activeSharePreparationIdentity);
   const durableNoteQuery = useDurableSharedNote(
     accountUserId,
     activeSharePanelIdentity?.shareId ?? "",
@@ -234,22 +261,28 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
   const initializeMutation = useMutation({
     mutationFn: ({
       publish,
-      ownerUserId,
+      identity,
     }: {
       publish: boolean;
-      ownerUserId: string;
+      identity: SharePreparationIdentity;
     }) =>
       runPrepareOperation(async (signal) => {
-        let context = requireActivePrepareContext(ownerUserId, signal);
-        await flushCanonicalSessionEditorChanges(sessionId);
-        context = requireActivePrepareContext(ownerUserId, signal);
-        const source = await loadSessionShareSource(sessionId, ownerUserId);
-        context = requireActivePrepareContext(ownerUserId, signal);
+        let context = requireActivePrepareContext(identity, signal);
+        await flushCanonicalSessionEditorChanges(identity.sessionId);
+        context = requireActivePrepareContext(identity, signal);
+        const source = await loadSessionShareSource(
+          identity.sessionId,
+          identity.ownerUserId,
+        );
+        context = requireActivePrepareContext(identity, signal);
+        if (source.sessionId !== identity.sessionId) {
+          throw new ShareManagementError();
+        }
         const share = await createOrReuseSessionShare(context, {
           workspaceId: source.workspaceId,
           sessionId: source.sessionId,
         });
-        context = requireActivePrepareContext(ownerUserId, signal);
+        context = requireActivePrepareContext(identity, signal);
         const management = await getSessionShareManagement(
           context,
           share.shareId,
@@ -261,9 +294,12 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
           throw new ShareManagementError();
         }
         const cachedManagedShare = publish
-          ? await loadManagedSharedNoteForSession(ownerUserId, source.sessionId)
+          ? await loadManagedSharedNoteForSession(
+              identity.ownerUserId,
+              source.sessionId,
+            )
           : null;
-        context = requireActivePrepareContext(ownerUserId, signal);
+        context = requireActivePrepareContext(identity, signal);
         if (
           cachedManagedShare &&
           (cachedManagedShare.shareId !== share.shareId ||
@@ -293,15 +329,15 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
             attachmentIds: [],
             signal,
           });
-          context = requireActivePrepareContext(ownerUserId, signal);
+          context = requireActivePrepareContext(identity, signal);
           await recordPublishedSessionShareState({
-            viewerUserId: ownerUserId,
+            viewerUserId: identity.ownerUserId,
             shareId: published.shareId,
             sessionId: source.sessionId,
             contentRevision: published.contentRevision,
             sourceHash,
           });
-          await upsertDurableSharedNoteCache(ownerUserId, {
+          await upsertDurableSharedNoteCache(identity.ownerUserId, {
             shareId: published.shareId,
             workspaceId: source.workspaceId,
             sessionId: source.sessionId,
@@ -317,17 +353,20 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
             webEditBase: null,
             publishedAt: published.publishedAt,
           });
-          context = requireActivePrepareContext(ownerUserId, signal);
+          context = requireActivePrepareContext(identity, signal);
         }
         const access = await listSessionShareAccess(context, share.shareId);
-        requireActivePrepareContext(ownerUserId, signal);
+        requireActivePrepareContext(identity, signal);
         return {
-          identity: { ownerUserId, shareId: share.shareId },
+          identity: { ...identity, shareId: share.shareId },
           data: { management, access },
         };
       }),
     onSuccess: ({ identity, data }) => {
-      if (latestAuthRef.current.session?.user.id !== identity.ownerUserId) {
+      if (
+        latestAuthRef.current.session?.user.id !== identity.ownerUserId ||
+        latestSessionIdRef.current !== identity.sessionId
+      ) {
         return;
       }
       queryClient.setQueryData(
@@ -337,10 +376,15 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
       void queryClient.invalidateQueries({
         queryKey: ["durable-shared-note-cache", identity.ownerUserId],
       });
+      setSharePreparationIdentity(null);
       setSharePanelIdentity(identity);
     },
     onError: (error, variables) => {
-      if (latestAuthRef.current.session?.user.id !== variables.ownerUserId) {
+      if (
+        latestAuthRef.current.session?.user.id !==
+          variables.identity.ownerUserId ||
+        latestSessionIdRef.current !== variables.identity.sessionId
+      ) {
         return;
       }
       console.error("[session-sharing] could not prepare note", error);
@@ -348,17 +392,29 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     },
   });
   const freeShareMutation = useMutation({
-    mutationFn: (ownerUserId: string) =>
-      loadManagedSharedNoteForSession(ownerUserId, sessionId),
-    onSuccess: (managedShare, ownerUserId) => {
-      if (latestAuthRef.current.session?.user.id !== ownerUserId) return;
-      if (!managedShare) {
-        setUpgradePromptOpen(true);
+    mutationFn: (identity: SharePreparationIdentity) =>
+      loadManagedSharedNoteForSession(identity.ownerUserId, identity.sessionId),
+    onSuccess: (managedShare, identity) => {
+      if (
+        latestAuthRef.current.session?.user.id !== identity.ownerUserId ||
+        latestSessionIdRef.current !== identity.sessionId
+      ) {
         return;
       }
-      initializeMutation.mutate({ publish: false, ownerUserId });
+      if (!managedShare) {
+        setSharePreparationIdentity(null);
+        setUpgradePromptIdentity(identity);
+        return;
+      }
+      initializeMutation.mutate({ publish: false, identity });
     },
-    onError: () => {
+    onError: (_error, identity) => {
+      if (
+        latestAuthRef.current.session?.user.id !== identity.ownerUserId ||
+        latestSessionIdRef.current !== identity.sessionId
+      ) {
+        return;
+      }
       sonnerToast.error("Could not check this note's sharing status.");
     },
   });
@@ -390,28 +446,50 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     durableNoteQuery.data,
   );
 
+  const closeSharePopover = () => {
+    setSharePanelIdentity(null);
+    setSharePreparationIdentity(null);
+    setWaitingForBilling(false);
+    setUpgradePromptIdentity(null);
+    initializeMutation.reset();
+    freeShareMutation.reset();
+  };
+
+  const runSharePreparation = (identity: SharePreparationIdentity) => {
+    setWaitingForBilling(false);
+    if (!billing.isPaid) {
+      freeShareMutation.mutate(identity);
+      return;
+    }
+    initializeMutation.mutate({ publish: true, identity });
+  };
+
+  const startSharePreparation = (identity: SharePreparationIdentity) => {
+    setSharePreparationIdentity(identity);
+    if (!billing.isReady) {
+      setWaitingForBilling(true);
+      return;
+    }
+    runSharePreparation(identity);
+  };
+
   const handleShare = () => {
     if (sharePopoverOpen) {
-      if (!sharePanelPendingRef.current) {
-        setSharePanelIdentity(null);
-        setUpgradePromptOpen(false);
+      if (!shareButtonPending && !sharePanelPendingRef.current) {
+        closeSharePopover();
       }
       return;
     }
-    if (!billing.isReady || shareButtonPending) return;
     if (!auth.session || auth.session.user.is_anonymous === true) {
       void auth.signIn().catch(() => {
         sonnerToast.error("Could not start sign-in.");
       });
       return;
     }
-    if (!billing.isPaid) {
-      freeShareMutation.mutate(auth.session.user.id);
-      return;
-    }
-    initializeMutation.mutate({
-      publish: true,
+    if (shareButtonPending) return;
+    startSharePreparation({
       ownerUserId: auth.session.user.id,
+      sessionId,
     });
   };
 
@@ -419,9 +497,8 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     <Popover
       open={sharePopoverOpen}
       onOpenChange={(open) => {
-        if (!open && !sharePanelPendingRef.current) {
-          setSharePanelIdentity(null);
-          setUpgradePromptOpen(false);
+        if (!open && !shareButtonPending && !sharePanelPendingRef.current) {
+          closeSharePopover();
         }
       }}
     >
@@ -453,8 +530,8 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
         <SessionShareUpgradeContent onUpgrade={billing.upgradeToPro} />
       ) : activeSharePanelIdentity ? (
         <SessionSharePopoverContent
-          key={`${activeSharePanelIdentity.ownerUserId}:${activeSharePanelIdentity.shareId}:${sessionId}`}
-          sessionId={sessionId}
+          key={`${activeSharePanelIdentity.ownerUserId}:${activeSharePanelIdentity.shareId}:${activeSharePanelIdentity.sessionId}`}
+          sessionId={activeSharePanelIdentity.sessionId}
           identity={activeSharePanelIdentity}
           data={shareQuery.data}
           loading={shareQuery.isPending}
@@ -466,7 +543,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
           sharedAttachmentsReady={sharedAttachmentsReady}
           pendingRef={sharePanelPendingRef}
           onRetry={() => void shareQuery.refetch()}
-          onClose={() => setSharePanelIdentity(null)}
+          onClose={closeSharePopover}
           onChanged={() =>
             Promise.all([
               queryClient.invalidateQueries({ queryKey }),
@@ -479,8 +556,120 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
             ])
           }
         />
+      ) : activeSharePreparationIdentity ? (
+        <>
+          {waitingForBilling && billing.isReady ? (
+            <SharePreparationStarter
+              identity={activeSharePreparationIdentity}
+              onStart={runSharePreparation}
+            />
+          ) : null}
+          <SessionSharePreparationContent
+            loading={shareButtonPending}
+            error={initializeMutation.isError || freeShareMutation.isError}
+            onRetry={() =>
+              startSharePreparation(activeSharePreparationIdentity)
+            }
+            onClose={closeSharePopover}
+          />
+        </>
       ) : null}
     </Popover>
+  );
+}
+
+function SharePreparationStarter({
+  identity,
+  onStart,
+}: {
+  identity: SharePreparationIdentity;
+  onStart: (identity: SharePreparationIdentity) => void;
+}) {
+  const startedRef = useRef(false);
+  useMountEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    onStart(identity);
+  });
+  return null;
+}
+
+function SessionSharePreparationContent({
+  loading,
+  error,
+  onRetry,
+  onClose,
+}: {
+  loading: boolean;
+  error: boolean;
+  onRetry: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <PopoverContent
+      variant="app"
+      align="end"
+      sideOffset={8}
+      aria-labelledby="session-share-heading"
+      aria-describedby="session-share-description"
+      className="w-[min(500px,calc(100vw-16px))] overflow-hidden"
+      onEscapeKeyDown={(event) => {
+        if (loading) event.preventDefault();
+      }}
+      onInteractOutside={(event) => {
+        if (loading) event.preventDefault();
+      }}
+    >
+      <AppFloatingPanel className="flex max-h-[calc(100vh-64px)] flex-col overflow-hidden">
+        <header className="border-border/60 border-b px-5 py-4 text-left">
+          <div className="flex items-center gap-3">
+            <div className="bg-accent flex size-9 items-center justify-center rounded-full">
+              <UsersIcon className="size-4" aria-hidden="true" />
+            </div>
+            <div className="min-w-0">
+              <h2
+                id="session-share-heading"
+                className="text-sm leading-5 font-semibold tracking-normal"
+              >
+                <Trans>Share note</Trans>
+              </h2>
+              <p
+                id="session-share-description"
+                className="text-muted-foreground mt-0.5 text-xs leading-4"
+              >
+                <Trans>Choose who can open this note.</Trans>
+              </p>
+            </div>
+          </div>
+        </header>
+
+        <div className="flex min-h-52 items-center justify-center px-5 py-4">
+          {error ? (
+            <div className="flex flex-col items-center gap-3 text-center">
+              <p className="text-muted-foreground text-xs">
+                <Trans>Access settings could not be loaded.</Trans>
+              </p>
+              <Button size="sm" variant="outline" onClick={onRetry}>
+                <RefreshCwIcon className="size-3.5" aria-hidden="true" />
+                <Trans>Try again</Trans>
+              </Button>
+            </div>
+          ) : (
+            <div className="text-muted-foreground flex items-center gap-2 text-xs">
+              <Loader2Icon className="size-4 animate-spin" aria-hidden="true" />
+              <Trans>Loading access…</Trans>
+            </div>
+          )}
+        </div>
+
+        <footer className="border-border/60 flex justify-end border-t px-5 py-3">
+          <Button type="button" size="sm" onClick={onClose} disabled={loading}>
+            <CheckIcon className="size-3.5" aria-hidden="true" />
+            <Trans>Done</Trans>
+          </Button>
+        </footer>
+      </AppFloatingPanel>
+    </PopoverContent>
   );
 }
 

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -254,6 +254,17 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     );
   };
   const accountUserId = auth.session?.user.id ?? null;
+  // Drop abandoned preparation state the moment the account or note stops
+  // matching, so returning to the original identity cannot auto-resume a
+  // publish the user never re-requested.
+  if (
+    sharePreparationIdentity &&
+    (sharePreparationIdentity.ownerUserId !== accountUserId ||
+      sharePreparationIdentity.sessionId !== sessionId)
+  ) {
+    setSharePreparationIdentity(null);
+    setWaitingForBilling(false);
+  }
   const activeSharePanelIdentity =
     sharePanelIdentity?.ownerUserId === accountUserId &&
     sharePanelIdentity.sessionId === sessionId

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -171,6 +171,13 @@ const capabilityRanks: Record<SessionAccessCapability, number> = {
   editor: 3,
 };
 
+class SharePreparationAbortedError extends ShareManagementError {
+  constructor() {
+    super();
+    this.name = "SharePreparationAbortedError";
+  }
+}
+
 export function sessionShareManagementQueryKey(
   ownerUserId: string,
   shareId: string,
@@ -202,6 +209,11 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     prepareControllersRef.current.add(controller);
     try {
       return await operation(controller.signal);
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new SharePreparationAbortedError();
+      }
+      throw error;
     } finally {
       prepareControllersRef.current.delete(controller);
     }
@@ -381,6 +393,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     },
     onError: (error, variables) => {
       if (
+        error instanceof SharePreparationAbortedError ||
         latestAuthRef.current.session?.user.id !==
           variables.identity.ownerUserId ||
         latestSessionIdRef.current !== variables.identity.sessionId
@@ -644,7 +657,7 @@ function SessionSharePreparationContent({
         </header>
 
         <div className="flex min-h-52 items-center justify-center px-5 py-4">
-          {error ? (
+          {error && !loading ? (
             <div className="flex flex-col items-center gap-3 text-center">
               <p className="text-muted-foreground text-xs">
                 <Trans>Access settings could not be loaded.</Trans>

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -91,7 +91,7 @@ export function OuterHeader({
         className="relative z-10 ml-auto flex shrink-0 items-center gap-0 pr-1"
       >
         <HeaderMeetingControl sessionId={sessionId} sessionMode={sessionMode} />
-        <SessionShareButton sessionId={sessionId} />
+        <SessionShareButton key={sessionId} sessionId={sessionId} />
         <OverflowButton
           standaloneWindow={standaloneWindow}
           sessionId={sessionId}

--- a/crates/api-sync/src/lib.rs
+++ b/crates/api-sync/src/lib.rs
@@ -7,7 +7,9 @@ mod state;
 
 pub use config::{SharedNotesConfig, SyncConfig, SyncEnv};
 pub use error::{Result, SyncError};
-pub use routes::{e2ee_witness_router, openapi, pro_router, web_edit_router};
+pub use routes::{
+    cloudsync_router, e2ee_witness_router, openapi, session_share_router, web_edit_router,
+};
 pub use shared_notes::{
     SharedNotesState, authenticated_router as authenticated_shared_notes_router,
     openapi as shared_notes_openapi, router as shared_notes_router,

--- a/crates/api-sync/src/routes/mod.rs
+++ b/crates/api-sync/src/routes/mod.rs
@@ -313,16 +313,21 @@ pub fn openapi() -> utoipa::openapi::OpenApi {
     openapi
 }
 
-pub fn pro_router(state: AppState) -> Router {
+pub fn cloudsync_router(state: AppState) -> Router {
     Router::new()
         .route("/token", post(create_credentials))
         .route("/e2ee/identity", put(claim_e2ee_identity))
+        .merge(attachment_backups::router())
+        .with_state(state)
+}
+
+pub fn session_share_router(state: AppState) -> Router {
+    Router::new()
         .route(
             "/shares/{share_id}/snapshot",
             put(publish_session_share_snapshot)
                 .layer(DefaultBodyLimit::max(MAX_SNAPSHOT_REQUEST_BYTES)),
         )
-        .merge(attachment_backups::router())
         .merge(shared_attachments::router())
         .with_state(state)
 }
@@ -1226,7 +1231,8 @@ mod tests {
             supabase_anon_key: "anon-key".to_string(),
             supabase_service_role_key: "service-role-key".to_string(),
         });
-        pro_router(state.clone())
+        cloudsync_router(state.clone())
+            .merge(session_share_router(state.clone()))
             .merge(web_edit_router(state))
             .layer(Extension(AuthContext {
                 token: "supabase-token".to_string(),


### PR DESCRIPTION
Separate CloudSync and sharing rate-limit buckets. Open the share panel before preparation finishes, scope every transition to the active account and note, keep failures retryable, and cover desktop, web, and API sharing flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated sync route composition and rate limiting for Pro features; desktop changes affect share publish timing and cancellation but are well covered by tests.
> 
> **Overview**
> **API:** Sync routes are split into separate **CloudSync** (`cloudsync_router`: token, E2EE identity, attachment backups) and **session sharing** (`session_share_router`: snapshots and shared attachments) stacks, each with its own `RateLimitState` so heavy CloudSync traffic cannot throttle share publish/web-edit. `pro_router` is removed in favor of these routers. Rate-limit middleware gains a test-only `enforce_in_debug` flag so composition tests can assert 429 behavior in debug builds.
> 
> **Desktop:** `SessionShareButton` opens the popover before preparation finishes, shows a loading/retry panel on failure (popover stays open), waits for billing readiness then continues via `SharePreparationStarter`, and keys all panel/upgrade/preparation state by **owner + session** so switching accounts or notes abandons in-flight work without toasts or auto-resume. The session header remounts the button with `key={sessionId}`.
> 
> **Tests:** Broad Vitest coverage for billing wait, note switch, upgrade dismissal, and API test that sharing still runs when CloudSync is rate-limited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4795ce02103456fca4b1171677346a9dd2fbd83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->