### PR TITLE
fix(desktop): stop gating local note deletion on remote share cleanup

### DIFF
--- a/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
+++ b/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
@@ -13,12 +13,14 @@ const mocks = vi.hoisted(() => {
     deletedAt: 1,
   };
 
+  const getSession = vi.fn<() => Promise<{ data: { session: any } }>>(() =>
+    Promise.resolve({ data: { session: null } }),
+  );
+
   return {
     addDeletion: vi.fn(),
-    auth: {
-      session: null as any,
-      supabase: null as any,
-    },
+    getSession,
+    supabaseClient: { auth: { getSession } },
     deleteSessionShareBySession: vi.fn(),
     emitTo: vi.fn(() => Promise.resolve()),
     finalizeSessionDeletion: vi.fn(),
@@ -57,8 +59,8 @@ vi.mock("@hypr/ui/components/ui/toast", () => ({
   sonnerToast: { error: mocks.toastError, warning: mocks.toastWarning },
 }));
 
-vi.mock("~/auth", () => ({
-  useOptionalAuth: () => mocks.auth,
+vi.mock("~/auth/client", () => ({
+  supabase: mocks.supabaseClient,
 }));
 
 vi.mock("~/calendar/ignored-events", () => ({
@@ -121,8 +123,7 @@ describe("useDeleteSession", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
-    mocks.auth.session = null;
-    mocks.auth.supabase = null;
+    mocks.getSession.mockResolvedValue({ data: { session: null } });
     mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);
     mocks.removeDurableSharedNoteCache.mockResolvedValue(undefined);
     mocks.softDeleteSession.mockResolvedValue(mocks.deletedSessionData);
@@ -143,7 +144,7 @@ describe("useDeleteSession", () => {
   it("revokes a known managed share when the local deletion is finalized", async () => {
     const shareId = "33333333-3333-4333-8333-333333333333";
     const workspaceId = "22222222-2222-4222-8222-222222222222";
-    mocks.auth.session = {
+    const session = {
       access_token: "expired-pro-access-token",
       token_type: "bearer",
       user: {
@@ -151,7 +152,7 @@ describe("useDeleteSession", () => {
         is_anonymous: false,
       },
     };
-    mocks.auth.supabase = {};
+    mocks.getSession.mockResolvedValue({ data: { session } });
     mocks.loadManagedSharedNoteForSession.mockResolvedValue({
       shareId,
       workspaceId,
@@ -183,14 +184,14 @@ describe("useDeleteSession", () => {
     await waitFor(() => {
       expect(mocks.deleteSessionShareBySession).toHaveBeenCalledWith(
         {
-          session: mocks.auth.session,
-          supabase: mocks.auth.supabase,
+          session,
+          supabase: mocks.supabaseClient,
         },
         { workspaceId, sessionId: "session-1" },
       );
     });
     expect(mocks.removeDurableSharedNoteCache).toHaveBeenCalledWith(
-      mocks.auth.session.user.id,
+      session.user.id,
       shareId,
     );
     expect(mocks.softDeleteSession.mock.invocationCallOrder[0]!).toBeLessThan(
@@ -203,15 +204,18 @@ describe("useDeleteSession", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    mocks.auth.session = {
-      access_token: "owner-access-token",
-      token_type: "bearer",
-      user: {
-        id: "11111111-1111-4111-8111-111111111111",
-        is_anonymous: false,
+    mocks.getSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "owner-access-token",
+          token_type: "bearer",
+          user: {
+            id: "11111111-1111-4111-8111-111111111111",
+            is_anonymous: false,
+          },
+        },
       },
-    };
-    mocks.auth.supabase = {};
+    });
     mocks.loadManagedSharedNoteForSession.mockResolvedValue({
       shareId: "33333333-3333-4333-8333-333333333333",
       workspaceId: "22222222-2222-4222-8222-222222222222",
@@ -242,7 +246,7 @@ describe("useDeleteSession", () => {
   });
 
   it("deletes an unshared signed-in note without a remote mutation", async () => {
-    mocks.auth.session = {
+    const session = {
       access_token: "owner-access-token",
       token_type: "bearer",
       user: {
@@ -250,7 +254,7 @@ describe("useDeleteSession", () => {
         is_anonymous: false,
       },
     };
-    mocks.auth.supabase = {};
+    mocks.getSession.mockResolvedValue({ data: { session } });
     const { result } = renderHook(() => useDeleteSession());
 
     act(() => {
@@ -269,7 +273,7 @@ describe("useDeleteSession", () => {
 
     await waitFor(() => {
       expect(mocks.loadManagedSharedNoteForSession).toHaveBeenCalledWith(
-        mocks.auth.session.user.id,
+        session.user.id,
         "session-1",
       );
     });

--- a/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
+++ b/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => {
     removeDurableSharedNoteCache: vi.fn(),
     softDeleteSession: vi.fn(() => Promise.resolve(deletedSessionData)),
     toastError: vi.fn(),
+    toastWarning: vi.fn(),
     deletedSessionData,
   };
 });
@@ -53,7 +54,7 @@ vi.mock("@hypr/plugin-windows", () => ({
 }));
 
 vi.mock("@hypr/ui/components/ui/toast", () => ({
-  sonnerToast: { error: mocks.toastError },
+  sonnerToast: { error: mocks.toastError, warning: mocks.toastWarning },
 }));
 
 vi.mock("~/auth", () => ({
@@ -139,7 +140,7 @@ describe("useDeleteSession", () => {
     mocks.listen.mockResolvedValue(vi.fn());
   });
 
-  it("revokes a known managed share before deleting its local note", async () => {
+  it("revokes a known managed share when the local deletion is finalized", async () => {
     const shareId = "33333333-3333-4333-8333-333333333333";
     const workspaceId = "22222222-2222-4222-8222-222222222222";
     mocks.auth.session = {
@@ -169,25 +170,35 @@ describe("useDeleteSession", () => {
     });
 
     await waitFor(() => {
-      expect(mocks.softDeleteSession).toHaveBeenCalledWith("session-1");
+      expect(mocks.addDeletion).toHaveBeenCalledOnce();
     });
-    expect(mocks.deleteSessionShareBySession).toHaveBeenCalledWith(
-      {
-        session: mocks.auth.session,
-        supabase: mocks.auth.supabase,
-      },
-      { workspaceId, sessionId: "session-1" },
-    );
+    expect(mocks.softDeleteSession).toHaveBeenCalledWith("session-1");
+    expect(mocks.deleteSessionShareBySession).not.toHaveBeenCalled();
+
+    const finalize = mocks.addDeletion.mock.calls[0]?.[1] as () => void;
+    act(() => {
+      finalize();
+    });
+
+    await waitFor(() => {
+      expect(mocks.deleteSessionShareBySession).toHaveBeenCalledWith(
+        {
+          session: mocks.auth.session,
+          supabase: mocks.auth.supabase,
+        },
+        { workspaceId, sessionId: "session-1" },
+      );
+    });
     expect(mocks.removeDurableSharedNoteCache).toHaveBeenCalledWith(
       mocks.auth.session.user.id,
       shareId,
     );
-    expect(
+    expect(mocks.softDeleteSession.mock.invocationCallOrder[0]!).toBeLessThan(
       mocks.deleteSessionShareBySession.mock.invocationCallOrder[0],
-    ).toBeLessThan(mocks.softDeleteSession.mock.invocationCallOrder[0]!);
+    );
   });
 
-  it("keeps a known shared note local when remote revocation fails", async () => {
+  it("still deletes the local note when remote revocation fails", async () => {
     const token = "secret-share-token";
     const consoleError = vi
       .spyOn(console, "error")
@@ -213,9 +224,19 @@ describe("useDeleteSession", () => {
       result.current("session-1");
     });
 
-    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledOnce());
-    expect(mocks.softDeleteSession).not.toHaveBeenCalled();
-    expect(mocks.getAllWebviewWindows).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mocks.addDeletion).toHaveBeenCalledOnce();
+    });
+    expect(mocks.softDeleteSession).toHaveBeenCalledWith("session-1");
+
+    const finalize = mocks.addDeletion.mock.calls[0]?.[1] as () => void;
+    act(() => {
+      finalize();
+    });
+
+    await waitFor(() => expect(mocks.toastWarning).toHaveBeenCalledOnce());
+    expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(mocks.removeDurableSharedNoteCache).not.toHaveBeenCalled();
     expect(JSON.stringify(consoleError.mock.calls)).not.toContain(token);
     consoleError.mockRestore();
   });
@@ -237,12 +258,21 @@ describe("useDeleteSession", () => {
     });
 
     await waitFor(() => {
-      expect(mocks.softDeleteSession).toHaveBeenCalledWith("session-1");
+      expect(mocks.addDeletion).toHaveBeenCalledOnce();
     });
-    expect(mocks.loadManagedSharedNoteForSession).toHaveBeenCalledWith(
-      mocks.auth.session.user.id,
-      "session-1",
-    );
+    expect(mocks.softDeleteSession).toHaveBeenCalledWith("session-1");
+
+    const finalize = mocks.addDeletion.mock.calls[0]?.[1] as () => void;
+    act(() => {
+      finalize();
+    });
+
+    await waitFor(() => {
+      expect(mocks.loadManagedSharedNoteForSession).toHaveBeenCalledWith(
+        mocks.auth.session.user.id,
+        "session-1",
+      );
+    });
     expect(mocks.deleteSessionShareBySession).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -55,13 +55,21 @@ async function revokeManagedShare(sessionId: string) {
   if (!session || session.user.is_anonymous === true) return;
   const context = { session, supabase };
 
-  const managedShare = await loadManagedSharedNoteForSession(
-    session.user.id,
-    sessionId,
-  ).catch((error: unknown) => {
-    console.error("[delete-session] failed to look up managed share", error);
-    return null;
-  });
+  // A failed lookup is not the same as "no share": without a warning a
+  // shared link could stay live after delete with no user signal. Retry
+  // once (the flush can rethrow an unrelated transient write failure),
+  // then surface it.
+  const lookupShare = () =>
+    loadManagedSharedNoteForSession(session.user.id, sessionId);
+  const managedShare = await lookupShare()
+    .catch(lookupShare)
+    .catch((error: unknown) => {
+      console.error("[delete-session] failed to look up managed share", error);
+      sonnerToast.warning(
+        "Note deleted, but its shared link could not be verified as removed.",
+      );
+      return null;
+    });
   if (!managedShare) return;
 
   try {

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -1,3 +1,4 @@
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
 import { emitTo, listen } from "@tauri-apps/api/event";
 import { getAllWebviewWindows } from "@tauri-apps/api/webviewWindow";
 import { useCallback, useEffect } from "react";
@@ -44,6 +45,74 @@ async function closeSessionNoteWindows(sessionId: string) {
   }
 }
 
+// Share revocation runs after the local deletion is finalized and must never
+// block or fail it — local deletes have to work offline.
+async function revokeManagedShare(
+  context: { session: Session; supabase: SupabaseClient },
+  sessionId: string,
+) {
+  const managedShare = await loadManagedSharedNoteForSession(
+    context.session.user.id,
+    sessionId,
+  ).catch((error: unknown) => {
+    console.error("[delete-session] failed to look up managed share", error);
+    return null;
+  });
+  if (!managedShare) return;
+
+  try {
+    const deletedShare = await deleteSessionShareBySession(context, {
+      workspaceId: managedShare.workspaceId,
+      sessionId: managedShare.sessionId,
+    });
+    if (
+      deletedShare.shareId !== null &&
+      deletedShare.shareId !== managedShare.shareId
+    ) {
+      throw new ShareManagementError();
+    }
+  } catch (error) {
+    // Share RPC failures can carry tokens in their messages; log the name only.
+    console.error(
+      "[delete-session] failed to revoke shared link",
+      error instanceof Error ? error.name : typeof error,
+    );
+    sonnerToast.warning(
+      "Note deleted, but its shared link could not be removed.",
+    );
+    return;
+  }
+
+  try {
+    await removeDurableSharedNoteCache(
+      context.session.user.id,
+      managedShare.shareId,
+    );
+  } catch {
+    console.error("[delete-session] failed to clear shared-note cache");
+  }
+}
+
+function revokeManagedShareBestEffort(
+  auth: {
+    session: Session | null | undefined;
+    supabase: SupabaseClient | null;
+  } | null,
+  sessionId: string,
+) {
+  if (
+    !auth?.session ||
+    !auth.supabase ||
+    auth.session.user.is_anonymous === true
+  ) {
+    return;
+  }
+  void revokeManagedShare(
+    { session: auth.session, supabase: auth.supabase },
+    sessionId,
+  );
+}
+
 function isSessionDeletedForUndoPayload(
   payload: unknown,
 ): payload is SessionDeletedForUndoPayload {
@@ -80,42 +149,6 @@ export function useDeleteSession() {
       void (async () => {
         let didDelete = false;
         try {
-          if (
-            auth?.session &&
-            auth.supabase &&
-            auth.session.user.is_anonymous !== true
-          ) {
-            const managedShare = await loadManagedSharedNoteForSession(
-              auth.session.user.id,
-              sessionId,
-            );
-            if (managedShare) {
-              const deletedShare = await deleteSessionShareBySession(
-                { session: auth.session, supabase: auth.supabase },
-                {
-                  workspaceId: managedShare.workspaceId,
-                  sessionId: managedShare.sessionId,
-                },
-              );
-              if (
-                deletedShare.shareId !== null &&
-                deletedShare.shareId !== managedShare.shareId
-              ) {
-                throw new ShareManagementError();
-              }
-              try {
-                await removeDurableSharedNoteCache(
-                  auth.session.user.id,
-                  managedShare.shareId,
-                );
-              } catch {
-                console.error(
-                  "[delete-session] failed to clear shared-note cache",
-                );
-              }
-            }
-          }
-
           const deletedData = await softDeleteSession(sessionId);
           if (!deletedData) return;
           didDelete = true;
@@ -125,6 +158,7 @@ export function useDeleteSession() {
           if (windowLabel === "main") {
             const finalize = () => {
               void finalizeSessionDeletion(sessionId);
+              revokeManagedShareBestEffort(auth, sessionId);
             };
             if (batchId) {
               addDeletion(deletedData, finalize, batchId);
@@ -137,8 +171,8 @@ export function useDeleteSession() {
               data: deletedData,
             } satisfies SessionDeletedForUndoPayload);
           }
-        } catch {
-          console.error("[delete-session] failed to finish deletion");
+        } catch (error) {
+          console.error("[delete-session] failed to finish deletion", error);
           sonnerToast.error("Could not delete this note. Please try again.");
         } finally {
           if (didDelete) {
@@ -158,6 +192,7 @@ export function useDeleteSession() {
 }
 
 export function useRemoteSessionDeletionUndoListener(active: boolean) {
+  const auth = useOptionalAuth();
   const invalidateResource = useTabs((state) => state.invalidateResource);
   const addDeletion = useUndoDelete((state) => state.addDeletion);
 
@@ -177,6 +212,7 @@ export function useRemoteSessionDeletionUndoListener(active: boolean) {
       invalidateResource("sessions", payload.sessionId);
       addDeletion(payload.data, () => {
         void finalizeSessionDeletion(payload.sessionId);
+        revokeManagedShareBestEffort(auth, payload.sessionId);
       });
       void closeSessionNoteWindows(payload.sessionId);
     }).then((fn) => {
@@ -186,5 +222,5 @@ export function useRemoteSessionDeletionUndoListener(active: boolean) {
     return () => {
       unlisten?.();
     };
-  }, [active, invalidateResource, addDeletion]);
+  }, [active, auth, invalidateResource, addDeletion]);
 }

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -1,4 +1,3 @@
-import type { Session, SupabaseClient } from "@supabase/supabase-js";
 import { emitTo, listen } from "@tauri-apps/api/event";
 import { getAllWebviewWindows } from "@tauri-apps/api/webviewWindow";
 import { useCallback, useEffect } from "react";
@@ -6,7 +5,7 @@ import { useCallback, useEffect } from "react";
 import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";
 import { sonnerToast } from "@hypr/ui/components/ui/toast";
 
-import { useOptionalAuth } from "~/auth";
+import { supabase } from "~/auth/client";
 import { useIgnoredEvents } from "~/calendar/ignored-events";
 import {
   deleteSessionShareBySession,
@@ -46,13 +45,18 @@ async function closeSessionNoteWindows(sessionId: string) {
 }
 
 // Share revocation runs after the local deletion is finalized and must never
-// block or fail it — local deletes have to work offline.
-async function revokeManagedShare(
-  context: { session: Session; supabase: SupabaseClient },
-  sessionId: string,
-) {
+// block or fail it — local deletes have to work offline. Auth is read from
+// the module-level client because this can run in windows (or the AppRoot
+// listener) mounted outside AuthProvider.
+async function revokeManagedShare(sessionId: string) {
+  if (!supabase) return;
+  const { data } = await supabase.auth.getSession();
+  const session = data.session;
+  if (!session || session.user.is_anonymous === true) return;
+  const context = { session, supabase };
+
   const managedShare = await loadManagedSharedNoteForSession(
-    context.session.user.id,
+    session.user.id,
     sessionId,
   ).catch((error: unknown) => {
     console.error("[delete-session] failed to look up managed share", error);
@@ -84,33 +88,19 @@ async function revokeManagedShare(
   }
 
   try {
-    await removeDurableSharedNoteCache(
-      context.session.user.id,
-      managedShare.shareId,
-    );
+    await removeDurableSharedNoteCache(session.user.id, managedShare.shareId);
   } catch {
     console.error("[delete-session] failed to clear shared-note cache");
   }
 }
 
-function revokeManagedShareBestEffort(
-  auth: {
-    session: Session | null | undefined;
-    supabase: SupabaseClient | null;
-  } | null,
-  sessionId: string,
-) {
-  if (
-    !auth?.session ||
-    !auth.supabase ||
-    auth.session.user.is_anonymous === true
-  ) {
-    return;
-  }
-  void revokeManagedShare(
-    { session: auth.session, supabase: auth.supabase },
-    sessionId,
-  );
+function revokeManagedShareBestEffort(sessionId: string) {
+  void revokeManagedShare(sessionId).catch((error: unknown) => {
+    console.error(
+      "[delete-session] failed to revoke shared link",
+      error instanceof Error ? error.name : typeof error,
+    );
+  });
 }
 
 function isSessionDeletedForUndoPayload(
@@ -128,7 +118,6 @@ function isSessionDeletedForUndoPayload(
 }
 
 export function useDeleteSession() {
-  const auth = useOptionalAuth();
   const invalidateResource = useTabs((state) => state.invalidateResource);
   const addDeletion = useUndoDelete((state) => state.addDeletion);
   const { ignoreEvent } = useIgnoredEvents();
@@ -158,7 +147,7 @@ export function useDeleteSession() {
           if (windowLabel === "main") {
             const finalize = () => {
               void finalizeSessionDeletion(sessionId);
-              revokeManagedShareBestEffort(auth, sessionId);
+              revokeManagedShareBestEffort(sessionId);
             };
             if (batchId) {
               addDeletion(deletedData, finalize, batchId);
@@ -181,18 +170,11 @@ export function useDeleteSession() {
         }
       })();
     },
-    [
-      auth?.session,
-      auth?.supabase,
-      ignoreEvent,
-      invalidateResource,
-      addDeletion,
-    ],
+    [ignoreEvent, invalidateResource, addDeletion],
   );
 }
 
 export function useRemoteSessionDeletionUndoListener(active: boolean) {
-  const auth = useOptionalAuth();
   const invalidateResource = useTabs((state) => state.invalidateResource);
   const addDeletion = useUndoDelete((state) => state.addDeletion);
 
@@ -212,7 +194,7 @@ export function useRemoteSessionDeletionUndoListener(active: boolean) {
       invalidateResource("sessions", payload.sessionId);
       addDeletion(payload.data, () => {
         void finalizeSessionDeletion(payload.sessionId);
-        revokeManagedShareBestEffort(auth, payload.sessionId);
+        revokeManagedShareBestEffort(payload.sessionId);
       });
       void closeSessionNoteWindows(payload.sessionId);
     }).then((fn) => {
@@ -222,5 +204,5 @@ export function useRemoteSessionDeletionUndoListener(active: boolean) {
     return () => {
       unlisten?.();
     };
-  }, [active, auth, invalidateResource, addDeletion]);
+  }, [active, invalidateResource, addDeletion]);
 }


### PR DESCRIPTION
Deleting a shared note ran the Supabase share-revocation RPC and a global
write-queue flush before the local soft-delete, so any remote failure or
DB contention aborted or hung the delete with no diagnostics (shipped in
1.3.0 via #6090).

Soft-delete the session first, then revoke the managed share best-effort
when the deletion is finalized after the undo window, delegating to the
main window for standalone note windows. Restore error logging in the
delete path; share RPC failures log the error name only to avoid leaking
tokens, and surface a warning toast instead of failing the delete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session deletion ordering and share-revocation error handling; local deletes always proceed but shared links might remain live if remote cleanup fails (now surfaced via warnings).
> 
> **Overview**
> **Local note deletion no longer waits on or fails because of remote share revocation.** The delete path runs `softDeleteSession` first, registers undo, and only then—when deletion is finalized after the undo window—runs best-effort managed-share cleanup.
> 
> Share lookup/revoke moved into `revokeManagedShare` / `revokeManagedShareBestEffort`, using the module-level `supabase` client (so note windows and the main undo listener work outside `AuthProvider`). Lookup retries once; RPC/cache failures log without leaking token details and show a **warning** toast while the local delete still succeeds. The same revoke hook runs from the main-window undo finalize callback and from `useRemoteSessionDeletionUndoListener`.
> 
> Tests were updated to drive the finalize callback, assert soft-delete happens before share RPC, and expect warnings (not delete errors) when revocation fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f23c73ca697ca72a0543ad52aafd700e75b03b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6189 
- <kbd>&nbsp;1&nbsp;</kbd> #6185 👈 
<!-- GitButler Footer Boundary Bottom -->

