### PR TITLE
feat(editor): add comment anchor plugin and quote-anchoring module

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./app-link": "./src/app-link/index.ts",
     "./chat": "./src/chat/index.tsx",
+    "./comments": "./src/comments/index.ts",
     "./daily": "./src/daily/index.ts",
     "./markdown": "./src/markdown.ts",
     "./node-views": "./src/node-views/index.ts",

--- a/packages/editor/src/comments/anchor-text.ts
+++ b/packages/editor/src/comments/anchor-text.ts
@@ -19,6 +19,8 @@ export type DocTextIndex = {
   endPosAt(index: number): number;
   /** ProseMirror position → text offset. */
   indexAt(pos: number): number;
+  /** Whether the character at this text offset is a block separator (as opposed to a real newline inside a code block). */
+  isSeparatorAt(index: number): boolean;
 };
 
 /**
@@ -77,6 +79,17 @@ export function buildDocTextIndex(doc: PMNode): DocTextIndex {
   const contentSegments = segments.filter(
     (segment) => segment.kind !== "separator",
   );
+  const separatorOffsets = new Set<number>();
+  for (const segment of segments) {
+    if (segment.kind !== "separator") continue;
+    for (
+      let offset = segment.textStart;
+      offset < segment.textEnd;
+      offset += 1
+    ) {
+      separatorOffsets.add(offset);
+    }
+  }
 
   const posAt = (index: number): number => {
     for (const segment of contentSegments) {
@@ -117,5 +130,11 @@ export function buildDocTextIndex(doc: PMNode): DocTextIndex {
     return text.length;
   };
 
-  return { text, posAt, endPosAt, indexAt };
+  return {
+    text,
+    posAt,
+    endPosAt,
+    indexAt,
+    isSeparatorAt: (index: number) => separatorOffsets.has(index),
+  };
 }

--- a/packages/editor/src/comments/anchor-text.ts
+++ b/packages/editor/src/comments/anchor-text.ts
@@ -86,7 +86,7 @@ export function buildDocTextIndex(doc: PMNode): DocTextIndex {
         ? segment.posStart + (index - segment.textStart)
         : segment.posStart;
     }
-    const last = contentSegments.at(-1);
+    const last = contentSegments[contentSegments.length - 1];
     return last ? last.posEnd : 0;
   };
 

--- a/packages/editor/src/comments/anchor-text.ts
+++ b/packages/editor/src/comments/anchor-text.ts
@@ -1,0 +1,121 @@
+import { type Node as PMNode } from "prosemirror-model";
+
+export const ANCHOR_BLOCK_SEPARATOR = "\n";
+export const ANCHOR_LEAF_TEXT = "￼";
+
+type Segment = {
+  kind: "text" | "leaf" | "separator";
+  textStart: number;
+  textEnd: number;
+  posStart: number;
+  posEnd: number;
+};
+
+export type DocTextIndex = {
+  text: string;
+  /** Text offset of a match start → ProseMirror position (skips separators forward). */
+  posAt(index: number): number;
+  /** Exclusive text offset of a match end → ProseMirror position (skips separators backward). */
+  endPosAt(index: number): number;
+  /** ProseMirror position → text offset. */
+  indexAt(pos: number): number;
+};
+
+/**
+ * Builds a text projection of the document equal to
+ * `doc.textBetween(0, doc.content.size, ANCHOR_BLOCK_SEPARATOR, ANCHOR_LEAF_TEXT)`
+ * together with an offset↔position mapping. Capture and resolution share this
+ * one traversal so surfaces can never disagree on separator semantics.
+ */
+export function buildDocTextIndex(doc: PMNode): DocTextIndex {
+  const segments: Segment[] = [];
+  let text = "";
+  let first = true;
+
+  doc.nodesBetween(0, doc.content.size, (node, pos) => {
+    const leafText = node.isText ? "" : node.isLeaf ? ANCHOR_LEAF_TEXT : "";
+    const nodeText = node.isText ? (node.text ?? "") : leafText;
+    if (
+      node.isBlock &&
+      ((node.isLeaf && nodeText !== "") || node.isTextblock)
+    ) {
+      if (first) {
+        first = false;
+      } else {
+        segments.push({
+          kind: "separator",
+          textStart: text.length,
+          textEnd: text.length + ANCHOR_BLOCK_SEPARATOR.length,
+          posStart: pos,
+          posEnd: pos,
+        });
+        text += ANCHOR_BLOCK_SEPARATOR;
+      }
+    }
+    if (node.isText) {
+      segments.push({
+        kind: "text",
+        textStart: text.length,
+        textEnd: text.length + nodeText.length,
+        posStart: pos,
+        posEnd: pos + nodeText.length,
+      });
+      text += nodeText;
+    } else if (node.isLeaf && nodeText !== "") {
+      segments.push({
+        kind: "leaf",
+        textStart: text.length,
+        textEnd: text.length + nodeText.length,
+        posStart: pos,
+        posEnd: pos + node.nodeSize,
+      });
+      text += nodeText;
+    }
+    return undefined;
+  });
+
+  const contentSegments = segments.filter(
+    (segment) => segment.kind !== "separator",
+  );
+
+  const posAt = (index: number): number => {
+    for (const segment of contentSegments) {
+      if (index >= segment.textEnd) continue;
+      if (index < segment.textStart) return segment.posStart;
+      return segment.kind === "text"
+        ? segment.posStart + (index - segment.textStart)
+        : segment.posStart;
+    }
+    const last = contentSegments.at(-1);
+    return last ? last.posEnd : 0;
+  };
+
+  const endPosAt = (index: number): number => {
+    for (let i = contentSegments.length - 1; i >= 0; i -= 1) {
+      const segment = contentSegments[i];
+      if (index <= segment.textStart) continue;
+      if (index > segment.textEnd) return segment.posEnd;
+      return segment.kind === "text"
+        ? segment.posStart + (index - segment.textStart)
+        : segment.posEnd;
+    }
+    const firstSegment = contentSegments[0];
+    return firstSegment ? firstSegment.posStart : 0;
+  };
+
+  const indexAt = (pos: number): number => {
+    for (const segment of contentSegments) {
+      if (pos < segment.posStart) return segment.textStart;
+      if (pos <= segment.posEnd) {
+        return segment.kind === "text"
+          ? segment.textStart + (pos - segment.posStart)
+          : pos === segment.posStart
+            ? segment.textStart
+            : segment.textEnd;
+      }
+    }
+    return text.length;
+  };
+
+  return { text, posAt, endPosAt, indexAt };
+}

