### PR TITLE
Keep local interactions responsive

### DIFF
--- a/apps/desktop/src/db/write-queue.test.ts
+++ b/apps/desktop/src/db/write-queue.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { enqueueDatabaseWrite, flushDatabaseWrites } from "./write-queue";
+import {
+  enqueueDatabaseWrite,
+  flushDatabaseWrites,
+  flushDatabaseWritesByPrefix,
+  flushDatabaseWritesWithin,
+} from "./write-queue";
 
 describe("database write queue", () => {
   it("serializes writes for the same record", async () => {
@@ -122,9 +127,171 @@ describe("database write queue", () => {
     await expect(flush).rejects.toThrow("first write failed");
   });
 
+  it("drains writes added to an earlier key while another key is pending", async () => {
+    let releaseFirst: (() => void) | undefined;
+    let releaseSecond: (() => void) | undefined;
+    let releaseLateFirst: (() => void) | undefined;
+    const first = enqueueDatabaseWrite(
+      "session:first",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        }),
+    );
+    const second = enqueueDatabaseWrite(
+      "session:second",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSecond = resolve;
+        }),
+    );
+    const flushed = vi.fn();
+    const flush = flushDatabaseWrites(["session:first", "session:second"]).then(
+      flushed,
+    );
+
+    await vi.waitFor(() => {
+      expect(releaseFirst).toBeTypeOf("function");
+      expect(releaseSecond).toBeTypeOf("function");
+    });
+    releaseFirst?.();
+    await first;
+    await Promise.resolve();
+    const lateFirst = enqueueDatabaseWrite(
+      "session:first",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseLateFirst = resolve;
+        }),
+    );
+    await vi.waitFor(() => expect(releaseLateFirst).toBeTypeOf("function"));
+
+    releaseSecond?.();
+    await second;
+    expect(flushed).not.toHaveBeenCalled();
+
+    releaseLateFirst?.();
+    await Promise.all([lateFirst, flush]);
+    expect(flushed).toHaveBeenCalledOnce();
+  });
+
   it("returns a serialized write's result", async () => {
     await expect(
       enqueueDatabaseWrite("human:1", async () => "human-1"),
     ).resolves.toBe("human-1");
+  });
+
+  it("flushes a write domain without waiting for unrelated keys", async () => {
+    let releaseCache: (() => void) | undefined;
+    let releaseBackground: (() => void) | undefined;
+    const cacheWrite = enqueueDatabaseWrite(
+      "shared-note-cache:viewer-1",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseCache = resolve;
+        }),
+    );
+    const backgroundWrite = enqueueDatabaseWrite(
+      "background-sync",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseBackground = resolve;
+        }),
+    );
+
+    const flushed = vi.fn();
+    const flush = flushDatabaseWritesByPrefix(["shared-note-cache:"]).then(
+      flushed,
+    );
+    await vi.waitFor(() => {
+      expect(releaseCache).toBeTypeOf("function");
+      expect(releaseBackground).toBeTypeOf("function");
+    });
+
+    releaseCache?.();
+    await Promise.all([cacheWrite, flush]);
+    expect(flushed).toHaveBeenCalledOnce();
+
+    releaseBackground?.();
+    await backgroundWrite;
+  });
+
+  it("drains sibling prefix writes before reporting a failure", async () => {
+    let rejectFirst: ((error: Error) => void) | undefined;
+    let releaseSibling: (() => void) | undefined;
+    let releaseLate: (() => void) | undefined;
+    const first = enqueueDatabaseWrite(
+      "shared-note-cache:first",
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectFirst = reject;
+        }),
+    );
+    const sibling = enqueueDatabaseWrite(
+      "shared-note-cache:sibling",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSibling = resolve;
+        }),
+    );
+    const flush = flushDatabaseWritesByPrefix(["shared-note-cache:"]);
+
+    await vi.waitFor(() => {
+      expect(rejectFirst).toBeTypeOf("function");
+      expect(releaseSibling).toBeTypeOf("function");
+    });
+    rejectFirst?.(new Error("first write failed"));
+    await expect(first).rejects.toThrow("first write failed");
+    await Promise.resolve();
+    const late = enqueueDatabaseWrite(
+      "shared-note-cache:first",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseLate = resolve;
+        }),
+    );
+    await vi.waitFor(() => expect(releaseLate).toBeTypeOf("function"));
+
+    releaseSibling?.();
+    await sibling;
+    let flushSettled = false;
+    void flush.then(
+      () => {
+        flushSettled = true;
+      },
+      () => {
+        flushSettled = true;
+      },
+    );
+    await Promise.resolve();
+    expect(flushSettled).toBe(false);
+
+    releaseLate?.();
+    await late;
+    await expect(flush).rejects.toThrow("first write failed");
+  });
+
+  it("bounds lifecycle flushes without discarding the pending write", async () => {
+    let rejectWrite: ((error: Error) => void) | undefined;
+    const write = enqueueDatabaseWrite(
+      "session:slow",
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectWrite = reject;
+        }),
+    );
+    await vi.waitFor(() => expect(rejectWrite).toBeTypeOf("function"));
+    vi.useFakeTimers();
+
+    const flush = flushDatabaseWritesWithin(5000);
+    const rejection = expect(flush).rejects.toThrow(
+      "Timed out waiting for local database writes",
+    );
+    await vi.advanceTimersByTimeAsync(5000);
+    await rejection;
+
+    vi.useRealTimers();
+    rejectWrite?.(new Error("late write failure"));
+    await expect(write).rejects.toThrow("late write failure");
   });
 });

--- a/apps/desktop/src/db/write-queue.ts
+++ b/apps/desktop/src/db/write-queue.ts
@@ -22,8 +22,27 @@ export async function flushDatabaseWrites(
   keys?: readonly string[],
 ): Promise<void> {
   if (keys) {
-    await Promise.all([...new Set(keys)].map(flushDatabaseWriteKey));
-    return;
+    const uniqueKeys = [...new Set(keys)];
+    let failed = false;
+    let failure: unknown;
+    while (true) {
+      const activeKeys = uniqueKeys.filter((key) => tails.has(key));
+      if (activeKeys.length === 0) {
+        if (failed) throw failure;
+        return;
+      }
+      const results = await Promise.allSettled(
+        activeKeys.map(flushDatabaseWriteKey),
+      );
+      const rejected = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (!failed && rejected) {
+        failed = true;
+        failure = rejected.reason;
+      }
+    }
   }
 
   while (pending.size > 0) {
@@ -32,6 +51,53 @@ export async function flushDatabaseWrites(
       (result): result is PromiseRejectedResult => result.status === "rejected",
     );
     if (failure) throw failure.reason;
+  }
+}
+
+export async function flushDatabaseWritesByPrefix(
+  prefixes: readonly string[],
+): Promise<void> {
+  const uniquePrefixes = [...new Set(prefixes)];
+  let failed = false;
+  let failure: unknown;
+  while (true) {
+    const keys = [...tails.keys()].filter((key) =>
+      uniquePrefixes.some((prefix) => key.startsWith(prefix)),
+    );
+    if (keys.length === 0) {
+      if (failed) throw failure;
+      return;
+    }
+    const results = await Promise.allSettled(keys.map(flushDatabaseWriteKey));
+    const rejected = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (!failed && rejected) {
+      failed = true;
+      failure = rejected.reason;
+    }
+  }
+}
+
+export async function flushDatabaseWritesWithin(
+  timeoutMs: number,
+  keys?: readonly string[],
+): Promise<void> {
+  const flush = flushDatabaseWrites(keys);
+  const timeoutError = new Error("Timed out waiting for local database writes");
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      flush,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(timeoutError), timeoutMs);
+      }),
+    ]);
+  } catch (error) {
+    if (error === timeoutError) void flush.catch(() => undefined);
+    throw error;
+  } finally {
+    if (timeout) clearTimeout(timeout);
   }
 }
 

--- a/apps/desktop/src/services/calendar/ctx.test.ts
+++ b/apps/desktop/src/services/calendar/ctx.test.ts
@@ -10,6 +10,10 @@ const storage = vi.hoisted(() => ({
   loadEnabledCalendars: vi.fn(),
 }));
 
