### PR TITLE
Refresh Granola AI alternatives guide

### DIFF
--- a/apps/web/content/articles/granola-ai-alternatives.mdx
+++ b/apps/web/content/articles/granola-ai-alternatives.mdx
@@ -1,275 +1,253 @@
 ---
 meta_title: "6 Best Granola AI Alternatives in 2026"
-meta_description: "Looking for Granola AI alternatives? Compare top meeting assistants with better privacy, platform support, integrations & pricing."
+meta_description: "Compare six Granola AI alternatives for local Markdown files, bot-free capture, browser transcription, multilingual notes, automation, and local AI."
 author: "John Jeong"
 category: "Comparisons"
-date: "2025-08-15"
+date: "2026-07-22"
 ---
 
-Granola gets one thing very right: it makes AI notes feel like note-taking, not like operating a meeting bot.
+Granola is one of the better-designed AI meeting notepads because it does not try to remove you from note-taking. You write what matters, Granola captures the conversation in the background, and its AI fills in the details afterward.
 
-That is why people try it. It is also why the trade-offs become obvious fast. You are still tied to their stack, their platform support, and their decisions about where your meeting data goes.
+That workflow is not the right fit for everyone. You may need meeting notes stored as local files, a live transcript in the browser, stronger multilingual support, unattended meeting attendance, or an open-source stack you can operate yourself.
 
-This list is for people who like the notepad-first workflow but want a better trade-off on privacy, portability, integrations, or platform coverage.
+This guide compares six Granola alternatives by those workflow differences. It does not rank them by the length of their feature lists.
 
-> 💡 **Before we proceed:** You might want to check out our comparison of the [best bot-free AI meeting assistants](/blog/bot-free-ai-meeting-assistants) like Granola.
+## The short answer
 
-## Our Top Picks
+- **Choose Anarlog** if you want bot-free capture, local transcription, and meeting notes stored as Markdown files you control.
+- **Choose Jamie** if you want a polished bot-free assistant with multilingual notes and European data hosting.
+- **Choose Tactiq** if your meetings happen in a browser and you want to see the transcript live.
+- **Choose Notta** if multilingual transcription, translation, mobile capture, and imported recordings matter most.
+- **Choose Otter** if a notetaker should be able to attend a scheduled meeting without you.
+- **Choose Meetily** if you want an open-source local setup and are comfortable operating more of the stack yourself.
+- **Stay with Granola** if its human-in-the-loop notepad and managed collaborative workspace already match how you work.
 
-1. **Anarlog:** Open-source AI notepad with zero lock-in and complete control over your data and AI stack
-2. **Jamie AI:** GDPR-compliant European alternative with 100+ language support
-3. **Tactiq:** Chrome extension with real-time transcription and rich integrations
-4. **Krisp:** Audio enhancement specialist with noise cancellation and accent conversion
-5. **Sonnet AI:** CRM automation expert for sales teams
-6. **tl;dv:** Video-first platform with advanced sales coaching
+There is no universal best Granola alternative. The best choice depends on what you want to happen before, during, and after a meeting.
 
-## How We Selected the Best Granola AI Alternatives
+## Granola is the benchmark: a human-guided AI notepad
 
-We did not treat this like a generic feature checklist. Granola already does a few things well: the interface is simple, it stays out of the participant list, and it works for people who still want to type during meetings.
+Granola captures device audio without adding a bot to the participant list. During the meeting, you can jot down the points that matter to you. Afterward, Granola combines those notes with its transcript to create a more complete document.
 
-So we looked for alternatives that break from Granola in useful ways, not just tools with longer feature pages.
+<Image src="/api/assets/blog/library/products/granola/notepad/2026-07-19-meeting-note.jpg" alt="Granola note beside a video call with background transcription active" />
 
-### 1. Privacy & Data Control
+*Granola's first-party product image shows the notepad working beside a call without another participant joining the meeting. Source: [Granola](https://www.granola.ai/).*
 
