### PR TITLE
fix(desktop): hide transcript finalizing banner

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/index.test.tsx
@@ -122,7 +122,7 @@ describe("Transcript", () => {
     expect(screen.queryByTestId("transcript-viewer")).not.toBeNull();
   });
 
-  it("shows finalizing status over existing transcript content", () => {
+  it("keeps existing transcript content unobstructed while finalizing", () => {
     listenerState = {
       ...listenerState,
       getSessionMode: () => "finalizing",
@@ -133,7 +133,7 @@ describe("Transcript", () => {
 
     render(<Transcript sessionId={sessionId} scrollRef={createRef()} />);
 
-    expect(screen.getByText("Finalizing transcript...")).not.toBeNull();
+    expect(screen.queryByText("Finalizing transcript...")).toBeNull();
     expect(screen.getByTestId("transcript-viewer")).not.toBeNull();
   });
 

--- a/apps/desktop/src/session/components/note-input/transcript/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/index.tsx
@@ -1,8 +1,6 @@
 import type { RefObject } from "react";
 import { useCallback } from "react";
 
-import { Spinner } from "@hypr/ui/components/ui/spinner";
-
 import { useRegenerateTranscript } from "./actions";
 import { TranscriptViewer } from "./renderer";
 import { BatchState } from "./screens/batch";
@@ -60,25 +58,13 @@ export function Transcript({
         />
       )}
       {screen.kind === "ready" && (
-        <>
-          {screen.isFinalizing ? <FinalizingTranscriptBanner /> : null}
-          <TranscriptViewer
-            transcriptIds={screen.transcriptIds}
-            liveSegments={screen.liveSegments}
-            currentActive={screen.currentActive}
-            scrollRef={scrollRef}
-          />
-        </>
+        <TranscriptViewer
+          transcriptIds={screen.transcriptIds}
+          liveSegments={screen.liveSegments}
+          currentActive={screen.currentActive}
+          scrollRef={scrollRef}
+        />
       )}
-    </div>
-  );
-}
-
-function FinalizingTranscriptBanner() {
-  return (
-    <div className="bg-background/95 pointer-events-none absolute top-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium shadow-sm">
-      <Spinner size={14} />
-      <span>Finalizing transcript...</span>
     </div>
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/state.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/state.ts
@@ -35,7 +35,6 @@ export type TranscriptScreen =
       transcriptIds: string[];
       liveSegments: Segment[];
       currentActive: boolean;
-      isFinalizing: boolean;
     };
 
 export function useTranscriptScreen({
@@ -97,7 +96,6 @@ export function useTranscriptScreen({
     transcriptIds,
     liveSegments,
     currentActive,
-    isFinalizing: sessionMode === "finalizing",
   };
 }
 


### PR DESCRIPTION
Keep persisted transcript content unobstructed after meetings while finalization completes in the background.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in the desktop transcript panel; no auth, data, or transcription pipeline logic touched.
> 
> **Overview**
> Removes the **floating “Finalizing transcript…” banner** that appeared over the transcript viewer while a session was in `finalizing` mode after words were already on screen.
> 
> The **ready** transcript screen now always renders **`TranscriptViewer` alone**—no overlay, spinner import, or `isFinalizing` flag on `useTranscriptScreen`. Finalization still runs in the background; users keep reading persisted transcript text without obstruction.
> 
> Tests now assert that finalizing with existing content does **not** show that banner and still shows the viewer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d02c6755db70391a66be6c697c56e6033baaeb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->