### PR TITLE
fix(desktop): make timeline delete, undo, and ignore optimistic

### DIFF
--- a/apps/desktop/src/calendar/components/session-chip.tsx
+++ b/apps/desktop/src/calendar/components/session-chip.tsx
@@ -46,8 +46,11 @@ export function SessionChip({
 
   const handleDelete = useCallback(() => {
     const sessionEvent = getSessionEvent({ event_json: eventJson });
-    deleteSession(sessionId, sessionEvent?.tracking_id);
-  }, [deleteSession, sessionId, eventJson]);
+    deleteSession(sessionId, {
+      trackingId: sessionEvent?.tracking_id,
+      title,
+    });
+  }, [deleteSession, sessionId, eventJson, title]);
 
   const contextMenu = useMemo<MenuItemDef[]>(
     () => [

--- a/apps/desktop/src/calendar/ignored-events.ts
+++ b/apps/desktop/src/calendar/ignored-events.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import { create } from "zustand";
 
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
@@ -14,17 +15,71 @@ type AppSettingSqlRow = { id?: string; value_json: string | null };
 const IGNORED_EVENTS_ID = "ignored_events";
 const IGNORED_SERIES_ID = "ignored_recurring_series";
 
+// Optimistic overlay for ignore/unignore: each override wins only while the
+// live query still reports the base state it was created against, so it goes
+// inert on its own once the queued write lands and the base data re-emits.
+type IgnoredOverride = { ignored: boolean; baseIgnored: boolean };
+
+const useIgnoredOverrides = create<{
+  events: Record<string, IgnoredOverride>;
+  series: Record<string, IgnoredOverride>;
+  set: (
+    kind: "events" | "series",
+    id: string,
+    override: IgnoredOverride,
+  ) => void;
+  clear: (kind: "events" | "series", id: string) => void;
+}>((set) => ({
+  events: {},
+  series: {},
+  set: (kind, id, override) =>
+    set((state) => ({ [kind]: { ...state[kind], [id]: override } })),
+  clear: (kind, id) =>
+    set((state) => {
+      const { [id]: _, ...rest } = state[kind];
+      return { [kind]: rest };
+    }),
+}));
+
+function applyOverrides(
+  baseIds: Set<string>,
+  overrides: Record<string, IgnoredOverride>,
+): Set<string> {
+  let result = baseIds;
+  for (const [id, override] of Object.entries(overrides)) {
+    if (baseIds.has(id) !== override.baseIgnored) continue;
+    if (baseIds.has(id) === override.ignored) continue;
+    if (result === baseIds) result = new Set(baseIds);
+    if (override.ignored) {
+      result.add(id);
+    } else {
+      result.delete(id);
+    }
+  }
+  return result;
+}
+
 export function useIgnoredEvents() {
   const ignoredEvents = useSettingList<IgnoredEvent>(IGNORED_EVENTS_ID);
   const ignoredSeries =
     useSettingList<IgnoredRecurringSeries>(IGNORED_SERIES_ID);
-  const ignoredIds = useMemo(
+  const eventOverrides = useIgnoredOverrides((state) => state.events);
+  const seriesOverrides = useIgnoredOverrides((state) => state.series);
+  const baseIgnoredIds = useMemo(
     () => new Set(ignoredEvents.map((event) => event.tracking_id)),
     [ignoredEvents],
   );
-  const ignoredSeriesIds = useMemo(
+  const baseIgnoredSeriesIds = useMemo(
     () => new Set(ignoredSeries.map((series) => series.id)),
     [ignoredSeries],
+  );
+  const ignoredIds = useMemo(
+    () => applyOverrides(baseIgnoredIds, eventOverrides),
+    [baseIgnoredIds, eventOverrides],
+  );
+  const ignoredSeriesIds = useMemo(
+    () => applyOverrides(baseIgnoredSeriesIds, seriesOverrides),
+    [baseIgnoredSeriesIds, seriesOverrides],
   );
 
   const isIgnored = useCallback(
@@ -39,40 +94,76 @@ export function useIgnoredEvents() {
       ),
     [ignoredIds, ignoredSeriesIds],
   );
-  const ignoreEvent = useCallback((trackingId: string) => {
-    void mutateSettingList<IgnoredEvent>(IGNORED_EVENTS_ID, (events) => [
-      ...events.filter((event) => event.tracking_id !== trackingId),
-      { tracking_id: trackingId, last_seen: new Date().toISOString() },
-    ]).catch((error) => {
-      console.error("[calendar] failed to ignore event", error);
-    });
-  }, []);
-  const unignoreEvent = useCallback((trackingId: string) => {
-    void mutateSettingList<IgnoredEvent>(IGNORED_EVENTS_ID, (events) =>
-      events.filter((event) => event.tracking_id !== trackingId),
-    ).catch((error) => {
-      console.error("[calendar] failed to unignore event", error);
-    });
-  }, []);
-  const ignoreSeries = useCallback((seriesId: string) => {
-    void mutateSettingList<IgnoredRecurringSeries>(
-      IGNORED_SERIES_ID,
-      (series) => [
-        ...series.filter((entry) => entry.id !== seriesId),
-        { id: seriesId, last_seen: new Date().toISOString() },
-      ],
-    ).catch((error) => {
-      console.error("[calendar] failed to ignore series", error);
-    });
-  }, []);
-  const unignoreSeries = useCallback((seriesId: string) => {
-    void mutateSettingList<IgnoredRecurringSeries>(
-      IGNORED_SERIES_ID,
-      (series) => series.filter((entry) => entry.id !== seriesId),
-    ).catch((error) => {
-      console.error("[calendar] failed to unignore series", error);
-    });
-  }, []);
+  const ignoreEvent = useCallback(
+    (trackingId: string) => {
+      const overrides = useIgnoredOverrides.getState();
+      overrides.set("events", trackingId, {
+        ignored: true,
+        baseIgnored: baseIgnoredIds.has(trackingId),
+      });
+      void mutateSettingList<IgnoredEvent>(IGNORED_EVENTS_ID, (events) => [
+        ...events.filter((event) => event.tracking_id !== trackingId),
+        { tracking_id: trackingId, last_seen: new Date().toISOString() },
+      ]).catch((error) => {
+        console.error("[calendar] failed to ignore event", error);
+        useIgnoredOverrides.getState().clear("events", trackingId);
+      });
+    },
+    [baseIgnoredIds],
+  );
+  const unignoreEvent = useCallback(
+    (trackingId: string) => {
+      const overrides = useIgnoredOverrides.getState();
+      overrides.set("events", trackingId, {
+        ignored: false,
+        baseIgnored: baseIgnoredIds.has(trackingId),
+      });
+      void mutateSettingList<IgnoredEvent>(IGNORED_EVENTS_ID, (events) =>
+        events.filter((event) => event.tracking_id !== trackingId),
+      ).catch((error) => {
+        console.error("[calendar] failed to unignore event", error);
+        useIgnoredOverrides.getState().clear("events", trackingId);
+      });
+    },
+    [baseIgnoredIds],
+  );
+  const ignoreSeries = useCallback(
+    (seriesId: string) => {
+      const overrides = useIgnoredOverrides.getState();
+      overrides.set("series", seriesId, {
+        ignored: true,
+        baseIgnored: baseIgnoredSeriesIds.has(seriesId),
+      });
+      void mutateSettingList<IgnoredRecurringSeries>(
+        IGNORED_SERIES_ID,
+        (series) => [
+          ...series.filter((entry) => entry.id !== seriesId),
+          { id: seriesId, last_seen: new Date().toISOString() },
+        ],
+      ).catch((error) => {
+        console.error("[calendar] failed to ignore series", error);
+        useIgnoredOverrides.getState().clear("series", seriesId);
+      });
+    },
+    [baseIgnoredSeriesIds],
+  );
+  const unignoreSeries = useCallback(
+    (seriesId: string) => {
+      const overrides = useIgnoredOverrides.getState();
+      overrides.set("series", seriesId, {
+        ignored: false,
+        baseIgnored: baseIgnoredSeriesIds.has(seriesId),
+      });
+      void mutateSettingList<IgnoredRecurringSeries>(
+        IGNORED_SERIES_ID,
+        (series) => series.filter((entry) => entry.id !== seriesId),
+      ).catch((error) => {
+        console.error("[calendar] failed to unignore series", error);
+        useIgnoredOverrides.getState().clear("series", seriesId);
+      });
+    },
+    [baseIgnoredSeriesIds],
+  );
 
   return {
     isIgnored,

--- a/apps/desktop/src/calendar/ignored-events.ts
+++ b/apps/desktop/src/calendar/ignored-events.ts
@@ -15,10 +15,18 @@ type AppSettingSqlRow = { id?: string; value_json: string | null };
 const IGNORED_EVENTS_ID = "ignored_events";
 const IGNORED_SERIES_ID = "ignored_recurring_series";
 
-// Optimistic overlay for ignore/unignore: each override wins only while the
-// live query still reports the base state it was created against, so it goes
-// inert on its own once the queued write lands and the base data re-emits.
-type IgnoredOverride = { ignored: boolean; baseIgnored: boolean };
+// Optimistic overlay for ignore/unignore: an override forces its desired
+// state until its own write settles, so rapid toggles keep showing the
+// latest intent even while earlier writes are still landing. Tokens let a
+// newer toggle supersede an older override's cleanup.
+type IgnoredOverride = { ignored: boolean; token: number };
+
+let overrideToken = 0;
+
+// After a write settles, the live query needs a beat to re-emit the new base
+// before the override is dropped — clearing instantly would flash the stale
+// base state.
+const OVERRIDE_SETTLE_GRACE_MS = 1000;
 
 const useIgnoredOverrides = create<{
   events: Record<string, IgnoredOverride>;
@@ -47,7 +55,6 @@ function applyOverrides(
 ): Set<string> {
   let result = baseIds;
   for (const [id, override] of Object.entries(overrides)) {
-    if (baseIds.has(id) !== override.baseIgnored) continue;
     if (baseIds.has(id) === override.ignored) continue;
     if (result === baseIds) result = new Set(baseIds);
     if (override.ignored) {
@@ -57,6 +64,30 @@ function applyOverrides(
     }
   }
   return result;
+}
+
+function runWithIgnoredOverride(
+  kind: "events" | "series",
+  id: string,
+  ignored: boolean,
+  write: () => Promise<void>,
+  errorMessage: string,
+) {
+  const token = ++overrideToken;
+  useIgnoredOverrides.getState().set(kind, id, { ignored, token });
+  const clearIfCurrent = () => {
+    const current = useIgnoredOverrides.getState()[kind][id];
+    if (current?.token === token) {
+      useIgnoredOverrides.getState().clear(kind, id);
+    }
+  };
+  write().then(
+    () => setTimeout(clearIfCurrent, OVERRIDE_SETTLE_GRACE_MS),
+    (error: unknown) => {
+      console.error(errorMessage, error);
+      clearIfCurrent();
+    },
+  );
 }
 
 export function useIgnoredEvents() {
@@ -94,76 +125,59 @@ export function useIgnoredEvents() {
       ),
     [ignoredIds, ignoredSeriesIds],
   );
-  const ignoreEvent = useCallback(
-    (trackingId: string) => {
-      const overrides = useIgnoredOverrides.getState();
-      overrides.set("events", trackingId, {
-        ignored: true,
-        baseIgnored: baseIgnoredIds.has(trackingId),
-      });
-      void mutateSettingList<IgnoredEvent>(IGNORED_EVENTS_ID, (events) => [
-        ...events.filter((event) => event.tracking_id !== trackingId),
-        { tracking_id: trackingId, last_seen: new Date().toISOString() },
-      ]).catch((error) => {
-        console.error("[calendar] failed to ignore event", error);
-        useIgnoredOverrides.getState().clear("events", trackingId);
-      });
-    },
-    [baseIgnoredIds],
-  );
-  const unignoreEvent = useCallback(
-    (trackingId: string) => {
-      const overrides = useIgnoredOverrides.getState();
-      overrides.set("events", trackingId, {
-        ignored: false,
-        baseIgnored: baseIgnoredIds.has(trackingId),
-      });
-      void mutateSettingList<IgnoredEvent>(IGNORED_EVENTS_ID, (events) =>
-        events.filter((event) => event.tracking_id !== trackingId),
-      ).catch((error) => {
-        console.error("[calendar] failed to unignore event", error);
-        useIgnoredOverrides.getState().clear("events", trackingId);
-      });
-    },
-    [baseIgnoredIds],
-  );
-  const ignoreSeries = useCallback(
-    (seriesId: string) => {
-      const overrides = useIgnoredOverrides.getState();
-      overrides.set("series", seriesId, {
-        ignored: true,
-        baseIgnored: baseIgnoredSeriesIds.has(seriesId),
-      });
-      void mutateSettingList<IgnoredRecurringSeries>(
-        IGNORED_SERIES_ID,
-        (series) => [
-          ...series.filter((entry) => entry.id !== seriesId),
-          { id: seriesId, last_seen: new Date().toISOString() },
-        ],
-      ).catch((error) => {
-        console.error("[calendar] failed to ignore series", error);
-        useIgnoredOverrides.getState().clear("series", seriesId);
-      });
-    },
-    [baseIgnoredSeriesIds],
-  );
-  const unignoreSeries = useCallback(
-    (seriesId: string) => {
-      const overrides = useIgnoredOverrides.getState();
-      overrides.set("series", seriesId, {
-        ignored: false,
-        baseIgnored: baseIgnoredSeriesIds.has(seriesId),
-      });
-      void mutateSettingList<IgnoredRecurringSeries>(
-        IGNORED_SERIES_ID,
-        (series) => series.filter((entry) => entry.id !== seriesId),
-      ).catch((error) => {
-        console.error("[calendar] failed to unignore series", error);
-        useIgnoredOverrides.getState().clear("series", seriesId);
-      });
-    },
-    [baseIgnoredSeriesIds],
-  );
+  const ignoreEvent = useCallback((trackingId: string) => {
+    runWithIgnoredOverride(
+      "events",
+      trackingId,
+      true,
+      () =>
+        mutateSettingList<IgnoredEvent>(IGNORED_EVENTS_ID, (events) => [
+          ...events.filter((event) => event.tracking_id !== trackingId),
+          { tracking_id: trackingId, last_seen: new Date().toISOString() },
+        ]),
+      "[calendar] failed to ignore event",
+    );
+  }, []);
+  const unignoreEvent = useCallback((trackingId: string) => {
+    runWithIgnoredOverride(
+      "events",
+      trackingId,
+      false,
+      () =>
+        mutateSettingList<IgnoredEvent>(IGNORED_EVENTS_ID, (events) =>
+          events.filter((event) => event.tracking_id !== trackingId),
+        ),
+      "[calendar] failed to unignore event",
+    );
+  }, []);
+  const ignoreSeries = useCallback((seriesId: string) => {
+    runWithIgnoredOverride(
+      "series",
+      seriesId,
+      true,
+      () =>
+        mutateSettingList<IgnoredRecurringSeries>(
+          IGNORED_SERIES_ID,
+          (series) => [
+            ...series.filter((entry) => entry.id !== seriesId),
+            { id: seriesId, last_seen: new Date().toISOString() },
+          ],
+        ),
+      "[calendar] failed to ignore series",
+    );
+  }, []);
+  const unignoreSeries = useCallback((seriesId: string) => {
+    runWithIgnoredOverride(
+      "series",
+      seriesId,
+      false,
+      () =>
+        mutateSettingList<IgnoredRecurringSeries>(IGNORED_SERIES_ID, (series) =>
+          series.filter((entry) => entry.id !== seriesId),
+        ),
+      "[calendar] failed to unignore series",
+    );
+  }, []);
 
   return {
     isIgnored,

--- a/apps/desktop/src/calendar/queries.ts
+++ b/apps/desktop/src/calendar/queries.ts
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import type { EventParticipant } from "@hypr/store";
 
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
@@ -8,6 +10,7 @@ import type {
   TimelineSessionRow,
   TimelineSessionsTable,
 } from "~/sidebar/timeline/utils";
+import { useUndoDelete } from "~/store/zustand/undo-delete";
 
 type TimelineEventSqlRow = Omit<
   TimelineEventRow,
@@ -148,8 +151,22 @@ export function useTimelineSessionsTable(): TimelineSessionsTable {
     `,
     mapRows: mapTimelineSessionRows,
   });
+  const pendingDeletions = useUndoDelete((state) => state.pendingDeletions);
 
-  return timelineSessionsTable;
+  // Sessions with a pending deletion are hidden optimistically, before the
+  // soft-delete write commits and the live query re-emits.
+  return useMemo(() => {
+    const pendingIds = Object.keys(pendingDeletions).filter(
+      (sessionId) => sessionId in timelineSessionsTable,
+    );
+    if (pendingIds.length === 0) return timelineSessionsTable;
+
+    const filtered = { ...timelineSessionsTable };
+    for (const sessionId of pendingIds) {
+      delete filtered[sessionId];
+    }
+    return filtered;
+  }, [timelineSessionsTable, pendingDeletions]);
 }
 
 export function useCalendarRow(

--- a/apps/desktop/src/session/components/outer-header/overflow/delete.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/delete.tsx
@@ -8,6 +8,7 @@ import { cn } from "@hypr/utils";
 
 import { useAudioPlayer } from "~/audio-player";
 import { useDeleteSession } from "~/session/hooks/useDeleteSession";
+import { useSessionSummary } from "~/session/queries";
 import { useListener } from "~/stt/contexts";
 
 export function DeleteRecording({ sessionId }: { sessionId: string }) {
@@ -50,15 +51,16 @@ export function DeleteRecording({ sessionId }: { sessionId: string }) {
 
 export function DeleteNote({ sessionId }: { sessionId: string }) {
   const deleteSession = useDeleteSession();
+  const title = useSessionSummary(sessionId)?.title;
 
   const handleDeleteNote = useCallback(() => {
-    deleteSession(sessionId);
+    deleteSession(sessionId, { title });
 
     void analyticsCommands.event({
       event: "session_deleted",
       includes_recording: true,
     });
-  }, [sessionId, deleteSession]);
+  }, [sessionId, deleteSession, title]);
 
   return (
     <DropdownMenuItem

--- a/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
+++ b/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
@@ -32,7 +32,10 @@ const mocks = vi.hoisted(() => {
     getCurrentWebviewWindowLabel: vi.fn(() => "main"),
     ignoreEvent: vi.fn(),
     unignoreEvent: vi.fn(),
+    isIgnored: vi.fn(() => false),
     invalidateResource: vi.fn(),
+    openCurrent: vi.fn(),
+    openTabs: [] as Array<{ type: string; id: string }>,
     listenerGetState: vi.fn(),
     listenerStop: vi.fn(),
     listen: vi.fn(),
@@ -72,6 +75,7 @@ vi.mock("~/calendar/ignored-events", () => ({
   useIgnoredEvents: () => ({
     ignoreEvent: mocks.ignoreEvent,
     unignoreEvent: mocks.unignoreEvent,
+    isIgnored: mocks.isIgnored,
   }),
 }));
 
@@ -100,16 +104,17 @@ vi.mock("~/store/zustand/listener/instance", () => ({
   },
 }));
 
-vi.mock("~/store/zustand/tabs", () => ({
-  useTabs: (
-    selector: (state: {
-      invalidateResource: typeof mocks.invalidateResource;
-    }) => unknown,
-  ) =>
-    selector({
-      invalidateResource: mocks.invalidateResource,
-    }),
-}));
+vi.mock("~/store/zustand/tabs", () => {
+  const getState = () => ({
+    tabs: mocks.openTabs,
+    invalidateResource: mocks.invalidateResource,
+    openCurrent: mocks.openCurrent,
+  });
+  const useTabs = (selector: (state: ReturnType<typeof getState>) => unknown) =>
+    selector(getState());
+  useTabs.getState = getState;
+  return { useTabs };
+});
 
 vi.mock("~/store/zustand/undo-delete", () => {
   const getState = () => ({
@@ -142,6 +147,7 @@ describe("useDeleteSession", () => {
     mocks.clearDeletion.mockImplementation((sessionId: string) => {
       delete mocks.pendingDeletions[sessionId];
     });
+    mocks.openTabs.length = 0;
     mocks.getSession.mockResolvedValue({ data: { session: null } });
     mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);
     mocks.removeDurableSharedNoteCache.mockResolvedValue(undefined);

--- a/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
+++ b/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
@@ -19,6 +19,8 @@ const mocks = vi.hoisted(() => {
 
   return {
     addDeletion: vi.fn(),
+    clearDeletion: vi.fn(),
+    pendingDeletions: {} as Record<string, { data: DeletedSessionData }>,
     getSession,
     supabaseClient: { auth: { getSession } },
     deleteSessionShareBySession: vi.fn(),
@@ -29,13 +31,16 @@ const mocks = vi.hoisted(() => {
     >(() => Promise.resolve([])),
     getCurrentWebviewWindowLabel: vi.fn(() => "main"),
     ignoreEvent: vi.fn(),
+    unignoreEvent: vi.fn(),
     invalidateResource: vi.fn(),
     listenerGetState: vi.fn(),
     listenerStop: vi.fn(),
     listen: vi.fn(),
     loadManagedSharedNoteForSession: vi.fn(),
     removeDurableSharedNoteCache: vi.fn(),
-    softDeleteSession: vi.fn(() => Promise.resolve(deletedSessionData)),
+    softDeleteSession: vi.fn<() => Promise<DeletedSessionData | null>>(() =>
+      Promise.resolve(deletedSessionData),
+    ),
     toastError: vi.fn(),
     toastWarning: vi.fn(),
     deletedSessionData,
@@ -66,6 +71,7 @@ vi.mock("~/auth/client", () => ({
 vi.mock("~/calendar/ignored-events", () => ({
   useIgnoredEvents: () => ({
     ignoreEvent: mocks.ignoreEvent,
+    unignoreEvent: mocks.unignoreEvent,
   }),
 }));
 
@@ -105,14 +111,18 @@ vi.mock("~/store/zustand/tabs", () => ({
     }),
 }));
 
-vi.mock("~/store/zustand/undo-delete", () => ({
-  useUndoDelete: (
-    selector: (state: { addDeletion: typeof mocks.addDeletion }) => unknown,
-  ) =>
-    selector({
-      addDeletion: mocks.addDeletion,
-    }),
-}));
+vi.mock("~/store/zustand/undo-delete", () => {
+  const getState = () => ({
+    pendingDeletions: mocks.pendingDeletions,
+    addDeletion: mocks.addDeletion,
+    clearDeletion: mocks.clearDeletion,
+  });
+  const useUndoDelete = (
+    selector: (state: ReturnType<typeof getState>) => unknown,
+  ) => selector(getState());
+  useUndoDelete.getState = getState;
+  return { useUndoDelete };
+});
 
 import {
   useDeleteSession,
@@ -123,6 +133,15 @@ describe("useDeleteSession", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
+    for (const key of Object.keys(mocks.pendingDeletions)) {
+      delete mocks.pendingDeletions[key];
+    }
+    mocks.addDeletion.mockImplementation((data: DeletedSessionData) => {
+      mocks.pendingDeletions[data.session.id] = { data };
+    });
+    mocks.clearDeletion.mockImplementation((sessionId: string) => {
+      delete mocks.pendingDeletions[sessionId];
+    });
     mocks.getSession.mockResolvedValue({ data: { session: null } });
     mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);
     mocks.removeDurableSharedNoteCache.mockResolvedValue(undefined);
@@ -173,7 +192,10 @@ describe("useDeleteSession", () => {
     await waitFor(() => {
       expect(mocks.addDeletion).toHaveBeenCalledOnce();
     });
-    expect(mocks.softDeleteSession).toHaveBeenCalledWith("session-1");
+    expect(mocks.softDeleteSession).toHaveBeenCalledWith(
+      "session-1",
+      expect.any(String),
+    );
     expect(mocks.deleteSessionShareBySession).not.toHaveBeenCalled();
 
     const finalize = mocks.addDeletion.mock.calls[0]?.[1] as () => void;
@@ -231,7 +253,10 @@ describe("useDeleteSession", () => {
     await waitFor(() => {
       expect(mocks.addDeletion).toHaveBeenCalledOnce();
     });
-    expect(mocks.softDeleteSession).toHaveBeenCalledWith("session-1");
+    expect(mocks.softDeleteSession).toHaveBeenCalledWith(
+      "session-1",
+      expect.any(String),
+    );
 
     const finalize = mocks.addDeletion.mock.calls[0]?.[1] as () => void;
     act(() => {
@@ -264,7 +289,10 @@ describe("useDeleteSession", () => {
     await waitFor(() => {
       expect(mocks.addDeletion).toHaveBeenCalledOnce();
     });
-    expect(mocks.softDeleteSession).toHaveBeenCalledWith("session-1");
+    expect(mocks.softDeleteSession).toHaveBeenCalledWith(
+      "session-1",
+      expect.any(String),
+    );
 
     const finalize = mocks.addDeletion.mock.calls[0]?.[1] as () => void;
     act(() => {
@@ -280,26 +308,95 @@ describe("useDeleteSession", () => {
     expect(mocks.deleteSessionShareBySession).not.toHaveBeenCalled();
   });
 
-  it("adds the undo deletion locally in the main window", async () => {
+  it("adds the undo deletion optimistically in the main window", async () => {
+    // Never resolves: the optimistic UI must not wait for the write.
+    mocks.softDeleteSession.mockImplementation(() => new Promise(() => {}));
     const { result } = renderHook(() => useDeleteSession());
 
     act(() => {
-      result.current("session-1", "tracking-1");
+      result.current("session-1", { trackingId: "tracking-1", title: "Note" });
     });
 
-    await waitFor(() => {
-      expect(mocks.addDeletion).toHaveBeenCalledWith(
-        mocks.deletedSessionData,
-        expect.any(Function),
-      );
-    });
+    expect(mocks.addDeletion).toHaveBeenCalledWith(
+      {
+        session: { id: "session-1", title: "Note" },
+        tombstone: expect.any(String),
+        deletedAt: expect.any(Number),
+      },
+      expect.any(Function),
+      undefined,
+    );
     expect(mocks.ignoreEvent).toHaveBeenCalledWith("tracking-1");
-    expect(mocks.softDeleteSession).toHaveBeenCalledWith("session-1");
+    expect(mocks.softDeleteSession).toHaveBeenCalledWith(
+      "session-1",
+      expect.any(String),
+    );
     expect(mocks.invalidateResource).toHaveBeenCalledWith(
       "sessions",
       "session-1",
     );
     expect(mocks.emitTo).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the optimistic deletion when the soft delete fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mocks.softDeleteSession.mockRejectedValue(new Error("db locked"));
+    const { result } = renderHook(() => useDeleteSession());
+
+    act(() => {
+      result.current("session-1", { trackingId: "tracking-1" });
+    });
+
+    expect(mocks.addDeletion).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledOnce();
+    });
+    expect(mocks.clearDeletion).toHaveBeenCalledWith("session-1");
+    expect(mocks.unignoreEvent).toHaveBeenCalledWith("tracking-1");
+    expect(mocks.finalizeSessionDeletion).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("drops the optimistic toast quietly when the session is already deleted", async () => {
+    mocks.softDeleteSession.mockResolvedValue(null);
+    const { result } = renderHook(() => useDeleteSession());
+
+    act(() => {
+      result.current("session-1");
+    });
+
+    expect(mocks.addDeletion).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(mocks.clearDeletion).toHaveBeenCalledWith("session-1");
+    });
+    expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(mocks.unignoreEvent).not.toHaveBeenCalled();
+  });
+
+  it("never finalizes a deletion whose write failed", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mocks.softDeleteSession.mockRejectedValue(new Error("db locked"));
+    const { result } = renderHook(() => useDeleteSession());
+
+    act(() => {
+      result.current("session-1");
+    });
+
+    const finalize = mocks.addDeletion.mock.calls[0]?.[1] as () => void;
+    act(() => {
+      finalize();
+    });
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledOnce();
+    });
+    expect(mocks.finalizeSessionDeletion).not.toHaveBeenCalled();
+    expect(mocks.loadManagedSharedNoteForSession).not.toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 
   it("stops listening before deleting the active session", async () => {
@@ -318,7 +415,10 @@ describe("useDeleteSession", () => {
     });
 
     await waitFor(() => {
-      expect(mocks.softDeleteSession).toHaveBeenCalledWith("session-1");
+      expect(mocks.softDeleteSession).toHaveBeenCalledWith(
+        "session-1",
+        expect.any(String),
+      );
     });
     expect(mocks.listenerStop).toHaveBeenCalledTimes(1);
     expect(mocks.listenerStop.mock.invocationCallOrder[0]).toBeLessThan(

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -128,11 +128,21 @@ function isSessionDeletedForUndoPayload(
 export function useDeleteSession() {
   const invalidateResource = useTabs((state) => state.invalidateResource);
   const addDeletion = useUndoDelete((state) => state.addDeletion);
-  const { ignoreEvent } = useIgnoredEvents();
+  const clearDeletion = useUndoDelete((state) => state.clearDeletion);
+  const { ignoreEvent, unignoreEvent } = useIgnoredEvents();
 
   return useCallback(
-    (sessionId: string, trackingId?: string | null, batchId?: string) => {
+    (
+      sessionId: string,
+      options?: {
+        trackingId?: string | null;
+        batchId?: string;
+        title?: string;
+      },
+    ) => {
+      const { trackingId, batchId, title } = options ?? {};
       const windowLabel = getCurrentWebviewWindowLabel();
+      const isMainWindow = windowLabel === "main";
       const listenerState = listenerStore.getState();
       const live = listenerState.live;
 
@@ -143,26 +153,56 @@ export function useDeleteSession() {
         listenerState.stop();
       }
 
+      // Optimistic path: hide the row, drop tab history, and show the undo
+      // toast before the soft-delete commits; rolled back below on failure.
+      const tombstone = new Date().toISOString();
+      if (trackingId) ignoreEvent(trackingId);
+      invalidateResource("sessions", sessionId);
+
+      const commit = softDeleteSession(sessionId, tombstone);
+
+      const clearOptimisticDeletion = () => {
+        const pending = useUndoDelete.getState().pendingDeletions[sessionId];
+        if (pending?.data.tombstone === tombstone) {
+          clearDeletion(sessionId);
+        }
+      };
+
+      if (isMainWindow) {
+        // Finalize gates on the commit so a failed or no-op delete never
+        // removes the session folder or revokes the shared link.
+        const finalize = () => {
+          void commit
+            .then((deletedData) => {
+              if (!deletedData) return;
+              void finalizeSessionDeletion(sessionId);
+              revokeManagedShareBestEffort(sessionId);
+            })
+            .catch(() => undefined);
+        };
+        addDeletion(
+          {
+            session: { id: sessionId, title: title ?? "" },
+            tombstone,
+            deletedAt: Date.now(),
+          },
+          finalize,
+          batchId,
+        );
+      }
+
       void (async () => {
         let didDelete = false;
         try {
-          const deletedData = await softDeleteSession(sessionId);
-          if (!deletedData) return;
+          const deletedData = await commit;
+          if (!deletedData) {
+            // The session was already deleted; drop the optimistic toast.
+            if (isMainWindow) clearOptimisticDeletion();
+            return;
+          }
           didDelete = true;
 
-          if (trackingId) ignoreEvent(trackingId);
-          invalidateResource("sessions", sessionId);
-          if (windowLabel === "main") {
-            const finalize = () => {
-              void finalizeSessionDeletion(sessionId);
-              revokeManagedShareBestEffort(sessionId);
-            };
-            if (batchId) {
-              addDeletion(deletedData, finalize, batchId);
-            } else {
-              addDeletion(deletedData, finalize);
-            }
-          } else {
+          if (!isMainWindow) {
             await emitTo("main", SESSION_DELETED_FOR_UNDO_EVENT, {
               sessionId,
               data: deletedData,
@@ -170,6 +210,10 @@ export function useDeleteSession() {
           }
         } catch (error) {
           console.error("[delete-session] failed to finish deletion", error);
+          if (!didDelete) {
+            if (isMainWindow) clearOptimisticDeletion();
+            if (trackingId) unignoreEvent(trackingId);
+          }
           sonnerToast.error("Could not delete this note. Please try again.");
         } finally {
           if (didDelete) {
@@ -178,7 +222,13 @@ export function useDeleteSession() {
         }
       })();
     },
-    [ignoreEvent, invalidateResource, addDeletion],
+    [
+      ignoreEvent,
+      unignoreEvent,
+      invalidateResource,
+      addDeletion,
+      clearDeletion,
+    ],
   );
 }
 

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -103,8 +103,8 @@ async function revokeManagedShare(sessionId: string) {
   }
 }
 
-function revokeManagedShareBestEffort(sessionId: string) {
-  void revokeManagedShare(sessionId).catch((error: unknown) => {
+function revokeManagedShareBestEffort(sessionId: string): Promise<void> {
+  return revokeManagedShare(sessionId).catch((error: unknown) => {
     console.error(
       "[delete-session] failed to revoke shared link",
       error instanceof Error ? error.name : typeof error,
@@ -142,6 +142,12 @@ export function useDeleteSession() {
       },
     ) => {
       const { trackingId, batchId, title } = options ?? {};
+      // A repeat delete would replace the pending tombstone and its finalize
+      // callback, then no-op in softDeleteSession and clear the undo toast —
+      // leaving the note soft-deleted with no undo and no share cleanup.
+      if (useUndoDelete.getState().pendingDeletions[sessionId]) {
+        return;
+      }
       const windowLabel = getCurrentWebviewWindowLabel();
       const isMainWindow = windowLabel === "main";
       const listenerState = listenerStore.getState();
@@ -176,16 +182,16 @@ export function useDeleteSession() {
 
       if (isMainWindow) {
         // Finalize gates on the commit so a failed or no-op delete never
-        // removes the session folder or revokes the shared link.
-        const finalize = () => {
-          void commit
-            .then((deletedData) => {
+        // removes the session folder or revokes the shared link. It returns
+        // its promise so app exit can await the share revocation.
+        const finalize = () =>
+          commit
+            .then(async (deletedData) => {
               if (!deletedData) return;
-              void finalizeSessionDeletion(sessionId);
-              revokeManagedShareBestEffort(sessionId);
+              await finalizeSessionDeletion(sessionId);
+              await revokeManagedShareBestEffort(sessionId);
             })
             .catch(() => undefined);
-        };
         addDeletion(
           {
             session: { id: sessionId, title: title ?? "" },
@@ -226,8 +232,14 @@ export function useDeleteSession() {
                 .getState()
                 .openCurrent({ type: "sessions", id: sessionId });
             }
+            sonnerToast.error("Could not delete this note. Please try again.");
+          } else {
+            // The delete committed but main never learned about it, so its
+            // finalize-time cleanup will not run. Finalize here — losing the
+            // undo window beats leaving the shared link live forever.
+            void finalizeSessionDeletion(sessionId);
+            void revokeManagedShareBestEffort(sessionId);
           }
-          sonnerToast.error("Could not delete this note. Please try again.");
         } finally {
           if (didDelete) {
             await closeSessionNoteWindows(sessionId);
@@ -264,9 +276,9 @@ export function useRemoteSessionDeletionUndoListener(active: boolean) {
       }
 
       invalidateResource("sessions", payload.sessionId);
-      addDeletion(payload.data, () => {
-        void finalizeSessionDeletion(payload.sessionId);
-        revokeManagedShareBestEffort(payload.sessionId);
+      addDeletion(payload.data, async () => {
+        await finalizeSessionDeletion(payload.sessionId);
+        await revokeManagedShareBestEffort(payload.sessionId);
       });
       void closeSessionNoteWindows(payload.sessionId);
     }).then((fn) => {

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -11,6 +11,7 @@ import {
   deleteSessionShareBySession,
   ShareManagementError,
 } from "~/session-sharing/client";
+import { trackPendingSoftDelete } from "~/session/pending-soft-deletes";
 import { finalizeSessionDeletion, softDeleteSession } from "~/session/queries";
 import {
   loadManagedSharedNoteForSession,
@@ -129,7 +130,7 @@ export function useDeleteSession() {
   const invalidateResource = useTabs((state) => state.invalidateResource);
   const addDeletion = useUndoDelete((state) => state.addDeletion);
   const clearDeletion = useUndoDelete((state) => state.clearDeletion);
-  const { ignoreEvent, unignoreEvent } = useIgnoredEvents();
+  const { ignoreEvent, unignoreEvent, isIgnored } = useIgnoredEvents();
 
   return useCallback(
     (
@@ -156,10 +157,15 @@ export function useDeleteSession() {
       // Optimistic path: hide the row, drop tab history, and show the undo
       // toast before the soft-delete commits; rolled back below on failure.
       const tombstone = new Date().toISOString();
+      const wasIgnored = trackingId ? isIgnored(trackingId, null) : false;
+      const hadOpenTab = useTabs
+        .getState()
+        .tabs.some((tab) => tab.type === "sessions" && tab.id === sessionId);
       if (trackingId) ignoreEvent(trackingId);
       invalidateResource("sessions", sessionId);
 
       const commit = softDeleteSession(sessionId, tombstone);
+      trackPendingSoftDelete(sessionId, commit);
 
       const clearOptimisticDeletion = () => {
         const pending = useUndoDelete.getState().pendingDeletions[sessionId];
@@ -212,7 +218,14 @@ export function useDeleteSession() {
           console.error("[delete-session] failed to finish deletion", error);
           if (!didDelete) {
             if (isMainWindow) clearOptimisticDeletion();
-            if (trackingId) unignoreEvent(trackingId);
+            // Only undo the optimistic ignore; a pre-existing ignore must
+            // survive a failed delete.
+            if (trackingId && !wasIgnored) unignoreEvent(trackingId);
+            if (hadOpenTab) {
+              useTabs
+                .getState()
+                .openCurrent({ type: "sessions", id: sessionId });
+            }
           }
           sonnerToast.error("Could not delete this note. Please try again.");
         } finally {
@@ -225,6 +238,7 @@ export function useDeleteSession() {
     [
       ignoreEvent,
       unignoreEvent,
+      isIgnored,
       invalidateResource,
       addDeletion,
       clearDeletion,

--- a/apps/desktop/src/session/pending-soft-deletes.ts
+++ b/apps/desktop/src/session/pending-soft-deletes.ts
@@ -1,0 +1,23 @@
+// In-flight soft-delete writes by session id. The undo toast appears before
+// the tombstone commits, so a restore must wait for the write to settle —
+// otherwise "session still alive" can mean "delete not committed yet" and the
+// in-flight delete lands after the undo, vanishing the note with no toast.
+const pending = new Map<string, Promise<unknown>>();
+
+export function trackPendingSoftDelete(
+  sessionId: string,
+  write: Promise<unknown>,
+) {
+  const entry = write
+    .catch(() => undefined)
+    .finally(() => {
+      if (pending.get(sessionId) === entry) {
+        pending.delete(sessionId);
+      }
+    });
+  pending.set(sessionId, entry);
+}
+
+export function waitForPendingSoftDelete(sessionId: string): Promise<unknown> {
+  return pending.get(sessionId) ?? Promise.resolve();
+}

--- a/apps/desktop/src/session/queries.ts
+++ b/apps/desktop/src/session/queries.ts
@@ -825,6 +825,7 @@ export async function getOrCreateSessionForEventId(
 
 export async function softDeleteSession(
   sessionId: string,
+  tombstone = new Date().toISOString(),
 ): Promise<DeletedSessionData | null> {
   const [session] = await liveQueryClient.execute<SessionDeleteSqlRow>(
     `SELECT id, title FROM sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1`,
@@ -832,7 +833,6 @@ export async function softDeleteSession(
   );
   if (!session) return null;
 
-  const tombstone = new Date().toISOString();
   const rowsAffected = await executeTransaction(
     buildSessionTombstoneStatements(sessionId, tombstone),
   );
@@ -912,9 +912,24 @@ export async function isSessionEmpty(sessionId: string): Promise<boolean> {
 export async function restoreDeletedSession(
   data: DeletedSessionData,
 ): Promise<void> {
-  await executeTransaction(
-    buildSessionTombstoneStatements(data.session.id, data.tombstone, true),
-  );
+  // The undo toast shows before the soft-delete write commits, so an early
+  // undo can race the in-flight delete; retry until its tombstone appears.
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const rowsAffected = await executeTransaction(
+      buildSessionTombstoneStatements(data.session.id, data.tombstone, true),
+    );
+    if (rowsAffected[rowsAffected.length - 1] === 1) return;
+
+    const [alive] = await liveQueryClient.execute<SessionIdentitySqlRow>(
+      `SELECT id FROM sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1`,
+      [data.session.id],
+    );
+    if (alive) return;
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error(`Session ${data.session.id} was never soft-deleted`);
 }
 
 export async function finalizeSessionDeletion(

--- a/apps/desktop/src/session/queries.ts
+++ b/apps/desktop/src/session/queries.ts
@@ -7,6 +7,7 @@ import type { EventParticipant, SessionEvent } from "@hypr/store";
 
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
+import { waitForPendingSoftDelete } from "~/session/pending-soft-deletes";
 import { DEFAULT_USER_ID, id } from "~/shared/utils";
 import type { DeletedSessionData } from "~/store/zustand/undo-delete";
 
@@ -912,8 +913,10 @@ export async function isSessionEmpty(sessionId: string): Promise<boolean> {
 export async function restoreDeletedSession(
   data: DeletedSessionData,
 ): Promise<void> {
-  // The undo toast shows before the soft-delete write commits, so an early
-  // undo can race the in-flight delete; retry until its tombstone appears.
+  // The undo toast shows before the soft-delete write commits. Wait for the
+  // in-flight delete to settle first — an "alive" session during that window
+  // is not restored, it just isn't tombstoned yet.
+  await waitForPendingSoftDelete(data.session.id);
   for (let attempt = 0; attempt < 10; attempt += 1) {
     const rowsAffected = await executeTransaction(
       buildSessionTombstoneStatements(data.session.id, data.tombstone, true),

--- a/apps/desktop/src/shared/app-exit.ts
+++ b/apps/desktop/src/shared/app-exit.ts
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { commands as store2Commands } from "@hypr/plugin-store2";
 
 import { flushDatabaseWrites } from "~/db/write-queue";
+import { confirmAllPendingDeletions } from "~/store/zustand/undo-delete";
 import { commands } from "~/types/tauri.gen";
 
 const APP_EXIT_REQUESTED_EVENT = "app-exit-requested";
@@ -20,8 +21,19 @@ export async function initializeAppExitFlush(): Promise<void> {
   });
 }
 
+const PENDING_DELETION_EXIT_TIMEOUT_MS = 3000;
+
 async function flushAndExit(): Promise<void> {
   try {
+    // Confirm pending undo-deletions first: quitting inside the undo window
+    // must not leave a note soft-deleted with its shared link still live.
+    // Bounded so a slow revoke cannot hang exit.
+    await Promise.race([
+      confirmAllPendingDeletions(),
+      new Promise((resolve) =>
+        setTimeout(resolve, PENDING_DELETION_EXIT_TIMEOUT_MS),
+      ),
+    ]);
     await Promise.all([flushDatabaseWrites(), store2Commands.save()]);
   } catch (error) {
     console.error("Failed to flush application data before exit", error);

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -366,11 +366,14 @@ export const TimelineView = memo(function TimelineView({
     const batchId = sessionIds.length > 1 ? crypto.randomUUID() : undefined;
 
     for (const sessionId of sessionIds) {
-      deleteSession(sessionId, undefined, batchId);
+      deleteSession(sessionId, {
+        batchId,
+        title: timelineSessionsTable?.[sessionId]?.title ?? undefined,
+      });
     }
 
     clearSelection();
-  }, [selectedIds, deleteSession, clearSelection]);
+  }, [selectedIds, deleteSession, clearSelection, timelineSessionsTable]);
 
   const sessionCount = useMemo(
     () => selectedIds.filter((key) => key.startsWith("session-")).length,

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -588,8 +588,11 @@ const SessionItem = memo(
     );
 
     const handleDelete = useCallback(() => {
-      deleteSession(sessionId, sessionEvent?.tracking_id);
-    }, [deleteSession, sessionId, sessionEvent?.tracking_id]);
+      deleteSession(sessionId, {
+        trackingId: sessionEvent?.tracking_id,
+        title,
+      });
+    }, [deleteSession, sessionId, sessionEvent?.tracking_id, title]);
 
     const handleShowInFinder = useCallback(async () => {
       const result = await fsSyncCommands.sessionDir(sessionId);

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
@@ -97,6 +97,41 @@ describe("UndoDeleteToast", () => {
     expect(mocks.dismiss).toHaveBeenCalledWith("undo-delete:session-1");
   });
 
+  it("dismisses the toast and reopens the tab before the restore resolves", () => {
+    // Never resolves: undo feedback must not wait for the restore write.
+    mocks.restoreDeletedSession.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+
+    act(() => {
+      useUndoDelete.getState().addDeletion({
+        session: { id: "session-1", title: "Design sync" },
+        tombstone: "tombstone",
+        deletedAt: Date.now(),
+      });
+    });
+
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <UndoDeleteToast />
+      </QueryClientProvider>,
+    );
+
+    const options =
+      mocks.message.mock.calls[mocks.message.mock.calls.length - 1][1];
+    act(() => {
+      options.action.onClick();
+    });
+
+    expect(mocks.restoreDeletedSession).toHaveBeenCalledOnce();
+    expect(mocks.openCurrent).toHaveBeenCalledWith({
+      type: "sessions",
+      id: "session-1",
+    });
+    expect(useUndoDelete.getState().pendingDeletions).toEqual({});
+  });
+
   it("updates a batch toast when later deletions join the batch", async () => {
     const queryClient = new QueryClient();
     render(

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
@@ -61,6 +61,7 @@ function useRestoreGroup() {
   const clearDeletion = useUndoDelete((state) => state.clearDeletion);
   const clearBatch = useUndoDelete((state) => state.clearBatch);
   const openCurrent = useTabs((state) => state.openCurrent);
+  const invalidateResource = useTabs((state) => state.invalidateResource);
 
   return useCallback(
     (group: ToastGroup) => {
@@ -98,13 +99,16 @@ function useRestoreGroup() {
           console.error("[undo-delete] failed to restore session", error);
           sonnerToast.error("Could not restore deleted note");
           // Re-add the unrestored deletions so their undo toast (and the
-          // finalize path) comes back instead of leaving them tombstoned.
+          // finalize path) comes back instead of leaving them tombstoned,
+          // and close the optimistically reopened tab — it still points at
+          // a tombstoned note.
           for (const pending of remaining) {
             addDeletion(
               pending.data,
               pending.onDeleteConfirm ?? undefined,
               pending.batchId ?? undefined,
             );
+            invalidateResource("sessions", pending.data.session.id);
           }
         }
       })();
@@ -112,6 +116,7 @@ function useRestoreGroup() {
     [
       pendingDeletions,
       openCurrent,
+      invalidateResource,
       addDeletion,
       clearDeletion,
       clearBatch,

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
@@ -57,40 +57,66 @@ function useToastGroups(): ToastGroup[] {
 function useRestoreGroup() {
   const queryClient = useQueryClient();
   const pendingDeletions = useUndoDelete((state) => state.pendingDeletions);
+  const addDeletion = useUndoDelete((state) => state.addDeletion);
   const clearDeletion = useUndoDelete((state) => state.clearDeletion);
   const clearBatch = useUndoDelete((state) => state.clearBatch);
   const openCurrent = useTabs((state) => state.openCurrent);
 
   return useCallback(
     (group: ToastGroup) => {
+      const entries = group.sessionIds
+        .map((sessionId) => pendingDeletions[sessionId])
+        .filter((pending) => pending !== undefined);
+
+      // Optimistic: dismiss the toast (also cancelling the finalize timers)
+      // and reopen the tab before the restore writes commit.
+      if (group.isBatch) {
+        clearBatch(group.key);
+      } else {
+        clearDeletion(group.sessionIds[0]);
+      }
+      if (group.sessionIds.length > 0) {
+        openCurrent({ type: "sessions", id: group.sessionIds[0] });
+      }
+
       void (async () => {
-        for (const sessionId of group.sessionIds) {
-          const pending = pendingDeletions[sessionId];
-          if (!pending) continue;
-          await restoreDeletedSession(pending.data);
-          void queryClient.invalidateQueries({
-            predicate: (query) =>
-              query.queryKey.length >= 2 &&
-              query.queryKey[0] === "audio" &&
-              query.queryKey[1] === sessionId,
-          });
+        const remaining = [...entries];
+        try {
+          while (remaining.length > 0) {
+            const pending = remaining[0];
+            await restoreDeletedSession(pending.data);
+            remaining.shift();
+            const sessionId = pending.data.session.id;
+            void queryClient.invalidateQueries({
+              predicate: (query) =>
+                query.queryKey.length >= 2 &&
+                query.queryKey[0] === "audio" &&
+                query.queryKey[1] === sessionId,
+            });
+          }
+        } catch (error) {
+          console.error("[undo-delete] failed to restore session", error);
+          sonnerToast.error("Could not restore deleted note");
+          // Re-add the unrestored deletions so their undo toast (and the
+          // finalize path) comes back instead of leaving them tombstoned.
+          for (const pending of remaining) {
+            addDeletion(
+              pending.data,
+              pending.onDeleteConfirm ?? undefined,
+              pending.batchId ?? undefined,
+            );
+          }
         }
-
-        if (group.sessionIds.length > 0) {
-          openCurrent({ type: "sessions", id: group.sessionIds[0] });
-        }
-
-        if (group.isBatch) {
-          clearBatch(group.key);
-        } else {
-          clearDeletion(group.sessionIds[0]);
-        }
-      })().catch((error) => {
-        console.error("[undo-delete] failed to restore session", error);
-        sonnerToast.error("Could not restore deleted note");
-      });
+      })();
     },
-    [pendingDeletions, openCurrent, clearDeletion, clearBatch, queryClient],
+    [
+      pendingDeletions,
+      openCurrent,
+      addDeletion,
+      clearDeletion,
+      clearBatch,
+      queryClient,
+    ],
   );
 }
 

--- a/apps/desktop/src/store/zustand/undo-delete.ts
+++ b/apps/desktop/src/store/zustand/undo-delete.ts
@@ -16,7 +16,7 @@ export const UNDO_TIMEOUT_MS = 5000;
 export type PendingDeletion = {
   data: DeletedSessionData;
   timeoutId: ReturnType<typeof setTimeout> | null;
-  onDeleteConfirm: (() => void) | null;
+  onDeleteConfirm: (() => void | Promise<unknown>) | null;
   addedAt: number;
   batchId: string | null;
 };
@@ -25,11 +25,11 @@ interface UndoDeleteState {
   pendingDeletions: Record<string, PendingDeletion>;
   addDeletion: (
     data: DeletedSessionData,
-    onConfirm?: () => void,
+    onConfirm?: () => void | Promise<unknown>,
     batchId?: string,
   ) => void;
   clearDeletion: (sessionId: string) => void;
-  confirmDeletion: (sessionId: string) => void;
+  confirmDeletion: (sessionId: string) => void | Promise<unknown>;
   clearBatch: (batchId: string) => void;
   confirmBatch: (batchId: string) => void;
 }
@@ -81,10 +81,9 @@ export const useUndoDelete = create<UndoDeleteState>((set, get) => ({
     const pending = get().pendingDeletions[sessionId];
     if (!pending) return;
 
-    if (pending.onDeleteConfirm) {
-      pending.onDeleteConfirm();
-    }
+    const result = pending.onDeleteConfirm?.();
     get().clearDeletion(sessionId);
+    return result;
   },
 
   clearBatch: (batchId) => {
@@ -105,3 +104,14 @@ export const useUndoDelete = create<UndoDeleteState>((set, get) => ({
     }
   },
 }));
+
+// App exit must not strand notes soft-deleted with live shared links: confirm
+// every pending deletion now and let the caller await the finalize work.
+export function confirmAllPendingDeletions(): Promise<void> {
+  const { pendingDeletions, confirmDeletion } = useUndoDelete.getState();
+  return Promise.allSettled(
+    Object.keys(pendingDeletions).map((sessionId) =>
+      confirmDeletion(sessionId),
+    ),
+  ).then(() => undefined);
+}


### PR DESCRIPTION
Replaces #6189, which was auto-closed when its stacked base branch was deleted on merge. Same content, rebased onto main: optimistic delete/undo/ignore with race-safe rollback and the Bugbot fixes for double-delete undo loss and rapid ignore toggling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core delete/restore/undo timing, share revocation on finalize, and app-exit behavior; mitigated by tombstone matching, pending-write tracking, rollbacks, and expanded tests, but regressions could still strand or lose notes.
> 
> **Overview**
> Makes **note delete**, **undo**, and **calendar ignore** feel instant by updating UI before database writes finish, with explicit rollback and race handling.
> 
> **Delete / undo:** Deleting a note now immediately hides it on the timeline (via pending-deletion state), invalidates the session tab, optionally ignores the linked calendar event, and shows the undo toast **before** the soft-delete commits. `softDeleteSession` accepts a shared **tombstone** so undo can match the in-flight write; in-flight deletes are tracked so restore waits for the delete to settle. Failed deletes roll back the toast, calendar ignore (only if delete added it), and reopen a tab that was open. Repeat deletes while undo is pending are ignored to avoid losing the undo window and finalize cleanup. Finalize (folder removal + managed share revocation) runs only after a successful commit; app exit confirms pending deletions (bounded timeout) so quit during the undo window does not leave soft-deleted notes with live shares.
> 
> **Undo toast:** Undo dismisses the toast and reopens the note tab optimistically, then restores in the background; failed restores re-queue pending deletions and invalidate the session.
> 
> **Ignore:** Calendar ignore/unignore uses a Zustand override layer (tokenized) so rapid toggles show the latest intent without flashing stale live-query state.
> 
> Call sites pass `deleteSession(sessionId, { trackingId, title, batchId })` for correct toast labels and batch deletes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 860bd9da99891f8633f06ad919bbac99354a8780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->