-Granola processes meeting data through external AI providers with limited privacy controls. We looked at tools that keep data local or provide stronger privacy protections.
+Granola now supports Mac, Windows, and mobile workflows, so the old criticism that it is a Mac-only product is no longer accurate. Its current [transcription documentation](https://docs.granola.ai/help-center/taking-notes/transcription) says desktop audio is passed to its transcription provider without being recorded or saved, while the transcript and notes remain in the Granola workspace. Its [Business plan](https://www.granola.ai/pricing) also includes integrations and API access.
 
-<Image src="/api/assets/blog/granola-ai-alternatives/granola-1.webp" alt="Granola Data Processing"/>
-Source: [Granola's Data Processing Addendum](https://help.granola.ai/article/data-processing-addendum#5-security-of-personal-data)
+Those changes make the real comparison more specific. You should switch when another product's capture method, storage model, or downstream workflow fits you better—not because an old comparison says Granola lacks a platform or feature it now supports.
 
-### 2. Platform Compatibility
+## Granola alternatives compared by workflow
 
-Granola currently supports Mac only and lacks mobile apps, which restricts usage on other devices or while traveling.
+| Tool | Capture model | Where the meeting record lives | Best fit | Main tradeoff |
+| --- | --- | --- | --- | --- |
+| **Anarlog** | Desktop system audio, no meeting bot | Local Markdown files | Ownership, privacy, and offline work | Mac-focused product experience today |
+| **Jamie** | Desktop and mobile capture, no meeting bot | Jamie workspace | Multilingual bot-free notes with EU hosting | Managed service rather than a local file workflow |
+| **Tactiq** | Browser extension using meeting captions | Tactiq workspace and exports | Live browser transcripts | Depends on supported browsers and meeting web apps |
+| **Notta** | Desktop, mobile, browser, imports, and meeting workflows | Notta workspace or local Privacy Mode | Multilingual and cross-device work | Capture and storage behavior varies by mode |
+| **Otter** | Meeting bot, desktop app, or browser extension | Otter workspace | Unattended attendance and searchable archives | The visible-bot workflow stores more meeting media |
+| **Meetily** | Local desktop capture | Local or self-managed data | Open-source, self-managed meeting AI | More setup and operational responsibility |
+| **Granola** | Device audio paired with personal notes | Granola workspace | Collaborative, human-guided meeting notes | The archive remains centered on Granola |
 
-### 3. Integration Limitations
+Pricing changes too often to be the foundation of a durable comparison. Check the current plan against your actual meeting volume, history requirements, integrations, export needs, and team size before deciding.
 
-Granola doesn't integrate with popular workplace tools like Asana, ClickUp, or Zapier, which limits its usefulness for teams wanting to share notes automatically. We focused on tools with robust third-party integrations beyond basic calendar sync.
+## 1. Anarlog: best for local Markdown files and AI-provider control
 
-<Image src="/api/assets/blog/granola-ai-alternatives/granola-2.webp" alt="G2 Review Screenshot"/>
-Source: [G2](https://www.g2.com/products/granola/reviews/granola-review-10322423)
+[Anarlog](/) is an open-source, local-first meeting notetaker. It captures microphone and system audio without joining the call as a participant, transcribes the conversation, and keeps notes as plain Markdown files on your computer.
 
-### 4. Missing Advanced Features
+<Image src="/api/assets/blog/library/products/anarlog/desktop/2026-07-17-meeting-note.png" alt="Anarlog desktop meeting note with a transcript, personal notes, and meeting controls" />
 
-Granola doesn't record video or allow access to audio recordings, making it less suitable for hiring interviews or user research.
+The important difference is not simply that Anarlog is bot-free. Granola is bot-free too. The difference is what becomes the source of truth after the meeting.
 
-### 5. Value & Pricing Concerns
+With Anarlog, the durable artifact is a file you can open with other editors, index with your own tools, back up using your existing system, or include in a broader knowledge workflow. Transcription can run locally, and AI can use local models, your own provider keys, or Anarlog's hosted service.
 
-Granola's $18/month individual plan and limited free tier prompted us to look for alternatives offering better features-to-price ratios or more generous free plans for teams and individuals.
+**Choose Anarlog when:**
 
-> 💡 If budget is a concern, explore our guide to [free AI notetakers](/blog/free-ai-notetakers) that offer powerful features at no cost.
+- the meeting record should remain in files you own;
+- offline transcription matters;
+- you want to choose which AI provider processes your notes;
+- open-source code matters to security or technical review;
+- your notes need to work with tools beyond the notetaker's own workspace.
 
-## Review of The 6 Best Granola AI Alternatives
+**Consider the tradeoffs:**
 
-### 1. Anarlog: The Open-Source Granola Alternative
+- The current product experience is focused on macOS.
+- Device-based capture cannot attend a meeting when your computer is absent.
+- Local models use your machine's storage and compute.
+- Local ownership means you are responsible for backup and access controls.
 
-**Best for:** High-agency professionals who demand complete control over their data, AI stack, and workflow—especially engineers, developers, and teams in regulated industries.
+If storage architecture is your main concern, read our deeper guide to [local AI meeting notes](/blog/local-ai-meeting-notes/).
 
-<Image src="/api/assets/blog/granola-ai-alternatives/granola-3.webp" alt="Anarlog"/>
+## 2. Jamie: best for a managed, multilingual bot-free assistant
 
-[Anarlog](/) is an open-source AI notepad for meetings that gives you complete control over your data, AI stack, and workflow. Everything is stored as plain markdown files on your device—not in proprietary databases or cloud servers.
+[Jamie](https://www.meetjamie.ai/en) records online, hybrid, and in-person meetings without adding a bot. Its current product page advertises notes in more than 100 languages, automatic speaker labeling, European hosting, and integrations with tools including Notion, Google Docs, OneNote, and HubSpot.
 
-You can inspect the code, customize functionality, and choose which AI processes your data. Zero lock-in, zero compromises.
+<Image src="/api/assets/blog/library/products/jamie/speaker-identification/2026-07-22-speaker-identification.webp" alt="Jamie interface identifying and labeling three speakers from a meeting" />
 
-#### Key Features
+*Jamie's first-party editorial image demonstrates automatic speaker labeling in the current product. Source: [Jamie](https://www.meetjamie.ai/en/blog/ai-note-taker).*
 
-- Plain markdown files stored locally—works with any tool (Obsidian, Notion, VS Code)
-- Your choice of AI stack: managed cloud, bring your own API keys, or run local models
-- Works with all meeting platforms and offline scenarios
-- Real-time transcription with system audio capture (no bots, no calendar permissions)
-- Open-source with full customization capabilities
-- Zero vendor lock-in—switch AI providers anytime
-- Currently macOS only (Windows and Linux coming in Q2 2026)
-- Unlimited AI summaries and conversational search
+Jamie is the closest alternative here when you like Granola's quiet, bot-free meeting experience but want a different managed product. The interface handles transcription, structured summaries, action items, speaker recognition, and cross-meeting questions without asking you to assemble a local AI stack.
 
-#### Anarlog vs Granola Strengths
+**Choose Jamie when:**
 
-You take notes, the AI enhances them with transcript insights, and you get polished summaries. The difference is who controls the stack. With Anarlog, you own your files, choose your AI, and have zero lock-in. Granola sends your meetings to OpenAI and Anthropic with no way out.
+- bot-free capture is non-negotiable;
+- conversations regularly move between languages;
+- EU data hosting is an organizational requirement;
+- a conventional managed app is preferable to a local file workflow;
+- automatic speaker memory is valuable across recurring meetings.
 
-| Feature                 | Anarlog                                                                                        | Granola                                                    |
-| ----------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Ownership**           | Plain markdown files on your device. Your data, your files.                                     | Proprietary format locked in their platform                |
-| **AI Stack**            | Your choice: managed cloud, bring your own keys, or run local models                            | Sends your meetings to OpenAI and Anthropic for processing |
-| **Lock-in**             | Zero. Open source, portable format, switch AI providers anytime                                 | Third-party vendor lock-in                                 |
-| **Real-time Features**  | Live transcription visible during meetings                                                      | Post-meeting processing only                               |
-| **Pricing**             | Free forever for local transcription, BYOK, and all core features. $25/month for managed cloud. | $10/month per user (adds up fast for teams)                |
-| **Transparency**        | Open source—audit the code, customize functionality, and know exactly how your data is processed | Closed source—you have no idea how it works                |
+**Consider the tradeoffs:**
 
-#### Anarlog vs Granola Limitations
+- Notes live in a vendor-managed workspace rather than your file system.
+- It cannot attend a meeting when your device and app are absent.
+- Language count does not guarantee equal accuracy across accents, audio conditions, or specialized vocabulary.
 
-- No mobile app currently available
-- May not include the absolute latest AI capabilities if you prioritize cutting-edge features over privacy
+Jamie and Granola are both designed to stay out of the participant list. Jamie leans harder into multilingual capture and speaker memory; Granola leans into the human-guided notepad and collaborative meeting context.
 
----
+## 3. Tactiq: best for live transcription in browser meetings
 
-### 2. Jamie AI - The Best Bot-Free European Alternative
+[Tactiq](https://tactiq.io/) is a browser extension for Google Meet, Zoom, and Microsoft Teams. It displays a live transcript beside the meeting without sending a separate participant into the call.
 
-**Best for:** Privacy-focused teams, multilingual organizations, and users requiring GDPR compliance
+<Image src="/api/assets/blog/library/products/tactiq/microsoft-teams/tactiq-2026-07-17-live-transcript.png" alt="Microsoft Teams web meeting with the Tactiq Live Transcript panel beside the call" />
 
-<Image src="/api/assets/blog/granola-ai-alternatives/granola-4.webp" alt="Jamie AI"/>
+*Tactiq's official Teams guide shows the Live Transcript panel inside a browser meeting. Source: [Tactiq](https://help.tactiq.io/en/articles/9560779-how-to-use-tactiq-with-microsoft-teams).*
 
-#### Jamie AI vs Granola
+The live transcript is the reason to choose Tactiq. You can follow the conversation as it happens, highlight key moments, and generate a summary after the call. Its current plans also support transcript exports and AI workflows.
 
-[Jamie AI](https://www.meetjamie.ai/) creates comprehensive meeting notes and action items across any meeting platform without using visible bots. It hosts all data in Europe and supports offline capabilities and 100+ languages for global teams.
+**Choose Tactiq when:**
 
-#### Jamie vs Granola Strengths
+- most meetings happen in a supported browser;
+- seeing the transcript during the call improves participation or accessibility;
+- a lightweight extension is preferable to a desktop meeting app;
+- PDF or text exports are sufficient for your archive;
+- the team wants quick AI workflows from browser transcripts.
 
-Both tools deliver intelligent meeting assistance by combining transcription with AI-powered enhancement. Jamie focuses on privacy and European data hosting, while Granola prioritizes simplicity.
+**Consider the tradeoffs:**
 
-| Feature                  | Jamie                                                       | Granola                                          |
-| ------------------------ | ----------------------------------------------------------- | ------------------------------------------------ |
-| **Meeting Experience**   | No bots, plus works offline for in-person meetings          | No bots, clean meeting experience                |
-| **Privacy & Compliance** | GDPR-compliant with all data hosted in Europe               | Data processed by OpenAI and Anthropic in the US |
-| **Language Support**     | 100+ languages with automatic detection and transcription   | Limited language capabilities                    |
-| **Offline Capability**   | Works completely offline for in-person meetings             | Requires internet for all AI processing          |
-| **Data Sovereignty**     | European data residency meets stricter privacy requirements | US-based cloud processing                        |
+- Microsoft Teams transcription requires the web app or PWA, not the native desktop client.
+- The browser, meeting platform, and caption behavior become dependencies.
+- Tactiq supports many languages, but it does not currently support multiple spoken languages in the same meeting.
 
-#### Jamie vs Granola Limitations
+Tactiq is less like a local meeting memory system and more like an efficient transcription layer for browser calls.
 
-- Costs €24/month compared to Granola's $18/month
-- Summaries take 5-8 minutes to generate after meetings
-- Only connects to Google/Outlook calendars; no Slack, Notion, or CRM integrations
-- Even paid plans have monthly meeting quotas (20-50 meetings)
+## 4. Notta: best for multilingual and cross-device capture
 
----
+[Notta](https://www.notta.ai/en) covers more recording situations than a desktop-only meeting notepad. It supports live online meetings, mobile and desktop recording, imported audio and video, transcription, translation, summaries, and a searchable workspace.
 
-### 3. Tactiq: The Best Chrome Extension Solution
+<Image src="/api/assets/blog/library/products/notta/ai-brain/2026-07-19-notta-brain.webp" alt="Notta Brain interface for asking questions across meeting files and creating follow-up material" />
 
-**Best for:** Chrome users, teams wanting real-time transcription, and budget-conscious users
+*Notta Brain turns meeting material into questions and follow-up deliverables inside the Notta workspace. Source: [Notta](https://www.notta.ai/en).*
 
-<Image src="/api/assets/blog/granola-ai-alternatives/granola-5.webp" alt="Tactiq"/>
+Notta's [language documentation](https://support.notta.ai/hc/en-us/articles/4403155631131-What-languages-does-Notta-support) currently lists 58 languages for monolingual transcription, with separate language sets for translation, real-time translation, and bilingual transcription. That distinction matters: a product may advertise a large total while supporting a smaller set in the exact mode you need.
 
-#### Tactiq vs Granola
+**Choose Notta when:**
 
-[Tactiq](https://tactiq.io/) provides real-time AI meeting transcription for Google Meet, Zoom, and Microsoft Teams. It runs directly in your browser without requiring software installation, capturing live transcripts with speaker identification and generating AI-powered summaries and action items after meetings.
+- multilingual transcription or translation is the primary requirement;
+- meetings and interviews are captured across several devices;
+- imported recordings are a major part of the workflow;
+- the team wants a managed transcription archive;
+- local Privacy Mode fits a subset of sensitive conversations.
 
-#### Tactiq vs Granola Strengths
+**Consider the tradeoffs:**
 
-Both tools provide intelligent meeting assistance. Tactiq operates as a Chrome extension and offers real-time transcription, while Granola requires a native desktop app installation.
+- Capture and storage behavior differs across bot, desktop, mobile, import, and Privacy Mode workflows.
+- Most collaboration and AI workflows are organized around Notta's workspace.
+- Accuracy varies by language pair, speaker mix, microphone quality, and domain vocabulary.
 
-| Feature                   | Tactiq                                              | Granola                                  |
-| ------------------------- | --------------------------------------------------- | ---------------------------------------- |
-| **Setup & Installation**  | Simple Chrome extension, instant setup              | Native desktop app installation required |
-| **Real-time Features**    | Live transcription visible during meetings          | Post-meeting processing only             |
-| **Language Support**      | 60+ languages with automatic detection              | Limited language capabilities            |
-| **Integration Ecosystem** | Rich integrations (Slack, HubSpot, Jira, Linear)    | Minimal third-party integrations         |
-| **Workflow Automation**   | Custom AI actions and reusable prompts              | Basic note enhancement                   |
-| **Pricing**               | $12/month for unlimited transcripts + 10 AI credits | $18/month for unlimited meetings         |
+Test the actual language combinations you use. The headline number is less important than reliable performance on your meetings.
 
-#### Tactiq vs Granola Limitations
+## 5. Otter: best when the notetaker must attend without you
 
-- Only works in Chrome, limiting flexibility for users of other browsers
-- Limited to three meeting platforms vs Granola's universal compatibility
-- AI summaries often need manual correction for accuracy
+[Otter](https://otter.ai/) is the strongest alternative here when unattended attendance matters. Its Notetaker can join scheduled Zoom, Google Meet, and Microsoft Teams calls as a visible participant—even when you cannot attend—and create a transcript, summary, and searchable meeting record.
 
----
+<Image src="/api/assets/blog/library/products/otter/notetaker/2026-07-17-notetaker-overview.png" alt="Otter Notetaker joining a calendar meeting as a visible guest and producing a transcript" />
 
-### 4. Krisp: The Audio Enhancement Specialist
+*Otter's official Notetaker overview shows the calendar, visible guest, and transcript workflow. Source: [Otter](https://help.otter.ai/hc/en-us/articles/4425393298327-Otter-Notetaker-Overview).*
 
-**Best for:** Users in noisy environments, teams prioritizing audio quality, and professionals needing accent clarity
+Otter is no longer bot-only. Its [Mac and Windows desktop apps](https://help.otter.ai/hc/en-us/articles/35973988280215-Otter-Desktop-App-Mac-Windows) can capture meeting audio without the Notetaker joining. That makes the decision more nuanced than many comparison posts suggest.
 
-<Image src="/api/assets/blog/granola-ai-alternatives/granola-6.webp" alt="Krisp"/>
+**Choose Otter when:**
 
-#### Krisp vs Granola AI
+- a meeting assistant needs to attend when you are absent;
+- a centralized transcript archive is more important than local files;
+- teams want several capture methods in one product;
+- searchable transcripts, summaries, and slides are core requirements.
 
-[Krisp](https://krisp.ai/) combines strong AI noise cancellation with meeting transcription, delivering clear audio quality and accurate meeting documentation without visible bots.
+**Consider the tradeoffs:**
 
-#### Krisp vs Granola Strengths
+- The unattended workflow requires a visible meeting participant.
+- Bot-based and bot-free capture produce different social and privacy expectations.
+- The meeting record remains inside a hosted workspace.
 
-Both tools provide bot-free meeting assistance. Krisp's unique focus on audio quality sets it apart from purely transcription-focused solutions.
+If you are comparing capture methods in more depth, see our current guide to the [best Otter.ai alternatives](/blog/otter-ai-alternatives/).
 
-| Feature                     | Krisp                                                       | Granola                           |
-| --------------------------- | ----------------------------------------------------------- | --------------------------------- |
-| **Audio Quality**           | Bidirectional noise cancellation           | Standard meeting audio processing |
-| **Accent Support**          | AI accent conversion for clearer communication              | No accent assistance features     |
-| **Environment Flexibility** | Specifically designed for noisy environments                | Works in quiet environments       |
-| **Meeting Coverage**        | Virtual + in-person meetings with mobile apps               | Virtual meetings only             |
-| **Pricing**                 | $16/month for unlimited features + noise cancellation       | $18/month for unlimited meetings  |
-| **Language Support**        | 16+ languages with multilingual transcription               | Limited language capabilities     |
-| **Processing Approach**     | Local audio processing                                      | Cloud-based AI processing         |
-| **Integration Scope**       | CRM integrations (Salesforce, HubSpot) + productivity tools | Minimal third-party connections   |
+## 6. Meetily: best for an open-source, self-managed setup
 
-#### Krisp vs Granola Limitations
+[Meetily](https://meetily.ai/) is an open-source meeting assistant built around local processing. Its current desktop app uses an embedded SQLite database, supports local transcription and AI summaries, and provides releases for Windows and Apple Silicon Macs, with Linux available through a source build.
 
-- Free tier limited to 60 minutes/day noise cancellation vs Granola's 25 full meetings
-- English-only on free tier, limited multilingual support
-- Requires desktop app installation vs Granola's simpler approach
+<Image src="/api/assets/blog/library/products/meetily/meeting-summary/2026-07-19-summary.png" alt="Meetily interface showing a timestamped transcript beside a generated summary, decisions, and action items" />
 
----
+*Meetily's official repository screenshot shows the transcript and generated meeting record side by side. Source: [Meetily](https://github.com/Zackriya-Solutions/meetily/blob/main/docs/summary.png).*
 
-### 5. Sonnet AI: The CRM Integration Expert
+Meetily is relevant to technical users who want local meeting AI but need a different platform or operating model from Anarlog. Its [open-source repository](https://github.com/Zackriya-Solutions/meetily) exposes the implementation, and local Ollama support can keep summarization on your own machine.
 
-**Best for:** Sales teams, customer success professionals, and CRM-heavy workflows
+**Choose Meetily when:**
 
-<Image src="/api/assets/blog/granola-ai-alternatives/granola-7.webp" alt="Sonnet"/>
+- open-source software is a requirement;
+- you need Windows support or are comfortable building on Linux;
+- local transcription and summarization matter more than a managed workspace;
+- your team can troubleshoot models, hardware, and deployment.
 
-#### Sonnet AI vs Granola AI
+**Consider the tradeoffs:**
 
-[Sonnet AI](https://www.sonnetai.com/) is an end-to-end meeting assistant that specializes in automatically updating CRM systems with meeting insights. Founded by Y Combinator alumni, Sonnet records device audio without visible bots and transforms conversations into structured CRM data, eliminating manual data entry while providing customizable AI-generated meeting notes.
+- Self-managed software requires more setup and maintenance.
+- Local model speed and quality depend on the machine.
+- Product polish, support, and operational burden should be evaluated alongside features.
 
-#### Sonnet AI vs Granola Strengths
+Anarlog and Meetily share a local-first direction. The practical choice comes down to platform support, file format, product experience, and how much of the stack you want to operate yourself.
 
-Both tools provide bot-free meeting assistance. Sonnet AI's focus on CRM automation and relationship management sets it apart from general note-taking solutions.
+## How to choose the right Granola alternative
 
-| Feature                     | Sonnet AI                                                | Granola                       |
-| --------------------------- | -------------------------------------------------------- | ----------------------------- |
-| **CRM Integration**         | Automatic CRM data population and updates                | No built-in CRM functionality |
-| **Pre-meeting Prep**        | Participant research and background information          | Basic meeting preparation     |
-| **Data Structure**          | Structured CRM data and custom templates                 | General meeting notes format  |
-| **Relationship Management** | Comprehensive relationship tracking across conversations | Individual meeting focus      |
-| **Follow-up Automation**    | Automated follow-up emails and task creation             | Manual follow-up required     |
-| **Recording & Sharing**     | Shareable recordings for absent team members             | No recording functionality    |
-| **Workflow Integration**    | End-to-end meeting workflow automation                   | Basic note enhancement        |
+Start with the meeting artifact you want to keep.
 
-#### Sonnet AI vs Granola Limitations
+- If it should be a local Markdown file, start with **Anarlog**.
+- If it should live in a polished collaborative notepad, stay with **Granola** or test **Jamie**.
+- If the live browser transcript is the product, test **Tactiq**.
+- If language and device coverage dominate the decision, test **Notta**.
+- If the assistant must join without you, test **Otter**.
+- If the whole stack should be open and self-managed, evaluate **Meetily**.
 
-- More complex setup and configuration vs Granola's simplicity
-- Stores audio, video, and transcripts on servers vs Granola's lighter approach
-- Many features may be excessive for simple note-taking needs
-- Paid plans start at $25/month compared to Granola's pricing structure
+Then run the same real meeting through your two finalists. Do not use a clean demo call. Use the kind of conversation that normally breaks transcription: overlapping speakers, a poor microphone, names and product terms, an accent mix, and a few decisions that must survive the summary.
 
----
+Score the result on five questions:
 
-### 6. tl;dv: The Video-First Meeting Intelligence Platform
+1. Did capture start reliably without changing how people joined the meeting?
+2. Could you identify who spoke and correct mistakes quickly?
+3. Did the summary preserve decisions, owners, and unresolved questions?
+4. Can you export the complete record in a format that remains useful without the product?
+5. Do you understand where audio, transcripts, notes, and AI prompts are processed and stored?
 
-**Best for:** Sales teams, customer success managers, and organizations needing video recording capabilities
+That test will tell you more than another grid of checkmarks.
 
-<Image src="/api/assets/blog/granola-ai-alternatives/granola-8.webp" alt="tl;dv"/>
+## Frequently asked questions
 
-#### tl;dv vs Granola AI
+### What is the best free alternative to Granola?
 
-[tl;dv](https://tldv.io/) is a comprehensive AI meeting assistant that records video, provides sales coaching, and analyzes multiple meetings for patterns. It goes beyond simple note-taking to transform conversations into actionable insights with enterprise-grade video capabilities that bot-free alternatives cannot match.
+Anarlog is the strongest fit when you want local transcription, Markdown files, and bring-your-own-key or local-model workflows. Tactiq and several managed products also offer free tiers, but their current limits can change. Compare meeting quotas, history access, AI credits, and exports—not just whether the signup page says free.
 
-> **Note:** tl;dv is the only bot-based tool in this comparison list. Unlike the other bot-free alternatives, tl;dv sends a visible bot to join your meetings to enable video recording and advanced features that aren't possible with device-level audio capture alone.
->
-> For more bot-based options similar to tl;dv, explore our [comprehensive AI meeting assistant guide](/blog/best-ai-meeting-assistant-for-taking-notes).
+### Which Granola alternatives do not use meeting bots?
 
-#### tl;dv vs Granola Strengths
+Anarlog, Jamie, Tactiq, and Meetily are built around capture without a visible meeting participant. Notta and Otter offer multiple capture methods, so the answer depends on which app or workflow you select. Our [bot-free AI meeting assistant guide](/blog/bot-free-ai-meeting-assistants/) explains the architectural differences.
 
-While both tools provide meeting intelligence, tl;dv's bot-based approach enables video capabilities and advanced features that device-level solutions cannot offer.
+### Which alternative keeps meeting notes locally?
 
-| Feature                        | tl;dv                                                                | Granola                                |
-| ------------------------------ | -------------------------------------------------------------------- | -------------------------------------- |
-| **Video Recording**            | High-quality video recording with unlimited meetings                 | No video capabilities                  |
-| **Pricing Value**              | $20/month for advanced features + unlimited video recordings         | $18/month for basic unlimited meetings |
-| **Sales Coaching**             | Advanced playbook tracking, objection analysis, performance insights | Basic meeting notes only               |
-| **Multi-Meeting Intelligence** | Cross-meeting trend analysis and aggregated insights                 | Single meeting focus                   |
-| **Content Sharing**            | Video clips, highlight reels, and training content creation          | Text-based notes sharing               |
-| **Language Support**           | 30+ languages with high-accuracy transcription                       | Limited language capabilities          |
-| **Integration Depth**          | 5,000+ tool integrations with workflow automation                    | Basic note enhancement                 |
+Anarlog keeps notes as local Markdown files and can run transcription locally. Meetily is also designed for local or self-managed processing. Notta documents a local Privacy Mode for supported plans and workflows, but that should not be confused with making every Notta workflow local.
 
-#### tl;dv vs Granola Limitations
+### Is Granola private because it has no meeting bot?
 
-- Relies on meeting platform bot capabilities and permissions
-- Video files require significant storage vs text-only notes
-- More features mean steeper learning curve for basic users
+Not necessarily. A missing participant icon tells you how audio is captured, not the complete data path. Review where audio is processed, whether it is retained, where transcripts and notes live, which AI providers receive content, and what deletion and export controls exist. Granola says desktop audio is discarded after real-time transcription, while transcripts and notes persist in its workspace.
 
----
+### What is the closest open-source alternative to Granola?
 
-## Choose the Best Granola AI Alternative
+Anarlog is the closest match when you want a polished bot-free notepad with local Markdown storage and control over the AI stack. Meetily is another open-source option for users who prioritize a local, self-managed setup and broader desktop platform coverage.
 
-The real question is not whether you want AI meeting notes. Granola already proved there is demand for that workflow.
-
-The real question is what you want to own.
-
-If you want the closest thing to Granola with more control, Anarlog is the cleanest fork in the road. You keep the notepad-first workflow, but your notes stay as files, your AI stack stays flexible, and you are not betting your whole system on one vendor's roadmap.
-
-[Download Anarlog](/download) if that trade-off sounds closer to how you actually want to work.
+If the real reason you are leaving Granola is ownership rather than interface preference, [try Anarlog](/). Your meeting memory stays in files you control, and you decide which AI stack touches it.


### PR DESCRIPTION
Replace the stale comparison with current workflow-based research across Anarlog, Jamie, Tactiq, Notta, Otter, and Meetily. Reuse verified first-party product visuals and add the new cataloged Jamie speaker-identification asset.

Checks:
- pnpm -F @hypr/web typecheck
- infisical run --silent --env=prod --path=/web -- pnpm -F @hypr/web build
- verified all seven /api/assets/blog proxy URLs return 200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial MDX-only change with no application or auth logic; main risk is SEO/content accuracy, not runtime behavior.
> 
> **Overview**
> **Rewrites** the Granola alternatives post as a **workflow-first** guide (capture model, where records live, when to switch) instead of a stale feature checklist, and bumps metadata to **2026-07-22** with an updated meta description.
> 
> **Product set** changes: drops Krisp, Sonnet AI, and tl;dv in favor of **Notta**, **Otter**, and **Meetily**, while keeping Anarlog, Jamie, and Tactiq. Adds a short-answer picker, a workflow comparison table, per-tool “choose when / tradeoffs” sections, a decision framework, and expanded FAQs. **Granola** is reframed with current platform support and first-party doc links rather than outdated “Mac-only” claims.
> 
> **Visuals** move from legacy `granola-ai-alternatives/*.webp` assets to cataloged **`/api/assets/blog/library/products/...`** images (including the new Jamie speaker-identification asset), with sourced captions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bdba9a6b0d72f23d707b3602aa68c4464c9dfdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->