### PR TITLE
fix(desktop): render chat sends immediately instead of after persist

### DIFF
--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -90,9 +90,19 @@ export function ChatPanelFrame({
     [setGroupId],
   );
 
+  const handleGroupCreateFailed = useCallback(
+    (failedGroupId: string) => {
+      if (groupId === failedGroupId) {
+        setGroupId(undefined);
+      }
+    },
+    [groupId, setGroupId],
+  );
+
   const { handleSendMessage } = useChatActions({
     groupId,
     onGroupCreated: handleGroupCreated,
+    onGroupCreateFailed: handleGroupCreateFailed,
   });
 
   return (

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -78,7 +78,7 @@ export function ChatPanelFrame({
   sessionProps: ChatSessionRenderProps | null;
 }) {
   const { chat } = useShell();
-  const { groupId, setGroupId } = chat;
+  const { groupId, setGroupId, rollbackFailedGroup } = chat;
   const { panelClassName, toolbarSurface } = useChatAppearance();
   const isFloating = layout === "floating";
   const model = useLanguageModel("chat");
@@ -92,11 +92,9 @@ export function ChatPanelFrame({
 
   const handleGroupCreateFailed = useCallback(
     (failedGroupId: string) => {
-      if (groupId === failedGroupId) {
-        setGroupId(undefined);
-      }
+      rollbackFailedGroup(failedGroupId);
     },
-    [groupId, setGroupId],
+    [rollbackFailedGroup],
   );
 
   const { handleSendMessage } = useChatActions({

--- a/apps/desktop/src/chat/components/session-provider.test.tsx
+++ b/apps/desktop/src/chat/components/session-provider.test.tsx
@@ -306,7 +306,17 @@ describe("ChatSession", () => {
       messages: [userMessage, assistant],
     });
 
-    await waitFor(() => expect(mocks.upsertChatMessage).toHaveBeenCalledOnce());
+    await waitFor(() =>
+      expect(mocks.upsertChatMessage).toHaveBeenCalledTimes(2),
+    );
+    // The user row was missing at finish time, so the turn is repaired
+    // before the assistant lands in the same group.
+    expect(mocks.upsertChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "user-1",
+        chatGroupId: "new-group",
+      }),
+    );
     expect(mocks.upsertChatMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "assistant-1",
@@ -351,9 +361,10 @@ describe("ChatSession", () => {
       messages: [userMessage, assistant],
     });
 
-    await waitFor(() => expect(mocks.upsertChatMessage).toHaveBeenCalledOnce());
-    expect(mocks.upsertChatMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ chatGroupId: "group-1" }),
+    await waitFor(() =>
+      expect(mocks.upsertChatMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "assistant-1", chatGroupId: "group-1" }),
+      ),
     );
     expect(consoleError).toHaveBeenCalledWith(
       "Failed to resolve the persisted chat message group",
@@ -415,13 +426,19 @@ describe("ChatSession", () => {
     });
 
     await waitFor(() =>
-      expect(mocks.upsertChatMessage).toHaveBeenCalledTimes(2),
+      expect(mocks.upsertChatMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "assistant-2", chatGroupId: "group-2" }),
+      ),
     );
     expect(mocks.upsertChatMessage).toHaveBeenCalledWith(
       expect.objectContaining({ id: "assistant-1", chatGroupId: "group-1" }),
     );
+    // Unpersisted user turns are repaired alongside their assistant rows.
     expect(mocks.upsertChatMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "assistant-2", chatGroupId: "group-2" }),
+      expect.objectContaining({ id: "user-1", chatGroupId: "group-1" }),
+    );
+    expect(mocks.upsertChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "user-2", chatGroupId: "group-2" }),
     );
   });
 });

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -14,6 +14,7 @@ import {
   type DisplayEntity,
   useChatContextPipeline,
 } from "~/chat/context/use-chat-context-pipeline";