--- a/packages/editor/src/comments/anchor.test.ts
+++ b/packages/editor/src/comments/anchor.test.ts
@@ -1,0 +1,223 @@
+import { type Node as PMNode } from "prosemirror-model";
+import { describe, expect, it } from "vitest";
+
+import { schema } from "../note/schema";
+import {
+  captureCommentAnchor,
+  MAX_ANCHOR_QUOTE_LENGTH,
+  resolveCommentAnchor,
+  resolveCommentAnchors,
+} from "./anchor";
+import {
+  ANCHOR_BLOCK_SEPARATOR,
+  ANCHOR_LEAF_TEXT,
+  buildDocTextIndex,
+} from "./anchor-text";
+
+const paragraph = (text: string) =>
+  schema.node("paragraph", null, text ? [schema.text(text)] : []);
+
+const doc = (...children: PMNode[]) => schema.node("doc", null, children);
+
+const fixture = () =>
+  doc(
+    schema.node("heading", { level: 1 }, [schema.text("Fixture title")]),
+    paragraph("The quick brown fox jumps over the lazy dog."),
+    schema.node("bulletList", null, [
+      schema.node("listItem", null, [paragraph("First bullet point")]),
+      schema.node("listItem", null, [paragraph("Second bullet point")]),
+    ]),
+    paragraph("A closing paragraph with unique words."),
+  );
+
+describe("buildDocTextIndex", () => {
+  it("matches ProseMirror textBetween over mixed fixtures", () => {
+    const fixtures = [
+      fixture(),
+      doc(paragraph("only one paragraph")),
+      doc(
+        paragraph("before image"),
+        schema.node("paragraph", null, [
+          schema.text("with "),
+          schema.node("hardBreak"),
+          schema.text(" break"),
+        ]),
+        paragraph("after"),
+      ),
+      doc(
+        schema.node("blockquote", null, [paragraph("quoted block")]),
+        paragraph("plain"),
+      ),
+    ];
+    for (const document of fixtures) {
+      expect(buildDocTextIndex(document).text).toBe(
+        document.textBetween(
+          0,
+          document.content.size,
+          ANCHOR_BLOCK_SEPARATOR,
+          ANCHOR_LEAF_TEXT,
+        ),
+      );
+    }
+  });
+
+  it("round-trips offsets and positions inside a text block", () => {
+    const document = doc(paragraph("hello world"));
+    const index = buildDocTextIndex(document);
+    const offset = index.text.indexOf("world");
+    const pos = index.posAt(offset);
+    expect(index.indexAt(pos)).toBe(offset);
+    expect(document.textBetween(pos, index.endPosAt(offset + 5))).toBe("world");
+  });
+});
+
+describe("captureCommentAnchor", () => {
+  it("captures the quote with prefix and suffix context", () => {
+    const document = fixture();
+    const index = buildDocTextIndex(document);
+    const offset = index.text.indexOf("brown fox");
+    const from = index.posAt(offset);
+    const to = index.endPosAt(offset + "brown fox".length);
+
+    const anchor = captureCommentAnchor(document, from, to, 3);
+    expect(anchor).not.toBeNull();
+    expect(anchor?.quoteExact).toBe("brown fox");
+    expect(anchor?.quotePrefix.endsWith("The quick ")).toBe(true);
+    expect(anchor?.quoteSuffix.startsWith(" jumps over")).toBe(true);
+    expect(anchor?.fromHint).toBe(from);
+    expect(anchor?.toHint).toBe(to);
+    expect(anchor?.snapshotRevision).toBe(3);
+  });
+
+  it("captures across block boundaries with the separator", () => {
+    const document = fixture();
+    const index = buildDocTextIndex(document);
+    const offset = index.text.indexOf("First bullet");
+    const end = index.text.indexOf("Second bullet") + "Second".length;
+    const anchor = captureCommentAnchor(
+      document,
+      index.posAt(offset),
+      index.endPosAt(end),
+      1,
+    );
+    expect(anchor?.quoteExact).toContain(ANCHOR_BLOCK_SEPARATOR);
+    expect(anchor?.quoteExact.startsWith("First bullet")).toBe(true);
+  });
+
+  it("returns null for empty or oversized selections", () => {
+    const document = fixture();
+    expect(captureCommentAnchor(document, 5, 5, 1)).toBeNull();
+
+    const longText = "y".repeat(MAX_ANCHOR_QUOTE_LENGTH + 10);
+    const longDoc = doc(paragraph(longText));
+    expect(captureCommentAnchor(longDoc, 1, 1 + longText.length, 1)).toBeNull();
+  });
+});
+
+describe("resolveCommentAnchor", () => {
+  it("uses verified hints at the matching revision", () => {
+    const document = fixture();
+    const index = buildDocTextIndex(document);
+    const offset = index.text.indexOf("lazy dog");
+    const from = index.posAt(offset);
+    const to = index.endPosAt(offset + "lazy dog".length);
+    const anchor = captureCommentAnchor(document, from, to, 5)!;
+
+    expect(resolveCommentAnchor(document, anchor, 5)).toEqual({ from, to });
+  });
+
+  it("rejects stale hints and re-resolves by quote", () => {
+    const document = fixture();
+    const index = buildDocTextIndex(document);
+    const offset = index.text.indexOf("closing paragraph");
+    const anchor = captureCommentAnchor(
+      document,
+      index.posAt(offset),
+      index.endPosAt(offset + "closing paragraph".length),
+      5,
+    )!;
+
+    const grown = doc(
+      paragraph("A brand new opening paragraph."),
+      ...document.children,
+    );
+    const resolved = resolveCommentAnchor(grown, anchor, 6);
+    expect(resolved).not.toBeNull();
+    expect(grown.textBetween(resolved!.from, resolved!.to)).toBe(
+      "closing paragraph",
+    );
+  });
+
+  it("disambiguates duplicate quotes by context and refuses ties", () => {
+    const duplicated = doc(
+      paragraph("alpha target beta"),
+      paragraph("gamma target delta"),
+    );
+    const index = buildDocTextIndex(duplicated);
+    const second = index.text.lastIndexOf("target");
+    const anchor = captureCommentAnchor(
+      duplicated,
+      index.posAt(second),
+      index.endPosAt(second + "target".length),
+      1,
+    )!;
+
+    const resolved = resolveCommentAnchor(duplicated, anchor, 2);
+    expect(resolved).not.toBeNull();
+    expect(index.indexAt(resolved!.from)).toBe(second);
+
+    const tied = doc(
+      paragraph("alpha target beta"),
+      paragraph("alpha target beta"),
+    );
+    const tieAnchor = {
+      ...anchor,
+      quotePrefix: "alpha ",
+      quoteSuffix: " beta",
+    };
+    expect(resolveCommentAnchor(tied, tieAnchor, 2)).toBeNull();
+  });
+
+  it("returns null when the quoted text is gone", () => {
+    const document = fixture();
+    const index = buildDocTextIndex(document);
+    const offset = index.text.indexOf("unique words");
+    const anchor = captureCommentAnchor(
+      document,
+      index.posAt(offset),
+      index.endPosAt(offset + "unique words".length),
+      1,
+    )!;
+
+    const rewritten = doc(paragraph("Entirely different content now."));
+    expect(resolveCommentAnchor(rewritten, anchor, 2)).toBeNull();
+  });
+
+  it("resolves batches with one shared index", () => {
+    const document = fixture();
+    const index = buildDocTextIndex(document);
+    const offset = index.text.indexOf("Fixture title");
+    const anchor = captureCommentAnchor(
+      document,
+      index.posAt(offset),
+      index.endPosAt(offset + "Fixture title".length),
+      1,
+    )!;
+
+    const resolved = resolveCommentAnchors(
+      document,
+      [
+        { commentId: "a", anchor },
+        { commentId: "b", anchor: null },
+        {
+          commentId: "c",
+          anchor: { ...anchor, quoteExact: "not in the document" },
+        },
+      ],
+      1,
+    );
+    expect(resolved[0].range).not.toBeNull();
+    expect(resolved[1].range).toBeNull();
+    expect(resolved[2].range).toBeNull();
+  });
+});

