### PR TITLE
fix(desktop): trip stall watchdog when partials never finalize

### DIFF
--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -255,7 +255,9 @@ const createSessionEventHandlers = <T extends LiveStore>(
         (delta.new_words.length > 0 || delta.partials.length > 0)
       ) {
         setLiveState(set, (live) => {
-          noteLiveTranscriptActivity(live);
+          noteLiveTranscriptActivity(live, {
+            hasFinalWords: delta.new_words.length > 0,
+          });
         });
       }
       get().handleTranscriptDelta(targetSessionId, delta, {

--- a/apps/desktop/src/store/zustand/listener/general-shared.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general-shared.test.ts
@@ -4,6 +4,7 @@ import {
   type GeneralState,
   initialGeneralState,
   noteLiveTranscriptActivity,
+  TRANSCRIPTION_FINAL_STALL_AUDIBLE_SECONDS,
   TRANSCRIPTION_STALL_AUDIBLE_SECONDS,
   tickTranscriptionStallWatchdog,
 } from "./general-shared";
@@ -73,11 +74,46 @@ describe("tickTranscriptionStallWatchdog", () => {
       TRANSCRIPTION_STALL_AUDIBLE_SECONDS - 1,
     );
 
-    noteLiveTranscriptActivity(live);
+    noteLiveTranscriptActivity(live, { hasFinalWords: true });
     expect(live.stallAudibleSeconds).toBe(0);
+    expect(live.finalStallAudibleSeconds).toBe(0);
 
     expect(tickTranscriptionStallWatchdog(live)).toBe(false);
     expect(live.transcriptionStalled).toBe(false);
+  });
+
+  it("flags a stall when partials keep flowing but nothing finalizes", () => {
+    const live = createActiveLive();
+
+    let stalledAt: number | null = null;
+    for (
+      let second = 1;
+      second <= TRANSCRIPTION_FINAL_STALL_AUDIBLE_SECONDS + 5;
+      second += 1
+    ) {
+      if (tickTranscriptionStallWatchdog(live)) {
+        stalledAt = second;
+        break;
+      }
+      noteLiveTranscriptActivity(live, { hasFinalWords: false });
+    }
+
+    expect(stalledAt).toBe(TRANSCRIPTION_FINAL_STALL_AUDIBLE_SECONDS);
+    expect(live.transcriptionStalled).toBe(true);
+    expect(live.needsBatchRepair).toBe(true);
+  });
+
+  it("keeps the stalled flag until finalized words arrive", () => {
+    const live = createActiveLive();
+    live.transcriptionStalled = true;
+    live.needsBatchRepair = true;
+
+    noteLiveTranscriptActivity(live, { hasFinalWords: false });
+    expect(live.transcriptionStalled).toBe(true);
+
+    noteLiveTranscriptActivity(live, { hasFinalWords: true });
+    expect(live.transcriptionStalled).toBe(false);
+    expect(live.needsBatchRepair).toBe(true);
   });
 
   it("stays quiet for record-only sessions and repeated stalls", () => {
@@ -113,7 +149,7 @@ describe("tickTranscriptionStallWatchdog", () => {
     }
     expect(live.needsBatchRepair).toBe(true);
 
-    noteLiveTranscriptActivity(live);
+    noteLiveTranscriptActivity(live, { hasFinalWords: true });
     expect(live.transcriptionStalled).toBe(false);
     expect(live.needsBatchRepair).toBe(true);
   });

--- a/apps/desktop/src/store/zustand/listener/general-shared.ts
+++ b/apps/desktop/src/store/zustand/listener/general-shared.ts
@@ -27,6 +27,7 @@ export type LiveIntervalId = ReturnType<typeof setInterval>;
 
 export const TRANSCRIPTION_STALL_AMPLITUDE_THRESHOLD = 0.05;
 export const TRANSCRIPTION_STALL_AUDIBLE_SECONDS = 45;
+export const TRANSCRIPTION_FINAL_STALL_AUDIBLE_SECONDS = 90;
 
 export type GeneralState = {
   live: {
@@ -46,6 +47,7 @@ export type GeneralState = {
     liveTranscriptionActive: boolean | null;
     needsBatchRepair: boolean;
     stallAudibleSeconds: number;
+    finalStallAudibleSeconds: number;
     transcriptionStalled: boolean;
     finalizingBySession: Record<
       string,
@@ -73,6 +75,7 @@ const initialLiveState: LiveState = {
   liveTranscriptionActive: null,
   needsBatchRepair: false,
   stallAudibleSeconds: 0,
+  finalStallAudibleSeconds: 0,
   transcriptionStalled: false,
   finalizingBySession: {},
   triggerAppIds: null,
@@ -136,6 +139,7 @@ export const markLiveStartRequested = (live: LiveState, sessionId: string) => {
   live.liveTranscriptionActive = null;
   live.needsBatchRepair = false;
   live.stallAudibleSeconds = 0;
+  live.finalStallAudibleSeconds = 0;
   live.transcriptionStalled = false;
 };
 
@@ -160,6 +164,7 @@ export const markLiveActive = (
     requestedLiveTranscription &&
     (!liveTranscriptionActive || degraded !== null);
   live.stallAudibleSeconds = 0;
+  live.finalStallAudibleSeconds = 0;
   live.transcriptionStalled = false;
 };
 
@@ -196,6 +201,7 @@ export const markLiveInactive = (live: LiveState, error: string | null) => {
   live.liveTranscriptionActive = null;
   live.needsBatchRepair = false;
   live.stallAudibleSeconds = 0;
+  live.finalStallAudibleSeconds = 0;
   live.transcriptionStalled = false;
   live.muted = initialLiveState.muted;
   live.triggerAppIds = null;
@@ -217,13 +223,16 @@ export const markLiveStartFailed = (live: LiveState) => {
   live.liveTranscriptionActive = null;
   live.needsBatchRepair = false;
   live.stallAudibleSeconds = 0;
+  live.finalStallAudibleSeconds = 0;
   live.transcriptionStalled = false;
   live.triggerAppIds = null;
 };
 
 // Live STT can hang mid-session without any error or degraded event from the
-// capture pipeline (the stream simply stops delivering words while audio keeps
-// flowing). Count audible seconds since the last transcript activity; past the
+// capture pipeline: either the stream stops delivering anything, or it keeps
+// streaming partial words that never finalize (only finalized words are
+// persisted, so the live view looks fine while nothing reaches the database).
+// Count audible seconds since the last activity of each kind; past either
 // threshold, flag the session so stop() runs a batch repair from the recording.
 export const tickTranscriptionStallWatchdog = (live: LiveState): boolean => {
   // Mic mute must not disable the watchdog: speaker audio keeps feeding live
@@ -245,7 +254,11 @@ export const tickTranscriptionStallWatchdog = (live: LiveState): boolean => {
   }
 
   live.stallAudibleSeconds += 1;
-  if (live.stallAudibleSeconds < TRANSCRIPTION_STALL_AUDIBLE_SECONDS) {
+  live.finalStallAudibleSeconds += 1;
+  if (
+    live.stallAudibleSeconds < TRANSCRIPTION_STALL_AUDIBLE_SECONDS &&
+    live.finalStallAudibleSeconds < TRANSCRIPTION_FINAL_STALL_AUDIBLE_SECONDS
+  ) {
     return false;
   }
 
@@ -254,9 +267,17 @@ export const tickTranscriptionStallWatchdog = (live: LiveState): boolean => {
   return true;
 };
 
-export const noteLiveTranscriptActivity = (live: LiveState) => {
+// Partials only prove the stream is alive; finalized words are what gets
+// persisted, so only they mark the pipeline healthy again.
+export const noteLiveTranscriptActivity = (
+  live: LiveState,
+  activity: { hasFinalWords: boolean },
+) => {
   live.stallAudibleSeconds = 0;
-  live.transcriptionStalled = false;
+  if (activity.hasFinalWords) {
+    live.finalStallAudibleSeconds = 0;
+    live.transcriptionStalled = false;
+  }
 };
 
 export const updateLiveProgress = (


### PR DESCRIPTION
The stall watchdog reset on any transcript delta, so a live stream
that kept sending partial words without ever finalizing never tripped
it - the live view looked healthy while nothing was persisted, ending
the session with audio but no transcript. Add a second, longer audible
window (90s) that only finalized words reset, and keep the stalled
flag until finals resume so batch repair still runs on stop.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6191 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6186 
- <kbd>&nbsp;1&nbsp;</kbd> #6184 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when live sessions are marked stalled and `needsBatchRepair` is set, affecting post-stop transcript repair behavior; logic is isolated to the desktop listener store with new unit tests.
> 
> **Overview**
> Fixes a gap where the live transcription stall watchdog treated **any** transcript delta as healthy activity, so streams that kept sending **partials** without **finalized** words never stalled—even though only finals are persisted.
> 
> The watchdog now tracks two audible timers: the existing **45s** window for any transcript activity, plus a **90s** window (`finalStallAudibleSeconds`) that only **finalized words** reset. `noteLiveTranscriptActivity` takes `hasFinalWords`; partial-only deltas clear the short counter but not the final counter, and **`transcriptionStalled` stays set until finals resume** (while **`needsBatchRepair` remains** for stop-time batch repair). Live transcript handling passes `hasFinalWords: delta.new_words.length > 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2748cc5ad63410b9e07003572fc74f112f5fc5df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->