### PR TITLE
feat(web): add an Ask-anything AI chat panel to shared-note pages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -82,6 +82,7 @@
     "tailwindcss": "^4.2.2",
     "unpic": "^4.2.2",
     "usehooks-ts": "^3.1.1",
+    "vaul": "^1.1.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/web/src/components/shared-note-chat-panel.tsx
+++ b/apps/web/src/components/shared-note-chat-panel.tsx
@@ -1,0 +1,336 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+  ArrowUpIcon,
+  ChevronRightIcon,
+  LoaderCircleIcon,
+  LogInIcon,
+  SparklesIcon,
+} from "lucide-react";
+import { useRef, useState } from "react";
+import { Streamdown } from "streamdown";
+import { useMediaQuery } from "usehooks-ts";
+import { Drawer } from "vaul";
+
+import { cn } from "@hypr/utils";
+
+import { sharedPrimaryButtonClassName } from "@/components/shared-note-viewer";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import {
+  SharedNoteChatError,
+  type SharedNoteChatMessage,
+  streamSharedNoteChat,
+} from "@/lib/shared-note-chat";
+import type { SharedNoteSnapshot } from "@/lib/shared-notes";
+
+export function SharedNoteChatPanel({
+  returnPath,
+  signedIn,
+  snapshot,
+}: {
+  returnPath: string;
+  signedIn: boolean;
+  snapshot: SharedNoteSnapshot;
+}) {
+  const isDesktop = useMediaQuery("(min-width: 1024px)", {
+    defaultValue: false,
+    initializeWithValue: false,
+  });
+  const [desktopOpen, setDesktopOpen] = useState(true);
+  const [messages, setMessages] = useState<SharedNoteChatMessage[]>([]);
+  const [draft, setDraft] = useState("");
+  const [streaming, setStreaming] = useState<string | null>(null);
+  const streamingRef = useRef("");
+  const abortRef = useRef<AbortController | null>(null);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useMountEffect(() => () => abortRef.current?.abort());
+
+  const scrollToBottom = () => {
+    requestAnimationFrame(() =>
+      bottomRef.current?.scrollIntoView({ block: "nearest" }),
+    );
+  };
+
+  const sendMutation = useMutation({
+    mutationFn: async (history: SharedNoteChatMessage[]) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      streamingRef.current = "";
+      setStreaming("");
+      await streamSharedNoteChat({
+        messages: history,
+        snapshot,
+        signal: controller.signal,
+        onDelta: (delta) => {
+          streamingRef.current += delta;
+          setStreaming(streamingRef.current);
+          scrollToBottom();
+        },
+      });
+    },
+    onSettled: () => {
+      const reply = streamingRef.current;
+      streamingRef.current = "";
+      setStreaming(null);
+      if (reply) {
+        setMessages((prev) => [...prev, { role: "assistant", content: reply }]);
+      }
+      scrollToBottom();
+    },
+  });
+
+  const send = () => {
+    const content = draft.trim();
+    if (!content || sendMutation.isPending) {
+      return;
+    }
+    const history = [...messages, { role: "user" as const, content }];
+    setMessages(history);
+    setDraft("");
+    sendMutation.mutate(history);
+    scrollToBottom();
+  };
+
+  const errorMessage = sendMutation.isError
+    ? sendMutation.error instanceof SharedNoteChatError &&
+      sendMutation.error.status === 429
+      ? "You’ve reached the free AI limit for now. Try again later."
+      : "The AI couldn’t answer right now. Please try again."
+    : null;
+
+  const body = (
+    <ChatBody
+      bottomRef={bottomRef}
+      draft={draft}
+      errorMessage={errorMessage}
+      messages={messages}
+      pending={sendMutation.isPending}
+      returnPath={returnPath}
+      signedIn={signedIn}
+      streaming={streaming}
+      onDraftChange={setDraft}
+      onSend={send}
+    />
+  );
+
+  if (isDesktop) {
+    if (!desktopOpen) {
+      return (
+        <button
+          type="button"
+          className={cn([
+            "fixed right-4 bottom-4 z-30",
+            "surface border-color-subtle inline-flex min-h-11 items-center gap-2 rounded-full border px-5 shadow-sm",
+            "text-color hover:bg-surface-subtle font-mono text-sm font-medium transition-colors",
+            "focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden",
+          ])}
+          onClick={() => setDesktopOpen(true)}
+        >
+          <SparklesIcon className="size-4" aria-hidden="true" />
+          Ask anything
+        </button>
+      );
+    }
+    return (
+      <aside
+        aria-label="Ask about this note"
+        className="surface border-color-subtle fixed inset-y-0 right-0 z-30 flex w-[380px] flex-col border-l"
+      >
+        <header className="border-color-subtle flex items-center justify-between gap-3 border-b px-5 py-4">
+          <div className="text-color flex items-center gap-2">
+            <SparklesIcon className="size-4" aria-hidden="true" />
+            <h2 className="font-mono text-sm font-medium">
+              Ask about this note
+            </h2>
+          </div>
+          <button
+            type="button"
+            className="text-color-muted hover:text-color rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden"
+            aria-label="Collapse chat panel"
+            onClick={() => setDesktopOpen(false)}
+          >
+            <ChevronRightIcon className="size-4" aria-hidden="true" />
+          </button>
+        </header>
+        {body}
+      </aside>
+    );
+  }
+
+  return (
+    <Drawer.Root>
+      <div aria-hidden="true" className="h-24" />
+      <div className="fixed inset-x-0 bottom-0 z-30 px-4 pb-[max(env(safe-area-inset-bottom),1rem)]">
+        <Drawer.Trigger
+          className={cn([
+            "surface border-color-subtle mx-auto flex min-h-12 w-full max-w-[420px] items-center gap-2 rounded-full border px-5 shadow-lg",
+            "text-color-muted font-mono text-sm",
+            "focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden",
+          ])}
+        >
+          <SparklesIcon className="size-4" aria-hidden="true" />
+          Ask anything
+        </Drawer.Trigger>
+      </div>
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-40 bg-black/40" />
+        <Drawer.Content
+          aria-label="Ask about this note"
+          className="bg-page border-color-subtle fixed inset-x-0 bottom-0 z-50 flex h-[85dvh] flex-col rounded-t-3xl border-t"
+        >
+          <div className="bg-surface-subtle mx-auto mt-3 h-1.5 w-10 shrink-0 rounded-full" />
+          <Drawer.Title className="text-color flex items-center gap-2 px-5 pt-4 pb-2 font-mono text-sm font-medium">
+            <SparklesIcon className="size-4" aria-hidden="true" />
+            Ask about this note
+          </Drawer.Title>
+          <Drawer.Description className="sr-only">
+            Chat with AI about this shared note.
+          </Drawer.Description>
+          {body}
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+}
+
+function ChatBody({
+  bottomRef,
+  draft,
+  errorMessage,
+  messages,
+  onDraftChange,
+  onSend,
+  pending,
+  returnPath,
+  signedIn,
+  streaming,
+}: {
+  bottomRef: React.RefObject<HTMLDivElement | null>;
+  draft: string;
+  errorMessage: string | null;
+  messages: SharedNoteChatMessage[];
+  onDraftChange: (draft: string) => void;
+  onSend: () => void;
+  pending: boolean;
+  returnPath: string;
+  signedIn: boolean;
+  streaming: string | null;
+}) {
+  return (
+    <>
+      <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+        {messages.length === 0 && streaming === null && (
+          <p className="text-color-muted text-sm leading-6">
+            Ask anything about this note — a summary, action items, or details
+            you may have missed.
+          </p>
+        )}
+        {messages.map((message, index) =>
+          message.role === "user" ? (
+            <div key={index} className="flex justify-end">
+              <p className="surface-subtle text-color max-w-[85%] rounded-2xl px-3.5 py-2 text-sm leading-6 whitespace-pre-wrap">
+                {message.content}
+              </p>
+            </div>
+          ) : (
+            <div key={index} className="text-color min-w-0 text-sm leading-6">
+              <Streamdown>{message.content}</Streamdown>
+            </div>
+          ),
+        )}
+        {streaming !== null &&
+          (streaming === "" ? (
+            <p className="text-color-muted flex items-center gap-2 text-sm">
+              <LoaderCircleIcon
+                className="size-4 animate-spin"
+                aria-hidden="true"
+              />
+              Thinking…
+            </p>
+          ) : (
+            <div className="text-color min-w-0 text-sm leading-6">
+              <Streamdown>{streaming}</Streamdown>
+            </div>
+          ))}
+        {errorMessage && (
+          <p className="text-sm text-red-700" role="status">
+            {errorMessage}
+          </p>
+        )}
+        <div ref={bottomRef} />
+      </div>
+      <div className="border-color-subtle border-t px-5 py-4">
+        {signedIn ? (
+          <form
+            className="flex items-end gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              onSend();
+            }}
+          >
+            <textarea
+              className="surface-subtle text-color placeholder:text-color-muted min-h-11 flex-1 resize-none rounded-2xl px-4 py-2.5 text-sm leading-6 focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden"
+              placeholder="Ask anything"
+              rows={Math.min(3, draft.split("\n").length)}
+              value={draft}
+              onChange={(event) => onDraftChange(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  onSend();
+                }
+              }}
+            />
+            <button
+              type="submit"
+              aria-label="Send message"
+              className={cn([
+                "inline-flex size-11 shrink-0 items-center justify-center rounded-full",
+                "bg-linear-to-t from-stone-600 to-stone-500 text-white transition-opacity hover:opacity-90",
+                "focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+              ])}
+              disabled={pending || draft.trim() === ""}
+            >
+              {pending ? (
+                <LoaderCircleIcon
+                  className="size-4 animate-spin"
+                  aria-hidden="true"
+                />
+              ) : (
+                <ArrowUpIcon className="size-4" aria-hidden="true" />
+              )}
+            </button>
+          </form>
+        ) : (
+          <SignInToChat returnPath={returnPath} />
+        )}
+      </div>
+    </>
+  );
+}
+
+function SignInToChat({ returnPath }: { returnPath: string }) {
+  const search = new URLSearchParams({
+    flow: "web",
+    redirect: returnPath,
+  });
+  return (
+    <div className="surface-subtle border-color-subtle rounded-2xl border px-4 py-5">
+      <p className="text-color font-mono text-sm font-medium">
+        Sign in to ask about this note
+      </p>
+      <p className="text-color-muted mt-1 text-sm leading-6">
+        Sign in to chat with AI about this shared note.
+      </p>
+      <a
+        href={`/auth/?${search.toString()}`}
+        className={cn([sharedPrimaryButtonClassName, "mt-4"])}
+      >
+        <LogInIcon className="mr-2 size-4" aria-hidden="true" />
+        Sign in
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/components/shared-note-chat-panel.tsx
+++ b/apps/web/src/components/shared-note-chat-panel.tsx
@@ -160,6 +160,7 @@ export function SharedNoteChatPanel({
     return (
       <aside
         aria-label="Ask about this note"
+        data-chat-panel-open=""
         className="surface border-color-subtle fixed inset-y-0 right-0 z-30 flex w-[380px] flex-col border-l"
       >
         <header className="border-color-subtle flex items-center justify-between gap-3 border-b px-5 py-4">

--- a/apps/web/src/components/shared-note-chat-panel.tsx
+++ b/apps/web/src/components/shared-note-chat-panel.tsx
@@ -35,6 +35,9 @@ export function SharedNoteChatPanel({
     defaultValue: false,
     initializeWithValue: false,
   });
+  // Render nothing until the media query resolves after hydration, so wide
+  // viewports never flash the mobile bottom bar before the desktop aside.
+  const [interactive, setInteractive] = useState(false);
   const [desktopOpen, setDesktopOpen] = useState(true);
   const [messages, setMessages] = useState<SharedNoteChatMessage[]>([]);
   const [draft, setDraft] = useState("");
@@ -43,7 +46,10 @@ export function SharedNoteChatPanel({
   const abortRef = useRef<AbortController | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
-  useMountEffect(() => () => abortRef.current?.abort());
+  useMountEffect(() => {
+    setInteractive(true);
+    return () => abortRef.current?.abort();
+  });
 
   const scrollToBottom = () => {
     requestAnimationFrame(() =>
@@ -52,30 +58,45 @@ export function SharedNoteChatPanel({
   };
 
   const sendMutation = useMutation({
-    mutationFn: async (history: SharedNoteChatMessage[]) => {
+    // The controller doubles as the request's identity: every callback of a
+    // superseded request bails out so it can never touch the active stream.
+    onMutate: () => {
       abortRef.current?.abort();
       const controller = new AbortController();
       abortRef.current = controller;
       streamingRef.current = "";
       setStreaming("");
+      return { controller };
+    },
+    mutationFn: async (history: SharedNoteChatMessage[]) => {
+      const controller = abortRef.current;
+      if (!controller) return;
       await streamSharedNoteChat({
         messages: history,
         snapshot,
         signal: controller.signal,
         onDelta: (delta) => {
+          if (abortRef.current !== controller) return;
           streamingRef.current += delta;
           setStreaming(streamingRef.current);
           scrollToBottom();
         },
       });
     },
-    onSettled: () => {
+    // A failed or interrupted stream discards its partial reply: keeping it
+    // would show an error beside a half answer and feed the fragment into
+    // the next request's history.
+    onSuccess: (_data, _history, context) => {
+      if (abortRef.current !== context.controller) return;
       const reply = streamingRef.current;
-      streamingRef.current = "";
-      setStreaming(null);
       if (reply) {
         setMessages((prev) => [...prev, { role: "assistant", content: reply }]);
       }
+    },
+    onSettled: (_data, _error, _history, context) => {
+      if (abortRef.current !== context?.controller) return;
+      streamingRef.current = "";
+      setStreaming(null);
       scrollToBottom();
     },
   });
@@ -113,6 +134,10 @@ export function SharedNoteChatPanel({
       onSend={send}
     />
   );
+
+  if (!interactive) {
+    return null;
+  }
 
   if (isDesktop) {
     if (!desktopOpen) {

--- a/apps/web/src/components/shared-note-chat-panel.tsx
+++ b/apps/web/src/components/shared-note-chat-panel.tsx
@@ -94,6 +94,7 @@ export function SharedNoteChatPanel({
       }
     },
     onSettled: (_data, _error, _history, context) => {
+      sendInFlightRef.current = false;
       if (abortRef.current !== context?.controller) return;
       streamingRef.current = "";
       setStreaming(null);
@@ -101,11 +102,16 @@ export function SharedNoteChatPanel({
     },
   });
 
+  // isPending only flips after a re-render, so a double submit in the same
+  // tick could start two requests and build the second history without the
+  // first user turn. The ref blocks re-entry synchronously.
+  const sendInFlightRef = useRef(false);
   const send = () => {
     const content = draft.trim();
-    if (!content || sendMutation.isPending) {
+    if (!content || sendInFlightRef.current) {
       return;
     }
+    sendInFlightRef.current = true;
     const history = [...messages, { role: "user" as const, content }];
     setMessages(history);
     setDraft("");
@@ -245,7 +251,7 @@ function ChatBody({
 }) {
   return (
     <>
-      <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
         {messages.length === 0 && streaming === null && (
           <p className="text-color-muted text-sm leading-6">
             Ask anything about this note — a summary, action items, or details

--- a/apps/web/src/components/shared-note-editable-viewer.tsx
+++ b/apps/web/src/components/shared-note-editable-viewer.tsx
@@ -34,6 +34,7 @@ export function SharedNoteEditableViewer({
   accessLabel,
   actions,
   authenticatedNote,
+  chat,
   collaboration,
   fallbackAccessLabel,
   fallbackSnapshot,
@@ -46,6 +47,10 @@ export function SharedNoteEditableViewer({
   accessLabel: string;
   actions?: React.ReactNode;
   authenticatedNote: AuthenticatedSharedNote | null;
+  // Render slot for the chat panel; receives the live snapshot so the chat
+  // always answers about the content currently on screen, and lives inside
+  // this shareId-keyed subtree so its state resets on navigation.
+  chat?: (snapshot: SharedNoteSnapshot) => React.ReactNode;
   collaboration?: React.ReactNode;
   fallbackAccessLabel?: string;
   fallbackSnapshot?: SharedNoteSnapshot | null;
@@ -145,7 +150,7 @@ export function SharedNoteEditableViewer({
     </SharedNoteEditNotice>
   ) : null;
 
-  return (
+  const viewer = (
     <SharedNoteViewer
       accessLabel={
         accessRevoked
@@ -239,6 +244,13 @@ export function SharedNoteEditableViewer({
       showTitle={!isEditing}
       snapshot={activeSnapshot}
     />
+  );
+
+  return (
+    <>
+      {viewer}
+      {chat?.(activeSnapshot)}
+    </>
   );
 
   function applyEditedSnapshot(edited: SharedNoteWebEditSnapshot) {

--- a/apps/web/src/components/shared-note-viewer.tsx
+++ b/apps/web/src/components/shared-note-viewer.tsx
@@ -191,7 +191,15 @@ export function SharedNotePrompt({
 
 function SharedNoteShell({ children }: { children: React.ReactNode }) {
   return (
-    <main className="bg-page text-color min-h-screen overflow-x-clip px-4 py-5 sm:px-6 sm:py-8">
+    <main
+      className={cn([
+        "bg-page text-color min-h-screen overflow-x-clip px-4 py-5 sm:px-6 sm:py-8",
+        // The desktop chat panel ([data-chat-panel-open]) is fixed to the
+        // right edge outside this shell; reserving its width here keeps the
+        // note column and the anchored-comment rail clear of it.
+        "lg:[body:has([data-chat-panel-open])_&]:pr-[380px]",
+      ])}
+    >
       <div
         className={cn([
           "mx-auto w-full max-w-[760px]",

--- a/apps/web/src/lib/shared-note-chat.test.ts
+++ b/apps/web/src/lib/shared-note-chat.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildSharedNoteChatSystemPrompt,
+  feedSseChunk,
+  parseSseLine,
+  SharedNoteChatError,
+} from "./shared-note-chat.ts";
+import type { SharedNoteSnapshot } from "./shared-notes.ts";
+
+function makeSnapshot(bodyText: string): SharedNoteSnapshot {
+  return {
+    shareId: "82a163dd-d595-45f8-8d71-cf38bbb1ce12",
+    schemaVersion: 1,
+    contentRevision: 1,
+    title: "Weekly sync",
+    body: {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Weekly sync" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: bodyText }],
+        },
+      ],
+    },
+    attachments: [],
+    publishedAt: "2026-07-01T00:00:00.000Z",
+  };
+}
+
+test("system prompt embeds the note title and body text", () => {
+  const prompt = buildSharedNoteChatSystemPrompt(
+    makeSnapshot("Decisions and next steps."),
+  );
+
+  assert.ok(prompt.includes("Title: Weekly sync"));
+  assert.ok(prompt.includes("Decisions and next steps."));
+  assert.ok(!prompt.includes("[truncated]"));
+});
+
+test("system prompt truncates long note content with a suffix", () => {
+  const prompt = buildSharedNoteChatSystemPrompt(
+    makeSnapshot("x".repeat(30_000)),
+  );
+
+  assert.ok(prompt.includes(`${"x".repeat(24_000)}[truncated]`));
+  assert.ok(!prompt.includes("x".repeat(24_001)));
+  assert.ok(prompt.endsWith("[truncated]"));
+});
+
+test("parseSseLine extracts delta content from data lines", () => {
+  assert.deepEqual(
+    parseSseLine('data: {"choices":[{"delta":{"content":"Hello"}}]}'),
+    { type: "delta", content: "Hello" },
+  );
+});
+
+test("parseSseLine reports the [DONE] sentinel", () => {
+  assert.deepEqual(parseSseLine("data: [DONE]"), { type: "done" });
+});
+
+test("parseSseLine ignores comments, empty, and malformed lines", () => {
+  assert.deepEqual(parseSseLine(": keep-alive"), { type: "none" });
+  assert.deepEqual(parseSseLine(""), { type: "none" });
+  assert.deepEqual(parseSseLine("event: message"), { type: "none" });
+  assert.deepEqual(parseSseLine("data: {not json"), { type: "none" });
+  assert.deepEqual(parseSseLine('data: {"choices":[{"delta":{}}]}'), {
+    type: "none",
+  });
+});
+
+test("feedSseChunk buffers deltas split across chunks", () => {
+  const first = feedSseChunk(
+    "",
+    'data: {"choices":[{"delta":{"content":"Hel"}}]}\n' +
+      'data: {"choices":[{"delta":{"content":"lo"}}]}\n' +
+      'data: {"choices":[{"delta":{"cont',
+  );
+  assert.deepEqual(first.deltas, ["Hel", "lo"]);
+  assert.equal(first.done, false);
+
+  const second = feedSseChunk(
+    first.buffer,
+    'ent":" world"}}]}\ndata: [DONE]\n',
+  );
+  assert.deepEqual(second.deltas, [" world"]);
+  assert.equal(second.done, true);
+  assert.equal(second.buffer, "");
+});
+
+test("SharedNoteChatError surfaces the response status", () => {
+  const error = new SharedNoteChatError(429);
+
+  assert.ok(error instanceof Error);
+  assert.equal(error.name, "SharedNoteChatError");
+  assert.equal(error.status, 429);
+});

--- a/apps/web/src/lib/shared-note-chat.ts
+++ b/apps/web/src/lib/shared-note-chat.ts
@@ -1,0 +1,153 @@
+import {
+  getSharedNotePlainText,
+  type SharedNoteSnapshot,
+  withoutDuplicateLeadingTitle,
+} from "./shared-notes.ts";
+
+const MAX_NOTE_CONTEXT_CHARS = 24_000;
+
+export type SharedNoteChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+export class SharedNoteChatError extends Error {
+  status: number;
+
+  constructor(status: number) {
+    super(`Shared note chat request failed with status ${status}`);
+    this.name = "SharedNoteChatError";
+    this.status = status;
+  }
+}
+
+export function buildSharedNoteChatSystemPrompt(snapshot: SharedNoteSnapshot) {
+  const body = withoutDuplicateLeadingTitle(snapshot.body, snapshot.title);
+  const text = getSharedNotePlainText(body);
+  const noteText =
+    text.length > MAX_NOTE_CONTEXT_CHARS
+      ? `${text.slice(0, MAX_NOTE_CONTEXT_CHARS)}[truncated]`
+      : text;
+  return [
+    "You are a helpful assistant answering questions about one shared note.",
+    "Answer using only the note content below. If the note does not contain the answer, say so instead of guessing.",
+    "Keep answers concise. Use Markdown formatting when it helps readability.",
+    "",
+    `Title: ${snapshot.title || "Untitled note"}`,
+    "Content:",
+    noteText,
+  ].join("\n");
+}
+
+export function parseSseLine(
+  line: string,
+): { type: "delta"; content: string } | { type: "done" } | { type: "none" } {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("data:")) {
+    return { type: "none" };
+  }
+  const payload = trimmed.slice("data:".length).trim();
+  if (payload === "[DONE]") {
+    return { type: "done" };
+  }
+  if (!payload) {
+    return { type: "none" };
+  }
+  try {
+    const parsed = JSON.parse(payload) as {
+      choices?: Array<{ delta?: { content?: unknown } }>;
+    };
+    const content = parsed.choices?.[0]?.delta?.content;
+    return typeof content === "string" && content.length > 0
+      ? { type: "delta", content }
+      : { type: "none" };
+  } catch {
+    return { type: "none" };
+  }
+}
+
+export function feedSseChunk(buffer: string, chunk: string) {
+  const lines = `${buffer}${chunk}`.split("\n");
+  const rest = lines.pop() ?? "";
+  const deltas: string[] = [];
+  let done = false;
+  for (const line of lines) {
+    const event = parseSseLine(line);
+    if (event.type === "done") {
+      done = true;
+      break;
+    }
+    if (event.type === "delta") {
+      deltas.push(event.content);
+    }
+  }
+  return { buffer: rest, deltas, done };
+}
+
+export async function streamSharedNoteChat({
+  messages,
+  onDelta,
+  signal,
+  snapshot,
+}: {
+  messages: SharedNoteChatMessage[];
+  onDelta: (delta: string) => void;
+  signal?: AbortSignal;
+  snapshot: SharedNoteSnapshot;
+}): Promise<void> {
+  // Dynamic imports keep this module loadable under node --test, which cannot
+  // resolve the "@/" alias used by the env and Supabase auth modules.
+  const [{ env }, { getAccessToken }] = await Promise.all([
+    import("@/env"),
+    import("@/functions/access-token"),
+  ]);
+  const token = await getAccessToken();
+  const base = env.VITE_API_URL.endsWith("/")
+    ? env.VITE_API_URL
+    : `${env.VITE_API_URL}/`;
+  const response = await fetch(new URL("chat/completions", base), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "x-char-task": "chat",
+    },
+    body: JSON.stringify({
+      model: "auto",
+      stream: true,
+      messages: [
+        { role: "system", content: buildSharedNoteChatSystemPrompt(snapshot) },
+        ...messages,
+      ],
+    }),
+    signal,
+  });
+  if (!response.ok || !response.body) {
+    throw new SharedNoteChatError(response.status);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    const result = feedSseChunk(
+      buffer,
+      decoder.decode(value, { stream: true }),
+    );
+    buffer = result.buffer;
+    for (const delta of result.deltas) {
+      onDelta(delta);
+    }
+    if (result.done) {
+      return;
+    }
+  }
+  const tail = parseSseLine(buffer + decoder.decode());
+  if (tail.type === "delta") {
+    onDelta(tail.content);
+  }
+}

--- a/apps/web/src/routes/share/$shareId.tsx
+++ b/apps/web/src/routes/share/$shareId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import { AccountSharedNoteActions } from "@/components/shared-note-actions";
+import { SharedNoteChatPanel } from "@/components/shared-note-chat-panel";
 import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import { SharedNoteEditableViewer } from "@/components/shared-note-editable-viewer";
@@ -83,42 +84,51 @@ function Component() {
     return <SharedNoteUnavailable />;
   }
 
+  const returnPath = buildSharedNoteWebPath(
+    `/share/${encodeURIComponent(note.snapshot.shareId)}/`,
+    scheme,
+  );
+
   return (
-    <SharedNoteEditableViewer
-      key={note.snapshot.shareId}
-      snapshot={note.snapshot}
-      authenticatedNote={note}
-      fallbackAccessLabel="Shared note · View only"
-      fallbackSnapshot={note.snapshot}
-      onAccessChanged={async () => {
-        await router.invalidate();
-        const refreshed = await readAuthenticatedSharedNote({
-          data: note.snapshot.shareId,
-        });
-        return refreshed.status === "ready" ? refreshed.note : null;
-      }}
-      resolveAttachment={resolveAttachment}
-      revokedBehavior="read-only"
-      signedIn={true}
-      accessLabel={formatAuthenticatedSharedNoteAccessLabel(note)}
-      collaboration={
-        <SharedNoteCollaboration
-          capability={note.capability}
-          currentUserId={user.id}
-          manageAccess={note.manageAccess}
-          returnPath={buildSharedNoteWebPath(
-            `/share/${encodeURIComponent(note.snapshot.shareId)}/`,
-            scheme,
-          )}
-          shareId={note.snapshot.shareId}
-        />
-      }
-      actions={
-        <AccountSharedNoteActions
-          scheme={scheme}
-          shareId={note.snapshot.shareId}
-        />
-      }
-    />
+    <>
+      <SharedNoteEditableViewer
+        key={note.snapshot.shareId}
+        snapshot={note.snapshot}
+        authenticatedNote={note}
+        fallbackAccessLabel="Shared note · View only"
+        fallbackSnapshot={note.snapshot}
+        onAccessChanged={async () => {
+          await router.invalidate();
+          const refreshed = await readAuthenticatedSharedNote({
+            data: note.snapshot.shareId,
+          });
+          return refreshed.status === "ready" ? refreshed.note : null;
+        }}
+        resolveAttachment={resolveAttachment}
+        revokedBehavior="read-only"
+        signedIn={true}
+        accessLabel={formatAuthenticatedSharedNoteAccessLabel(note)}
+        collaboration={
+          <SharedNoteCollaboration
+            capability={note.capability}
+            currentUserId={user.id}
+            manageAccess={note.manageAccess}
+            returnPath={returnPath}
+            shareId={note.snapshot.shareId}
+          />
+        }
+        actions={
+          <AccountSharedNoteActions
+            scheme={scheme}
+            shareId={note.snapshot.shareId}
+          />
+        }
+      />
+      <SharedNoteChatPanel
+        returnPath={returnPath}
+        signedIn={true}
+        snapshot={note.snapshot}
+      />
+    </>
   );
 }

--- a/apps/web/src/routes/share/$shareId.tsx
+++ b/apps/web/src/routes/share/$shareId.tsx
@@ -123,11 +123,13 @@ function Component() {
             shareId={note.snapshot.shareId}
           />
         }
-      />
-      <SharedNoteChatPanel
-        returnPath={returnPath}
-        signedIn={true}
-        snapshot={note.snapshot}
+        chat={(liveSnapshot) => (
+          <SharedNoteChatPanel
+            returnPath={returnPath}
+            signedIn={true}
+            snapshot={liveSnapshot}
+          />
+        )}
       />
     </>
   );

--- a/apps/web/src/routes/share/link/$shareId.tsx
+++ b/apps/web/src/routes/share/link/$shareId.tsx
@@ -227,11 +227,13 @@ function LinkSharedNoteClient({
             shareId={validShareId.data}
           />
         }
-      />
-      <SharedNoteChatPanel
-        returnPath={returnPath}
-        signedIn={currentUserId !== null}
-        snapshot={snapshot}
+        chat={(liveSnapshot) => (
+          <SharedNoteChatPanel
+            returnPath={returnPath}
+            signedIn={currentUserId !== null}
+            snapshot={liveSnapshot}
+          />
+        )}
       />
     </>
   );

--- a/apps/web/src/routes/share/link/$shareId.tsx
+++ b/apps/web/src/routes/share/link/$shareId.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 
 import { useShareRouteContinuation } from "@/components/share-route-continuation";
 import { LinkSharedNoteActions } from "@/components/shared-note-actions";
+import { SharedNoteChatPanel } from "@/components/shared-note-chat-panel";
 import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import { SharedNoteEditableViewer } from "@/components/shared-note-editable-viewer";
@@ -177,53 +178,61 @@ function LinkSharedNoteClient({
     authenticatedSnapshot: authenticatedNote?.snapshot ?? null,
     linkSnapshot,
   });
+  const returnPath = buildSharedNoteWebPath(pathname, scheme);
 
   return (
-    <SharedNoteEditableViewer
-      key={snapshot.shareId}
-      snapshot={snapshot}
-      authenticatedNote={authenticatedNote}
-      fallbackAccessLabel={
-        linkSnapshot
-          ? "Anyone with the link · View only"
-          : "Shared note · View only"
-      }
-      fallbackSnapshot={fallbackSnapshot}
-      onAccessChanged={async () => {
-        const [refreshed] = await Promise.all([
-          authenticatedQuery.refetch(),
-          hasToken ? snapshotQuery.refetch() : Promise.resolve(null),
-        ]);
-        return refreshed.status === "success" &&
-          refreshed.data.status === "ready"
-          ? refreshed.data.note
-          : null;
-      }}
-      resolveAttachment={resolveAttachment}
-      revokedBehavior="read-only"
-      signedIn={currentUserId !== null}
-      accessLabel={
-        authenticatedNote &&
-        shouldUseAuthenticatedSharedNoteAccessLabel(authenticatedNote)
-          ? formatAuthenticatedSharedNoteAccessLabel(authenticatedNote)
-          : "Anyone with the link · View only"
-      }
-      collaboration={
-        <SharedNoteCollaboration
-          capability={authenticatedNote?.capability ?? "viewer"}
-          currentUserId={currentUserId}
-          manageAccess={authenticatedNote?.manageAccess ?? false}
-          returnPath={buildSharedNoteWebPath(pathname, scheme)}
-          shareId={validShareId.data}
-        />
-      }
-      actions={
-        <LinkSharedNoteActions
-          pathname={pathname}
-          scheme={scheme}
-          shareId={validShareId.data}
-        />
-      }
-    />
+    <>
+      <SharedNoteEditableViewer
+        key={snapshot.shareId}
+        snapshot={snapshot}
+        authenticatedNote={authenticatedNote}
+        fallbackAccessLabel={
+          linkSnapshot
+            ? "Anyone with the link · View only"
+            : "Shared note · View only"
+        }
+        fallbackSnapshot={fallbackSnapshot}
+        onAccessChanged={async () => {
+          const [refreshed] = await Promise.all([
+            authenticatedQuery.refetch(),
+            hasToken ? snapshotQuery.refetch() : Promise.resolve(null),
+          ]);
+          return refreshed.status === "success" &&
+            refreshed.data.status === "ready"
+            ? refreshed.data.note
+            : null;
+        }}
+        resolveAttachment={resolveAttachment}
+        revokedBehavior="read-only"
+        signedIn={currentUserId !== null}
+        accessLabel={
+          authenticatedNote &&
+          shouldUseAuthenticatedSharedNoteAccessLabel(authenticatedNote)
+            ? formatAuthenticatedSharedNoteAccessLabel(authenticatedNote)
+            : "Anyone with the link · View only"
+        }
+        collaboration={
+          <SharedNoteCollaboration
+            capability={authenticatedNote?.capability ?? "viewer"}
+            currentUserId={currentUserId}
+            manageAccess={authenticatedNote?.manageAccess ?? false}
+            returnPath={returnPath}
+            shareId={validShareId.data}
+          />
+        }
+        actions={
+          <LinkSharedNoteActions
+            pathname={pathname}
+            scheme={scheme}
+            shareId={validShareId.data}
+          />
+        }
+      />
+      <SharedNoteChatPanel
+        returnPath={returnPath}
+        signedIn={currentUserId !== null}
+        snapshot={snapshot}
+      />
+    </>
   );
 }

--- a/apps/web/src/routes/share/public/$publicSlug.tsx
+++ b/apps/web/src/routes/share/public/$publicSlug.tsx
@@ -143,11 +143,13 @@ function Component() {
       actions={
         <PublicSharedNoteActions publicSlug={publicSlug} scheme={scheme} />
       }
-      />
-      <SharedNoteChatPanel
-        returnPath={returnPath}
-        signedIn={user !== null}
-        snapshot={snapshot}
+      chat={(liveSnapshot) => (
+        <SharedNoteChatPanel
+          returnPath={returnPath}
+          signedIn={user !== null}
+          snapshot={liveSnapshot}
+        />
+      )}
       />
     </>
   );

--- a/apps/web/src/routes/share/public/$publicSlug.tsx
+++ b/apps/web/src/routes/share/public/$publicSlug.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useRouter } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import { PublicSharedNoteActions } from "@/components/shared-note-actions";
+import { SharedNoteChatPanel } from "@/components/shared-note-chat-panel";
 import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import { SharedNoteEditableViewer } from "@/components/shared-note-editable-viewer";
@@ -101,6 +102,10 @@ function Component() {
   }
 
   const snapshot = authenticatedNote?.snapshot ?? result.snapshot;
+  const returnPath = buildSharedNoteWebPath(
+    `/share/public/${encodeURIComponent(publicSlug)}/`,
+    scheme,
+  );
   const accessLabel =
     authenticatedNote &&
     shouldUseAuthenticatedSharedNoteAccessLabel(authenticatedNote)
@@ -108,8 +113,9 @@ function Component() {
       : "Public note · View only";
 
   return (
-    <SharedNoteEditableViewer
-      key={snapshot.shareId}
+    <>
+      <SharedNoteEditableViewer
+        key={snapshot.shareId}
       snapshot={snapshot}
       authenticatedNote={authenticatedNote}
       fallbackAccessLabel="Public note · View only"
@@ -130,16 +136,19 @@ function Component() {
           capability={authenticatedNote?.capability ?? "viewer"}
           currentUserId={user?.id ?? null}
           manageAccess={authenticatedNote?.manageAccess ?? false}
-          returnPath={buildSharedNoteWebPath(
-            `/share/public/${encodeURIComponent(publicSlug)}/`,
-            scheme,
-          )}
+          returnPath={returnPath}
           shareId={snapshot.shareId}
         />
       }
       actions={
         <PublicSharedNoteActions publicSlug={publicSlug} scheme={scheme} />
       }
-    />
+      />
+      <SharedNoteChatPanel
+        returnPath={returnPath}
+        signedIn={user !== null}
+        snapshot={snapshot}
+      />
+    </>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,6 +692,9 @@ importers:
       usehooks-ts:
         specifier: ^3.1.1
         version: 3.1.1(react@19.2.5)
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -15252,6 +15255,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-location@4.1.0:
     resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}
@@ -32005,6 +32014,15 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-location@4.1.0:
     dependencies:


### PR DESCRIPTION
Granola-style chat about the shared note on all three share routes:
SSE-streamed replies from the existing OpenAI-compatible LLM proxy with
the viewer's Supabase bearer, note context built from the snapshot
title and plain text (24k-char cap), Streamdown rendering, a
collapsible right panel open by default on desktop, a vaul bottom
sheet behind a docked Ask-anything bar on mobile, a sign-in gate for
anonymous viewers, and friendly copy for free-tier rate limits.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6181 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6180
- <kbd>&nbsp;1&nbsp;</kbd> #6179
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated LLM calls send full note plain text to the proxy (bounded but sensitive); UI-only changes to share routes with established auth patterns.
> 
> **Overview**
> Adds an **“Ask about this note”** AI chat on all three shared-note routes (account, link, and public), wired through a new optional `chat` render slot on `SharedNoteEditableViewer` so answers use the **live** snapshot (including after edits).
> 
> **Client streaming** posts to the existing `chat/completions` proxy with the viewer’s Supabase bearer, builds a system prompt from note title plus plain text (24k-char cap), and renders replies with Streamdown. **UI**: collapsible 380px right panel (open by default) on desktop—with shell right padding via `[data-chat-panel-open]`—and a **vaul** bottom sheet plus docked “Ask anything” bar on mobile; hydration waits on a media query to avoid layout flash. Signed-out users see a sign-in CTA; **429** shows free-tier limit copy. Streaming uses abort/supersede handling and drops partial replies on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d2bfe01e0f8a1c9d834343f7eb7a8d883bbd06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->