### PR TITLE
feat(stripe): email cardless trials before they end via Loops

### DIFF
--- a/apps/stripe/src/env.ts
+++ b/apps/stripe/src/env.ts
@@ -13,6 +13,8 @@ export const env = createEnv({
     STRIPE_SECRET_KEY: z.string().min(1),
     STRIPE_WEBHOOK_SECRET: z.string().min(1),
     POSTHOG_API_KEY: z.string().min(1).optional(),
+    LOOPS_API_KEY: z.string().min(1).optional(),
+    LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID: z.string().min(1).optional(),
   },
   runtimeEnv: Bun.env,
   emptyStringAsUndefined: true,

--- a/apps/stripe/src/routes/webhook.ts
+++ b/apps/stripe/src/routes/webhook.ts
@@ -6,6 +6,7 @@ import { syncBillingBridge } from "../billing-bridge";
 import { env } from "../env";
 import type { AppBindings } from "../hono-bindings";
 import { stripeSync } from "../integration/stripe-sync";
+import { sendTrialEndingEmail } from "../trial-emails";
 
 export const webhook = new Hono<AppBindings>();
 
@@ -68,6 +69,18 @@ webhook.post("/stripe", async (c) => {
       tags: {
         webhook: "stripe",
         step: "posthog",
+        event_type: stripeEvent.type,
+      },
+    });
+  }
+
+  try {
+    await sendTrialEndingEmail(stripeEvent);
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: {
+        webhook: "stripe",
+        step: "loops",
         event_type: stripeEvent.type,
       },
     });

