### PR TITLE
fix(desktop): show empty view after note deletion

### DIFF
--- a/apps/desktop/src/store/zustand/tabs/navigation.test.ts
+++ b/apps/desktop/src/store/zustand/tabs/navigation.test.ts
@@ -183,7 +183,7 @@ describe("navigation", () => {
       expect(history.currentIndex).toBe(1);
     });
 
-    test("removes current active tab when invalidated", () => {
+    test("replaces the invalidated active session with the empty view", () => {
       const tab1 = createSessionTab();
       const tab2 = createSessionTab();
 
@@ -196,11 +196,28 @@ describe("navigation", () => {
       useTabs.getState().invalidateResource("sessions", tab2.id);
 
       const state = useTabs.getState();
-      expect(state.tabs).toHaveLength(1);
-      expect(state).toHaveCurrentTab({ id: tab1.id });
+      expect(state.tabs).toHaveLength(2);
+      expect(state).toHaveCurrentTab({ type: "empty" });
+      expect(state.tabs[0]).toMatchObject({ id: tab1.id, active: false });
     });
 
-    test("removes slot when all tabs in slot are invalidated", () => {
+    test("shows the empty view instead of restoring prior slot history", () => {
+      const tab = createSessionTab();
+
+      useTabs.getState().openNew({ type: "settings" });
+      useTabs.getState().openCurrent(tab);
+
+      useTabs.getState().invalidateResource("sessions", tab.id);
+
+      const state = useTabs.getState();
+      expect(state.tabs).toHaveLength(1);
+      expect(state).toHaveCurrentTab({ type: "empty" });
+      expect(
+        Array.from(state.history.values()).flatMap((entry) => entry.stack),
+      ).not.toContainEqual(expect.objectContaining({ id: tab.id }));
+    });
+
+    test("keeps the empty view after all sessions in a slot are invalidated", () => {
       const tab1 = createSessionTab();
       const tab2 = createSessionTab();
 
@@ -214,8 +231,8 @@ describe("navigation", () => {
       useTabs.getState().invalidateResource("sessions", tab2.id);
 
       const state = useTabs.getState();
-      expect(state.tabs).toHaveLength(0);
-      expect(state.currentTab).toBeNull();
+      expect(state.tabs).toHaveLength(1);
+      expect(state).toHaveCurrentTab({ type: "empty" });
       expect(state.history.size).toBe(0);
     });
 

--- a/apps/desktop/src/store/zustand/tabs/navigation.ts
+++ b/apps/desktop/src/store/zustand/tabs/navigation.ts
@@ -105,17 +105,25 @@ export const createNavigationSlice = <T extends NavigationState & BasicState>(
       const slotHistory = nextHistory.get(currentTab.slotId);
       const historyFallback = slotHistory?.stack[slotHistory.currentIndex];
       const otherFallback = nextTabs.find((tab) => tab.active) ?? nextTabs[0];
-      const fallback = historyFallback ?? otherFallback;
+      const fallback: Tab | undefined =
+        type === "sessions"
+          ? {
+              type: "empty",
+              active: true,
+              slotId: currentTab.slotId,
+              pinned: false,
+            }
+          : (historyFallback ?? otherFallback);
 
       nextTabs = nextTabs.map((tab) => ({ ...tab, active: false }));
-      if (historyFallback) {
+      if (fallback && (type === "sessions" || historyFallback)) {
         const removedIndex = tabs.findIndex((tab) =>
           isResourceMatch(tab, type, id),
         );
         nextTabs.splice(
           Math.max(0, Math.min(removedIndex, nextTabs.length)),
           0,
-          { ...historyFallback, active: true },
+          { ...fallback, active: true },
         );
       } else if (fallback) {
         const fallbackIndex = nextTabs.findIndex(


### PR DESCRIPTION
Replace deleted active note tabs with the empty view instead of reviving navigation history.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to desktop tab invalidation for sessions only, with updated unit tests and no auth or data-path changes.
> 
> **Overview**
> When a **session** tab is invalidated while it is active (e.g. after deleting a note), the tab store no longer restores the previous entry from slot history or another open session. It now activates an **`empty`** tab in the same slot instead.
> 
> Invalidation of other resource types (shared sessions, contacts, etc.) still uses the existing history / active-tab fallback. Tests for `invalidateResource` were updated to expect the empty view when sessions are removed, including when history would previously have shown settings or another session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32779d30404c5af396e29c2d264a60176dac72be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->