### PR TITLE
feat(sharing): add anchor storage and RPCs for shared-note comments

### DIFF
--- a/apps/web/src/functions/shared-notes.ts
+++ b/apps/web/src/functions/shared-notes.ts
@@ -9,7 +9,10 @@ import {
   type SharedNoteReadResult,
 } from "@/lib/shared-note-api";
 import {
+  MAX_SHARED_NOTE_COMMENT_ANCHOR_CONTEXT_BYTES,
+  MAX_SHARED_NOTE_COMMENT_ANCHOR_EXACT_BYTES,
   MAX_SHARED_NOTE_COMMENT_BYTES,
+  validateSharedNoteCommentAnchor,
   validateSharedNoteCommentBody,
 } from "@/lib/shared-note-collaboration";
 import { deriveSharedNoteEditorTitle } from "@/lib/shared-note-editing";
@@ -72,10 +75,29 @@ const sharedNoteWebEditInputSchema = z
 
 const MAX_WEB_EDIT_RESPONSE_BYTES = 2_250_000;
 
+const sharedNoteCommentAnchorInputSchema = z
+  .object({
+    quoteExact: z
+      .string()
+      .min(1)
+      .max(MAX_SHARED_NOTE_COMMENT_ANCHOR_EXACT_BYTES),
+    quotePrefix: z.string().max(MAX_SHARED_NOTE_COMMENT_ANCHOR_CONTEXT_BYTES),
+    quoteSuffix: z.string().max(MAX_SHARED_NOTE_COMMENT_ANCHOR_CONTEXT_BYTES),
+    fromHint: z.number().int().positive().safe().nullable(),
+    toHint: z.number().int().positive().safe().nullable(),
+  })
+  .strict()
+  .refine(({ fromHint, toHint }) => (fromHint === null) === (toHint === null))
+  .refine(
+    ({ fromHint, toHint }) =>
+      fromHint === null || toHint === null || toHint > fromHint,
+  );
+
 const sharedNoteCommentInputSchema = z
   .object({
     shareId: shareIdSchema,
     body: z.string().max(MAX_SHARED_NOTE_COMMENT_BYTES),
+    anchor: sharedNoteCommentAnchorInputSchema.nullable().optional(),
   })
   .strict();
 
@@ -274,6 +296,10 @@ export const createSharedNoteComment = createServerFn({ method: "POST" })
       if (!comment.valid) {
         return { status: "unavailable" };
       }
+      const anchor = validateSharedNoteCommentAnchor(data.anchor);
+      if (!anchor.valid) {
+        return { status: "unavailable" };
+      }
 
       const supabase = getSupabaseServerClient();
       const { data: commentRows, error } = await supabase.rpc(
@@ -281,6 +307,11 @@ export const createSharedNoteComment = createServerFn({ method: "POST" })
         {
           p_share_id: data.shareId,
           p_body: comment.body,
+          p_anchor_quote_exact: anchor.anchor?.quoteExact ?? null,
+          p_anchor_quote_prefix: anchor.anchor?.quotePrefix ?? null,
+          p_anchor_quote_suffix: anchor.anchor?.quoteSuffix ?? null,
+          p_anchor_from_hint: anchor.anchor?.fromHint ?? null,
+          p_anchor_to_hint: anchor.anchor?.toHint ?? null,
         },
       );
       if (error) return unavailableOrError(error.code);
@@ -290,10 +321,11 @@ export const createSharedNoteComment = createServerFn({ method: "POST" })
       if (commentRows.length !== 1) return { status: "error" };
 
       try {
-        return {
-          status: "ready",
-          comment: parseSharedNoteComment(commentRows[0]),
-        };
+        const created = parseSharedNoteComment(commentRows[0]);
+        if ((created.anchor === null) !== (anchor.anchor === null)) {
+          return { status: "error" };
+        }
+        return { status: "ready", comment: created };
       } catch {
         return { status: "error" };
       }

--- a/apps/web/src/lib/shared-note-collaboration.test.ts
+++ b/apps/web/src/lib/shared-note-collaboration.test.ts
@@ -6,10 +6,96 @@ import {
   formatAuthenticatedSharedNoteAccessLabel,
   formatSharedNoteAccessRequestDescription,
   hasSharedNoteCollaborationAccess,
+  MAX_SHARED_NOTE_COMMENT_ANCHOR_CONTEXT_BYTES,
+  MAX_SHARED_NOTE_COMMENT_ANCHOR_EXACT_BYTES,
   MAX_SHARED_NOTE_COMMENT_BYTES,
   shouldUseAuthenticatedSharedNoteAccessLabel,
+  validateSharedNoteCommentAnchor,
   validateSharedNoteCommentBody,
 } from "./shared-note-collaboration.ts";
