### PR TITLE
Keep floating panels on their initial display

### DIFF
--- a/plugins/windows/swift-lib/src/DevtoolsPanelManager.swift
+++ b/plugins/windows/swift-lib/src/DevtoolsPanelManager.swift
@@ -7,7 +7,6 @@ final class DevtoolsPanelManager {
   private var panel: NSPanel?
   private let placement = FloatingPanelPositionController()
   private var displayChangeObserver: Any?
-  private var followActiveScreenTimer: Timer?
   private var targetPanelSize = NSSize(
     width: DevtoolsPanelLayout.containerWidth,
     height: DevtoolsPanelLayout.containerHeight)
@@ -20,7 +19,7 @@ final class DevtoolsPanelManager {
 
       if let panel = self.panel {
         self.position(panel, force: true)
-        self.startFollowingActiveScreen()
+        self.startObservingDisplayChanges()
         panel.orderFrontRegardless()
         RustBridge.devtoolsPanelAction("panel:opened")
         return
@@ -45,7 +44,7 @@ final class DevtoolsPanelManager {
       self.position(panel, force: true)
       panel.orderFrontRegardless()
       self.panel = panel
-      self.startFollowingActiveScreen()
+      self.startObservingDisplayChanges()
       RustBridge.devtoolsPanelAction("panel:opened")
     }
   }
@@ -53,7 +52,7 @@ final class DevtoolsPanelManager {
   func hide() {
     DispatchQueue.main.async { [weak self] in
       guard let self, let panel = self.panel else { return }
-      self.stopFollowingActiveScreen()
+      self.stopObservingDisplayChanges()
       self.placement.preparePinnedFrameForReplacement(
         panel,
         size: NSSize(
@@ -94,7 +93,12 @@ final class DevtoolsPanelManager {
   }
 
   private func position(_ panel: NSPanel, force: Bool = false) {
-    placement.position(panel, force: force, size: targetPanelSize) { screen, size in
+    placement.position(
+      panel,
+      force: force,
+      size: targetPanelSize,
+      followsPointer: false
+    ) { screen, size in
       let frame = screen.visibleFrame
       let x = frame.maxX - size.width - DevtoolsPanelLayout.screenMargin
       let y = frame.maxY - size.height - DevtoolsPanelLayout.screenMargin
@@ -102,15 +106,8 @@ final class DevtoolsPanelManager {
     }
   }
 
-  private func startFollowingActiveScreen() {
-    guard followActiveScreenTimer == nil else { return }
-
-    let timer = Timer(timeInterval: 0.35, repeats: true) { [weak self] _ in
-      guard let self, let panel = self.panel else { return }
-      self.position(panel)
-    }
-    RunLoop.main.add(timer, forMode: .common)
-    followActiveScreenTimer = timer
+  private func startObservingDisplayChanges() {
+    guard displayChangeObserver == nil else { return }
 
     displayChangeObserver = NotificationCenter.default.addObserver(
       forName: NSApplication.didChangeScreenParametersNotification,
@@ -122,10 +119,7 @@ final class DevtoolsPanelManager {
     }
   }
 
-  private func stopFollowingActiveScreen() {
-    followActiveScreenTimer?.invalidate()
-    followActiveScreenTimer = nil
-
+  private func stopObservingDisplayChanges() {
     if let displayChangeObserver {
       NotificationCenter.default.removeObserver(displayChangeObserver)
       self.displayChangeObserver = nil

--- a/plugins/windows/swift-lib/src/FloatingBarManager.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarManager.swift
@@ -10,7 +10,6 @@ final class FloatingBarManager {
   private let settingsModel = FloatingOverlaySettingsModel.shared
   private let placement = FloatingPanelPositionController()
   private var displayChangeObserver: Any?
-  private var followActiveScreenTimer: Timer?
   private var isApplyingExternalState = false
   private var cancellables = Set<AnyCancellable>()
 
@@ -35,7 +34,7 @@ final class FloatingBarManager {
 
       if let panel = self.panel {
         self.position(panel, force: true)
-        self.startFollowingActiveScreen()
+        self.startObservingDisplayChanges()
         panel.orderFrontRegardless()
         return
       }
@@ -66,14 +65,14 @@ final class FloatingBarManager {
       self.position(panel, force: true)
       panel.orderFrontRegardless()
       self.panel = panel
-      self.startFollowingActiveScreen()
+      self.startObservingDisplayChanges()
     }
   }
 
   func hide() {
     DispatchQueue.main.async { [weak self] in
       guard let self, let panel = self.panel else { return }
-      self.stopFollowingActiveScreen()
+      self.stopObservingDisplayChanges()
       FloatingOverlaySettingsPanelManager.shared.hide()
       panel.orderOut(nil)
       self.panel = nil
@@ -141,7 +140,8 @@ final class FloatingBarManager {
       panel,
       force: force,
       size: size,
-      anchorOffset: controlAnchorOffset(for: layout)
+      anchorOffset: controlAnchorOffset(for: layout),
+      followsPointer: false
     ) { screen, size in
       let frame = screen.visibleFrame
       let x = frame.maxX - size.width - FloatingBarLayout.screenMargin
@@ -236,15 +236,8 @@ final class FloatingBarManager {
     )
   }
 
-  private func startFollowingActiveScreen() {
-    guard followActiveScreenTimer == nil else { return }
-
-    let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
-      guard let self, let panel = self.panel else { return }
-      self.position(panel)
-    }
-    RunLoop.main.add(timer, forMode: .common)
-    followActiveScreenTimer = timer
+  private func startObservingDisplayChanges() {
+    guard displayChangeObserver == nil else { return }
 
     displayChangeObserver = NotificationCenter.default.addObserver(
       forName: NSApplication.didChangeScreenParametersNotification,
@@ -256,10 +249,7 @@ final class FloatingBarManager {
     }
   }
 
-  private func stopFollowingActiveScreen() {
-    followActiveScreenTimer?.invalidate()
-    followActiveScreenTimer = nil
-
+  private func stopObservingDisplayChanges() {
     if let displayChangeObserver {
       NotificationCenter.default.removeObserver(displayChangeObserver)
       self.displayChangeObserver = nil

--- a/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
+++ b/plugins/windows/swift-lib/src/FloatingPanelPositionController.swift
@@ -14,6 +14,7 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
     force: Bool = false,
     size: NSSize? = nil,
     anchorOffset: NSPoint? = nil,
+    followsPointer: Bool = true,
     defaultOrigin: (NSScreen, NSSize) -> NSPoint
   ) {
     let panelSize = size ?? panel.frame.size
@@ -35,7 +36,7 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
       return
     }
 
-    let screen = activeScreen()
+    let screen = activeScreen(followsPointer: followsPointer)
     let screenId = displayId(for: screen)
     if !force, screenId == activeScreenId {
       return
@@ -164,9 +165,17 @@ final class FloatingPanelPositionController: NSObject, NSWindowDelegate {
     }
   }
 
-  private func activeScreen() -> NSScreen {
-    let mouse = NSEvent.mouseLocation
+  private func activeScreen(followsPointer: Bool) -> NSScreen {
     let screens = NSScreen.screens
+
+    if !followsPointer,
+      let activeScreenId,
+      let currentScreen = screens.first(where: { displayId(for: $0) == activeScreenId })
+    {
+      return currentScreen
+    }
+
+    let mouse = NSEvent.mouseLocation
 
     if let exactScreen = screens.first(where: { $0.frame.contains(mouse) }) {
       return exactScreen


### PR DESCRIPTION
- Ensure floating panels remain on their initial display position/state instead of resetting or reflowing after render/updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized macOS overlay positioning behavior with no auth, data, or network impact; main risk is edge cases on multi-monitor layout changes.
> 
> **Overview**
> Floating **devtools** and **floating bar** panels no longer jump to whichever monitor the cursor is on during routine repositioning.
> 
> **`FloatingPanelPositionController`** gains a **`followsPointer`** flag (default `true`). When **`false`**, screen selection sticks to the stored **`activeScreenId`** instead of **`NSEvent.mouseLocation`**. Both panel managers pass **`followsPointer: false`** when placing.
> 
> The **repeating timers** (~0.25–0.35s) that continuously re-ran placement to “follow” the active screen are **removed**. Repositioning on **display layout changes** still uses **`NSApplication.didChangeScreenParametersNotification`** (lifecycle helpers renamed to **`startObservingDisplayChanges`** / **`stopObservingDisplayChanges`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172e3232177be8ac9342d7fa0d16dfd8ec796da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->