### PR TITLE
feat(web): render anchored comments on the shared note page

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@chenglou/pretext": "^0.0.4",
     "@deepgram/sdk": "^4.11.3",
+    "@floating-ui/dom": "^1.7.6",
     "@honeycombio/opentelemetry-web": "^1.3.0",
     "@hypr/api-client": "workspace:*",
     "@hypr/changelog": "workspace:^",

--- a/apps/web/src/components/shared-note-collaboration.tsx
+++ b/apps/web/src/components/shared-note-collaboration.tsx
@@ -1,4 +1,3 @@
-import { useForm } from "@tanstack/react-form";
 import {
   useInfiniteQuery,
   useMutation,
@@ -11,7 +10,6 @@ import {
   LoaderCircleIcon,
   LogInIcon,
   MessageSquareIcon,
-  SendIcon,
   Trash2Icon,
   XIcon,
 } from "lucide-react";
@@ -19,15 +17,16 @@ import {
 import { cn } from "@hypr/utils";
 
 import {
+  useDeleteSharedNoteComment,
+  useSharedNoteComments,
+} from "@/components/shared-note-comments-data";
+import {
   sharedPrimaryButtonClassName,
   sharedSecondaryButtonClassName,
 } from "@/components/shared-note-viewer";
 import {
   cancelMySharedNoteAccessRequest,
-  createSharedNoteComment,
-  deleteSharedNoteComment,
   getMySharedNoteAccessRequest,
-  listSharedNoteComments,
   listSharedNoteManagerAccess,
   requestSharedNoteCommentAccess,
   reviewSharedNoteAccessRequest,
@@ -36,17 +35,15 @@ import {
   canComposeSharedNoteComments,
   formatSharedNoteAccessRequestDescription,
   hasSharedNoteCollaborationAccess,
-  MAX_SHARED_NOTE_COMMENT_BYTES,
-  validateSharedNoteCommentBody,
+  truncateSharedNoteCommentQuote,
 } from "@/lib/shared-note-collaboration";
 import type {
   SessionAccessRequestState,
   SessionShareAccessCursor,
-  SharedNoteCommentCursor,
   SharedNoteCapability,
+  SharedNoteComment,
 } from "@/lib/shared-notes";
 
-const commentsQueryKey = (shareId: string) => ["shared-note-comments", shareId];
 const accessRequestQueryKey = (shareId: string) => [
   "shared-note-access-request",
   shareId,
@@ -71,29 +68,7 @@ export function SharedNoteCollaboration({
 }) {
   const queryClient = useQueryClient();
   const signedIn = currentUserId !== null;
-  const commentsQuery = useInfiniteQuery({
-    queryKey: commentsQueryKey(shareId),
-    queryFn: async ({ pageParam }) => {
-      const result = await listSharedNoteComments({
-        data: {
-          shareId,
-          beforeCreatedAt: pageParam?.beforeCreatedAt ?? null,
-          beforeCommentId: pageParam?.beforeCommentId ?? null,
-        },
-      });
-      if (result.status === "error") {
-        throw new Error("comments unavailable");
-      }
-      return result;
-    },
-    enabled: signedIn,
-    initialPageParam: null as SharedNoteCommentCursor | null,
-    getNextPageParam: (lastPage) =>
-      lastPage.status === "ready"
-        ? (lastPage.nextCursor ?? undefined)
-        : undefined,
-    retry: false,
-  });
+  const commentsQuery = useSharedNoteComments({ enabled: signedIn, shareId });
   const accessRequestQuery = useQuery({
     queryKey: accessRequestQueryKey(shareId),
     queryFn: async () => {
@@ -126,35 +101,7 @@ export function SharedNoteCollaboration({
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     retry: false,
   });
-  const createMutation = useMutation({
-    mutationFn: async (body: string) => {
-      const result = await createSharedNoteComment({
-        data: { shareId, body },
-      });
-      if (result.status !== "ready") {
-        throw new Error("comment unavailable");
-      }
-      return result.comment;
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: commentsQueryKey(shareId),
-      });
-    },
-  });
-  const deleteMutation = useMutation({
-    mutationFn: async (commentId: string) => {
-      const result = await deleteSharedNoteComment({ data: commentId });
-      if (result.status !== "ready") {
-        throw new Error("comment unavailable");
-      }
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: commentsQueryKey(shareId),
-      });
-    },
-  });
+  const deleteMutation = useDeleteSharedNoteComment({ shareId });
   const requestMutation = useMutation({
     mutationFn: async () => {
       const result = await requestSharedNoteCommentAccess({ data: shareId });
@@ -208,16 +155,6 @@ export function SharedNoteCollaboration({
       });
     },
   });
-  const commentForm = useForm({
-    defaultValues: { body: "" },
-    onSubmit: async ({ formApi, value }) => {
-      const comment = validateSharedNoteCommentBody(value.body);
-      if (!comment.valid) return;
-      await createMutation.mutateAsync(comment.body);
-      formApi.reset();
-    },
-  });
-
   const hasCollaborationAccess = hasSharedNoteCollaborationAccess(
     commentsQuery.data?.pages[0],
   );
@@ -296,91 +233,10 @@ export function SharedNoteCollaboration({
           )}
 
           {canCompose && (
-            <form
-              className="border-color-subtle mt-6 border-t pt-5"
-              onSubmit={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                void commentForm.handleSubmit();
-              }}
-            >
-              <commentForm.Field name="body">
-                {(field) => {
-                  const comment = validateSharedNoteCommentBody(
-                    field.state.value,
-                  );
-                  const tooLong =
-                    comment.byteLength > MAX_SHARED_NOTE_COMMENT_BYTES;
-                  const errorId = "shared-note-comment-body-error";
-                  return (
-                    <>
-                      <label
-                        htmlFor="shared-note-comment-body"
-                        className="text-color font-mono text-sm font-medium"
-                      >
-                        Add a comment
-                      </label>
-                      <textarea
-                        id="shared-note-comment-body"
-                        className={cn([
-                          "surface-subtle border-color-subtle text-color mt-2 min-h-24 w-full resize-y rounded-2xl border px-4 py-3",
-                          "placeholder:text-color-muted text-sm leading-6 focus:border-stone-400 focus:ring-2 focus:ring-stone-300 focus:outline-hidden",
-                        ])}
-                        aria-describedby={tooLong ? errorId : undefined}
-                        aria-invalid={tooLong}
-                        placeholder="Share a thought about this note…"
-                        required
-                        value={field.state.value}
-                        onBlur={field.handleBlur}
-                        onChange={(event) =>
-                          field.handleChange(event.target.value)
-                        }
-                      />
-                      {tooLong && (
-                        <p
-                          id={errorId}
-                          className="mt-2 text-sm text-red-700"
-                          role="alert"
-                        >
-                          Comment is too long (
-                          {comment.byteLength.toLocaleString()}/
-                          {MAX_SHARED_NOTE_COMMENT_BYTES.toLocaleString()}{" "}
-                          bytes).
-                        </p>
-                      )}
-                      <div className="mt-3 flex items-center justify-between gap-4">
-                        <p className="text-color-muted text-xs">
-                          Visible only to people who can open this note.
-                        </p>
-                        <button
-                          type="submit"
-                          className={sharedPrimaryButtonClassName}
-                          disabled={createMutation.isPending || !comment.valid}
-                        >
-                          {createMutation.isPending ? (
-                            <LoaderCircleIcon
-                              className="mr-2 size-4 animate-spin"
-                              aria-hidden="true"
-                            />
-                          ) : (
-                            <SendIcon
-                              className="mr-2 size-4"
-                              aria-hidden="true"
-                            />
-                          )}
-                          Comment
-                        </button>
-                      </div>
-                    </>
-                  );
-                }}
-              </commentForm.Field>
-              {createMutation.isError && (
-                <p className="mt-3 text-sm text-red-700" role="status">
-                  Your comment couldn’t be added. Try again.
-                </p>
-              )}
-            </form>
+            <p className="border-color-subtle text-color-muted mt-6 border-t pt-5 text-sm leading-6">
+              Select text in the note to comment. Comments are visible only to
+              people who can open this note.
+            </p>
           )}
 
           {!canCompose &&
@@ -446,12 +302,7 @@ function CommentList({
   onDelete,
   onLoadEarlier,
 }: {
-  comments: Array<{
-    body: string;
-    commentId: string;
-    createdAt: string;
-    isAuthor: boolean;
-  }>;
+  comments: SharedNoteComment[];
   deletePending: boolean;
   deletingCommentId: string | null;
   error: boolean;
@@ -515,7 +366,11 @@ function CommentList({
           const deleting =
             deletePending && deletingCommentId === comment.commentId;
           return (
-            <li key={comment.commentId} className="py-5">
+            <li
+              key={comment.commentId}
+              id={`shared-comment-${comment.commentId}`}
+              className="py-5"
+            >
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <p className="text-color font-mono text-sm font-medium">
@@ -547,6 +402,11 @@ function CommentList({
                   </button>
                 )}
               </div>
+              {comment.anchor && (
+                <p className="border-color-subtle text-color-muted mt-3 truncate border-l-2 pl-3 text-xs leading-5">
+                  {truncateSharedNoteCommentQuote(comment.anchor.quoteExact)}
+                </p>
+              )}
               <p className="text-color mt-3 text-sm leading-6 whitespace-pre-wrap">
                 {comment.body}
               </p>

--- a/apps/web/src/components/shared-note-comment-rail.tsx
+++ b/apps/web/src/components/shared-note-comment-rail.tsx
@@ -1,0 +1,255 @@
+import { Trash2Icon } from "lucide-react";
+import { useRef, useState } from "react";
+
+import { cn } from "@hypr/utils";
+
+import { truncateSharedNoteCommentQuote } from "@/lib/shared-note-collaboration";
+import type { AnchoredSharedNoteComment } from "@/lib/shared-note-comment-anchors";
+import { layoutRailCards } from "@/lib/shared-note-comment-rail-layout";
+
+export const DRAFT_COMMENT_ID = "draft";
+
+const RAIL_CARD_GAP = 12;
+
+export function SharedNoteCommentRail({
+  activeCommentId,
+  canDelete,
+  composer,
+  composerNode,
+  items,
+  onActivate,
+  onDelete,
+  screenTops,
+}: {
+  items: AnchoredSharedNoteComment[];
+  screenTops: ReadonlyMap<string, number>;
+  activeCommentId: string | null;
+  onActivate: (commentId: string | null) => void;
+  composer: { top: number } | null;
+  composerNode?: React.ReactNode;
+  onDelete: (commentId: string) => void;
+  canDelete: (comment: AnchoredSharedNoteComment) => boolean;
+}) {
+  const [heights, setHeights] = useState<ReadonlyMap<string, number>>(
+    new Map(),
+  );
+  // Cached per card so React only re-runs a ref (and its ResizeObserver
+  // cleanup) when the card unmounts, not on every render.
+  const measureRefs = useRef(
+    new Map<string, (element: HTMLDivElement | null) => (() => void) | void>(),
+  );
+
+  const measureRef = (id: string) => {
+    const cached = measureRefs.current.get(id);
+    if (cached) return cached;
+    const ref = (element: HTMLDivElement | null) => {
+      if (!element) return;
+      const observer = new ResizeObserver(() => {
+        const height = element.getBoundingClientRect().height;
+        setHeights((previous) =>
+          previous.get(id) === height
+            ? previous
+            : new Map(previous).set(id, height),
+        );
+      });
+      observer.observe(element);
+      return () => {
+        observer.disconnect();
+        setHeights((previous) => {
+          if (!previous.has(id)) return previous;
+          const next = new Map(previous);
+          next.delete(id);
+          return next;
+        });
+      };
+    };
+    measureRefs.current.set(id, ref);
+    return ref;
+  };
+
+  const anchoredItems = items.filter((item) => item.range !== null);
+  const unanchoredItems = items.filter((item) => item.range === null);
+  const placements = layoutRailCards(
+    [
+      ...(composer
+        ? [
+            {
+              id: DRAFT_COMMENT_ID,
+              desiredTop: composer.top,
+              height: heights.get(DRAFT_COMMENT_ID) ?? 0,
+            },
+          ]
+        : []),
+      ...anchoredItems.map((item) => ({
+        id: item.commentId,
+        desiredTop: screenTops.get(item.commentId) ?? 0,
+        height: heights.get(item.commentId) ?? 0,
+      })),
+    ],
+    {
+      activeId: composer ? DRAFT_COMMENT_ID : activeCommentId,
+      gap: RAIL_CARD_GAP,
+    },
+  );
+  const topById = new Map(
+    placements.map((placement) => [placement.id, placement.top]),
+  );
+  const stackBottom = placements.reduce(
+    (bottom, placement) =>
+      Math.max(bottom, placement.top + (heights.get(placement.id) ?? 0)),
+    0,
+  );
+
+  if (!composer && anchoredItems.length === 0 && unanchoredItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="relative h-full">
+      {composer && (
+        <div
+          ref={measureRef(DRAFT_COMMENT_ID)}
+          className="absolute inset-x-0 transition-[top] duration-200"
+          style={{ top: topById.get(DRAFT_COMMENT_ID) ?? composer.top }}
+        >
+          {composerNode}
+        </div>
+      )}
+      {anchoredItems.map((item) => (
+        <div
+          key={item.commentId}
+          ref={measureRef(item.commentId)}
+          className="absolute inset-x-0 transition-[top] duration-200"
+          style={{ top: topById.get(item.commentId) ?? 0 }}
+        >
+          <RailCard
+            active={item.commentId === activeCommentId}
+            comment={item}
+            onActivate={() =>
+              onActivate(
+                item.commentId === activeCommentId ? null : item.commentId,
+              )
+            }
+            onDelete={() => onDelete(item.commentId)}
+            showDelete={canDelete(item)}
+          />
+        </div>
+      ))}
+      {unanchoredItems.length > 0 && (
+        <div
+          className="absolute inset-x-0 space-y-3"
+          style={{ top: stackBottom + RAIL_CARD_GAP * 2 }}
+        >
+          <p className="border-color-subtle text-color-muted border-t pt-3 font-mono text-xs">
+            No longer anchored
+          </p>
+          {unanchoredItems.map((item) => (
+            <RailCard
+              key={item.commentId}
+              active={false}
+              comment={item}
+              onDelete={() => onDelete(item.commentId)}
+              showDelete={canDelete(item)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RailCard({
+  active,
+  comment,
+  onActivate,
+  onDelete,
+  showDelete,
+}: {
+  active: boolean;
+  comment: AnchoredSharedNoteComment;
+  onActivate?: () => void;
+  onDelete: () => void;
+  showDelete: boolean;
+}) {
+  return (
+    <div
+      role={onActivate ? "button" : undefined}
+      tabIndex={onActivate ? 0 : undefined}
+      onClick={onActivate}
+      onKeyDown={
+        onActivate
+          ? (event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onActivate();
+              }
+            }
+          : undefined
+      }
+      className={cn([
+        "surface rounded-2xl border p-4 text-left shadow-sm transition-shadow",
+        active ? "border-stone-400 shadow-md" : "border-color-subtle",
+        onActivate && "cursor-pointer",
+      ])}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-color font-mono text-xs font-medium">
+            {comment.isAuthor ? "You" : "Collaborator"}
+          </p>
+          <time
+            className="text-color-muted mt-0.5 block text-[11px]"
+            dateTime={comment.createdAt}
+          >
+            {formatRelativeTime(comment.createdAt)}
+          </time>
+        </div>
+        {showDelete && (
+          <button
+            type="button"
+            aria-label="Delete comment"
+            className="text-color-muted hover:text-color rounded-full p-1.5 transition-colors focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden"
+            onClick={(event) => {
+              event.stopPropagation();
+              onDelete();
+            }}
+          >
+            <Trash2Icon className="size-3.5" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+      {comment.anchor && (
+        <p className="border-color-subtle text-color-muted mt-2 truncate border-l-2 pl-2 text-xs leading-5">
+          {truncateSharedNoteCommentQuote(comment.anchor.quoteExact)}
+        </p>
+      )}
+      <p className="text-color mt-2 text-sm leading-6 whitespace-pre-wrap">
+        {comment.body}
+      </p>
+    </div>
+  );
+}
+
+const RELATIVE_TIME_DIVISIONS: Array<
+  [amount: number, unit: Intl.RelativeTimeFormatUnit]
+> = [
+  [60, "second"],
+  [60, "minute"],
+  [24, "hour"],
+  [7, "day"],
+  [4.34524, "week"],
+  [12, "month"],
+  [Number.POSITIVE_INFINITY, "year"],
+];
+
+function formatRelativeTime(value: string) {
+  const formatter = new Intl.RelativeTimeFormat("en-US", { numeric: "auto" });
+  let duration = (Date.parse(value) - Date.now()) / 1000;
+  for (const [amount, unit] of RELATIVE_TIME_DIVISIONS) {
+    if (Math.abs(duration) < amount) {
+      return formatter.format(Math.round(duration), unit);
+    }
+    duration /= amount;
+  }
+  return "";
+}

--- a/apps/web/src/components/shared-note-comment-rail.tsx
+++ b/apps/web/src/components/shared-note-comment-rail.tsx
@@ -1,4 +1,4 @@
-import { Trash2Icon } from "lucide-react";
+import { LoaderCircleIcon, Trash2Icon } from "lucide-react";
 import { useRef, useState } from "react";
 
 import { cn } from "@hypr/utils";
@@ -16,6 +16,8 @@ export function SharedNoteCommentRail({
   canDelete,
   composer,
   composerNode,
+  deletePending = false,
+  deletingCommentId = null,
   items,
   onActivate,
   onDelete,
@@ -29,6 +31,8 @@ export function SharedNoteCommentRail({
   composerNode?: React.ReactNode;
   onDelete: (commentId: string) => void;
   canDelete: (comment: AnchoredSharedNoteComment) => boolean;
+  deletePending?: boolean;
+  deletingCommentId?: string | null;
 }) {
   const [heights, setHeights] = useState<ReadonlyMap<string, number>>(
     new Map(),
@@ -125,6 +129,8 @@ export function SharedNoteCommentRail({
           <RailCard
             active={item.commentId === activeCommentId}
             comment={item}
+            deleteDisabled={deletePending}
+            deleting={deletePending && item.commentId === deletingCommentId}
             onActivate={() =>
               onActivate(
                 item.commentId === activeCommentId ? null : item.commentId,
@@ -148,6 +154,8 @@ export function SharedNoteCommentRail({
               key={item.commentId}
               active={false}
               comment={item}
+              deleteDisabled={deletePending}
+              deleting={deletePending && item.commentId === deletingCommentId}
               onDelete={() => onDelete(item.commentId)}
               showDelete={canDelete(item)}
             />
@@ -161,12 +169,16 @@ export function SharedNoteCommentRail({
 function RailCard({
   active,
   comment,
+  deleteDisabled = false,
+  deleting = false,
   onActivate,
   onDelete,
   showDelete,
 }: {
   active: boolean;
   comment: AnchoredSharedNoteComment;
+  deleteDisabled?: boolean;
+  deleting?: boolean;
   onActivate?: () => void;
   onDelete: () => void;
   showDelete: boolean;
@@ -208,13 +220,21 @@ function RailCard({
           <button
             type="button"
             aria-label="Delete comment"
-            className="text-color-muted hover:text-color rounded-full p-1.5 transition-colors focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden"
+            className="text-color-muted hover:text-color rounded-full p-1.5 transition-colors focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={deleteDisabled}
             onClick={(event) => {
               event.stopPropagation();
               onDelete();
             }}
           >
-            <Trash2Icon className="size-3.5" aria-hidden="true" />
+            {deleting ? (
+              <LoaderCircleIcon
+                className="size-3.5 animate-spin"
+                aria-hidden="true"
+              />
+            ) : (
+              <Trash2Icon className="size-3.5" aria-hidden="true" />
+            )}
           </button>
         )}
       </div>

--- a/apps/web/src/components/shared-note-comments-data.ts
+++ b/apps/web/src/components/shared-note-comments-data.ts
@@ -129,7 +129,13 @@ export function useDeleteSharedNoteComment({ shareId }: { shareId: string }) {
 }
 
 export function collectSharedNoteComments(
-  data: CommentsData | undefined,
+  data:
+    | InfiniteData<
+        | ({ status: "ready" } & SharedNoteCommentPage)
+        | { status: "unavailable" },
+        unknown
+      >
+    | undefined,
 ): SharedNoteComment[] {
   return (
     data?.pages.flatMap((page) =>

--- a/apps/web/src/components/shared-note-comments-data.ts
+++ b/apps/web/src/components/shared-note-comments-data.ts
@@ -57,7 +57,13 @@ export function useSharedNoteComments({
   });
 }
 
-export function useCreateSharedNoteComment({ shareId }: { shareId: string }) {
+export function useCreateSharedNoteComment({
+  shareId,
+  snapshotRevision,
+}: {
+  shareId: string;
+  snapshotRevision: number;
+}) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({
@@ -87,7 +93,7 @@ export function useCreateSharedNoteComment({ shareId }: { shareId: string }) {
               globalThis.crypto?.randomUUID?.() ?? `optimistic-${Date.now()}`,
             isAuthor: true,
             body,
-            snapshotRevision: 1,
+            snapshotRevision,
             anchor,
             createdAt: new Date().toISOString(),
           }),

--- a/apps/web/src/components/shared-note-comments-data.ts
+++ b/apps/web/src/components/shared-note-comments-data.ts
@@ -1,0 +1,154 @@
+import {
+  type InfiniteData,
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import {
+  createSharedNoteComment,
+  deleteSharedNoteComment,
+  listSharedNoteComments,
+} from "@/functions/shared-notes";
+import type {
+  SharedNoteComment,
+  SharedNoteCommentAnchor,
+  SharedNoteCommentCursor,
+  SharedNoteCommentPage,
+} from "@/lib/shared-notes";
+
+export const sharedNoteCommentsQueryKey = (shareId: string) => [
+  "shared-note-comments",
+  shareId,
+];
+
+type CommentsPage = { status: "ready" | "unavailable" } & SharedNoteCommentPage;
+type CommentsData = InfiniteData<CommentsPage, SharedNoteCommentCursor | null>;
+
+export function useSharedNoteComments({
+  shareId,
+  enabled,
+}: {
+  shareId: string;
+  enabled: boolean;
+}) {
+  return useInfiniteQuery({
+    queryKey: sharedNoteCommentsQueryKey(shareId),
+    queryFn: async ({ pageParam }) => {
+      const result = await listSharedNoteComments({
+        data: {
+          shareId,
+          beforeCreatedAt: pageParam?.beforeCreatedAt ?? null,
+          beforeCommentId: pageParam?.beforeCommentId ?? null,
+        },
+      });
+      if (result.status === "error") {
+        throw new Error("comments unavailable");
+      }
+      return result;
+    },
+    enabled,
+    initialPageParam: null as SharedNoteCommentCursor | null,
+    getNextPageParam: (lastPage) =>
+      lastPage.status === "ready"
+        ? (lastPage.nextCursor ?? undefined)
+        : undefined,
+    retry: false,
+  });
+}
+
+export function useCreateSharedNoteComment({ shareId }: { shareId: string }) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      body,
+      anchor,
+    }: {
+      body: string;
+      anchor: SharedNoteCommentAnchor | null;
+    }) => {
+      const result = await createSharedNoteComment({
+        data: { shareId, body, anchor },
+      });
+      if (result.status !== "ready") {
+        throw new Error("comment unavailable");
+      }
+      return result.comment;
+    },
+    onMutate: async ({ body, anchor }) => {
+      const queryKey = sharedNoteCommentsQueryKey(shareId);
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<CommentsData>(queryKey);
+      if (previous) {
+        queryClient.setQueryData<CommentsData>(
+          queryKey,
+          insertOptimisticComment(previous, {
+            commentId:
+              globalThis.crypto?.randomUUID?.() ?? `optimistic-${Date.now()}`,
+            isAuthor: true,
+            body,
+            snapshotRevision: 1,
+            anchor,
+            createdAt: new Date().toISOString(),
+          }),
+        );
+      }
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          sharedNoteCommentsQueryKey(shareId),
+          context.previous,
+        );
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: sharedNoteCommentsQueryKey(shareId),
+      });
+    },
+  });
+}
+
+export function useDeleteSharedNoteComment({ shareId }: { shareId: string }) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (commentId: string) => {
+      const result = await deleteSharedNoteComment({ data: commentId });
+      if (result.status !== "ready") {
+        throw new Error("comment unavailable");
+      }
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: sharedNoteCommentsQueryKey(shareId),
+      });
+    },
+  });
+}
+
+export function collectSharedNoteComments(
+  data: CommentsData | undefined,
+): SharedNoteComment[] {
+  return (
+    data?.pages.flatMap((page) =>
+      page.status === "ready" ? page.comments : [],
+    ) ?? []
+  );
+}
+
+function insertOptimisticComment(
+  data: CommentsData,
+  comment: SharedNoteComment,
+): CommentsData {
+  const [firstPage, ...rest] = data.pages;
+  if (!firstPage || firstPage.status !== "ready") return data;
+  return {
+    ...data,
+    pages: [
+      { ...firstPage, comments: [...firstPage.comments, comment] },
+      ...rest,
+    ],
+  };
+}

--- a/apps/web/src/components/shared-note-editable-viewer.tsx
+++ b/apps/web/src/components/shared-note-editable-viewer.tsx
@@ -215,6 +215,7 @@ export function SharedNoteEditableViewer({
         ) : (
           <SharedNoteReader
             canCompose={canComposeComments}
+            manageAccess={readyNote?.manageAccess ?? false}
             resolveAttachment={resolveAttachment}
             shareId={activeSnapshot.shareId}
             signedIn={signedIn && collaborationActive}

--- a/apps/web/src/components/shared-note-editable-viewer.tsx
+++ b/apps/web/src/components/shared-note-editable-viewer.tsx
@@ -1,11 +1,13 @@
 import { lazy, Suspense, useState } from "react";
 
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
+import { SharedNoteReader } from "@/components/shared-note-reader";
 import {
   sharedSecondaryButtonClassName,
   SharedNoteUnavailable,
   SharedNoteViewer,
 } from "@/components/shared-note-viewer";
+import { canComposeSharedNoteComments } from "@/lib/shared-note-collaboration";
 import {
   canEditSharedNoteOnWeb,
   getSharedNoteReadOnlySnapshot,
@@ -38,6 +40,7 @@ export function SharedNoteEditableViewer({
   onAccessChanged,
   resolveAttachment,
   revokedBehavior,
+  signedIn,
   snapshot: initialSnapshot,
 }: {
   accessLabel: string;
@@ -49,6 +52,7 @@ export function SharedNoteEditableViewer({
   onAccessChanged?: () => Promise<AuthenticatedSharedNote | null>;
   resolveAttachment?: SharedAttachmentResolver;
   revokedBehavior: "read-only" | "unavailable";
+  signedIn: boolean;
   snapshot: SharedNoteSnapshot;
 }) {
   const [snapshot, setSnapshot] = useState(initialSnapshot);
@@ -100,6 +104,18 @@ export function SharedNoteEditableViewer({
     authorization.state === "ready" ? authorization.note : null,
     hasUnsupportedContent,
   );
+  const collaborationActive = !accessRevoked && !requiresSignIn;
+  const readyNote = authorization.state === "ready" ? authorization.note : null;
+  // hasCollaborationAccess is true here because the read surface re-checks
+  // actual access from the comments query before enabling composition.
+  const canComposeComments =
+    collaborationActive &&
+    readyNote !== null &&
+    canComposeSharedNoteComments({
+      capability: readyNote.capability,
+      hasCollaborationAccess: true,
+      manageAccess: readyNote.manageAccess,
+    });
 
   if (
     shouldRenderSharedNoteUnavailable({
@@ -196,7 +212,15 @@ export function SharedNoteEditableViewer({
               }}
             />
           </Suspense>
-        ) : undefined
+        ) : (
+          <SharedNoteReader
+            canCompose={canComposeComments}
+            resolveAttachment={resolveAttachment}
+            shareId={activeSnapshot.shareId}
+            signedIn={signedIn && collaborationActive}
+            snapshot={activeSnapshot}
+          />
+        )
       }
       headerActions={
         canEdit && !isEditing ? (

--- a/apps/web/src/components/shared-note-editor-surface.tsx
+++ b/apps/web/src/components/shared-note-editor-surface.tsx
@@ -11,6 +11,7 @@ import {
   createContext,
   forwardRef,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -21,13 +22,19 @@ import {
   type NoteEditorProps,
   type NoteEditorRef,
   schema,
+  setCommentAnchors,
 } from "@hypr/editor/note";
 
+import {
+  collectSharedNoteComments,
+  useSharedNoteComments,
+} from "@/components/shared-note-comments-data";
 import {
   sharedPrimaryButtonClassName,
   sharedSecondaryButtonClassName,
 } from "@/components/shared-note-viewer";
 import { editAuthenticatedSharedNote } from "@/functions/shared-notes";
+import { resolveSharedNoteCommentRanges } from "@/lib/shared-note-comment-anchors";
 import {
   buildSharedNoteWebEditInput,
   canonicalizeSharedNoteWebDraft,
@@ -65,8 +72,43 @@ export function SharedNoteEditorSurface({
   snapshot: SharedNoteSnapshot;
 }) {
   const editorRef = useRef<NoteEditorRef>(null);
+  const [editorView, setEditorView] = useState<NonNullable<
+    NoteEditorRef["view"]
+  > | null>(null);
   const [clientError, setClientError] = useState<string | null>(null);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const commentsQuery = useSharedNoteComments({
+    shareId: snapshot.shareId,
+    enabled: true,
+  });
+  const comments = useMemo(
+    () => collectSharedNoteComments(commentsQuery.data),
+    [commentsQuery.data],
+  );
+  // External sync: resolved anchor highlights are pushed into the ProseMirror
+  // plugin; decoration mapping then tracks live edits on its own.
+  useEffect(() => {
+    if (!editorView) return;
+    const anchored = resolveSharedNoteCommentRanges(
+      editorView.state.doc,
+      comments,
+      snapshot.contentRevision,
+    );
+    setCommentAnchors(
+      editorView,
+      anchored.flatMap((comment) =>
+        comment.range
+          ? [
+              {
+                commentId: comment.commentId,
+                from: comment.range.from,
+                to: comment.range.to,
+              },
+            ]
+          : [],
+      ),
+    );
+  }, [editorView, comments, snapshot.contentRevision]);
   const attachmentById = useMemo(
     () =>
       new Map(
@@ -231,12 +273,15 @@ export function SharedNoteEditorSurface({
         <NoteEditor
           ref={editorRef}
           className="min-h-80 outline-hidden"
+          commentAnchorsEnabled
           extraNodeViews={lockedAttachmentNodeViews}
           initialContent={initialContent}
           handleChange={() => {
             setClientError(null);
             if (hasServerError && !mutation.isPending) mutation.reset();
           }}
+          onViewReady={setEditorView}
+          onViewDisposed={() => setEditorView(null)}
           readOnly={
             mutation.isPending ||
             conflict !== null ||

--- a/apps/web/src/components/shared-note-read-surface.tsx
+++ b/apps/web/src/components/shared-note-read-surface.tsx
@@ -1,0 +1,622 @@
+import { useForm } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import { FileIcon, ImageIcon, LoaderCircleIcon } from "lucide-react";
+import {
+  type ComponentProps,
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  captureCommentAnchor,
+  type CommentAnchor,
+} from "@hypr/editor/comments";
+import {
+  type CommentAnchorsEvent,
+  getCommentAnchorScreenPositions,
+  getSelectionScreenRect,
+  NoteEditor,
+  type NoteEditorProps,
+  type NoteEditorRef,
+  schema,
+  setActiveCommentAnchor,
+  setCommentAnchors,
+} from "@hypr/editor/note";
+import { cn } from "@hypr/utils";
+
+import {
+  DRAFT_COMMENT_ID,
+  SharedNoteCommentRail,
+} from "@/components/shared-note-comment-rail";
+import {
+  collectSharedNoteComments,
+  useCreateSharedNoteComment,
+  useDeleteSharedNoteComment,
+  useSharedNoteComments,
+} from "@/components/shared-note-comments-data";
+import {
+  type SharedAttachmentResolver,
+  SharedNoteDocument,
+} from "@/components/shared-note-document";
+import {
+  type SelectionRect,
+  SharedNoteSelectionComment,
+} from "@/components/shared-note-selection-comment";
+import {
+  sharedPrimaryButtonClassName,
+  sharedSecondaryButtonClassName,
+} from "@/components/shared-note-viewer";
+import {
+  hasSharedNoteCollaborationAccess,
+  MAX_SHARED_NOTE_COMMENT_BYTES,
+  validateSharedNoteCommentBody,
+} from "@/lib/shared-note-collaboration";
+import {
+  type AnchoredSharedNoteComment,
+  fromCaptured,
+  resolveSharedNoteCommentRanges,
+} from "@/lib/shared-note-comment-anchors";
+import { pickActiveCommentId } from "@/lib/shared-note-comment-rail-layout";
+import {
+  type SharedNoteAttachment,
+  type SharedNoteAttachmentDownload,
+  type SharedNoteNode,
+  type SharedNoteSnapshot,
+  withoutDuplicateLeadingTitle,
+} from "@/lib/shared-notes";
+
+type EditorView = NonNullable<NoteEditorRef["view"]>;
+type EditorNodeView = NonNullable<NoteEditorProps["extraNodeViews"]>[string];
+type EditorNodeViewProps = ComponentProps<EditorNodeView>;
+
+const SharedReadAttachmentsContext = createContext<{
+  attachments: ReadonlyMap<string, SharedNoteAttachment>;
+  resolve: SharedAttachmentResolver | null;
+}>({ attachments: new Map(), resolve: null });
+
+export function SharedNoteReadSurface({
+  canCompose,
+  resolveAttachment,
+  shareId,
+  signedIn,
+  snapshot,
+}: {
+  canCompose: boolean;
+  resolveAttachment?: SharedAttachmentResolver;
+  shareId: string;
+  signedIn: boolean;
+  snapshot: SharedNoteSnapshot;
+}) {
+  const [view, setView] = useState<EditorView | null>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const [screenTops, setScreenTops] = useState<ReadonlyMap<string, number>>(
+    new Map(),
+  );
+  const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
+  const [selectionRect, setSelectionRect] = useState<SelectionRect | null>(
+    null,
+  );
+  const [draft, setDraft] = useState<{
+    anchor: CommentAnchor;
+    from: number;
+    to: number;
+    top: number;
+  } | null>(null);
+  const [anchoredComments, setAnchoredComments] = useState<
+    AnchoredSharedNoteComment[]
+  >([]);
+
+  const commentsQuery = useSharedNoteComments({ enabled: signedIn, shareId });
+  const createMutation = useCreateSharedNoteComment({ shareId });
+  const deleteMutation = useDeleteSharedNoteComment({ shareId });
+  const comments = useMemo(
+    () => collectSharedNoteComments(commentsQuery.data),
+    [commentsQuery.data],
+  );
+  const composeEnabled =
+    canCompose &&
+    hasSharedNoteCollaborationAccess(commentsQuery.data?.pages[0]);
+
+  const body = useMemo(
+    () => withoutDuplicateLeadingTitle(snapshot.body, snapshot.title),
+    [snapshot],
+  );
+  // The editor silently falls back to an empty document for content the
+  // schema rejects, so anything unparsable keeps the static renderer.
+  const editorBodyIsValid = useMemo(() => {
+    try {
+      schema.nodeFromJSON(body).check();
+      return true;
+    } catch {
+      return false;
+    }
+  }, [body]);
+  const attachmentContext = useMemo(
+    () => ({
+      attachments: new Map(
+        snapshot.attachments.map((attachment) => [attachment.id, attachment]),
+      ),
+      resolve: resolveAttachment ?? null,
+    }),
+    [snapshot.attachments, resolveAttachment],
+  );
+  const unreferencedAttachments = useMemo(() => {
+    const referenced = new Set<string>();
+    const visit = (node: SharedNoteNode) => {
+      if (typeof node.attrs?.sharedAttachmentId === "string") {
+        referenced.add(node.attrs.sharedAttachmentId);
+      }
+      node.content?.forEach(visit);
+    };
+    visit(body);
+    return snapshot.attachments.filter(
+      (attachment) => !referenced.has(attachment.id),
+    );
+  }, [body, snapshot.attachments]);
+
+  const scheduleLayoutMeasure = useCallback(() => {
+    if (frameRef.current !== null) return;
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null;
+      const currentView = viewRef.current;
+      const container = containerRef.current;
+      if (!currentView || !container) return;
+      const containerTop = container.getBoundingClientRect().top;
+      const positions = getCommentAnchorScreenPositions(currentView);
+      setScreenTops((previous) => {
+        const next = new Map(
+          positions.map((position) => [
+            position.commentId,
+            position.top - containerTop,
+          ]),
+        );
+        const unchanged =
+          previous.size === next.size &&
+          [...next].every(([id, top]) => previous.get(id) === top);
+        return unchanged ? previous : next;
+      });
+    });
+  }, []);
+
+  const attachContainer = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (!element) return;
+      containerRef.current = element;
+      const observer = new ResizeObserver(() => scheduleLayoutMeasure());
+      observer.observe(element);
+      return () => {
+        observer.disconnect();
+        containerRef.current = null;
+        if (frameRef.current !== null) {
+          cancelAnimationFrame(frameRef.current);
+          frameRef.current = null;
+        }
+      };
+    },
+    [scheduleLayoutMeasure],
+  );
+
+  // External sync: anchor highlights live in the ProseMirror plugin, so
+  // resolved ranges are pushed into the view whenever comments change.
+  useEffect(() => {
+    if (!view) return;
+    const anchored = resolveSharedNoteCommentRanges(
+      view.state.doc,
+      comments,
+      snapshot.contentRevision,
+    );
+    setAnchoredComments(anchored);
+    setCommentAnchors(view, [
+      ...anchored.flatMap((comment) =>
+        comment.range
+          ? [
+              {
+                commentId: comment.commentId,
+                from: comment.range.from,
+                to: comment.range.to,
+              },
+            ]
+          : [],
+      ),
+      ...(draft
+        ? [{ commentId: DRAFT_COMMENT_ID, from: draft.from, to: draft.to }]
+        : []),
+    ]);
+    scheduleLayoutMeasure();
+  }, [view, comments, draft, snapshot.contentRevision, scheduleLayoutMeasure]);
+
+  const activateComment = (commentId: string | null) => {
+    setActiveCommentId(commentId);
+    const currentView = viewRef.current;
+    if (currentView) setActiveCommentAnchor(currentView, commentId);
+    if (commentId && !window.matchMedia("(min-width: 80rem)").matches) {
+      document
+        .getElementById(`shared-comment-${commentId}`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  };
+
+  const handleAnchorsEvent = (event: CommentAnchorsEvent) => {
+    const currentView = viewRef.current;
+    if (!currentView) return;
+    if (event.type === "selection") {
+      if (!composeEnabled || draft) {
+        setSelectionRect(null);
+        return;
+      }
+      setSelectionRect(
+        event.empty ? null : getSelectionScreenRect(currentView),
+      );
+      return;
+    }
+    if (event.type === "anchor-click") {
+      const picked = pickActiveCommentId(
+        getCommentAnchorScreenPositions(currentView),
+        event.commentIds.filter((id) => id !== DRAFT_COMMENT_ID),
+      );
+      if (picked) activateComment(picked);
+      return;
+    }
+    scheduleLayoutMeasure();
+  };
+
+  const startDraft = () => {
+    const currentView = viewRef.current;
+    const container = containerRef.current;
+    if (!currentView || !container) return;
+    const { from, to } = currentView.state.selection;
+    const captured = captureCommentAnchor(
+      currentView.state.doc,
+      from,
+      to,
+      snapshot.contentRevision,
+    );
+    if (!captured) return;
+    const top =
+      currentView.coordsAtPos(from).top - container.getBoundingClientRect().top;
+    setSelectionRect(null);
+    setActiveCommentId(null);
+    setActiveCommentAnchor(currentView, null);
+    setDraft({ anchor: captured, from, to, top });
+  };
+
+  const submitDraft = (commentBody: string) => {
+    if (!draft) return;
+    createMutation.mutate(
+      { anchor: fromCaptured(draft.anchor), body: commentBody },
+      { onSuccess: () => setDraft(null) },
+    );
+  };
+
+  if (!editorBodyIsValid) {
+    return (
+      <SharedNoteDocument
+        attachments={snapshot.attachments}
+        document={body}
+        resolveAttachment={resolveAttachment}
+      />
+    );
+  }
+
+  return (
+    <div ref={attachContainer} className="relative">
+      <SharedReadAttachmentsContext.Provider value={attachmentContext}>
+        <NoteEditor
+          className="outline-hidden"
+          commentAnchorsEnabled
+          enforceTitleHeading={false}
+          extraNodeViews={readAttachmentNodeViews}
+          initialContent={body}
+          onCommentAnchorsEvent={handleAnchorsEvent}
+          onViewDisposed={() => {
+            viewRef.current = null;
+            setView(null);
+          }}
+          onViewReady={(readyView) => {
+            viewRef.current = readyView;
+            setView(readyView);
+          }}
+          readOnly
+          showFormatToolbar={false}
+          showSlashCommand={false}
+        />
+      </SharedReadAttachmentsContext.Provider>
+      {unreferencedAttachments.length > 0 && (
+        <section className="border-color-subtle mt-10 border-t pt-6">
+          <h2 className="mb-3 font-mono text-sm font-medium">Attachments</h2>
+          {unreferencedAttachments.map((attachment) => (
+            <SharedReadAttachment
+              key={attachment.id}
+              attachment={attachment}
+              isImage={false}
+              resolve={resolveAttachment ?? null}
+            />
+          ))}
+        </section>
+      )}
+      <SharedNoteSelectionComment
+        onStart={startDraft}
+        rect={selectionRect}
+        visible={composeEnabled && !draft}
+      />
+      <div className="absolute inset-y-0 left-full ml-6 hidden w-80 xl:block">
+        <SharedNoteCommentRail
+          activeCommentId={activeCommentId}
+          canDelete={(comment) => comment.isAuthor}
+          composer={
+            draft
+              ? { top: screenTops.get(DRAFT_COMMENT_ID) ?? draft.top }
+              : null
+          }
+          composerNode={
+            draft ? (
+              <DraftComposer
+                error={createMutation.isError}
+                onCancel={() => {
+                  createMutation.reset();
+                  setDraft(null);
+                }}
+                onSubmit={submitDraft}
+                pending={createMutation.isPending}
+              />
+            ) : undefined
+          }
+          items={anchoredComments.filter((comment) => comment.anchor !== null)}
+          onActivate={activateComment}
+          onDelete={(commentId) => deleteMutation.mutate(commentId)}
+          screenTops={screenTops}
+        />
+      </div>
+    </div>
+  );
+}
+
+function DraftComposer({
+  error,
+  onCancel,
+  onSubmit,
+  pending,
+}: {
+  error: boolean;
+  onCancel: () => void;
+  onSubmit: (body: string) => void;
+  pending: boolean;
+}) {
+  const form = useForm({
+    defaultValues: { body: "" },
+    onSubmit: ({ value }) => {
+      const comment = validateSharedNoteCommentBody(value.body);
+      if (!comment.valid) return;
+      onSubmit(comment.body);
+    },
+  });
+
+  return (
+    <form
+      className="surface border-color-subtle rounded-2xl border p-4 shadow-md"
+      onSubmit={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void form.handleSubmit();
+      }}
+    >
+      <form.Field name="body">
+        {(field) => {
+          const comment = validateSharedNoteCommentBody(field.state.value);
+          const tooLong = comment.byteLength > MAX_SHARED_NOTE_COMMENT_BYTES;
+          return (
+            <>
+              <textarea
+                autoFocus
+                aria-label="Comment on selected text"
+                className={cn([
+                  "surface-subtle border-color-subtle text-color min-h-20 w-full resize-y rounded-xl border px-3 py-2",
+                  "placeholder:text-color-muted text-sm leading-6 focus:border-stone-400 focus:ring-2 focus:ring-stone-300 focus:outline-hidden",
+                ])}
+                aria-invalid={tooLong}
+                placeholder="Comment on the selected text…"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+              />
+              {tooLong && (
+                <p className="mt-2 text-xs text-red-700" role="alert">
+                  Comment is too long ({comment.byteLength.toLocaleString()}/
+                  {MAX_SHARED_NOTE_COMMENT_BYTES.toLocaleString()} bytes).
+                </p>
+              )}
+              {error && (
+                <p className="mt-2 text-xs text-red-700" role="status">
+                  Your comment couldn’t be added. Try again.
+                </p>
+              )}
+              <div className="mt-3 flex justify-end gap-2">
+                <button
+                  type="button"
+                  className={cn([
+                    sharedSecondaryButtonClassName,
+                    "min-h-9 px-3 text-xs",
+                  ])}
+                  disabled={pending}
+                  onClick={onCancel}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className={cn([
+                    sharedPrimaryButtonClassName,
+                    "min-h-9 px-3 text-xs",
+                  ])}
+                  disabled={pending || !comment.valid}
+                >
+                  {pending && (
+                    <LoaderCircleIcon
+                      className="mr-1.5 size-3.5 animate-spin"
+                      aria-hidden="true"
+                    />
+                  )}
+                  Comment
+                </button>
+              </div>
+            </>
+          );
+        }}
+      </form.Field>
+    </form>
+  );
+}
+
+const SharedReadAttachmentView = forwardRef<
+  HTMLDivElement,
+  EditorNodeViewProps
+>(function SharedReadAttachmentView({ nodeProps, ...htmlAttrs }, ref) {
+  const { attachments, resolve } = useContext(SharedReadAttachmentsContext);
+  const sharedAttachmentId = nodeProps.node.attrs.sharedAttachmentId;
+  const attachment =
+    typeof sharedAttachmentId === "string"
+      ? attachments.get(sharedAttachmentId)
+      : undefined;
+
+  return (
+    <div
+      ref={ref}
+      {...htmlAttrs}
+      contentEditable={false}
+      suppressContentEditableWarning
+    >
+      <SharedReadAttachment
+        attachment={attachment}
+        isImage={nodeProps.node.type.name === "image"}
+        resolve={resolve}
+      />
+    </div>
+  );
+});
+
+const readAttachmentNodeViews = {
+  fileAttachment: SharedReadAttachmentView,
+  image: SharedReadAttachmentView,
+};
+
+function SharedReadAttachment({
+  attachment,
+  isImage,
+  resolve,
+}: {
+  attachment: SharedNoteAttachment | undefined;
+  isImage: boolean;
+  resolve: SharedAttachmentResolver | null;
+}) {
+  const downloadQuery = useQuery({
+    queryKey: ["shared-note-attachment-download", attachment?.id ?? ""],
+    queryFn: ({ signal }) => resolve!(attachment!, signal),
+    enabled: Boolean(attachment && resolve),
+    retry: false,
+    staleTime: 45_000,
+    refetchInterval: 45_000,
+    gcTime: 0,
+  });
+  const download =
+    !downloadQuery.error &&
+    attachment &&
+    isMatchingDownload(attachment, downloadQuery.data)
+      ? downloadQuery.data
+      : null;
+
+  if (
+    attachment &&
+    download &&
+    isImage &&
+    isInlineImage(attachment.contentType)
+  ) {
+    return (
+      <figure className="my-6">
+        <img
+          src={download.signedUrl}
+          alt={attachment.filename}
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          className="border-color-subtle max-h-[70vh] max-w-full rounded-xl border object-contain"
+        />
+      </figure>
+    );
+  }
+
+  if (attachment && download && !isImage) {
+    return (
+      <a
+        href={download.signedUrl}
+        download={attachment.filename}
+        target="_blank"
+        rel="ugc noopener noreferrer"
+        referrerPolicy="no-referrer"
+        className="surface-subtle border-color-subtle text-color my-4 flex items-center justify-between gap-4 rounded-xl border px-4 py-3 no-underline"
+      >
+        <span className="min-w-0 truncate font-medium">
+          {attachment.filename}
+        </span>
+        <span className="text-color-muted shrink-0 text-xs">
+          {formatFileSize(attachment.sizeBytes)}
+        </span>
+      </a>
+    );
+  }
+
+  const Icon = isImage ? ImageIcon : FileIcon;
+  return (
+    <div className="border-color-subtle bg-surface-subtle my-3 flex items-center gap-3 rounded-xl border px-4 py-3">
+      <div className="bg-surface flex size-10 shrink-0 items-center justify-center rounded-lg">
+        <Icon className="text-color-muted size-5" aria-hidden="true" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-color truncate text-sm font-medium">
+          {attachment?.filename ?? "Attachment unavailable"}
+        </p>
+        <p className="text-color-muted mt-0.5 text-xs">
+          {attachment
+            ? `${formatFileSize(attachment.sizeBytes)} · Included with shared note`
+            : "Included attachment"}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function isMatchingDownload(
+  attachment: SharedNoteAttachment,
+  download: SharedNoteAttachmentDownload | null | undefined,
+): download is SharedNoteAttachmentDownload {
+  return Boolean(
+    download &&
+    download.id === attachment.id &&
+    download.filename === attachment.filename &&
+    download.contentType === attachment.contentType &&
+    download.sizeBytes === attachment.sizeBytes &&
+    download.sha256 === attachment.sha256,
+  );
+}
+
+function isInlineImage(contentType: string) {
+  return [
+    "image/avif",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+  ].includes(contentType);
+}
+
+function formatFileSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/web/src/components/shared-note-read-surface.tsx
+++ b/apps/web/src/components/shared-note-read-surface.tsx
@@ -11,6 +11,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 
 import {
@@ -80,14 +81,34 @@ const SharedReadAttachmentsContext = createContext<{
   resolve: SharedAttachmentResolver | null;
 }>({ attachments: new Map(), resolve: null });
 
+// Tailwind's xl breakpoint — the width from which the comment rail (and its
+// draft composer) is visible.
+const RAIL_MEDIA_QUERY = "(min-width: 80rem)";
+
+function subscribeRailMedia(onChange: () => void) {
+  const media = window.matchMedia(RAIL_MEDIA_QUERY);
+  media.addEventListener("change", onChange);
+  return () => media.removeEventListener("change", onChange);
+}
+
+function useCommentRailVisible() {
+  return useSyncExternalStore(
+    subscribeRailMedia,
+    () => window.matchMedia(RAIL_MEDIA_QUERY).matches,
+    () => false,
+  );
+}
+
 export function SharedNoteReadSurface({
   canCompose,
+  manageAccess,
   resolveAttachment,
   shareId,
   signedIn,
   snapshot,
 }: {
   canCompose: boolean;
+  manageAccess: boolean;
   resolveAttachment?: SharedAttachmentResolver;
   shareId: string;
   signedIn: boolean;
@@ -114,8 +135,18 @@ export function SharedNoteReadSurface({
     AnchoredSharedNoteComment[]
   >([]);
 
+  const railVisible = useCommentRailVisible();
+  // The draft composer lives in the rail; when the viewport shrinks below
+  // the rail's breakpoint an open draft would have no cancel/submit UI.
+  if (!railVisible && draft) {
+    setDraft(null);
+  }
+
   const commentsQuery = useSharedNoteComments({ enabled: signedIn, shareId });
-  const createMutation = useCreateSharedNoteComment({ shareId });
+  const createMutation = useCreateSharedNoteComment({
+    shareId,
+    snapshotRevision: snapshot.contentRevision,
+  });
   const deleteMutation = useDeleteSharedNoteComment({ shareId });
   const comments = useMemo(
     () => collectSharedNoteComments(commentsQuery.data),
@@ -252,9 +283,17 @@ export function SharedNoteReadSurface({
         setSelectionRect(null);
         return;
       }
-      setSelectionRect(
-        event.empty ? null : getSelectionScreenRect(currentView),
-      );
+      // Only offer the pill for selections a draft can actually anchor to;
+      // startDraft silently no-ops when anchor capture fails.
+      const anchorable =
+        !event.empty &&
+        captureCommentAnchor(
+          currentView.state.doc,
+          event.from,
+          event.to,
+          snapshot.contentRevision,
+        ) !== null;
+      setSelectionRect(anchorable ? getSelectionScreenRect(currentView) : null);
       return;
     }
     if (event.type === "anchor-click") {
@@ -282,6 +321,9 @@ export function SharedNoteReadSurface({
     if (!captured) return;
     const top =
       currentView.coordsAtPos(from).top - container.getBoundingClientRect().top;
+    // A previous draft's failed submit must not surface its error in the
+    // composer of this new draft.
+    createMutation.reset();
     setSelectionRect(null);
     setActiveCommentId(null);
     setActiveCommentAnchor(currentView, null);
@@ -290,9 +332,15 @@ export function SharedNoteReadSurface({
 
   const submitDraft = (commentBody: string) => {
     if (!draft) return;
+    const submitted = draft;
     createMutation.mutate(
-      { anchor: fromCaptured(draft.anchor), body: commentBody },
-      { onSuccess: () => setDraft(null) },
+      { anchor: fromCaptured(submitted.anchor), body: commentBody },
+      {
+        // Only clear the draft this submit belongs to; a draft opened after
+        // a resize-triggered cleanup must survive the earlier completion.
+        onSuccess: () =>
+          setDraft((current) => (current === submitted ? null : current)),
+      },
     );
   };
 
@@ -347,10 +395,17 @@ export function SharedNoteReadSurface({
         rect={selectionRect}
         visible={composeEnabled && !draft}
       />
-      <div className="absolute inset-y-0 left-full ml-6 hidden w-80 xl:block">
+      {/* The page shell reserves this width at xl+ via a :has() rule keyed
+          on data-comment-rail, so the rail stays inside its clip bounds.
+          Signed-out readers render no rail marker and keep the centered
+          column. */}
+      <div
+        className="absolute inset-y-0 left-full ml-6 hidden w-80 xl:block"
+        data-comment-rail={signedIn ? "" : undefined}
+      >
         <SharedNoteCommentRail
           activeCommentId={activeCommentId}
-          canDelete={(comment) => comment.isAuthor}
+          canDelete={(comment) => comment.isAuthor || manageAccess}
           composer={
             draft
               ? { top: screenTops.get(DRAFT_COMMENT_ID) ?? draft.top }
@@ -369,6 +424,8 @@ export function SharedNoteReadSurface({
               />
             ) : undefined
           }
+          deletePending={deleteMutation.isPending}
+          deletingCommentId={deleteMutation.variables ?? null}
           items={anchoredComments.filter((comment) => comment.anchor !== null)}
           onActivate={activateComment}
           onDelete={(commentId) => deleteMutation.mutate(commentId)}

--- a/apps/web/src/components/shared-note-reader.tsx
+++ b/apps/web/src/components/shared-note-reader.tsx
@@ -1,0 +1,60 @@
+import { lazy, Suspense, useState } from "react";
+
+import {
+  type SharedAttachmentResolver,
+  SharedNoteDocument,
+} from "@/components/shared-note-document";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { hasUnsupportedSharedNoteEditorNode } from "@/lib/shared-note-editing";
+import {
+  type SharedNoteSnapshot,
+  withoutDuplicateLeadingTitle,
+} from "@/lib/shared-notes";
+
+const SharedNoteReadSurface = lazy(() =>
+  import("@/components/shared-note-read-surface").then((module) => ({
+    default: module.SharedNoteReadSurface,
+  })),
+);
+
+export function SharedNoteReader({
+  canCompose,
+  resolveAttachment,
+  shareId,
+  signedIn,
+  snapshot,
+}: {
+  canCompose: boolean;
+  resolveAttachment?: SharedAttachmentResolver;
+  shareId: string;
+  signedIn: boolean;
+  snapshot: SharedNoteSnapshot;
+}) {
+  const [interactive, setInteractive] = useState(false);
+  useMountEffect(() => setInteractive(true));
+
+  const staticDocument = (
+    <SharedNoteDocument
+      attachments={snapshot.attachments}
+      document={withoutDuplicateLeadingTitle(snapshot.body, snapshot.title)}
+      resolveAttachment={resolveAttachment}
+    />
+  );
+
+  if (!interactive || hasUnsupportedSharedNoteEditorNode(snapshot.body)) {
+    return staticDocument;
+  }
+
+  return (
+    <Suspense fallback={staticDocument}>
+      <SharedNoteReadSurface
+        key={`${snapshot.shareId}:${snapshot.contentRevision}`}
+        canCompose={canCompose}
+        resolveAttachment={resolveAttachment}
+        shareId={shareId}
+        signedIn={signedIn}
+        snapshot={snapshot}
+      />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/shared-note-reader.tsx
+++ b/apps/web/src/components/shared-note-reader.tsx
@@ -19,12 +19,14 @@ const SharedNoteReadSurface = lazy(() =>
 
 export function SharedNoteReader({
   canCompose,
+  manageAccess,
   resolveAttachment,
   shareId,
   signedIn,
   snapshot,
 }: {
   canCompose: boolean;
+  manageAccess: boolean;
   resolveAttachment?: SharedAttachmentResolver;
   shareId: string;
   signedIn: boolean;
@@ -50,6 +52,7 @@ export function SharedNoteReader({
       <SharedNoteReadSurface
         key={`${snapshot.shareId}:${snapshot.contentRevision}`}
         canCompose={canCompose}
+        manageAccess={manageAccess}
         resolveAttachment={resolveAttachment}
         shareId={shareId}
         signedIn={signedIn}

--- a/apps/web/src/components/shared-note-selection-comment.tsx
+++ b/apps/web/src/components/shared-note-selection-comment.tsx
@@ -1,0 +1,93 @@
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  offset,
+  shift,
+} from "@floating-ui/dom";
+import { MessageSquarePlusIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@hypr/utils";
+
+export type SelectionRect = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+
+export function SharedNoteSelectionComment({
+  onStart,
+  rect,
+  visible,
+}: {
+  rect: SelectionRect | null;
+  visible: boolean;
+  onStart: () => void;
+}) {
+  const [pill, setPill] = useState<HTMLButtonElement | null>(null);
+  const rectRef = useRef(rect);
+  rectRef.current = rect;
+
+  const active = visible && rect !== null;
+
+  // External sync: floating-ui keeps the portal pill aligned with the
+  // viewport rect of the current selection.
+  useEffect(() => {
+    if (!pill || !active) return;
+    const reference = {
+      getBoundingClientRect: () => {
+        const current = rectRef.current ?? {
+          bottom: 0,
+          left: 0,
+          right: 0,
+          top: 0,
+        };
+        return {
+          ...current,
+          x: current.left,
+          y: current.top,
+          width: current.right - current.left,
+          height: current.bottom - current.top,
+        };
+      },
+    };
+    const update = () => {
+      void computePosition(reference, pill, {
+        middleware: [offset(8), flip(), shift({ padding: 8 })],
+        placement: "top",
+        strategy: "fixed",
+      }).then(({ x, y }) => {
+        pill.style.left = `${x}px`;
+        pill.style.top = `${y}px`;
+        pill.style.visibility = "visible";
+      });
+    };
+    return autoUpdate(reference, pill, update);
+  }, [pill, active, rect]);
+
+  if (!active) return null;
+
+  return createPortal(
+    <button
+      ref={setPill}
+      type="button"
+      style={{ left: 0, position: "fixed", top: 0, visibility: "hidden" }}
+      className={cn([
+        "z-50 hidden items-center gap-1.5 xl:inline-flex",
+        "surface border-color-subtle rounded-full border px-3 py-1.5 shadow-md",
+        "text-color font-mono text-xs font-medium",
+        "hover:bg-surface-subtle transition-colors",
+        "focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden",
+      ])}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onStart}
+    >
+      <MessageSquarePlusIcon className="size-4" aria-hidden="true" />
+      Comment
+    </button>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/shared-note-selection-comment.tsx
+++ b/apps/web/src/components/shared-note-selection-comment.tsx
@@ -76,6 +76,8 @@ export function SharedNoteSelectionComment({
       type="button"
       style={{ left: 0, position: "fixed", top: 0, visibility: "hidden" }}
       className={cn([
+        // Matches the comment rail's breakpoint: drafts compose inside the
+        // rail, so the pill only shows where the rail is visible.
         "z-50 hidden items-center gap-1.5 xl:inline-flex",
         "surface border-color-subtle rounded-full border px-3 py-1.5 shadow-md",
         "text-color font-mono text-xs font-medium",

--- a/apps/web/src/components/shared-note-viewer.tsx
+++ b/apps/web/src/components/shared-note-viewer.tsx
@@ -56,7 +56,7 @@ export function SharedNoteViewer({
 
   return (
     <SharedNoteShell>
-      <article className="surface border-color-subtle overflow-hidden rounded-3xl border shadow-sm">
+      <article className="surface border-color-subtle overflow-hidden rounded-3xl border shadow-sm xl:overflow-visible">
         <header className="border-color-subtle border-b px-6 py-7 sm:px-10 sm:py-10">
           <div className="flex items-start justify-between gap-4">
             <div className="text-color-muted flex min-w-0 flex-wrap items-center gap-2 text-sm">
@@ -191,7 +191,7 @@ export function SharedNotePrompt({
 
 function SharedNoteShell({ children }: { children: React.ReactNode }) {
   return (
-    <main className="bg-page text-color min-h-screen px-4 py-5 sm:px-6 sm:py-8">
+    <main className="bg-page text-color min-h-screen overflow-x-clip px-4 py-5 sm:px-6 sm:py-8">
       <div className="mx-auto w-full max-w-[760px]">
         <header className="mb-8 flex items-center justify-between gap-4 px-1">
           <a href="/" aria-label="Anarlog home">

--- a/apps/web/src/components/shared-note-viewer.tsx
+++ b/apps/web/src/components/shared-note-viewer.tsx
@@ -192,7 +192,17 @@ export function SharedNotePrompt({
 function SharedNoteShell({ children }: { children: React.ReactNode }) {
   return (
     <main className="bg-page text-color min-h-screen overflow-x-clip px-4 py-5 sm:px-6 sm:py-8">
-      <div className="mx-auto w-full max-w-[760px]">
+      <div
+        className={cn([
+          "mx-auto w-full max-w-[760px]",
+          // When an anchored comment rail is mounted ([data-comment-rail]),
+          // right padding reserves its width while keeping a 760px content
+          // box, so the rail renders inside the shell instead of being
+          // clipped by overflow-x-clip. Static fallbacks render no rail and
+          // keep the centered column.
+          "xl:has-[[data-comment-rail]]:max-w-[1104px] xl:has-[[data-comment-rail]]:pr-[344px]",
+        ])}
+      >
         <header className="mb-8 flex items-center justify-between gap-4 px-1">
           <a href="/" aria-label="Anarlog home">
             <AnarlogLogo className="h-8 w-auto" />

--- a/apps/web/src/lib/shared-note-collaboration.ts
+++ b/apps/web/src/lib/shared-note-collaboration.ts
@@ -42,6 +42,11 @@ export function validateSharedNoteCommentAnchor(
   return { anchor, valid };
 }
 
+export function truncateSharedNoteCommentQuote(quote: string, maxLength = 80) {
+  if (quote.length <= maxLength) return quote;
+  return `${quote.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
 export function formatAuthenticatedSharedNoteAccessLabel({
   capability,
   manageAccess,

--- a/apps/web/src/lib/shared-note-comment-anchors.ts
+++ b/apps/web/src/lib/shared-note-comment-anchors.ts
@@ -1,0 +1,57 @@
+import {
+  type CommentAnchor,
+  type ResolvedAnchorRange,
+  resolveCommentAnchors,
+} from "@hypr/editor/comments";
+
+import type {
+  SharedNoteComment,
+  SharedNoteCommentAnchor,
+} from "@/lib/shared-notes";
+
+type EditorDoc = Parameters<typeof resolveCommentAnchors>[0];
+
+export type AnchoredSharedNoteComment = SharedNoteComment & {
+  range: ResolvedAnchorRange | null;
+};
+
+export function toEditorAnchor(
+  anchor: SharedNoteCommentAnchor,
+  snapshotRevision: number,
+): CommentAnchor {
+  return { ...anchor, snapshotRevision };
+}
+
+export function fromCaptured(captured: CommentAnchor): SharedNoteCommentAnchor {
+  return {
+    quoteExact: captured.quoteExact,
+    quotePrefix: captured.quotePrefix,
+    quoteSuffix: captured.quoteSuffix,
+    fromHint: captured.fromHint,
+    toHint: captured.toHint,
+  };
+}
+
+export function resolveSharedNoteCommentRanges(
+  doc: EditorDoc,
+  comments: readonly SharedNoteComment[],
+  currentRevision: number,
+): AnchoredSharedNoteComment[] {
+  const resolved = resolveCommentAnchors(
+    doc,
+    comments.map((comment) => ({
+      commentId: comment.commentId,
+      anchor: comment.anchor
+        ? toEditorAnchor(comment.anchor, comment.snapshotRevision)
+        : null,
+    })),
+    currentRevision,
+  );
+  const rangeById = new Map(
+    resolved.map((entry) => [entry.commentId, entry.range]),
+  );
+  return comments.map((comment) => ({
+    ...comment,
+    range: rangeById.get(comment.commentId) ?? null,
+  }));
+}

--- a/apps/web/src/lib/shared-note-comment-rail-layout.test.ts
+++ b/apps/web/src/lib/shared-note-comment-rail-layout.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  layoutRailCards,
+  pickActiveCommentId,
+} from "./shared-note-comment-rail-layout.ts";
+
+test("stacks cards without overlap in anchor order", () => {
+  const placements = layoutRailCards(
+    [
+      { id: "a", desiredTop: 0, height: 80 },
+      { id: "b", desiredTop: 20, height: 60 },
+      { id: "c", desiredTop: 400, height: 40 },
+    ],
+    { gap: 12, activeId: null },
+  );
+
+  assert.deepEqual(
+    placements.map((placement) => placement.id),
+    ["a", "b", "c"],
+  );
+  assert.equal(placements[0].top, 0);
+  assert.equal(placements[1].top, 92);
+  assert.equal(placements[2].top, 400);
+});
+
+test("pins the active card at its desired top and pushes neighbors", () => {
+  const placements = layoutRailCards(
+    [
+      { id: "a", desiredTop: 100, height: 80 },
+      { id: "b", desiredTop: 110, height: 60 },
+      { id: "c", desiredTop: 120, height: 40 },
+    ],
+    { gap: 10, activeId: "b" },
+  );
+  const byId = new Map(placements.map((p) => [p.id, p.top]));
+
+  assert.equal(byId.get("b"), 110);
+  assert.ok(byId.get("a")! + 80 + 10 <= byId.get("b")!);
+  assert.ok(byId.get("c")! >= byId.get("b")! + 60 + 10);
+});
+
+test("normalizes when upward pushes go negative", () => {
+  const placements = layoutRailCards(
+    [
+      { id: "a", desiredTop: 0, height: 100 },
+      { id: "b", desiredTop: 10, height: 50 },
+    ],
+    { gap: 8, activeId: "b" },
+  );
+  for (const placement of placements) {
+    assert.ok(placement.top >= 0);
+  }
+  const byId = new Map(placements.map((p) => [p.id, p.top]));
+  assert.ok(byId.get("a")! + 100 + 8 <= byId.get("b")!);
+});
+
+test("orders deterministically for equal desired tops", () => {
+  const placements = layoutRailCards(
+    [
+      { id: "z", desiredTop: 50, height: 30 },
+      { id: "a", desiredTop: 50, height: 30 },
+    ],
+    { gap: 6, activeId: null },
+  );
+  assert.deepEqual(
+    placements.map((placement) => placement.id),
+    ["a", "z"],
+  );
+});
+
+test("picks the smallest overlapping highlight", () => {
+  const candidates = [
+    { commentId: "outer", from: 1, to: 100 },
+    { commentId: "inner", from: 10, to: 20 },
+    { commentId: "other", from: 200, to: 210 },
+  ];
+  assert.equal(pickActiveCommentId(candidates, ["outer", "inner"]), "inner");
+  assert.equal(pickActiveCommentId(candidates, ["outer"]), "outer");
+  assert.equal(pickActiveCommentId(candidates, ["missing"]), null);
+});

--- a/apps/web/src/lib/shared-note-comment-rail-layout.ts
+++ b/apps/web/src/lib/shared-note-comment-rail-layout.ts
@@ -1,0 +1,82 @@
+export type RailCardInput = {
+  id: string;
+  desiredTop: number;
+  height: number;
+};
+
+export type RailCardPlacement = {
+  id: string;
+  top: number;
+};
+
+/**
+ * Stacks comment cards in the rail without overlap. Cards are ordered by
+ * their anchor's vertical position; the active card is pinned exactly at its
+ * desired top, and neighbors are pushed up/down around it with `gap` spacing.
+ */
+export function layoutRailCards(
+  cards: readonly RailCardInput[],
+  options: { gap: number; activeId: string | null },
+): RailCardPlacement[] {
+  if (cards.length === 0) return [];
+  const { gap, activeId } = options;
+  const ordered = [...cards].sort(
+    (left, right) =>
+      left.desiredTop - right.desiredTop || left.id.localeCompare(right.id),
+  );
+
+  const activeIndex = activeId
+    ? ordered.findIndex((card) => card.id === activeId)
+    : -1;
+
+  const tops = new Array<number>(ordered.length);
+  if (activeIndex === -1) {
+    let cursor = -Infinity;
+    ordered.forEach((card, index) => {
+      const top = Math.max(card.desiredTop, cursor);
+      tops[index] = top;
+      cursor = top + card.height + gap;
+    });
+  } else {
+    tops[activeIndex] = Math.max(0, ordered[activeIndex].desiredTop);
+
+    let above = tops[activeIndex];
+    for (let index = activeIndex - 1; index >= 0; index -= 1) {
+      const card = ordered[index];
+      const top = Math.min(card.desiredTop, above - gap - card.height);
+      tops[index] = top;
+      above = top;
+    }
+
+    let cursor = tops[activeIndex] + ordered[activeIndex].height + gap;
+    for (let index = activeIndex + 1; index < ordered.length; index += 1) {
+      const card = ordered[index];
+      const top = Math.max(card.desiredTop, cursor);
+      tops[index] = top;
+      cursor = top + card.height + gap;
+    }
+  }
+
+  const shift = Math.min(...tops);
+  const normalized = shift < 0 ? tops.map((top) => top - shift) : tops;
+  return ordered.map((card, index) => ({
+    id: card.id,
+    top: normalized[index],
+  }));
+}
+
+/** Smallest range wins when several highlights overlap a click. */
+export function pickActiveCommentId(
+  candidates: ReadonlyArray<{ commentId: string; from: number; to: number }>,
+  commentIds: readonly string[],
+): string | null {
+  const eligible = candidates
+    .filter((candidate) => commentIds.includes(candidate.commentId))
+    .sort(
+      (left, right) =>
+        left.to - left.from - (right.to - right.from) ||
+        left.from - right.from ||
+        left.commentId.localeCompare(right.commentId),
+    );
+  return eligible[0]?.commentId ?? null;
+}

--- a/apps/web/src/routes/share/$shareId.tsx
+++ b/apps/web/src/routes/share/$shareId.tsx
@@ -99,6 +99,7 @@ function Component() {
       }}
       resolveAttachment={resolveAttachment}
       revokedBehavior="read-only"
+      signedIn={true}
       accessLabel={formatAuthenticatedSharedNoteAccessLabel(note)}
       collaboration={
         <SharedNoteCollaboration

--- a/apps/web/src/routes/share/link/$shareId.tsx
+++ b/apps/web/src/routes/share/link/$shareId.tsx
@@ -201,6 +201,7 @@ function LinkSharedNoteClient({
       }}
       resolveAttachment={resolveAttachment}
       revokedBehavior="read-only"
+      signedIn={currentUserId !== null}
       accessLabel={
         authenticatedNote &&
         shouldUseAuthenticatedSharedNoteAccessLabel(authenticatedNote)

--- a/apps/web/src/routes/share/public/$publicSlug.tsx
+++ b/apps/web/src/routes/share/public/$publicSlug.tsx
@@ -123,6 +123,7 @@ function Component() {
       }}
       resolveAttachment={resolveAttachment}
       revokedBehavior="read-only"
+      signedIn={user !== null}
       accessLabel={accessLabel}
       collaboration={
         <SharedNoteCollaboration

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,6 +482,9 @@ importers:
       '@deepgram/sdk':
         specifier: ^4.11.3
         version: 4.11.3
+      '@floating-ui/dom':
+        specifier: ^1.7.6
+        version: 1.7.6
       '@honeycombio/opentelemetry-web':
         specifier: ^1.3.0
         version: 1.3.0(@opentelemetry/auto-instrumentations-web@0.49.1(@opentelemetry/api@1.9.1)(zone.js@0.15.1))
@@ -1242,7 +1245,7 @@ importers:
         version: 22.19.17
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -9424,8 +9427,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.7.8:
-    resolution: {integrity: sha512-QMmb3Z/ARvYZmZneudb8cnY/4mVvZTdhUyA9TC2skwOcm7KvY9zyOdn0TApQc4rL0VM2TffFkmo3ky/lJZX7qw==}
+  deslop-js@0.8.1:
+    resolution: {integrity: sha512-a8wpwOPo6HsYyRndn17C88mNzeQD6t17yhZ8qpyFWTxj5jQeWtXDj+zJfnuT8++5A4LaNeNAnKs1edVWuadNdQ==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -12717,8 +12720,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-plugin-react-doctor@0.7.8:
-    resolution: {integrity: sha512-3f9/jFLIC/KRLPYqxiXSk20cq47luGy9Oz5Ru7nK7w0EI9B9zuMvAU92bK9jFiwFE7Lc9PA8ER6Y+naYaGFQGw==}
+  oxlint-plugin-react-doctor@0.8.1:
+    resolution: {integrity: sha512-ETjgoKrY0EYpK51BsbvgpWySkWaLgJ6z7yB/BfOosi+TUY4+GiDmhWfjJCeul+tpDJEFKR5MnpENjlUrmtZ5Dw==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tsgolint@0.21.1:
@@ -13497,8 +13500,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  react-doctor@0.7.8:
-    resolution: {integrity: sha512-G3spmtZJE/gWWPRJ3rpgUWTPRDJpEmdRja7iNZ7RAXlfpEO+NWVzPTca/cPI9hLwPo2Aq5/BZggo5JDBrwGrlA==}
+  react-doctor@0.8.1:
+    resolution: {integrity: sha512-lP/MaS7dDMeVFpWBjh8qYp6NYcb/1TmsAwSixqkqOI50fea9kfh89fyn+UUAC3vb53FGIqwvDPZIjlJR6BgGAQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -24545,7 +24548,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.7.8:
+  deslop-js@0.8.1:
     dependencies:
       '@oxc-project/types': 0.138.0
       fast-glob: 3.3.3
@@ -29056,7 +29059,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.45.0
       '@oxfmt/binding-win32-x64-msvc': 0.45.0
 
-  oxlint-plugin-react-doctor@0.7.8:
+  oxlint-plugin-react-doctor@0.8.1:
     dependencies:
       '@typescript-eslint/types': 8.62.1
       eslint-scope: 9.1.2
@@ -30040,19 +30043,19 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  react-doctor@0.7.8(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1):
+  react-doctor@0.8.1(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@sentry/node': 10.63.0(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.7.8
+      deslop-js: 0.8.1
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0(oxlint-tsgolint@0.21.1)
-      oxlint-plugin-react-doctor: 0.7.8
+      oxlint-plugin-react-doctor: 0.8.1
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -30193,7 +30196,7 @@ snapshots:
       preact: 10.29.1
       prompts: 2.4.2
       react: 19.2.5
-      react-doctor: 0.7.8(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1)
+      react-doctor: 0.8.1(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1)
       react-dom: 19.2.5(react@19.2.5)
       react-grab: 0.1.48(react@19.2.5)
     optionalDependencies:
@@ -32128,6 +32131,35 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.17
       jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.19.17
+      jsdom: 27.4.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
Replaces #6180, which was auto-closed when its stacked base branch was deleted on merge. Same content, rebased onto main.

Renders anchored comments on the shared note web page using the anchor data added in #6179.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI surface around collaboration (create/delete comments, anchor resolution, layout) with new editor integration paths, but changes are scoped to shared-note web views and reuse existing comment APIs with anchor payloads.
> 
> **Overview**
> Adds **anchored collaboration** on shared notes: comments tie to text selections, show as in-document highlights, and align with a **comment rail** beside the note on xl viewports.
> 
> **Read path:** View mode uses a lazy-loaded read-only `NoteEditor` (`SharedNoteReader` / `SharedNoteReadSurface`) instead of only static HTML. Users with comment permission select text, get a floating **Comment** pill (`@floating-ui/dom`), and compose in the rail; creates send **`anchor`** metadata with optimistic React Query updates. Clicking highlights or rail cards syncs active state; narrow screens scroll to the list entry in `SharedNoteCollaboration`.
> 
> **Collaboration panel:** The bottom **Comments** section drops the freeform textarea in favor of copy pointing users to select text in the note. List items show truncated anchor quotes and `id`s for mobile deep-scroll.
> 
> **Layout:** `reserveCommentRail` widens the page shell and reserves right padding so the rail is not clipped; the web editor also enables comment anchor decorations while editing.
> 
> Shared comment fetching/mutations move into `shared-note-comments-data.ts`; anchor resolution bridges `@hypr/editor/comments` via `shared-note-comment-anchors.ts` and rail stacking via `layoutRailCards` (with unit tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc98088a464883f7e70a1fa641390f30b9753df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->