### PR TITLE
Recover CloudSync from transient conflicts

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -206,6 +206,7 @@ msgstr "Anarlog sends these separately, so editing the prompt cannot remove the 
 msgid "Anarlog will keep retrying"
 msgstr "Anarlog will keep retrying"
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr "Anarlog will retry automatically. This does not affect your notes."
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr "Resume sync"
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -206,6 +206,7 @@ msgstr ""
 msgid "Anarlog will keep retrying"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Anarlog will retry automatically. This does not affect your notes."
 msgstr ""
@@ -1634,6 +1635,7 @@ msgid "Resume sync"
 msgstr ""
 
 #: src/chat/components/message/error.tsx
+#: src/main/sync-status.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"

--- a/apps/desktop/src/main/sync-status.test.tsx
+++ b/apps/desktop/src/main/sync-status.test.tsx
@@ -244,6 +244,34 @@ describe("SyncStatusIndicator", () => {
     expect(screen.getByText("token rejected")).toBeTruthy();
   });
 
+  it("makes a transient sync issue retryable without exposing the server error", async () => {
+    mocks.getCloudsyncStatus.mockResolvedValue(
+      syncedStatus({
+        last_error:
+          'sqlx error: {"errors":[{"status":"409","code":"already_exists"}]}',
+        last_error_kind: "transient",
+        consecutive_failures: 1,
+      }),
+    );
+
+    renderIndicator();
+    await openMenu();
+
+    expect(await screen.findByText("Sync issue")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Anarlog will retry automatically. This does not affect your notes.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/already_exists/)).toBeNull();
+
+    fireEvent.click(screen.getByText("Retry"));
+
+    await vi.waitFor(() => {
+      expect(mocks.syncCloudsyncNow).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("triggers a manual sync", async () => {
     renderIndicator();
     await openMenu();

--- a/apps/desktop/src/main/sync-status.tsx
+++ b/apps/desktop/src/main/sync-status.tsx
@@ -145,7 +145,10 @@ export function SyncStatusIndicator() {
       return {
         kind: "error" as const,
         label: t`Sync issue`,
-        description: status.last_error ?? t`Anarlog will keep retrying`,
+        description:
+          status.last_error_kind === "transient"
+            ? t`Anarlog will retry automatically. This does not affect your notes.`
+            : (status.last_error ?? t`Anarlog will keep retrying`),
       };
     }
 
@@ -174,6 +177,8 @@ export function SyncStatusIndicator() {
       )}`,
     };
   })();
+  const canRetry =
+    view.kind === "error" && status?.last_error_kind === "transient";
 
   return (
     <DropdownMenu>
@@ -228,11 +233,14 @@ export function SyncStatusIndicator() {
         ) : (
           <>
             <DropdownMenuItem
-              disabled={syncNowMutation.isPending || view.kind !== "synced"}
+              disabled={
+                syncNowMutation.isPending ||
+                (view.kind !== "synced" && !canRetry)
+              }
               onSelect={() => syncNowMutation.mutate()}
             >
               <RefreshCwIcon className="size-4" />
-              <Trans>Sync now</Trans>
+              {canRetry ? <Trans>Retry</Trans> : <Trans>Sync now</Trans>}
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={preferenceMutation.isPending}

--- a/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
@@ -1,5 +1,5 @@
 import { APICallError } from "ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TASK_CONFIGS } from "./task-configs";
 import {
@@ -21,6 +21,14 @@ vi.mock("~/settings/queries", () => ({
 }));
 
 const originalEnhanceConfig = { ...TASK_CONFIGS.enhance };
+
+beforeEach(() => {
+  mocks.getStoredSettingValues.mockReset();
+  mocks.getStoredSettingValues.mockResolvedValue({
+    values: {},
+    hasValues: new Set(),
+  });
+});
 
 afterEach(() => {
   vi.useRealTimers();
@@ -187,6 +195,88 @@ describe("createTasksSlice", () => {
       status: "error",
       streamedText: "",
       error: expect.objectContaining({ message: "database write failed" }),
+    });
+  });
+
+  it("retries database contention before starting generation", async () => {
+    vi.useFakeTimers();
+    let state: ReturnType<typeof createTasksSlice>;
+    const set = (updater: any) => {
+      state =
+        typeof updater === "function"
+          ? updater(state)
+          : { ...state, ...updater };
+    };
+    const get = () => state;
+    state = createTasksSlice(set, get);
+
+    TASK_CONFIGS.enhance.transformArgs = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("error returned from database: (code: 5) database is locked"),
+      )
+      .mockResolvedValue({} as any);
+    TASK_CONFIGS.enhance.transforms = [];
+    TASK_CONFIGS.enhance.executeWorkflow = vi.fn(async function* () {
+      yield { type: "text-delta", text: "Generated summary" } as any;
+    });
+    TASK_CONFIGS.enhance.onSuccess = vi.fn(async () => {});
+
+    const taskId = "session-locked-read-enhance" as const;
+    const promise = state.generate(taskId, {
+      model: {} as any,
+      taskType: "enhance",
+      args: { sessionId: "session-1", enhancedNoteId: "note-1" },
+    });
+
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(TASK_CONFIGS.enhance.transformArgs).toHaveBeenCalledTimes(2);
+    expect(TASK_CONFIGS.enhance.executeWorkflow).toHaveBeenCalledOnce();
+    expect(state.tasks[taskId]).toMatchObject({
+      status: "success",
+      streamedText: "Generated summary",
+    });
+  });
+
+  it("retries summary persistence without generating it twice", async () => {
+    vi.useFakeTimers();
+    let state: ReturnType<typeof createTasksSlice>;
+    const set = (updater: any) => {
+      state =
+        typeof updater === "function"
+          ? updater(state)
+          : { ...state, ...updater };
+    };
+    const get = () => state;
+    state = createTasksSlice(set, get);
+
+    TASK_CONFIGS.enhance.transformArgs = vi.fn(async () => ({}) as any);
+    TASK_CONFIGS.enhance.transforms = [];
+    TASK_CONFIGS.enhance.executeWorkflow = vi.fn(async function* () {
+      yield { type: "text-delta", text: "Generated summary" } as any;
+    });
+    TASK_CONFIGS.enhance.onSuccess = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("database table is locked"))
+      .mockResolvedValue(undefined);
+
+    const taskId = "session-locked-write-enhance" as const;
+    const promise = state.generate(taskId, {
+      model: {} as any,
+      taskType: "enhance",
+      args: { sessionId: "session-1", enhancedNoteId: "note-1" },
+    });
+
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(TASK_CONFIGS.enhance.executeWorkflow).toHaveBeenCalledOnce();
+    expect(TASK_CONFIGS.enhance.onSuccess).toHaveBeenCalledTimes(2);
+    expect(state.tasks[taskId]).toMatchObject({
+      status: "success",
+      streamedText: "Generated summary",
     });
   });
 

--- a/apps/desktop/src/store/zustand/ai-task/tasks.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.ts
@@ -114,15 +114,28 @@ async function waitForDatabaseRetry(delayMs: number, signal: AbortSignal) {
   throwIfAborted(signal);
 
   await new Promise<void>((resolve, reject) => {
+    let settled = false;
     const handleAbort = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       clearTimeout(timeout);
+      signal.removeEventListener("abort", handleAbort);
       reject(createAbortError());
     };
     const timeout = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       signal.removeEventListener("abort", handleAbort);
       resolve();
     }, delayMs);
     signal.addEventListener("abort", handleAbort, { once: true });
+    if (signal.aborted) {
+      handleAbort();
+    }
   });
 }
 

--- a/apps/desktop/src/store/zustand/ai-task/tasks.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.ts
@@ -82,7 +82,72 @@ const initialState: TasksState = {
 export const TASK_STREAM_IDLE_TIMEOUT_MS = 15_000;
 export const TASK_STREAM_START_TIMEOUT_MS = 60_000;
 
+const DATABASE_LOCK_RETRY_DELAYS_MS = [
+  250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 30_000,
+];
 const STREAM_TIMEOUT = Symbol("stream-timeout");
+
+function createAbortError() {
+  const error = new Error("Aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal: AbortSignal) {
+  if (signal.aborted) {
+    throw createAbortError();
+  }
+}
+
+function isDatabaseLockError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("database is locked") ||
+    normalized.includes("database table is locked") ||
+    normalized.includes("(code: 5)") ||
+    normalized.includes("(code: 6)")
+  );
+}
+
+async function waitForDatabaseRetry(delayMs: number, signal: AbortSignal) {
+  throwIfAborted(signal);
+
+  await new Promise<void>((resolve, reject) => {
+    const handleAbort = () => {
+      clearTimeout(timeout);
+      reject(createAbortError());
+    };
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", handleAbort);
+      resolve();
+    }, delayMs);
+    signal.addEventListener("abort", handleAbort, { once: true });
+  });
+}
+
+async function withDatabaseLockRetry<T>(
+  run: () => Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    throwIfAborted(signal);
+    try {
+      return await run();
+    } catch (error) {
+      if (
+        !isDatabaseLockError(error) ||
+        attempt >= DATABASE_LOCK_RETRY_DELAYS_MS.length
+      ) {
+        throw error;
+      }
+      await waitForDatabaseRetry(
+        DATABASE_LOCK_RETRY_DELAYS_MS[attempt],
+        signal,
+      );
+    }
+  }
+}
 
 async function readStreamChunkWithTimeout<T>(
   iterator: AsyncIterator<T>,
@@ -217,19 +282,18 @@ export const createTasksSlice = <T extends TasksState & TasksActions>(
         }),
       );
 
-      const { values: settingsValues } = await getStoredSettingValues();
-      const enrichedArgs = await taskConfig.transformArgs(
-        config.args,
-        settingsValues,
+      const { values: settingsValues } = await withDatabaseLockRetry(
+        getStoredSettingValues,
+        abortController.signal,
+      );
+      const enrichedArgs = await withDatabaseLockRetry(
+        () => taskConfig.transformArgs(config.args, settingsValues),
+        abortController.signal,
       );
       let fullText = "";
 
       const checkAbort = () => {
-        if (abortController.signal.aborted) {
-          const error = new Error("Aborted");
-          error.name = "AbortError";
-          throw error;
-        }
+        throwIfAborted(abortController.signal);
       };
 
       const onProgress = (step: TaskStepInfo<Task>) => {
@@ -310,17 +374,27 @@ export const createTasksSlice = <T extends TasksState & TasksActions>(
         abortController.signal.removeEventListener("abort", abortWorkflow);
       }
 
-      await taskConfig.onSuccess?.({
-        taskId,
-        text: fullText,
-        model: config.model,
-        args: config.args,
-        transformedArgs: enrichedArgs,
-        signal: abortController.signal,
-        startTask: (nextTaskId, nextConfig) =>
-          get().generate(nextTaskId, nextConfig),
-        getTaskState: (nextTaskId) => getTaskState(get().tasks, nextTaskId),
-      });
+      const onSuccess = taskConfig.onSuccess;
+      if (onSuccess) {
+        await withDatabaseLockRetry(
+          () =>
+            Promise.resolve(
+              onSuccess({
+                taskId,
+                text: fullText,
+                model: config.model,
+                args: config.args,
+                transformedArgs: enrichedArgs,
+                signal: abortController.signal,
+                startTask: (nextTaskId, nextConfig) =>
+                  get().generate(nextTaskId, nextConfig),
+                getTaskState: (nextTaskId) =>
+                  getTaskState(get().tasks, nextTaskId),
+              }),
+            ),
+          abortController.signal,
+        );
+      }
 
       checkAbort();
 

--- a/crates/cloudsync/src/error.rs
+++ b/crates/cloudsync/src/error.rs
@@ -40,20 +40,57 @@ pub enum Error {
 
 impl Error {
     pub fn kind(&self) -> ErrorKind {
-        if let Self::Sqlx(sqlx_err) = self {
-            if let Some(code) = extract_error_code(sqlx_err) {
-                return classify_error_code(code);
+        match self {
+            Self::Sqlx(sqlx_err) => {
+                if let Some(db_err) = sqlx_err.as_database_error() {
+                    return classify_database_error(db_err.code().as_deref(), db_err.message());
+                }
             }
+            Self::Io(error) => return classify_io_error(error),
+            _ => {}
         }
         ErrorKind::Fatal
     }
 }
 
-fn extract_error_code(err: &sqlx::Error) -> Option<i64> {
-    match err {
-        sqlx::Error::Database(db_err) => db_err.code().and_then(|c| c.parse::<i64>().ok()),
-        _ => None,
+fn classify_database_error(code: Option<&str>, message: &str) -> ErrorKind {
+    if let Some(kind) = classify_error_message(message) {
+        return kind;
     }
+
+    code.and_then(|code| code.parse().ok())
+        .map_or(ErrorKind::Fatal, classify_error_code)
+}
+
+fn classify_io_error(error: &std::io::Error) -> ErrorKind {
+    match error.kind() {
+        std::io::ErrorKind::BrokenPipe
+        | std::io::ErrorKind::ConnectionAborted
+        | std::io::ErrorKind::ConnectionReset
+        | std::io::ErrorKind::Interrupted
+        | std::io::ErrorKind::NotConnected
+        | std::io::ErrorKind::TimedOut
+        | std::io::ErrorKind::WouldBlock => ErrorKind::Transient,
+        _ => classify_error_message(&error.to_string()).unwrap_or(ErrorKind::Fatal),
+    }
+}
+
+fn classify_error_message(message: &str) -> Option<ErrorKind> {
+    if message.contains("\"status\":\"409\"") && message.contains("\"code\":\"already_exists\"") {
+        return Some(ErrorKind::Transient);
+    }
+
+    let message = message.to_ascii_lowercase();
+    [
+        "connection reset by peer",
+        "database is locked",
+        "database table is locked",
+        "error sending request for url",
+        "status 429 too many requests",
+    ]
+    .iter()
+    .any(|fragment| message.contains(fragment))
+    .then_some(ErrorKind::Transient)
 }
 
 // SQLite Cloud error code ranges:
@@ -72,10 +109,51 @@ fn classify_error_code(code: i64) -> ErrorKind {
         100002 | 100003 | 100006 => ErrorKind::Fatal, // TLS, URL, FORMAT
         100000 | 100001 | 100004 | 100007 => ErrorKind::Transient, // GENERIC, PUBSUB, MEMORY, INDEX
 
-        // SQLite native errors (< 10_000) are schema/constraint issues
+        // SQLite contention
+        5 | 6 => ErrorKind::Transient, // SQLITE_BUSY, SQLITE_LOCKED
+
+        // Other SQLite native errors (< 10_000) are schema/constraint issues
         _ if code < 10_000 => ErrorKind::Fatal,
 
         // Unknown codes in cloud/sdk ranges — assume transient
         _ => ErrorKind::Transient,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn already_existing_cloud_resource_is_transient() {
+        let message = r#"{"errors":[{"status":"409","code":"already_exists","title":"Conflict","detail":"resource already exists"}]}"#;
+
+        assert_eq!(
+            classify_database_error(Some("1"), message),
+            ErrorKind::Transient
+        );
+    }
+
+    #[test]
+    fn other_sqlite_errors_remain_fatal() {
+        assert_eq!(
+            classify_database_error(Some("1"), "no such table: sessions"),
+            ErrorKind::Fatal
+        );
+    }
+
+    #[test]
+    fn sqlite_contention_and_transport_failures_are_transient() {
+        assert_eq!(classify_error_code(5), ErrorKind::Transient);
+        assert_eq!(
+            classify_database_error(Some("1"), "Recv failure: Connection reset by peer"),
+            ErrorKind::Transient
+        );
+        assert_eq!(
+            classify_io_error(&std::io::Error::other(
+                "E2EE pre-sync witness apply failed: database is locked"
+            )),
+            ErrorKind::Transient
+        );
     }
 }

--- a/crates/cloudsync/src/error.rs
+++ b/crates/cloudsync/src/error.rs
@@ -45,6 +45,7 @@ impl Error {
                 if let Some(db_err) = sqlx_err.as_database_error() {
                     return classify_database_error(db_err.code().as_deref(), db_err.message());
                 }
+                return classify_error_message(&sqlx_err.to_string()).unwrap_or(ErrorKind::Fatal);
             }
             Self::Io(error) => return classify_io_error(error),
             _ => {}
@@ -153,6 +154,14 @@ mod tests {
             classify_io_error(&std::io::Error::other(
                 "E2EE pre-sync witness apply failed: database is locked"
             )),
+            ErrorKind::Transient
+        );
+        assert_eq!(
+            Error::Sqlx(sqlx::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "connection reset by peer",
+            )))
+            .kind(),
             ErrorKind::Transient
         );
     }

--- a/crates/db-core/src/cloudsync/types.rs
+++ b/crates/db-core/src/cloudsync/types.rs
@@ -91,6 +91,15 @@ pub enum CloudsyncRuntimeError {
     Cloudsync(#[from] hypr_cloudsync::Error),
 }
 
+impl CloudsyncRuntimeError {
+    pub fn is_transient(&self) -> bool {
+        matches!(
+            self,
+            Self::Cloudsync(error) if error.kind() == hypr_cloudsync::ErrorKind::Transient
+        )
+    }
+}
+
 impl From<hypr_cloudsync::ErrorKind> for CloudsyncErrorKind {
     fn from(kind: hypr_cloudsync::ErrorKind) -> Self {
         match kind {
@@ -142,5 +151,16 @@ mod tests {
         );
         assert!(!api_key.contains("api-key-secret"));
         assert!(api_key.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn runtime_exposes_transient_cloudsync_errors() {
+        let error = CloudsyncRuntimeError::from(hypr_cloudsync::Error::from(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "connection reset",
+        )));
+
+        assert!(error.is_transient());
+        assert!(!CloudsyncRuntimeError::NotStarted.is_transient());
     }
 }

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -712,6 +712,7 @@ impl PluginDbRuntime {
                             tracing::warn!(%error, "CloudSync full resync remains pending");
                             return;
                         }
+                        retry_delay = CLOUDSYNC_FULL_RESYNC_MIN_RETRY_DELAY;
                         tracing::warn!(%error, "CloudSync full resync will retry after reconfigure");
                     }
                 }

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -9,6 +9,10 @@ use tauri::ipc::Channel;
 use crate::{QueryEvent, Result, TransactionStatement};
 
 const DEFAULT_CLOUDSYNC_INTERVAL_MS: u64 = 30_000;
+const CLOUDSYNC_FULL_RESYNC_MAX_RETRY_DELAY: std::time::Duration =
+    std::time::Duration::from_secs(5 * 60);
+const CLOUDSYNC_FULL_RESYNC_MIN_RETRY_DELAY: std::time::Duration =
+    std::time::Duration::from_secs(5);
 const CLOUDSYNC_WRITE_FILTER: &str =
     "workspace_id IN (SELECT allowed_workspace_id FROM cloudsync_writable_workspaces)";
 
@@ -161,6 +165,7 @@ pub struct PluginDbRuntime {
     executor: DbExecutor,
     live_query_runtime: LiveQueryRuntime<QueryEventChannel>,
     e2ee_sync_hook: std::sync::Arc<E2eeSyncHook>,
+    scheduled_cloudsync_full_resync: std::sync::Arc<std::sync::Mutex<Option<String>>>,
 }
 
 impl PluginDbRuntime {
@@ -174,6 +179,7 @@ impl PluginDbRuntime {
             executor: DbExecutor::new(std::sync::Arc::clone(&db)),
             live_query_runtime: LiveQueryRuntime::new(db),
             e2ee_sync_hook,
+            scheduled_cloudsync_full_resync: Default::default(),
         }
     }
 
@@ -616,30 +622,58 @@ impl PluginDbRuntime {
     }
 
     fn schedule_cloudsync_full_resync(&self, generation: String) {
+        {
+            let mut scheduled = self.scheduled_cloudsync_full_resync.lock().unwrap();
+            if scheduled.as_deref() == Some(&generation) {
+                return;
+            }
+            *scheduled = Some(generation.clone());
+        }
+
         let db = std::sync::Arc::clone(&self.db);
+        let scheduled = std::sync::Arc::clone(&self.scheduled_cloudsync_full_resync);
         tokio::spawn(async move {
-            for attempt in 0..3 {
+            let mut retry_delay = CLOUDSYNC_FULL_RESYNC_MIN_RETRY_DELAY;
+            loop {
+                if scheduled.lock().unwrap().as_deref() != Some(&generation) {
+                    return;
+                }
+
                 match db.cloudsync_trigger_sync().await {
                     Ok(result) if cloudsync_snapshot_completed(&result) => {
-                        if let Err(error) =
-                            hypr_db_app::clear_cloudsync_full_resync_pending(db.pool(), &generation)
-                                .await
+                        match hypr_db_app::clear_cloudsync_full_resync_pending(
+                            db.pool(),
+                            &generation,
+                        )
+                        .await
                         {
-                            tracing::warn!(%error, "failed to clear CloudSync full resync marker");
+                            Ok(()) => break,
+                            Err(error) => {
+                                tracing::warn!(%error, "failed to clear CloudSync full resync marker");
+                            }
                         }
-                        return;
-                    }
-                    Ok(_) if attempt < 2 => {
-                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                     }
                     Ok(_) => {
-                        tracing::warn!("CloudSync full resync remains incomplete");
+                        tracing::warn!(?retry_delay, "CloudSync full resync remains incomplete");
+                    }
+                    Err(error) if error.is_transient() => {
+                        tracing::warn!(%error, ?retry_delay, "CloudSync full resync will retry");
                     }
                     Err(error) => {
                         tracing::warn!(%error, "CloudSync full resync remains pending");
-                        return;
+                        break;
                     }
                 }
+
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = retry_delay
+                    .saturating_mul(2)
+                    .min(CLOUDSYNC_FULL_RESYNC_MAX_RETRY_DELAY);
+            }
+
+            let mut active = scheduled.lock().unwrap();
+            if active.as_deref() == Some(&generation) {
+                *active = None;
             }
         });
     }

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -656,7 +656,7 @@ impl PluginDbRuntime {
                     Ok(_) => {
                         tracing::warn!(?retry_delay, "CloudSync full resync remains incomplete");
                     }
-                    Err(error) if error.is_transient() => {
+                    Err(error) if should_retry_cloudsync_full_resync(&error) => {
                         tracing::warn!(%error, ?retry_delay, "CloudSync full resync will retry");
                     }
                     Err(error) => {
@@ -785,6 +785,15 @@ fn cloudsync_snapshot_completed(result: &hypr_db_core::CloudsyncNetworkResult) -
         && receive.complete
         && receive.error.is_none()
         && receive.last_failure.is_none()
+}
+
+fn should_retry_cloudsync_full_resync(error: &hypr_db_core::CloudsyncRuntimeError) -> bool {
+    error.is_transient()
+        || matches!(
+            error,
+            hypr_db_core::CloudsyncRuntimeError::NotConfigured
+                | hypr_db_core::CloudsyncRuntimeError::NotStarted
+        )
 }
 
 fn is_permanent_cloudsync_workspace_rejection(
@@ -964,6 +973,19 @@ mod tests {
         assert!(!cloudsync_snapshot_completed(&send_only));
         assert!(!cloudsync_send_completed(
             &hypr_db_core::CloudsyncNetworkResult::default()
+        ));
+    }
+
+    #[test]
+    fn full_resync_waits_for_cloudsync_to_restart() {
+        assert!(should_retry_cloudsync_full_resync(
+            &hypr_db_core::CloudsyncRuntimeError::NotConfigured
+        ));
+        assert!(should_retry_cloudsync_full_resync(
+            &hypr_db_core::CloudsyncRuntimeError::NotStarted
+        ));
+        assert!(!should_retry_cloudsync_full_resync(
+            &hypr_db_core::CloudsyncRuntimeError::Unavailable
         ));
     }
 

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -165,7 +165,49 @@ pub struct PluginDbRuntime {
     executor: DbExecutor,
     live_query_runtime: LiveQueryRuntime<QueryEventChannel>,
     e2ee_sync_hook: std::sync::Arc<E2eeSyncHook>,
-    scheduled_cloudsync_full_resync: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    scheduled_cloudsync_full_resync: std::sync::Arc<std::sync::Mutex<CloudsyncFullResyncSchedule>>,
+}
+
+#[derive(Default)]
+struct CloudsyncFullResyncSchedule {
+    generation: Option<String>,
+    restart_requested: bool,
+}
+
+impl CloudsyncFullResyncSchedule {
+    fn claim(&mut self, generation: &str) -> bool {
+        if self.generation.as_deref() == Some(generation) {
+            self.restart_requested = true;
+            return false;
+        }
+
+        self.generation = Some(generation.to_string());
+        self.restart_requested = false;
+        true
+    }
+
+    fn is_active(&self, generation: &str) -> bool {
+        self.generation.as_deref() == Some(generation)
+    }
+
+    fn handle_non_transient_error(&mut self, generation: &str) -> bool {
+        if !self.is_active(generation) {
+            return false;
+        }
+        if std::mem::take(&mut self.restart_requested) {
+            return true;
+        }
+
+        self.generation = None;
+        false
+    }
+
+    fn complete(&mut self, generation: &str) {
+        if self.is_active(generation) {
+            self.generation = None;
+            self.restart_requested = false;
+        }
+    }
 }
 
 impl PluginDbRuntime {
@@ -624,10 +666,9 @@ impl PluginDbRuntime {
     fn schedule_cloudsync_full_resync(&self, generation: String) {
         {
             let mut scheduled = self.scheduled_cloudsync_full_resync.lock().unwrap();
-            if scheduled.as_deref() == Some(&generation) {
+            if !scheduled.claim(&generation) {
                 return;
             }
-            *scheduled = Some(generation.clone());
         }
 
         let db = std::sync::Arc::clone(&self.db);
@@ -635,7 +676,7 @@ impl PluginDbRuntime {
         tokio::spawn(async move {
             let mut retry_delay = CLOUDSYNC_FULL_RESYNC_MIN_RETRY_DELAY;
             loop {
-                if scheduled.lock().unwrap().as_deref() != Some(&generation) {
+                if !scheduled.lock().unwrap().is_active(&generation) {
                     return;
                 }
 
@@ -647,7 +688,10 @@ impl PluginDbRuntime {
                         )
                         .await
                         {
-                            Ok(()) => break,
+                            Ok(()) => {
+                                scheduled.lock().unwrap().complete(&generation);
+                                return;
+                            }
                             Err(error) => {
                                 tracing::warn!(%error, "failed to clear CloudSync full resync marker");
                             }
@@ -656,12 +700,19 @@ impl PluginDbRuntime {
                     Ok(_) => {
                         tracing::warn!(?retry_delay, "CloudSync full resync remains incomplete");
                     }
-                    Err(error) if should_retry_cloudsync_full_resync(&error) => {
+                    Err(error) if error.is_transient() => {
                         tracing::warn!(%error, ?retry_delay, "CloudSync full resync will retry");
                     }
                     Err(error) => {
-                        tracing::warn!(%error, "CloudSync full resync remains pending");
-                        break;
+                        let retry_after_restart = scheduled
+                            .lock()
+                            .unwrap()
+                            .handle_non_transient_error(&generation);
+                        if !retry_after_restart {
+                            tracing::warn!(%error, "CloudSync full resync remains pending");
+                            return;
+                        }
+                        tracing::warn!(%error, "CloudSync full resync will retry after reconfigure");
                     }
                 }
 
@@ -669,11 +720,6 @@ impl PluginDbRuntime {
                 retry_delay = retry_delay
                     .saturating_mul(2)
                     .min(CLOUDSYNC_FULL_RESYNC_MAX_RETRY_DELAY);
-            }
-
-            let mut active = scheduled.lock().unwrap();
-            if active.as_deref() == Some(&generation) {
-                *active = None;
             }
         });
     }
@@ -785,15 +831,6 @@ fn cloudsync_snapshot_completed(result: &hypr_db_core::CloudsyncNetworkResult) -
         && receive.complete
         && receive.error.is_none()
         && receive.last_failure.is_none()
-}
-
-fn should_retry_cloudsync_full_resync(error: &hypr_db_core::CloudsyncRuntimeError) -> bool {
-    error.is_transient()
-        || matches!(
-            error,
-            hypr_db_core::CloudsyncRuntimeError::NotConfigured
-                | hypr_db_core::CloudsyncRuntimeError::NotStarted
-        )
 }
 
 fn is_permanent_cloudsync_workspace_rejection(
@@ -977,16 +1014,16 @@ mod tests {
     }
 
     #[test]
-    fn full_resync_waits_for_cloudsync_to_restart() {
-        assert!(should_retry_cloudsync_full_resync(
-            &hypr_db_core::CloudsyncRuntimeError::NotConfigured
-        ));
-        assert!(should_retry_cloudsync_full_resync(
-            &hypr_db_core::CloudsyncRuntimeError::NotStarted
-        ));
-        assert!(!should_retry_cloudsync_full_resync(
-            &hypr_db_core::CloudsyncRuntimeError::Unavailable
-        ));
+    fn full_resync_hands_off_reconfigure_without_retrying_after_suspend() {
+        let mut schedule = CloudsyncFullResyncSchedule::default();
+
+        assert!(schedule.claim("generation-1"));
+        assert!(!schedule.claim("generation-1"));
+        assert!(schedule.handle_non_transient_error("generation-1"));
+        assert!(schedule.is_active("generation-1"));
+
+        assert!(!schedule.handle_non_transient_error("generation-1"));
+        assert!(!schedule.is_active("generation-1"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Classify recoverable CloudSync conflicts and transport failures as transient, keep full resync retries alive with bounded backoff, and give users a safe retry action without exposing server details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cloud sync error handling and long-running full-resync retry logic, which can affect data sync behavior; scope is mitigated by tests and bounded backoff.
> 
> **Overview**
> Treats more CloudSync and SQLite failures as **transient** so sync and resync can recover instead of surfacing fatal errors. Rust error classification now maps conflicts like `409` / `already_exists`, `SQLITE_BUSY` / locked tables, connection resets, rate limits, and similar message patterns to transient kinds, with tests covering the new rules.
> 
> **Full resync** in the DB plugin no longer stops after three quick attempts; it retries with exponential backoff (capped) while errors stay transient, and it can hand off to a new run after reconfigure without duplicate schedulers.
> 
> The desktop **sync status** menu shows a generic reassurance for transient issues (no raw server JSON) and enables a **Retry** action that triggers sync immediately. Locale catalogs pick up the new string references.
> 
> **AI enhance tasks** retry settings reads, argument transforms, and success persistence when SQLite reports lock/contention, without re-running generation after text is already produced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da78148f45489a5eace1d678f25ba0e08b566bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->