--- a/apps/stripe/src/trial-email-payload.test.ts
+++ b/apps/stripe/src/trial-email-payload.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import type Stripe from "stripe";
+
+import { buildTrialEndingEmail } from "./trial-email-payload";
+
+const NOW = Date.UTC(2026, 6, 30);
+const TRIAL_END = Math.floor(Date.UTC(2026, 7, 2) / 1000);
+
+const subscription = (overrides: Record<string, unknown> = {}) =>
+  ({
+    trial_end: TRIAL_END,
+    default_payment_method: null,
+    ...overrides,
+  }) as unknown as Stripe.Subscription;
+
+const customer = (overrides: Record<string, unknown> = {}) =>
+  ({
+    email: "user@example.com",
+    invoice_settings: { default_payment_method: null },
+    default_source: null,
+    ...overrides,
+  }) as unknown as Stripe.Customer;
+
+describe("buildTrialEndingEmail", () => {
+  it("builds a reminder for a cardless trial", () => {
+    const payload = buildTrialEndingEmail({
+      subscription: subscription(),
+      customer: customer(),
+      now: NOW,
+    });
+
+    expect(payload).toEqual({
+      email: "user@example.com",
+      dataVariables: {
+        daysRemaining: 3,
+        trialEndDate: "August 2, 2026",
+      },
+    });
+  });
+
+  it("skips card-backed trials", () => {
+    expect(
+      buildTrialEndingEmail({
+        subscription: subscription({ default_payment_method: "pm_123" }),
+        customer: customer(),
+        now: NOW,
+      }),
+    ).toBeNull();
+
+    expect(
+      buildTrialEndingEmail({
+        subscription: subscription(),
+        customer: customer({
+          invoice_settings: { default_payment_method: "pm_123" },
+        }),
+        now: NOW,
+      }),
+    ).toBeNull();
+
+    expect(
+      buildTrialEndingEmail({
+        subscription: subscription(),
+        customer: customer({ default_source: "card_123" }),
+        now: NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("skips customers without an email", () => {
+    expect(
+      buildTrialEndingEmail({
+        subscription: subscription(),
+        customer: customer({ email: null }),
+        now: NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("skips trials that already ended", () => {
+    expect(
+      buildTrialEndingEmail({
+        subscription: subscription({ trial_end: Math.floor(NOW / 1000) - 60 }),
+        customer: customer(),
+        now: NOW,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/stripe/src/trial-email-payload.ts
+++ b/apps/stripe/src/trial-email-payload.ts
@@ -1,0 +1,43 @@
+import type Stripe from "stripe";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function buildTrialEndingEmail({
+  subscription,
+  customer,
+  now,
+}: {
+  subscription: Stripe.Subscription;
+  customer: Stripe.Customer;
+  now: number;
+}): { email: string; dataVariables: Record<string, string | number> } | null {
+  if (!customer.email || !subscription.trial_end) {
+    return null;
+  }
+
+  // Same payment-method presence rule as the has_payment_method auth claim:
+  // card-backed trials auto-convert, so they need no reminder.
+  const hasPaymentMethod =
+    subscription.default_payment_method != null ||
+    customer.invoice_settings?.default_payment_method != null ||
+    customer.default_source != null;
+  if (hasPaymentMethod) {
+    return null;
+  }
+
+  const trialEndMs = subscription.trial_end * 1000;
+  if (trialEndMs <= now) {
+    return null;
+  }
+
+  return {
+    email: customer.email,
+    dataVariables: {
+      daysRemaining: Math.ceil((trialEndMs - now) / DAY_MS),
+      trialEndDate: new Intl.DateTimeFormat("en", {
+        dateStyle: "long",
+        timeZone: "UTC",
+      }).format(new Date(trialEndMs)),
+    },
+  };
+}

--- a/apps/stripe/src/trial-emails.ts
+++ b/apps/stripe/src/trial-emails.ts
@@ -1,0 +1,57 @@
+import Stripe from "stripe";
+
+import { getCustomerId, getStripeCustomer } from "./billing-bridge";
+import { env } from "./env";
+import { buildTrialEndingEmail } from "./trial-email-payload";
+
+const LOOPS_TRANSACTIONAL_URL = "https://app.loops.so/api/v1/transactional";
+
+export async function sendTrialEndingEmail(event: Stripe.Event) {
+  if (event.type !== "customer.subscription.trial_will_end") {
+    return;
+  }
+
+  if (!env.LOOPS_API_KEY || !env.LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID) {
+    return;
+  }
+
+  const subscription = event.data.object as Stripe.Subscription;
+  const customerId = getCustomerId(subscription);
+  if (!customerId) {
+    return;
+  }
+
+  const customer = await getStripeCustomer(customerId);
+  if (!customer) {
+    return;
+  }
+
+  const payload = buildTrialEndingEmail({
+    subscription,
+    customer,
+    now: Date.now(),
+  });
+  if (!payload) {
+    return;
+  }
+
+  const response = await fetch(LOOPS_TRANSACTIONAL_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.LOOPS_API_KEY}`,
+      "Content-Type": "application/json",
+      "Idempotency-Key": event.id,
+    },
+    body: JSON.stringify({
+      transactionalId: env.LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID,
+      email: payload.email,
+      dataVariables: payload.dataVariables,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Loops transactional send failed (${response.status}): ${await response.text()}`,
+    );
+  }
+}

--- a/apps/stripe/src/trial-emails.ts
+++ b/apps/stripe/src/trial-emails.ts
@@ -40,12 +40,14 @@ export async function sendTrialEndingEmail(event: Stripe.Event) {
     headers: {
       Authorization: `Bearer ${env.LOOPS_API_KEY}`,
       "Content-Type": "application/json",
-      "Idempotency-Key": event.id,
     },
     body: JSON.stringify({
       transactionalId: env.LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID,
       email: payload.email,
       dataVariables: payload.dataVariables,
+      // Loops takes idempotency in the body, not an Idempotency-Key header;
+      // this is what dedupes webhook retries into a single email.
+      idempotencyKey: event.id,
     }),
   });
 


### PR DESCRIPTION
Desktop trials have no card and auto-cancel at trial end, and the in-app
reminder only reaches users who open an updated app. Handle Stripe's
customer.subscription.trial_will_end webhook and send a Loops transactional
reminder with days remaining and the trial end date. Skip card-backed trials
using the same payment-method rule as the has_payment_method auth claim.
Gated on LOOPS_API_KEY and LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID; send failures
go to Sentry without failing the webhook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Stripe webhook path and sends customer email via a third-party API, but failures are isolated from billing sync and sends are gated on optional env config.
> 
> **Overview**
> Adds **Loops transactional email** when Stripe fires `customer.subscription.trial_will_end`, so users on **cardless** desktop trials get an out-of-app reminder with **days remaining** and **trial end date**.
> 
> Eligibility is centralized in `buildTrialEndingEmail`: skip missing email, ended trials, and any customer/subscription with a default payment method (same rule as `has_payment_method`). The webhook path loads the Stripe customer, posts to Loops with `event.id` as idempotency, and only runs when `LOOPS_API_KEY` and `LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID` are set. Loops errors are reported to Sentry under step `loops` and **do not** fail the Stripe webhook response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5838e503f37f40c60da93bd7afb18aba54ecdc1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->