### PR TITLE
Fix sign-out and local model download reliability

### DIFF
--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -822,6 +822,27 @@ describe("CloudSync auth lifecycle", () => {
     await suspension;
   });
 
+  test("does not resume token refresh when a timed-out suspension later fails", async () => {
+    let failSuspension!: (error: Error) => void;
+    const suspension = new Promise<void>((_resolve, reject) => {
+      failSuspension = reject;
+    });
+    const fetchMock = vi.fn(() => Promise.resolve(credentialsResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(suspendCloudsync).mockReturnValueOnce(suspension);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const preparation = prepareCloudsyncSignOut(session());
+    await vi.advanceTimersByTimeAsync(2000);
+    await preparation;
+
+    failSuspension(new Error("cloudsync suspension failed"));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(configureCloudsyncToken).not.toHaveBeenCalled();
+  });
+
   test("resumes token refresh when sign-out suspension fails", async () => {
     const fetchMock = vi.fn(() => Promise.resolve(credentialsResponse()));
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -795,6 +795,33 @@ describe("CloudSync auth lifecycle", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  test("does not block sign-out on a stalled cloudsync suspension", async () => {
+    let finishSuspension!: () => void;
+    const suspension = new Promise<void>((resolve) => {
+      finishSuspension = resolve;
+    });
+    vi.mocked(suspendCloudsync).mockReturnValueOnce(suspension);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const preparation = prepareCloudsyncSignOut(session());
+    await vi.advanceTimersByTimeAsync(1999);
+
+    let completed = false;
+    void preparation.then(() => {
+      completed = true;
+    });
+    expect(completed).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await preparation;
+    expect(console.warn).toHaveBeenCalledWith(
+      "[cloudsync] sign-out suspension is finishing in background",
+    );
+
+    finishSuspension();
+    await suspension;
+  });
+
   test("resumes token refresh when sign-out suspension fails", async () => {
     const fetchMock = vi.fn(() => Promise.resolve(credentialsResponse()));
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -865,14 +865,6 @@ export async function prepareCloudsyncSignOut(
           "[cloudsync] background sign-out suspension failed",
           error,
         );
-        if (session && activeGeneration === generation) {
-          scheduleExchange(
-            session,
-            activeGeneration,
-            MIN_REFRESH_DELAY_MS,
-            onAccountMismatch,
-          );
-        }
       });
     }
   } catch (error) {

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -30,6 +30,7 @@ const RETRY_DELAY_MS = 60 * 1000;
 const MIN_REFRESH_DELAY_MS = 1000;
 const EXCHANGE_TIMEOUT_MS = 25 * 1000;
 const EVICTION_RETRY_DELAY_MS = 30 * 1000;
+const SIGN_OUT_SUSPEND_TIMEOUT_MS = 2 * 1000;
 
 export type CloudsyncAuthChangeResult = "ok" | "account_mismatch";
 
@@ -841,9 +842,39 @@ export async function prepareCloudsyncSignOut(
 ): Promise<void> {
   const activeGeneration = beginTransition();
   stopCloudsyncInitialSyncProgress();
+  const suspension = enqueuePluginOperation(suspendCloudsync);
+  let timeout: ReturnType<typeof setTimeout> | null = null;
 
   try {
-    await enqueuePluginOperation(suspendCloudsync);
+    const result = await Promise.race([
+      suspension.then(() => "suspended" as const),
+      new Promise<"timed_out">((resolve) => {
+        timeout = setTimeout(
+          () => resolve("timed_out"),
+          SIGN_OUT_SUSPEND_TIMEOUT_MS,
+        );
+      }),
+    ]);
+
+    if (result === "timed_out") {
+      console.warn(
+        "[cloudsync] sign-out suspension is finishing in background",
+      );
+      void suspension.catch((error) => {
+        console.warn(
+          "[cloudsync] background sign-out suspension failed",
+          error,
+        );
+        if (session && activeGeneration === generation) {
+          scheduleExchange(
+            session,
+            activeGeneration,
+            MIN_REFRESH_DELAY_MS,
+            onAccountMismatch,
+          );
+        }
+      });
+    }
   } catch (error) {
     if (session) {
       scheduleExchange(
@@ -854,6 +885,10 @@ export async function prepareCloudsyncSignOut(
       );
     }
     throw error;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
   }
 }
 

--- a/apps/desktop/src/auth/context.test.tsx
+++ b/apps/desktop/src/auth/context.test.tsx
@@ -885,6 +885,37 @@ describe("AuthProvider", () => {
     ).toBeLessThan(mocks.signOut.mock.invocationCallOrder[0]);
   });
 
+  it("clears the visible session before cloudsync teardown finishes", async () => {
+    const currentSession = makeSession("bound-account");
+    const teardown = deferred<"ok">();
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", currentSession);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe(
+        currentSession.user.id,
+      );
+    });
+    mocks.handleCloudsyncAuthChange.mockReturnValueOnce(teardown.promise);
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe("none");
+    });
+
+    teardown.resolve("ok");
+    await teardown.promise;
+  });
+
   it("fails remote sign-out closed when the React session is empty", async () => {
     mocks.prepareCloudsyncSignOut.mockRejectedValueOnce(
       new Error("cloudsync suspension failed"),

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -379,11 +379,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       trackedIdentifySignature = null;
       trackedSignedInUserId = null;
+      setSession(null);
       if (managesCloudsync) {
         await handleCloudsyncAuthChange("SIGNED_OUT", null);
-      }
-      if (transition === authTransitionRef.current) {
-        setSession(null);
       }
     },
     [coordinateMainSignOut, managesCloudsync],

--- a/apps/desktop/src/contexts/notifications.test.tsx
+++ b/apps/desktop/src/contexts/notifications.test.tsx
@@ -1,0 +1,92 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  downloadHandler: null as
+    | null
+    | ((event: {
+        payload: {
+          model: "soniqo-parakeet-batch";
+          status: { failed: string };
+        };
+      }) => void),
+  listen: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-local-stt", () => ({
+  commands: { getServerForModel: vi.fn() },
+  events: {
+    downloadProgressPayload: {
+      listen: mocks.listen,
+    },
+  },
+}));
+
+vi.mock("@hypr/ui/components/ui/toast", () => ({
+  sonnerToast: { error: mocks.toastError },
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValues: () => ({
+    current_stt_provider: "hyprnote",
+    current_stt_model: "cloud",
+    current_llm_provider: "hyprnote",
+    current_llm_model: "default",
+  }),
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: (selector: (state: { currentTab: null }) => unknown) =>
+    selector({ currentTab: null }),
+}));
+
+vi.mock("~/stt/capabilities", () => ({
+  isConfiguredSttModel: () => true,
+  isHyprnoteLocalSttModel: () => false,
+}));
+
+import { NotificationProvider } from "./notifications";
+
+describe("NotificationProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.downloadHandler = null;
+    mocks.listen.mockImplementation(async (handler) => {
+      mocks.downloadHandler = handler;
+      return vi.fn();
+    });
+  });
+
+  it("surfaces an asynchronous model download failure", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <NotificationProvider>
+          <div />
+        </NotificationProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.downloadHandler).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.downloadHandler?.({
+        payload: {
+          model: "soniqo-parakeet-batch",
+          status: { failed: "download server rejected the model" },
+        },
+      });
+    });
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "Couldn’t download Soniqo Parakeet Batch",
+      { description: "download server rejected the model" },
+    );
+  });
+});

