### PR TITLE
Fix standalone note window startup

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -95,7 +95,6 @@ function AppRoot() {
   const manager = useCreateManager(() => {
     return createManager().start();
   });
-  const isMainWindow = getCurrentWebviewWindowLabel() === "main";
   const theme = useConfigValue("theme") as ThemePreference;
   useRemoteSessionDeletionUndoListener(isMainWindow);
 
@@ -115,7 +114,9 @@ function AppRoot() {
 
 initWindowsPlugin();
 
-if (getCurrentWebviewWindowLabel() === "main") {
+const isMainWindow = getCurrentWebviewWindowLabel() === "main";
+
+if (isMainWindow) {
   void initializeAppExitFlush().catch((error) => {
     console.error("Failed to initialize the exit flush listener", error);
   });
@@ -137,15 +138,17 @@ async function enableReactScanInDev() {
 }
 
 async function renderApp() {
-  await refreshLegacySettingsSnapshots().catch((error) => {
-    console.error("Failed to refresh legacy settings snapshots", error);
-  });
-  await initializeApplicationSettings().catch((error) => {
-    console.error("Failed to initialize application settings", error);
-  });
-  await migratePlaintextAiProviderApiKeys().catch((error) => {
-    console.error("Failed to migrate AI provider credentials", error);
-  });
+  if (isMainWindow) {
+    await refreshLegacySettingsSnapshots().catch((error) => {
+      console.error("Failed to refresh legacy settings snapshots", error);
+    });
+    await initializeApplicationSettings().catch((error) => {
+      console.error("Failed to initialize application settings", error);
+    });
+    await migratePlaintextAiProviderApiKeys().catch((error) => {
+      console.error("Failed to migrate AI provider credentials", error);
+    });
+  }
   await Promise.all([bootstrapThemeFromSettings(), enableReactScanInDev()]);
   const root = ReactDOM.createRoot(rootElement);
   root.render(

--- a/apps/desktop/src/routes/app/-resolve-entry-path.test.ts
+++ b/apps/desktop/src/routes/app/-resolve-entry-path.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeAppPath,
   resolveAppEntryPath,
   resolveShellEntryPath,
+  shouldCheckOnboarding,
 } from "./-resolve-entry-path";
 
 import { commands } from "~/types/tauri.gen";
@@ -48,5 +49,14 @@ describe("app entry path resolution", () => {
     expect(isShellEntryPath("/app/main/")).toBe(true);
     expect(isShellEntryPath("/app/unknown")).toBe(false);
     expect(isShellEntryPath("/app/onboarding")).toBe(false);
+  });
+
+  it("keeps standalone routes out of onboarding resolution", () => {
+    expect(shouldCheckOnboarding("/app")).toBe(true);
+    expect(shouldCheckOnboarding("/app/main/")).toBe(true);
+    expect(shouldCheckOnboarding("/app/onboarding")).toBe(true);
+    expect(shouldCheckOnboarding("/app/note/session-1")).toBe(false);
+    expect(shouldCheckOnboarding("/app/composer")).toBe(false);
+    expect(shouldCheckOnboarding("/app/instruction")).toBe(false);
   });
 });

--- a/apps/desktop/src/routes/app/-resolve-entry-path.ts
+++ b/apps/desktop/src/routes/app/-resolve-entry-path.ts
@@ -37,3 +37,10 @@ export function isShellEntryPath(pathname: string): boolean {
   const normalizedPath = normalizeAppPath(pathname);
   return normalizedPath === "/app" || normalizedPath === "/app/main";
 }
+
+export function shouldCheckOnboarding(pathname: string): boolean {
+  const normalizedPath = normalizeAppPath(pathname);
+  return (
+    normalizedPath === "/app/onboarding" || isShellEntryPath(normalizedPath)
+  );
+}

--- a/apps/desktop/src/routes/app/route.tsx
+++ b/apps/desktop/src/routes/app/route.tsx
@@ -7,6 +7,7 @@ import {
   isShellEntryPath,
   normalizeAppPath,
   resolveShellEntryPath,
+  shouldCheckOnboarding,
 } from "./-resolve-entry-path";
 
 import { useDeeplinkHandler } from "~/shared/hooks/useDeeplinkHandler";
@@ -15,6 +16,10 @@ import { ListenerProvider } from "~/stt/contexts";
 export const Route = createFileRoute("/app")({
   beforeLoad: async ({ location }) => {
     const pathname = normalizeAppPath(location.pathname);
+    if (!shouldCheckOnboarding(pathname)) {
+      return;
+    }
+
     const onboardingNeeded = await getOnboardingNeeded();
 
     if (pathname === "/app/onboarding") {


### PR DESCRIPTION
- Fixed the standalone note window failing to start by addressing startup initialization issues.
- Ensured the standalone window reliably launches for note viewing/editing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted routing and startup guards with tests; onboarding behavior unchanged for the main shell paths.
> 
> **Overview**
> Fixes **standalone note (and similar) windows** failing at startup by limiting **main-window-only** work and stopping **onboarding redirects** from hijacking deep-linked routes.
> 
> **Startup (`main.tsx`):** `isMainWindow` is computed once at module load. App exit flush, legacy settings refresh, application settings init, and AI key migration run only when the label is `main`. Secondary webviews still get theme bootstrap and React render.
> 
> **Routing (`/app` `beforeLoad`):** New `shouldCheckOnboarding()` limits onboarding checks to shell paths (`/app`, `/app/main`) and `/app/onboarding`. Routes like `/app/note/$sessionId`, `/app/composer`, and `/app/instruction` skip `getOnboardingNeeded` and redirect logic so they can load directly.
> 
> Tests cover `shouldCheckOnboarding` behavior for shell vs standalone paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aa1ab2c979662c7ca7008921f37e41449e94f96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->