### PR TITLE
fix(desktop): recover post-meeting processing

### DIFF
--- a/apps/desktop/src/services/enhancer/eligibility.ts
+++ b/apps/desktop/src/services/enhancer/eligibility.ts
@@ -5,6 +5,10 @@ import {
 
 export const MIN_WORDS_FOR_ENHANCEMENT = 5;
 
+export type EnhanceEligibilitySkipCode =
+  | "no_transcript"
+  | "transcript_too_short";
+
 export function countTranscriptWords(
   transcripts: ReadonlyArray<{ words: readonly unknown[] }>,
 ): number {
@@ -18,6 +22,7 @@ type EligibilityResult =
   | { eligible: true; characterCount: number; wordCount: number }
   | {
       eligible: false;
+      code: EnhanceEligibilitySkipCode;
       characterCount: number;
       reason: string;
       wordCount: number;
@@ -31,6 +36,7 @@ export function getEligibility(
   if (transcripts.length === 0) {
     return {
       eligible: false,
+      code: "no_transcript",
       reason: "No transcript recorded",
       characterCount: 0,
       wordCount: 0,
@@ -43,6 +49,7 @@ export function getEligibility(
   if (wordCount < MIN_WORDS_FOR_ENHANCEMENT) {
     return {
       eligible: false,
+      code: "transcript_too_short",
       reason: `Not enough words recorded (${wordCount}/${MIN_WORDS_FOR_ENHANCEMENT} minimum)`,
       characterCount,
       wordCount,
@@ -52,6 +59,7 @@ export function getEligibility(
   if (characterCount < MIN_TRANSCRIPT_CHARACTERS_FOR_SUMMARY) {
     return {
       eligible: false,
+      code: "transcript_too_short",
       reason: `Transcript too short to summarize (${characterCount}/${MIN_TRANSCRIPT_CHARACTERS_FOR_SUMMARY} characters minimum)`,
       characterCount,
       wordCount,

--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -424,6 +424,7 @@ describe("EnhancerService", () => {
       type: "auto-enhance-skipped",
       sessionId: "session-1",
       reason: "Not enough words recorded (1/5 minimum)",
+      reasonCode: "transcript_too_short",
     });
   });
 

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -2,7 +2,7 @@ import type { LanguageModel } from "ai";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 
-import { getEligibility } from "./eligibility";
+import { type EnhanceEligibilitySkipCode, getEligibility } from "./eligibility";
 import {
   type EnhancerNote,
   ensureSummaryDocument,
@@ -36,7 +36,12 @@ type EnhanceOpts = {
 };
 
 type EnhancerEvent =
-  | { type: "auto-enhance-skipped"; sessionId: string; reason: string }
+  | {
+      type: "auto-enhance-skipped";
+      sessionId: string;
+      reason: string;
+      reasonCode: EnhanceEligibilitySkipCode | "error";
+    }
   | { type: "auto-enhance-started"; sessionId: string; noteId: string }
   | { type: "auto-enhance-no-model"; sessionId: string };
 
@@ -236,6 +241,7 @@ export class EnhancerService {
         type: "auto-enhance-skipped",
         sessionId,
         reason: eligibility.reason,
+        reasonCode: eligibility.code,
       });
       return;
     }
@@ -262,7 +268,12 @@ export class EnhancerService {
     this.clearRetry(sessionId);
     const reason = error instanceof Error ? error.message : String(error);
     console.error("[enhancer] auto-enhance failed", error);
-    this.emit({ type: "auto-enhance-skipped", sessionId, reason });
+    this.emit({
+      type: "auto-enhance-skipped",
+      sessionId,
+      reason,
+      reasonCode: "error",
+    });
   }
 
   private clearRetry(sessionId: string) {

--- a/apps/desktop/src/session/components/note-input/transcript/actions.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/actions.test.tsx
@@ -1,0 +1,65 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  audioPath: vi.fn(),
+  handleBatchFailed: vi.fn(),
+  queueAutoEnhanceIfSummaryEmpty: vi.fn(),
+  runBatch: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-fs-sync", () => ({
+  commands: { audioPath: mocks.audioPath },
+}));
+
+vi.mock("@hypr/ui/components/ui/toast", () => ({
+  sonnerToast: { error: mocks.toastError },
+}));
+
+vi.mock("~/services/enhancer", () => ({
+  getEnhancerService: () => ({
+    queueAutoEnhanceIfSummaryEmpty: mocks.queueAutoEnhanceIfSummaryEmpty,
+  }),
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: (selector: (state: unknown) => unknown) =>
+    selector({ handleBatchFailed: mocks.handleBatchFailed }),
+}));
+
+vi.mock("~/stt/useRunBatch", () => ({
+  isStoppedTranscriptionError: (error: unknown) =>
+    error instanceof Error && error.message === "Transcription stopped.",
+  useRunBatch: () => mocks.runBatch,
+}));
+
+import { useRegenerateTranscript } from "./actions";
+
+describe("useRegenerateTranscript", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.audioPath.mockResolvedValue({
+      status: "ok",
+      data: "/tmp/session.wav",
+    });
+  });
+
+  it("shows batch transcription failures even when an old transcript exists", async () => {
+    mocks.runBatch.mockRejectedValue(new Error("Authentication failed"));
+    const { result } = renderHook(() => useRegenerateTranscript("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(mocks.handleBatchFailed).toHaveBeenCalledWith(
+      "session-1",
+      "Authentication failed",
+    );
+    expect(mocks.toastError).toHaveBeenCalledWith("Re-transcription failed", {
+      id: "transcript-regenerate-failed-session-1",
+      description: "Authentication failed",
+    });
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/actions.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/actions.ts
@@ -31,6 +31,10 @@ export function useRegenerateTranscript(sessionId: string) {
       }
       const msg = error instanceof Error ? error.message : String(error);
       handleBatchFailed(sessionId, msg);
+      sonnerToast.error("Re-transcription failed", {
+        id: `transcript-regenerate-failed-${sessionId}`,
+        description: msg,
+      });
     }
   }, [handleBatchFailed, runBatch, sessionId]);
 }

--- a/apps/desktop/src/session/hooks/useAutoEnhance.test.tsx
+++ b/apps/desktop/src/session/hooks/useAutoEnhance.test.tsx
@@ -1,0 +1,59 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listener: undefined as ((event: any) => void) | undefined,
+  on: vi.fn(),
+  toastWarning: vi.fn(),
+  tabsGetState: vi.fn(),
+}));
+
+vi.mock("@hypr/ui/components/ui/toast", () => ({
+  sonnerToast: { warning: mocks.toastWarning },
+}));
+
+vi.mock("~/services/enhancer", () => ({
+  getEnhancerService: () => ({ on: mocks.on }),
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: { getState: mocks.tabsGetState },
+}));
+
+import { useAutoEnhance } from "./useAutoEnhance";
+
+describe("useAutoEnhance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listener = undefined;
+    mocks.on.mockImplementation((listener) => {
+      mocks.listener = listener;
+      return vi.fn();
+    });
+  });
+
+  it("shows why an automatic summary was skipped for a short transcript", () => {
+    renderHook(() =>
+      useAutoEnhance({ type: "sessions", id: "session-1" } as any),
+    );
+
+    act(() => {
+      mocks.listener?.({
+        type: "auto-enhance-skipped",
+        sessionId: "session-1",
+        reason:
+          "Transcript too short to summarize (120/160 characters minimum)",
+        reasonCode: "transcript_too_short",
+      });
+    });
+
+    expect(mocks.toastWarning).toHaveBeenCalledWith(
+      "Summary wasn't generated",
+      {
+        id: "auto-summary-too-short-session-1",
+        description:
+          "Transcript too short to summarize (120/160 characters minimum)",
+      },
+    );
+  });
+});