+const writeQueue = vi.hoisted(() => ({
+  enqueueDatabaseWrite: vi.fn(),
+}));
+
 vi.mock("@hypr/plugin-calendar", () => ({
   commands: {
     listConnectionIds: pluginCalendar.listConnectionIds,
@@ -18,12 +22,16 @@ vi.mock("@hypr/plugin-calendar", () => ({
 }));
 
 vi.mock("./storage", () => storage);
+vi.mock("~/db/write-queue", () => writeQueue);
 
 import { createCtx, getProviderConnections, syncCalendars } from "./ctx";
 
 describe("calendar sync context", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    writeQueue.enqueueDatabaseWrite.mockImplementation(
+      (_key: string, write: () => Promise<unknown>) => write(),
+    );
     storage.applyCalendarInventory.mockResolvedValue(undefined);
     storage.loadEnabledCalendars.mockResolvedValue([
       {
@@ -113,6 +121,10 @@ describe("calendar sync context", () => {
         },
       ],
     });
+    expect(writeQueue.enqueueDatabaseWrite).toHaveBeenCalledWith(
+      "calendar-sync",
+      expect.any(Function),
+    );
   });
 
   test("does not treat a failed calendar listing as an empty listing", async () => {

--- a/apps/desktop/src/services/calendar/ctx.ts
+++ b/apps/desktop/src/services/calendar/ctx.ts
@@ -7,6 +7,8 @@ import type {
 
 import { applyCalendarInventory, loadEnabledCalendars } from "./storage";
 
+import { enqueueDatabaseWrite } from "~/db/write-queue";
+
 export interface Ctx {
   provider: CalendarProviderType;
   connectionId: string;
@@ -60,9 +62,10 @@ export async function getProviderConnections(): Promise<
 export async function syncCalendars(
   providerConnections: ProviderConnectionIds[],
   signal?: AbortSignal,
+  shouldStop: () => boolean = () => signal?.aborted === true,
 ): Promise<void> {
   for (const { provider, connection_ids } of providerConnections) {
-    if (signal?.aborted) return;
+    if (shouldStop()) return;
 
     const successfulConnections: Array<{
       connectionId: string;
@@ -70,22 +73,25 @@ export async function syncCalendars(
     }> = [];
 
     for (const connectionId of connection_ids) {
-      if (signal?.aborted) return;
+      if (shouldStop()) return;
 
       const result = await calendarCommands.listCalendars(
         provider,
         connectionId,
       );
-      if (signal?.aborted) return;
+      if (shouldStop()) return;
       if (result.status === "error") continue;
       successfulConnections.push({ connectionId, calendars: result.data });
     }
 
-    if (signal?.aborted) return;
-    await applyCalendarInventory({
-      provider,
-      requestedConnectionIds: connection_ids,
-      successfulConnections,
+    if (shouldStop()) return;
+    await enqueueDatabaseWrite("calendar-sync", async () => {
+      if (shouldStop()) return;
+      await applyCalendarInventory({
+        provider,
+        requestedConnectionIds: connection_ids,
+        successfulConnections,
+      });
     });
   }
 }

--- a/apps/desktop/src/services/calendar/index.test.ts
+++ b/apps/desktop/src/services/calendar/index.test.ts
@@ -25,6 +25,10 @@ const storageMocks = vi.hoisted(() => ({
   tombstoneCalendarConnection: vi.fn(),
 }));
 
+const writeQueueMocks = vi.hoisted(() => ({
+  enqueueDatabaseWrite: vi.fn(),
+}));
+
 vi.mock("./ctx", () => ctxMocks);
 
 vi.mock("./fetch", () => ({
@@ -35,14 +39,10 @@ vi.mock("./fetch", () => ({
 
 vi.mock("./process", () => processMocks);
 vi.mock("./storage", () => storageMocks);
-vi.mock("~/db/write-queue", () => ({
-  enqueueDatabaseWrite: (
-    _key: string,
-    write: () => Promise<unknown>,
-  ): Promise<unknown> => write(),
-}));
+vi.mock("~/db/write-queue", () => writeQueueMocks);
 
 import {
+  allowReconnectedCalendarConnections,
   CALENDAR_SYNC_TASK_ID,
   removeDisconnectedCalendarConnection,
   scheduleCalendarSync,
@@ -64,6 +64,9 @@ const managers: ReturnType<typeof createManager>[] = [];
 describe("syncCalendarEventsForRange", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    writeQueueMocks.enqueueDatabaseWrite.mockImplementation(
+      (_key: string, write: () => Promise<unknown>) => write(),
+    );
     ctxMocks.getProviderConnections.mockResolvedValue([
       { provider: "google", connection_ids: ["conn-1"] },
     ]);
@@ -116,6 +119,23 @@ describe("syncCalendarEventsForRange", () => {
     expect(ctxMocks.getProviderConnections).not.toHaveBeenCalled();
   });
 
+  test("allows recovery sync when disconnect persistence fails", async () => {
+    storageMocks.tombstoneCalendarConnection.mockRejectedValueOnce(
+      new Error("write failed"),
+    );
+
+    await expect(
+      removeDisconnectedCalendarConnection("google-calendar", "conn-1"),
+    ).rejects.toThrow("write failed");
+    await syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+
+    expect(ctxMocks.syncCalendars).toHaveBeenCalledWith(
+      [{ provider: "google", connection_ids: ["conn-1"] }],
+      undefined,
+      expect.any(Function),
+    );
+  });
+
   test("does not start a range sync when already aborted", async () => {
     const abortController = new AbortController();
     abortController.abort();
@@ -139,6 +159,187 @@ describe("syncCalendarEventsForRange", () => {
     await syncCalendarEvents({ signal: abortController.signal });
 
     expect(ctxMocks.getProviderConnections).not.toHaveBeenCalled();
+  });
+
+  test("does not hold the database write queue while remote discovery is pending", async () => {
+    let resolveConnections:
+      | ((
+          connections: Array<{ provider: string; connection_ids: string[] }>,
+        ) => void)
+      | undefined;
+    ctxMocks.getProviderConnections.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveConnections = resolve;
+      }),
+    );
+
+    const sync = syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+    await vi.waitFor(() => {
+      expect(ctxMocks.getProviderConnections).toHaveBeenCalledOnce();
+    });
+
+    expect(writeQueueMocks.enqueueDatabaseWrite).not.toHaveBeenCalled();
+
+    resolveConnections?.([]);
+    await sync;
+  });
+
+  test("serializes remote calendar syncs outside the database write queue", async () => {
+    let resolveFirst:
+      | ((
+          connections: Array<{ provider: string; connection_ids: string[] }>,
+        ) => void)
+      | undefined;
+    ctxMocks.getProviderConnections
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockResolvedValueOnce([]);
+
+    const first = syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+    const second = syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+    await vi.waitFor(() => {
+      expect(ctxMocks.getProviderConnections).toHaveBeenCalledOnce();
+    });
+
+    resolveFirst?.([]);
+    await first;
+    await second;
+
+    expect(ctxMocks.getProviderConnections).toHaveBeenCalledTimes(2);
+    expect(writeQueueMocks.enqueueDatabaseWrite).not.toHaveBeenCalled();
+  });
+
+  test("starts a queued sync with the latest connection generation", async () => {
+    let resolveFirst:
+      | ((
+          connections: Array<{ provider: string; connection_ids: string[] }>,
+        ) => void)
+      | undefined;
+    ctxMocks.getProviderConnections.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+
+    const first = syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+    const second = syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+    await vi.waitFor(() => {
+      expect(ctxMocks.getProviderConnections).toHaveBeenCalledOnce();
+    });
+
+    await removeDisconnectedCalendarConnection(
+      "google-calendar",
+      "conn-removed",
+    );
+    resolveFirst?.([{ provider: "google", connection_ids: ["conn-1"] }]);
+    await Promise.all([first, second]);
+
+    expect(ctxMocks.getProviderConnections).toHaveBeenCalledTimes(2);
+    expect(ctxMocks.syncCalendars).toHaveBeenCalledWith(
+      [{ provider: "google", connection_ids: ["conn-1"] }],
+      undefined,
+      expect.any(Function),
+    );
+  });
+
+  test("disconnect invalidates remote work before it can restore stale data", async () => {
+    let resolveConnections:
+      | ((
+          connections: Array<{ provider: string; connection_ids: string[] }>,
+        ) => void)
+      | undefined;
+    ctxMocks.getProviderConnections.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveConnections = resolve;
+      }),
+    );
+
+    const sync = syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+    await vi.waitFor(() => {
+      expect(ctxMocks.getProviderConnections).toHaveBeenCalledOnce();
+    });
+
+    await removeDisconnectedCalendarConnection("google-calendar", "conn-1");
+    resolveConnections?.([{ provider: "google", connection_ids: ["conn-1"] }]);
+    await sync;
+
+    expect(storageMocks.tombstoneCalendarConnection).toHaveBeenCalledWith(
+      "google",
+      "conn-1",
+    );
+    expect(ctxMocks.syncCalendars).not.toHaveBeenCalled();
+    expect(fetchMocks.fetchIncomingEvents).not.toHaveBeenCalled();
+
+    ctxMocks.getProviderConnections.mockResolvedValueOnce([]);
+    await syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+
+    ctxMocks.syncCalendars.mockClear();
+    await syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+    expect(ctxMocks.syncCalendars).toHaveBeenCalledWith(
+      [],
+      undefined,
+      expect.any(Function),
+    );
+    expect(ctxMocks.createCtx).not.toHaveBeenCalled();
+  });
+
+  test("ignores a stale connection without syncing provider inventory", async () => {
+    await removeDisconnectedCalendarConnection("google-calendar", "conn-1");
+    ctxMocks.syncCalendars.mockClear();
+
+    await syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+
+    expect(ctxMocks.syncCalendars).toHaveBeenCalledWith(
+      [],
+      undefined,
+      expect.any(Function),
+    );
+    expect(ctxMocks.createCtx).not.toHaveBeenCalled();
+    expect(fetchMocks.fetchIncomingEvents).not.toHaveBeenCalled();
+
+    ctxMocks.getProviderConnections.mockResolvedValueOnce([]);
+    await syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+  });
+
+  test("allows a calendar connection after the provider reconnects", async () => {
+    await removeDisconnectedCalendarConnection("google-calendar", "conn-1");
+    allowReconnectedCalendarConnections("google-calendar");
+    ctxMocks.syncCalendars.mockClear();
+
+    await syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+
+    expect(ctxMocks.syncCalendars).toHaveBeenCalledWith(
+      [{ provider: "google", connection_ids: ["conn-1"] }],
+      undefined,
+      expect.any(Function),
+    );
+    expect(ctxMocks.createCtx).toHaveBeenCalledWith(
+      "google",
+      "conn-1",
+      expect.anything(),
+    );
+  });
+
+  test("reconnect invalidates a sync that filtered the disconnected connection", async () => {
+    await removeDisconnectedCalendarConnection("google-calendar", "conn-1");
+    ctxMocks.syncCalendars.mockImplementationOnce(
+      async (_connections, _signal, shouldStop) => {
+        allowReconnectedCalendarConnections("google-calendar");
+        expect(shouldStop()).toBe(true);
+      },
+    );
+
+    await syncCalendarEventsForRange({ from: ctx.from, to: ctx.to });
+
+    expect(ctxMocks.syncCalendars).toHaveBeenCalledWith(
+      [],
+      undefined,
+      expect.any(Function),
+    );
+    expect(ctxMocks.createCtx).not.toHaveBeenCalled();
   });
 
   test("reuses an active scheduled calendar sync", () => {
@@ -251,5 +452,9 @@ describe("syncCalendarEventsForRange", () => {
       sessionUpdates,
       participants,
     });
+    expect(writeQueueMocks.enqueueDatabaseWrite).toHaveBeenCalledWith(
+      "calendar-sync",
+      expect.any(Function),
+    );
   });
 });

--- a/apps/desktop/src/services/calendar/index.ts
+++ b/apps/desktop/src/services/calendar/index.ts
@@ -34,13 +34,24 @@ type CalendarSyncOptions = {
   signal?: AbortSignal;
 };
 
+let calendarSyncTail: Promise<void> = Promise.resolve();
+let calendarSyncGeneration = 0;
+const disconnectedCalendarConnections = new Set<string>();
+
+function enqueueCalendarSync(sync: () => Promise<void>): Promise<void> {
+  const result = calendarSyncTail.catch(() => undefined).then(sync);
+  calendarSyncTail = result.catch(() => undefined);
+  return result;
+}
+
 export function syncCalendarEvents(
   options: CalendarSyncOptions = {},
 ): Promise<void> {
-  return enqueueDatabaseWrite("calendar-sync", async () => {
+  return enqueueCalendarSync(async () => {
+    const generation = calendarSyncGeneration;
     await Promise.all([
       new Promise((resolve) => setTimeout(resolve, 250)),
-      run(undefined, options),
+      run(undefined, options, generation),
     ]);
   });
 }
@@ -61,45 +72,70 @@ export function syncCalendarEventsForRange(
   range: CalendarSyncRange,
   options: CalendarSyncOptions = {},
 ): Promise<void> {
-  return enqueueDatabaseWrite("calendar-sync", () => run(range, options));
+  return enqueueCalendarSync(() => run(range, options, calendarSyncGeneration));
 }
 
 export function removeDisconnectedCalendarConnection(
   integrationId: string,
   connectionId: string,
 ): Promise<void> {
-  const provider: CalendarProviderType | null =
-    integrationId === "google-calendar"
-      ? "google"
-      : integrationId === "outlook"
-        ? "outlook"
-        : null;
+  const provider = calendarProviderForIntegration(integrationId);
 
   if (!provider) return Promise.resolve();
 
+  const key = connectionKey(provider, connectionId);
+  calendarSyncGeneration += 1;
+  disconnectedCalendarConnections.add(key);
   return enqueueDatabaseWrite("calendar-sync", () =>
     tombstoneCalendarConnection(provider, connectionId),
-  );
+  ).catch((error) => {
+    disconnectedCalendarConnections.delete(key);
+    throw error;
+  });
+}
+
+export function allowReconnectedCalendarConnections(
+  integrationId: string,
+): void {
+  const provider = calendarProviderForIntegration(integrationId);
+  if (!provider) return;
+
+  calendarSyncGeneration += 1;
+  const prefix = `${provider}:`;
+  for (const key of disconnectedCalendarConnections) {
+    if (key.startsWith(prefix)) disconnectedCalendarConnections.delete(key);
+  }
 }
 
 async function run(
   range?: CalendarSyncRange,
   options: CalendarSyncOptions = {},
+  generation = calendarSyncGeneration,
 ) {
-  if (isAborted(options.signal)) return;
+  const shouldStop = () => isStopped(options.signal, generation);
+  if (shouldStop()) return;
 
-  const providerConnections = await getProviderConnections();
-  if (isAborted(options.signal)) return;
+  const discoveredConnections = await getProviderConnections();
+  if (shouldStop()) return;
+  const providerConnections = excludeDisconnectedConnections(
+    discoveredConnections,
+  );
 
-  await syncCalendars(providerConnections, options.signal);
-  if (isAborted(options.signal)) return;
+  await syncCalendars(providerConnections, options.signal, shouldStop);
+  if (shouldStop()) return;
 
   for (const { provider, connection_ids } of providerConnections) {
     for (const connectionId of connection_ids) {
-      if (isAborted(options.signal)) return;
+      if (shouldStop()) return;
 
       try {
-        await runForConnection(provider, connectionId, range, options);
+        await runForConnection(
+          provider,
+          connectionId,
+          range,
+          options,
+          generation,
+        );
       } catch (error) {
         console.error(
           `[calendar-sync] Error syncing ${provider} (${connectionId}): ${error}`,
@@ -114,9 +150,11 @@ async function runForConnection(
   connectionId: string,
   range?: CalendarSyncRange,
   options: CalendarSyncOptions = {},
+  generation = calendarSyncGeneration,
 ) {
+  const shouldStop = () => isStopped(options.signal, generation);
   const ctx = await createCtx(provider, connectionId, range);
-  if (isAborted(options.signal)) return;
+  if (shouldStop()) return;
 
   let incoming;
   let incomingParticipants;
@@ -135,10 +173,10 @@ async function runForConnection(
     throw error;
   }
 
-  if (isAborted(options.signal)) return;
+  if (shouldStop()) return;
 
   const existing = await fetchExistingEvents(ctx, incoming);
-  if (isAborted(options.signal)) return;
+  if (shouldStop()) return;
 
   const events = syncEvents(ctx, {
     incoming,
@@ -148,27 +186,63 @@ async function runForConnection(
   const sessions = await loadSessionsForTrackingIds(
     incoming.map((event) => event.tracking_id_event),
   );
-  if (isAborted(options.signal)) return;
+  if (shouldStop()) return;
 
   const sessionUpdates = syncSessionEmbeddedEvents(ctx, incoming, sessions);
   const participantSnapshot = await loadParticipantSyncSnapshot(
     sessions,
     incomingParticipants,
   );
-  if (isAborted(options.signal)) return;
+  if (shouldStop()) return;
 
   const participants = syncSessionParticipants({
     incomingParticipants,
     snapshot: participantSnapshot,
   });
-  await applyConnectionSync({
-    ctx,
-    events,
-    sessionUpdates,
-    participants,
+  await enqueueDatabaseWrite("calendar-sync", async () => {
+    if (shouldStop()) return;
+    await applyConnectionSync({
+      ctx,
+      events,
+      sessionUpdates,
+      participants,
+    });
   });
 }
 
-function isAborted(signal: AbortSignal | undefined) {
-  return signal?.aborted === true;
+function isStopped(signal: AbortSignal | undefined, generation: number) {
+  return signal?.aborted === true || generation !== calendarSyncGeneration;
+}
+
+function excludeDisconnectedConnections(
+  providerConnections: Awaited<ReturnType<typeof getProviderConnections>>,
+) {
+  return providerConnections.flatMap(({ provider, connection_ids }) => {
+    const activeConnectionIds = connection_ids.filter(
+      (connectionId) =>
+        !disconnectedCalendarConnections.has(
+          connectionKey(provider, connectionId),
+        ),
+    );
+    return activeConnectionIds.length > 0
+      ? [{ provider, connection_ids: activeConnectionIds }]
+      : [];
+  });
+}
+
+function connectionKey(
+  provider: CalendarProviderType,
+  connectionId: string,
+): string {
+  return `${provider}:${connectionId}`;
+}
+
+function calendarProviderForIntegration(
+  integrationId: string,
+): CalendarProviderType | null {
+  return integrationId === "google-calendar"
+    ? "google"
+    : integrationId === "outlook"
+      ? "outlook"
+      : null;
 }

--- a/apps/desktop/src/session-sharing/attachments.test.ts
+++ b/apps/desktop/src/session-sharing/attachments.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it, vi } from "vitest";
 
+const dbMocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+  flushDatabaseWrites: vi.fn(),
+}));
+
+vi.mock("~/db", () => ({
+  liveQueryClient: { execute: dbMocks.execute },
+  useLiveQuery: vi.fn(),
+}));
+
+vi.mock("~/db/write-queue", () => ({
+  flushDatabaseWrites: dbMocks.flushDatabaseWrites,
+}));
+
 import {
   addSharedAttachmentIds,
   isAttachmentShareable,
+  loadSessionShareAttachments,
   matchSharedAttachmentsToLocal,
   prepareSessionShareAttachment,
   restoreLocalAttachmentIds,
@@ -27,6 +42,18 @@ const attachment: SessionShareAttachment = {
 };
 
 describe("shared attachment selection", () => {
+  it("waits for session and transfer writes before reading attachments", async () => {
+    dbMocks.execute.mockResolvedValueOnce([]);
+    dbMocks.flushDatabaseWrites.mockResolvedValueOnce(undefined);
+
+    await expect(loadSessionShareAttachments("session-1")).resolves.toEqual([]);
+
+    expect(dbMocks.flushDatabaseWrites).toHaveBeenCalledWith([
+      "session:session-1",
+      "attachment-transfers",
+    ]);
+  });
+
   it("requires a completed private backup before sharing", async () => {
     expect(isAttachmentShareable(attachment)).toBe(true);
     expect(

--- a/apps/desktop/src/session-sharing/attachments.ts
+++ b/apps/desktop/src/session-sharing/attachments.ts
@@ -109,7 +109,7 @@ export function useSessionShareAttachments(sessionId: string) {
 }
 
 export async function loadSessionShareAttachments(sessionId: string) {
-  await flushDatabaseWrites();
+  await flushDatabaseWrites([`session:${sessionId}`, "attachment-transfers"]);
   return mapAttachmentRows(
     await liveQueryClient.execute<AttachmentRow>(SESSION_ATTACHMENTS_SQL, [
       sessionId,

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -169,7 +169,22 @@ vi.mock("@hypr/ui/components/ui/popover", () => ({
   AppFloatingPanel: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Popover: ({
+    children,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    onOpenChange?: (open: boolean) => void;
+  }) => (
+    <div
+      data-testid="share-popover-root"
+      onKeyDown={(event) => {
+        if (event.key === "Escape") onOpenChange?.(false);
+      }}
+    >
+      {children}
+    </div>
+  ),
   PopoverContent: ({
     children,
     className,
@@ -534,6 +549,85 @@ describe("SessionShareButton", () => {
     expect(mocks.loadSessionShareSource).toHaveBeenCalledOnce();
   });
 
+  it("cancels preparation immediately when the pending popover is dismissed", async () => {
+    let resolveSource: ((value: any) => void) | undefined;
+    mocks.loadSessionShareSource.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSource = resolve;
+      }),
+    );
+    renderShareButton();
+
+    const trigger = screen.getByRole("button", { name: "Share note" });
+    fireEvent.click(trigger);
+    expect(await screen.findByText("Loading access…")).not.toBeNull();
+
+    const done = screen.getByRole("button", { name: "Done" });
+    expect((done as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.keyDown(screen.getByTestId("share-popover-root"), {
+      key: "Escape",
+    });
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+
+    await act(async () => {
+      resolveSource?.({
+        sessionId: "session-1",
+        workspaceId: WORKSPACE_ID,
+        title: "Planning",
+        body: { type: "doc", content: [] },
+      });
+      await Promise.resolve();
+    });
+
+    expect(mocks.createOrReuseSessionShare).not.toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("share-popover")).toBeNull();
+  });
+
+  it("does not let a dismissed free-share check clear a restarted preparation", async () => {
+    mocks.billing.isPaid = false;
+    let resolveFirstCheck!: (value: unknown) => void;
+    mocks.loadManagedSharedNoteForSession
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirstCheck = resolve;
+        }),
+      )
+      .mockResolvedValueOnce({
+        shareId: SHARE_ID,
+        workspaceId: WORKSPACE_ID,
+        sessionId: "session-1",
+      });
+    renderShareButton();
+
+    const trigger = screen.getByRole("button", { name: "Share note" });
+    fireEvent.click(trigger);
+    await waitFor(() =>
+      expect(mocks.loadManagedSharedNoteForSession).toHaveBeenCalledOnce(),
+    );
+
+    fireEvent.keyDown(screen.getByTestId("share-popover-root"), {
+      key: "Escape",
+    });
+    fireEvent.click(trigger);
+    expect(
+      await screen.findByRole("heading", { name: "People with access" }),
+    ).not.toBeNull();
+
+    await act(async () => {
+      resolveFirstCheck(null);
+    });
+
+    expect(
+      screen.getByRole("heading", { name: "People with access" }),
+    ).not.toBeNull();
+    expect(
+      screen.queryByRole("heading", { name: "Share notes with others" }),
+    ).toBeNull();
+  });
+
   it("validates the remote identity before publishing and then loads access", async () => {
     renderShareButton();
 
@@ -761,6 +855,7 @@ describe("SessionShareButton", () => {
       expect(mocks.loadSessionShareSyncState).toHaveBeenCalledWith(
         USER_ID,
         SHARE_ID,
+        "session-1",
       ),
     );
     expect(mocks.publishSessionShareSnapshot).not.toHaveBeenCalled();
@@ -789,6 +884,7 @@ describe("SessionShareButton", () => {
       expect(mocks.loadSessionShareSyncState).toHaveBeenCalledWith(
         USER_ID,
         SHARE_ID,
+        "session-1",
       ),
     );
     expect(mocks.publishSessionShareSnapshot).not.toHaveBeenCalled();
@@ -1365,6 +1461,34 @@ describe("SessionShareButton", () => {
     fireEvent.click(screen.getByRole("button", { name: "Share note" }));
     await act(async () => {
       resolveEmail?.();
+      await Promise.resolve();
+    });
+
+    expect(mocks.revokeSessionAccessInvitation).not.toHaveBeenCalled();
+    expect(mocks.clipboardWriteText).not.toHaveBeenCalled();
+  });
+
+  it("does not revoke an invitation when dismissed email delivery fails", async () => {
+    let rejectEmail!: (reason?: unknown) => void;
+    mocks.sendSessionAccessInvitationEmail.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectEmail = reject;
+      }),
+    );
+    renderShareButton();
+    await openSharePopover();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Invitee email" }), {
+      target: { value: "person@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+    await waitFor(() =>
+      expect(mocks.sendSessionAccessInvitationEmail).toHaveBeenCalledOnce(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Share note" }));
+    await act(async () => {
+      rejectEmail(new Error("mail unavailable"));
       await Promise.resolve();
     });
 

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -50,7 +50,6 @@ import {
 import {
   createOrReuseSessionShare,
   createSessionAccessInvitation,
-  enableSessionShareLink,
   getSessionShareManagement,
   listSessionShareAccess,
   publishSessionShareSnapshot,
@@ -58,7 +57,6 @@ import {
   reviewSessionAccessRequest,
   revokeSessionAccessGrant,
   revokeSessionAccessInvitation,
-  rotateSessionShareLink,
   setSessionShareScope,
   sendSessionAccessInvitationEmail,
   type SessionAccessCapability,
@@ -75,12 +73,11 @@ import {
   loadSessionShareSyncState,
   recordPublishedSessionShareState,
 } from "./reconciliation";
-import { loadSessionShareSource, useAvailableShareWorkspaces } from "./source";
+import { loadSessionShareSource } from "./source";
 import { useSessionShareSyncStatus } from "./sync-state";
 import {
   buildAccountSessionShareUrl,
   buildSessionInvitationUrl,
-  buildSessionShareLinkUrl,
   type ShareDesktopScheme,
 } from "./urls";
 
@@ -108,6 +105,7 @@ type SharePanelData = {
 type SharePreparationIdentity = {
   ownerUserId: string;
   sessionId: string;
+  attemptId: number;
 };
 
 type SharePanelIdentity = SharePreparationIdentity & {
@@ -179,10 +177,10 @@ function isInviteEmail(value: string) {
   );
 }
 
-class SharePreparationAbortedError extends ShareManagementError {
+class ShareOperationAbortedError extends ShareManagementError {
   constructor() {
     super();
-    this.name = "SharePreparationAbortedError";
+    this.name = "ShareOperationAbortedError";
   }
 }
 
@@ -200,6 +198,24 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
   const latestSessionIdRef = useRef(sessionId);
   latestSessionIdRef.current = sessionId;
   const prepareControllersRef = useRef(new Set<AbortController>());
+  const sharePreparationIdentityRef = useRef<SharePreparationIdentity | null>(
+    null,
+  );
+  const nextSharePreparationAttemptRef = useRef(0);
+  const cancelSharePreparation = () => {
+    for (const controller of prepareControllersRef.current) {
+      controller.abort();
+    }
+    prepareControllersRef.current.clear();
+  };
+  const isActiveSharePreparation = (identity: SharePreparationIdentity) => {
+    const active = sharePreparationIdentityRef.current;
+    return (
+      active?.ownerUserId === identity.ownerUserId &&
+      active.sessionId === identity.sessionId &&
+      active.attemptId === identity.attemptId
+    );
+  };
   const shareButtonLifecycleRef = useCallback(
     (node: HTMLButtonElement | null) => {
       if (node) return;
@@ -216,10 +232,12 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     const controller = new AbortController();
     prepareControllersRef.current.add(controller);
     try {
-      return await operation(controller.signal);
+      const result = await operation(controller.signal);
+      if (controller.signal.aborted) throw new ShareOperationAbortedError();
+      return result;
     } catch (error) {
       if (controller.signal.aborted) {
-        throw new SharePreparationAbortedError();
+        throw new ShareOperationAbortedError();
       }
       throw error;
     } finally {
@@ -253,10 +271,14 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
   const clearAbandonedSharePreparation = (
     identity: SharePreparationIdentity,
   ) => {
+    if (isActiveSharePreparation(identity)) {
+      sharePreparationIdentityRef.current = null;
+    }
     setSharePreparationIdentity((current) =>
       current &&
       current.ownerUserId === identity.ownerUserId &&
-      current.sessionId === identity.sessionId
+      current.sessionId === identity.sessionId &&
+      current.attemptId === identity.attemptId
         ? null
         : current,
     );
@@ -270,6 +292,8 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     (sharePreparationIdentity.ownerUserId !== accountUserId ||
       sharePreparationIdentity.sessionId !== sessionId)
   ) {
+    sharePreparationIdentityRef.current = null;
+    cancelSharePreparation();
     setSharePreparationIdentity(null);
     setWaitingForBilling(false);
   }
@@ -305,8 +329,6 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     accountUserId,
     activeSharePanelIdentity?.shareId ?? "",
   );
-  const workspaces = useAvailableShareWorkspaces(accountUserId);
-
   const initializeMutation = useMutation({
     mutationFn: ({
       publish,
@@ -413,6 +435,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
       }),
     onSuccess: ({ identity, data }) => {
       if (
+        !isActiveSharePreparation(identity) ||
         latestAuthRef.current.session?.user.id !== identity.ownerUserId ||
         latestSessionIdRef.current !== identity.sessionId
       ) {
@@ -426,12 +449,14 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
       void queryClient.invalidateQueries({
         queryKey: ["durable-shared-note-cache", identity.ownerUserId],
       });
+      sharePreparationIdentityRef.current = null;
       setSharePreparationIdentity(null);
       setSharePanelIdentity(identity);
     },
     onError: (error, variables) => {
       if (
-        error instanceof SharePreparationAbortedError ||
+        error instanceof ShareOperationAbortedError ||
+        !isActiveSharePreparation(variables.identity) ||
         latestAuthRef.current.session?.user.id !==
           variables.identity.ownerUserId ||
         latestSessionIdRef.current !== variables.identity.sessionId
@@ -448,6 +473,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
       loadManagedSharedNoteForSession(identity.ownerUserId, identity.sessionId),
     onSuccess: (managedShare, identity) => {
       if (
+        !isActiveSharePreparation(identity) ||
         latestAuthRef.current.session?.user.id !== identity.ownerUserId ||
         latestSessionIdRef.current !== identity.sessionId
       ) {
@@ -455,6 +481,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
         return;
       }
       if (!managedShare) {
+        sharePreparationIdentityRef.current = null;
         setSharePreparationIdentity(null);
         setUpgradePromptIdentity(identity);
         return;
@@ -463,6 +490,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     },
     onError: (_error, identity) => {
       if (
+        !isActiveSharePreparation(identity) ||
         latestAuthRef.current.session?.user.id !== identity.ownerUserId ||
         latestSessionIdRef.current !== identity.sessionId
       ) {
@@ -501,6 +529,8 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
   );
 
   const closeSharePopover = () => {
+    sharePreparationIdentityRef.current = null;
+    cancelSharePreparation();
     setSharePanelIdentity(null);
     setSharePreparationIdentity(null);
     setWaitingForBilling(false);
@@ -510,6 +540,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
   };
 
   const runSharePreparation = (identity: SharePreparationIdentity) => {
+    if (!isActiveSharePreparation(identity)) return;
     setWaitingForBilling(false);
     if (!billing.isPaid) {
       freeShareMutation.mutate(identity);
@@ -518,22 +549,29 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     initializeMutation.mutate({ publish: true, identity });
   };
 
-  const startSharePreparation = (identity: SharePreparationIdentity) => {
+  const startSharePreparation = (
+    identity: Omit<SharePreparationIdentity, "attemptId">,
+  ) => {
+    cancelSharePreparation();
     initializeMutation.reset();
     freeShareMutation.reset();
-    setSharePreparationIdentity(identity);
+    const preparation = {
+      ...identity,
+      attemptId: nextSharePreparationAttemptRef.current,
+    };
+    nextSharePreparationAttemptRef.current += 1;
+    sharePreparationIdentityRef.current = preparation;
+    setSharePreparationIdentity(preparation);
     if (!billing.isReady) {
       setWaitingForBilling(true);
       return;
     }
-    runSharePreparation(identity);
+    runSharePreparation(preparation);
   };
 
   const handleShare = () => {
     if (sharePopoverOpen) {
-      if (!shareButtonPending && !sharePanelPendingRef.current) {
-        closeSharePopover();
-      }
+      closeSharePopover();
       return;
     }
     if (!auth.session || auth.session.user.is_anonymous === true) {
@@ -553,9 +591,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     <Popover
       open={sharePopoverOpen}
       onOpenChange={(open) => {
-        if (!open && !shareButtonPending && !sharePanelPendingRef.current) {
-          closeSharePopover();
-        }
+        if (!open) closeSharePopover();
       }}
     >
       <PopoverTrigger asChild>
@@ -593,7 +629,6 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
           loading={shareQuery.isPending}
           error={shareQuery.isError}
           canExpand={billing.isPaid}
-          workspaces={workspaces}
           sharedAttachments={sharedAttachments}
           sharedSnapshot={durableNoteQuery.data ?? null}
           sharedAttachmentsReady={sharedAttachmentsReady}
@@ -668,12 +703,6 @@ function SessionSharePreparationContent({
       aria-labelledby="session-share-heading"
       aria-describedby="session-share-description"
       className="h-[240px] max-h-[calc(100vh-64px)] w-[320px] max-w-[calc(100vw-16px)] overflow-hidden"
-      onEscapeKeyDown={(event) => {
-        if (loading) event.preventDefault();
-      }}
-      onInteractOutside={(event) => {
-        if (loading) event.preventDefault();
-      }}
     >
       <AppFloatingPanel className="flex h-full flex-col overflow-hidden">
         <header className="border-border/60 border-b px-5 py-4 text-left">
@@ -718,7 +747,7 @@ function SessionSharePreparationContent({
         </div>
 
         <footer className="border-border/60 flex justify-end border-t px-5 py-3">
-          <Button type="button" size="sm" onClick={onClose} disabled={loading}>
+          <Button type="button" size="sm" onClick={onClose}>
             <CheckIcon className="size-3.5" aria-hidden="true" />
             <Trans>Done</Trans>
           </Button>
@@ -771,7 +800,6 @@ function SessionSharePopoverContent({
   loading,
   error,
   canExpand,
-  workspaces,
   sharedAttachments,
   sharedSnapshot,
   sharedAttachmentsReady,
@@ -785,7 +813,6 @@ function SessionSharePopoverContent({
   loading: boolean;
   error: boolean;
   canExpand: boolean;
-  workspaces: Array<{ id: string; name: string }>;
   sharedAttachments: SharedNoteAttachment[];
   sharedSnapshot: SharedNoteSnapshot | null;
   sharedAttachmentsReady: boolean;
@@ -815,7 +842,12 @@ function SessionSharePopoverContent({
     const controller = new AbortController();
     operationControllersRef.current.add(controller);
     try {
-      return await operation(controller.signal);
+      const result = await operation(controller.signal);
+      if (controller.signal.aborted) throw new ShareOperationAbortedError();
+      return result;
+    } catch (error) {
+      if (controller.signal.aborted) throw new ShareOperationAbortedError();
+      throw error;
     } finally {
       operationControllersRef.current.delete(controller);
     }
@@ -870,6 +902,7 @@ function SessionSharePopoverContent({
     const syncState = await loadSessionShareSyncState(
       identity.ownerUserId,
       identity.shareId,
+      sessionId,
     );
     const syncStateIsCurrent =
       syncState?.status === "clean" &&
@@ -1036,7 +1069,8 @@ function SessionSharePopoverContent({
     onSuccess: () => {
       sonnerToast.success("Attachment settings updated.");
     },
-    onError: () => {
+    onError: (error) => {
+      if (error instanceof ShareOperationAbortedError) return;
       sonnerToast.error("Could not update attachment sharing.");
     },
     onSettled: onChanged,
@@ -1084,6 +1118,7 @@ function SessionSharePopoverContent({
               inviteToken: invitation.inviteToken,
             },
             () => requireActiveContext(signal),
+            signal,
           );
           return { deliveredBy: "clipboard" as const };
         }
@@ -1098,7 +1133,8 @@ function SessionSharePopoverContent({
           : "Email unavailable. Invite link copied instead.",
       );
     },
-    onError: () => {
+    onError: (error) => {
+      if (error instanceof ShareOperationAbortedError) return;
       sonnerToast.error("Could not create this invitation.");
     },
     onSettled: onChanged,
@@ -1113,7 +1149,8 @@ function SessionSharePopoverContent({
     onSuccess: () => {
       sonnerToast.success("Shared copy updated.");
     },
-    onError: () => {
+    onError: (error) => {
+      if (error instanceof ShareOperationAbortedError) return;
       sonnerToast.error("Could not update the shared copy.");
     },
     onSettled: onChanged,
@@ -1132,7 +1169,8 @@ function SessionSharePopoverContent({
     onSuccess: () => {
       sonnerToast.success("Desktop edits published. Sharing resumed.");
     },
-    onError: () => {
+    onError: (error) => {
+      if (error instanceof ShareOperationAbortedError) return;
       sonnerToast.error(
         "Could not publish the desktop edits. Check the latest web copy and try again.",
       );
@@ -1153,7 +1191,8 @@ function SessionSharePopoverContent({
         );
         requireActiveContext(signal);
       }),
-    onError: () => {
+    onError: (error) => {
+      if (error instanceof ShareOperationAbortedError) return;
       sonnerToast.error("Could not open the web copy.");
     },
   });
@@ -1162,82 +1201,21 @@ function SessionSharePopoverContent({
   // management state confirms it, so the select never flashes the old scope.
   const [optimisticScope, setOptimisticScope] = useState<string | null>(null);
   const scopeMutation = useMutation({
-    mutationFn: (target: string) =>
+    mutationFn: () =>
       runOperation(async (signal) => {
         if (!management) throw new ShareManagementError();
-        let context = requireActiveContext(signal);
-        if (target === "restricted") {
-          await setSessionShareScope(context, {
-            shareId: identity.shareId,
-            scope: "restricted",
-          });
-          return { copied: false };
-        }
-        if (!canExpand) throw new ShareManagementError();
-        await publishLatest(signal);
-        context = requireActiveContext(signal);
-        if (target === "link") {
-          try {
-            let link = management.hasActiveLink
-              ? await rotateSessionShareLink(context, identity.shareId)
-              : await enableSessionShareLink(context, identity.shareId);
-            if (!link.linkToken) {
-              link = await rotateSessionShareLink(context, identity.shareId);
-            }
-            const linkToken = link.linkToken;
-            if (!linkToken) throw new ShareManagementError();
-            requireActiveContext(signal);
-            await copyText(
-              buildSessionShareLinkUrl({
-                appBaseUrl: env.VITE_APP_URL,
-                shareId: identity.shareId,
-                linkToken,
-                desktopScheme: await getSessionShareDesktopScheme(),
-              }),
-            );
-            requireActiveContext(signal);
-          } catch {
-            await restrictShare(withoutSignal(context), identity.shareId);
-            throw new ShareManagementError();
-          }
-          return { copied: true };
-        }
-
-        const scopeInput =
-          target === "public"
-            ? ({
-                shareId: identity.shareId,
-                scope: "public" as const,
-              } as const)
-            : (() => {
-                const workspaceId = target.startsWith("workspace:")
-                  ? target.slice("workspace:".length)
-                  : "";
-                if (
-                  !workspaces.some((workspace) => workspace.id === workspaceId)
-                ) {
-                  throw new ShareManagementError();
-                }
-                return {
-                  shareId: identity.shareId,
-                  scope: "workspace" as const,
-                  workspaceId,
-                };
-              })();
-        try {
-          await setSessionShareScope(context, scopeInput);
-          requireActiveContext(signal);
-        } catch {
-          await restrictShare(withoutSignal(context), identity.shareId);
-          throw new ShareManagementError();
-        }
-        return { copied: false };
+        const context = requireActiveContext(signal);
+        await setSessionShareScope(context, {
+          shareId: identity.shareId,
+          scope: "restricted",
+        });
       }),
-    onSuccess: ({ copied }) => {
-      sonnerToast.success(copied ? "Share link copied." : "Access updated.");
+    onSuccess: () => {
+      sonnerToast.success("Access updated.");
     },
-    onError: () => {
+    onError: (error) => {
       setOptimisticScope(null);
+      if (error instanceof ShareOperationAbortedError) return;
       sonnerToast.error("Could not update general access.");
     },
     onSettled: async () => {
@@ -1270,6 +1248,7 @@ function SessionSharePopoverContent({
               });
               requireActiveContext(signal);
             } catch {
+              if (signal.aborted) throw new ShareOperationAbortedError();
               await updateSessionAccessGrant(withoutSignal(context), {
                 grantId: input.entry.entryId,
                 capability: input.entry.capability,
@@ -1311,6 +1290,7 @@ function SessionSharePopoverContent({
               withoutSignal(context),
               invitation,
               () => requireActiveContext(signal),
+              signal,
             );
             return { deliveredBy: "clipboard" as const };
           }
@@ -1354,6 +1334,7 @@ function SessionSharePopoverContent({
                 inviteToken: invitation.inviteToken,
               },
               () => requireActiveContext(signal),
+              signal,
             );
             return { deliveredBy: "clipboard" as const };
           }
@@ -1387,6 +1368,7 @@ function SessionSharePopoverContent({
           });
           requireActiveContext(signal);
         } catch {
+          if (signal.aborted) throw new ShareOperationAbortedError();
           const rollbackContext = withoutSignal(context);
           if (previousGrant) {
             await updateSessionAccessGrant(rollbackContext, {
@@ -1423,7 +1405,8 @@ function SessionSharePopoverContent({
             : "Access updated.",
       );
     },
-    onError: () => {
+    onError: (error) => {
+      if (error instanceof ShareOperationAbortedError) return;
       sonnerToast.error("Could not update this person's access.");
     },
     onSettled: onChanged,
@@ -1448,7 +1431,8 @@ function SessionSharePopoverContent({
     onSuccess: () => {
       sonnerToast.success("Share link copied.");
     },
-    onError: () => {
+    onError: (error) => {
+      if (error instanceof ShareOperationAbortedError) return;
       sonnerToast.error("Could not copy the share link.");
     },
   });
@@ -1506,12 +1490,6 @@ function SessionSharePopoverContent({
       aria-labelledby="session-share-heading"
       aria-describedby="session-share-description"
       className="h-[240px] max-h-[calc(100vh-64px)] w-[320px] max-w-[calc(100vw-16px)] overflow-hidden"
-      onEscapeKeyDown={(event) => {
-        if (anyPending) event.preventDefault();
-      }}
-      onInteractOutside={(event) => {
-        if (anyPending) event.preventDefault();
-      }}
     >
       <AppFloatingPanel className="flex h-full flex-col overflow-hidden">
         <div ref={operationLifecycleRef} className="contents">
@@ -1854,7 +1832,7 @@ function SessionSharePopoverContent({
                         disabled={scopeMutation.isPending}
                         onClick={() => {
                           setOptimisticScope("restricted");
-                          scopeMutation.mutate("restricted");
+                          scopeMutation.mutate();
                         }}
                         className="h-7 shrink-0 px-2 text-[11px]"
                       >
@@ -2127,6 +2105,7 @@ async function copyInvitationOrRevoke(
   context: ShareManagementContext,
   invitation: { invitationId: string; inviteToken: string },
   assertActive: () => unknown,
+  signal?: AbortSignal,
 ) {
   try {
     assertActive();
@@ -2140,6 +2119,7 @@ async function copyInvitationOrRevoke(
     );
     assertActive();
   } catch {
+    if (signal?.aborted) throw new ShareOperationAbortedError();
     await revokeSessionAccessInvitation(context, invitation.invitationId).catch(
       () => undefined,
     );
@@ -2151,12 +2131,6 @@ function withoutSignal(
   context: ShareManagementContext,
 ): ShareManagementContext {
   return { supabase: context.supabase, session: context.session };
-}
-
-async function restrictShare(context: ShareManagementContext, shareId: string) {
-  await setSessionShareScope(context, { shareId, scope: "restricted" }).catch(
-    () => undefined,
-  );
 }
 
 async function getSessionShareDesktopScheme(): Promise<ShareDesktopScheme> {

--- a/apps/desktop/src/session-sharing/reconciliation.test.ts
+++ b/apps/desktop/src/session-sharing/reconciliation.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
     vi.fn<(sql: string, params?: unknown[]) => Promise<any[]>>(),
   loadAttachments: vi.fn<() => Promise<any[]>>().mockResolvedValue([]),
   loadSource: vi.fn<() => Promise<any>>(),
+  flushDatabaseWrites: vi.fn(async () => {}),
 }));
 
 vi.mock("~/db", () => ({
@@ -21,7 +22,7 @@ vi.mock("~/db", () => ({
 }));
 vi.mock("~/db/write-queue", () => ({
   enqueueDatabaseWrite: mocks.enqueueDatabaseWrite,
-  flushDatabaseWrites: vi.fn(async () => {}),
+  flushDatabaseWrites: mocks.flushDatabaseWrites,
 }));
 vi.mock("./source", () => ({
   loadSessionShareSource: mocks.loadSource,
@@ -36,6 +37,7 @@ import type { SessionShareAttachment } from "./attachments";
 import {
   createSessionShareMutationId,
   hashSessionShareProjection,
+  loadSessionShareSyncState,
   reconcileManagedSessionShareSnapshot,
 } from "./reconciliation";
 
@@ -216,6 +218,17 @@ describe("session share reconciliation", () => {
     );
     expect(nextRevision).not.toBe(first);
     expect(attachmentChange).not.toBe(first);
+  });
+
+  it("loads sync state after only its session and viewer cache are flushed", async () => {
+    await expect(
+      loadSessionShareSyncState(VIEWER_ID, SHARE_ID, SESSION_ID),
+    ).resolves.toBeNull();
+
+    expect(mocks.flushDatabaseWrites).toHaveBeenCalledWith([
+      `session:${SESSION_ID}`,
+      `shared-note-cache:${VIEWER_ID}`,
+    ]);
   });
 
   it("keeps an unchanged acknowledged snapshot idle", async () => {

--- a/apps/desktop/src/session-sharing/reconciliation.ts
+++ b/apps/desktop/src/session-sharing/reconciliation.ts
@@ -12,6 +12,7 @@ import { executeTransaction, liveQueryClient } from "~/db";
 import { enqueueDatabaseWrite, flushDatabaseWrites } from "~/db/write-queue";
 import {
   enqueueDurableSharedNoteCacheMutation,
+  sharedNoteCacheWriteKey,
   type SharedNoteSnapshot,
 } from "~/shared-notes/cache";
 
@@ -129,8 +130,12 @@ export async function loadManagedShareProjection(
 export async function loadSessionShareSyncState(
   viewerUserId: string,
   shareId: string,
+  sessionId: string,
 ): Promise<SessionShareSyncState | null> {
-  await flushDatabaseWrites();
+  await flushDatabaseWrites([
+    `session:${sessionId}`,
+    sharedNoteCacheWriteKey(viewerUserId),
+  ]);
   const rows = await liveQueryClient.execute<SessionShareSyncStateSqlRow>(
     `
       SELECT
@@ -203,7 +208,11 @@ export async function reconcileManagedSessionShareSnapshot(input: {
 
   const projection = await loadManagedShareProjection(viewerUserId, snapshot);
   input.signal?.throwIfAborted();
-  const state = await loadSessionShareSyncState(viewerUserId, snapshot.shareId);
+  const state = await loadSessionShareSyncState(
+    viewerUserId,
+    snapshot.shareId,
+    snapshot.sessionId,
+  );
   input.signal?.throwIfAborted();
   if (state && state.sessionId !== snapshot.sessionId) {
     throw new Error("Shared note sync state changed sessions");
@@ -380,6 +389,7 @@ async function importSnapshot(input: {
     const existing = await loadSessionShareSyncState(
       viewerUserId,
       snapshot.shareId,
+      snapshot.sessionId,
     );
     input.signal?.throwIfAborted();
     await writeSyncState(
@@ -440,6 +450,7 @@ async function importSnapshot(input: {
     const state = await loadSessionShareSyncState(
       viewerUserId,
       snapshot.shareId,
+      snapshot.sessionId,
     );
     input.signal?.throwIfAborted();
     await writeSyncState(

--- a/apps/desktop/src/session-sharing/sync.tsx
+++ b/apps/desktop/src/session-sharing/sync.tsx
@@ -140,6 +140,7 @@ export function OwnedSharedNotePublisher() {
             const currentState = await loadSessionShareSyncState(
               ownerUserId,
               revision.shareId,
+              durable.sessionId,
             );
             signal.throwIfAborted();
             if (durable.webEditBase || currentState?.status === "conflict") {

--- a/apps/desktop/src/shared-notes/attachment-cache-store.test.ts
+++ b/apps/desktop/src/shared-notes/attachment-cache-store.test.ts
@@ -2,22 +2,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   executeTransaction: vi.fn(),
+  liveQueryExecute: vi.fn(),
   enqueueDatabaseWrite: vi.fn(
     async (_key: string, write: () => Promise<unknown>) => write(),
   ),
+  flushDatabaseWrites: vi.fn(),
+  flushDatabaseWritesByPrefix: vi.fn(),
 }));
 
 vi.mock("~/db", () => ({
   executeTransaction: mocks.executeTransaction,
-  liveQueryClient: { execute: vi.fn() },
+  liveQueryClient: { execute: mocks.liveQueryExecute },
 }));
 
 vi.mock("~/db/write-queue", () => ({
   enqueueDatabaseWrite: mocks.enqueueDatabaseWrite,
-  flushDatabaseWrites: vi.fn(),
+  flushDatabaseWrites: mocks.flushDatabaseWrites,
+  flushDatabaseWritesByPrefix: mocks.flushDatabaseWritesByPrefix,
 }));
 
 import {
+  purgeForeignViewerSharedNoteCaches,
   purgeViewerSharedNoteCache,
   type SharedAttachmentCacheJob,
   sharedAttachmentCacheStore,
@@ -41,6 +46,35 @@ const job: SharedAttachmentCacheJob = {
 describe("shared attachment cache store", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.liveQueryExecute.mockResolvedValue([]);
+    mocks.flushDatabaseWrites.mockResolvedValue(undefined);
+    mocks.flushDatabaseWritesByPrefix.mockResolvedValue(undefined);
+  });
+
+  it("waits only for the active viewer cache before claiming work", async () => {
+    await expect(
+      sharedAttachmentCacheStore.claimNext("viewer-1"),
+    ).resolves.toBe(null);
+
+    expect(mocks.flushDatabaseWrites).toHaveBeenCalledWith([
+      "shared-attachment-cache-runner",
+      "shared-note-cache:viewer-1",
+    ]);
+  });
+
+  it("flushes only shared-cache domains before purging foreign viewers", async () => {
+    await purgeForeignViewerSharedNoteCaches(
+      "viewer-1",
+      vi.fn(async () => {}),
+      new AbortController().signal,
+    );
+
+    expect(mocks.flushDatabaseWrites).toHaveBeenCalledWith([
+      "shared-attachment-cache-runner",
+    ]);
+    expect(mocks.flushDatabaseWritesByPrefix).toHaveBeenCalledWith([
+      "shared-note-cache:",
+    ]);
   });
 
   it("invalidates a same-generation row resurrected while its bytes were deleted", async () => {

--- a/apps/desktop/src/shared-notes/attachment-cache-store.ts
+++ b/apps/desktop/src/shared-notes/attachment-cache-store.ts
@@ -1,7 +1,14 @@
-import { enqueueDurableSharedNoteCacheMutation } from "./cache";
+import {
+  enqueueDurableSharedNoteCacheMutation,
+  sharedNoteCacheWriteKey,
+} from "./cache";
 
 import { executeTransaction, liveQueryClient } from "~/db";
-import { enqueueDatabaseWrite, flushDatabaseWrites } from "~/db/write-queue";
+import {
+  enqueueDatabaseWrite,
+  flushDatabaseWrites,
+  flushDatabaseWritesByPrefix,
+} from "~/db/write-queue";
 
 export type SharedAttachmentCacheJob = {
   viewerUserId: string;
@@ -60,7 +67,10 @@ export const sharedAttachmentCacheStore = {
   async claimNext(
     viewerUserId: string,
   ): Promise<SharedAttachmentCacheJob | null> {
-    await flushDatabaseWrites();
+    await flushDatabaseWrites([
+      WRITE_KEY,
+      sharedNoteCacheWriteKey(viewerUserId),
+    ]);
     const rows = await liveQueryClient.execute<CacheSqlRow>(
       `
         SELECT
@@ -286,7 +296,10 @@ export const sharedAttachmentCacheStore = {
   },
 
   async listPresent(viewerUserId: string) {
-    await flushDatabaseWrites();
+    await flushDatabaseWrites([
+      WRITE_KEY,
+      sharedNoteCacheWriteKey(viewerUserId),
+    ]);
     return liveQueryClient.execute<
       Pick<CacheSqlRow, "share_id" | "attachment_id">
     >(
@@ -364,7 +377,10 @@ export async function purgeForeignViewerSharedNoteCaches(
   signal: AbortSignal,
 ) {
   signal.throwIfAborted();
-  await flushDatabaseWrites();
+  await Promise.all([
+    flushDatabaseWrites([WRITE_KEY]),
+    flushDatabaseWritesByPrefix(["shared-note-cache:"]),
+  ]);
   signal.throwIfAborted();
   const viewers = await liveQueryClient.execute<{ viewer_user_id: string }>(
     `

--- a/apps/desktop/src/shared-notes/cache.ts
+++ b/apps/desktop/src/shared-notes/cache.ts
@@ -151,16 +151,19 @@ export async function replaceDurableSharedNoteCache(
     sessionShareSyncStatePruneStatement(viewerUserId, snapshots),
   ];
 
-  return enqueueDatabaseWrite(cacheWriteKey(viewerUserId), async () => {
-    if (
-      expectedMutationVersion !== undefined &&
-      expectedMutationVersion !== currentCacheMutationVersion(viewerUserId)
-    ) {
-      return false;
-    }
-    await executeTransaction(statements);
-    return true;
-  });
+  return enqueueDatabaseWrite(
+    sharedNoteCacheWriteKey(viewerUserId),
+    async () => {
+      if (
+        expectedMutationVersion !== undefined &&
+        expectedMutationVersion !== currentCacheMutationVersion(viewerUserId)
+      ) {
+        return false;
+      }
+      await executeTransaction(statements);
+      return true;
+    },
+  );
 }
 
 export function captureDurableSharedNoteCacheMutationVersion(
@@ -179,7 +182,7 @@ export function enqueueDurableSharedNoteCacheMutation<T>(
     viewerUserId,
     currentCacheMutationVersion(viewerUserId) + 1,
   );
-  return enqueueDatabaseWrite(cacheWriteKey(viewerUserId), write);
+  return enqueueDatabaseWrite(sharedNoteCacheWriteKey(viewerUserId), write);
 }
 
 function sessionShareSyncStatePruneStatement(
@@ -315,7 +318,7 @@ function currentCacheMutationVersion(viewerUserId: string) {
   return cacheMutationVersions.get(viewerUserId) ?? 0;
 }
 
-function cacheWriteKey(viewerUserId: string) {
+export function sharedNoteCacheWriteKey(viewerUserId: string) {
   return `shared-note-cache:${viewerUserId}`;
 }
 
@@ -329,7 +332,7 @@ export async function loadManagedSharedNoteForSession(
 } | null> {
   const normalizedViewerUserId = requireIdentity(viewerUserId, "viewer user");
   const normalizedSessionId = requireIdentity(sessionId, "session");
-  await flushDatabaseWrites([cacheWriteKey(normalizedViewerUserId)]);
+  await flushDatabaseWrites([sharedNoteCacheWriteKey(normalizedViewerUserId)]);
   const rows = await liveQueryClient.execute<ManagedSharedNoteSqlRow>(
     `
       SELECT share_id, workspace_id, session_id

--- a/apps/desktop/src/shared/app-exit.test.ts
+++ b/apps/desktop/src/shared/app-exit.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   completeAppExit: vi.fn().mockResolvedValue(undefined),
-  flushDatabaseWrites: vi.fn().mockResolvedValue(undefined),
+  flushDatabaseWritesWithin: vi.fn().mockResolvedValue(undefined),
   listener: null as (() => void) | null,
   save: vi.fn().mockResolvedValue(undefined),
 }));
@@ -19,7 +19,7 @@ vi.mock("@hypr/plugin-store2", () => ({
 }));
 
 vi.mock("~/db/write-queue", () => ({
-  flushDatabaseWrites: mocks.flushDatabaseWrites,
+  flushDatabaseWritesWithin: mocks.flushDatabaseWritesWithin,
 }));
 
 vi.mock("~/types/tauri.gen", () => ({
@@ -32,7 +32,7 @@ describe("initializeAppExitFlush", () => {
     vi.clearAllMocks();
     mocks.listener = null;
     mocks.completeAppExit.mockResolvedValue(undefined);
-    mocks.flushDatabaseWrites.mockResolvedValue(undefined);
+    mocks.flushDatabaseWritesWithin.mockResolvedValue(undefined);
     mocks.save.mockResolvedValue(undefined);
   });
 
@@ -45,11 +45,11 @@ describe("initializeAppExitFlush", () => {
     await vi.waitFor(() =>
       expect(mocks.completeAppExit).toHaveBeenCalledOnce(),
     );
-    expect(mocks.flushDatabaseWrites).toHaveBeenCalledOnce();
+    expect(mocks.flushDatabaseWritesWithin).toHaveBeenCalledWith(5000);
     expect(mocks.save).toHaveBeenCalledOnce();
-    expect(mocks.flushDatabaseWrites.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.completeAppExit.mock.invocationCallOrder[0],
-    );
+    expect(
+      mocks.flushDatabaseWritesWithin.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.completeAppExit.mock.invocationCallOrder[0]);
   });
 
   it("still exits when flushing fails", async () => {
@@ -57,7 +57,7 @@ describe("initializeAppExitFlush", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
-    mocks.flushDatabaseWrites.mockRejectedValue(error);
+    mocks.flushDatabaseWritesWithin.mockRejectedValue(error);
     const { initializeAppExitFlush } = await import("./app-exit");
     await initializeAppExitFlush();
 
@@ -71,5 +71,27 @@ describe("initializeAppExitFlush", () => {
       error,
     );
     consoleError.mockRestore();
+  });
+
+  it("waits for settings to save when the database flush fails", async () => {
+    let resolveSave!: () => void;
+    mocks.flushDatabaseWritesWithin.mockRejectedValue(new Error("timed out"));
+    mocks.save.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      }),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { initializeAppExitFlush } = await import("./app-exit");
+    await initializeAppExitFlush();
+
+    mocks.listener?.();
+    await vi.waitFor(() => expect(mocks.save).toHaveBeenCalledOnce());
+
+    expect(mocks.completeAppExit).not.toHaveBeenCalled();
+    resolveSave();
+    await vi.waitFor(() =>
+      expect(mocks.completeAppExit).toHaveBeenCalledOnce(),
+    );
   });
 });

--- a/apps/desktop/src/shared/app-exit.ts
+++ b/apps/desktop/src/shared/app-exit.ts
@@ -2,7 +2,7 @@ import { listen } from "@tauri-apps/api/event";
 
 import { commands as store2Commands } from "@hypr/plugin-store2";
 
-import { flushDatabaseWrites } from "~/db/write-queue";
+import { flushDatabaseWritesWithin } from "~/db/write-queue";
 import { confirmAllPendingDeletions } from "~/store/zustand/undo-delete";
 import { commands } from "~/types/tauri.gen";
 
@@ -22,6 +22,7 @@ export async function initializeAppExitFlush(): Promise<void> {
 }
 
 const PENDING_DELETION_EXIT_TIMEOUT_MS = 3000;
+const APPLICATION_STATE_FLUSH_TIMEOUT_MS = 5000;
 
 async function flushAndExit(): Promise<void> {
   try {
@@ -34,7 +35,12 @@ async function flushAndExit(): Promise<void> {
         setTimeout(resolve, PENDING_DELETION_EXIT_TIMEOUT_MS),
       ),
     ]);
-    await Promise.all([flushDatabaseWrites(), store2Commands.save()]);
+    const results = await Promise.allSettled([
+      flushDatabaseWritesWithin(APPLICATION_STATE_FLUSH_TIMEOUT_MS),
+      store2Commands.save(),
+    ]);
+    const failure = results.find((result) => result.status === "rejected");
+    if (failure) throw failure.reason;
   } catch (error) {
     console.error("Failed to flush application data before exit", error);
   } finally {

--- a/apps/desktop/src/shared/hooks/useDeeplinkHandler.ts
+++ b/apps/desktop/src/shared/hooks/useDeeplinkHandler.ts
@@ -11,8 +11,10 @@ import { dismissInstruction } from "@hypr/plugin-windows";
 
 import { useAuth } from "~/auth";
 import {
+  allowReconnectedCalendarConnections,
   CALENDAR_SYNC_TASK_ID,
   removeDisconnectedCalendarConnection,
+  syncCalendarEvents,
 } from "~/services/calendar";
 import {
   createShareOpenProcessor,
@@ -78,13 +80,22 @@ export function useDeeplinkHandler() {
             void removeDisconnectedCalendarConnection(
               integration_id,
               disconnected_connection_id,
-            ).catch((error) => {
-              console.error(
-                "[calendar] failed to remove disconnected calendar data",
-                error,
-              );
-            });
+            )
+              .catch((error) => {
+                console.error(
+                  "[calendar] failed to remove disconnected calendar data",
+                  error,
+                );
+              })
+              .then(() => syncCalendarEvents())
+              .catch((error) => {
+                console.error(
+                  "[calendar] failed to sync after disconnect",
+                  error,
+                );
+              });
           } else {
+            allowReconnectedCalendarConnections(integration_id);
             refreshIntegrationState();
             for (const delay of [1000, 3000]) {
               const timeoutId = window.setTimeout(() => {

--- a/apps/desktop/src/shared/relaunch.test.ts
+++ b/apps/desktop/src/shared/relaunch.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const saveMock = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 const relaunchMock = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
-const flushDatabaseWritesMock = vi
+const flushDatabaseWritesWithinMock = vi
   .fn<() => Promise<void>>()
   .mockResolvedValue(undefined);
 const getOnboardingNeededMock = vi
@@ -20,7 +20,7 @@ vi.mock("@tauri-apps/plugin-process", () => ({
 }));
 
 vi.mock("~/db/write-queue", () => ({
-  flushDatabaseWrites: flushDatabaseWritesMock,
+  flushDatabaseWritesWithin: flushDatabaseWritesWithinMock,
 }));
 
 vi.mock("~/types/tauri.gen", () => ({
@@ -34,6 +34,9 @@ describe("automatic relaunch", () => {
     vi.useFakeTimers();
     vi.resetModules();
     vi.clearAllMocks();
+    flushDatabaseWritesWithinMock.mockResolvedValue(undefined);
+    saveMock.mockResolvedValue(undefined);
+    relaunchMock.mockResolvedValue(undefined);
     getOnboardingNeededMock.mockResolvedValue({ status: "ok", data: false });
   });
 
@@ -53,7 +56,7 @@ describe("automatic relaunch", () => {
     await vi.advanceTimersByTimeAsync(2000);
 
     expect(saveMock).toHaveBeenCalledTimes(1);
-    expect(flushDatabaseWritesMock).toHaveBeenCalledTimes(1);
+    expect(flushDatabaseWritesWithinMock).toHaveBeenCalledWith(5000);
     expect(relaunchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -65,6 +68,46 @@ describe("automatic relaunch", () => {
 
     expect(saveMock).not.toHaveBeenCalled();
     expect(relaunchMock).not.toHaveBeenCalled();
+  });
+
+  test("still relaunches when flushing application state fails", async () => {
+    const error = new Error("flush timed out");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    flushDatabaseWritesWithinMock.mockRejectedValue(error);
+    const { scheduleAutomaticRelaunch } = await import("./relaunch");
+
+    await scheduleAutomaticRelaunch();
+    await vi.runAllTimersAsync();
+
+    expect(relaunchMock).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to flush application data before relaunch",
+      error,
+    );
+    consoleError.mockRestore();
+  });
+
+  test("waits for settings to save when the database flush fails", async () => {
+    let resolveSave!: () => void;
+    flushDatabaseWritesWithinMock.mockRejectedValue(new Error("timed out"));
+    saveMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      }),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { scheduleAutomaticRelaunch } = await import("./relaunch");
+
+    await scheduleAutomaticRelaunch();
+    vi.advanceTimersByTime(0);
+    await vi.waitFor(() => expect(saveMock).toHaveBeenCalledOnce());
+
+    expect(relaunchMock).not.toHaveBeenCalled();
+    resolveSave();
+    await vi.runAllTimersAsync();
+    expect(relaunchMock).toHaveBeenCalledOnce();
   });
 
   test("flushes a deferred relaunch after onboarding completes", async () => {

--- a/apps/desktop/src/shared/relaunch.ts
+++ b/apps/desktop/src/shared/relaunch.ts
@@ -2,18 +2,28 @@ import { relaunch as tauriRelaunch } from "@tauri-apps/plugin-process";
 
 import { commands as store2Commands } from "@hypr/plugin-store2";
 
-import { flushDatabaseWrites } from "~/db/write-queue";
+import { flushDatabaseWritesWithin } from "~/db/write-queue";
 import { commands } from "~/types/tauri.gen";
 
 let pendingAutomaticRelaunch = false;
 let automaticRelaunchTimeout: ReturnType<typeof setTimeout> | null = null;
+const APPLICATION_STATE_FLUSH_TIMEOUT_MS = 5000;
 
 async function saveApplicationState(): Promise<void> {
-  await Promise.all([flushDatabaseWrites(), store2Commands.save()]);
+  const results = await Promise.allSettled([
+    flushDatabaseWritesWithin(APPLICATION_STATE_FLUSH_TIMEOUT_MS),
+    store2Commands.save(),
+  ]);
+  const failure = results.find((result) => result.status === "rejected");
+  if (failure) throw failure.reason;
 }
 
 async function relaunch(): Promise<void> {
-  await saveApplicationState();
+  try {
+    await saveApplicationState();
+  } catch (error) {
+    console.error("Failed to flush application data before relaunch", error);
+  }
   await tauriRelaunch();
 }
 


### PR DESCRIPTION
Cancel dismissible sharing work, keep calendar network activity out of the local write queue, and scope persistence flushes.

Supersedes #6204, which GitHub automatically closed when its stacked base #6202 merged and was deleted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches calendar disconnect invalidation, global write-queue flush semantics, and sharing lifecycle—areas where races could affect data consistency, though behavior is heavily test-covered.
> 
> **Overview**
> Improves **local responsiveness** by narrowing when the app waits on SQLite writes, moving slow calendar work off the write queue, and making session sharing dismissible without stray side effects.
> 
> **Database write queue** — Keyed `flushDatabaseWrites` now loops until targeted keys are idle (including writes enqueued mid-flush) and still surfaces the first failure after draining. Adds **`flushDatabaseWritesByPrefix`** and **`flushDatabaseWritesWithin`** (timeout without abandoning in-flight writes). Call sites flush only relevant keys (e.g. `session:{id}`, `attachment-transfers`, `shared-note-cache:{viewer}`) instead of the whole queue. Exit/relaunch use a **5s bounded** flush with `Promise.allSettled` so settings save can finish even if the DB flush times out.
> 
> **Calendar sync** — Full sync runs on a separate **`enqueueCalendarSync`** chain; only inventory/event commits use `enqueueDatabaseWrite("calendar-sync", …)`. **Generation** and a disconnected-connection set invalidate in-flight work so disconnect/reconnect cannot restore stale data; tombstone failures roll back the disconnect marker. Deeplink handler triggers **`syncCalendarEvents`** after disconnect and **`allowReconnectedCalendarConnections`** on reconnect.
> 
> **Session sharing** — Share popover can close anytime; preparation uses **attempt IDs** and abort controllers so dismissed work does not publish or show errors. **`ShareOperationAbortedError`** suppresses toasts on cancel; invitation rollback respects abort. General access scope UI is **restrict-only** (link/workspace scope flows removed). Sync state loads after scoped flushes including `sessionId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4e5b66007e94299cecff6131588c079601e80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->