### PR TITLE
Use generated initials avatars across sharing

### DIFF
--- a/apps/desktop/src/contacts/details.tsx
+++ b/apps/desktop/src/contacts/details.tsx
@@ -17,7 +17,6 @@ import {
   PopoverTrigger,
 } from "@hypr/ui/components/ui/popover";
 import { Textarea } from "@hypr/ui/components/ui/textarea";
-import { cn } from "@hypr/utils";
 
 import {
   createOrganization,
@@ -27,7 +26,7 @@ import {
   updateHuman,
   useHumanSessions,
 } from "./queries";
-import { ContactFacehash, getContactBgClass } from "./shared";
+import { ContactFacehash } from "./shared";
 
 export function DetailsColumn({
   human,
@@ -64,7 +63,6 @@ export function DetailsColumn({
   );
 
   const facehashName = String(human?.name || human?.email || human?.id || "");
-  const bgClass = getContactBgClass(facehashName);
 
   return (
     <div className="flex h-full flex-1 flex-col">
@@ -74,17 +72,8 @@ export function DetailsColumn({
             data-tauri-drag-region
             className="border-border flex items-center justify-center border-b py-6"
           >
-            <div
-              data-tauri-drag-region="false"
-              className={cn(["rounded-full", bgClass])}
-            >
-              <ContactFacehash
-                name={facehashName}
-                size={64}
-                interactive={true}
-                showInitial={true}
-                colorClasses={[bgClass]}
-              />
+            <div data-tauri-drag-region="false">
+              <ContactFacehash name={facehashName} size={64} />
             </div>
           </div>
 
@@ -110,26 +99,10 @@ export function DetailsColumn({
                       className="border-border bg-muted flex items-center justify-between rounded-md border p-2"
                     >
                       <div className="flex items-center gap-2">
-                        <div
-                          className={cn([
-                            "shrink-0 rounded-full",
-                            getContactBgClass(
-                              String(dup.name || dup.email || dup.id),
-                            ),
-                          ])}
-                        >
-                          <ContactFacehash
-                            name={String(dup.name || dup.email || dup.id)}
-                            size={32}
-                            interactive={false}
-                            showInitial={false}
-                            colorClasses={[
-                              getContactBgClass(
-                                String(dup.name || dup.email || dup.id),
-                              ),
-                            ]}
-                          />
-                        </div>
+                        <ContactFacehash
+                          name={String(dup.name || dup.email || dup.id)}
+                          size={32}
+                        />
                         <div>
                           <div className="text-foreground text-sm font-medium">
                             {dup.name || "Unnamed Contact"}

--- a/apps/desktop/src/contacts/organization-details.tsx
+++ b/apps/desktop/src/contacts/organization-details.tsx
@@ -5,14 +5,13 @@ import { Building2, Mail } from "lucide-react";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { Button } from "@hypr/ui/components/ui/button";
 import { Input } from "@hypr/ui/components/ui/input";
-import { cn } from "@hypr/utils";
 
 import {
   type HumanRecord,
   type OrganizationRecord,
   updateOrganization,
 } from "./queries";
-import { ContactFacehash, getContactBgClass } from "./shared";
+import { ContactFacehash } from "./shared";
 
 export function OrganizationDetailsColumn({
   organization,
@@ -76,30 +75,12 @@ export function OrganizationDetailsColumn({
                           onClick={() => onPersonClick?.(human.id)}
                         >
                           <div className="flex flex-col items-center gap-3 text-center">
-                            <div
-                              className={cn([
-                                "shrink-0 rounded-full",
-                                getContactBgClass(
-                                  String(human.name || human.email || human.id),
-                                ),
-                              ])}
-                            >
-                              <ContactFacehash
-                                name={String(
-                                  human.name || human.email || human.id,
-                                )}
-                                size={48}
-                                interactive={false}
-                                showInitial={false}
-                                colorClasses={[
-                                  getContactBgClass(
-                                    String(
-                                      human.name || human.email || human.id,
-                                    ),
-                                  ),
-                                ]}
-                              />
-                            </div>
+                            <ContactFacehash
+                              name={String(
+                                human.name || human.email || human.id,
+                              )}
+                              size={48}
+                            />
                             <div className="w-full">
                               <div className="truncate text-sm font-semibold">
                                 {human.name || human.email || t`Unnamed`}

--- a/apps/desktop/src/contacts/person-item.tsx
+++ b/apps/desktop/src/contacts/person-item.tsx
@@ -4,7 +4,7 @@ import React, { useCallback } from "react";
 import { cn } from "@hypr/utils";
 
 import { type HumanRecord, toggleContactPin } from "~/contacts/queries";
-import { ContactFacehash, getContactBgClass } from "~/contacts/shared";
+import { ContactFacehash } from "~/contacts/shared";
 import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
 
 export function PersonItem({
@@ -22,7 +22,6 @@ export function PersonItem({
   const personName = person.name;
   const personEmail = person.email;
   const facehashName = personName || personEmail || person.id;
-  const bgClass = getContactBgClass(facehashName);
 
   const togglePin = useCallback(() => {
     void toggleContactPin("human", person.id).catch((error) => {
@@ -68,15 +67,7 @@ export function PersonItem({
         active ? "bg-accent" : "hover:bg-accent/50",
       ])}
     >
-      <div className={cn(["shrink-0 rounded-full", bgClass])}>
-        <ContactFacehash
-          name={facehashName}
-          size={32}
-          interactive={true}
-          showInitial={true}
-          colorClasses={[bgClass]}
-        />
-      </div>
+      <ContactFacehash name={facehashName} size={32} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1 truncate font-medium">
           {personName || personEmail || "Unnamed"}

--- a/apps/desktop/src/contacts/shared.tsx
+++ b/apps/desktop/src/contacts/shared.tsx
@@ -1,8 +1,8 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import { Facehash, stringHash } from "facehash";
 import { ArrowDownUp, Plus, Search, X } from "lucide-react";
-import type { ComponentProps, KeyboardEvent, RefObject } from "react";
+import type { KeyboardEvent, RefObject } from "react";
 
+import { Avatar } from "@hypr/ui/components/avatar";
 import { Button } from "@hypr/ui/components/ui/button";
 import {
   AppFloatingPanel,
@@ -12,46 +12,19 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@hypr/ui/components/ui/dropdown-menu";
-import { cn } from "@hypr/utils";
 
 import { CustomSidebarHeader } from "~/sidebar/custom-sidebar-header";
 
-const COLOR_PALETTES = [
-  "bg-amber-50 dark:bg-amber-950",
-  "bg-rose-50 dark:bg-rose-950",
-  "bg-violet-50 dark:bg-violet-950",
-  "bg-blue-50 dark:bg-blue-950",
-  "bg-teal-50 dark:bg-teal-950",
-  "bg-green-50 dark:bg-green-950",
-  "bg-cyan-50 dark:bg-cyan-950",
-  "bg-fuchsia-50 dark:bg-fuchsia-950",
-  "bg-indigo-50 dark:bg-indigo-950",
-  "bg-yellow-50 dark:bg-yellow-950",
-] as const;
-
-export const CONTACT_FACEHASH_CLASS = "text-foreground";
-
-export function getContactBgClass(name: string) {
-  const hash = stringHash(name);
-  return COLOR_PALETTES[hash % COLOR_PALETTES.length];
-}
-
 export function ContactFacehash({
   name,
+  size = 40,
   className,
-  colorClasses,
-  ...props
-}: ComponentProps<typeof Facehash>) {
-  const bgClass = colorClasses?.[0] ?? getContactBgClass(name);
-
-  return (
-    <Facehash
-      name={name}
-      className={cn([CONTACT_FACEHASH_CLASS, className])}
-      colorClasses={colorClasses ?? [bgClass]}
-      {...props}
-    />
-  );
+}: {
+  name: string;
+  size?: number;
+  className?: string;
+}) {
+  return <Avatar seed={name} label={name} size={size} className={className} />;
 }
 
 export type SortOption =

--- a/apps/desktop/src/session-sharing/comments.tsx
+++ b/apps/desktop/src/session-sharing/comments.tsx
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -18,6 +18,7 @@ import {
   getCommentAnchorRanges,
   setActiveCommentAnchor,
 } from "@hypr/editor/note";
+import { Avatar } from "@hypr/ui/components/avatar";
 import { Button } from "@hypr/ui/components/ui/button";
 import {
   Popover,
@@ -512,29 +513,37 @@ function CommentComposer({
           const comment = validateComment(field.state.value);
           return (
             <>
-              <Textarea
-                autoFocus
-                aria-label="Comment on selected text"
-                aria-invalid={comment.tooLong}
-                className="min-h-20 resize-none"
-                placeholder="Comment on the selected text…"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Escape") {
-                    event.preventDefault();
-                    onCancel();
-                  }
-                  if (
-                    event.key === "Enter" &&
-                    (event.metaKey || event.ctrlKey)
-                  ) {
-                    event.preventDefault();
-                    void form.handleSubmit();
-                  }
-                }}
-              />
+              <div className="flex items-start gap-2">
+                <Avatar
+                  seed="shared-note:you"
+                  label="You"
+                  size={28}
+                  className="mt-1"
+                />
+                <Textarea
+                  autoFocus
+                  aria-label="Comment on selected text"
+                  aria-invalid={comment.tooLong}
+                  className="min-h-20 min-w-0 flex-1 resize-none"
+                  placeholder="Comment on the selected text…"
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Escape") {
+                      event.preventDefault();
+                      onCancel();
+                    }
+                    if (
+                      event.key === "Enter" &&
+                      (event.metaKey || event.ctrlKey)
+                    ) {
+                      event.preventDefault();
+                      void form.handleSubmit();
+                    }
+                  }}
+                />
+              </div>
               {comment.tooLong && (
                 <p className="text-destructive mt-2 text-xs" role="alert">
                   <Trans>Comment is too long.</Trans>
@@ -590,12 +599,27 @@ function SessionCommentItem({
   onDelete: () => void;
   showDelete: boolean;
 }) {
+  const { t } = useLingui();
+
   return (
     <div className="border-border/60 border-b px-4 py-3 last:border-b-0">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-sm font-medium">
-          {comment.isAuthor ? <Trans>You</Trans> : <Trans>Collaborator</Trans>}
-        </span>
+        <div className="flex min-w-0 items-center gap-2">
+          <Avatar
+            seed={
+              comment.isAuthor ? "shared-note:you" : "shared-note:collaborator"
+            }
+            label={comment.isAuthor ? t`You` : t`Collaborator`}
+            size={24}
+          />
+          <span className="truncate text-sm font-medium">
+            {comment.isAuthor ? (
+              <Trans>You</Trans>
+            ) : (
+              <Trans>Collaborator</Trans>
+            )}
+          </span>
+        </div>
         {showDelete && (
           <Button
             type="button"

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -76,7 +76,6 @@ vi.mock("~/contacts/queries", () => ({
 }));
 
 vi.mock("~/contacts/shared", () => ({
-  getContactBgClass: () => "bg-muted",
   ContactFacehash: ({ name }: { name: string }) => <span>{name[0]}</span>,
 }));
 

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -84,7 +84,7 @@ import {
 import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
 import { useHumans } from "~/contacts/queries";
-import { ContactFacehash, getContactBgClass } from "~/contacts/shared";
+import { ContactFacehash } from "~/contacts/shared";
 import { env } from "~/env";
 import { setAttachmentCloudSyncEnabled } from "~/session/attachments";
 import {
@@ -1656,9 +1656,6 @@ function SessionSharePopoverContent({
                       return suggestions.length ? (
                         <div className="mt-1 space-y-0.5 rounded-lg border p-1">
                           {suggestions.map((contact) => {
-                            const bgClass = getContactBgClass(
-                              contact.name || contact.email,
-                            );
                             return (
                               <button
                                 key={contact.id}
@@ -1671,19 +1668,10 @@ function SessionSharePopoverContent({
                                   )
                                 }
                               >
-                                <span
-                                  className={cn([
-                                    "shrink-0 rounded-full",
-                                    bgClass,
-                                  ])}
-                                >
-                                  <ContactFacehash
-                                    name={contact.name || contact.email}
-                                    size={22}
-                                    showInitial={true}
-                                    colorClasses={[bgClass]}
-                                  />
-                                </span>
+                                <ContactFacehash
+                                  name={contact.name || contact.email}
+                                  size={22}
+                                />
                                 <span className="min-w-0 flex-1">
                                   <span className="block truncate text-xs font-medium">
                                     {contact.name || contact.email}
@@ -1704,19 +1692,7 @@ function SessionSharePopoverContent({
 
                   <div className="mt-2 space-y-0.5">
                     <div className="flex min-h-9 items-center gap-2 rounded-lg px-1.5 py-1">
-                      <span
-                        className={cn([
-                          "shrink-0 rounded-full",
-                          getContactBgClass(ownerName),
-                        ])}
-                      >
-                        <ContactFacehash
-                          name={ownerName}
-                          size={24}
-                          showInitial={true}
-                          colorClasses={[getContactBgClass(ownerName)]}
-                        />
-                      </span>
+                      <ContactFacehash name={ownerName} size={24} />
                       <div className="min-w-0 flex-1">
                         <p className="truncate text-xs font-medium">
                           {ownerName}{" "}
@@ -1910,17 +1886,9 @@ function AccessEntryRow({
   onMutate: (mutation: AccessMutation) => void;
 }) {
   const label = contactName || entry.userEmail || "Anarlog user";
-  const bgClass = getContactBgClass(label);
   return (
     <div className="hover:bg-accent/50 flex min-h-9 items-center gap-2 rounded-lg px-1.5 py-1">
-      <span className={cn(["shrink-0 rounded-full", bgClass])}>
-        <ContactFacehash
-          name={label}
-          size={24}
-          showInitial={true}
-          colorClasses={[bgClass]}
-        />
-      </span>
+      <ContactFacehash name={label} size={24} />
       <div className="min-w-0 flex-1">
         <p className="truncate text-xs font-medium">{label}</p>
         <p className="text-muted-foreground truncate text-[10px]">

--- a/apps/web/src/components/shared-note-collaboration.tsx
+++ b/apps/web/src/components/shared-note-collaboration.tsx
@@ -14,6 +14,7 @@ import {
   XIcon,
 } from "lucide-react";
 
+import { Avatar } from "@hypr/ui/components/avatar";
 import { cn } from "@hypr/utils";
 
 import {
@@ -372,16 +373,27 @@ function CommentList({
               className="py-5"
             >
               <div className="flex items-start justify-between gap-4">
-                <div>
-                  <p className="text-color font-mono text-sm font-medium">
-                    {comment.isAuthor ? "You" : "Collaborator"}
-                  </p>
-                  <time
-                    className="text-color-muted mt-0.5 block text-xs"
-                    dateTime={comment.createdAt}
-                  >
-                    {formatCommentDate(comment.createdAt)}
-                  </time>
+                <div className="flex min-w-0 items-center gap-2.5">
+                  <Avatar
+                    seed={
+                      comment.isAuthor
+                        ? "shared-note:you"
+                        : "shared-note:collaborator"
+                    }
+                    label={comment.isAuthor ? "You" : "Collaborator"}
+                    size={28}
+                  />
+                  <div>
+                    <p className="text-color font-mono text-sm font-medium">
+                      {comment.isAuthor ? "You" : "Collaborator"}
+                    </p>
+                    <time
+                      className="text-color-muted mt-0.5 block text-xs"
+                      dateTime={comment.createdAt}
+                    >
+                      {formatCommentDate(comment.createdAt)}
+                    </time>
+                  </div>
                 </div>
                 {canDelete && (
                   <button

--- a/apps/web/src/components/shared-note-comment-rail.tsx
+++ b/apps/web/src/components/shared-note-comment-rail.tsx
@@ -1,6 +1,7 @@
-import { LoaderCircleIcon, Trash2Icon, UserRoundIcon } from "lucide-react";
+import { LoaderCircleIcon, Trash2Icon } from "lucide-react";
 import { useRef, useState } from "react";
 
+import { Avatar } from "@hypr/ui/components/avatar";
 import { cn } from "@hypr/utils";
 
 import type { AnchoredSharedNoteComment } from "@/lib/shared-note-comment-anchors";
@@ -178,9 +179,13 @@ export function SharedNoteCommentCard({
     >
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
-          <span className="surface-subtle text-color-muted flex size-6 shrink-0 items-center justify-center rounded-full">
-            <UserRoundIcon className="size-3.5" aria-hidden="true" />
-          </span>
+          <Avatar
+            seed={
+              comment.isAuthor ? "shared-note:you" : "shared-note:collaborator"
+            }
+            label={comment.isAuthor ? "You" : "Collaborator"}
+            size={24}
+          />
           <p className="text-color min-w-0 truncate text-xs font-medium">
             {comment.isAuthor ? "You" : "Collaborator"}{" "}
             <time

--- a/apps/web/src/components/shared-note-read-surface.tsx
+++ b/apps/web/src/components/shared-note-read-surface.tsx
@@ -29,6 +29,7 @@ import {
   setActiveCommentAnchor,
   setCommentAnchors,
 } from "@hypr/editor/note";
+import { Avatar } from "@hypr/ui/components/avatar";
 import { cn } from "@hypr/utils";
 
 import {
@@ -494,19 +495,27 @@ function DraftComposer({
           const tooLong = comment.byteLength > MAX_SHARED_NOTE_COMMENT_BYTES;
           return (
             <>
-              <textarea
-                autoFocus
-                aria-label="Comment on selected text"
-                className={cn([
-                  "surface-subtle border-color-subtle text-color min-h-20 w-full resize-y rounded-xl border px-3 py-2",
-                  "placeholder:text-color-muted text-sm leading-6 focus:border-stone-400 focus:ring-2 focus:ring-stone-300 focus:outline-hidden",
-                ])}
-                aria-invalid={tooLong}
-                placeholder="Comment on the selected text…"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.target.value)}
-              />
+              <div className="flex items-start gap-2.5">
+                <Avatar
+                  seed="shared-note:you"
+                  label="You"
+                  size={28}
+                  className="mt-1"
+                />
+                <textarea
+                  autoFocus
+                  aria-label="Comment on selected text"
+                  className={cn([
+                    "surface-subtle border-color-subtle text-color min-h-20 min-w-0 flex-1 resize-y rounded-xl border px-3 py-2",
+                    "placeholder:text-color-muted text-sm leading-6 focus:border-stone-400 focus:ring-2 focus:ring-stone-300 focus:outline-hidden",
+                  ])}
+                  aria-invalid={tooLong}
+                  placeholder="Comment on the selected text…"
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(event.target.value)}
+                />
+              </div>
               {tooLong && (
                 <p className="mt-2 text-xs text-red-700" role="alert">
                   Comment is too long ({comment.byteLength.toLocaleString()}/

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -1,0 +1,377 @@
+import { useState, type CSSProperties } from "react";
+
+import { useMountEffect } from "@hypr/ui/hooks/use-mount-effect";
+
+export type AvatarRenderStyle = "dithered" | "smooth";
+
+export type AvatarProps = Readonly<{
+  seed: string;
+  label?: string;
+  size?: number;
+  colorCount?: number;
+  sphereCount?: number;
+  dither?: number;
+  renderStyle?: AvatarRenderStyle;
+  className?: string;
+}>;
+
+type AvatarRecipe = Readonly<{
+  seed: string;
+  colorCount: number;
+  sphereCount: number;
+  dither: number;
+  renderStyle: AvatarRenderStyle;
+}>;
+
+type Rgb = readonly [red: number, green: number, blue: number];
+
+type Sphere = Readonly<{
+  x: number;
+  y: number;
+  radius: number;
+  color: Rgb;
+}>;
+
+const BAYER_4X4 = [
+  0, 8, 2, 10, 12, 4, 14, 6, 3, 11, 1, 9, 15, 7, 13, 5,
+] as const;
+const imageCache = new Map<string, string>();
+const MAX_CACHE_ENTRIES = 512;
+const RASTER_SIZE = 64;
+
+export function Avatar({
+  seed,
+  label = seed,
+  size = 40,
+  colorCount = 4,
+  sphereCount = 4,
+  dither = 0.3,
+  renderStyle = "dithered",
+  className,
+}: AvatarProps) {
+  const recipe = { seed, colorCount, sphereCount, dither, renderStyle };
+  const cacheKey = recipeKey(recipe);
+
+  return (
+    <AvatarImage
+      key={cacheKey}
+      cacheKey={cacheKey}
+      className={className}
+      label={label}
+      recipe={recipe}
+      size={size}
+    />
+  );
+}
+
+function AvatarImage({
+  cacheKey,
+  className,
+  label,
+  recipe,
+  size,
+}: {
+  cacheKey: string;
+  className?: string;
+  label: string;
+  recipe: AvatarRecipe;
+  size: number;
+}) {
+  const [src, setSrc] = useState<string | undefined>(() =>
+    imageCache.get(cacheKey),
+  );
+  const dimension = Math.max(1, size);
+  const containerStyle = {
+    width: dimension,
+    height: dimension,
+    display: "inline-flex",
+    position: "relative",
+    flexShrink: 0,
+    overflow: "hidden",
+    boxSizing: "border-box",
+    border: "1px solid rgb(0 0 0 / 0.1)",
+    borderRadius: "9999px",
+    background: fallbackGradient(recipe.seed),
+    boxShadow: "0 1px 2px rgb(0 0 0 / 0.08)",
+  } satisfies CSSProperties;
+  const initialsStyle = {
+    position: "absolute",
+    inset: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: "white",
+    fontSize: Math.max(7, dimension * 0.38),
+    fontWeight: 600,
+    lineHeight: 1,
+    letterSpacing: "-0.04em",
+    mixBlendMode: "overlay",
+  } satisfies CSSProperties;
+
+  useMountEffect(() => {
+    const cached = imageCache.get(cacheKey);
+    if (cached) {
+      imageCache.delete(cacheKey);
+      imageCache.set(cacheKey, cached);
+      setSrc(cached);
+      return;
+    }
+    if (!canRenderAvatarPng()) return;
+
+    const timeout = window.setTimeout(() => {
+      setSrc(renderAvatarPng(recipe));
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  });
+
+  return (
+    <span aria-hidden="true" className={className} style={containerStyle}>
+      {src ? (
+        <img
+          alt=""
+          draggable={false}
+          src={src}
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+          }}
+        />
+      ) : null}
+      <span aria-hidden="true" style={initialsStyle}>
+        {initials(label)}
+      </span>
+    </span>
+  );
+}
+
+function renderAvatarPng(recipe: AvatarRecipe): string | undefined {
+  const key = recipeKey(recipe);
+  const cached = imageCache.get(key);
+  if (cached) {
+    imageCache.delete(key);
+    imageCache.set(key, cached);
+    return cached;
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = RASTER_SIZE;
+  canvas.height = RASTER_SIZE;
+
+  try {
+    const context = canvas.getContext("2d", { alpha: false });
+    if (!context) return undefined;
+
+    const image = context.createImageData(RASTER_SIZE, RASTER_SIZE);
+    const random = mulberry32(hashString(recipe.seed));
+    const colors = createPalette(random, recipe.colorCount);
+    const angle = random() * Math.PI * 2;
+    const spheres = createSpheres(random, colors, recipe.sphereCount);
+    const quantizationSteps = 6;
+
+    for (let y = 0; y < RASTER_SIZE; y += 1) {
+      for (let x = 0; x < RASTER_SIZE; x += 1) {
+        const normalizedX = (x + 0.5) / RASTER_SIZE;
+        const normalizedY = (y + 0.5) / RASTER_SIZE;
+        const directional = clamp(
+          0.5 +
+            (normalizedX - 0.5) * Math.cos(angle) +
+            (normalizedY - 0.5) * Math.sin(angle),
+          0,
+          1,
+        );
+        const baseColor = interpolatePalette(colors, directional);
+        const color = blendSpheres(
+          baseColor,
+          normalizedX,
+          normalizedY,
+          spheres,
+        );
+        const threshold =
+          ((BAYER_4X4[(y % 4) * 4 + (x % 4)] ?? 7.5) / 16 - 0.5) * 255;
+        const pixelIndex = (y * RASTER_SIZE + x) * 4;
+
+        for (let channel = 0; channel < 3; channel += 1) {
+          const value = color[channel] ?? 0;
+          image.data[pixelIndex + channel] =
+            recipe.renderStyle === "dithered"
+              ? quantize(value + threshold * recipe.dither, quantizationSteps)
+              : Math.round(value);
+        }
+        image.data[pixelIndex + 3] = 255;
+      }
+    }
+
+    context.putImageData(image, 0, 0);
+    const url = canvas.toDataURL("image/png");
+    imageCache.set(key, url);
+    if (imageCache.size > MAX_CACHE_ENTRIES) {
+      const oldestKey = imageCache.keys().next().value;
+      if (oldestKey) imageCache.delete(oldestKey);
+    }
+    return url;
+  } catch {
+    return undefined;
+  }
+}
+
+function canRenderAvatarPng(): boolean {
+  return (
+    typeof document !== "undefined" &&
+    typeof CanvasRenderingContext2D !== "undefined"
+  );
+}
+
+function fallbackGradient(seed: string): string {
+  const random = mulberry32(hashString(seed));
+  const colors = createPalette(random, 3);
+  const angle = Math.round(random() * 360);
+  return `linear-gradient(${angle}deg, ${colors.map(rgbString).join(", ")})`;
+}
+
+function rgbString([red, green, blue]: Rgb): string {
+  return `rgb(${Math.round(red)} ${Math.round(green)} ${Math.round(blue)})`;
+}
+
+function createPalette(random: () => number, colorCount: number): Rgb[] {
+  const count = clamp(Math.round(colorCount), 2, 5);
+  const baseHue = random() * 360;
+  const hueSpreads = [32, 52, 138, 208] as const;
+  const spread = hueSpreads[Math.floor(random() * hueSpreads.length)] ?? 52;
+
+  return Array.from({ length: count }, (_, index) => {
+    const hue = (baseHue + spread * index + (random() - 0.5) * 18) % 360;
+    const saturation = 58 + random() * 24;
+    const lightness = 48 + random() * 24;
+    return hslToRgb(hue, saturation, lightness);
+  });
+}
+
+function createSpheres(
+  random: () => number,
+  colors: readonly Rgb[],
+  count: number,
+): Sphere[] {
+  return Array.from({ length: clamp(Math.round(count), 1, 7) }, (_, index) => ({
+    x: -0.1 + random() * 1.2,
+    y: -0.1 + random() * 1.2,
+    radius: 0.24 + random() * 0.42,
+    color: colors[(index + 1) % colors.length] ?? [128, 128, 128],
+  }));
+}
+
+function blendSpheres(
+  base: Rgb,
+  x: number,
+  y: number,
+  spheres: readonly Sphere[],
+): Rgb {
+  let red = base[0];
+  let green = base[1];
+  let blue = base[2];
+
+  for (const sphere of spheres) {
+    const distanceSquared = (x - sphere.x) ** 2 + (y - sphere.y) ** 2;
+    const influence =
+      Math.exp(-distanceSquared / (2 * sphere.radius ** 2)) * 0.72;
+    red += (sphere.color[0] - red) * influence;
+    green += (sphere.color[1] - green) * influence;
+    blue += (sphere.color[2] - blue) * influence;
+  }
+
+  return [red, green, blue];
+}
+
+function interpolatePalette(colors: readonly Rgb[], position: number): Rgb {
+  const scaled = position * (colors.length - 1);
+  const leftIndex = Math.floor(scaled);
+  const rightIndex = Math.min(leftIndex + 1, colors.length - 1);
+  const amount = scaled - leftIndex;
+  const left = colors[leftIndex] ?? [128, 128, 128];
+  const right = colors[rightIndex] ?? left;
+  return [
+    left[0] + (right[0] - left[0]) * amount,
+    left[1] + (right[1] - left[1]) * amount,
+    left[2] + (right[2] - left[2]) * amount,
+  ];
+}
+
+function hslToRgb(hue: number, saturation: number, lightness: number): Rgb {
+  const s = saturation / 100;
+  const l = lightness / 100;
+  const chroma = (1 - Math.abs(2 * l - 1)) * s;
+  const segment = (((hue % 360) + 360) % 360) / 60;
+  const secondary = chroma * (1 - Math.abs((segment % 2) - 1));
+  const [red, green, blue]: Rgb =
+    segment < 1
+      ? [chroma, secondary, 0]
+      : segment < 2
+        ? [secondary, chroma, 0]
+        : segment < 3
+          ? [0, chroma, secondary]
+          : segment < 4
+            ? [0, secondary, chroma]
+            : segment < 5
+              ? [secondary, 0, chroma]
+              : [chroma, 0, secondary];
+  const match = l - chroma / 2;
+  return [(red + match) * 255, (green + match) * 255, (blue + match) * 255];
+}
+
+function quantize(value: number, steps: number): number {
+  return clamp(
+    Math.round((clamp(value, 0, 255) / 255) * steps) * (255 / steps),
+    0,
+    255,
+  );
+}
+
+function hashString(value: string): number {
+  let hash = 2166136261;
+  for (const character of value.normalize("NFKC")) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+function recipeKey(recipe: AvatarRecipe): string {
+  return [
+    recipe.seed,
+    recipe.colorCount,
+    recipe.sphereCount,
+    recipe.dither,
+    recipe.renderStyle,
+  ].join("|");
+}
+
+function initials(value: string): string {
+  return value
+    .trim()
+    .split(/\s+/)
+    .map((part) =>
+      Array.from(part.normalize("NFKC").replace(/[^\p{L}\p{N}]/gu, "")),
+    )
+    .filter((part) => part.length > 0)
+    .slice(0, 2)
+    .map((part) => part[0] ?? "")
+    .join("")
+    .toUpperCase();
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}

--- a/packages/ui/src/hooks/use-mount-effect.tsx
+++ b/packages/ui/src/hooks/use-mount-effect.tsx
@@ -1,0 +1,5 @@
+import { useEffect } from "react";
+
+export function useMountEffect(effect: () => void | (() => void)) {
+  useEffect(effect, []);
+}


### PR DESCRIPTION
Add the shared Char-style avatar renderer and use it in web and desktop collaboration UI.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6209 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6208 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UI refactor with no changes to sharing, auth, or data APIs; main risk is visual/regression in avatar rendering across environments without canvas support.
> 
> **Overview**
> Introduces a shared **`Avatar`** component in `@hypr/ui` that renders deterministic, seed-based circular avatars (canvas-generated dithered art with initials overlay and a gradient fallback), plus a small **`useMountEffect`** helper for deferred PNG generation.
> 
> **Contacts (desktop)** stop using the `facehash` package and local `getContactBgClass` palette wrappers. **`ContactFacehash`** becomes a thin adapter over **`Avatar`**, and list/detail/share UI drops the extra rounded background divs and `colorClasses` / `interactive` props.
> 
> **Shared-note collaboration** on desktop and web adds **`Avatar`** beside comment composers and in comment lists/rails (You vs Collaborator via fixed seeds), replacing generic user icons or name-only headers. Session-sharing invite suggestions and access rows use the simplified contact avatar as well.
> 
> Test mocks are updated to match the slimmer **`ContactFacehash`** API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e23446393521e31122f1a17030c5cc0fb8f00c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->