### PR TITLE
Harden email auth and recovery flows

### DIFF
--- a/apps/web/src/components/web-providers.tsx
+++ b/apps/web/src/components/web-providers.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { useMountEffect } from "@/hooks/useMountEffect";
-import { isShareRoutePathname } from "@/lib/share-route-privacy";
+import { isTelemetryPrivateLocation } from "@/lib/auth-route-privacy";
 import { PostHogProvider } from "@/providers/posthog";
 import { bootstrapBrowserTelemetry, stopBrowserTelemetry } from "@/telemetry";
 
@@ -30,7 +30,10 @@ function GoogleAnalyticsScript() {
       typeof document === "undefined" ||
       import.meta.env.DEV ||
       window.location.pathname.startsWith("/admin") ||
-      isShareRoutePathname(window.location.pathname)
+      isTelemetryPrivateLocation(
+        window.location.pathname,
+        window.location.search,
+      )
     ) {
       return;
     }
@@ -69,7 +72,10 @@ function MicrosoftClarityScript() {
       typeof document === "undefined" ||
       import.meta.env.DEV ||
       window.location.pathname.startsWith("/admin") ||
-      isShareRoutePathname(window.location.pathname)
+      isTelemetryPrivateLocation(
+        window.location.pathname,
+        window.location.search,
+      )
     ) {
       return;
     }

