### PR TITLE
Round undo toast gauge corners

### DIFF
--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
@@ -92,6 +92,9 @@ describe("UndoDeleteToast", () => {
         descriptionClassName: expect.stringContaining("bottom-0"),
       }),
     );
+    expect(mocks.message.mock.calls[0][1].descriptionClassName).toContain(
+      "rounded-b-xl",
+    );
 
     view.unmount();
     expect(mocks.dismiss).toHaveBeenCalledWith("undo-delete:session-1");

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
@@ -171,7 +171,7 @@ function UndoDeleteSonnerToast({ group }: { group: ToastGroup }) {
         />
       ),
       descriptionClassName:
-        "bg-muted absolute inset-x-0 bottom-0 h-1 overflow-hidden",
+        "bg-muted absolute inset-x-0 bottom-0 h-1 overflow-hidden rounded-b-xl",
       action: {
         label: "Undo",
         onClick: () => restoreGroup(group),


### PR DESCRIPTION
Clip the deletion countdown gauge to the toast bottom radius.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class on the undo-delete toast gauge only; no behavior or data-path changes.
> 
> **Overview**
> Adds **`rounded-b-xl`** to the undo-delete toast’s countdown gauge wrapper (`descriptionClassName`) so the progress bar is clipped to the toast’s bottom radius instead of sticking out square at the corners.
> 
> The Sonner render test now asserts that class is present on `descriptionClassName`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57e404366209be9b553022718ebe4303fc9d169a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->