### PR TITLE
chore: refresh landing page SEO

### DIFF
--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,10 +1,10 @@
 export const ANARLOG_SITE_URL = "https://anarlog.so";
 export const DEFAULT_OG_IMAGE_URL = `${ANARLOG_SITE_URL}/og.jpg`;
-export const ROOT_TITLE = "Anarlog - Meeting Notes You Own";
+export const ROOT_TITLE = "AI notepad for private meetings.";
 export const ROOT_DESCRIPTION =
-  "Private, bot-free meeting notes that stay under your control. Anarlog stores notes as files you own and works fully offline with on-device models or your own keys.";
+  "Anarlog is the open-source, privacy-first, local-first alternative to Granola AI. Take notes during private meetings, turn them into editable summaries, and keep your files and AI stack under your control.";
 export const ROOT_KEYWORDS =
-  "private meeting notes, bot-free AI notes, local transcription, AI meeting notes, AI notetaker, meeting transcription, meeting summaries, BYOK AI, open source note taking, local AI";
+  "private meeting notes, open source meeting notes, local-first AI notepad, Granola AI alternatives, Granola AI alternative, AI meeting notes, local meeting transcription, bot-free AI notes, offline meeting notes, on-device AI, BYOK AI, meeting transcription, meeting summaries, data ownership";
 
 export function getBlogOgImageUrl(slug: string) {
   return `${ANARLOG_SITE_URL}/api/og/blog/${encodeURIComponent(slug)}`;


### PR DESCRIPTION
- Updated landing page SEO settings to refresh metadata and improve discoverability
- Applied SEO-related housekeeping changes to the landing page as part of the refresh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only metadata changes with no security, data, or runtime behavior impact.
> 
> **Overview**
> Updates the **global SEO copy** in `seo.ts` so the site’s default title, meta description, and keywords reflect a clearer product pitch and competitive positioning.
> 
> **`ROOT_TITLE`** shifts from “Anarlog - Meeting Notes You Own” to **“AI notepad for private meetings.”** **`ROOT_DESCRIPTION`** now frames Anarlog as an open-source, privacy-first, local-first **Granola AI alternative**, with emphasis on private meetings, editable summaries, and owning files plus the AI stack. **`ROOT_KEYWORDS`** expands to include open-source/local-first notepad terms, Granola alternative phrases, offline notes, on-device AI, and data ownership, while keeping core meeting-notes terms.
> 
> Because these constants drive the root route’s `<title>`, description/keywords meta, Open Graph, Twitter cards, and landing structured data, the change affects how the homepage appears in search and social previews only—no application logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 978255f0a882b561bbaec8b9e6bae28798f67bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->