### PR TITLE
Improve comparison article product visuals

### DIFF
--- a/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
@@ -108,9 +108,9 @@ Because capture happens on your device, Anarlog does not need to join the Teams 
 
 You can use a supported AI provider with your own key or connect a local model. This separates the transcription and note files from the model used to summarize them.
 
-![Anarlog displaying a locally stored meeting summary](/api/assets/blog/library/products/anarlog/desktop/2026-07-17-meeting-note.png)
+![Anarlog desktop quick-start screen with New Note, Start Recording, and Settings actions](/api/assets/blog/library/products/anarlog/desktop/2026-07-22-quick-start.jpg)
 
-*A current Anarlog desktop note using staged sample data, captured from an isolated demo profile on July 17, 2026.*
+*The current Anarlog desktop quick-start screen shows the bot-free recording entry point.*
 
 If the underlying workflow matters more than a feature checklist, see how [bot-free meeting notes differ from meeting-bot workflows](/blog/ai-meeting-notes-without-bot) and what to evaluate in a [local AI meeting-notes system](/blog/local-ai-meeting-notes).
 

--- a/apps/web/content/articles/granola-ai-alternatives.mdx
+++ b/apps/web/content/articles/granola-ai-alternatives.mdx
@@ -54,7 +54,9 @@ Pricing changes too often to be the foundation of a durable comparison. Check th
 
 [Anarlog](/) is an open-source, local-first meeting notetaker. It captures microphone and system audio without joining the call as a participant, transcribes the conversation, and keeps notes as plain Markdown files on your computer.
 
-<Image src="/api/assets/blog/library/products/anarlog/desktop/2026-07-17-meeting-note.png" alt="Anarlog desktop meeting note with a transcript, personal notes, and meeting controls" />
+<Image src="/api/assets/blog/library/products/anarlog/desktop/2026-07-22-quick-start.jpg" alt="Anarlog desktop quick-start screen with New Note, Start Recording, and Settings actions" />
+
+*The current Anarlog desktop quick-start screen shows the bot-free recording entry point.*
 
 The important difference is not simply that Anarlog is bot-free. Granola is bot-free too. The difference is what becomes the source of truth after the meeting.
 