+
+test("comment anchors validate byte caps without trimming", () => {
+  const anchor = {
+    quoteExact: "  quoted text  ",
+    quotePrefix: "before ",
+    quoteSuffix: " after",
+    fromHint: 2,
+    toHint: 17,
+  };
+  const validated = validateSharedNoteCommentAnchor(anchor);
+  assert.equal(validated.valid, true);
+  assert.equal(validated.anchor?.quoteExact, "  quoted text  ");
+
+  assert.equal(validateSharedNoteCommentAnchor(null).valid, true);
+  assert.equal(validateSharedNoteCommentAnchor(null).anchor, null);
+  assert.equal(validateSharedNoteCommentAnchor(undefined).valid, true);
+
+  const cjk = "ㄱ".repeat(
+    Math.floor(MAX_SHARED_NOTE_COMMENT_ANCHOR_EXACT_BYTES / 3),
+  );
+  assert.equal(
+    validateSharedNoteCommentAnchor({ ...anchor, quoteExact: cjk }).valid,
+    true,
+  );
+  assert.equal(
+    validateSharedNoteCommentAnchor({ ...anchor, quoteExact: `${cjk}xx` })
+      .valid,
+    false,
+  );
+
+  assert.equal(
+    validateSharedNoteCommentAnchor({ ...anchor, quoteExact: "" }).valid,
+    false,
+  );
+  assert.equal(
+    validateSharedNoteCommentAnchor({
+      ...anchor,
+      quotePrefix: "p".repeat(MAX_SHARED_NOTE_COMMENT_ANCHOR_CONTEXT_BYTES + 1),
+    }).valid,
+    false,
+  );
+  assert.equal(
+    validateSharedNoteCommentAnchor({
+      ...anchor,
+      quoteSuffix: "s".repeat(MAX_SHARED_NOTE_COMMENT_ANCHOR_CONTEXT_BYTES + 1),
+    }).valid,
+    false,
+  );
+});
+
+test("comment anchor hints must be paired and ordered", () => {
+  const anchor = {
+    quoteExact: "quoted",
+    quotePrefix: "",
+    quoteSuffix: "",
+    fromHint: null,
+    toHint: null,
+  };
+  assert.equal(validateSharedNoteCommentAnchor(anchor).valid, true);
+  assert.equal(
+    validateSharedNoteCommentAnchor({ ...anchor, fromHint: 1, toHint: 5 })
+      .valid,
+    true,
+  );
+  assert.equal(
+    validateSharedNoteCommentAnchor({ ...anchor, fromHint: 1 }).valid,
+    false,
+  );
+  assert.equal(
+    validateSharedNoteCommentAnchor({ ...anchor, toHint: 5 }).valid,
+    false,
+  );
+  assert.equal(
+    validateSharedNoteCommentAnchor({ ...anchor, fromHint: 0, toHint: 5 })
+      .valid,
+    false,
+  );
+  assert.equal(
+    validateSharedNoteCommentAnchor({ ...anchor, fromHint: 5, toHint: 5 })
+      .valid,
+    false,
+  );
+});
 
 test("general viewer access never implies comment access", () => {
   assert.equal(

--- a/apps/web/src/lib/shared-note-collaboration.ts
+++ b/apps/web/src/lib/shared-note-collaboration.ts
@@ -1,6 +1,11 @@
-import type { SharedNoteCapability } from "@/lib/shared-notes";
+import type {
+  SharedNoteCapability,
+  SharedNoteCommentAnchor,
+} from "@/lib/shared-notes";
 
 export const MAX_SHARED_NOTE_COMMENT_BYTES = 16_384;
+export const MAX_SHARED_NOTE_COMMENT_ANCHOR_EXACT_BYTES = 4_096;
+export const MAX_SHARED_NOTE_COMMENT_ANCHOR_CONTEXT_BYTES = 256;
 
 export function validateSharedNoteCommentBody(value: string) {
   const body = value.trim();
@@ -10,6 +15,31 @@ export function validateSharedNoteCommentBody(value: string) {
     byteLength,
     valid: body.length > 0 && byteLength <= MAX_SHARED_NOTE_COMMENT_BYTES,
   };
+}
+
+export function validateSharedNoteCommentAnchor(
+  anchor: SharedNoteCommentAnchor | null | undefined,
+): { anchor: SharedNoteCommentAnchor | null; valid: boolean } {
+  if (anchor == null) {
+    return { anchor: null, valid: true };
+  }
+  const encoder = new TextEncoder();
+  const hintsPaired = (anchor.fromHint == null) === (anchor.toHint == null);
+  const hintsOrdered =
+    anchor.fromHint == null ||
+    anchor.toHint == null ||
+    (anchor.fromHint >= 1 && anchor.toHint > anchor.fromHint);
+  const valid =
+    anchor.quoteExact.length > 0 &&
+    encoder.encode(anchor.quoteExact).byteLength <=
+      MAX_SHARED_NOTE_COMMENT_ANCHOR_EXACT_BYTES &&
+    encoder.encode(anchor.quotePrefix).byteLength <=
+      MAX_SHARED_NOTE_COMMENT_ANCHOR_CONTEXT_BYTES &&
+    encoder.encode(anchor.quoteSuffix).byteLength <=
+      MAX_SHARED_NOTE_COMMENT_ANCHOR_CONTEXT_BYTES &&
+    hintsPaired &&
+    hintsOrdered;
+  return { anchor, valid };
 }
 
 export function formatAuthenticatedSharedNoteAccessLabel({

--- a/apps/web/src/lib/shared-notes.test.ts
+++ b/apps/web/src/lib/shared-notes.test.ts
@@ -200,6 +200,7 @@ test("parses bounded shared-note comment rows", () => {
       isAuthor: true,
       body: "Looks good to me.",
       snapshotRevision: 4,
+      anchor: null,
       createdAt: "2026-07-17T12:00:00Z",
     },
   );
@@ -220,6 +221,109 @@ test("parses bounded shared-note comment rows", () => {
     parseSharedNoteComment({ ...valid, snapshot_content_revision: 0 }),
   );
   assert.throws(() => parseSharedNoteComment({ ...valid, private_note: true }));
+});
+
+test("parses anchored comment rows across schema generations", () => {
+  const base = {
+    comment_id: "00000000-0000-4000-8000-000000000002",
+    is_author: true,
+    body: "Looks good to me.",
+    snapshot_content_revision: 4,
+    created_at: "2026-07-17T12:00:00Z",
+  };
+
+  assert.deepEqual(
+    parseSharedNoteComment({
+      ...base,
+      anchor_quote_exact: "quoted text",
+      anchor_quote_prefix: "",
+      anchor_quote_suffix: " and after",
+      anchor_from_hint: 2,
+      anchor_to_hint: 13,
+    }).anchor,
+    {
+      quoteExact: "quoted text",
+      quotePrefix: "",
+      quoteSuffix: " and after",
+      fromHint: 2,
+      toHint: 13,
+    },
+  );
+
+  const anchoredWithoutHints = parseSharedNoteComment({
+    ...base,
+    anchor_quote_exact: "quoted text",
+    anchor_quote_prefix: "before ",
+    anchor_quote_suffix: "",
+    anchor_from_hint: null,
+    anchor_to_hint: null,
+  });
+  assert.deepEqual(anchoredWithoutHints.anchor, {
+    quoteExact: "quoted text",
+    quotePrefix: "before ",
+    quoteSuffix: "",
+    fromHint: null,
+    toHint: null,
+  });
+
+  assert.equal(parseSharedNoteComment(base).anchor, null);
+  assert.equal(
+    parseSharedNoteComment({
+      ...base,
+      anchor_quote_exact: null,
+      anchor_quote_prefix: null,
+      anchor_quote_suffix: null,
+      anchor_from_hint: null,
+      anchor_to_hint: null,
+    }).anchor,
+    null,
+  );
+
+  const anchored = {
+    ...base,
+    anchor_quote_exact: "quoted text",
+    anchor_quote_prefix: "",
+    anchor_quote_suffix: "",
+    anchor_from_hint: 2,
+    anchor_to_hint: 13,
+  };
+  assert.throws(() =>
+    parseSharedNoteComment({ ...anchored, anchor_quote_prefix: null }),
+  );
+  assert.throws(() =>
+    parseSharedNoteComment({
+      ...base,
+      anchor_from_hint: 2,
+      anchor_to_hint: 13,
+    }),
+  );
+  assert.throws(() =>
+    parseSharedNoteComment({ ...anchored, anchor_to_hint: 2 }),
+  );
+  assert.throws(() =>
+    parseSharedNoteComment({ ...anchored, anchor_from_hint: 0 }),
+  );
+  assert.throws(() =>
+    parseSharedNoteComment({ ...anchored, anchor_to_hint: null }),
+  );
+  assert.throws(() =>
+    parseSharedNoteComment({
+      ...anchored,
+      anchor_quote_exact: "a".repeat(4097),
+    }),
+  );
+  assert.throws(() =>
+    parseSharedNoteComment({
+      ...anchored,
+      anchor_quote_prefix: "p".repeat(257),
+    }),
+  );
+  assert.throws(() =>
+    parseSharedNoteComment({ ...anchored, anchor_quote_exact: "" }),
+  );
+
+  const page = parseSharedNoteCommentPage([anchored]);
+  assert.equal(page.comments[0]?.anchor?.quoteExact, "quoted text");
 });
 
 test("bounds comment pages and derives an older-history cursor", () => {

--- a/apps/web/src/lib/shared-notes.ts
+++ b/apps/web/src/lib/shared-notes.ts
@@ -103,11 +103,20 @@ export type AuthenticatedSharedNote = {
   webEditable: boolean;
 };
 
+export type SharedNoteCommentAnchor = {
+  quoteExact: string;
+  quotePrefix: string;
+  quoteSuffix: string;
+  fromHint: number | null;
+  toHint: number | null;
+};
+
 export type SharedNoteComment = {
   commentId: string;
   isAuthor: boolean;
   body: string;
   snapshotRevision: number;
+  anchor: SharedNoteCommentAnchor | null;
   createdAt: string;
 };
 
@@ -264,9 +273,25 @@ const sharedNoteCommentRowSchema = z
     is_author: z.boolean(),
     body: z.string().min(1).max(16384),
     snapshot_content_revision: z.number().int().positive().safe(),
+    anchor_quote_exact: z.string().min(1).max(4096).nullish(),
+    anchor_quote_prefix: z.string().max(256).nullish(),
+    anchor_quote_suffix: z.string().max(256).nullish(),
+    anchor_from_hint: z.number().int().positive().safe().nullish(),
+    anchor_to_hint: z.number().int().positive().safe().nullish(),
     created_at: rpcTimestampSchema,
   })
-  .strict();
+  .strict()
+  .refine(
+    ({ anchor_quote_exact, anchor_quote_prefix, anchor_quote_suffix }) =>
+      (anchor_quote_exact == null) === (anchor_quote_prefix == null) &&
+      (anchor_quote_exact == null) === (anchor_quote_suffix == null),
+  )
+  .refine(
+    ({ anchor_quote_exact, anchor_from_hint, anchor_to_hint }) =>
+      (anchor_from_hint == null) === (anchor_to_hint == null) &&
+      (anchor_from_hint == null ||
+        (anchor_quote_exact != null && anchor_to_hint! > anchor_from_hint)),
+  );
 
 const sessionAccessRequestStateRowSchema = z
   .object({
@@ -416,6 +441,16 @@ export function parseSharedNoteComment(value: unknown): SharedNoteComment {
     isAuthor: parsed.is_author,
     body: parsed.body,
     snapshotRevision: parsed.snapshot_content_revision,
+    anchor:
+      parsed.anchor_quote_exact == null
+        ? null
+        : {
+            quoteExact: parsed.anchor_quote_exact,
+            quotePrefix: parsed.anchor_quote_prefix ?? "",
+            quoteSuffix: parsed.anchor_quote_suffix ?? "",
+            fromHint: parsed.anchor_from_hint ?? null,
+            toHint: parsed.anchor_to_hint ?? null,
+          },
     createdAt: parsed.created_at,
   };
 }

--- a/supabase/migrations/20260721100000_session_share_comment_anchors.sql
+++ b/supabase/migrations/20260721100000_session_share_comment_anchors.sql
@@ -1,0 +1,457 @@
+-- Anchored comments: store a W3C-style text quote (exact + prefix + suffix)
+-- plus from/to position hints on session share comments so clients can
+-- highlight the commented range. Hints are valid at the row's
+-- snapshot_content_revision; the quote is the source of truth and renderers
+-- must verify hints against it before trusting them (the snapshot may have
+-- been republished between capture and insert).
+
+ALTER TABLE public.session_share_comments
+  ADD COLUMN anchor_quote_exact text,
+  ADD COLUMN anchor_quote_prefix text,
+  ADD COLUMN anchor_quote_suffix text,
+  ADD COLUMN anchor_from_hint bigint,
+  ADD COLUMN anchor_to_hint bigint;
+
+ALTER TABLE public.session_share_comments
+  ADD CONSTRAINT session_share_comments_anchor_check CHECK (
+    (
+      anchor_quote_exact IS NULL
+      AND anchor_quote_prefix IS NULL
+      AND anchor_quote_suffix IS NULL
+      AND anchor_from_hint IS NULL
+      AND anchor_to_hint IS NULL
+    )
+    OR (
+      deleted_at IS NULL
+      AND anchor_quote_exact IS NOT NULL
+      AND anchor_quote_prefix IS NOT NULL
+      AND anchor_quote_suffix IS NOT NULL
+      AND anchor_quote_exact <> ''
+      AND octet_length(anchor_quote_exact) <= 4096
+      AND octet_length(anchor_quote_prefix) <= 256
+      AND octet_length(anchor_quote_suffix) <= 256
+      AND (anchor_from_hint IS NULL) = (anchor_to_hint IS NULL)
+      AND (
+        anchor_from_hint IS NULL
+        OR (anchor_from_hint > 0 AND anchor_to_hint > anchor_from_hint)
+      )
+    )
+  );
+
+-- Adding defaulted parameters or extending RETURNS TABLE cannot be done with
+-- CREATE OR REPLACE (ambiguous overload 42725 / return-type change 42P13), so
+-- the create/list functions are dropped and recreated under the same names.
+DROP FUNCTION public.create_session_share_comment(uuid, text);
+DROP FUNCTION private.create_session_share_comment(uuid, text);
+DROP FUNCTION public.list_session_share_comments(uuid, timestamptz, uuid, integer);
+DROP FUNCTION private.list_session_share_comments(uuid, timestamptz, uuid, integer);
+
+CREATE FUNCTION private.create_session_share_comment(
+  p_share_id uuid,
+  p_body text,
+  p_anchor_quote_exact text DEFAULT NULL,
+  p_anchor_quote_prefix text DEFAULT NULL,
+  p_anchor_quote_suffix text DEFAULT NULL,
+  p_anchor_from_hint bigint DEFAULT NULL,
+  p_anchor_to_hint bigint DEFAULT NULL
+)
+RETURNS TABLE (
+  comment_id uuid,
+  is_author boolean,
+  snapshot_content_revision bigint,
+  body text,
+  anchor_quote_exact text,
+  anchor_quote_prefix text,
+  anchor_quote_suffix text,
+  anchor_from_hint bigint,
+  anchor_to_hint bigint,
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := private.require_permanent_user();
+  v_body text := btrim(p_body, E' \t\n\r\v\f');
+  v_capability text;
+  v_manage_access boolean;
+  v_revision bigint;
+  v_comment public.session_share_comments%ROWTYPE;
+BEGIN
+  PERFORM 1
+  FROM public.session_shares AS share
+  JOIN public.workspaces AS workspace
+    ON workspace.id = share.workspace_id
+  WHERE share.id = p_share_id
+    AND share.deleted_at IS NULL
+    AND workspace.deleted_at IS NULL
+  FOR UPDATE OF share;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT access.capability, access.manage_access
+  INTO v_capability, v_manage_access
+  FROM private.resolve_my_session_access(p_share_id) AS access;
+
+  IF COALESCE(private.session_capability_rank(v_capability), 0) < 2
+    AND NOT COALESCE(v_manage_access, false)
+  THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_body IS NULL
+    OR v_body = ''
+    OR octet_length(v_body) > 16384
+  THEN
+    RAISE EXCEPTION 'invalid session comment'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF (p_anchor_quote_exact IS NULL) <> (p_anchor_quote_prefix IS NULL)
+    OR (p_anchor_quote_exact IS NULL) <> (p_anchor_quote_suffix IS NULL)
+  THEN
+    RAISE EXCEPTION 'invalid session comment'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_anchor_quote_exact IS NOT NULL AND (
+    p_anchor_quote_exact = ''
+    OR octet_length(p_anchor_quote_exact) > 4096
+    OR octet_length(p_anchor_quote_prefix) > 256
+    OR octet_length(p_anchor_quote_suffix) > 256
+  )
+  THEN
+    RAISE EXCEPTION 'invalid session comment'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF (p_anchor_from_hint IS NULL) <> (p_anchor_to_hint IS NULL)
+    OR (p_anchor_from_hint IS NOT NULL AND (
+      p_anchor_quote_exact IS NULL
+      OR p_anchor_from_hint < 1
+      OR p_anchor_to_hint <= p_anchor_from_hint
+    ))
+  THEN
+    RAISE EXCEPTION 'invalid session comment'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT snapshot.content_revision
+  INTO v_revision
+  FROM public.session_share_snapshots AS snapshot
+  WHERE snapshot.share_id = p_share_id;
+
+  IF v_revision IS NULL THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  INSERT INTO public.session_share_comments (
+    share_id,
+    author_user_id,
+    snapshot_content_revision,
+    body,
+    anchor_quote_exact,
+    anchor_quote_prefix,
+    anchor_quote_suffix,
+    anchor_from_hint,
+    anchor_to_hint
+  ) VALUES (
+    p_share_id,
+    v_actor_id,
+    v_revision,
+    v_body,
+    p_anchor_quote_exact,
+    p_anchor_quote_prefix,
+    p_anchor_quote_suffix,
+    p_anchor_from_hint,
+    p_anchor_to_hint
+  )
+  RETURNING * INTO v_comment;
+
+  PERFORM private.write_session_access_event(
+    p_share_id,
+    'comment_created',
+    v_actor_id,
+    v_actor_id,
+    v_comment.id,
+    NULL,
+    v_revision::text
+  );
+
+  RETURN QUERY
+  SELECT
+    v_comment.id,
+    true,
+    v_comment.snapshot_content_revision,
+    v_comment.body,
+    v_comment.anchor_quote_exact,
+    v_comment.anchor_quote_prefix,
+    v_comment.anchor_quote_suffix,
+    v_comment.anchor_from_hint,
+    v_comment.anchor_to_hint,
+    v_comment.created_at;
+END;
+$$;
+
+CREATE FUNCTION private.list_session_share_comments(
+  p_share_id uuid,
+  p_before_created_at timestamptz DEFAULT NULL,
+  p_before_comment_id uuid DEFAULT NULL,
+  p_limit integer DEFAULT 100
+)
+RETURNS TABLE (
+  comment_id uuid,
+  is_author boolean,
+  snapshot_content_revision bigint,
+  body text,
+  anchor_quote_exact text,
+  anchor_quote_prefix text,
+  anchor_quote_suffix text,
+  anchor_from_hint bigint,
+  anchor_to_hint bigint,
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := private.require_permanent_user();
+  v_limit integer := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 101);
+BEGIN
+  IF (p_before_created_at IS NULL) <> (p_before_comment_id IS NULL) THEN
+    RAISE EXCEPTION 'invalid session comment cursor'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT private.is_session_share_manager(p_share_id, v_actor_id)
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.session_access_grants AS access_grant
+      JOIN public.session_shares AS share
+        ON share.id = access_grant.share_id
+      JOIN public.workspaces AS workspace
+        ON workspace.id = share.workspace_id
+      WHERE access_grant.share_id = p_share_id
+        AND access_grant.grantee_user_id = v_actor_id
+        AND access_grant.capability IN ('viewer', 'commenter', 'editor')
+        AND access_grant.revoked_at IS NULL
+        AND share.deleted_at IS NULL
+        AND workspace.deleted_at IS NULL
+    )
+  THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    comment.id,
+    comment.author_user_id = v_actor_id,
+    comment.snapshot_content_revision,
+    comment.body,
+    comment.anchor_quote_exact,
+    comment.anchor_quote_prefix,
+    comment.anchor_quote_suffix,
+    comment.anchor_from_hint,
+    comment.anchor_to_hint,
+    comment.created_at
+  FROM public.session_share_comments AS comment
+  WHERE comment.share_id = p_share_id
+    AND comment.deleted_at IS NULL
+    AND (
+      p_before_created_at IS NULL
+      OR (comment.created_at, comment.id)
+        < (p_before_created_at, p_before_comment_id)
+    )
+  ORDER BY comment.created_at DESC, comment.id DESC
+  LIMIT v_limit;
+END;
+$$;
+
+-- Soft delete scrubs the anchor alongside the body: anchors quote note
+-- content, so a deleted comment must not retain it.
+CREATE OR REPLACE FUNCTION private.delete_session_share_comment(
+  p_comment_id uuid
+)
+RETURNS TABLE (
+  comment_id uuid,
+  deleted_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := private.require_permanent_user();
+  v_share_id uuid;
+  v_comment public.session_share_comments%ROWTYPE;
+  v_deleted_at timestamptz;
+BEGIN
+  SELECT comment.share_id
+  INTO v_share_id
+  FROM public.session_share_comments AS comment
+  WHERE comment.id = p_comment_id;
+
+  IF v_share_id IS NULL THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM 1
+  FROM public.session_shares AS share
+  WHERE share.id = v_share_id
+  FOR UPDATE;
+
+  SELECT comment.*
+  INTO v_comment
+  FROM public.session_share_comments AS comment
+  WHERE comment.id = p_comment_id
+    AND comment.share_id = v_share_id
+  FOR UPDATE;
+
+  IF NOT FOUND
+    OR (
+      v_comment.author_user_id <> v_actor_id
+      AND NOT private.is_session_share_manager(v_share_id, v_actor_id)
+    )
+  THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_comment.deleted_at IS NULL THEN
+    v_deleted_at := now();
+
+    UPDATE public.session_share_comments
+    SET
+      body = '',
+      anchor_quote_exact = NULL,
+      anchor_quote_prefix = NULL,
+      anchor_quote_suffix = NULL,
+      anchor_from_hint = NULL,
+      anchor_to_hint = NULL,
+      deleted_at = v_deleted_at,
+      deleted_by_user_id = v_actor_id
+    WHERE id = v_comment.id;
+
+    PERFORM private.write_session_access_event(
+      v_share_id,
+      'comment_deleted',
+      v_actor_id,
+      v_comment.author_user_id,
+      v_comment.id,
+      v_comment.snapshot_content_revision::text,
+      NULL
+    );
+  ELSE
+    v_deleted_at := v_comment.deleted_at;
+  END IF;
+
+  RETURN QUERY SELECT v_comment.id, v_deleted_at;
+END;
+$$;
+
+CREATE FUNCTION public.create_session_share_comment(
+  p_share_id uuid,
+  p_body text,
+  p_anchor_quote_exact text DEFAULT NULL,
+  p_anchor_quote_prefix text DEFAULT NULL,
+  p_anchor_quote_suffix text DEFAULT NULL,
+  p_anchor_from_hint bigint DEFAULT NULL,
+  p_anchor_to_hint bigint DEFAULT NULL
+)
+RETURNS TABLE (
+  comment_id uuid,
+  is_author boolean,
+  snapshot_content_revision bigint,
+  body text,
+  anchor_quote_exact text,
+  anchor_quote_prefix text,
+  anchor_quote_suffix text,
+  anchor_from_hint bigint,
+  anchor_to_hint bigint,
+  created_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.create_session_share_comment(
+    p_share_id,
+    p_body,
+    p_anchor_quote_exact,
+    p_anchor_quote_prefix,
+    p_anchor_quote_suffix,
+    p_anchor_from_hint,
+    p_anchor_to_hint
+  );
+$$;
+
+CREATE FUNCTION public.list_session_share_comments(
+  p_share_id uuid,
+  p_before_created_at timestamptz DEFAULT NULL,
+  p_before_comment_id uuid DEFAULT NULL,
+  p_limit integer DEFAULT 100
+)
+RETURNS TABLE (
+  comment_id uuid,
+  is_author boolean,
+  snapshot_content_revision bigint,
+  body text,
+  anchor_quote_exact text,
+  anchor_quote_prefix text,
+  anchor_quote_suffix text,
+  anchor_from_hint bigint,
+  anchor_to_hint bigint,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.list_session_share_comments(
+    p_share_id,
+    p_before_created_at,
+    p_before_comment_id,
+    p_limit
+  );
+$$;
+
+-- Dropped functions lose their ACLs and new functions default to EXECUTE for
+-- PUBLIC, so the grants must be re-established explicitly.
+REVOKE ALL ON FUNCTION private.create_session_share_comment(
+  uuid, text, text, text, text, bigint, bigint
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.list_session_share_comments(
+  uuid, timestamptz, uuid, integer
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.create_session_share_comment(
+  uuid, text, text, text, text, bigint, bigint
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_session_share_comments(
+  uuid, timestamptz, uuid, integer
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION private.create_session_share_comment(
+  uuid, text, text, text, text, bigint, bigint
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION private.list_session_share_comments(
+  uuid, timestamptz, uuid, integer
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_session_share_comment(
+  uuid, text, text, text, text, bigint, bigint
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_session_share_comments(
+  uuid, timestamptz, uuid, integer
+) TO authenticated;

--- a/supabase/tests/025-session-share-comment-anchors.sql
+++ b/supabase/tests/025-session-share-comment-anchors.sql
@@ -1,0 +1,563 @@
+begin;
+select plan(23);
+
+select tests.create_supabase_user('anchor_owner', 'anchor-owner@example.com');
+select tests.create_supabase_user('anchor_commenter', 'anchor-commenter@example.com');
+select tests.create_supabase_user('anchor_viewer', 'anchor-viewer@example.com');
+
+create temporary table session_share_comment_anchor_test_state (
+  name text primary key,
+  workspace_id uuid,
+  share_id uuid,
+  entity_id uuid
+);
+
+grant all on session_share_comment_anchor_test_state
+  to anon, authenticated, service_role;
+
+insert into session_share_comment_anchor_test_state (
+  name,
+  workspace_id,
+  share_id
+) values (
+  'share',
+  gen_random_uuid(),
+  gen_random_uuid()
+);
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('anchor_owner'),
+  tests.get_supabase_uid('anchor_commenter'),
+  tests.get_supabase_uid('anchor_viewer')
+);
+
+select tests.authenticate_as_service_role();
+
+insert into public.workspaces (id, owner_user_id, kind, name)
+select
+  workspace_id,
+  tests.get_supabase_uid('anchor_owner'),
+  'shared',
+  'Comment anchor workspace'
+from session_share_comment_anchor_test_state
+where name = 'share';
+
+insert into public.workspace_memberships (workspace_id, user_id, role)
+select
+  workspace_id,
+  tests.get_supabase_uid('anchor_owner'),
+  'owner'
+from session_share_comment_anchor_test_state
+where name = 'share';
+
+insert into public.session_shares (
+  id,
+  workspace_id,
+  session_id,
+  created_by_user_id
+)
+select
+  share_id,
+  workspace_id,
+  'comment-anchor-session',
+  tests.get_supabase_uid('anchor_owner')
+from session_share_comment_anchor_test_state
+where name = 'share';
+
+insert into public.session_share_snapshots (
+  share_id,
+  content_revision,
+  title,
+  body_json,
+  published_by_user_id
+)
+select
+  share_id,
+  7,
+  'Comment anchor fixture',
+  '{"type":"doc","content":[{"type":"paragraph"}]}'::jsonb,
+  tests.get_supabase_uid('anchor_owner')
+from session_share_comment_anchor_test_state
+where name = 'share';
+
+insert into public.session_access_grants (
+  share_id,
+  grantee_user_id,
+  capability,
+  granted_by_user_id
+)
+select
+  share_id,
+  tests.get_supabase_uid('anchor_commenter'),
+  'commenter',
+  tests.get_supabase_uid('anchor_owner')
+from session_share_comment_anchor_test_state
+where name = 'share'
+union all
+select
+  share_id,
+  tests.get_supabase_uid('anchor_viewer'),
+  'viewer',
+  tests.get_supabase_uid('anchor_owner')
+from session_share_comment_anchor_test_state
+where name = 'share';
+
+select tests.clear_authentication();
+reset role;
+
+select ok(
+  (
+    select count(*) = 5
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'session_share_comments'
+      and column_name in (
+        'anchor_quote_exact',
+        'anchor_quote_prefix',
+        'anchor_quote_suffix',
+        'anchor_from_hint',
+        'anchor_to_hint'
+      )
+  ),
+  'Shared comments carry the five anchor columns'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.session_share_comments'::regclass
+      and conname = 'session_share_comments_anchor_check'
+  ),
+  'Shared comment anchors are constrained all-or-nothing with bounded quotes'
+);
+
+select ok(
+  (
+    select count(*) = 2
+      and bool_and(not proc.prosecdef)
+      and bool_and(
+        'search_path=""' = any(coalesce(proc.proconfig, array[]::text[]))
+      )
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'public'
+      and proc.proname in (
+        'create_session_share_comment',
+        'list_session_share_comments'
+      )
+  ),
+  'Recreated public comment wrappers stay hardened security invokers'
+);
+
+select ok(
+  (
+    select count(*) = 2
+      and bool_and(proc.prosecdef)
+      and bool_and(
+        'search_path=""' = any(coalesce(proc.proconfig, array[]::text[]))
+      )
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'private'
+      and proc.proname in (
+        'create_session_share_comment',
+        'list_session_share_comments'
+      )
+  ),
+  'Recreated private comment implementations stay hardened security definers'
+);
+
+select ok(
+  (
+    select count(*) = 2
+      and bool_and(has_function_privilege('authenticated', proc.oid, 'EXECUTE'))
+      and bool_and(not has_function_privilege('anon', proc.oid, 'EXECUTE'))
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'public'
+      and proc.proname in (
+        'create_session_share_comment',
+        'list_session_share_comments'
+      )
+  ),
+  'Recreated comment wrappers keep authenticated-only execute grants'
+);
+
+select tests.authenticate_as('anchor_commenter');
+
+select lives_ok(
+  $$
+    insert into session_share_comment_anchor_test_state (name, entity_id)
+    select
+      'anchored_comment',
+      comment_id
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      '  Anchored comment  ',
+      'quoted fixture text',
+      '',
+      'trailing context',
+      2,
+      9
+    )
+  $$,
+  'A commenter can create an anchored comment with an empty prefix'
+);
+
+select tests.authenticate_as_service_role();
+
+select ok(
+  (
+    select
+      comment.body = 'Anchored comment'
+      and comment.snapshot_content_revision = 7
+      and comment.anchor_quote_exact = 'quoted fixture text'
+      and comment.anchor_quote_prefix = ''
+      and comment.anchor_quote_suffix = 'trailing context'
+      and comment.anchor_from_hint = 2
+      and comment.anchor_to_hint = 9
+    from public.session_share_comments as comment
+    where comment.id = (
+      select entity_id
+      from session_share_comment_anchor_test_state
+      where name = 'anchored_comment'
+    )
+  ),
+  'The stored anchored comment keeps the verbatim quote and hints'
+);
+
+select tests.authenticate_as('anchor_commenter');
+
+select lives_ok(
+  $$
+    insert into session_share_comment_anchor_test_state (name, entity_id)
+    select
+      'legacy_comment',
+      comment_id
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'Legacy comment'
+    )
+  $$,
+  'The legacy two-argument create call still works'
+);
+
+select tests.authenticate_as_service_role();
+
+select ok(
+  (
+    select
+      comment.anchor_quote_exact is null
+      and comment.anchor_quote_prefix is null
+      and comment.anchor_quote_suffix is null
+      and comment.anchor_from_hint is null
+      and comment.anchor_to_hint is null
+    from public.session_share_comments as comment
+    where comment.id = (
+      select entity_id
+      from session_share_comment_anchor_test_state
+      where name = 'legacy_comment'
+    )
+  ),
+  'Legacy comments stay unanchored'
+);
+
+select tests.authenticate_as('anchor_commenter');
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'rejection probe',
+      '',
+      '',
+      ''
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'An empty exact quote is rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'rejection probe',
+      repeat('x', 4097),
+      '',
+      ''
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'An oversized exact quote is rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'rejection probe',
+      'quote',
+      repeat('p', 257),
+      ''
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'An oversized quote prefix is rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'rejection probe',
+      'quote',
+      '',
+      repeat('s', 257)
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'An oversized quote suffix is rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'rejection probe',
+      'quote',
+      'prefix'
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'A partial quote trio is rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'rejection probe',
+      null,
+      null,
+      null,
+      1,
+      5
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'Position hints without quotes are rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'rejection probe',
+      'quote',
+      '',
+      '',
+      0,
+      5
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'A zero from hint is rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'rejection probe',
+      'quote',
+      '',
+      '',
+      5,
+      5
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'A collapsed hint range is rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'rejection probe',
+      'quote',
+      '',
+      '',
+      5,
+      null
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'An unpaired from hint is rejected'
+);
+
+select tests.authenticate_as('anchor_viewer');
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      ),
+      'viewer comment',
+      'quote',
+      '',
+      ''
+    )
+  $$,
+  '42501',
+  'session comment operation not permitted',
+  'A viewer still cannot create comments, anchored or not'
+);
+
+select ok(
+  (
+    select
+      count(*) = 2
+      and count(*) filter (where result.anchor_quote_exact is not null) = 1
+    from public.list_session_share_comments(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      )
+    ) as result
+  ),
+  'A viewer lists anchored and unanchored comments together'
+);
+
+select tests.authenticate_as('anchor_commenter');
+
+select lives_ok(
+  $$
+    select *
+    from public.delete_session_share_comment(
+      (
+        select entity_id
+        from session_share_comment_anchor_test_state
+        where name = 'anchored_comment'
+      )
+    )
+  $$,
+  'The author can delete their anchored comment'
+);
+
+select tests.authenticate_as_service_role();
+
+select ok(
+  (
+    select
+      comment.body = ''
+      and comment.deleted_at is not null
+      and comment.anchor_quote_exact is null
+      and comment.anchor_quote_prefix is null
+      and comment.anchor_quote_suffix is null
+      and comment.anchor_from_hint is null
+      and comment.anchor_to_hint is null
+    from public.session_share_comments as comment
+    where comment.id = (
+      select entity_id
+      from session_share_comment_anchor_test_state
+      where name = 'anchored_comment'
+    )
+  ),
+  'Deleting an anchored comment scrubs the quote and hints'
+);
+
+select tests.authenticate_as('anchor_viewer');
+
+select ok(
+  (
+    select
+      count(*) = 1
+      and bool_and(result.anchor_quote_exact is null)
+    from public.list_session_share_comments(
+      (
+        select share_id
+        from session_share_comment_anchor_test_state
+        where name = 'share'
+      )
+    ) as result
+  ),
+  'Deleted anchored comments drop out of the list'
+);
+
+select finish();
+rollback;


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6181
- <kbd>&nbsp;2&nbsp;</kbd> #6180
- <kbd>&nbsp;1&nbsp;</kbd> #6179 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Drops and recreates comment RPCs during migration (brief deploy ordering risk) and extends security-definer comment paths; behavior is heavily tested and existing callers without anchors remain compatible.
> 
> **Overview**
> Adds **text-range anchors** to shared-note comments so clients can tie a comment to a quoted span in the note (W3C-style exact/prefix/suffix quote plus optional position hints).
> 
> **Database:** New nullable columns on `session_share_comments` with an all-or-nothing CHECK (byte limits, paired hints). `create_session_share_comment` and `list_session_share_comments` are dropped and recreated with optional anchor parameters and anchor fields in the return shape; the two-argument create path still works. Soft delete now clears anchor fields with the body.
> 
> **Web:** `SharedNoteComment` gains optional `anchor`; create-comment server input validates anchors and forwards them to the RPC, with a post-create check that anchored vs unanchored matches the request. List/create responses parse anchor columns with the same invariants as the DB.
> 
> **Tests:** Unit tests for anchor validation/parsing and a Supabase pgTAP suite for RPCs, constraints, ACLs, and delete scrubbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d73d46132901e1464f278680f7030b5d0ac0821f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->