--- a/apps/desktop/src/contexts/notifications.tsx
+++ b/apps/desktop/src/contexts/notifications.tsx
@@ -14,6 +14,7 @@ import {
   type ServerStatus,
   type LocalModel,
 } from "@hypr/plugin-local-stt";
+import { sonnerToast } from "@hypr/ui/components/ui/toast";
 
 import { useConfigValues } from "~/shared/config";
 import type { DownloadProgress } from "~/sidebar/toast/types";
@@ -38,6 +39,8 @@ interface NotificationState {
 const NotificationContext = createContext<NotificationState | null>(null);
 
 const MODEL_DISPLAY_NAMES: Partial<Record<LocalModel, string>> = {
+  "soniqo-parakeet-streaming": "Soniqo Parakeet Streaming",
+  "soniqo-parakeet-batch": "Soniqo Parakeet Batch",
   "am-parakeet-v2": "Parakeet v2",
   "am-parakeet-v3": "Parakeet v3",
   "am-whisper-large-v3": "Whisper Large v3",
@@ -94,10 +97,17 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const unlisten = localSttEvents.downloadProgressPayload.listen((event) => {
       const { model: eventModel, status } = event.payload;
+      const isFailed = typeof status === "object" && "failed" in status;
+
+      if (isFailed) {
+        const modelName = MODEL_DISPLAY_NAMES[eventModel] ?? eventModel;
+        sonnerToast.error(`Couldn’t download ${modelName}`, {
+          description: status.failed,
+        });
+      }
 
       setActiveDownloads((prev) => {
         const next = new Map(prev);
-        const isFailed = typeof status === "object" && "failed" in status;
         if (isFailed || status === "completed") {
           next.delete(eventModel);
         } else if (typeof status === "object" && "downloading" in status) {

--- a/apps/desktop/src/settings/ai/stt/context.test.tsx
+++ b/apps/desktop/src/settings/ai/stt/context.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clearTarget: vi.fn(),
+  downloadModel: vi.fn(),
+  toastError: vi.fn(),
+  upgradeToPro: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-local-stt", () => ({
+  commands: { downloadModel: mocks.downloadModel },
+}));
+
+vi.mock("@hypr/ui/components/ui/toast", () => ({
+  sonnerToast: { error: mocks.toastError },
+}));
+
+vi.mock("~/auth/billing-context", () => ({
+  useBillingAccess: () => ({ upgradeToPro: mocks.upgradeToPro }),
+}));
+
+vi.mock("~/store/zustand/toast-action", () => ({
+  useToastAction: (selector: (state: unknown) => unknown) =>
+    selector({ target: null, clearTarget: mocks.clearTarget }),
+}));
+
+import { SttSettingsProvider, useSttSettings } from "./context";
+
+function Probe() {
+  const { queuedDownloads, startDownload } = useSttSettings();
+
+  return (
+    <>
+      <div data-testid="queued">{queuedDownloads.join(",")}</div>
+      <button onClick={() => startDownload("soniqo-parakeet-batch")}>
+        Download
+      </button>
+    </>
+  );
+}
+
+describe("SttSettingsProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the command error and makes a failed model retryable", async () => {
+    mocks.downloadModel.mockResolvedValue({
+      status: "error",
+      error: "batch model is unavailable",
+    });
+
+    render(
+      <SttSettingsProvider>
+        <Probe />
+      </SttSettingsProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Model download couldn’t start",
+        { description: "batch model is unavailable" },
+      );
+    });
+    expect(screen.getByTestId("queued").textContent).toBe("");
+  });
+});