--- a/apps/desktop/src/session/hooks/useAutoEnhance.ts
+++ b/apps/desktop/src/session/hooks/useAutoEnhance.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import { sonnerToast } from "@hypr/ui/components/ui/toast";
+
 import { getEnhancerService } from "~/services/enhancer";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 
@@ -14,6 +16,12 @@ export function useAutoEnhance(tab: Extract<Tab, { type: "sessions" }>) {
       if (event.sessionId !== sessionId) return;
       if (event.type === "auto-enhance-skipped") {
         setSkipReason(event.reason);
+        if (event.reasonCode === "transcript_too_short") {
+          sonnerToast.warning("Summary wasn't generated", {
+            id: `auto-summary-too-short-${sessionId}`,
+            description: event.reason,
+          });
+        }
       }
       if (event.type === "auto-enhance-started") {
         const tabsState = useTabs.getState();

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
@@ -146,20 +146,18 @@ IMPORTANT: Previous attempt failed. ${previousFeedback}`;
       signal.addEventListener("abort", abortFromOuter);
       retrySignal.addEventListener("abort", abortFromRetry);
 
-      try {
-        const result = streamText({
-          model,
-          system,
-          ...createPromptInput(enhancedPrompt, args.imageContext),
-          abortSignal: combinedController.signal,
-          maxRetries: AI_GENERATION_MAX_RETRIES,
-          maxOutputTokens: SUMMARY_MAX_OUTPUT_TOKENS,
-        });
-        return result.fullStream;
-      } finally {
+      const result = streamText({
+        model,
+        system,
+        ...createPromptInput(enhancedPrompt, args.imageContext),
+        abortSignal: combinedController.signal,
+        maxRetries: AI_GENERATION_MAX_RETRIES,
+        maxOutputTokens: SUMMARY_MAX_OUTPUT_TOKENS,
+      });
+      return withCleanup(result.fullStream, () => {
         signal.removeEventListener("abort", abortFromOuter);
         retrySignal.removeEventListener("abort", abortFromRetry);
-      }
+      });
     },
     validator,
     {
@@ -177,6 +175,17 @@ IMPORTANT: Previous attempt failed. ${previousFeedback}`;
       },
     },
   );
