### PR TITLE
Fix FaceTime notification icon detection

### DIFF
--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -1794,6 +1794,10 @@ describe("ListenerProvider detect events", () => {
       icon: { type: "bundle_id", bundle_id: "com.apple.FaceTime" },
     },
     {
+      app: { id: "com.apple.avconferenced", name: "FaceTime" },
+      icon: { type: "bundle_id", bundle_id: "com.apple.FaceTime" },
+    },
+    {
       app: { id: "net.whatsapp.WhatsApp", name: "WhatsApp" },
       icon: {
         type: "path",

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -316,9 +316,11 @@ const MIC_APP_NOTIFICATION_OVERRIDES = [
 
 function getMicAppNotificationOverride(app: MicApp) {
   const normalizedName = app.name.trim().toLowerCase();
-  return MIC_APP_NOTIFICATION_OVERRIDES.find(
-    (override) =>
-      override.ids.has(app.id) || override.names.has(normalizedName),
+  return (
+    MIC_APP_NOTIFICATION_OVERRIDES.find((override) =>
+      override.names.has(normalizedName),
+    ) ??
+    MIC_APP_NOTIFICATION_OVERRIDES.find((override) => override.ids.has(app.id))
   );
 }
 

--- a/crates/detect/src/list/macos.rs
+++ b/crates/detect/src/list/macos.rs
@@ -101,33 +101,51 @@ pub fn list_mic_using_apps() -> Result<Vec<InstalledApp>, crate::Error> {
     });
 
     let mut apps = build_mic_using_apps(snapshots, resolve_to_app, fallback_app_for_pid)?;
-    label_apple_call_daemon(&mut apps, active_apple_call_app_name());
+    label_apple_call_daemon(&mut apps, detected_apple_call_app_name());
     Ok(apps)
 }
 
-fn active_apple_call_app_name() -> Option<&'static str> {
-    [
-        ("com.apple.FaceTime", "FaceTime"),
-        ("com.apple.mobilephone", "iPhone Call"),
-    ]
-    .into_iter()
-    .find_map(|(bundle_id, name)| {
-        let bundle_id = NSString::from_str(bundle_id);
-        NSRunningApplication::runningApplicationsWithBundleIdentifier(&bundle_id)
-            .iter()
-            .any(|app| app.isActive())
-            .then_some(name)
-    })
+fn detected_apple_call_app_name() -> Option<&'static str> {
+    let face_time = apple_call_app_state("com.apple.FaceTime");
+    let phone = apple_call_app_state("com.apple.mobilephone");
+
+    select_apple_call_app_name(face_time.0, face_time.1, phone.0, phone.1)
 }
 
-fn label_apple_call_daemon(apps: &mut [InstalledApp], active_app_name: Option<&str>) {
-    let Some(active_app_name) = active_app_name else {
+fn apple_call_app_state(bundle_id: &str) -> (bool, bool) {
+    let bundle_id = NSString::from_str(bundle_id);
+    let apps = NSRunningApplication::runningApplicationsWithBundleIdentifier(&bundle_id);
+    (!apps.is_empty(), apps.iter().any(|app| app.isActive()))
+}
+
+fn select_apple_call_app_name(
+    face_time_running: bool,
+    face_time_active: bool,
+    phone_running: bool,
+    phone_active: bool,
+) -> Option<&'static str> {
+    if face_time_active {
+        return Some("FaceTime");
+    }
+    if phone_active {
+        return Some("iPhone Call");
+    }
+
+    match (face_time_running, phone_running) {
+        (true, false) => Some("FaceTime"),
+        (false, true) => Some("iPhone Call"),
+        _ => None,
+    }
+}
+
+fn label_apple_call_daemon(apps: &mut [InstalledApp], running_app_name: Option<&str>) {
+    let Some(running_app_name) = running_app_name else {
         return;
     };
 
     for app in apps {
         if APPLE_CALL_DAEMON_IDS.contains(&app.id.as_str()) {
-            app.name = active_app_name.to_string();
+            app.name = running_app_name.to_string();
         }
     }
 }
@@ -317,7 +335,36 @@ mod tests {
     }
 
     #[test]
-    fn test_label_apple_call_daemon_uses_active_call_app_name() {
+    fn test_select_apple_call_app_name_uses_only_running_app() {
+        assert_eq!(
+            select_apple_call_app_name(true, false, false, false),
+            Some("FaceTime")
+        );
+        assert_eq!(
+            select_apple_call_app_name(false, false, true, false),
+            Some("iPhone Call")
+        );
+    }
+
+    #[test]
+    fn test_select_apple_call_app_name_uses_active_app_when_both_are_running() {
+        assert_eq!(
+            select_apple_call_app_name(true, true, true, false),
+            Some("FaceTime")
+        );
+        assert_eq!(
+            select_apple_call_app_name(true, false, true, true),
+            Some("iPhone Call")
+        );
+    }
+
+    #[test]
+    fn test_select_apple_call_app_name_leaves_ambiguous_apps_unlabeled() {
+        assert_eq!(select_apple_call_app_name(true, false, true, false), None);
+    }
+
+    #[test]
+    fn test_label_apple_call_daemon_uses_detected_call_app_name() {
         let mut apps = vec![InstalledApp {
             id: "com.apple.avconferenced".to_string(),
             name: "avconferenced".to_string(),

--- a/crates/detect/src/list/macos.rs
+++ b/crates/detect/src/list/macos.rs
@@ -3,9 +3,17 @@ use std::path::{Path, PathBuf};
 use cidre::core_audio as ca;
 use hypr_bundle::{is_app_bundle, read_bundle_info};
 use objc2_app_kit::NSRunningApplication;
+use objc2_foundation::NSString;
 use sysinfo::{Pid, System};
 
 use super::InstalledApp;
+
+const APPLE_CALL_DAEMON_IDS: &[&str] = &[
+    "/usr/libexec/avconferenced",
+    "com.apple.avconferenced",
+    "com.apple.TelephonyUtilities",
+    "com.apple.TelephonyUtilities.callservicesd",
+];
 
 #[cfg(target_os = "macos")]
 struct MicProcessSnapshot {
@@ -92,7 +100,36 @@ pub fn list_mic_using_apps() -> Result<Vec<InstalledApp>, crate::Error> {
         }
     });
 
-    build_mic_using_apps(snapshots, resolve_to_app, fallback_app_for_pid)
+    let mut apps = build_mic_using_apps(snapshots, resolve_to_app, fallback_app_for_pid)?;
+    label_apple_call_daemon(&mut apps, active_apple_call_app_name());
+    Ok(apps)
+}
+
+fn active_apple_call_app_name() -> Option<&'static str> {
+    [
+        ("com.apple.FaceTime", "FaceTime"),
+        ("com.apple.mobilephone", "iPhone Call"),
+    ]
+    .into_iter()
+    .find_map(|(bundle_id, name)| {
+        let bundle_id = NSString::from_str(bundle_id);
+        NSRunningApplication::runningApplicationsWithBundleIdentifier(&bundle_id)
+            .iter()
+            .any(|app| app.isActive())
+            .then_some(name)
+    })
+}
+
+fn label_apple_call_daemon(apps: &mut [InstalledApp], active_app_name: Option<&str>) {
+    let Some(active_app_name) = active_app_name else {
+        return;
+    };
+
+    for app in apps {
+        if APPLE_CALL_DAEMON_IDS.contains(&app.id.as_str()) {
+            app.name = active_app_name.to_string();
+        }
+    }
 }
 
 fn resolve_to_app(pid: i32) -> Option<InstalledApp> {
@@ -277,6 +314,31 @@ mod tests {
         assert_eq!(apps.len(), 1);
         assert_eq!(apps[0].id, "pid:7");
         assert_eq!(apps[0].name, "Fallback");
+    }
+
+    #[test]
+    fn test_label_apple_call_daemon_uses_active_call_app_name() {
+        let mut apps = vec![InstalledApp {
+            id: "com.apple.avconferenced".to_string(),
+            name: "avconferenced".to_string(),
+        }];
+
+        label_apple_call_daemon(&mut apps, Some("FaceTime"));
+
+        assert_eq!(apps[0].id, "com.apple.avconferenced");
+        assert_eq!(apps[0].name, "FaceTime");
+    }
+
+    #[test]
+    fn test_label_apple_call_daemon_leaves_other_apps_unchanged() {
+        let mut apps = vec![InstalledApp {
+            id: "us.zoom.xos".to_string(),
+            name: "zoom.us".to_string(),
+        }];
+
+        label_apple_call_daemon(&mut apps, Some("FaceTime"));
+
+        assert_eq!(apps[0].name, "zoom.us");
     }
 
     #[test]


### PR DESCRIPTION
- Fixed FaceTime notification icon detection to reliably identify the correct icon in notifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to macOS mic-app labeling and mic-detected notification icon/name resolution, with unit tests; no auth or data-path changes.
> 
> **Overview**
> **FaceTime mic prompts** now show the FaceTime app icon when macOS reports the call through `avconferenced` (and related Telephony daemons) instead of defaulting to the iPhone Call treatment.
> 
> On **macOS**, after mic-using apps are built, known Apple call daemon IDs are renamed to **FaceTime** or **iPhone Call** based on whether FaceTime / Phone are running and which is frontmost; if both run without a clear active app, the daemon name is left unchanged. Unit tests cover that selection and labeling logic.
> 
> On the **desktop**, `getMicAppNotificationOverride` now matches **display name before bundle/path id**, so a relabeled **FaceTime** name wins over the `com.apple.avconferenced` id that still maps to the phone override. Tests add `com.apple.avconferenced` with name FaceTime expecting the FaceTime bundle icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04193516c611171dafffd1d968a01758b0fdb72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->