### PR TITLE
Show sync status only in note surfaces

### DIFF
--- a/apps/desktop/src/main/shell-frame.test.tsx
+++ b/apps/desktop/src/main/shell-frame.test.tsx
@@ -71,11 +71,28 @@ describe("ClassicMainShellFrame", () => {
     render(<ClassicMainShellFrame />);
 
     expect(screen.getByTestId("toast-notifications")).not.toBeNull();
+    expect(screen.getByTestId("sync-status-indicator")).not.toBeNull();
     expect(
       screen
         .getByTestId("main-shell-scaffold")
         .getAttribute("data-main-surface-chrome"),
     ).toBe("left");
+  });
+
+  it("shows sync status in note views", () => {
+    mocks.currentTab = { type: "sessions" };
+
+    render(<ClassicMainShellFrame />);
+
+    expect(screen.getByTestId("sync-status-indicator")).not.toBeNull();
+  });
+
+  it("hides sync status outside empty and note views", () => {
+    mocks.currentTab = { type: "settings" };
+
+    render(<ClassicMainShellFrame />);
+
+    expect(screen.queryByTestId("sync-status-indicator")).toBeNull();
   });
 
   it("uses borderless top-edge main surface chrome while the sidebar timeline is collapsed", () => {
@@ -124,5 +141,6 @@ describe("ClassicMainShellFrame", () => {
 
     expect(scaffold.getAttribute("data-edge-to-edge")).toBe("true");
     expect(scaffold.getAttribute("data-main-surface-chrome")).toBeNull();
+    expect(screen.queryByTestId("sync-status-indicator")).toBeNull();
   });
 });

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -19,6 +19,8 @@ export function ClassicMainShellFrame() {
 
   const isOnboarding = currentTab?.type === "onboarding";
   const isChangelog = currentTab?.type === "changelog";
+  const showSyncStatus =
+    currentTab?.type === "empty" || currentTab?.type === "sessions";
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
@@ -38,7 +40,7 @@ export function ClassicMainShellFrame() {
       mainSurfaceChrome={isOnboarding ? undefined : mainSurfaceChrome}
     >
       <ClassicMainBodyHost />
-      {!isOnboarding && <SyncStatusIndicator />}
+      {showSyncStatus && <SyncStatusIndicator />}
       <ToastNotifications />
     </MainShellScaffold>
   );


### PR DESCRIPTION
Limit the global sync indicator to empty and regular note tabs, with shell coverage for visible and hidden states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI visibility change with no auth, data, or sync logic changes—only when the indicator mounts.
> 
> **Overview**
> **Limits where the global sync indicator appears** in the classic main shell: it now renders only on the empty tab and `sessions` (note) tabs, instead of on every non-onboarding view.
> 
> `ClassicMainShellFrame` introduces `showSyncStatus` and gates `SyncStatusIndicator` on that flag. Shell tests cover visible states (empty, sessions), hidden states (settings), and confirm onboarding still omits the indicator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61bdc5c189bb7bdd53ff31e6cb37ca6dcaba68d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->