@@ -81,9 +83,9 @@ If storage architecture is your main concern, read our deeper guide to [local AI
 
 [Jamie](https://www.meetjamie.ai/en) records online, hybrid, and in-person meetings without adding a bot. Its current product page advertises notes in more than 100 languages, automatic speaker labeling, European hosting, and integrations with tools including Notion, Google Docs, OneNote, and HubSpot.
 
-<Image src="/api/assets/blog/library/products/jamie/speaker-identification/2026-07-22-speaker-identification.webp" alt="Jamie interface identifying and labeling three speakers from a meeting" />
+<Image src="/api/assets/blog/library/products/jamie/meeting-notes/2026-07-22-meeting-notes.webp" alt="Jamie workspace showing a generated meeting note and AI assistant" />
 
-*Jamie's first-party editorial image demonstrates automatic speaker labeling in the current product. Source: [Jamie](https://www.meetjamie.ai/en/blog/ai-note-taker).*
+*Jamie's first-party editorial image shows the current meeting-note workspace and Ask AI entry point. Source: [Jamie](https://www.meetjamie.ai/en/blog/ai-note-taker).*
 
 Jamie is the closest alternative here when you like Granola's quiet, bot-free meeting experience but want a different managed product. The interface handles transcription, structured summaries, action items, speaker recognition, and cross-meeting questions without asking you to assemble a local AI stack.
 
@@ -133,9 +135,9 @@ Tactiq is less like a local meeting memory system and more like an efficient tra
 
 [Notta](https://www.notta.ai/en) covers more recording situations than a desktop-only meeting notepad. It supports live online meetings, mobile and desktop recording, imported audio and video, transcription, translation, summaries, and a searchable workspace.
 
-<Image src="/api/assets/blog/library/products/notta/ai-brain/2026-07-19-notta-brain.webp" alt="Notta Brain interface for asking questions across meeting files and creating follow-up material" />
+<Image src="/api/assets/blog/library/products/notta/cross-device-transcription/2026-07-22-cross-device-transcription.webp" alt="Notta desktop and mobile interfaces showing AI notes, speakers, and transcript playback" />
 
-*Notta Brain turns meeting material into questions and follow-up deliverables inside the Notta workspace. Source: [Notta](https://www.notta.ai/en).*
+*Notta's first-party product image shows the same meeting record across its desktop and mobile interfaces. Source: [Notta](https://www.notta.ai/en/features/ai-transcription).*
 
 Notta's [language documentation](https://support.notta.ai/hc/en-us/articles/4403155631131-What-languages-does-Notta-support) currently lists 58 languages for monolingual transcription, with separate language sets for translation, real-time translation, and bilingual transcription. That distinction matters: a product may advertise a large total while supporting a smaller set in the exact mode you need.
 

--- a/apps/web/content/articles/otter-ai-alternatives.mdx
+++ b/apps/web/content/articles/otter-ai-alternatives.mdx
@@ -63,7 +63,9 @@ Pricing changes too frequently to be a reliable differentiator in a long-lived c
 
 It captures meeting audio from your device without joining the call as a participant. Transcription can run locally, and your audio, transcripts, and notes remain available as files on your computer. You can use local models, connect your own AI provider, or use Anarlog’s hosted AI depending on the workflow you want.
 
-<Image src="/api/assets/blog/library/products/anarlog/desktop/2026-07-17-meeting-note.png" alt="Anarlog desktop meeting note with a live transcript, personal notes, and local meeting controls" />
+<Image src="/api/assets/blog/library/products/anarlog/desktop/2026-07-22-quick-start.jpg" alt="Anarlog desktop quick-start screen with New Note, Start Recording, and Settings actions" />
+
+*The current Anarlog desktop quick-start screen shows the bot-free recording entry point.*
 
 That difference becomes more important after the meeting. A local, file-based record can participate in the rest of your knowledge system: folders, search tools, scripts, backups, editors, and coding agents. You are not limited to whatever integrations the notetaker vendor decides to maintain.
 
@@ -171,9 +173,9 @@ Notta is the strongest multilingual option in this shortlist.
 
 Its current documentation lists 58 monolingual transcription languages, along with separate bilingual transcription and translation capabilities. Language availability differs by feature, so verify the exact language pair and workflow you need rather than relying on the headline number. [Notta language support](https://support.notta.ai/hc/en-us/articles/4403155631131-What-languages-does-Notta-support)
 
-<Image src="/api/assets/blog/library/products/notta/ai-brain/2026-07-19-notta-brain.webp" alt="Notta Brain interface for asking questions across meeting files and generating images or slides" />
+<Image src="/api/assets/blog/library/products/notta/cross-device-transcription/2026-07-22-cross-device-transcription.webp" alt="Notta desktop and mobile interfaces showing AI notes, speakers, and transcript playback" />
 
-*Notta Brain turns meeting material into questions and deliverables inside the Notta workspace. Source: [Notta](https://www.notta.ai/en).*
+*Notta's first-party product image shows the same meeting record across its desktop and mobile interfaces. Source: [Notta](https://www.notta.ai/en/features/ai-transcription).*
 
 Notta supports online meetings, in-person recording, and imported media. That makes it useful for teams whose “meeting notes” also include interviews, lectures, field recordings, or conversations captured across several devices.
 


### PR DESCRIPTION
Replace weak Jamie and Notta crops with verified first-party workflow images and refresh Anarlog screenshots across comparison posts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only MDX image and caption updates with no application or data-handling changes.
> 
> **Overview**
> Updates **product visuals** in three comparison MDX articles (`best-ai-notetaker-for-microsoft-teams`, `granola-ai-alternatives`, `otter-ai-alternatives`) so screenshots match current, first-party workflows.
> 
> **Anarlog** sections now use the **2026-07-22 quick-start** image (replacing the older meeting-note screenshot) with new alt text and a caption about the bot-free recording entry point.
> 
> **Jamie** (Granola alternatives) swaps a speaker-identification crop for a **meeting-notes workspace** image and revises the caption to highlight Ask AI.
> 
> **Notta** in Granola and Otter alternatives replaces **Notta Brain** imagery with **cross-device transcription** desktop/mobile shots and updated source links and captions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a0197bfed751a097e1b16212a84ad045ce870ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->