--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -414,13 +414,18 @@ export const doPasswordResetRequest = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       email: z.string().email(),
+      flow: z.enum(["desktop", "web"]).default("web"),
+      scheme: desktopSchemeSchema.optional(),
+      redirect: z.string().optional(),
     }),
   )
   .handler(async ({ data }) => {
     const supabase = getSupabaseServerClient();
+    const params = buildAuthCallbackParams(data);
+    params.set("type", "recovery");
 
     const { error } = await supabase.auth.resetPasswordForEmail(data.email, {
-      redirectTo: `${getRequestAppOrigin()}/callback/auth?flow=web&type=recovery`,
+      redirectTo: buildAuthCallbackUrl(params),
     });
 
     if (error) {
@@ -434,17 +439,29 @@ export const doUpdatePassword = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       password: z.string().min(6),
+      flow: z.enum(["desktop", "web"]).default("web"),
     }),
   )
   .handler(async ({ data }) => {
     const supabase = getSupabaseServerClient();
 
-    const { error } = await supabase.auth.updateUser({
+    const { data: authData, error } = await supabase.auth.updateUser({
       password: data.password,
     });
 
     if (error) {
       return { error: true, message: error.message };
+    }
+
+    if (data.flow === "desktop" && authData.user.email) {
+      const session = await mintDesktopSessionFromEmail(authData.user.email);
+      if (session) {
+        return {
+          success: true,
+          access_token: session.access_token,
+          refresh_token: session.refresh_token,
+        };
+      }
     }
 
     return { success: true };

--- a/apps/web/src/lib/auth-flow-context.test.ts
+++ b/apps/web/src/lib/auth-flow-context.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  resolveAuthFlowContext,
+  toAuthFlowSearch,
+} from "./auth-flow-context.ts";
+
+test("restores desktop recovery context from the encoded Supabase redirect", () => {
+  const context = resolveAuthFlowContext({
+    redirectTo:
+      "https://anarlog.so/callback/auth?flow=desktop&scheme=hyprnote-staging&redirect=%2Fshare%2Finvite%2Fabc%2F",
+  });
+
+  assert.deepEqual(context, {
+    flow: "desktop",
+    scheme: "hyprnote-staging",
+    redirect: "/share/invite/abc/",
+  });
+  assert.deepEqual(toAuthFlowSearch(context), context);
+});
+
+test("ignores unrelated redirect URLs and unsafe return paths", () => {
+  assert.deepEqual(
+    resolveAuthFlowContext({
+      redirectTo: "https://attacker.example/callback?flow=desktop&scheme=char",
+    }),
+    { flow: "web" },
+  );
+
+  assert.deepEqual(
+    resolveAuthFlowContext({
+      flow: "web",
+      redirect: "//attacker.example",
+    }),
+    { flow: "web", redirect: "/app/account/" },
+  );
+});
+
+test("explicit route context takes precedence over template redirect context", () => {
+  assert.deepEqual(
+    resolveAuthFlowContext({
+      flow: "web",
+      redirect: "/app/account/",
+      redirectTo: "https://anarlog.so/callback/auth?flow=desktop&scheme=char",
+    }),
+    { flow: "web", scheme: "char", redirect: "/app/account/" },
+  );
+});

--- a/apps/web/src/lib/auth-flow-context.ts
+++ b/apps/web/src/lib/auth-flow-context.ts
@@ -1,0 +1,92 @@
+import {
+  desktopSchemeSchema,
+  type DesktopScheme,
+} from "../functions/desktop-flow.ts";
+import { sanitizeInternalReturnPath } from "./auth-redirect.ts";
+
+export type AuthFlowContext = {
+  flow: "desktop" | "web";
+  scheme?: DesktopScheme;
+  redirect?: string;
+};
+
+export function resolveAuthFlowContext({
+  flow,
+  scheme,
+  redirect,
+  redirectTo,
+}: {
+  flow?: "desktop" | "web";
+  scheme?: DesktopScheme;
+  redirect?: string;
+  redirectTo?: string;
+}): AuthFlowContext {
+  const redirectContext = parseAuthCallbackUrl(redirectTo);
+  const resolvedFlow = flow ?? redirectContext?.flow ?? "web";
+  const resolvedScheme =
+    scheme ??
+    redirectContext?.scheme ??
+    (resolvedFlow === "desktop" ? "hyprnote" : undefined);
+  const resolvedRedirect = redirect ?? redirectContext?.redirect;
+
+  return {
+    flow: resolvedFlow,
+    ...(resolvedScheme ? { scheme: resolvedScheme } : {}),
+    ...(resolvedRedirect
+      ? { redirect: sanitizeInternalReturnPath(resolvedRedirect) }
+      : {}),
+  };
+}
+
+export function toAuthFlowSearch(context: AuthFlowContext) {
+  if (context.flow === "desktop") {
+    return {
+      flow: "desktop" as const,
+      scheme: context.scheme ?? "hyprnote",
+      redirect: context.redirect,
+    };
+  }
+
+  return {
+    flow: "web" as const,
+    scheme: context.scheme,
+    redirect: context.redirect,
+  };
+}
+
+function parseAuthCallbackUrl(
+  value: string | undefined,
+): AuthFlowContext | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+    if (
+      (url.protocol !== "https:" && url.protocol !== "http:") ||
+      canonicalPath(url.pathname) !== "/callback/auth"
+    ) {
+      return null;
+    }
+
+    const parsedFlow = url.searchParams.get("flow");
+    const flow = parsedFlow === "desktop" ? "desktop" : "web";
+    const parsedScheme = desktopSchemeSchema.safeParse(
+      url.searchParams.get("scheme"),
+    );
+    const redirect = url.searchParams.get("redirect") ?? undefined;
+
+    return {
+      flow,
+      ...(parsedScheme.success ? { scheme: parsedScheme.data } : {}),
+      ...(redirect ? { redirect } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function canonicalPath(pathname: string) {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+}

--- a/apps/web/src/lib/auth-route-privacy.test.ts
+++ b/apps/web/src/lib/auth-route-privacy.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isTelemetryPrivateLocation,
+  prepareAuthRoutePrivacy,
+  readDesktopAuthHandoff,
+} from "./auth-route-privacy.ts";
+
+test("keeps auth, callback, recovery, and share routes telemetry private", () => {
+  for (const pathname of [
+    "/auth/",
+    "/callback/auth/",
+    "/confirm-auth/",
+    "/reset-password/",
+    "/update-password/",
+    "/share/link/example/",
+  ]) {
+    assert.equal(isTelemetryPrivateLocation(pathname), true);
+  }
+
+  assert.equal(isTelemetryPrivateLocation("/blog/auth/"), false);
+  assert.equal(isTelemetryPrivateLocation("/"), false);
+});
+
+test("keeps legacy root callbacks private only when auth parameters exist", () => {
+  assert.equal(isTelemetryPrivateLocation("/", "?code=secret"), true);
+  assert.equal(
+    isTelemetryPrivateLocation("/", { token_hash: "secret", type: "email" }),
+    true,
+  );
+  assert.equal(isTelemetryPrivateLocation("/", "?period=monthly"), false);
+});
+
+test("stores desktop handoff tokens and removes secrets from browser history", () => {
+  const location = {
+    hash: "",
+    pathname: "/callback/auth/",
+    search:
+      "?flow=desktop&scheme=hyprnote&access_token=access&refresh_token=refresh",
+  };
+  const storage = new Map<string, string>();
+  let replacedUrl = "";
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      history: {
+        state: { key: "router" },
+        replaceState: (_state: unknown, _title: string, url: string) => {
+          replacedUrl = url;
+        },
+      },
+      location,
+      sessionStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+    },
+  });
+
+  try {
+    prepareAuthRoutePrivacy();
+    assert.equal(
+      replacedUrl,
+      "/callback/auth/?flow=desktop&scheme=hyprnote&handoff=stored",
+    );
+    assert.deepEqual(readDesktopAuthHandoff(), {
+      accessToken: "access",
+      refreshToken: "refresh",
+    });
+  } finally {
+    Reflect.deleteProperty(globalThis, "window");
+  }
+});
+
+test("does not rewrite one-time verification URLs before the router exchanges them", () => {
+  let replacedUrl = "";
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      history: {
+        state: null,
+        replaceState: (_state: unknown, _title: string, url: string) => {
+          replacedUrl = url;
+        },
+      },
+      location: {
+        hash: "",
+        pathname: "/",
+        search: "?token_hash=secret&type=recovery&flow=web",
+      },
+      sessionStorage: {
+        getItem: () => null,
+        setItem: () => {},
+      },
+    },
+  });
+
+  try {
+    prepareAuthRoutePrivacy();
+    assert.equal(replacedUrl, "");
+  } finally {
+    Reflect.deleteProperty(globalThis, "window");
+  }
+});
+
+test("keeps desktop handoff tokens in the URL when storage is unavailable", () => {
+  let replacedUrl = "";
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      history: {
+        state: null,
+        replaceState: (_state: unknown, _title: string, url: string) => {
+          replacedUrl = url;
+        },
+      },
+      location: {
+        hash: "",
+        pathname: "/callback/auth/",
+        search: "?access_token=access&refresh_token=refresh",
+      },
+      sessionStorage: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error("storage unavailable");
+        },
+      },
+    },
+  });
+
+  try {
+    prepareAuthRoutePrivacy();
+    assert.equal(replacedUrl, "");
+    assert.equal(readDesktopAuthHandoff(), null);
+  } finally {
+    Reflect.deleteProperty(globalThis, "window");
+  }
+});