--- a/apps/desktop/src/settings/ai/stt/context.tsx
+++ b/apps/desktop/src/settings/ai/stt/context.tsx
@@ -11,6 +11,7 @@ import {
   commands as localSttCommands,
   type LocalModel,
 } from "@hypr/plugin-local-stt";
+import { sonnerToast } from "@hypr/ui/components/ui/toast";
 
 import { useBillingAccess } from "~/auth/billing-context";
 import { useToastAction } from "~/store/zustand/toast-action";
@@ -60,11 +61,26 @@ export function SttSettingsProvider({
     queuedDownloadsRef.current.add(model);
     setQueuedDownloads([...queuedDownloadsRef.current]);
     void localSttCommands.downloadModel(model).then(
-      // The command resolves when the download starts, not when it finishes.
-      // Keep the queue entry until progress events take over the row state,
-      // so the gap cannot accept another click.
-      () => setTimeout(dequeue, DOWNLOAD_PROGRESS_GRACE_MS),
-      dequeue,
+      (result) => {
+        if (result.status === "error") {
+          sonnerToast.error("Model download couldn’t start", {
+            description: result.error,
+          });
+          dequeue();
+          return;
+        }
+
+        // The command resolves when the download starts, not when it finishes.
+        // Keep the queue entry until progress events take over the row state,
+        // so the gap cannot accept another click.
+        setTimeout(dequeue, DOWNLOAD_PROGRESS_GRACE_MS);
+      },
+      (error) => {
+        sonnerToast.error("Model download couldn’t start", {
+          description: error instanceof Error ? error.message : String(error),
+        });
+        dequeue();
+      },
     );
   }, []);
 