--- a/packages/editor/src/comments/anchor.test.ts
+++ b/packages/editor/src/comments/anchor.test.ts
@@ -104,6 +104,28 @@ describe("captureCommentAnchor", () => {
     expect(anchor?.quoteExact.startsWith("First bullet")).toBe(true);
   });
 
+  it("trims boundary separators so quotes survive neighbor-block changes", () => {
+    const document = doc(paragraph("first block"), paragraph("second block"));
+    const index = buildDocTextIndex(document);
+    const separator = index.text.indexOf(ANCHOR_BLOCK_SEPARATOR);
+    // Selection starts at the end of block one, before the separator.
+    const from = index.endPosAt(separator);
+    const to = index.endPosAt(index.text.indexOf("second") + "second".length);
+
+    const anchor = captureCommentAnchor(document, from, to, 1)!;
+    expect(anchor.quoteExact).toBe("second");
+    expect(anchor.quoteExact.startsWith(ANCHOR_BLOCK_SEPARATOR)).toBe(false);
+
+    expect(resolveCommentAnchor(document, anchor, 1)).not.toBeNull();
+
+    const withoutFirstBlock = doc(paragraph("second block"));
+    const resolved = resolveCommentAnchor(withoutFirstBlock, anchor, 2);
+    expect(resolved).not.toBeNull();
+    expect(withoutFirstBlock.textBetween(resolved!.from, resolved!.to)).toBe(
+      "second",
+    );
+  });
+
   it("returns null for empty or oversized selections", () => {
     const document = fixture();
     expect(captureCommentAnchor(document, 5, 5, 1)).toBeNull();

--- a/packages/editor/src/comments/anchor.test.ts
+++ b/packages/editor/src/comments/anchor.test.ts
@@ -126,6 +126,28 @@ describe("captureCommentAnchor", () => {
     );
   });
 
+  it("keeps real newlines inside code blocks while trimming separators", () => {
+    const document = doc(
+      paragraph("before"),
+      schema.node("codeBlock", null, [schema.text("line one\nline two")]),
+    );
+    const index = buildDocTextIndex(document);
+    const start = index.text.indexOf("one");
+    // Selection ends on the literal newline inside the code block.
+    const end = index.text.indexOf("\nline two", start) + 1;
+    const anchor = captureCommentAnchor(
+      document,
+      index.posAt(start),
+      index.endPosAt(end),
+      1,
+    )!;
+    expect(anchor.quoteExact).toBe("one\n");
+
+    const resolved = resolveCommentAnchor(document, anchor, 1);
+    expect(resolved).not.toBeNull();
+    expect(document.textBetween(resolved!.from, resolved!.to)).toBe("one\n");
+  });
+
   it("returns null for empty or oversized selections", () => {
     const document = fixture();
     expect(captureCommentAnchor(document, 5, 5, 1)).toBeNull();

--- a/packages/editor/src/comments/anchor.ts
+++ b/packages/editor/src/comments/anchor.ts
@@ -1,0 +1,183 @@
+import { type Node as PMNode } from "prosemirror-model";
+
+import {
+  ANCHOR_LEAF_TEXT,
+  buildDocTextIndex,
+  type DocTextIndex,
+} from "./anchor-text";
+
+export const ANCHOR_CONTEXT_LENGTH = 64;
+export const MAX_ANCHOR_QUOTE_LENGTH = 1024;
+
+export type CommentAnchor = {
+  quoteExact: string;
+  quotePrefix: string;
+  quoteSuffix: string;
+  fromHint: number | null;
+  toHint: number | null;
+  snapshotRevision: number;
+};
+
+export type ResolvedAnchorRange = { from: number; to: number };
+
+/**
+ * Captures a quote anchor for the selected range. Returns null when the
+ * selection has no anchorable text (empty, or only leaf placeholders) or is
+ * longer than MAX_ANCHOR_QUOTE_LENGTH — callers hide the comment affordance.
+ */
+export function captureCommentAnchor(
+  doc: PMNode,
+  from: number,
+  to: number,
+  snapshotRevision: number,
+): CommentAnchor | null {
+  if (to <= from) return null;
+  const index = buildDocTextIndex(doc);
+  const fromIndex = index.indexAt(from);
+  const toIndex = index.indexAt(to);
+  const quoteExact = index.text.slice(fromIndex, toIndex);
+  if (
+    quoteExact.length === 0 ||
+    quoteExact.length > MAX_ANCHOR_QUOTE_LENGTH ||
+    isPlaceholderOnly(quoteExact)
+  ) {
+    return null;
+  }
+  return {
+    quoteExact,
+    quotePrefix: index.text.slice(
+      Math.max(0, fromIndex - ANCHOR_CONTEXT_LENGTH),
+      fromIndex,
+    ),
+    quoteSuffix: index.text.slice(toIndex, toIndex + ANCHOR_CONTEXT_LENGTH),
+    fromHint: from,
+    toHint: to,
+    snapshotRevision,
+  };
+}
+
+/**
+ * Resolves an anchor against a document. The hint fast path is only trusted
+ * when the revision matches AND the hinted slice still equals the quote;
+ * otherwise the quote is searched. Several occurrences are disambiguated by
+ * prefix/suffix overlap; a tie resolves to null (unanchored) — never a guess.
+ */
+export function resolveCommentAnchor(
+  doc: PMNode,
+  anchor: CommentAnchor,
+  currentRevision: number,
+  index: DocTextIndex = buildDocTextIndex(doc),
+): ResolvedAnchorRange | null {
+  const { quoteExact } = anchor;
+  if (quoteExact.length === 0) return null;
+
+  if (
+    anchor.snapshotRevision === currentRevision &&
+    anchor.fromHint !== null &&
+    anchor.toHint !== null &&
+    anchor.fromHint >= 0 &&
+    anchor.toHint <= doc.content.size &&
+    anchor.fromHint < anchor.toHint
+  ) {
+    const hintedSlice = index.text.slice(
+      index.indexAt(anchor.fromHint),
+      index.indexAt(anchor.toHint),
+    );
+    if (hintedSlice === quoteExact) {
+      return { from: anchor.fromHint, to: anchor.toHint };
+    }
+  }
+
+  const occurrences: number[] = [];
+  let cursor = index.text.indexOf(quoteExact);
+  while (cursor !== -1) {
+    occurrences.push(cursor);
+    cursor = index.text.indexOf(quoteExact, cursor + 1);
+  }
+  if (occurrences.length === 0) return null;
+
+  let winner: number;
+  if (occurrences.length === 1) {
+    winner = occurrences[0];
+  } else {
+    let bestScore = -1;
+    let bestStart = -1;
+    let tie = false;
+    for (const start of occurrences) {
+      const score = contextScore(index.text, start, quoteExact.length, anchor);
+      if (score > bestScore) {
+        bestScore = score;
+        bestStart = start;
+        tie = false;
+      } else if (score === bestScore) {
+        tie = true;
+      }
+    }
+    if (tie) return null;
+    winner = bestStart;
+  }
+
+  const from = index.posAt(winner);
+  const to = index.endPosAt(winner + quoteExact.length);
+  return from < to ? { from, to } : null;
+}
+
+/** Batch resolution that builds the text index once. */
+export function resolveCommentAnchors<
+  T extends { commentId: string; anchor: CommentAnchor | null },
+>(
+  doc: PMNode,
+  comments: readonly T[],
+  currentRevision: number,
+): Array<{ commentId: string; range: ResolvedAnchorRange | null }> {
+  const index = buildDocTextIndex(doc);
+  return comments.map((comment) => ({
+    commentId: comment.commentId,
+    range: comment.anchor
+      ? resolveCommentAnchor(doc, comment.anchor, currentRevision, index)
+      : null,
+  }));
+}
+
+function contextScore(
+  text: string,
+  start: number,
+  quoteLength: number,
+  anchor: CommentAnchor,
+): number {
+  const before = text.slice(Math.max(0, start - ANCHOR_CONTEXT_LENGTH), start);
+  const after = text.slice(
+    start + quoteLength,
+    start + quoteLength + ANCHOR_CONTEXT_LENGTH,
+  );
+  return (
+    commonSuffixLength(anchor.quotePrefix, before) +
+    commonPrefixLength(anchor.quoteSuffix, after)
+  );
+}
+
+function commonPrefixLength(left: string, right: string): number {
+  const max = Math.min(left.length, right.length);
+  let length = 0;
+  while (length < max && left[length] === right[length]) length += 1;
+  return length;
+}
+
+function commonSuffixLength(left: string, right: string): number {
+  const max = Math.min(left.length, right.length);
+  let length = 0;
+  while (
+    length < max &&
+    left[left.length - 1 - length] === right[right.length - 1 - length]
+  ) {
+    length += 1;
+  }
+  return length;
+}
+
+function isPlaceholderOnly(quote: string): boolean {
+  for (const character of quote) {
+    if (character !== ANCHOR_LEAF_TEXT && character !== "\n") return false;
+  }
+  return true;
+}

--- a/packages/editor/src/comments/anchor.ts
+++ b/packages/editor/src/comments/anchor.ts
@@ -33,8 +33,13 @@ export function captureCommentAnchor(
 ): CommentAnchor | null {
   if (to <= from) return null;
   const index = buildDocTextIndex(doc);
-  const fromIndex = index.indexAt(from);
-  const toIndex = index.indexAt(to);
+  let fromIndex = index.indexAt(from);
+  let toIndex = index.indexAt(to);
+  // Trim boundary separators: a quote stored with a leading or trailing
+  // block separator would stop matching when the neighboring block changes,
+  // even though every visibly selected character still exists.
+  while (fromIndex < toIndex && index.text[fromIndex] === "\n") fromIndex += 1;
+  while (toIndex > fromIndex && index.text[toIndex - 1] === "\n") toIndex -= 1;
   const quoteExact = index.text.slice(fromIndex, toIndex);
   if (
     quoteExact.length === 0 ||
@@ -50,8 +55,8 @@ export function captureCommentAnchor(
       fromIndex,
     ),
     quoteSuffix: index.text.slice(toIndex, toIndex + ANCHOR_CONTEXT_LENGTH),
-    fromHint: from,
-    toHint: to,
+    fromHint: index.posAt(fromIndex),
+    toHint: index.endPosAt(toIndex),
     snapshotRevision,
   };
 }

--- a/packages/editor/src/comments/anchor.ts
+++ b/packages/editor/src/comments/anchor.ts
@@ -35,16 +35,17 @@ export function captureCommentAnchor(
   const index = buildDocTextIndex(doc);
   let fromIndex = index.indexAt(from);
   let toIndex = index.indexAt(to);
-  // Trim boundary separators: a quote stored with a leading or trailing
-  // block separator would stop matching when the neighboring block changes,
-  // even though every visibly selected character still exists.
-  while (fromIndex < toIndex && index.text[fromIndex] === "\n") fromIndex += 1;
-  while (toIndex > fromIndex && index.text[toIndex - 1] === "\n") toIndex -= 1;
+  // Trim boundary block separators: a quote stored with one would stop
+  // matching when the neighboring block changes, even though every visibly
+  // selected character still exists. Real newlines inside code blocks are
+  // content and must be kept, so this checks positions, not characters.
+  while (fromIndex < toIndex && index.isSeparatorAt(fromIndex)) fromIndex += 1;
+  while (toIndex > fromIndex && index.isSeparatorAt(toIndex - 1)) toIndex -= 1;
   const quoteExact = index.text.slice(fromIndex, toIndex);
   if (
     quoteExact.length === 0 ||
     quoteExact.length > MAX_ANCHOR_QUOTE_LENGTH ||
-    isPlaceholderOnly(quoteExact)
+    !hasAnchorableContent(index, fromIndex, toIndex)
   ) {
     return null;
   }
@@ -180,9 +181,16 @@ function commonSuffixLength(left: string, right: string): number {
   return length;
 }
 
-function isPlaceholderOnly(quote: string): boolean {
-  for (const character of quote) {
-    if (character !== ANCHOR_LEAF_TEXT && character !== "\n") return false;
+function hasAnchorableContent(
+  index: DocTextIndex,
+  fromIndex: number,
+  toIndex: number,
+): boolean {
+  for (let offset = fromIndex; offset < toIndex; offset += 1) {
+    const character = index.text[offset];
+    if (character === ANCHOR_LEAF_TEXT) continue;
+    if (character === "\n" && index.isSeparatorAt(offset)) continue;
+    return true;
   }
-  return true;
+  return false;
 }

--- a/packages/editor/src/comments/index.ts
+++ b/packages/editor/src/comments/index.ts
@@ -1,0 +1,15 @@
+export {
+  ANCHOR_BLOCK_SEPARATOR,
+  ANCHOR_LEAF_TEXT,
+  buildDocTextIndex,
+  type DocTextIndex,
+} from "./anchor-text";
+export {
+  ANCHOR_CONTEXT_LENGTH,
+  captureCommentAnchor,
+  type CommentAnchor,
+  MAX_ANCHOR_QUOTE_LENGTH,
+  resolveCommentAnchor,
+  resolveCommentAnchors,
+  type ResolvedAnchorRange,
+} from "./anchor";

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -53,6 +53,8 @@ import {
   clearMarksOnEnterPlugin,
   clipboardPlugin,
   clipPastePlugin,
+  type CommentAnchorsEvent,
+  commentAnchorsPlugin,
   docChangeListenerPlugin,
   ensureImageTrailingParagraphs,
   fileHandlerPlugin,
@@ -100,6 +102,16 @@ import {
 export type { MentionConfig, FileHandlerConfig, PlaceholderFunction };
 export { normalizePortableAttachmentUrls } from "./portable-attachments";
 export { schema };
+export {
+  type CommentAnchorInput,
+  type CommentAnchorsEvent,
+  commentAnchorsPluginKey,
+  getCommentAnchorRanges,
+  getCommentAnchorScreenPositions,
+  getSelectionScreenRect,
+  setActiveCommentAnchor,
+  setCommentAnchors,
+} from "../plugins/comment-anchors";
 export { useLinkedItemOpenBehavior };
 
 export interface JSONContent {
@@ -175,6 +187,9 @@ export interface NoteEditorProps {
   onViewDisposed?: (view: EditorView) => void;
   syncContentWhenFocused?: boolean;
   enforceTitleHeading?: boolean;
+  /** Fixed at mount: plugins are not reconfigurable afterwards. */
+  commentAnchorsEnabled?: boolean;
+  onCommentAnchorsEvent?: (event: CommentAnchorsEvent) => void;
 }
 
 const baseNodeViews = {
@@ -568,7 +583,12 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       onViewDisposed,
       syncContentWhenFocused = false,
       enforceTitleHeading = true,
+      commentAnchorsEnabled = false,
+      onCommentAnchorsEvent,
     } = props;
+
+    const commentAnchorsEventRef = useRef(onCommentAnchorsEvent);
+    commentAnchorsEventRef.current = onCommentAnchorsEvent;
 
     const taskStorage = useTaskStorageOptional();
     const normalizedInitialContent = useMemo(
@@ -688,6 +708,13 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         gapCursor(),
         clipboardPlugin(),
         hashtagPlugin(),
+        ...(commentAnchorsEnabled
+          ? [
+              commentAnchorsPlugin({
+                onEvent: (event) => commentAnchorsEventRef.current?.(event),
+              }),
+            ]
+          : []),
         imageTrailingParagraphPlugin(),
         searchPlugin(),
         placeholderPlugin(placeholderComponent),
@@ -712,6 +739,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         enforceTitleHeading,
         readOnly,
         setCompositionActive,
+        commentAnchorsEnabled,
       ],
     );
     const nodeViews = useMemo(

--- a/packages/editor/src/plugins/comment-anchors.test.ts
+++ b/packages/editor/src/plugins/comment-anchors.test.ts
@@ -111,6 +111,17 @@ describe("commentAnchorsPlugin", () => {
     expect(mapped).toEqual([{ commentId: "span", from: 4, to: size - 2 }]);
   });
 
+  it("keeps boundary insertions outside the anchored range", () => {
+    let state = createState();
+    state = setAnchors(state, [{ commentId: "c1", from: 7, to: 15 }]);
+    state = state.apply(state.tr.insertText("!!", 15));
+    state = state.apply(state.tr.insertText("--", 7));
+
+    expect(getCommentAnchorRanges(state)).toEqual([
+      { commentId: "c1", from: 9, to: 17 },
+    ]);
+  });
+
   it("ignores anchors outside the document", () => {
     let state = createState();
     state = setAnchors(state, [

--- a/packages/editor/src/plugins/comment-anchors.test.ts
+++ b/packages/editor/src/plugins/comment-anchors.test.ts
@@ -85,6 +85,21 @@ describe("commentAnchorsPlugin", () => {
     expect(classes.get("c2")).toBe("comment-anchor comment-anchor-active");
   });
 
+  it("remaps ranges when one transaction edits the doc and sets the active comment", () => {
+    let state = createState();
+    state = setAnchors(state, [{ commentId: "c1", from: 7, to: 15 }]);
+    state = state.apply(
+      state.tr
+        .insertText("XX", 1)
+        .setMeta(commentAnchorsPluginKey, { type: "active", commentId: "c1" }),
+    );
+
+    expect(getCommentAnchorRanges(state)).toEqual([
+      { commentId: "c1", from: 9, to: 17 },
+    ]);
+    expect(commentAnchorsPluginKey.getState(state)!.activeId).toBe("c1");
+  });
+
   it("returns one merged range for a cross-block anchor", () => {
     let state = EditorState.create({
       schema,

--- a/packages/editor/src/plugins/comment-anchors.test.ts
+++ b/packages/editor/src/plugins/comment-anchors.test.ts
@@ -85,6 +85,32 @@ describe("commentAnchorsPlugin", () => {
     expect(classes.get("c2")).toBe("comment-anchor comment-anchor-active");
   });
 
+  it("returns one merged range for a cross-block anchor", () => {
+    let state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [schema.text("first block")]),
+        schema.node("paragraph", null, [schema.text("second block")]),
+      ]),
+      plugins: [commentAnchorsPlugin()],
+    });
+    const size = state.doc.content.size;
+    state = setAnchors(state, [{ commentId: "span", from: 3, to: size - 3 }]);
+
+    const ranges = getCommentAnchorRanges(state);
+    expect(ranges).toEqual([{ commentId: "span", from: 3, to: size - 3 }]);
+
+    state = state.apply(state.tr.insertText("x", 1));
+    state = state.apply(
+      state.tr.setMeta(commentAnchorsPluginKey, {
+        type: "active",
+        commentId: "span",
+      }),
+    );
+    const mapped = getCommentAnchorRanges(state);
+    expect(mapped).toEqual([{ commentId: "span", from: 4, to: size - 2 }]);
+  });
+
   it("ignores anchors outside the document", () => {
     let state = createState();
     state = setAnchors(state, [

--- a/packages/editor/src/plugins/comment-anchors.test.ts
+++ b/packages/editor/src/plugins/comment-anchors.test.ts
@@ -1,0 +1,126 @@
+import { EditorState, TextSelection } from "prosemirror-state";
+import { describe, expect, it } from "vitest";
+
+import { schema } from "../note/schema";
+import {
+  commentAnchorsPlugin,
+  commentAnchorsPluginKey,
+  getCommentAnchorRanges,
+} from "./comment-anchors";
+
+const createState = () =>
+  EditorState.create({
+    schema,
+    doc: schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("hello anchored world")]),
+    ]),
+    plugins: [commentAnchorsPlugin()],
+  });
+
+const setAnchors = (
+  state: EditorState,
+  anchors: Array<{ commentId: string; from: number; to: number }>,
+) =>
+  state.apply(
+    state.tr.setMeta(commentAnchorsPluginKey, { type: "set", anchors }),
+  );
+
+describe("commentAnchorsPlugin", () => {
+  it("creates decorations from set metadata", () => {
+    let state = createState();
+    state = setAnchors(state, [{ commentId: "c1", from: 7, to: 15 }]);
+
+    const ranges = getCommentAnchorRanges(state);
+    expect(ranges).toEqual([{ commentId: "c1", from: 7, to: 15 }]);
+
+    const decorations = commentAnchorsPluginKey
+      .getState(state)!
+      .decorations.find();
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].spec.commentId).toBe("c1");
+  });
+
+  it("maps ranges through document edits", () => {
+    let state = createState();
+    state = setAnchors(state, [{ commentId: "c1", from: 7, to: 15 }]);
+    state = state.apply(state.tr.insertText("XX", 1));
+
+    expect(getCommentAnchorRanges(state)).toEqual([
+      { commentId: "c1", from: 9, to: 17 },
+    ]);
+  });
+
+  it("drops ranges whose text is deleted", () => {
+    let state = createState();
+    state = setAnchors(state, [{ commentId: "c1", from: 7, to: 15 }]);
+    state = state.apply(state.tr.delete(6, 16));
+
+    expect(getCommentAnchorRanges(state)).toEqual([]);
+  });
+
+  it("swaps the active class through active metadata", () => {
+    let state = createState();
+    state = setAnchors(state, [
+      { commentId: "c1", from: 1, to: 6 },
+      { commentId: "c2", from: 7, to: 15 },
+    ]);
+    state = state.apply(
+      state.tr.setMeta(commentAnchorsPluginKey, {
+        type: "active",
+        commentId: "c2",
+      }),
+    );
+
+    const classes = new Map(
+      commentAnchorsPluginKey
+        .getState(state)!
+        .decorations.find()
+        .map((decoration) => [
+          decoration.spec.commentId as string,
+          (decoration as unknown as { type: { attrs: { class: string } } }).type
+            .attrs.class,
+        ]),
+    );
+    expect(classes.get("c1")).toBe("comment-anchor");
+    expect(classes.get("c2")).toBe("comment-anchor comment-anchor-active");
+  });
+
+  it("ignores anchors outside the document", () => {
+    let state = createState();
+    state = setAnchors(state, [
+      { commentId: "ok", from: 1, to: 6 },
+      { commentId: "oob", from: 100, to: 120 },
+      { commentId: "collapsed", from: 3, to: 3 },
+    ]);
+
+    expect(getCommentAnchorRanges(state).map((a) => a.commentId)).toEqual([
+      "ok",
+    ]);
+  });
+
+  it("reports selection changes through the event callback", () => {
+    const events: Array<{ from: number; to: number; empty: boolean }> = [];
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [schema.text("hello anchored world")]),
+      ]),
+      plugins: [
+        commentAnchorsPlugin({
+          onEvent: (event) => {
+            if (event.type === "selection") events.push(event);
+          },
+        }),
+      ],
+    });
+    const selected = state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, 1, 6)),
+    );
+    // The selection event fires from the editor view; at the state level we
+    // assert the plugin state stays intact across selection transactions.
+    expect(
+      commentAnchorsPluginKey.getState(selected)?.decorations,
+    ).toBeDefined();
+    expect(events).toHaveLength(0);
+  });
+});

--- a/packages/editor/src/plugins/comment-anchors.ts
+++ b/packages/editor/src/plugins/comment-anchors.ts
@@ -159,10 +159,11 @@ export function getCommentAnchorScreenPositions(
 ): Array<CommentAnchorInput & { top: number; bottom: number; left: number }> {
   return getCommentAnchorRanges(view.state).map((anchor) => {
     const start = view.coordsAtPos(anchor.from);
+    const end = view.coordsAtPos(anchor.to);
     return {
       ...anchor,
-      top: start.top,
-      bottom: start.bottom,
+      top: Math.min(start.top, end.top),
+      bottom: Math.max(start.bottom, end.bottom),
       left: start.left,
     };
   });
@@ -210,16 +211,25 @@ function buildDecorations(
 }
 
 function collectAnchorRanges(decorations: DecorationSet): CommentAnchorInput[] {
-  return decorations
-    .find()
-    .filter(
-      (decoration) =>
-        typeof decoration.spec.commentId === "string" &&
-        decoration.from < decoration.to,
-    )
-    .map((decoration) => ({
-      commentId: decoration.spec.commentId as string,
-      from: decoration.from,
-      to: decoration.to,
-    }));
+  // A cross-block anchor may come back from find() as several fragments;
+  // merge per commentId so callers always see one range per comment.
+  const merged = new Map<string, CommentAnchorInput>();
+  for (const decoration of decorations.find()) {
+    const commentId = decoration.spec.commentId;
+    if (typeof commentId !== "string" || decoration.from >= decoration.to) {
+      continue;
+    }
+    const existing = merged.get(commentId);
+    if (existing) {
+      existing.from = Math.min(existing.from, decoration.from);
+      existing.to = Math.max(existing.to, decoration.to);
+    } else {
+      merged.set(commentId, {
+        commentId,
+        from: decoration.from,
+        to: decoration.to,
+      });
+    }
+  }
+  return [...merged.values()];
 }

--- a/packages/editor/src/plugins/comment-anchors.ts
+++ b/packages/editor/src/plugins/comment-anchors.ts
@@ -65,13 +65,12 @@ export function commentAnchorsPlugin(options?: {
           };
         }
         if (meta?.type === "active") {
+          const anchors = tr.docChanged
+            ? mapAnchorsThrough(tr.mapping, pluginState.anchors)
+            : pluginState.anchors;
           return {
-            decorations: buildDecorations(
-              tr.doc,
-              pluginState.anchors,
-              meta.commentId,
-            ),
-            anchors: pluginState.anchors,
+            decorations: buildDecorations(tr.doc, anchors, meta.commentId),
+            anchors,
             activeId: meta.commentId,
           };
         }
@@ -80,11 +79,7 @@ export function commentAnchorsPlugin(options?: {
         }
         return {
           decorations: pluginState.decorations.map(tr.mapping, tr.doc),
-          anchors: pluginState.anchors.flatMap((anchor) => {
-            const from = tr.mapping.map(anchor.from, 1);
-            const to = tr.mapping.map(anchor.to, -1);
-            return from < to ? [{ ...anchor, from, to }] : [];
-          }),
+          anchors: mapAnchorsThrough(tr.mapping, pluginState.anchors),
           activeId: pluginState.activeId,
         };
       },
@@ -200,6 +195,17 @@ export function getSelectionScreenRect(
     right: Math.max(start.right, end.right),
     bottom: Math.max(start.bottom, end.bottom),
   };
+}
+
+function mapAnchorsThrough(
+  mapping: { map(pos: number, assoc?: number): number },
+  anchors: CommentAnchorInput[],
+): CommentAnchorInput[] {
+  return anchors.flatMap((anchor) => {
+    const from = mapping.map(anchor.from, 1);
+    const to = mapping.map(anchor.to, -1);
+    return from < to ? [{ ...anchor, from, to }] : [];
+  });
 }
 
 function buildDecorations(

--- a/packages/editor/src/plugins/comment-anchors.ts
+++ b/packages/editor/src/plugins/comment-anchors.ts
@@ -14,6 +14,9 @@ export type CommentAnchorsEvent =
 
 type CommentAnchorsState = {
   decorations: DecorationSet;
+  // Canonical ranges mapped through every transaction; decorations are a
+  // render artifact and may fragment, so ranges are never derived from them.
+  anchors: CommentAnchorInput[];
   activeId: string | null;
 };
 
@@ -39,19 +42,25 @@ export function commentAnchorsPlugin(options?: {
     key: commentAnchorsPluginKey,
     state: {
       init() {
-        return { decorations: DecorationSet.empty, activeId: null };
+        return {
+          decorations: DecorationSet.empty,
+          anchors: [],
+          activeId: null,
+        };
       },
       apply(tr, pluginState) {
         const meta = tr.getMeta(commentAnchorsPluginKey) as
           | CommentAnchorsMeta
           | undefined;
         if (meta?.type === "set") {
+          const anchors = clampAnchors(meta.anchors, tr.doc.content.size);
           return {
             decorations: buildDecorations(
               tr.doc,
-              meta.anchors,
+              anchors,
               pluginState.activeId,
             ),
+            anchors,
             activeId: pluginState.activeId,
           };
         }
@@ -59,14 +68,23 @@ export function commentAnchorsPlugin(options?: {
           return {
             decorations: buildDecorations(
               tr.doc,
-              collectAnchorRanges(pluginState.decorations),
+              pluginState.anchors,
               meta.commentId,
             ),
+            anchors: pluginState.anchors,
             activeId: meta.commentId,
           };
         }
+        if (!tr.docChanged) {
+          return pluginState;
+        }
         return {
           decorations: pluginState.decorations.map(tr.mapping, tr.doc),
+          anchors: pluginState.anchors.flatMap((anchor) => {
+            const from = tr.mapping.map(anchor.from, 1);
+            const to = tr.mapping.map(anchor.to, -1);
+            return from < to ? [{ ...anchor, from, to }] : [];
+          }),
           activeId: pluginState.activeId,
         };
       },
@@ -149,8 +167,7 @@ export function setActiveCommentAnchor(
 export function getCommentAnchorRanges(
   state: EditorState,
 ): CommentAnchorInput[] {
-  const pluginState = commentAnchorsPluginKey.getState(state);
-  return pluginState ? collectAnchorRanges(pluginState.decorations) : [];
+  return commentAnchorsPluginKey.getState(state)?.anchors ?? [];
 }
 
 /** Viewport coordinates for each anchor, for aligning side cards. */
@@ -210,26 +227,12 @@ function buildDecorations(
   return DecorationSet.create(doc, decorations);
 }
 
-function collectAnchorRanges(decorations: DecorationSet): CommentAnchorInput[] {
-  // A cross-block anchor may come back from find() as several fragments;
-  // merge per commentId so callers always see one range per comment.
-  const merged = new Map<string, CommentAnchorInput>();
-  for (const decoration of decorations.find()) {
-    const commentId = decoration.spec.commentId;
-    if (typeof commentId !== "string" || decoration.from >= decoration.to) {
-      continue;
-    }
-    const existing = merged.get(commentId);
-    if (existing) {
-      existing.from = Math.min(existing.from, decoration.from);
-      existing.to = Math.max(existing.to, decoration.to);
-    } else {
-      merged.set(commentId, {
-        commentId,
-        from: decoration.from,
-        to: decoration.to,
-      });
-    }
-  }
-  return [...merged.values()];
+function clampAnchors(
+  anchors: CommentAnchorInput[],
+  size: number,
+): CommentAnchorInput[] {
+  return anchors.filter(
+    (anchor) =>
+      anchor.from < anchor.to && anchor.from >= 0 && anchor.to <= size,
+  );
 }

--- a/packages/editor/src/plugins/comment-anchors.ts
+++ b/packages/editor/src/plugins/comment-anchors.ts
@@ -1,0 +1,225 @@
+import { Plugin, PluginKey, type EditorState } from "prosemirror-state";
+import { Decoration, DecorationSet, type EditorView } from "prosemirror-view";
+
+export type CommentAnchorInput = {
+  commentId: string;
+  from: number;
+  to: number;
+};
+
+export type CommentAnchorsEvent =
+  | { type: "selection"; from: number; to: number; empty: boolean }
+  | { type: "anchor-click"; commentIds: string[]; pos: number }
+  | { type: "layout" };
+
+type CommentAnchorsState = {
+  decorations: DecorationSet;
+  activeId: string | null;
+};
+
+type CommentAnchorsMeta =
+  | { type: "set"; anchors: CommentAnchorInput[] }
+  | { type: "active"; commentId: string | null };
+
+export const commentAnchorsPluginKey = new PluginKey<CommentAnchorsState>(
+  "commentAnchors",
+);
+
+/**
+ * Highlights comment-anchored ranges. Anchors and the active highlight are
+ * controlled after mount through transaction metadata (the editor never
+ * reconfigures plugins), via setCommentAnchors / setActiveCommentAnchor.
+ */
+export function commentAnchorsPlugin(options?: {
+  onEvent?: (event: CommentAnchorsEvent) => void;
+}): Plugin<CommentAnchorsState> {
+  const emit = (event: CommentAnchorsEvent) => options?.onEvent?.(event);
+
+  return new Plugin<CommentAnchorsState>({
+    key: commentAnchorsPluginKey,
+    state: {
+      init() {
+        return { decorations: DecorationSet.empty, activeId: null };
+      },
+      apply(tr, pluginState) {
+        const meta = tr.getMeta(commentAnchorsPluginKey) as
+          | CommentAnchorsMeta
+          | undefined;
+        if (meta?.type === "set") {
+          return {
+            decorations: buildDecorations(
+              tr.doc,
+              meta.anchors,
+              pluginState.activeId,
+            ),
+            activeId: pluginState.activeId,
+          };
+        }
+        if (meta?.type === "active") {
+          return {
+            decorations: buildDecorations(
+              tr.doc,
+              collectAnchorRanges(pluginState.decorations),
+              meta.commentId,
+            ),
+            activeId: meta.commentId,
+          };
+        }
+        return {
+          decorations: pluginState.decorations.map(tr.mapping, tr.doc),
+          activeId: pluginState.activeId,
+        };
+      },
+    },
+    props: {
+      decorations(state) {
+        return commentAnchorsPluginKey.getState(state)?.decorations;
+      },
+      handleClick(view, pos) {
+        const pluginState = commentAnchorsPluginKey.getState(view.state);
+        if (!pluginState) return false;
+        const hits = pluginState.decorations.find(pos, pos);
+        const commentIds = [
+          ...new Set(
+            hits
+              .map((decoration) => decoration.spec.commentId as string)
+              .filter(Boolean),
+          ),
+        ];
+        if (commentIds.length > 0) {
+          emit({ type: "anchor-click", commentIds, pos });
+        }
+        return false;
+      },
+    },
+    view() {
+      return {
+        update(view, prevState) {
+          const selection = view.state.selection;
+          if (!selection.eq(prevState.selection)) {
+            emit({
+              type: "selection",
+              from: selection.from,
+              to: selection.to,
+              empty: selection.empty,
+            });
+          }
+          const decorations = commentAnchorsPluginKey.getState(
+            view.state,
+          )?.decorations;
+          const previousDecorations =
+            commentAnchorsPluginKey.getState(prevState)?.decorations;
+          if (
+            view.state.doc !== prevState.doc ||
+            decorations !== previousDecorations
+          ) {
+            emit({ type: "layout" });
+          }
+        },
+      };
+    },
+  });
+}
+
+export function setCommentAnchors(
+  view: EditorView,
+  anchors: CommentAnchorInput[],
+): void {
+  view.dispatch(
+    view.state.tr.setMeta(commentAnchorsPluginKey, {
+      type: "set",
+      anchors,
+    } satisfies CommentAnchorsMeta),
+  );
+}
+
+export function setActiveCommentAnchor(
+  view: EditorView,
+  commentId: string | null,
+): void {
+  view.dispatch(
+    view.state.tr.setMeta(commentAnchorsPluginKey, {
+      type: "active",
+      commentId,
+    } satisfies CommentAnchorsMeta),
+  );
+}
+
+/** Current anchor ranges, mapped through any edits since they were set. */
+export function getCommentAnchorRanges(
+  state: EditorState,
+): CommentAnchorInput[] {
+  const pluginState = commentAnchorsPluginKey.getState(state);
+  return pluginState ? collectAnchorRanges(pluginState.decorations) : [];
+}
+
+/** Viewport coordinates for each anchor, for aligning side cards. */
+export function getCommentAnchorScreenPositions(
+  view: EditorView,
+): Array<CommentAnchorInput & { top: number; bottom: number; left: number }> {
+  return getCommentAnchorRanges(view.state).map((anchor) => {
+    const start = view.coordsAtPos(anchor.from);
+    return {
+      ...anchor,
+      top: start.top,
+      bottom: start.bottom,
+      left: start.left,
+    };
+  });
+}
+
+/** Viewport rectangle spanning the current selection, for floating UI. */
+export function getSelectionScreenRect(
+  view: EditorView,
+): { left: number; top: number; right: number; bottom: number } | null {
+  const { from, to, empty } = view.state.selection;
+  if (empty) return null;
+  const start = view.coordsAtPos(from);
+  const end = view.coordsAtPos(to);
+  return {
+    left: Math.min(start.left, end.left),
+    top: Math.min(start.top, end.top),
+    right: Math.max(start.right, end.right),
+    bottom: Math.max(start.bottom, end.bottom),
+  };
+}
+
+function buildDecorations(
+  doc: Parameters<typeof DecorationSet.create>[0],
+  anchors: CommentAnchorInput[],
+  activeId: string | null,
+): DecorationSet {
+  const size = doc.content.size;
+  const decorations = anchors
+    .filter((anchor) => anchor.from < anchor.to && anchor.to <= size)
+    .map((anchor) =>
+      Decoration.inline(
+        anchor.from,
+        anchor.to,
+        {
+          class:
+            anchor.commentId === activeId
+              ? "comment-anchor comment-anchor-active"
+              : "comment-anchor",
+          "data-comment-id": anchor.commentId,
+        },
+        { commentId: anchor.commentId },
+      ),
+    );
+  return DecorationSet.create(doc, decorations);
+}
+
+function collectAnchorRanges(decorations: DecorationSet): CommentAnchorInput[] {
+  return decorations
+    .find()
+    .filter(
+      (decoration) =>
+        typeof decoration.spec.commentId === "string" &&
+        decoration.from < decoration.to,
+    )
+    .map((decoration) => ({
+      commentId: decoration.spec.commentId as string,
+      from: decoration.from,
+      to: decoration.to,
+    }));
+}

--- a/packages/editor/src/plugins/index.ts
+++ b/packages/editor/src/plugins/index.ts
@@ -1,6 +1,17 @@
 export { autolinkPlugin } from "./autolink";
 export { clipboardPlugin, serializeClipboardText } from "./clipboard";
 export { clearMarksOnEnterPlugin } from "./clear-marks-on-enter";
+export {
+  type CommentAnchorInput,
+  type CommentAnchorsEvent,
+  commentAnchorsPlugin,
+  commentAnchorsPluginKey,
+  getCommentAnchorRanges,
+  getCommentAnchorScreenPositions,
+  getSelectionScreenRect,
+  setActiveCommentAnchor,
+  setCommentAnchors,
+} from "./comment-anchors";
 export { docChangeListenerPlugin } from "./doc-change-listener";
 export {
   clipNodeSpec,

--- a/packages/editor/src/styles/prosemirror.css
+++ b/packages/editor/src/styles/prosemirror.css
@@ -12,6 +12,7 @@
 @import "./prosemirror/nodes/mark.css";
 @import "./prosemirror/nodes/ai-highlight.css";
 @import "./prosemirror/nodes/hashtag.css";
+@import "./prosemirror/nodes/comment-anchor.css";
 
 @import "./prosemirror/dark.css";
 @import "./prosemirror/mention.css";

--- a/packages/editor/src/styles/prosemirror/nodes/comment-anchor.css
+++ b/packages/editor/src/styles/prosemirror/nodes/comment-anchor.css
@@ -1,0 +1,19 @@
+.prosemirror-editor {
+  .comment-anchor {
+    background: rgb(251 191 36 / 0.22);
+    border-bottom: 2px solid rgb(245 158 11 / 0.55);
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+
+  .comment-anchor-active {
+    background: rgb(251 191 36 / 0.42);
+    border-bottom-color: rgb(217 119 6 / 0.85);
+  }
+
+  code .comment-anchor,
+  pre .comment-anchor {
+    background: rgb(251 191 36 / 0.28);
+    border-bottom: none;
+  }
+}

--- a/packages/editor/src/styles/prosemirror/nodes/comment-anchor.css
+++ b/packages/editor/src/styles/prosemirror/nodes/comment-anchor.css
@@ -16,4 +16,9 @@
     background: rgb(251 191 36 / 0.28);
     border-bottom: none;
   }
+
+  code .comment-anchor-active,
+  pre .comment-anchor-active {
+    background: rgb(251 191 36 / 0.5);
+  }
 }


### PR DESCRIPTION
Shared foundations for anchored comments: a @hypr/editor/comments module
with a doc-text index (textBetween-equivalent), quote capture, and
deterministic re-anchoring (verified hints, unique quote match,
context-scored disambiguation, ties resolve unanchored), plus a
comment-anchors decoration plugin controlled via transaction metadata
with selection/click/layout events and screen-position helpers, wired
into NoteEditor behind commentAnchorsEnabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New editor plugin and position-mapping logic affect how comment ranges track document edits; behavior is well-tested but incorrect anchoring could mis-highlight or lose threads until follow-up UI lands.
> 
> **Overview**
> Adds **shared foundations for anchored comments** in `@hypr/editor`: a new `@hypr/editor/comments` export plus optional wiring in `NoteEditor`.
> 
> The **`comments` module** introduces a doc text index aligned with ProseMirror `textBetween`, **quote capture** from selections (with prefix/suffix context, revision hints, and boundary separator trimming), and **re-anchoring** via verified hints, quote search, and context scoring—with ambiguous ties resolving to unanchored rather than guessing.
> 
> A **`commentAnchorsPlugin`** draws inline highlights from transaction metadata (`setCommentAnchors` / `setActiveCommentAnchor`), keeps canonical ranges mapped through edits, and emits selection, anchor-click, and layout events plus screen-position helpers for floating UI.
> 
> **`NoteEditor`** gains `commentAnchorsEnabled` (fixed at mount) and `onCommentAnchorsEvent`; styling adds `.comment-anchor` / active states. Vitest coverage covers anchor logic and plugin behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac02326347b4f51c59cf1d13e08d2221e7b1cd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6182
- <kbd>&nbsp;1&nbsp;</kbd> #6178 👈 
<!-- GitButler Footer Boundary Bottom -->