--- a/apps/web/src/lib/auth-route-privacy.ts
+++ b/apps/web/src/lib/auth-route-privacy.ts
@@ -1,0 +1,131 @@
+import { isShareRoutePathname } from "./share-route-privacy.ts";
+
+const AUTH_HANDOFF_STORAGE_KEY = "anarlog.desktop-auth-handoff";
+const AUTH_CALLBACK_SEARCH_KEYS = [
+  "access_token",
+  "refresh_token",
+  "code",
+  "token_hash",
+  "error",
+] as const;
+const AUTH_HANDOFF_SEARCH_KEYS = ["access_token", "refresh_token"] as const;
+const AUTH_PRIVATE_PATHS = new Set([
+  "/auth",
+  "/callback/auth",
+  "/confirm-auth",
+  "/reset-password",
+  "/update-password",
+]);
+
+type SearchValue =
+  | string
+  | URLSearchParams
+  | Record<string, unknown>
+  | undefined;
+
+export function isTelemetryPrivateLocation(
+  pathname: string,
+  search?: SearchValue,
+) {
+  const canonicalPathname = canonicalPath(pathname);
+  if (
+    isShareRoutePathname(canonicalPathname) ||
+    AUTH_PRIVATE_PATHS.has(canonicalPathname)
+  ) {
+    return true;
+  }
+
+  return (
+    canonicalPathname === "/" &&
+    AUTH_CALLBACK_SEARCH_KEYS.some((key) => hasSearchKey(search, key))
+  );
+}
+
+export function prepareAuthRoutePrivacy() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const { hash, pathname, search } = window.location;
+  if (!isTelemetryPrivateLocation(pathname, search)) {
+    return;
+  }
+
+  const params = new URLSearchParams(search);
+  const accessToken = params.get("access_token");
+  const refreshToken = params.get("refresh_token");
+  if (
+    canonicalPath(pathname) !== "/callback/auth" ||
+    !accessToken ||
+    !refreshToken
+  ) {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(
+      AUTH_HANDOFF_STORAGE_KEY,
+      JSON.stringify({ accessToken, refreshToken }),
+    );
+  } catch {
+    return;
+  }
+
+  params.set("handoff", "stored");
+  for (const key of AUTH_HANDOFF_SEARCH_KEYS) {
+    params.delete(key);
+  }
+
+  const sanitizedSearch = params.toString();
+  window.history.replaceState(
+    window.history.state,
+    "",
+    `${pathname}${sanitizedSearch ? `?${sanitizedSearch}` : ""}${hash}`,
+  );
+}
+
+export function readDesktopAuthHandoff() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(
+      window.sessionStorage.getItem(AUTH_HANDOFF_STORAGE_KEY) ?? "null",
+    ) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "accessToken" in parsed &&
+      "refreshToken" in parsed &&
+      typeof parsed.accessToken === "string" &&
+      typeof parsed.refreshToken === "string"
+    ) {
+      return {
+        accessToken: parsed.accessToken,
+        refreshToken: parsed.refreshToken,
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function canonicalPath(pathname: string) {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+}
+
+function hasSearchKey(search: SearchValue, key: string) {
+  if (!search) {
+    return false;
+  }
+  if (typeof search === "string") {
+    return new URLSearchParams(search).has(key);
+  }
+  if (search instanceof URLSearchParams) {
+    return search.has(key);
+  }
+  return key in search;
+}

--- a/apps/web/src/providers/posthog.tsx
+++ b/apps/web/src/providers/posthog.tsx
@@ -3,7 +3,7 @@ import posthog from "posthog-js";
 import { createContext, useContext, useEffect, useRef, useState } from "react";
 
 import { env } from "../env";
-import { isShareRoutePathname } from "../lib/share-route-privacy";
+import { isTelemetryPrivateLocation } from "../lib/auth-route-privacy";
 
 const isDev = import.meta.env.DEV;
 
@@ -30,7 +30,13 @@ export function PostHogProvider({
       return;
     }
 
-    if (!enabled || isShareRoutePathname(window.location.pathname)) {
+    if (
+      !enabled ||
+      isTelemetryPrivateLocation(
+        window.location.pathname,
+        window.location.search,
+      )
+    ) {
       if (didInitRef.current) {
         posthog.set_config({
           autocapture: false,
@@ -50,7 +56,12 @@ export function PostHogProvider({
         autocapture: true,
         capture_pageview: true,
         before_send: (event) =>
-          isShareRoutePathname(window.location.pathname) ? null : event,
+          isTelemetryPrivateLocation(
+            window.location.pathname,
+            window.location.search,
+          )
+            ? null
+            : event,
       });
       didInitRef.current = true;
     } else if (routeDisabledRef.current) {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as TermsRouteImport } from './routes/terms'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as DiscordRouteImport } from './routes/discord'
+import { Route as ConfirmAuthRouteImport } from './routes/confirm-auth'
 import { Route as AuthRouteImport } from './routes/auth'
 import { Route as ViewRouteRouteImport } from './routes/_view/route'
 import { Route as IndexRouteImport } from './routes/index'
@@ -100,6 +101,11 @@ const PrivacyRoute = PrivacyRouteImport.update({
 const DiscordRoute = DiscordRouteImport.update({
   id: '/discord',
   path: '/discord',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConfirmAuthRoute = ConfirmAuthRouteImport.update({
+  id: '/confirm-auth',
+  path: '/confirm-auth',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthRoute = AuthRouteImport.update({
@@ -423,6 +429,7 @@ const ApiOgSharePublicPublicSlugRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
+  '/confirm-auth': typeof ConfirmAuthRoute
   '/discord': typeof DiscordRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -491,6 +498,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
+  '/confirm-auth': typeof ConfirmAuthRoute
   '/discord': typeof DiscordRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -560,6 +568,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/_view': typeof ViewRouteRouteWithChildren
   '/auth': typeof AuthRoute
+  '/confirm-auth': typeof ConfirmAuthRoute
   '/discord': typeof DiscordRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -630,6 +639,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/auth'
+    | '/confirm-auth'
     | '/discord'
     | '/privacy'
     | '/reset-password'
@@ -698,6 +708,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/auth'
+    | '/confirm-auth'
     | '/discord'
     | '/privacy'
     | '/reset-password'
@@ -766,6 +777,7 @@ export interface FileRouteTypes {
     | '/'
     | '/_view'
     | '/auth'
+    | '/confirm-auth'
     | '/discord'
     | '/privacy'
     | '/reset-password'
@@ -836,6 +848,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ViewRouteRoute: typeof ViewRouteRouteWithChildren
   AuthRoute: typeof AuthRoute
+  ConfirmAuthRoute: typeof ConfirmAuthRoute
   DiscordRoute: typeof DiscordRoute
   PrivacyRoute: typeof PrivacyRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
@@ -924,6 +937,13 @@ declare module '@tanstack/react-router' {
       path: '/discord'
       fullPath: '/discord'
       preLoaderRoute: typeof DiscordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/confirm-auth': {
+      id: '/confirm-auth'
+      path: '/confirm-auth'
+      fullPath: '/confirm-auth'
+      preLoaderRoute: typeof ConfirmAuthRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/auth': {
@@ -1413,6 +1433,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ViewRouteRoute: ViewRouteRouteWithChildren,
   AuthRoute: AuthRoute,
+  ConfirmAuthRoute: ConfirmAuthRoute,
   DiscordRoute: DiscordRoute,
   PrivacyRoute: PrivacyRoute,
   ResetPasswordRoute: ResetPasswordRoute,

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -4,10 +4,8 @@ import { createRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 
 import { env } from "./env";
-import {
-  isShareRoutePathname,
-  prepareShareRoutePrivacy,
-} from "./lib/share-route-privacy";
+import { isTelemetryPrivateLocation } from "./lib/auth-route-privacy";
+import { prepareShareRoutePrivacy } from "./lib/share-route-privacy";
 import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
@@ -23,11 +21,7 @@ export function getRouter() {
 
   prepareShareRoutePrivacy();
 
-  if (
-    !router.isServer &&
-    env.VITE_SENTRY_DSN &&
-    !isShareRoutePathname(window.location.pathname)
-  ) {
+  if (!router.isServer && env.VITE_SENTRY_DSN) {
     Sentry.init({
       dsn: env.VITE_SENTRY_DSN,
       release: env.VITE_APP_VERSION
@@ -36,9 +30,19 @@ export function getRouter() {
       sendDefaultPii: true,
       tracePropagationTargets: [],
       beforeSend: (event) =>
-        isShareRoutePathname(window.location.pathname) ? null : event,
+        isTelemetryPrivateLocation(
+          window.location.pathname,
+          window.location.search,
+        )
+          ? null
+          : event,
       beforeSendTransaction: (event) =>
-        isShareRoutePathname(window.location.pathname) ? null : event,
+        isTelemetryPrivateLocation(
+          window.location.pathname,
+          window.location.search,
+        )
+          ? null
+          : event,
     });
   }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import {
 import { Toaster } from "@hypr/ui/components/ui/toast";
 
 import { WebProviders } from "@/components/web-providers";
+import { isTelemetryPrivateLocation } from "@/lib/auth-route-privacy";
 import {
   ANARLOG_SITE_URL,
   DEFAULT_OG_IMAGE_URL,
@@ -18,7 +19,6 @@ import {
   ROOT_KEYWORDS,
   ROOT_TITLE,
 } from "@/lib/seo";
-import { isShareRoutePathname } from "@/lib/share-route-privacy";
 import appCss from "@/styles.css?url";
 
 interface RouterContext {
@@ -99,7 +99,11 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 function RootApp() {
   const { queryClient } = Route.useRouteContext();
   const telemetryEnabled = useRouterState({
-    select: (state) => !isShareRoutePathname(state.location.pathname),
+    select: (state) =>
+      !isTelemetryPrivateLocation(
+        state.location.pathname,
+        state.location.search,
+      ),
   });
 
   return (

--- a/apps/web/src/routes/_view/callback/auth.tsx
+++ b/apps/web/src/routes/_view/callback/auth.tsx
@@ -1,10 +1,7 @@
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import { jwtDecode } from "jwt-decode";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { CheckIcon, CopyIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { z } from "zod";
-
-import { deriveBillingInfo, type SupabaseJwtPayload } from "@hypr/supabase";
 
 import {
   AuthShell,
@@ -12,13 +9,21 @@ import {
   authPrimaryButtonClassName,
   authSecondaryButtonClassName,
 } from "@/components/auth-shell";
-import { exchangeOAuthCode, exchangeOtpToken } from "@/functions/auth";
+import { exchangeOAuthCode } from "@/functions/auth";
 import { desktopSchemeSchema } from "@/functions/desktop-flow";
-import { useAnalytics } from "@/hooks/use-posthog";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import {
+  resolveAuthFlowContext,
+  toAuthFlowSearch,
+} from "@/lib/auth-flow-context";
 import {
   buildPostAuthDestination,
   sanitizeInternalReturnPath,
 } from "@/lib/auth-redirect";
+import {
+  prepareAuthRoutePrivacy,
+  readDesktopAuthHandoff,
+} from "@/lib/auth-route-privacy";
 
 const validateSearch = z.object({
   code: z.string().optional(),
@@ -33,11 +38,12 @@ const validateSearch = z.object({
       "email_change",
     ])
     .optional(),
-  flow: z.enum(["desktop", "web"]).default("desktop"),
+  flow: z.enum(["desktop", "web"]).default("web"),
   scheme: desktopSchemeSchema.catch("hyprnote"),
   redirect: z.string().optional(),
   access_token: z.string().optional(),
   refresh_token: z.string().optional(),
+  handoff: z.literal("stored").optional(),
   error: z.string().optional(),
   error_code: z.string().optional(),
   error_description: z.string().optional(),
@@ -50,131 +56,89 @@ export const Route = createFileRoute("/_view/callback/auth")({
     meta: [{ name: "robots", content: "noindex, nofollow" }],
   }),
   beforeLoad: async ({ search }) => {
-    if (search.flow === "web" && search.code) {
+    const context = resolveAuthFlowContext(search);
+
+    if (search.code) {
       const result = await exchangeOAuthCode({
-        data: { code: search.code, flow: "web" },
+        data: { code: search.code, flow: search.flow },
       });
 
-      if (result.success) {
-        if (search.type === "recovery") {
-          throw redirect({ to: "/update-password/", search: {} });
-        }
+      if (!result.success) {
+        throw redirectToExchangeError(search, result.error);
+      }
+
+      if (search.type === "recovery") {
+        throw redirect({
+          to: "/update-password/",
+          search: toAuthFlowSearch(context),
+        });
+      }
+
+      if (search.flow === "web") {
         throw redirect({
           href: buildPostAuthDestination({
             newAccount: result.newAccount,
             returnTo: search.redirect,
           }),
         } as any);
-      } else {
-        console.error(result.error);
       }
-    }
 
-    if (search.flow === "desktop" && search.code) {
-      const result = await exchangeOAuthCode({
-        data: { code: search.code, flow: "desktop" },
+      throw redirect({
+        to: "/callback/auth/",
+        search: {
+          flow: "desktop",
+          scheme: search.scheme,
+          access_token: result.access_token,
+          refresh_token: result.refresh_token,
+        },
       });
-
-      if (result.success) {
-        throw redirect({
-          to: "/callback/auth/",
-          search: {
-            flow: "desktop",
-            scheme: search.scheme,
-            access_token: result.access_token,
-            refresh_token: result.refresh_token,
-          },
-        });
-      } else {
-        console.error(result.error);
-      }
     }
 
     if (search.token_hash && search.type) {
-      if (search.type === "recovery") {
-        const result = await exchangeOtpToken({
-          data: {
-            token_hash: search.token_hash,
-            type: search.type,
-            flow: search.flow,
-          },
-        });
+      throw redirect({
+        to: "/confirm-auth/",
+        search: {
+          token_hash: search.token_hash,
+          type: search.type,
+          flow: search.flow,
+          scheme: search.scheme,
+          redirect: search.redirect,
+        },
+      });
+    }
 
-        if (result.success) {
-          throw redirect({ to: "/update-password/", search: {} });
-        } else {
-          console.error(result.error);
-        }
-      } else {
-        const result = await exchangeOtpToken({
-          data: {
-            token_hash: search.token_hash,
-            type: search.type,
-            flow: search.flow,
-          },
-        });
-
-        if (result.success) {
-          if (search.flow === "web") {
-            throw redirect({
-              href: buildPostAuthDestination({
-                newAccount: result.newAccount,
-                returnTo: search.redirect,
-              }),
-            } as any);
-          }
-
-          if (search.flow === "desktop") {
-            throw redirect({
-              to: "/callback/auth/",
-              search: {
-                flow: "desktop",
-                scheme: search.scheme,
-                access_token: result.access_token,
-                refresh_token: result.refresh_token,
-              },
-            });
-          }
-        } else {
-          console.error(result.error);
-        }
-      }
+    if (search.flow === "web" && !search.error) {
+      throw redirect({
+        href: sanitizeInternalReturnPath(search.redirect),
+      } as any);
     }
   },
 });
 
 function Component() {
   const search = Route.useSearch();
-  const navigate = useNavigate();
-  const { identify: identifyPosthog } = useAnalytics();
   const [copied, setCopied] = useState(false);
+  const [storedHandoff, setStoredHandoff] =
+    useState<ReturnType<typeof readDesktopAuthHandoff>>(null);
 
-  useEffect(() => {
-    if (!search.access_token) return;
-
-    try {
-      const payload = jwtDecode<SupabaseJwtPayload>(search.access_token);
-      const email = payload.email;
-      const userId = payload.sub;
-
-      if (userId) {
-        const billing = deriveBillingInfo(payload);
-        identifyPosthog(userId, {
-          ...(email ? { email } : {}),
-          plan: billing.plan,
-          trial_end_date: billing.trialEnd?.toISOString() ?? null,
-        });
-      }
-    } catch (e) {
-      console.error("Failed to decode JWT for identify:", e);
+  useMountEffect(() => {
+    prepareAuthRoutePrivacy();
+    if (
+      search.handoff === "stored" ||
+      (search.access_token && search.refresh_token)
+    ) {
+      setStoredHandoff(readDesktopAuthHandoff());
     }
-  }, [search.access_token, identifyPosthog]);
+  });
+
+  const accessToken = search.access_token ?? storedHandoff?.accessToken;
+  const refreshToken = search.refresh_token ?? storedHandoff?.refreshToken;
 
   const getDeeplink = () => {
-    if (search.access_token && search.refresh_token) {
+    if (accessToken && refreshToken) {
       const params = new URLSearchParams();
-      params.set("access_token", search.access_token);
-      params.set("refresh_token", search.refresh_token);
+      params.set("access_token", accessToken);
+      params.set("refresh_token", refreshToken);
       return `${search.scheme}://auth/callback?${params.toString()}`;
     }
     return null;
@@ -201,17 +165,12 @@ function Component() {
     }
   };
 
-  useEffect(() => {
-    if (search.flow === "web" && !search.error) {
-      navigate({
-        to: sanitizeInternalReturnPath(search.redirect),
-        search: {},
-        replace: true,
-      });
-    }
-  }, [search, navigate]);
-
   if (search.error) {
+    const retrySearch = toAuthFlowSearch(resolveAuthFlowContext(search));
+    const retryParams = new URLSearchParams({ flow: retrySearch.flow });
+    if (retrySearch.scheme) retryParams.set("scheme", retrySearch.scheme);
+    if (retrySearch.redirect) retryParams.set("redirect", retrySearch.redirect);
+
     return (
       <AuthShell
         title="Sign-in didn’t work"
@@ -225,7 +184,7 @@ function Component() {
           </p>
 
           <a
-            href={`/auth?flow=${search.flow}&scheme=${search.scheme}`}
+            href={`/auth?${retryParams.toString()}`}
             className={authPrimaryButtonClassName}
           >
             Try again
@@ -236,7 +195,7 @@ function Component() {
   }
 
   if (search.flow === "desktop") {
-    const hasTokens = search.access_token && search.refresh_token;
+    const hasTokens = accessToken && refreshToken;
 
     return (
       <AuthShell
@@ -307,4 +266,24 @@ function Component() {
       </AuthShell>
     );
   }
+}
+
+function redirectToExchangeError(
+  search: {
+    flow: "desktop" | "web";
+    scheme: z.infer<typeof desktopSchemeSchema>;
+    redirect?: string;
+  },
+  error: string,
+) {
+  return redirect({
+    to: "/callback/auth/",
+    search: {
+      flow: search.flow,
+      scheme: search.scheme,
+      redirect: search.redirect,
+      error: "exchange_failed",
+      error_description: error,
+    },
+  });
 }

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -23,6 +23,7 @@ import {
   fetchUser,
 } from "@/functions/auth";
 import { type DesktopScheme, flowSearchSchema } from "@/functions/desktop-flow";
+import { toAuthFlowSearch } from "@/lib/auth-flow-context";
 import {
   buildPostAuthDestination,
   sanitizeInternalReturnPath,
@@ -478,6 +479,7 @@ function PasswordForm({
         {!isSignUp && (
           <Link
             to="/reset-password/"
+            search={toAuthFlowSearch({ flow, scheme, redirect })}
             className="text-sm text-[#756b5d] transition-colors hover:text-[#181613] hover:underline"
           >
             Forgot password?

--- a/apps/web/src/routes/confirm-auth.tsx
+++ b/apps/web/src/routes/confirm-auth.tsx
@@ -1,0 +1,138 @@
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { ShieldCheckIcon } from "lucide-react";
+import { useState } from "react";
+import { z } from "zod";
+
+import {
+  AuthShell,
+  authNoticeClassName,
+  authPrimaryButtonClassName,
+} from "@/components/auth-shell";
+import { exchangeOtpToken } from "@/functions/auth";
+import { desktopSchemeSchema } from "@/functions/desktop-flow";
+import {
+  resolveAuthFlowContext,
+  toAuthFlowSearch,
+} from "@/lib/auth-flow-context";
+import { buildPostAuthDestination } from "@/lib/auth-redirect";
+
+const validateSearch = z.object({
+  token_hash: z.string().min(1),
+  type: z.enum([
+    "email",
+    "recovery",
+    "magiclink",
+    "signup",
+    "invite",
+    "email_change",
+  ]),
+  flow: z.enum(["desktop", "web"]).optional(),
+  scheme: desktopSchemeSchema.optional(),
+  redirect: z.string().optional(),
+  redirect_to: z.string().max(2048).optional(),
+});
+
+export const Route = createFileRoute("/confirm-auth")({
+  validateSearch,
+  component: Component,
+  head: () => ({
+    meta: [{ name: "robots", content: "noindex, nofollow" }],
+  }),
+});
+
+function Component() {
+  const search = Route.useSearch();
+  const navigate = useNavigate();
+  const [errorMessage, setErrorMessage] = useState("");
+  const context = resolveAuthFlowContext({
+    flow: search.flow,
+    scheme: search.scheme,
+    redirect: search.redirect,
+    redirectTo: search.redirect_to,
+  });
+
+  const confirmMutation = useMutation({
+    mutationFn: () =>
+      exchangeOtpToken({
+        data: {
+          token_hash: search.token_hash,
+          type: search.type,
+          flow: context.flow,
+        },
+      }),
+    onSuccess: (result) => {
+      if (!result.success) {
+        setErrorMessage(result.error);
+        return;
+      }
+
+      if (search.type === "recovery") {
+        navigate({
+          to: "/update-password/",
+          search: toAuthFlowSearch(context),
+        });
+        return;
+      }
+
+      if (context.flow === "web") {
+        window.location.href = buildPostAuthDestination({
+          newAccount: result.newAccount,
+          returnTo: context.redirect,
+        });
+        return;
+      }
+
+      const params = new URLSearchParams({
+        flow: "desktop",
+        scheme: context.scheme ?? "hyprnote",
+        access_token: result.access_token,
+        refresh_token: result.refresh_token,
+      });
+      window.location.href = `/callback/auth?${params.toString()}`;
+    },
+  });
+
+  return (
+    <AuthShell
+      title="Continue securely"
+      description="Confirm this action to continue with your account."
+    >
+      <div className="flex flex-col gap-4">
+        <div className={authNoticeClassName}>
+          <ShieldCheckIcon className="mx-auto mb-2 size-5 text-[#4f4940]" />
+          <p className="text-center text-sm leading-6 text-[#756b5d]">
+            This extra step keeps automated email scanners from using your
+            one-time link.
+          </p>
+        </div>
+
+        {errorMessage && (
+          <p className="text-center text-sm leading-6 text-red-700">
+            {errorMessage}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={() => {
+            setErrorMessage("");
+            confirmMutation.mutate();
+          }}
+          disabled={confirmMutation.isPending}
+          className={authPrimaryButtonClassName}
+        >
+          {confirmMutation.isPending ? "Confirming..." : "Continue"}
+        </button>
+
+        <Link
+          to="/auth/"
+          search={toAuthFlowSearch(context)}
+          className="text-center text-sm text-[#756b5d] transition-colors hover:text-[#181613] hover:underline"
+        >
+          Back to sign in
+        </Link>
+      </div>
+    </AuthShell>
+  );
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -287,9 +287,10 @@ const authCallbackSearchSchema = z.object({
     ])
     .optional()
     .catch(undefined),
-  flow: z.enum(["desktop", "web"]).optional().catch("desktop"),
+  flow: z.enum(["desktop", "web"]).optional().catch(undefined),
   scheme: desktopSchemeSchema.optional().catch("hyprnote"),
   redirect: z.string().optional(),
+  redirect_to: z.string().max(2048).optional(),
   error: z.string().optional(),
   error_description: z.string().optional(),
 });
@@ -297,24 +298,35 @@ const authCallbackSearchSchema = z.object({
 export const Route = createFileRoute("/")({
   validateSearch: authCallbackSearchSchema,
   beforeLoad: ({ search }) => {
-    const hasAuthCallback =
-      !!search.code || !!search.error || (!!search.token_hash && !!search.type);
+    if (search.token_hash && search.type) {
+      throw redirect({
+        to: "/confirm-auth/",
+        search: {
+          token_hash: search.token_hash,
+          type: search.type,
+          flow: search.flow,
+          scheme: search.scheme,
+          redirect: search.redirect,
+          redirect_to: search.redirect_to,
+        },
+      });
+    }
+
+    const hasAuthCallback = !!search.code || !!search.error;
 
     if (!hasAuthCallback) {
       return;
     }
 
-    const flow = search.flow ?? "desktop";
+    const flow = search.flow ?? "web";
     const scheme = search.scheme ?? "hyprnote";
 
     throw redirect({
-      to: "/auth/",
+      to: "/callback/auth/",
       search: {
         flow,
         scheme,
         code: search.code,
-        token_hash: search.token_hash,
-        type: search.type,
         redirect: search.redirect,
         error: search.error,
         error_description: search.error_description,

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowLeftIcon } from "lucide-react";
 import { useState } from "react";
+import { z } from "zod";
 
 import {
   AuthShell,
@@ -10,8 +11,15 @@ import {
   authPrimaryButtonClassName,
 } from "@/components/auth-shell";
 import { doPasswordResetRequest } from "@/functions/auth";
+import { flowSearchSchema } from "@/functions/desktop-flow";
+import { toAuthFlowSearch } from "@/lib/auth-flow-context";
+
+const validateSearch = flowSearchSchema({
+  redirect: z.string().optional(),
+});
 
 export const Route = createFileRoute("/reset-password")({
+  validateSearch,
   component: Component,
   head: () => ({
     meta: [{ name: "robots", content: "noindex, nofollow" }],
@@ -19,12 +27,13 @@ export const Route = createFileRoute("/reset-password")({
 });
 
 function Component() {
+  const context = Route.useSearch();
   const [email, setEmail] = useState("");
   const [submitted, setSubmitted] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
   const resetMutation = useMutation({
-    mutationFn: () => doPasswordResetRequest({ data: { email } }),
+    mutationFn: () => doPasswordResetRequest({ data: { email, ...context } }),
     onSuccess: (result) => {
       if (result && "error" in result && result.error) {
         setErrorMessage(
@@ -79,7 +88,7 @@ function Component() {
 
       <Link
         to="/auth/"
-        search={{ flow: "web" }}
+        search={toAuthFlowSearch(context)}
         className="mt-5 flex items-center justify-center gap-1 text-sm text-[#756b5d] transition-colors hover:text-[#181613]"
       >
         <ArrowLeftIcon className="size-3.5" />

--- a/apps/web/src/routes/update-password.tsx
+++ b/apps/web/src/routes/update-password.tsx
@@ -6,6 +6,7 @@ import {
   useNavigate,
 } from "@tanstack/react-router";
 import { useState } from "react";
+import { z } from "zod";
 
 import {
   AuthShell,
@@ -13,28 +14,40 @@ import {
   authPrimaryButtonClassName,
 } from "@/components/auth-shell";
 import { doUpdatePassword, fetchUser } from "@/functions/auth";
+import { flowSearchSchema } from "@/functions/desktop-flow";
+import { toAuthFlowSearch } from "@/lib/auth-flow-context";
+
+const validateSearch = flowSearchSchema({
+  redirect: z.string().optional(),
+});
 
 export const Route = createFileRoute("/update-password")({
+  validateSearch,
   component: Component,
   head: () => ({
     meta: [{ name: "robots", content: "noindex, nofollow" }],
   }),
-  beforeLoad: async () => {
+  beforeLoad: async ({ search }) => {
     const user = await fetchUser();
     if (!user) {
-      throw redirect({ to: "/auth/", search: { flow: "web" } });
+      throw redirect({
+        to: "/auth/",
+        search: toAuthFlowSearch(search),
+      });
     }
   },
 });
 
 function Component() {
+  const context = Route.useSearch();
   const navigate = useNavigate();
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
 
   const updateMutation = useMutation({
-    mutationFn: () => doUpdatePassword({ data: { password } }),
+    mutationFn: () =>
+      doUpdatePassword({ data: { password, flow: context.flow } }),
     onSuccess: (result) => {
       if (result && "error" in result && result.error) {
         setErrorMessage(
@@ -43,7 +56,27 @@ function Component() {
         return;
       }
       if (result && "success" in result && result.success) {
-        navigate({ to: "/auth/", search: { flow: "web" } });
+        if (
+          context.flow === "desktop" &&
+          "access_token" in result &&
+          "refresh_token" in result
+        ) {
+          navigate({
+            to: "/callback/auth/",
+            search: {
+              flow: "desktop",
+              scheme: context.scheme,
+              access_token: result.access_token,
+              refresh_token: result.refresh_token,
+            },
+          });
+          return;
+        }
+
+        navigate({
+          to: "/auth/",
+          search: toAuthFlowSearch(context),
+        });
       }
     },
   });
@@ -100,7 +133,7 @@ function Component() {
 
       <Link
         to="/auth/"
-        search={{ flow: "web" }}
+        search={toAuthFlowSearch(context)}
         className="mt-5 flex items-center justify-center gap-1 text-sm text-[#756b5d] transition-colors hover:text-[#181613]"
       >
         Back to sign in

--- a/apps/web/src/telemetry.ts
+++ b/apps/web/src/telemetry.ts
@@ -2,7 +2,7 @@ import { HoneycombWebSDK } from "@honeycombio/opentelemetry-web";
 import { getWebAutoInstrumentations } from "@opentelemetry/auto-instrumentations-web";
 
 import { env } from "./env";
-import { isShareRoutePathname } from "./lib/share-route-privacy";
+import { isTelemetryPrivateLocation } from "./lib/auth-route-privacy";
 
 declare global {
   interface Window {
@@ -79,7 +79,7 @@ function getPropagationTargets(): string[] {
 export function bootstrapBrowserTelemetry() {
   if (
     typeof window === "undefined" ||
-    isShareRoutePathname(window.location.pathname)
+    isTelemetryPrivateLocation(window.location.pathname, window.location.search)
   ) {
     return;
   }


### PR DESCRIPTION
Preserve desktop reset context, isolate auth telemetry, and add scanner-safe confirmation handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, password recovery, token handoff, and redirect sanitization; regressions could break sign-in, desktop handoff, or leak tokens to analytics if privacy guards miss a case.
> 
> **Overview**
> Hardens **email and recovery auth** with scanner-safe OTP handling, **desktop flow context** through reset/update, and **broader telemetry privacy** on auth routes.
> 
> **`/confirm-auth`** is new: magic-link and recovery links with `token_hash` no longer auto-exchange in `beforeLoad`. Users land on a **Continue** step so email scanners cannot burn one-time tokens; `exchangeOtpToken` runs only after a click. Root and `/callback/auth` redirect OTP traffic to this route instead of exchanging immediately.
> 
> **`auth-flow-context`** centralizes `flow` / `scheme` / `redirect` (including parsing trusted `/callback/auth` URLs from Supabase `redirect_to`) and threads that context through reset, update-password, auth links, and recovery redirects. Password reset emails use **`buildAuthCallbackUrl`** with desktop/web params; **`doUpdatePassword`** can mint a desktop session and return tokens when `flow=desktop`.
> 
> **`auth-route-privacy`** replaces share-only checks with **`isTelemetryPrivateLocation`** (auth paths, share routes, and `/` when auth query params are present). On desktop callback, **`prepareAuthRoutePrivacy`** stores tokens in `sessionStorage` and strips them from the URL via `history.replaceState`; the callback UI reads **`readDesktopAuthHandoff`**. PostHog, Sentry, GA, Clarity, and OTEL honor the same guard (pathname + search).
> 
> **Routing tweaks:** default callback flow is **web**; legacy root `code`/`error` callbacks go to `/callback/auth`; OAuth/OTP errors surface on the callback page with retry links preserving context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda944277a83f3f3abaea503b6ab633a44e9fc92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->