### PR TITLE
docs(changelog): add 1.3.5 desktop release notes

### DIFF
--- a/packages/changelog/content/1.3.5.md
+++ b/packages/changelog/content/1.3.5.md
@@ -1,0 +1,27 @@
+---
+date: "2026-07-22"
+summary: "Anarlog 1.3.5 guarantees post-meeting summaries, makes note deletion and undo instant, and adds anchored shared-note comments plus a sync status menu."
+---
+
+## Meetings & summaries
+
+- Always generate the automatic summary when listening stops — if live transcription stalls mid-meeting, the transcript is rebuilt from the recording
+- Scale summary length with the length of the meeting
+- Keep the recording whenever part of the live transcript could not be saved, so nothing is lost
+- Detect stalls even while your mic is muted and speaker audio keeps playing
+- Choose how long recorded meeting audio is kept on this device from the new Meetings settings section
+
+## Notes & timeline
+
+- Delete notes, undo deletions, and ignore calendar events with instant feedback
+- Delete notes fully offline — shared links are revoked in the background, even if you quit right after deleting
+- Date edits, participant chips, upgrades, and integration buttons respond immediately and can no longer double-trigger
+
+## Chat
+
+- Show sent chat messages instantly instead of after they save, and recover turns whose save failed
+
+## Sharing & sync
+
+- See comments on shared notes anchored to the quoted text across the app
+- Track sync at a glance with the new sync status indicator and menu, supporting up to 5 devices


### PR DESCRIPTION
Changelog gate for the 1.3.5 stable desktop release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of release notes; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.3.5.md`** as the changelog gate for the **1.3.5** stable desktop release, with front matter (`date`, `summary`) and user-facing bullets grouped by **Meetings & summaries**, **Notes & timeline**, **Chat**, and **Sharing & sync**.
> 
> The notes cover reliability and UX improvements (post-meeting summaries from recordings when live transcription stalls, instant note delete/undo, optimistic chat, offline delete with background link revocation, anchored comments on shared notes, and a sync status menu for up to five devices)—documentation only; no app code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c20d3a254a6f24172a09d2ea3e2d2d7b663c93ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->