### PR TITLE
Add desktop 1.3.6 changelog

### DIFF
--- a/packages/changelog/content/1.3.6.md
+++ b/packages/changelog/content/1.3.6.md
@@ -1,0 +1,15 @@
+---
+date: "2026-07-22"
+summary: "Anarlog 1.3.6 improves post-meeting recovery, keeps transcripts readable while finalizing, and opens a clean view after deleting the current note."
+---
+
+## Meetings & summaries
+
+- Recover unfinished words at the end of a live transcript from the recording before generating the summary
+- Retry cloud re-transcription automatically when your sign-in expires
+- Finish stalled summaries that already contain generated text, and explain when a transcript is too short to summarize
+- Keep the transcript readable while finalization continues in the background
+
+## Notes
+
+- Open a clean empty view after deleting the current note instead of returning to an older note from that tab


### PR DESCRIPTION
Document the user-facing desktop fixes shipping in the next stable release.

Validated with `pnpm exec dprint fmt` and `pnpm -F @hypr/changelog typecheck`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog package; no runtime or product code is modified.
> 
> **Overview**
> Adds **`packages/changelog/content/1.3.6.md`**, the user-facing changelog for the next stable desktop release, using the same frontmatter (`date`, `summary`) and section layout as earlier `1.3.x` entries.
> 
> **Meetings & summaries** documents post-meeting transcript recovery from the recording, automatic retry when cloud re-transcription fails after sign-in expiry, finishing stalled partial summaries with clearer “too short” messaging, and keeping the live transcript visible while finalization runs in the background.
> 
> **Notes** documents that deleting the current note opens an empty view in that tab instead of jumping back to an older note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b019f3cfeb52569b31ce6ee106ea790c44dc42d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->