### PR TITLE
Keep welcome auth header concise

### DIFF
--- a/apps/web/src/components/auth-shell.tsx
+++ b/apps/web/src/components/auth-shell.tsx
@@ -29,10 +29,12 @@ export const authNoticeClassName =
 export function AuthShell({
   title,
   description,
+  showEyebrow = true,
   children,
 }: {
   title: string;
-  description: string;
+  description?: string;
+  showEyebrow?: boolean;
   children: React.ReactNode;
 }) {
   return (
@@ -53,15 +55,24 @@ export function AuthShell({
 
           <section className="mx-auto w-full max-w-[440px] overflow-hidden rounded-[24px] border border-[#e5ddcf] bg-white shadow-[0_24px_80px_rgba(24,22,19,0.10)]">
             <header className="border-b border-[#ede7dc] px-6 py-7 sm:px-8 sm:py-8">
-              <p className="font-hand text-xl leading-none font-semibold text-[#756b5d]">
-                Private by default
-              </p>
-              <h1 className="font-hand mt-3 text-4xl leading-none font-semibold text-[#181613]">
+              {showEyebrow && (
+                <p className="font-hand text-xl leading-none font-semibold text-[#756b5d]">
+                  Private by default
+                </p>
+              )}
+              <h1
+                className={cn([
+                  "font-hand text-4xl leading-none font-semibold text-[#181613]",
+                  showEyebrow && "mt-3",
+                ])}
+              >
                 {title}
               </h1>
-              <p className="mt-3 text-sm leading-6 text-[#756b5d]">
-                {description}
-              </p>
+              {description && (
+                <p className="mt-3 text-sm leading-6 text-[#756b5d]">
+                  {description}
+                </p>
+              )}
             </header>
 
             <div className="p-6 sm:p-8">{children}</div>

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -127,10 +127,7 @@ function Component() {
   const showEmail = !provider;
 
   return (
-    <AuthShell
-      title="Welcome to Anarlog"
-      description="Choose how you’d like to continue."
-    >
+    <AuthShell title="Welcome to Anarlog" showEyebrow={false}>
       {view === "main" && (
         <>
           <div className="flex flex-col gap-3">


### PR DESCRIPTION
Show only the Anarlog welcome title on the initial auth screen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, presentation-only auth UI changes with no auth logic or data handling impact.
> 
> **Overview**
> **AuthShell** now supports an optional **`showEyebrow`** flag (default on) and an optional **`description`**, so the card header can show only the title when desired. The “Private by default” line and subtitle render only when those props are used; title spacing adjusts when the eyebrow is hidden.
> 
> The main **`/auth`** welcome screen sets **`showEyebrow={false}`** and drops the “Choose how you’d like to continue” copy, leaving **“Welcome to Anarlog”** as the sole header text. Other auth flows that pass a description keep the previous header layout via defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e07fbf6d251ac26797ca1afa5a2d5a5816eb153e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->