--- a/crates/db-core/src/cloudsync/runtime.rs
+++ b/crates/db-core/src/cloudsync/runtime.rs
@@ -463,6 +463,7 @@ mod tests {
         }
     }
 
+    use std::future::pending;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use crate::{CloudsyncAuth, CloudsyncTableSpec, DbOpenOptions, DbStorage};
@@ -784,6 +785,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shutdown_interrupts_an_active_sync_future() {
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+        shutdown_tx.send(()).unwrap();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            run_or_shutdown(pending::<()>(), &mut shutdown_rx),
+        )
+        .await
+        .expect("active sync ignored shutdown");
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
     async fn suspend_stops_runtime_and_clears_in_memory_credentials() {
         let db = Db::open(DbOpenOptions {
             storage: DbStorage::Memory,
@@ -926,15 +942,19 @@ async fn sync_cloudsync_with_retry(
         .build();
 
     loop {
-        match sync_cloudsync_connection(
-            pool,
-            connection,
-            sync_hook,
-            config.wait_ms,
-            config.max_retries,
+        let result = run_or_shutdown(
+            sync_cloudsync_connection(
+                pool,
+                connection,
+                sync_hook,
+                config.wait_ms,
+                config.max_retries,
+            ),
+            shutdown_rx,
         )
-        .await
-        {
+        .await?;
+
+        match result {
             Err(error) if error.kind() == hypr_cloudsync::ErrorKind::Transient => {
                 let Some(retry_after) = backoff.next() else {
                     return Some(Err(error));
@@ -960,6 +980,17 @@ async fn sync_cloudsync_with_retry(
             }
             result => return Some(result),
         }
+    }
+}
+
+async fn run_or_shutdown<T>(
+    future: impl Future<Output = T>,
+    shutdown_rx: &mut oneshot::Receiver<()>,
+) -> Option<T> {
+    tokio::select! {
+        biased;
+        _ = &mut *shutdown_rx => None,
+        result = future => Some(result),
     }
 }
 

--- a/crates/transcribe-soniqo/build.rs
+++ b/crates/transcribe-soniqo/build.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 #[cfg(target_os = "macos")]
-const SONIQO_SWIFT_MACOS_DEPLOYMENT_TARGET: &str = "14.0";
+const SONIQO_SWIFT_MACOS_DEPLOYMENT_TARGET: &str = "14.2";
 #[cfg(target_os = "macos")]
 const SONIQO_METALLIB_MACOS_DEPLOYMENT_TARGET: &str = "15.0";
 

--- a/crates/transcribe-soniqo/swift-lib/Package.resolved
+++ b/crates/transcribe-soniqo/swift-lib/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soniqo/speech-swift",
       "state" : {
-        "revision" : "03920e17671fc79d59da1573923958304e233c42",
-        "version" : "0.0.9"
+        "revision" : "335a68c0db92564527881962ff11eb686863d2b8",
+        "version" : "0.0.22"
       }
     },
     {
@@ -312,6 +312,15 @@
       "state" : {
         "revision" : "ca48d46c25f8fa948d37eaa480c73172182cf90f",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "whisperkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/argmaxinc/WhisperKit",
+      "state" : {
+        "revision" : "25c62997041c134b03ca82731ce2f6fd2cae1eb9",
+        "version" : "1.0.0"
       }
     },
     {

--- a/crates/transcribe-soniqo/swift-lib/Package.swift
+++ b/crates/transcribe-soniqo/swift-lib/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
   name: "soniqo-swift",
-  platforms: [.macOS("14.0")],
+  platforms: [.macOS("14.2")],
   products: [
     .library(
       name: "soniqo-swift",
@@ -15,7 +15,7 @@ let package = Package(
     .package(
       url: "https://github.com/Brendonovich/swift-rs",
       revision: "01980f981bc642a6da382cc0788f18fdd4cde6df"),
-    .package(url: "https://github.com/soniqo/speech-swift", exact: "0.0.9"),
+    .package(url: "https://github.com/soniqo/speech-swift", exact: "0.0.22"),
   ],
   targets: [
     .target(

--- a/plugins/local-stt/src/ext.rs
+++ b/plugins/local-stt/src/ext.rs
@@ -426,6 +426,13 @@ fn spawn_soniqo_progress_poller<R: Runtime>(
                 download_status,
                 DownloadStatus::Completed | DownloadStatus::Failed(_)
             );
+            if let DownloadStatus::Failed(error) = &download_status {
+                tracing::error!(
+                    model = soniqo_model.as_str(),
+                    error,
+                    "soniqo_model_download_failed"
+                );
+            }
             let _ = DownloadProgressPayload {
                 model: model.clone(),
                 status: download_status,
@@ -439,6 +446,10 @@ fn spawn_soniqo_progress_poller<R: Runtime>(
             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         }
 
+        tracing::error!(
+            model = soniqo_model.as_str(),
+            "soniqo_model_download_timed_out"
+        );
         let _ = DownloadProgressPayload {
             model,
             status: DownloadStatus::Failed("Soniqo model download timed out".to_string()),


### PR DESCRIPTION
Bound sign-out teardown so CloudSync cannot stall the UI, make active sync cancelable, update the pinned Soniqo downloader to the first tagged release with large-file stall recovery, and surface exact local model download failures with retryable state.

Verification:
- pnpm -F @hypr/desktop exec vitest run src/auth/cloudsync.test.ts src/auth/context.test.tsx src/settings/ai/stt/context.test.tsx src/contexts/notifications.test.tsx
- pnpm -F @hypr/desktop typecheck
- cargo test -p db-core shutdown_interrupts_an_active_sync_future
- cargo test -p db-core suspend_interrupts_active_retry_backoff
- swift package resolve (speech-swift 0.0.22)

The local native plugin check is blocked by this machine’s unaccepted Xcode license; desktop CI is the native build gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth sign-out, CloudSync suspend/teardown, and native sync shutdown; bounded suspend timeout trades a small window of background teardown for responsive UI.
> 
> **Overview**
> **Sign-out and CloudSync** no longer block on a hung native suspend: `prepareCloudsyncSignOut` races suspension against a **2s** timeout, logs and continues in the background on timeout, and avoids resuming token refresh if that background suspend later fails. The auth provider clears the **visible session** (`setSession(null)`) before awaiting CloudSync teardown on sign-out.
> 
> **db-core** makes the cloudsync loop honor shutdown while a sync is in flight via `run_or_shutdown`, with a new test for interrupting an active sync future.
> 
> **Local STT downloads** surface failures with error toasts (settings start, notification progress events), clear the download queue on command errors so retries work, and the local-stt plugin logs/emits explicit failure on Soniqo download timeout.
> 
> **Soniqo native stack** bumps `speech-swift` to **0.0.22**, raises the Swift package deployment target to **macOS 14.2**, and adds a **WhisperKit** resolved dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c34c574dca22c2973e9b882afecdfb3194d38002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->