+}
+
+async function* withCleanup<T>(
+  stream: AsyncIterable<T>,
+  cleanup: () => void,
+): AsyncIterable<T> {
+  try {
+    yield* stream;
+  } finally {
+    cleanup();
+  }
 }
 
 function withImageContextNote(prompt: string, imageCount: number): string {

--- a/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
@@ -2,7 +2,12 @@ import { APICallError } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TASK_CONFIGS } from "./task-configs";
-import { createTasksSlice, extractUnderlyingError } from "./tasks";
+import {
+  createTasksSlice,
+  extractUnderlyingError,
+  TASK_STREAM_IDLE_TIMEOUT_MS,
+  TASK_STREAM_START_TIMEOUT_MS,
+} from "./tasks";
 
 const mocks = vi.hoisted(() => ({
   getStoredSettingValues: vi.fn(async () => ({
@@ -18,6 +23,7 @@ vi.mock("~/settings/queries", () => ({
 const originalEnhanceConfig = { ...TASK_CONFIGS.enhance };
 
 afterEach(() => {
+  vi.useRealTimers();
   Object.assign(TASK_CONFIGS.enhance, originalEnhanceConfig);
 });
 
@@ -181,6 +187,125 @@ describe("createTasksSlice", () => {
       status: "error",
       streamedText: "",
       error: expect.objectContaining({ message: "database write failed" }),
+    });
+  });
+
+  it("persists streamed text when the provider never closes the stream", async () => {
+    vi.useFakeTimers();
+    let state: ReturnType<typeof createTasksSlice>;
+    const set = (updater: any) => {
+      state =
+        typeof updater === "function"
+          ? updater(state)
+          : { ...state, ...updater };
+    };
+    const get = () => state;
+    state = createTasksSlice(set, get);
+
+    TASK_CONFIGS.enhance.transformArgs = vi.fn(async () => ({}) as any);
+    TASK_CONFIGS.enhance.transforms = [];
+    TASK_CONFIGS.enhance.executeWorkflow = vi.fn(async function* () {
+      yield { type: "text-delta", text: "Generated summary" } as any;
+      await new Promise(() => {});
+    });
+    TASK_CONFIGS.enhance.onSuccess = vi.fn(async () => {});
+
+    const taskId = "session-idle-enhance" as const;
+    const promise = state.generate(taskId, {
+      model: {} as any,
+      taskType: "enhance",
+      args: { sessionId: "session-1", enhancedNoteId: "note-1" },
+    });
+
+    await vi.waitFor(() => {
+      expect(state.tasks[taskId]?.streamedText).toBe("Generated summary");
+    });
+    await vi.advanceTimersByTimeAsync(TASK_STREAM_IDLE_TIMEOUT_MS);
+    await promise;
+
+    expect(TASK_CONFIGS.enhance.onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Generated summary" }),
+    );
+    expect(state.tasks[taskId]).toMatchObject({
+      status: "success",
+      streamedText: "Generated summary",
+    });
+  });
+
+  it("does not persist streamed text after cancellation during the idle timeout", async () => {
+    vi.useFakeTimers();
+    let state: ReturnType<typeof createTasksSlice>;
+    const set = (updater: any) => {
+      state =
+        typeof updater === "function"
+          ? updater(state)
+          : { ...state, ...updater };
+    };
+    const get = () => state;
+    state = createTasksSlice(set, get);
+
+    TASK_CONFIGS.enhance.transformArgs = vi.fn(async () => ({}) as any);
+    TASK_CONFIGS.enhance.transforms = [];
+    TASK_CONFIGS.enhance.executeWorkflow = vi.fn(async function* () {
+      yield { type: "text-delta", text: "Generated summary" } as any;
+      await new Promise(() => {});
+    });
+    TASK_CONFIGS.enhance.onSuccess = vi.fn(async () => {});
+
+    const taskId = "session-cancelled-enhance" as const;
+    const promise = state.generate(taskId, {
+      model: {} as any,
+      taskType: "enhance",
+      args: { sessionId: "session-1", enhancedNoteId: "note-1" },
+    });
+
+    await vi.waitFor(() => {
+      expect(state.tasks[taskId]?.streamedText).toBe("Generated summary");
+    });
+    state.cancel(taskId);
+    await vi.advanceTimersByTimeAsync(TASK_STREAM_IDLE_TIMEOUT_MS);
+    await promise;
+
+    expect(TASK_CONFIGS.enhance.onSuccess).not.toHaveBeenCalled();
+    expect(state.tasks[taskId]).toMatchObject({ status: "idle" });
+  });
+
+  it("fails a task when the provider never returns text", async () => {
+    vi.useFakeTimers();
+    let state: ReturnType<typeof createTasksSlice>;
+    const set = (updater: any) => {
+      state =
+        typeof updater === "function"
+          ? updater(state)
+          : { ...state, ...updater };
+    };
+    const get = () => state;
+    state = createTasksSlice(set, get);
+
+    TASK_CONFIGS.enhance.transformArgs = vi.fn(async () => ({}) as any);
+    TASK_CONFIGS.enhance.transforms = [];
+    TASK_CONFIGS.enhance.executeWorkflow = vi.fn(async function* () {
+      await new Promise(() => {});
+    });
+    TASK_CONFIGS.enhance.onSuccess = vi.fn(async () => {});
+
+    const taskId = "session-start-timeout-enhance" as const;
+    const promise = state.generate(taskId, {
+      model: {} as any,
+      taskType: "enhance",
+      args: { sessionId: "session-1", enhancedNoteId: "note-1" },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(TASK_STREAM_START_TIMEOUT_MS);
+    await promise;
+
+    expect(TASK_CONFIGS.enhance.onSuccess).not.toHaveBeenCalled();
+    expect(state.tasks[taskId]).toMatchObject({
+      status: "error",
+      error: expect.objectContaining({
+        message: "AI generation did not return any text.",
+      }),
     });
   });
 });

--- a/apps/desktop/src/store/zustand/ai-task/tasks.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.ts
@@ -79,6 +79,27 @@ const initialState: TasksState = {
   tasks: {},
 };
 
+export const TASK_STREAM_IDLE_TIMEOUT_MS = 15_000;
+export const TASK_STREAM_START_TIMEOUT_MS = 60_000;
+
+const STREAM_TIMEOUT = Symbol("stream-timeout");
+
+async function readStreamChunkWithTimeout<T>(
+  iterator: AsyncIterator<T>,
+  timeoutMs: number,
+): Promise<IteratorResult<T> | typeof STREAM_TIMEOUT> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<typeof STREAM_TIMEOUT>((resolve) => {
+    timeoutId = setTimeout(() => resolve(STREAM_TIMEOUT), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([iterator.next(), timeout]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
 export const createTasksSlice = <T extends TasksState & TasksActions>(
   set: StoreApi<T>["setState"],
   get: StoreApi<T>["getState"],
@@ -222,35 +243,71 @@ export const createTasksSlice = <T extends TasksState & TasksActions>(
         );
       };
 
-      const workflowStream = taskConfig.executeWorkflow({
-        model: config.model,
-        args: enrichedArgs,
-        onProgress,
-        signal: abortController.signal,
+      const workflowAbortController = new AbortController();
+      const abortWorkflow = () => workflowAbortController.abort();
+      abortController.signal.addEventListener("abort", abortWorkflow, {
+        once: true,
       });
+      let workflowCompleted = false;
 
-      const transforms = taskConfig.transforms ?? [];
-      const transformedStream = applyTransforms(workflowStream, transforms, {
-        stopStream: () => abortController.abort(),
-      });
+      try {
+        const workflowStream = taskConfig.executeWorkflow({
+          model: config.model,
+          args: enrichedArgs,
+          onProgress,
+          signal: workflowAbortController.signal,
+        });
 
-      for await (const chunk of transformedStream) {
-        checkAbort();
+        const transforms = taskConfig.transforms ?? [];
+        const transformedStream = applyTransforms(workflowStream, transforms, {
+          stopStream: abortWorkflow,
+        });
+        const iterator = transformedStream[Symbol.asyncIterator]();
 
-        if (chunk.type === "error") {
-          throw chunk.error;
-        } else if (chunk.type === "text-delta") {
-          fullText += chunk.text;
-
-          set((state) =>
-            mutate(state, (draft) => {
-              const currentState = draft.tasks[taskId];
-              if (currentState) {
-                currentState.streamedText = fullText;
-              }
-            }),
+        while (true) {
+          const result = await readStreamChunkWithTimeout(
+            iterator,
+            fullText.trim()
+              ? TASK_STREAM_IDLE_TIMEOUT_MS
+              : TASK_STREAM_START_TIMEOUT_MS,
           );
+          checkAbort();
+
+          if (result === STREAM_TIMEOUT) {
+            workflowAbortController.abort();
+            if (fullText.trim()) {
+              break;
+            }
+            throw new Error("AI generation did not return any text.");
+          }
+
+          if (result.done) {
+            workflowCompleted = true;
+            break;
+          }
+
+          const chunk = result.value;
+
+          if (chunk.type === "error") {
+            throw chunk.error;
+          } else if (chunk.type === "text-delta") {
+            fullText += chunk.text;
+
+            set((state) =>
+              mutate(state, (draft) => {
+                const currentState = draft.tasks[taskId];
+                if (currentState) {
+                  currentState.streamedText = fullText;
+                }
+              }),
+            );
+          }
         }
+      } finally {
+        if (!workflowCompleted) {
+          workflowAbortController.abort();
+        }
+        abortController.signal.removeEventListener("abort", abortWorkflow);
       }
 
       await taskConfig.onSuccess?.({

--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -186,9 +186,15 @@ const createSessionEventHandlers = <T extends LiveStore>(
         : (currentLive.finalizingBySession[targetSessionId]?.seconds ?? 0);
     const onStopped = get().takeOnStopped(targetSessionId);
     const unlisteners = currentLive.eventUnlistenersBySession[targetSessionId];
+    const hasUnfinalizedTranscript =
+      currentLive.sessionId === targetSessionId &&
+      Object.values(get().partialWordsByChannel).some(
+        (words) => words.length > 0,
+      );
     const needsBatchRepair =
       currentLive.sessionId === targetSessionId
-        ? currentLive.needsBatchRepair
+        ? currentLive.needsBatchRepair ||
+          (payload.requested_live_transcription && hasUnfinalizedTranscript)
         : (currentLive.finalizingBySession[targetSessionId]?.needsBatchRepair ??
           false);
 

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -798,6 +798,64 @@ describe("General Listener Slice", () => {
       );
     });
 
+    test("repairs a live transcript when stop leaves unfinalized words", async () => {
+      let lifecycleHandler:
+        | ((event: { payload: Record<string, unknown> }) => void)
+        | undefined;
+      const onStopped = vi.fn();
+      listenCaptureLifecycleMock.mockImplementationOnce((handler) => {
+        lifecycleHandler = handler;
+        return Promise.resolve(() => {});
+      });
+      getCaptureSnapshotMock.mockResolvedValueOnce({
+        status: "ok",
+        data: {
+          activeSessionId: "session-a",
+          finalizingSessionIds: [],
+          liveTranscriptionActive: true,
+          requestedLiveTranscription: true,
+          state: "active",
+        },
+      });
+      store.getState().setOnStopped("session-a", onStopped);
+
+      await store.getState().attachLiveSession("session-a");
+      store.setState((state) =>
+        mutate(state, (draft) => {
+          draft.partialWordsByChannel[0] = [
+            {
+              text: " trailing words",
+              start_ms: 1_000,
+              end_ms: 2_000,
+              channel: 0,
+            },
+          ];
+        }),
+      );
+
+      lifecycleHandler?.({
+        payload: {
+          type: "finalizing",
+          session_id: "session-a",
+        },
+      });
+      lifecycleHandler?.({
+        payload: {
+          type: "stopped",
+          session_id: "session-a",
+          audio_path: "/tmp/session.wav",
+          requested_live_transcription: true,
+          live_transcription_active: true,
+          error: null,
+        },
+      });
+
+      expect(onStopped).toHaveBeenCalledWith(
+        "session-a",
+        expect.objectContaining({ needsBatchRepair: true }),
+      );
+    });
+
     test("attachLiveSession ignores overlapping attaches for the same session", async () => {
       await Promise.all([
         store.getState().attachLiveSession("session-a"),

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -16,6 +16,7 @@ const {
   useSessionParticipantsMock,
   useSTTConnectionMock,
   useAuthMock,
+  refreshSessionMock,
   useBillingAccessMock,
   useConfigValueMock,
   isSupportedLanguagesBatchMock,
@@ -31,6 +32,7 @@ const {
   useSessionParticipantsMock: vi.fn(),
   useSTTConnectionMock: vi.fn(),
   useAuthMock: vi.fn(),
+  refreshSessionMock: vi.fn(),
   useBillingAccessMock: vi.fn(),
   useConfigValueMock: vi.fn(),
   isSupportedLanguagesBatchMock: vi.fn(),
@@ -236,7 +238,9 @@ describe("useRunBatch", () => {
         access_token: "paid-token",
         user: { id: "user-1" },
       },
+      refreshSession: refreshSessionMock,
     });
+    refreshSessionMock.mockResolvedValue(null);
     useBillingAccessMock.mockReturnValue({
       isPaid: false,
     });
@@ -418,6 +422,46 @@ describe("useRunBatch", () => {
         description:
           "nova-3 is not available for batch transcription. Using Pro cloud transcription instead.",
       }),
+    );
+  });
+
+  test("refreshes an expired cloud token and retries transcription once", async () => {
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "hyprnote",
+        model: "cloud",
+        baseUrl: "https://api.test/stt",
+        apiKey: "stale-token",
+      },
+    });
+    useAuthMock.mockReturnValue({
+      session: {
+        access_token: "stale-token",
+        user: { id: "user-1" },
+      },
+      refreshSession: refreshSessionMock,
+    });
+    refreshSessionMock.mockResolvedValue({ access_token: "fresh-token" });
+    startTranscriptionMock
+      .mockRejectedValueOnce(
+        new Error(
+          "Authentication failed. Please check your API key in settings.",
+        ),
+      )
+      .mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav");
+    });
+
+    expect(refreshSessionMock).toHaveBeenCalledTimes(1);
+    expect(startTranscriptionMock).toHaveBeenCalledTimes(2);
+    expect(startTranscriptionMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ api_key: "fresh-token" }),
+      expect.any(Object),
     );
   });
 });

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -149,6 +149,13 @@ export function isStoppedTranscriptionError(error: unknown) {
   );
 }
 
+export function isTranscriptionAuthenticationError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /authentication failed|invalid_token|unauthorized|\b401\b/i.test(
+    message,
+  );
+}
+
 export function getSessionSpeakerCount(
   participantHumanIds: Iterable<string>,
   selfHumanId?: string | null,
@@ -364,7 +371,27 @@ export const useRunBatch = (sessionId: string) => {
       };
 
       try {
-        await startTranscription(params, { handlePersist: persist });
+        try {
+          await startTranscription(params, { handlePersist: persist });
+        } catch (error) {
+          if (
+            target.provider !== "hyprnote" ||
+            target.model !== "cloud" ||
+            !isTranscriptionAuthenticationError(error)
+          ) {
+            throw error;
+          }
+
+          const refreshedSession = await auth.refreshSession();
+          if (!refreshedSession?.access_token) {
+            throw error;
+          }
+
+          await startTranscription(
+            { ...params, api_key: refreshedSession.access_token },
+            { handlePersist: persist },
+          );
+        }
       } finally {
         await lastTranscriptWrite;
       }
@@ -375,6 +402,7 @@ export const useRunBatch = (sessionId: string) => {
     },
     [
       conn,
+      auth,
       auth?.session?.access_token,
       aiLanguage,
       audioRetention,


### PR DESCRIPTION
Repair trailing live transcript partials, refresh expired batch tokens, surface short-summary skips, and finalize stalled AI streams.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live-stop batch repair, auth retry, and AI task completion semantics; behavior changes could affect summary persistence and transcription timing but is covered by new tests.
> 
> **Overview**
> Improves **post-meeting reliability** when live capture, batch transcription, and auto-summary fail or stall.
> 
> After stop, live capture now flags **batch repair** when live transcription was requested but **unfinalized partial words** remain, so trailing audio can be rebuilt via batch. **Batch cloud transcription** refreshes the session token and **retries once** on authentication failures.
> 
> **Auto-summary** skip reasons gain stable **`reasonCode`** values; the session UI shows a **warning toast** when the transcript is too short to summarize, and **re-transcription** surfaces an error toast on failure.
> 
> **AI enhance tasks** use stream **start** (60s) and **idle** (15s) timeouts: stalled streams with partial text are finalized; empty streams error; cancellation during idle does not persist. The enhance workflow keeps **abort listener cleanup** tied to stream lifetime via `withCleanup`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce287da06c4c482fca39011879ceb1211b18c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->