### PR TITLE
Add Claude launch config to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ internal
 .tmp/
 .codex-security-artifacts-*/
 .codex-security-work-ledger-*.jsonl
+.claude/launch.json


### PR DESCRIPTION
Ignore `.claude/launch.json` to prevent committing local run configuration artifacts and reduce accidental inclusion of environment-specific files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates `.gitignore`; no application, auth, or runtime behavior changes.
> 
> **Overview**
> Adds **`.claude/launch.json`** to `.gitignore` under the existing agent scratch / reference material section, alongside entries like `.tmp/` and `.codex-security-*`.
> 
> This keeps local Claude run/launch configuration out of commits so environment-specific tooling files are not accidentally checked in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 355b6469cd4aa0deb462bf01e6761266fa784eb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->