+import { hasPendingChatPersist } from "~/chat/store/pending-persists";
 import {
   buildPersistedChatMessage,
   getVisibleChatMessages,
@@ -228,6 +229,10 @@ export function ChatSession({
     if (
       status !== "ready" ||
       !chatGroupId ||
+      // An outbound send's write (with retries) may still be in flight; the
+      // persisted set is legitimately behind it and reconciling now would
+      // wipe the turn the user just sent.
+      hasPendingChatPersist(chatGroupId) ||
       areMessagesEqual(messages, persistedVisibleMessages)
     ) {
       return;

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -14,7 +14,11 @@ import {
   type DisplayEntity,
   useChatContextPipeline,
 } from "~/chat/context/use-chat-context-pipeline";
-import { hasPendingChatPersist } from "~/chat/store/pending-persists";
+import {
+  hasPendingChatPersist,
+  isFailedChatGroupCreate,
+  waitForPendingChatPersists,
+} from "~/chat/store/pending-persists";
 import {
   buildPersistedChatMessage,
   getVisibleChatMessages,
@@ -168,6 +172,15 @@ export function ChatSession({
           }
 
           void (async () => {
+            // Outbound user writes may still be retrying; settle them first
+            // so the lookup below reflects the final truth and a failed
+            // persist can be repaired instead of orphaning the reply.
+            const awaitedChatGroupId =
+              submittedChatGroupId ?? latestChatGroupIdRef.current;
+            if (awaitedChatGroupId) {
+              await waitForPendingChatPersists(awaitedChatGroupId);
+            }
+
             let persistedChatGroupId: string | null = null;
             if (submittedUserMessage) {
               try {
@@ -189,16 +202,16 @@ export function ChatSession({
               return;
             }
 
+            // The group row was never created; persisting into it would
+            // produce orphaned rows that never appear in history.
+            if (isFailedChatGroupCreate(targetChatGroupId)) {
+              return;
+            }
+
             // If the outbound persist failed, the assistant row would land
             // with no matching user row and reconciliation would wipe the
             // turn — repair the user message before persisting the reply.
-            // A still-pending outbound write will land on its own; only a
-            // settled-and-missing row needs the repair.
-            if (
-              submittedUserMessage &&
-              !persistedChatGroupId &&
-              !hasPendingChatPersist(targetChatGroupId)
-            ) {
+            if (submittedUserMessage && !persistedChatGroupId) {
               await upsertChatMessage(
                 buildPersistedChatMessage({
                   message: submittedUserMessage,

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -169,7 +169,7 @@ export function ChatSession({
 
           void (async () => {
             let persistedChatGroupId: string | null = null;
-            if (!submittedChatGroupId && submittedUserMessage) {
+            if (submittedUserMessage) {
               try {
                 persistedChatGroupId = await getChatMessageGroupId(
                   submittedUserMessage.id,
@@ -187,6 +187,26 @@ export function ChatSession({
               latestChatGroupIdRef.current;
             if (!targetChatGroupId) {
               return;
+            }
+
+            // If the outbound persist failed, the assistant row would land
+            // with no matching user row and reconciliation would wipe the
+            // turn — repair the user message before persisting the reply.
+            // A still-pending outbound write will land on its own; only a
+            // settled-and-missing row needs the repair.
+            if (
+              submittedUserMessage &&
+              !persistedChatGroupId &&
+              !hasPendingChatPersist(targetChatGroupId)
+            ) {
+              await upsertChatMessage(
+                buildPersistedChatMessage({
+                  message: submittedUserMessage,
+                  chatGroupId: targetChatGroupId,
+                  ownerUserId: currentUserId,
+                  status: "ready",
+                }),
+              );
             }
 
             const sanitizedParts = stripEphemeralToolContext(message.parts);

--- a/apps/desktop/src/chat/state/chat-context.ts
+++ b/apps/desktop/src/chat/state/chat-context.ts
@@ -9,6 +9,7 @@ interface ChatContextState {
 
 interface ChatContextActions {
   setGroupId: (groupId: string | undefined) => void;
+  rollbackFailedGroup: (failedGroupId: string) => void;
   startNewChat: () => void;
   selectChat: (groupId: string) => void;
 }
@@ -18,6 +19,12 @@ export const useChatContext = create<ChatContextState & ChatContextActions>(
     groupId: undefined,
     sessionId: id(),
     setGroupId: (groupId) => set({ groupId }),
+    // Compares against the live groupId, not a value captured when the send
+    // started — the failure lands after onGroupCreated already updated it.
+    rollbackFailedGroup: (failedGroupId) =>
+      set((state) =>
+        state.groupId === failedGroupId ? { groupId: undefined } : state,
+      ),
     startNewChat: () => set({ groupId: undefined, sessionId: id() }),
     selectChat: (groupId) => set({ groupId, sessionId: groupId }),
   }),

--- a/apps/desktop/src/chat/state/use-chat-mode.ts
+++ b/apps/desktop/src/chat/state/use-chat-mode.ts
@@ -13,6 +13,9 @@ export function useChatMode() {
   const groupId = useChatContext((state) => state.groupId);
   const sessionId = useChatContext((state) => state.sessionId);
   const setGroupId = useChatContext((state) => state.setGroupId);
+  const rollbackFailedGroup = useChatContext(
+    (state) => state.rollbackFailedGroup,
+  );
   const startNewChat = useChatContext((state) => state.startNewChat);
   const selectChat = useChatContext((state) => state.selectChat);
 
@@ -35,6 +38,7 @@ export function useChatMode() {
     groupId,
     sessionId,
     setGroupId,
+    rollbackFailedGroup,
     startNewChat,
     selectChat,
   };

--- a/apps/desktop/src/chat/store/pending-persists.ts
+++ b/apps/desktop/src/chat/store/pending-persists.ts
@@ -2,22 +2,52 @@
 // ChatSession's reconciliation replaces in-memory messages with the SQLite
 // set once a stream settles; while a send's write is pending that set is
 // legitimately behind, so reconciliation must hold off or it wipes the turn
-// the user just sent.
-const pendingByGroup = new Map<string, number>();
+// the user just sent. onFinish also awaits settlement before persisting the
+// assistant, so a failed user persist can be repaired first.
+const pendingByGroup = new Map<string, Set<Promise<unknown>>>();
 
-export function beginPendingChatPersist(chatGroupId: string) {
-  pendingByGroup.set(chatGroupId, (pendingByGroup.get(chatGroupId) ?? 0) + 1);
-}
+// Group ids whose chat_groups row creation terminally failed. Persisting
+// messages into them would create permanent orphans that never appear in
+// history. Ids are never reused, so entries can live for the session.
+const failedGroupCreates = new Set<string>();
 
-export function endPendingChatPersist(chatGroupId: string) {
-  const count = pendingByGroup.get(chatGroupId) ?? 0;
-  if (count <= 1) {
-    pendingByGroup.delete(chatGroupId);
-  } else {
-    pendingByGroup.set(chatGroupId, count - 1);
-  }
+export function trackPendingChatPersist(
+  chatGroupId: string,
+  write: Promise<unknown>,
+) {
+  const settled: Promise<unknown> = write
+    .catch(() => undefined)
+    .finally(() => {
+      const writes = pendingByGroup.get(chatGroupId);
+      if (!writes) return;
+      writes.delete(settled);
+      if (writes.size === 0) {
+        pendingByGroup.delete(chatGroupId);
+      }
+    });
+  const writes = pendingByGroup.get(chatGroupId) ?? new Set();
+  writes.add(settled);
+  pendingByGroup.set(chatGroupId, writes);
 }
 
 export function hasPendingChatPersist(chatGroupId: string) {
   return pendingByGroup.has(chatGroupId);
+}
+
+export async function waitForPendingChatPersists(chatGroupId: string) {
+  // New writes can be tracked while earlier ones are awaited; a few rounds
+  // cover realistic pile-ups without risking an unbounded loop.
+  for (let round = 0; round < 5; round += 1) {
+    const writes = pendingByGroup.get(chatGroupId);
+    if (!writes || writes.size === 0) return;
+    await Promise.all([...writes]);
+  }
+}
+
+export function markFailedChatGroupCreate(chatGroupId: string) {
+  failedGroupCreates.add(chatGroupId);
+}
+
+export function isFailedChatGroupCreate(chatGroupId: string) {
+  return failedGroupCreates.has(chatGroupId);
 }

--- a/apps/desktop/src/chat/store/pending-persists.ts
+++ b/apps/desktop/src/chat/store/pending-persists.ts
@@ -1,0 +1,23 @@
+// Outbound chat persists that are still in flight (including retries).
+// ChatSession's reconciliation replaces in-memory messages with the SQLite
+// set once a stream settles; while a send's write is pending that set is
+// legitimately behind, so reconciliation must hold off or it wipes the turn
+// the user just sent.
+const pendingByGroup = new Map<string, number>();
+
+export function beginPendingChatPersist(chatGroupId: string) {
+  pendingByGroup.set(chatGroupId, (pendingByGroup.get(chatGroupId) ?? 0) + 1);
+}
+
+export function endPendingChatPersist(chatGroupId: string) {
+  const count = pendingByGroup.get(chatGroupId) ?? 0;
+  if (count <= 1) {
+    pendingByGroup.delete(chatGroupId);
+  } else {
+    pendingByGroup.set(chatGroupId, count - 1);
+  }
+}
+
+export function hasPendingChatPersist(chatGroupId: string) {
+  return pendingByGroup.has(chatGroupId);
+}

--- a/apps/desktop/src/chat/store/use-chat-actions.test.tsx
+++ b/apps/desktop/src/chat/store/use-chat-actions.test.tsx
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   createChatGroupWithMessage: vi.fn(),
   ids: [] as string[],
   setChatGroupTitleIfCurrent: vi.fn(),
+  toastError: vi.fn(),
   upsertChatMessage: vi.fn(),
 }));
 
@@ -16,6 +17,10 @@ vi.mock("~/chat/store/queries", () => ({
   createChatGroupWithMessage: mocks.createChatGroupWithMessage,
   setChatGroupTitleIfCurrent: mocks.setChatGroupTitleIfCurrent,
   upsertChatMessage: mocks.upsertChatMessage,
+}));
+
+vi.mock("@hypr/ui/components/ui/toast", () => ({
+  sonnerToast: { error: mocks.toastError },
 }));
 
 vi.mock("~/shared/utils", () => ({
@@ -37,12 +42,9 @@ describe("useChatActions", () => {
     mocks.upsertChatMessage.mockResolvedValue(undefined);
   });
 
-  it("durably commits the first group and message before sending", async () => {
-    let finishPersistence: (() => void) | undefined;
+  it("sends immediately and persists the first group in the background", () => {
     mocks.createChatGroupWithMessage.mockReturnValue(
-      new Promise<void>((resolve) => {
-        finishPersistence = resolve;
-      }),
+      new Promise<void>(() => {}),
     );
     const onGroupCreated = vi.fn();
     const sendMessage = vi.fn();
@@ -58,6 +60,11 @@ describe("useChatActions", () => {
       );
     });
 
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "message-1", role: "user" }),
+      { chatGroupId: "group-1" },
+    );
+    expect(onGroupCreated).toHaveBeenCalledWith("group-1");
     expect(mocks.createChatGroupWithMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         groupId: "group-1",
@@ -70,19 +77,9 @@ describe("useChatActions", () => {
         }),
       }),
     );
-    expect(onGroupCreated).not.toHaveBeenCalled();
-    expect(sendMessage).not.toHaveBeenCalled();
-
-    await act(async () => finishPersistence?.());
-
-    expect(onGroupCreated).toHaveBeenCalledWith("group-1");
-    expect(sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "message-1", role: "user" }),
-      { chatGroupId: "group-1" },
-    );
   });
 
-  it("upserts into an existing group before sending", async () => {
+  it("sends immediately when upserting into an existing group", () => {
     const sendMessage = vi.fn();
     const { result } = renderHook(() =>
       useChatActions({ groupId: "group-existing", onGroupCreated: vi.fn() }),
@@ -96,7 +93,7 @@ describe("useChatActions", () => {
       );
     });
 
-    await waitFor(() => expect(sendMessage).toHaveBeenCalledOnce());
+    expect(sendMessage).toHaveBeenCalledOnce();
     expect(mocks.createChatGroupWithMessage).not.toHaveBeenCalled();
     expect(mocks.upsertChatMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -106,7 +103,7 @@ describe("useChatActions", () => {
     );
   });
 
-  it("does not send a request when durable persistence fails", async () => {
+  it("still sends and surfaces an error toast when persistence fails", async () => {
     const error = new Error("database unavailable");
     mocks.createChatGroupWithMessage.mockRejectedValue(error);
     const consoleError = vi
@@ -125,13 +122,16 @@ describe("useChatActions", () => {
       );
     });
 
+    expect(sendMessage).toHaveBeenCalledOnce();
     await waitFor(() =>
       expect(consoleError).toHaveBeenCalledWith(
         "Failed to persist outgoing chat message",
         error,
       ),
     );
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "Could not save this chat message.",
+    );
     consoleError.mockRestore();
   });
 });

--- a/apps/desktop/src/chat/store/use-chat-actions.test.tsx
+++ b/apps/desktop/src/chat/store/use-chat-actions.test.tsx
@@ -110,8 +110,13 @@ describe("useChatActions", () => {
       .spyOn(console, "error")
       .mockImplementation(() => {});
     const sendMessage = vi.fn();
+    const onGroupCreateFailed = vi.fn();
     const { result } = renderHook(() =>
-      useChatActions({ groupId: undefined, onGroupCreated: vi.fn() }),
+      useChatActions({
+        groupId: undefined,
+        onGroupCreated: vi.fn(),
+        onGroupCreateFailed,
+      }),
     );
 
     act(() => {
@@ -123,15 +128,52 @@ describe("useChatActions", () => {
     });
 
     expect(sendMessage).toHaveBeenCalledOnce();
-    await waitFor(() =>
-      expect(consoleError).toHaveBeenCalledWith(
-        "Failed to persist outgoing chat message",
-        error,
-      ),
+    await waitFor(
+      () =>
+        expect(consoleError).toHaveBeenCalledWith(
+          "Failed to persist outgoing chat message",
+          error,
+        ),
+      { timeout: 3000 },
     );
     expect(mocks.toastError).toHaveBeenCalledWith(
       "Could not save this chat message.",
     );
+    expect(mocks.createChatGroupWithMessage).toHaveBeenCalledTimes(3);
+    expect(onGroupCreateFailed).toHaveBeenCalledWith("group-1");
+    consoleError.mockRestore();
+  });
+
+  it("retries a transient persist failure without failing the group", async () => {
+    mocks.createChatGroupWithMessage
+      .mockRejectedValueOnce(new Error("database is locked"))
+      .mockResolvedValueOnce(undefined);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const onGroupCreateFailed = vi.fn();
+    const { result } = renderHook(() =>
+      useChatActions({
+        groupId: undefined,
+        onGroupCreated: vi.fn(),
+        onGroupCreateFailed,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSendMessage(
+        "Hello",
+        [{ type: "text", text: "Hello" }],
+        vi.fn(),
+      );
+    });
+
+    await waitFor(
+      () => expect(mocks.createChatGroupWithMessage).toHaveBeenCalledTimes(2),
+      { timeout: 3000 },
+    );
+    expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(onGroupCreateFailed).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
 });

--- a/apps/desktop/src/chat/store/use-chat-actions.ts
+++ b/apps/desktop/src/chat/store/use-chat-actions.ts
@@ -4,8 +4,8 @@ import { sonnerToast } from "@hypr/ui/components/ui/toast";
 
 import { createFallbackChatTitle, generateChatTitle } from "./chat-title";
 import {
-  beginPendingChatPersist,
-  endPendingChatPersist,
+  markFailedChatGroupCreate,
+  trackPendingChatPersist,
 } from "./pending-persists";
 import { buildPersistedChatMessage } from "./persisted-messages";
 import {
@@ -141,8 +141,9 @@ export function useChatActions({
         onGroupCreated(currentGroupId);
       }
 
-      beginPendingChatPersist(currentGroupId);
-      void persistWithRetry(runPersist)
+      const persist = persistWithRetry(runPersist);
+      trackPendingChatPersist(currentGroupId, persist);
+      void persist
         .then(() => {
           if (fallbackTitle) {
             queueChatTitleGeneration({
@@ -157,12 +158,11 @@ export function useChatActions({
           sonnerToast.error("Could not save this chat message.");
           if (fallbackTitle) {
             // The group row was never created; leaving the shell pointed at
-            // it would orphan every follow-up message.
+            // it would orphan every follow-up message, and later persists
+            // into it would create rows that never appear in history.
+            markFailedChatGroupCreate(currentGroupId);
             onGroupCreateFailed?.(currentGroupId);
           }
-        })
-        .finally(() => {
-          endPendingChatPersist(currentGroupId);
         });
     },
     [

--- a/apps/desktop/src/chat/store/use-chat-actions.ts
+++ b/apps/desktop/src/chat/store/use-chat-actions.ts
@@ -1,5 +1,7 @@
 import { useCallback } from "react";
 
+import { sonnerToast } from "@hypr/ui/components/ui/toast";
+
 import { createFallbackChatTitle, generateChatTitle } from "./chat-title";
 import { buildPersistedChatMessage } from "./persisted-messages";
 import {
@@ -106,21 +108,24 @@ export function useChatActions({
           })
         : upsertChatMessage(message);
 
+      sendMessage(uiMessage, { chatGroupId: currentGroupId });
+      if (fallbackTitle) {
+        onGroupCreated(currentGroupId);
+      }
+
       void persist
         .then(() => {
           if (fallbackTitle) {
-            onGroupCreated(currentGroupId);
             queueChatTitleGeneration({
               groupId: currentGroupId,
               fallbackTitle,
               initialRequest: content,
             });
           }
-
-          sendMessage(uiMessage, { chatGroupId: currentGroupId });
         })
         .catch((error) => {
           console.error("Failed to persist outgoing chat message", error);
+          sonnerToast.error("Could not save this chat message.");
         });
     },
     [groupId, ownerUserId, onGroupCreated, queueChatTitleGeneration],

--- a/apps/desktop/src/chat/store/use-chat-actions.ts
+++ b/apps/desktop/src/chat/store/use-chat-actions.ts
@@ -3,6 +3,10 @@ import { useCallback } from "react";
 import { sonnerToast } from "@hypr/ui/components/ui/toast";
 
 import { createFallbackChatTitle, generateChatTitle } from "./chat-title";
+import {
+  beginPendingChatPersist,
+  endPendingChatPersist,
+} from "./pending-persists";
 import { buildPersistedChatMessage } from "./persisted-messages";
 import {
   createChatGroupWithMessage,
@@ -16,12 +20,35 @@ import type { HyprUIMessage } from "~/chat/types";
 import { useOwnerUserId } from "~/shared/owner-user";
 import { id } from "~/shared/utils";
 
+// Local writes normally land in milliseconds; retries cover transient
+// "database is locked" contention so a send does not lose its turn to a
+// momentary lock.
+const PERSIST_RETRY_DELAYS_MS = [120, 360];
+
+async function persistWithRetry(run: () => Promise<unknown>) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await run();
+      return;
+    } catch (error) {
+      if (attempt >= PERSIST_RETRY_DELAYS_MS.length) {
+        throw error;
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, PERSIST_RETRY_DELAYS_MS[attempt]),
+      );
+    }
+  }
+}
+
 export function useChatActions({
   groupId,
   onGroupCreated,
+  onGroupCreateFailed,
 }: {
   groupId: string | undefined;
   onGroupCreated: (newGroupId: string) => void;
+  onGroupCreateFailed?: (failedGroupId: string) => void;
 }) {
   const ownerUserId = useOwnerUserId();
   const titleModel = useLanguageModel("title");
@@ -98,22 +125,24 @@ export function useChatActions({
       const fallbackTitle = groupId
         ? undefined
         : createFallbackChatTitle(content);
-      const persist = fallbackTitle
-        ? createChatGroupWithMessage({
-            groupId: currentGroupId,
-            ownerUserId,
-            title: fallbackTitle,
-            createdAt: message.createdAt,
-            message,
-          })
-        : upsertChatMessage(message);
+      const runPersist = fallbackTitle
+        ? () =>
+            createChatGroupWithMessage({
+              groupId: currentGroupId,
+              ownerUserId,
+              title: fallbackTitle,
+              createdAt: message.createdAt,
+              message,
+            })
+        : () => upsertChatMessage(message);
 
       sendMessage(uiMessage, { chatGroupId: currentGroupId });
       if (fallbackTitle) {
         onGroupCreated(currentGroupId);
       }
 
-      void persist
+      beginPendingChatPersist(currentGroupId);
+      void persistWithRetry(runPersist)
         .then(() => {
           if (fallbackTitle) {
             queueChatTitleGeneration({
@@ -126,9 +155,23 @@ export function useChatActions({
         .catch((error) => {
           console.error("Failed to persist outgoing chat message", error);
           sonnerToast.error("Could not save this chat message.");
+          if (fallbackTitle) {
+            // The group row was never created; leaving the shell pointed at
+            // it would orphan every follow-up message.
+            onGroupCreateFailed?.(currentGroupId);
+          }
+        })
+        .finally(() => {
+          endPendingChatPersist(currentGroupId);
         });
     },
-    [groupId, ownerUserId, onGroupCreated, queueChatTitleGeneration],
+    [
+      groupId,
+      ownerUserId,
+      onGroupCreated,
+      onGroupCreateFailed,
+      queueChatTitleGeneration,
+    ],
   );
 
   return { handleSendMessage };

--- a/apps/desktop/src/composer/index.tsx
+++ b/apps/desktop/src/composer/index.tsx
@@ -35,6 +35,11 @@ export function ComposerScreen() {
   const { handleSendMessage } = useChatActions({
     groupId: chat.groupId,
     onGroupCreated: chat.setGroupId,
+    onGroupCreateFailed: (failedGroupId) => {
+      if (chat.groupId === failedGroupId) {
+        chat.setGroupId(undefined);
+      }
+    },
   });
 
   useEffect(() => {

--- a/apps/desktop/src/composer/index.tsx
+++ b/apps/desktop/src/composer/index.tsx
@@ -35,11 +35,7 @@ export function ComposerScreen() {
   const { handleSendMessage } = useChatActions({
     groupId: chat.groupId,
     onGroupCreated: chat.setGroupId,
-    onGroupCreateFailed: (failedGroupId) => {
-      if (chat.groupId === failedGroupId) {
-        chat.setGroupId(undefined);
-      }
-    },
+    onGroupCreateFailed: chat.rollbackFailedGroup,
   });
 
   useEffect(() => {


### PR DESCRIPTION
handleSendMessage only called sendMessage after the SQLite write
resolved, so suggestion-chip sends showed zero feedback until
persistence completed. Send the optimistic user message and switch to
the new group synchronously, keep persistence in the background, and
show an error toast when it fails. Title generation still waits for the
group row to exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chat persistence timing, reconciliation, and failure handling for SQLite-backed messages; incorrect coordination could drop turns or orphan rows, though tests cover the main paths.
> 
> **Overview**
> **Desktop chat no longer waits on SQLite before showing send feedback.** `handleSendMessage` now calls `sendMessage` and `onGroupCreated` synchronously, then persists in the background with short retries for transient lock errors.
> 
> To keep optimistic UI consistent with storage, a new **`pending-persists`** layer tracks in-flight writes per group. `ChatSession` **defers SQLite→SDK reconciliation** while a persist is pending (so the just-sent turn is not wiped), **awaits settlement in `onFinish`** before saving the assistant, **skips writes** for groups whose `chat_groups` row never created, and **re-upserts the user message** when the outbound row is still missing at finish time.
> 
> When **new-group persistence fails** after retries, the app shows a toast, marks the group id as failed, and **`rollbackFailedGroup`** clears the shell selection if it still points at that id (wired from chat panel and composer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f6fa9db92446b97957eacbd9df41f0868c0ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->