### PR TITLE
Tighten header action left padding

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -274,7 +274,7 @@ function HeaderMeetingActionPill({
           disabled={disabled}
           onClick={action.onClick}
           className={cn([
-            "flex h-full min-w-0 items-center gap-1.5 py-0 pr-1.5 pl-2.5",
+            "flex h-full min-w-0 items-center gap-1.5 py-0 pr-1.5 pl-1.5",
             "text-sm font-medium",
             "hover:bg-accent transition-colors",
             disabled && "cursor-default opacity-60 hover:bg-transparent",


### PR DESCRIPTION
Reduce the leading inset on the session header action pill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on header button spacing with no behavior or logic impact.
> 
> **Overview**
> Narrows the **leading inset** on the primary action button in the session header meeting pill (`Stop`, `Join & record`, `Resume`, etc.) by changing its left padding from `pl-2.5` to `pl-1.5`, matching the existing right padding for a more balanced pill layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c16bd72e213db97ce630eb42151ce4af28c2a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->