### PR TITLE
Match shared links to the public note layout

### DIFF
--- a/apps/web/src/components/shared-note-actions.tsx
+++ b/apps/web/src/components/shared-note-actions.tsx
@@ -1,12 +1,8 @@
 import { useMutation } from "@tanstack/react-query";
-import { ExternalLinkIcon } from "lucide-react";
 
 import { cn } from "@hypr/utils";
 
-import {
-  sharedPrimaryButtonClassName,
-  sharedSecondaryButtonClassName,
-} from "@/components/shared-note-viewer";
+import { sharedPrimaryButtonClassName } from "@/components/shared-note-viewer";
 import { getShareRouteToken } from "@/lib/share-route-privacy";
 import {
   createLinkShareHandoff,
@@ -30,7 +26,6 @@ export function AccountSharedNoteActions({
   return (
     <SharedNoteActionButtons
       canEdit={canEdit}
-      showAccountCreation={false}
       onOpen={() => {
         window.location.href = buildAccountShareDeepLink(shareId, scheme);
       }}
@@ -119,17 +114,15 @@ function SharedNoteActionButtons({
   error = false,
   isPending = false,
   onOpen,
-  showAccountCreation = true,
 }: {
   canEdit: boolean;
   error?: boolean;
   isPending?: boolean;
   onOpen: () => void;
-  showAccountCreation?: boolean;
 }) {
   return (
     <>
-      <div className="group relative hidden sm:block">
+      <div className="group relative">
         <button
           type="button"
           className={sharedPrimaryButtonClassName}
@@ -137,8 +130,10 @@ function SharedNoteActionButtons({
           aria-describedby={canEdit ? "open-in-anarlog-tooltip" : undefined}
           onClick={onOpen}
         >
-          <ExternalLinkIcon className="mr-2 size-4" aria-hidden="true" />
-          {isPending ? "Opening…" : "Open in Anarlog"}
+          <span className="hidden sm:inline">
+            {isPending ? "Opening…" : "Open in Anarlog"}
+          </span>
+          <span className="sm:hidden">{isPending ? "Opening…" : "Open"}</span>
         </button>
         {canEdit && (
           <span
@@ -153,23 +148,6 @@ function SharedNoteActionButtons({
           </span>
         )}
       </div>
-      {showAccountCreation && (
-        <a
-          href="/auth/?flow=web"
-          className={cn([
-            sharedSecondaryButtonClassName,
-            "hidden sm:inline-flex",
-          ])}
-        >
-          Create an account
-        </a>
-      )}
-      <a
-        href="/download/apple-silicon/"
-        className={cn([sharedPrimaryButtonClassName, "sm:hidden"])}
-      >
-        Download
-      </a>
       {error && (
         <p
           className="text-color-muted basis-full text-right text-xs"

--- a/apps/web/src/components/shared-note-audio-player.tsx
+++ b/apps/web/src/components/shared-note-audio-player.tsx
@@ -85,15 +85,7 @@ export function SharedNoteAudioPlayer({
     }
     setPinnedDownload(refreshed.data);
     if (activeDownload?.signedUrl === refreshed.data.signedUrl) {
-      requestAnimationFrame(() => {
-        const current = audioRef.current;
-        if (!current) return;
-        current.currentTime = playbackTime;
-        setCurrentTime(playbackTime);
-        if (shouldResume) {
-          void current.play().catch(() => setPlaying(false));
-        }
-      });
+      setPlaying(false);
       return;
     }
     pendingPlaybackRef.current = {

--- a/apps/web/src/components/shared-note-audio-player.tsx
+++ b/apps/web/src/components/shared-note-audio-player.tsx
@@ -51,12 +51,11 @@ export function SharedNoteAudioPlayer({
     refetchInterval: playing ? false : 45_000,
     gcTime: 0,
   });
-  const download = isMatchingSharedNoteAttachmentDownload(
-    attachment,
-    downloadQuery.data,
-  )
-    ? downloadQuery.data
-    : null;
+  const download =
+    !downloadQuery.error &&
+    isMatchingSharedNoteAttachmentDownload(attachment, downloadQuery.data)
+      ? downloadQuery.data
+      : null;
   const pinnedAudioDownload = isMatchingSharedNoteAttachmentDownload(
     attachment,
     pinnedDownload,
@@ -80,12 +79,21 @@ export function SharedNoteAudioPlayer({
       refreshed.isError ||
       !isMatchingSharedNoteAttachmentDownload(attachment, refreshed.data)
     ) {
+      setPinnedDownload(null);
       setPlaying(false);
       return;
     }
     setPinnedDownload(refreshed.data);
     if (activeDownload?.signedUrl === refreshed.data.signedUrl) {
-      setPlaying(false);
+      requestAnimationFrame(() => {
+        const current = audioRef.current;
+        if (!current) return;
+        current.currentTime = playbackTime;
+        setCurrentTime(playbackTime);
+        if (shouldResume) {
+          void current.play().catch(() => setPlaying(false));
+        }
+      });
       return;
     }
     pendingPlaybackRef.current = {
@@ -103,6 +111,38 @@ export function SharedNoteAudioPlayer({
     }
     audio.pause();
   };
+
+  if (downloadQuery.error && !activeDownload) {
+    return (
+      <section
+        aria-label={`Audio recording: ${attachment.filename}`}
+        className={cn([
+          "mb-6 flex min-w-0 items-center gap-3 rounded-[22px] border border-stone-200 bg-white/80 px-3 py-2",
+          "text-stone-600",
+        ])}
+      >
+        <Volume2Icon
+          className="size-3.5 shrink-0 text-stone-400"
+          aria-hidden="true"
+        />
+        <span className="min-w-0 flex-1 truncate text-sm">
+          Attachment unavailable
+        </span>
+        <button
+          type="button"
+          className={cn([
+            "shrink-0 rounded-full border border-stone-300 bg-white px-3 py-1 text-xs font-medium text-stone-700 shadow-xs",
+            "hover:bg-stone-50",
+            "focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+          ])}
+          disabled={downloadQuery.isFetching}
+          onClick={() => void downloadQuery.refetch()}
+        >
+          {downloadQuery.isFetching ? "Retrying…" : "Retry"}
+        </button>
+      </section>
+    );
+  }
 
   return (
     <section

--- a/apps/web/src/components/shared-note-audio-player.tsx
+++ b/apps/web/src/components/shared-note-audio-player.tsx
@@ -1,0 +1,175 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  LoaderCircleIcon,
+  PauseIcon,
+  PlayIcon,
+  Volume2Icon,
+} from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+
+import { cn } from "@hypr/utils";
+
+import type { SharedAttachmentResolver } from "@/components/shared-note-document";
+import {
+  createSharedNoteWaveform,
+  formatSharedNotePlaybackTime,
+} from "@/lib/shared-note-presentation";
+import type {
+  SharedNoteAttachment,
+  SharedNoteAttachmentDownload,
+} from "@/lib/shared-notes";
+
+export function SharedNoteAudioPlayer({
+  attachment,
+  resolve,
+}: {
+  attachment: SharedNoteAttachment;
+  resolve?: SharedAttachmentResolver;
+}) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const waveform = useMemo(
+    () => createSharedNoteWaveform(attachment.sha256),
+    [attachment.sha256],
+  );
+  const downloadQuery = useQuery({
+    queryKey: ["shared-note-featured-audio", attachment.id],
+    queryFn: ({ signal }) => resolve!(attachment, signal),
+    enabled: Boolean(resolve),
+    retry: false,
+    staleTime: 45_000,
+    refetchInterval: playing ? false : 45_000,
+    gcTime: 0,
+  });
+  const download = isMatchingDownload(attachment, downloadQuery.data)
+    ? downloadQuery.data
+    : null;
+  const progress = duration > 0 ? currentTime / duration : 0;
+
+  const togglePlayback = async () => {
+    const audio = audioRef.current;
+    if (!audio || !download) return;
+    if (audio.paused) {
+      await audio.play().catch(() => setPlaying(false));
+      return;
+    }
+    audio.pause();
+  };
+
+  return (
+    <section
+      aria-label={`Audio recording: ${attachment.filename}`}
+      className={cn([
+        "mb-6 flex min-w-0 items-center gap-2 rounded-[22px] border border-stone-200 bg-white/80 p-1.5 pr-2",
+        "text-stone-600",
+      ])}
+    >
+      {download ? (
+        <audio
+          ref={audioRef}
+          className="hidden"
+          aria-hidden="true"
+          src={download.signedUrl}
+          preload="metadata"
+          onDurationChange={(event) =>
+            setDuration(
+              Number.isFinite(event.currentTarget.duration)
+                ? event.currentTarget.duration
+                : 0,
+            )
+          }
+          onTimeUpdate={(event) =>
+            setCurrentTime(event.currentTarget.currentTime)
+          }
+          onPlay={() => setPlaying(true)}
+          onPause={() => setPlaying(false)}
+          onEnded={() => setPlaying(false)}
+        />
+      ) : null}
+      <button
+        type="button"
+        aria-label={playing ? "Pause recording" : "Play recording"}
+        className={cn([
+          "grid size-7 shrink-0 place-items-center rounded-full border border-stone-300 bg-white text-stone-800 shadow-xs",
+          "transition-transform hover:scale-105 hover:bg-stone-50",
+          "focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+          "disabled:cursor-default disabled:opacity-50",
+        ])}
+        disabled={!download}
+        onClick={() => void togglePlayback()}
+      >
+        {downloadQuery.isPending && resolve ? (
+          <LoaderCircleIcon
+            className="size-3.5 animate-spin"
+            aria-hidden="true"
+          />
+        ) : playing ? (
+          <PauseIcon className="size-3.5 fill-current" aria-hidden="true" />
+        ) : (
+          <PlayIcon
+            className="ml-0.5 size-3.5 fill-current"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+      <span className="flex shrink-0 gap-1 font-mono text-[10px] tabular-nums">
+        <span>{formatSharedNotePlaybackTime(currentTime)}</span>
+        <span aria-hidden="true">/</span>
+        <span>{formatSharedNotePlaybackTime(duration)}</span>
+      </span>
+      <div className="relative flex h-6 min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
+        {waveform.map((height, index) => (
+          <span
+            key={index}
+            aria-hidden="true"
+            className={cn([
+              "min-h-0.5 min-w-px flex-1 rounded-full",
+              index / waveform.length <= progress
+                ? "bg-stone-600"
+                : "bg-stone-300",
+            ])}
+            style={{ height: `${height}%` }}
+          />
+        ))}
+        <input
+          type="range"
+          aria-label="Recording position"
+          className="absolute inset-0 size-full cursor-pointer opacity-0"
+          min={0}
+          max={duration || 0}
+          step={0.1}
+          value={Math.min(currentTime, duration || 0)}
+          disabled={!download || duration === 0}
+          onChange={(event) => {
+            const next = Number(event.target.value);
+            if (!audioRef.current || !Number.isFinite(next)) return;
+            audioRef.current.currentTime = next;
+            setCurrentTime(next);
+          }}
+        />
+      </div>
+      {!resolve ? (
+        <Volume2Icon
+          className="size-3.5 shrink-0 text-stone-400"
+          aria-hidden="true"
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function isMatchingDownload(
+  attachment: SharedNoteAttachment,
+  download: SharedNoteAttachmentDownload | null | undefined,
+): download is SharedNoteAttachmentDownload {
+  return Boolean(
+    download &&
+    download.id === attachment.id &&
+    download.filename === attachment.filename &&
+    download.contentType === attachment.contentType &&
+    download.sizeBytes === attachment.sizeBytes &&
+    download.sha256 === attachment.sha256,
+  );
+}

--- a/apps/web/src/components/shared-note-audio-player.tsx
+++ b/apps/web/src/components/shared-note-audio-player.tsx
@@ -15,9 +15,10 @@ import {
   formatSharedNotePlaybackTime,
   isSharedNoteAudioGrantExpiring,
 } from "@/lib/shared-note-presentation";
-import type {
-  SharedNoteAttachment,
-  SharedNoteAttachmentDownload,
+import {
+  isMatchingSharedNoteAttachmentDownload,
+  type SharedNoteAttachment,
+  type SharedNoteAttachmentDownload,
 } from "@/lib/shared-notes";
 
 export function SharedNoteAudioPlayer({
@@ -50,10 +51,16 @@ export function SharedNoteAudioPlayer({
     refetchInterval: playing ? false : 45_000,
     gcTime: 0,
   });
-  const download = isMatchingDownload(attachment, downloadQuery.data)
+  const download = isMatchingSharedNoteAttachmentDownload(
+    attachment,
+    downloadQuery.data,
+  )
     ? downloadQuery.data
     : null;
-  const pinnedAudioDownload = isMatchingDownload(attachment, pinnedDownload)
+  const pinnedAudioDownload = isMatchingSharedNoteAttachmentDownload(
+    attachment,
+    pinnedDownload,
+  )
     ? pinnedDownload
     : null;
   const activeDownload = pinnedAudioDownload ?? download;
@@ -69,23 +76,30 @@ export function SharedNoteAudioPlayer({
     pendingPlaybackRef.current = null;
     audio.pause();
     const refreshed = await downloadQuery.refetch();
-    if (refreshed.isError || !isMatchingDownload(attachment, refreshed.data)) {
+    if (
+      refreshed.isError ||
+      !isMatchingSharedNoteAttachmentDownload(attachment, refreshed.data)
+    ) {
       setPlaying(false);
       return;
     }
+    setPinnedDownload(refreshed.data);
     if (activeDownload?.signedUrl === refreshed.data.signedUrl) {
-      audio.currentTime = playbackTime;
-      setCurrentTime(playbackTime);
-      if (shouldResume) {
-        void audio.play().catch(() => setPlaying(false));
-      }
+      requestAnimationFrame(() => {
+        const current = audioRef.current;
+        if (!current) return;
+        current.currentTime = playbackTime;
+        setCurrentTime(playbackTime);
+        if (shouldResume) {
+          void current.play().catch(() => setPlaying(false));
+        }
+      });
       return;
     }
     pendingPlaybackRef.current = {
       currentTime: playbackTime,
       resume: shouldResume,
     };
-    setPinnedDownload(refreshed.data);
   };
 
   const togglePlayback = async () => {
@@ -227,19 +241,5 @@ export function SharedNoteAudioPlayer({
         />
       ) : null}
     </section>
-  );
-}
-
-function isMatchingDownload(
-  attachment: SharedNoteAttachment,
-  download: SharedNoteAttachmentDownload | null | undefined,
-): download is SharedNoteAttachmentDownload {
-  return Boolean(
-    download &&
-    download.id === attachment.id &&
-    download.filename === attachment.filename &&
-    download.contentType === attachment.contentType &&
-    download.sizeBytes === attachment.sizeBytes &&
-    download.sha256 === attachment.sha256,
   );
 }

--- a/apps/web/src/components/shared-note-audio-player.tsx
+++ b/apps/web/src/components/shared-note-audio-player.tsx
@@ -13,6 +13,7 @@ import type { SharedAttachmentResolver } from "@/components/shared-note-document
 import {
   createSharedNoteWaveform,
   formatSharedNotePlaybackTime,
+  isSharedNoteAudioGrantExpiring,
 } from "@/lib/shared-note-presentation";
 import type {
   SharedNoteAttachment,
@@ -27,9 +28,15 @@ export function SharedNoteAudioPlayer({
   resolve?: SharedAttachmentResolver;
 }) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const pendingPlaybackRef = useRef<{
+    currentTime: number;
+    resume: boolean;
+  } | null>(null);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const [playing, setPlaying] = useState(false);
+  const [pinnedDownload, setPinnedDownload] =
+    useState<SharedNoteAttachmentDownload | null>(null);
   const waveform = useMemo(
     () => createSharedNoteWaveform(attachment.sha256),
     [attachment.sha256],
@@ -46,11 +53,44 @@ export function SharedNoteAudioPlayer({
   const download = isMatchingDownload(attachment, downloadQuery.data)
     ? downloadQuery.data
     : null;
+  const pinnedAudioDownload = isMatchingDownload(attachment, pinnedDownload)
+    ? pinnedDownload
+    : null;
+  const activeDownload = pinnedAudioDownload ?? download;
   const progress = duration > 0 ? currentTime / duration : 0;
+
+  const refreshAudioGrant = async (
+    audio: HTMLAudioElement,
+    resume: boolean,
+  ) => {
+    const pendingPlayback = pendingPlaybackRef.current;
+    const playbackTime = pendingPlayback?.currentTime ?? audio.currentTime;
+    const shouldResume = pendingPlayback?.resume ?? resume;
+    pendingPlaybackRef.current = null;
+    audio.pause();
+    const refreshed = await downloadQuery.refetch();
+    if (refreshed.isError || !isMatchingDownload(attachment, refreshed.data)) {
+      setPlaying(false);
+      return;
+    }
+    if (activeDownload?.signedUrl === refreshed.data.signedUrl) {
+      audio.currentTime = playbackTime;
+      setCurrentTime(playbackTime);
+      if (shouldResume) {
+        void audio.play().catch(() => setPlaying(false));
+      }
+      return;
+    }
+    pendingPlaybackRef.current = {
+      currentTime: playbackTime,
+      resume: shouldResume,
+    };
+    setPinnedDownload(refreshed.data);
+  };
 
   const togglePlayback = async () => {
     const audio = audioRef.current;
-    if (!audio || !download) return;
+    if (!audio || !activeDownload) return;
     if (audio.paused) {
       await audio.play().catch(() => setPlaying(false));
       return;
@@ -66,13 +106,24 @@ export function SharedNoteAudioPlayer({
         "text-stone-600",
       ])}
     >
-      {download ? (
+      {activeDownload ? (
         <audio
+          key={activeDownload.signedUrl}
           ref={audioRef}
           className="hidden"
           aria-hidden="true"
-          src={download.signedUrl}
+          src={activeDownload.signedUrl}
           preload="metadata"
+          onLoadedMetadata={(event) => {
+            const pendingPlayback = pendingPlaybackRef.current;
+            if (!pendingPlayback) return;
+            pendingPlaybackRef.current = null;
+            event.currentTarget.currentTime = pendingPlayback.currentTime;
+            setCurrentTime(pendingPlayback.currentTime);
+            if (pendingPlayback.resume) {
+              void event.currentTarget.play().catch(() => setPlaying(false));
+            }
+          }}
           onDurationChange={(event) =>
             setDuration(
               Number.isFinite(event.currentTarget.duration)
@@ -83,9 +134,28 @@ export function SharedNoteAudioPlayer({
           onTimeUpdate={(event) =>
             setCurrentTime(event.currentTarget.currentTime)
           }
-          onPlay={() => setPlaying(true)}
+          onPlay={(event) => {
+            const current = pinnedAudioDownload ?? download;
+            if (!current) {
+              event.currentTarget.pause();
+              return;
+            }
+            if (isSharedNoteAudioGrantExpiring(current.expiresAt)) {
+              void refreshAudioGrant(event.currentTarget, true);
+              return;
+            }
+            setPinnedDownload(current);
+            setPlaying(true);
+          }}
           onPause={() => setPlaying(false)}
-          onEnded={() => setPlaying(false)}
+          onEnded={() => {
+            setPlaying(false);
+            setPinnedDownload(null);
+          }}
+          onError={(event) => {
+            if (downloadQuery.isFetching) return;
+            void refreshAudioGrant(event.currentTarget, playing);
+          }}
         />
       ) : null}
       <button
@@ -97,7 +167,7 @@ export function SharedNoteAudioPlayer({
           "focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2 focus-visible:outline-hidden",
           "disabled:cursor-default disabled:opacity-50",
         ])}
-        disabled={!download}
+        disabled={!activeDownload}
         onClick={() => void togglePlayback()}
       >
         {downloadQuery.isPending && resolve ? (
@@ -141,7 +211,7 @@ export function SharedNoteAudioPlayer({
           max={duration || 0}
           step={0.1}
           value={Math.min(currentTime, duration || 0)}
-          disabled={!download || duration === 0}
+          disabled={!activeDownload || duration === 0}
           onChange={(event) => {
             const next = Number(event.target.value);
             if (!audioRef.current || !Number.isFinite(next)) return;

--- a/apps/web/src/components/shared-note-comment-rail.tsx
+++ b/apps/web/src/components/shared-note-comment-rail.tsx
@@ -15,6 +15,7 @@ import {
 import type { AnchoredSharedNoteComment } from "@/lib/shared-note-comment-anchors";
 import { layoutRailCards } from "@/lib/shared-note-comment-rail-layout";
 import { groupSharedNoteCommentThreads } from "@/lib/shared-note-comment-threads";
+import { formatSharedNoteRelativeTime } from "@/lib/shared-note-presentation";
 
 export const DRAFT_COMMENT_ID = "draft";
 
@@ -242,7 +243,7 @@ export function SharedNoteCommentCard({
                       className="font-normal text-stone-500"
                       dateTime={reply.createdAt}
                     >
-                      {formatRelativeTime(reply.createdAt)}
+                      {formatSharedNoteRelativeTime(reply.createdAt)}
                     </time>
                   </p>
                   <CommentActions
@@ -297,7 +298,7 @@ function CommentHeader({
             className="font-normal text-stone-500"
             dateTime={comment.createdAt}
           >
-            {formatRelativeTime(comment.createdAt)}
+            {formatSharedNoteRelativeTime(comment.createdAt)}
           </time>
         </p>
       </div>
@@ -450,28 +451,4 @@ function ReplyComposer({
       ) : null}
     </form>
   );
-}
-
-const RELATIVE_TIME_DIVISIONS: Array<
-  [amount: number, unit: Intl.RelativeTimeFormatUnit]
-> = [
-  [60, "second"],
-  [60, "minute"],
-  [24, "hour"],
-  [7, "day"],
-  [4.34524, "week"],
-  [12, "month"],
-  [Number.POSITIVE_INFINITY, "year"],
-];
-
-function formatRelativeTime(value: string) {
-  const formatter = new Intl.RelativeTimeFormat("en-US", { numeric: "auto" });
-  let duration = (Date.parse(value) - Date.now()) / 1000;
-  for (const [amount, unit] of RELATIVE_TIME_DIVISIONS) {
-    if (Math.abs(duration) < amount) {
-      return formatter.format(Math.round(duration), unit);
-    }
-    duration /= amount;
-  }
-  return "";
 }

--- a/apps/web/src/components/shared-note-comment-rail.tsx
+++ b/apps/web/src/components/shared-note-comment-rail.tsx
@@ -1,11 +1,20 @@
-import { LoaderCircleIcon, Trash2Icon } from "lucide-react";
+import {
+  ArrowUpIcon,
+  LoaderCircleIcon,
+  MoreHorizontalIcon,
+} from "lucide-react";
 import { useRef, useState } from "react";
 
 import { Avatar } from "@hypr/ui/components/avatar";
 import { cn } from "@hypr/utils";
 
+import {
+  MAX_SHARED_NOTE_COMMENT_BYTES,
+  validateSharedNoteCommentBody,
+} from "@/lib/shared-note-collaboration";
 import type { AnchoredSharedNoteComment } from "@/lib/shared-note-comment-anchors";
 import { layoutRailCards } from "@/lib/shared-note-comment-rail-layout";
+import { groupSharedNoteCommentThreads } from "@/lib/shared-note-comment-threads";
 
 export const DRAFT_COMMENT_ID = "draft";
 
@@ -21,6 +30,7 @@ export function SharedNoteCommentRail({
   items,
   onActivate,
   onDelete,
+  onReply,
   screenTops,
 }: {
   items: AnchoredSharedNoteComment[];
@@ -30,6 +40,10 @@ export function SharedNoteCommentRail({
   composer: { top: number } | null;
   composerNode?: React.ReactNode;
   onDelete: (commentId: string) => void;
+  onReply?: (
+    comment: AnchoredSharedNoteComment,
+    body: string,
+  ) => Promise<unknown>;
   canDelete: (comment: AnchoredSharedNoteComment) => boolean;
   deletePending?: boolean;
   deletingCommentId?: string | null;
@@ -37,8 +51,6 @@ export function SharedNoteCommentRail({
   const [heights, setHeights] = useState<ReadonlyMap<string, number>>(
     new Map(),
   );
-  // Cached per card so React only re-runs a ref (and its ResizeObserver
-  // cleanup) when the card unmounts, not on every render.
   const measureRefs = useRef(
     new Map<string, (element: HTMLDivElement | null) => (() => void) | void>(),
   );
@@ -71,7 +83,13 @@ export function SharedNoteCommentRail({
     return ref;
   };
 
-  const anchoredItems = items.filter((item) => item.range !== null);
+  const threads = groupSharedNoteCommentThreads(
+    items.filter((item) => item.range !== null),
+  );
+  const activeThread =
+    threads.find((thread) =>
+      thread.comments.some((comment) => comment.commentId === activeCommentId),
+    ) ?? null;
   const placements = layoutRailCards(
     [
       ...(composer
@@ -83,14 +101,16 @@ export function SharedNoteCommentRail({
             },
           ]
         : []),
-      ...anchoredItems.map((item) => ({
-        id: item.commentId,
-        desiredTop: screenTops.get(item.commentId) ?? 0,
-        height: heights.get(item.commentId) ?? 0,
+      ...threads.map((thread) => ({
+        id: thread.id,
+        desiredTop: screenTops.get(thread.comments[0].commentId) ?? 0,
+        height: heights.get(thread.id) ?? 0,
       })),
     ],
     {
-      activeId: composer ? DRAFT_COMMENT_ID : activeCommentId,
+      activeId: composer
+        ? DRAFT_COMMENT_ID
+        : (activeThread?.id ?? activeCommentId),
       gap: RAIL_CARD_GAP,
     },
   );
@@ -98,13 +118,13 @@ export function SharedNoteCommentRail({
     placements.map((placement) => [placement.id, placement.top]),
   );
 
-  if (!composer && anchoredItems.length === 0) {
+  if (!composer && threads.length === 0) {
     return null;
   }
 
   return (
     <div className="relative h-full">
-      {composer && (
+      {composer ? (
         <div
           ref={measureRef(DRAFT_COMMENT_ID)}
           className="absolute inset-x-0 transition-[top] duration-200"
@@ -112,49 +132,57 @@ export function SharedNoteCommentRail({
         >
           {composerNode}
         </div>
-      )}
-      {anchoredItems.map((item) => (
-        <div
-          key={item.commentId}
-          ref={measureRef(item.commentId)}
-          className="absolute inset-x-0 transition-[top] duration-200"
-          style={{ top: topById.get(item.commentId) ?? 0 }}
-        >
-          <SharedNoteCommentCard
-            active={item.commentId === activeCommentId}
-            comment={item}
-            deleteDisabled={deletePending}
-            deleting={deletePending && item.commentId === deletingCommentId}
-            onActivate={() =>
-              onActivate(
-                item.commentId === activeCommentId ? null : item.commentId,
-              )
-            }
-            onDelete={() => onDelete(item.commentId)}
-            showDelete={canDelete(item)}
-          />
-        </div>
-      ))}
+      ) : null}
+      {threads.map((thread) => {
+        const active = thread.id === activeThread?.id;
+        return (
+          <div
+            key={thread.id}
+            ref={measureRef(thread.id)}
+            className="absolute inset-x-0 transition-[top] duration-200"
+            style={{ top: topById.get(thread.id) ?? 0 }}
+          >
+            <SharedNoteCommentCard
+              active={active}
+              canDelete={canDelete}
+              comment={thread.comments[0]}
+              deleteDisabled={deletePending}
+              deletingCommentId={deletingCommentId}
+              onActivate={() => onActivate(active ? null : thread.id)}
+              onDelete={onDelete}
+              onReply={onReply}
+              replies={thread.comments.slice(1)}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 export function SharedNoteCommentCard({
   active,
+  canDelete,
   comment,
   deleteDisabled = false,
-  deleting = false,
+  deletingCommentId = null,
   onActivate,
   onDelete,
-  showDelete,
+  onReply,
+  replies = [],
 }: {
   active: boolean;
+  canDelete: (comment: AnchoredSharedNoteComment) => boolean;
   comment: AnchoredSharedNoteComment;
   deleteDisabled?: boolean;
-  deleting?: boolean;
+  deletingCommentId?: string | null;
   onActivate?: () => void;
-  onDelete: () => void;
-  showDelete: boolean;
+  onDelete: (commentId: string) => void;
+  onReply?: (
+    comment: AnchoredSharedNoteComment,
+    body: string,
+  ) => Promise<unknown>;
+  replies?: AnchoredSharedNoteComment[];
 }) {
   return (
     <div
@@ -172,56 +200,255 @@ export function SharedNoteCommentCard({
           : undefined
       }
       className={cn([
-        "surface rounded-xl border p-3.5 text-left shadow-sm transition-[border-color,box-shadow]",
-        active ? "border-stone-400 shadow-md" : "border-color-subtle",
+        "overflow-hidden rounded-[22px] border bg-white text-left shadow-[0_7px_22px_rgba(0,0,0,0.08)]",
+        "transition-[border-color,box-shadow]",
+        active ? "border-stone-400 shadow-lg" : "border-stone-300",
         onActivate && "cursor-pointer",
       ])}
     >
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <Avatar
-            seed={
-              comment.isAuthor ? "shared-note:you" : "shared-note:collaborator"
-            }
-            label={comment.isAuthor ? "You" : "Collaborator"}
-            size={24}
-          />
-          <p className="text-color min-w-0 truncate text-xs font-medium">
-            {comment.isAuthor ? "You" : "Collaborator"}{" "}
-            <time
-              className="text-color-muted font-normal"
-              dateTime={comment.createdAt}
+      <div className="p-3.5">
+        <CommentHeader
+          canDelete={canDelete(comment)}
+          comment={comment}
+          deleteDisabled={deleteDisabled}
+          deleting={deletingCommentId === comment.commentId}
+          onDelete={onDelete}
+        />
+        <p className="mt-3 text-sm leading-[1.5] whitespace-pre-wrap text-stone-800">
+          {comment.body}
+        </p>
+      </div>
+      {replies.length ? (
+        <div className="border-t border-stone-200">
+          {replies.map((reply) => (
+            <div
+              key={reply.commentId}
+              className="flex gap-2.5 border-b border-stone-100 px-3.5 py-3 last:border-b-0"
             >
-              {formatRelativeTime(comment.createdAt)}
-            </time>
-          </p>
+              <Avatar
+                seed={
+                  reply.isAuthor
+                    ? "shared-note:you"
+                    : "shared-note:collaborator"
+                }
+                label={reply.isAuthor ? "You" : "Collaborator"}
+                size={24}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-start justify-between gap-2">
+                  <p className="min-w-0 truncate text-[11px] font-semibold text-stone-700">
+                    {reply.isAuthor ? "You" : "Collaborator"}{" "}
+                    <time
+                      className="font-normal text-stone-500"
+                      dateTime={reply.createdAt}
+                    >
+                      {formatRelativeTime(reply.createdAt)}
+                    </time>
+                  </p>
+                  <CommentActions
+                    canDelete={canDelete(reply)}
+                    commentId={reply.commentId}
+                    deleteDisabled={deleteDisabled}
+                    deleting={deletingCommentId === reply.commentId}
+                    onDelete={onDelete}
+                  />
+                </div>
+                <p className="mt-1 text-xs leading-[1.45] whitespace-pre-wrap text-stone-700">
+                  {reply.body}
+                </p>
+              </div>
+            </div>
+          ))}
         </div>
-        {showDelete && (
+      ) : null}
+      {active && onReply && comment.anchor ? (
+        <ReplyComposer comment={comment} onReply={onReply} />
+      ) : null}
+    </div>
+  );
+}
+
+function CommentHeader({
+  canDelete,
+  comment,
+  deleteDisabled,
+  deleting,
+  onDelete,
+}: {
+  canDelete: boolean;
+  comment: AnchoredSharedNoteComment;
+  deleteDisabled: boolean;
+  deleting: boolean;
+  onDelete: (commentId: string) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex min-w-0 items-center gap-2">
+        <Avatar
+          seed={
+            comment.isAuthor ? "shared-note:you" : "shared-note:collaborator"
+          }
+          label={comment.isAuthor ? "You" : "Collaborator"}
+          size={25}
+        />
+        <p className="min-w-0 truncate text-xs font-semibold text-stone-800">
+          {comment.isAuthor ? "You" : "Collaborator"}{" "}
+          <time
+            className="font-normal text-stone-500"
+            dateTime={comment.createdAt}
+          >
+            {formatRelativeTime(comment.createdAt)}
+          </time>
+        </p>
+      </div>
+      <CommentActions
+        canDelete={canDelete}
+        commentId={comment.commentId}
+        deleteDisabled={deleteDisabled}
+        deleting={deleting}
+        onDelete={onDelete}
+      />
+    </div>
+  );
+}
+
+function CommentActions({
+  canDelete,
+  commentId,
+  deleteDisabled,
+  deleting,
+  onDelete,
+}: {
+  canDelete: boolean;
+  commentId: string;
+  deleteDisabled: boolean;
+  deleting: boolean;
+  onDelete: (commentId: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  if (!canDelete) return null;
+
+  return (
+    <div className="relative shrink-0">
+      <button
+        type="button"
+        aria-label="Comment actions"
+        aria-expanded={open}
+        className="grid size-6 place-items-center rounded-md text-stone-500 hover:bg-stone-100 hover:text-stone-700 focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:outline-hidden"
+        disabled={deleteDisabled}
+        onClick={(event) => {
+          event.stopPropagation();
+          setOpen((current) => !current);
+        }}
+      >
+        {deleting ? (
+          <LoaderCircleIcon
+            className="size-3.5 animate-spin"
+            aria-hidden="true"
+          />
+        ) : (
+          <MoreHorizontalIcon className="size-4" aria-hidden="true" />
+        )}
+      </button>
+      {open ? (
+        <div
+          className="absolute top-7 right-0 z-20 w-28 rounded-lg border border-stone-200 bg-white p-1 shadow-lg"
+          onClick={(event) => event.stopPropagation()}
+        >
           <button
             type="button"
-            aria-label="Delete comment"
-            className="text-color-muted hover:text-color rounded-full p-1.5 transition-colors focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full rounded-md px-2 py-1.5 text-left text-xs text-stone-700 hover:bg-stone-100"
             disabled={deleteDisabled}
-            onClick={(event) => {
-              event.stopPropagation();
-              onDelete();
+            onClick={() => {
+              setOpen(false);
+              onDelete(commentId);
             }}
           >
-            {deleting ? (
-              <LoaderCircleIcon
-                className="size-3.5 animate-spin"
-                aria-hidden="true"
-              />
-            ) : (
-              <Trash2Icon className="size-3.5" aria-hidden="true" />
-            )}
+            Delete
           </button>
-        )}
-      </div>
-      <p className="text-color mt-3 text-sm leading-5 whitespace-pre-wrap">
-        {comment.body}
-      </p>
+        </div>
+      ) : null}
     </div>
+  );
+}
+
+function ReplyComposer({
+  comment,
+  onReply,
+}: {
+  comment: AnchoredSharedNoteComment;
+  onReply: (
+    comment: AnchoredSharedNoteComment,
+    body: string,
+  ) => Promise<unknown>;
+}) {
+  const [body, setBody] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState(false);
+  const validated = validateSharedNoteCommentBody(body);
+
+  const submit = async () => {
+    if (!validated.valid || pending) return;
+    setPending(true);
+    setError(false);
+    try {
+      await onReply(comment, validated.body);
+      setBody("");
+    } catch {
+      setError(true);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <form
+      className="border-t border-stone-200 px-3 py-2.5"
+      onClick={(event) => event.stopPropagation()}
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submit();
+      }}
+    >
+      <div className="flex items-end gap-2 rounded-[10px] border border-stone-300 bg-white p-1.5 pl-2 focus-within:border-stone-400 focus-within:ring-2 focus-within:ring-stone-200">
+        <Avatar seed="shared-note:you" label="You" size={24} />
+        <textarea
+          aria-label="Reply to comment"
+          className="max-h-20 min-h-6 min-w-0 flex-1 resize-none bg-transparent py-0.5 text-xs leading-[18px] text-stone-800 placeholder:text-stone-400 focus:outline-hidden"
+          maxLength={MAX_SHARED_NOTE_COMMENT_BYTES}
+          placeholder="Reply…"
+          rows={1}
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              void submit();
+            }
+          }}
+        />
+        <button
+          type="submit"
+          aria-label="Send reply"
+          className="grid size-6 shrink-0 place-items-center rounded-full bg-stone-900 text-white disabled:bg-stone-200 disabled:text-stone-400"
+          disabled={!validated.valid || pending}
+        >
+          {pending ? (
+            <LoaderCircleIcon
+              className="size-3.5 animate-spin"
+              aria-hidden="true"
+            />
+          ) : (
+            <ArrowUpIcon className="size-3.5" aria-hidden="true" />
+          )}
+        </button>
+      </div>
+      {error ? (
+        <p className="mt-1.5 text-[11px] text-red-700" role="status">
+          Your reply couldn’t be added. Try again.
+        </p>
+      ) : null}
+    </form>
   );
 }
 

--- a/apps/web/src/components/shared-note-comment-rail.tsx
+++ b/apps/web/src/components/shared-note-comment-rail.tsx
@@ -193,6 +193,7 @@ export function SharedNoteCommentCard({
       onKeyDown={
         onActivate
           ? (event) => {
+              if (event.target !== event.currentTarget) return;
               if (event.key === "Enter" || event.key === " ") {
                 event.preventDefault();
                 onActivate();
@@ -220,7 +221,10 @@ export function SharedNoteCommentCard({
         </p>
       </div>
       {replies.length ? (
-        <div className="border-t border-stone-200">
+        <div
+          className="border-t border-stone-200"
+          onClick={(event) => event.stopPropagation()}
+        >
           {replies.map((reply) => (
             <div
               key={reply.commentId}

--- a/apps/web/src/components/shared-note-comment-rail.tsx
+++ b/apps/web/src/components/shared-note-comment-rail.tsx
@@ -391,6 +391,7 @@ function ReplyComposer({
   const [pending, setPending] = useState(false);
   const [error, setError] = useState(false);
   const validated = validateSharedNoteCommentBody(body);
+  const tooLong = validated.byteLength > MAX_SHARED_NOTE_COMMENT_BYTES;
 
   const submit = async () => {
     if (!validated.valid || pending) return;
@@ -419,8 +420,8 @@ function ReplyComposer({
         <Avatar seed="shared-note:you" label="You" size={24} />
         <textarea
           aria-label="Reply to comment"
+          aria-invalid={tooLong}
           className="max-h-20 min-h-6 min-w-0 flex-1 resize-none bg-transparent py-0.5 text-xs leading-[18px] text-stone-800 placeholder:text-stone-400 focus:outline-hidden"
-          maxLength={MAX_SHARED_NOTE_COMMENT_BYTES}
           placeholder="Reply…"
           rows={1}
           value={body}
@@ -448,6 +449,12 @@ function ReplyComposer({
           )}
         </button>
       </div>
+      {tooLong ? (
+        <p className="mt-1.5 text-[11px] text-red-700" role="alert">
+          Reply is too long ({validated.byteLength.toLocaleString()}/
+          {MAX_SHARED_NOTE_COMMENT_BYTES.toLocaleString()} bytes).
+        </p>
+      ) : null}
       {error ? (
         <p className="mt-1.5 text-[11px] text-red-700" role="status">
           Your reply couldn’t be added. Try again.

--- a/apps/web/src/components/shared-note-comments-drawer.tsx
+++ b/apps/web/src/components/shared-note-comments-drawer.tsx
@@ -1,0 +1,129 @@
+import { MessageSquareIcon } from "lucide-react";
+
+import { Avatar } from "@hypr/ui/components/avatar";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@hypr/ui/components/ui/dialog";
+import { cn } from "@hypr/utils";
+
+import { truncateSharedNoteCommentQuote } from "@/lib/shared-note-collaboration";
+import type { SharedNoteComment } from "@/lib/shared-notes";
+
+export function SharedNoteCommentsDrawer({
+  comments,
+}: {
+  comments: SharedNoteComment[];
+}) {
+  const count = comments.length;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Open comments${count ? ` (${count})` : ""}`}
+          className={cn([
+            "relative grid size-9 place-items-center rounded-lg bg-transparent text-stone-600",
+            "transition-colors hover:text-stone-900",
+            "focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+          ])}
+        >
+          <MessageSquareIcon className="size-[19px]" aria-hidden="true" />
+          {count > 0 ? (
+            <span className="absolute -top-0.5 -right-0.5 grid min-w-4 place-items-center rounded-full border-2 border-white bg-stone-700 px-0.5 text-[9px] leading-3 text-white">
+              {count > 99 ? "99+" : count}
+            </span>
+          ) : null}
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        className={cn([
+          "!top-0 !right-0 !bottom-0 !left-auto !h-dvh !w-[min(380px,100vw)] !max-w-none !translate-x-0 !translate-y-0",
+          "!flex !gap-0 !rounded-none !border-y-0 !border-r-0 !border-l !border-stone-200 !bg-white !p-0",
+          "flex-col overflow-hidden shadow-2xl",
+        ])}
+      >
+        <DialogDescription className="sr-only">
+          Comments attached to this shared note.
+        </DialogDescription>
+        <header className="flex h-14 shrink-0 items-center border-b border-stone-200 px-5 pr-14">
+          <DialogTitle className="text-sm font-semibold text-stone-900">
+            Comments
+          </DialogTitle>
+          <span className="ml-2 text-xs text-stone-500">{count}</span>
+        </header>
+        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
+          {comments.length ? (
+            comments.map((comment) => (
+              <article
+                key={comment.commentId}
+                className="rounded-2xl border border-stone-200 bg-white p-3.5 shadow-xs"
+              >
+                <div className="flex items-center gap-2">
+                  <Avatar
+                    seed={
+                      comment.isAuthor
+                        ? "shared-note:you"
+                        : "shared-note:collaborator"
+                    }
+                    label={comment.isAuthor ? "You" : "Collaborator"}
+                    size={25}
+                  />
+                  <p className="min-w-0 truncate text-xs font-semibold text-stone-800">
+                    {comment.isAuthor ? "You" : "Collaborator"}{" "}
+                    <time
+                      className="font-normal text-stone-500"
+                      dateTime={comment.createdAt}
+                    >
+                      {formatRelativeTime(comment.createdAt)}
+                    </time>
+                  </p>
+                </div>
+                {comment.anchor ? (
+                  <p className="mt-3 border-l-2 border-stone-200 pl-2 text-xs leading-5 text-stone-500">
+                    {truncateSharedNoteCommentQuote(comment.anchor.quoteExact)}
+                  </p>
+                ) : null}
+                <p className="mt-2 text-sm leading-5 whitespace-pre-wrap text-stone-800">
+                  {comment.body}
+                </p>
+              </article>
+            ))
+          ) : (
+            <p className="py-10 text-center text-sm text-stone-500">
+              No comments yet.
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+const RELATIVE_TIME_DIVISIONS: Array<
+  [amount: number, unit: Intl.RelativeTimeFormatUnit]
+> = [
+  [60, "second"],
+  [60, "minute"],
+  [24, "hour"],
+  [7, "day"],
+  [4.34524, "week"],
+  [12, "month"],
+  [Number.POSITIVE_INFINITY, "year"],
+];
+
+function formatRelativeTime(value: string) {
+  const formatter = new Intl.RelativeTimeFormat("en-US", { numeric: "auto" });
+  let duration = (Date.parse(value) - Date.now()) / 1000;
+  for (const [amount, unit] of RELATIVE_TIME_DIVISIONS) {
+    if (Math.abs(duration) < amount) {
+      return formatter.format(Math.round(duration), unit);
+    }
+    duration /= amount;
+  }
+  return "";
+}

--- a/apps/web/src/components/shared-note-comments-drawer.tsx
+++ b/apps/web/src/components/shared-note-comments-drawer.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from "@hypr/utils";
 
 import { truncateSharedNoteCommentQuote } from "@/lib/shared-note-collaboration";
+import { formatSharedNoteRelativeTime } from "@/lib/shared-note-presentation";
 import type { SharedNoteComment } from "@/lib/shared-notes";
 
 export function SharedNoteCommentsDrawer({
@@ -79,7 +80,7 @@ export function SharedNoteCommentsDrawer({
                       className="font-normal text-stone-500"
                       dateTime={comment.createdAt}
                     >
-                      {formatRelativeTime(comment.createdAt)}
+                      {formatSharedNoteRelativeTime(comment.createdAt)}
                     </time>
                   </p>
                 </div>
@@ -102,28 +103,4 @@ export function SharedNoteCommentsDrawer({
       </DialogContent>
     </Dialog>
   );
-}
-
-const RELATIVE_TIME_DIVISIONS: Array<
-  [amount: number, unit: Intl.RelativeTimeFormatUnit]
-> = [
-  [60, "second"],
-  [60, "minute"],
-  [24, "hour"],
-  [7, "day"],
-  [4.34524, "week"],
-  [12, "month"],
-  [Number.POSITIVE_INFINITY, "year"],
-];
-
-function formatRelativeTime(value: string) {
-  const formatter = new Intl.RelativeTimeFormat("en-US", { numeric: "auto" });
-  let duration = (Date.parse(value) - Date.now()) / 1000;
-  for (const [amount, unit] of RELATIVE_TIME_DIVISIONS) {
-    if (Math.abs(duration) < amount) {
-      return formatter.format(Math.round(duration), unit);
-    }
-    duration /= amount;
-  }
-  return "";
 }

--- a/apps/web/src/components/shared-note-document.tsx
+++ b/apps/web/src/components/shared-note-document.tsx
@@ -24,16 +24,19 @@ export type SharedAttachmentResolver = (
 
 const AttachmentContext = createContext<{
   attachments: ReadonlyMap<string, SharedNoteAttachment>;
+  excluded: ReadonlySet<string>;
   resolve: SharedAttachmentResolver | null;
-}>({ attachments: new Map(), resolve: null });
+}>({ attachments: new Map(), excluded: new Set(), resolve: null });
 
 export function SharedNoteDocument({
   attachments,
   document,
+  excludedAttachmentIds = [],
   resolveAttachment,
 }: {
   attachments: SharedNoteAttachment[];
   document: SharedNoteNode;
+  excludedAttachmentIds?: readonly string[];
   resolveAttachment?: SharedAttachmentResolver;
 }) {
   const context = useMemo(
@@ -41,17 +44,22 @@ export function SharedNoteDocument({
       attachments: new Map(
         attachments.map((attachment) => [attachment.id, attachment]),
       ),
+      excluded: new Set(excludedAttachmentIds),
       resolve: resolveAttachment ?? null,
     }),
-    [attachments, resolveAttachment],
+    [attachments, excludedAttachmentIds, resolveAttachment],
   );
   const unreferencedAttachments = useMemo(() => {
     const referenced = collectSharedAttachmentIds(document);
-    return attachments.filter((attachment) => !referenced.has(attachment.id));
-  }, [attachments, document]);
+    const excluded = new Set(excludedAttachmentIds);
+    return attachments.filter(
+      (attachment) =>
+        !referenced.has(attachment.id) && !excluded.has(attachment.id),
+    );
+  }, [attachments, document, excludedAttachmentIds]);
   return (
     <AttachmentContext.Provider value={context}>
-      <div className="ProseMirror prosemirror-editor session-note-editor shared-note-document text-color">
+      <div className="ProseMirror prosemirror-editor session-note-editor shared-note-document text-color [&_li]:!text-base [&_li]:!leading-5 [&_p]:!text-base [&_p]:!leading-5">
         {renderChildren(document.content, "document")}
         {unreferencedAttachments.length > 0 ? (
           <section className="border-color-subtle mt-10 border-t pt-6">
@@ -118,10 +126,18 @@ function renderNode(node: SharedNoteNode, key: string): ReactNode {
     case "clip":
       return <SharedAttachmentNode key={key} node={node} />;
     case "bulletList":
-      return <ul key={key}>{children}</ul>;
+      return (
+        <ul key={key} className="list-disc pl-6">
+          {children}
+        </ul>
+      );
     case "orderedList":
       return (
-        <ol key={key} start={getIntegerAttr(node, "start", 1, 1_000_000, 1)}>
+        <ol
+          key={key}
+          className="list-decimal pl-6"
+          start={getIntegerAttr(node, "start", 1, 1_000_000, 1)}
+        >
           {children}
         </ol>
       );
@@ -189,7 +205,7 @@ function renderNode(node: SharedNoteNode, key: string): ReactNode {
 }
 
 function SharedAttachmentNode({ node }: { node: SharedNoteNode }) {
-  const { attachments, resolve } = useContext(AttachmentContext);
+  const { attachments, excluded, resolve } = useContext(AttachmentContext);
   const [pinnedAudioDownload, setPinnedAudioDownload] =
     useState<SharedNoteAttachmentDownload | null>(null);
   const [audioPlaying, setAudioPlaying] = useState(false);
@@ -207,7 +223,7 @@ function SharedAttachmentNode({ node }: { node: SharedNoteNode }) {
   const downloadQuery = useQuery({
     queryKey: ["shared-note-attachment-download", attachment?.id ?? ""],
     queryFn: ({ signal }) => resolve!(attachment!, signal),
-    enabled: Boolean(attachment && resolve),
+    enabled: Boolean(attachment && resolve && !excluded.has(attachment.id)),
     retry: false,
     staleTime: 45_000,
     refetchInterval: audioPlaying ? false : 45_000,
@@ -220,6 +236,10 @@ function SharedAttachmentNode({ node }: { node: SharedNoteNode }) {
       ? downloadQuery.data
       : null;
   const activeDownload = isAudio ? (pinnedAudioDownload ?? download) : download;
+
+  if (attachment && excluded.has(attachment.id)) {
+    return null;
+  }
 
   if (!attachment || !resolve || !activeDownload) {
     return (

--- a/apps/web/src/components/shared-note-document.tsx
+++ b/apps/web/src/components/shared-note-document.tsx
@@ -12,6 +12,7 @@ import {
 
 import {
   getSafeSharedNoteHref,
+  isMatchingSharedNoteAttachmentDownload,
   type SharedNoteAttachment,
   type SharedNoteAttachmentDownload,
   type SharedNoteNode,
@@ -232,7 +233,7 @@ function SharedAttachmentNode({ node }: { node: SharedNoteNode }) {
   const download =
     !downloadQuery.error &&
     attachment &&
-    isMatchingDownload(attachment, downloadQuery.data)
+    isMatchingSharedNoteAttachmentDownload(attachment, downloadQuery.data)
       ? downloadQuery.data
       : null;
   const activeDownload = isAudio ? (pinnedAudioDownload ?? download) : download;
@@ -275,7 +276,7 @@ function SharedAttachmentNode({ node }: { node: SharedNoteNode }) {
       const refreshed = await downloadQuery.refetch();
       if (
         refreshed.isError ||
-        !isMatchingDownload(attachment, refreshed.data)
+        !isMatchingSharedNoteAttachmentDownload(attachment, refreshed.data)
       ) {
         return;
       }
@@ -340,20 +341,6 @@ function SharedAttachmentNode({ node }: { node: SharedNoteNode }) {
         {formatFileSize(attachment.sizeBytes)}
       </span>
     </a>
-  );
-}
-
-function isMatchingDownload(
-  attachment: SharedNoteAttachment,
-  download: SharedNoteAttachmentDownload | null | undefined,
-): download is SharedNoteAttachmentDownload {
-  return Boolean(
-    download &&
-    download.id === attachment.id &&
-    download.filename === attachment.filename &&
-    download.contentType === attachment.contentType &&
-    download.sizeBytes === attachment.sizeBytes &&
-    download.sha256 === attachment.sha256,
   );
 }
 

--- a/apps/web/src/components/shared-note-editable-viewer.tsx
+++ b/apps/web/src/components/shared-note-editable-viewer.tsx
@@ -1,18 +1,27 @@
 import { useState } from "react";
 
+import {
+  collectSharedNoteComments,
+  useSharedNoteComments,
+} from "@/components/shared-note-comments-data";
+import { SharedNoteCommentsDrawer } from "@/components/shared-note-comments-drawer";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import { SharedNoteReader } from "@/components/shared-note-reader";
 import {
   SharedNoteUnavailable,
   SharedNoteViewer,
 } from "@/components/shared-note-viewer";
-import { canComposeSharedNoteComments } from "@/lib/shared-note-collaboration";
+import {
+  canComposeSharedNoteComments,
+  hasSharedNoteCollaborationAccess,
+} from "@/lib/shared-note-collaboration";
 import {
   getSharedNoteReadOnlySnapshot,
   shouldRenderSharedNoteUnavailable,
   syncSharedNoteViewerAuthorization,
   type SharedNoteViewerAuthorization,
 } from "@/lib/shared-note-editing";
+import { findFeaturedSharedNoteAudio } from "@/lib/shared-note-presentation";
 import type {
   AuthenticatedSharedNote,
   SharedNoteSnapshot,
@@ -81,6 +90,15 @@ export function SharedNoteEditableViewer({
     accessRevoked && readOnlySnapshot ? readOnlySnapshot : snapshot;
   const collaborationActive = !accessRevoked && !requiresSignIn;
   const readyNote = authorization.state === "ready" ? authorization.note : null;
+  const commentsQuery = useSharedNoteComments({
+    enabled: signedIn && collaborationActive,
+    shareId: activeSnapshot.shareId,
+  });
+  const comments = collectSharedNoteComments(commentsQuery.data);
+  const commentsAvailable = hasSharedNoteCollaborationAccess(
+    commentsQuery.data?.pages[0],
+  );
+  const featuredAudio = findFeaturedSharedNoteAudio(activeSnapshot.attachments);
   // hasCollaborationAccess is true here because the read surface re-checks
   // actual access from the comments query before enabling composition.
   const canComposeComments =
@@ -130,12 +148,18 @@ export function SharedNoteEditableViewer({
       documentContent={
         <SharedNoteReader
           canCompose={canComposeComments}
+          excludedAttachmentIds={featuredAudio ? [featuredAudio.id] : undefined}
           manageAccess={readyNote?.manageAccess ?? false}
           resolveAttachment={resolveAttachment}
           shareId={activeSnapshot.shareId}
           signedIn={signedIn && collaborationActive}
           snapshot={activeSnapshot}
         />
+      }
+      headerActions={
+        commentsAvailable ? (
+          <SharedNoteCommentsDrawer comments={comments} />
+        ) : undefined
       }
       notice={accessNotice ?? signInNotice}
       resolveAttachment={resolveAttachment}

--- a/apps/web/src/components/shared-note-read-surface.tsx
+++ b/apps/web/src/components/shared-note-read-surface.tsx
@@ -66,7 +66,10 @@ import {
   resolveSharedNoteCommentRanges,
 } from "@/lib/shared-note-comment-anchors";
 import { pickActiveCommentId } from "@/lib/shared-note-comment-rail-layout";
-import { groupSharedNoteCommentThreads } from "@/lib/shared-note-comment-threads";
+import {
+  getSharedNoteCommentThreadAnchors,
+  groupSharedNoteCommentThreads,
+} from "@/lib/shared-note-comment-threads";
 import {
   type SharedNoteAttachment,
   type SharedNoteAttachmentDownload,
@@ -262,17 +265,7 @@ export function SharedNoteReadSurface({
     );
     setAnchoredComments(anchored);
     setCommentAnchors(view, [
-      ...anchored.flatMap((comment) =>
-        comment.range
-          ? [
-              {
-                commentId: comment.commentId,
-                from: comment.range.from,
-                to: comment.range.to,
-              },
-            ]
-          : [],
-      ),
+      ...getSharedNoteCommentThreadAnchors(anchored),
       ...(draft
         ? [{ commentId: DRAFT_COMMENT_ID, from: draft.from, to: draft.to }]
         : []),

--- a/apps/web/src/components/shared-note-read-surface.tsx
+++ b/apps/web/src/components/shared-note-read-surface.tsx
@@ -66,6 +66,7 @@ import {
   resolveSharedNoteCommentRanges,
 } from "@/lib/shared-note-comment-anchors";
 import { pickActiveCommentId } from "@/lib/shared-note-comment-rail-layout";
+import { groupSharedNoteCommentThreads } from "@/lib/shared-note-comment-threads";
 import {
   type SharedNoteAttachment,
   type SharedNoteAttachmentDownload,
@@ -157,10 +158,15 @@ export function SharedNoteReadSurface({
   const railItems = anchoredComments.filter(
     (comment) => comment.anchor !== null && comment.range !== null,
   );
-  const activeComment = activeCommentId
-    ? (railItems.find((comment) => comment.commentId === activeCommentId) ??
-      null)
+  const commentThreads = groupSharedNoteCommentThreads(railItems);
+  const activeThread = activeCommentId
+    ? (commentThreads.find((thread) =>
+        thread.comments.some(
+          (comment) => comment.commentId === activeCommentId,
+        ),
+      ) ?? null)
     : null;
+  const activeComment = activeThread?.comments[0] ?? null;
   const railHasContent = signedIn && (draft !== null || railItems.length > 0);
 
   const body = useMemo(
@@ -474,6 +480,7 @@ export function SharedNoteReadSurface({
                       })
                   : undefined
               }
+              replies={activeThread?.comments.slice(1)}
             />
           ) : null}
         </div>

--- a/apps/web/src/components/shared-note-read-surface.tsx
+++ b/apps/web/src/components/shared-note-read-surface.tsx
@@ -71,8 +71,8 @@ import {
   groupSharedNoteCommentThreads,
 } from "@/lib/shared-note-comment-threads";
 import {
+  isMatchingSharedNoteAttachmentDownload,
   type SharedNoteAttachment,
-  type SharedNoteAttachmentDownload,
   type SharedNoteNode,
   type SharedNoteSnapshot,
   withoutDuplicateLeadingTitle,
@@ -644,7 +644,7 @@ function SharedReadAttachment({
   const download =
     !downloadQuery.error &&
     attachment &&
-    isMatchingDownload(attachment, downloadQuery.data)
+    isMatchingSharedNoteAttachmentDownload(attachment, downloadQuery.data)
       ? downloadQuery.data
       : null;
 
@@ -704,20 +704,6 @@ function SharedReadAttachment({
         </p>
       </div>
     </div>
-  );
-}
-
-function isMatchingDownload(
-  attachment: SharedNoteAttachment,
-  download: SharedNoteAttachmentDownload | null | undefined,
-): download is SharedNoteAttachmentDownload {
-  return Boolean(
-    download &&
-    download.id === attachment.id &&
-    download.filename === attachment.filename &&
-    download.contentType === attachment.contentType &&
-    download.sizeBytes === attachment.sizeBytes &&
-    download.sha256 === attachment.sha256,
   );
 }
 

--- a/apps/web/src/components/shared-note-read-surface.tsx
+++ b/apps/web/src/components/shared-note-read-surface.tsx
@@ -80,8 +80,9 @@ type EditorNodeViewProps = ComponentProps<EditorNodeView>;
 
 const SharedReadAttachmentsContext = createContext<{
   attachments: ReadonlyMap<string, SharedNoteAttachment>;
+  excluded: ReadonlySet<string>;
   resolve: SharedAttachmentResolver | null;
-}>({ attachments: new Map(), resolve: null });
+}>({ attachments: new Map(), excluded: new Set(), resolve: null });
 
 // Tailwind's xl breakpoint — the width from which the comment rail (and its
 // draft composer) is visible.
@@ -103,6 +104,7 @@ function useCommentRailVisible() {
 
 export function SharedNoteReadSurface({
   canCompose,
+  excludedAttachmentIds = [],
   manageAccess,
   resolveAttachment,
   shareId,
@@ -110,6 +112,7 @@ export function SharedNoteReadSurface({
   snapshot,
 }: {
   canCompose: boolean;
+  excludedAttachmentIds?: readonly string[];
   manageAccess: boolean;
   resolveAttachment?: SharedAttachmentResolver;
   shareId: string;
@@ -179,9 +182,10 @@ export function SharedNoteReadSurface({
       attachments: new Map(
         snapshot.attachments.map((attachment) => [attachment.id, attachment]),
       ),
+      excluded: new Set(excludedAttachmentIds),
       resolve: resolveAttachment ?? null,
     }),
-    [snapshot.attachments, resolveAttachment],
+    [snapshot.attachments, excludedAttachmentIds, resolveAttachment],
   );
   const unreferencedAttachments = useMemo(() => {
     const referenced = new Set<string>();
@@ -193,9 +197,11 @@ export function SharedNoteReadSurface({
     };
     visit(body);
     return snapshot.attachments.filter(
-      (attachment) => !referenced.has(attachment.id),
+      (attachment) =>
+        !referenced.has(attachment.id) &&
+        !excludedAttachmentIds.includes(attachment.id),
     );
-  }, [body, snapshot.attachments]);
+  }, [body, excludedAttachmentIds, snapshot.attachments]);
 
   const scheduleLayoutMeasure = useCallback(() => {
     if (frameRef.current !== null) return;
@@ -348,6 +354,7 @@ export function SharedNoteReadSurface({
       <SharedNoteDocument
         attachments={snapshot.attachments}
         document={body}
+        excludedAttachmentIds={excludedAttachmentIds}
         resolveAttachment={resolveAttachment}
       />
     );
@@ -361,7 +368,7 @@ export function SharedNoteReadSurface({
     >
       <SharedReadAttachmentsContext.Provider value={attachmentContext}>
         <NoteEditor
-          className="session-note-editor outline-hidden"
+          className="session-note-editor outline-hidden [&_li]:!text-base [&_li]:!leading-5 [&_p]:!text-base [&_p]:!leading-5"
           commentAnchorsEnabled
           enforceTitleHeading={false}
           extraNodeViews={readAttachmentNodeViews}
@@ -425,6 +432,15 @@ export function SharedNoteReadSurface({
           items={railItems}
           onActivate={activateComment}
           onDelete={(commentId) => deleteMutation.mutate(commentId)}
+          onReply={
+            composeEnabled
+              ? (comment, commentBody) =>
+                  createMutation.mutateAsync({
+                    anchor: comment.anchor,
+                    body: commentBody,
+                  })
+              : undefined
+          }
           screenTops={screenTops}
         />
       </div>
@@ -443,15 +459,21 @@ export function SharedNoteReadSurface({
           ) : activeComment ? (
             <SharedNoteCommentCard
               active
+              canDelete={(comment) => comment.isAuthor || manageAccess}
               comment={activeComment}
               deleteDisabled={deleteMutation.isPending}
-              deleting={
-                deleteMutation.isPending &&
-                deleteMutation.variables === activeComment.commentId
-              }
+              deletingCommentId={deleteMutation.variables ?? null}
               onActivate={() => activateComment(null)}
-              onDelete={() => deleteMutation.mutate(activeComment.commentId)}
-              showDelete={activeComment.isAuthor || manageAccess}
+              onDelete={(commentId) => deleteMutation.mutate(commentId)}
+              onReply={
+                composeEnabled
+                  ? (comment, commentBody) =>
+                      createMutation.mutateAsync({
+                        anchor: comment.anchor,
+                        body: commentBody,
+                      })
+                  : undefined
+              }
             />
           ) : null}
         </div>
@@ -568,7 +590,9 @@ const SharedReadAttachmentView = forwardRef<
   HTMLDivElement,
   EditorNodeViewProps
 >(function SharedReadAttachmentView({ nodeProps, ...htmlAttrs }, ref) {
-  const { attachments, resolve } = useContext(SharedReadAttachmentsContext);
+  const { attachments, excluded, resolve } = useContext(
+    SharedReadAttachmentsContext,
+  );
   const sharedAttachmentId = nodeProps.node.attrs.sharedAttachmentId;
   const attachment =
     typeof sharedAttachmentId === "string"
@@ -582,16 +606,19 @@ const SharedReadAttachmentView = forwardRef<
       contentEditable={false}
       suppressContentEditableWarning
     >
-      <SharedReadAttachment
-        attachment={attachment}
-        isImage={nodeProps.node.type.name === "image"}
-        resolve={resolve}
-      />
+      {attachment && excluded.has(attachment.id) ? null : (
+        <SharedReadAttachment
+          attachment={attachment}
+          isImage={nodeProps.node.type.name === "image"}
+          resolve={resolve}
+        />
+      )}
     </div>
   );
 });
 
 const readAttachmentNodeViews = {
+  clip: SharedReadAttachmentView,
   fileAttachment: SharedReadAttachmentView,
   image: SharedReadAttachmentView,
 };

--- a/apps/web/src/components/shared-note-reader.tsx
+++ b/apps/web/src/components/shared-note-reader.tsx
@@ -19,6 +19,7 @@ const SharedNoteReadSurface = lazy(() =>
 
 export function SharedNoteReader({
   canCompose,
+  excludedAttachmentIds,
   manageAccess,
   resolveAttachment,
   shareId,
@@ -26,6 +27,7 @@ export function SharedNoteReader({
   snapshot,
 }: {
   canCompose: boolean;
+  excludedAttachmentIds?: readonly string[];
   manageAccess: boolean;
   resolveAttachment?: SharedAttachmentResolver;
   shareId: string;
@@ -39,6 +41,7 @@ export function SharedNoteReader({
     <SharedNoteDocument
       attachments={snapshot.attachments}
       document={withoutDuplicateLeadingTitle(snapshot.body, snapshot.title)}
+      excludedAttachmentIds={excludedAttachmentIds}
       resolveAttachment={resolveAttachment}
     />
   );
@@ -52,6 +55,7 @@ export function SharedNoteReader({
       <SharedNoteReadSurface
         key={`${snapshot.shareId}:${snapshot.contentRevision}`}
         canCompose={canCompose}
+        excludedAttachmentIds={excludedAttachmentIds}
         manageAccess={manageAccess}
         resolveAttachment={resolveAttachment}
         shareId={shareId}

--- a/apps/web/src/components/shared-note-viewer.tsx
+++ b/apps/web/src/components/shared-note-viewer.tsx
@@ -5,29 +5,34 @@ import {
   RefreshCwIcon,
   UsersRoundIcon,
 } from "lucide-react";
+import { useSyncExternalStore } from "react";
 
 import { cn } from "@hypr/utils";
 
+import { SharedNoteAudioPlayer } from "@/components/shared-note-audio-player";
 import {
   type SharedAttachmentResolver,
   SharedNoteDocument,
 } from "@/components/shared-note-document";
+import {
+  findFeaturedSharedNoteAudio,
+  formatSharedNotePublishedAt,
+} from "@/lib/shared-note-presentation";
 import {
   type SharedNoteSnapshot,
   withoutDuplicateLeadingTitle,
 } from "@/lib/shared-notes";
 
 export const sharedPrimaryButtonClassName = cn([
-  "inline-flex min-h-11 items-center justify-center rounded-full px-5",
-  "bg-linear-to-t from-stone-600 to-stone-500 text-white",
-  "font-mono text-sm font-medium transition-opacity hover:opacity-90",
-  "focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+  "inline-flex min-h-9 items-center justify-center rounded-full bg-stone-900 px-4 text-white",
+  "text-sm font-semibold transition-colors hover:bg-stone-800",
+  "focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2 focus-visible:outline-hidden",
   "disabled:cursor-not-allowed disabled:opacity-50",
 ]);
 
 export const sharedSecondaryButtonClassName = cn([
-  "surface border-color-subtle inline-flex min-h-11 items-center justify-center rounded-full border px-5",
-  "text-color hover:bg-surface-subtle font-mono text-sm font-medium transition-colors",
+  "surface border-color-subtle inline-flex min-h-9 items-center justify-center rounded-full border px-4",
+  "text-color hover:bg-surface-subtle text-sm font-medium transition-colors",
   "focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:ring-offset-2 focus-visible:outline-hidden",
 ]);
 
@@ -51,17 +56,13 @@ export function SharedNoteViewer({
   snapshot: SharedNoteSnapshot;
 }) {
   const body = withoutDuplicateLeadingTitle(snapshot.body, snapshot.title);
+  const featuredAudio = findFeaturedSharedNoteAudio(snapshot.attachments);
 
   return (
     <SharedNoteShell
       topActions={
         headerActions || actions ? (
-          <div
-            className={cn([
-              "flex items-center gap-2",
-              "[&>a]:min-h-9 [&>a]:px-4 [&>button]:min-h-9 [&>button]:px-4",
-            ])}
-          >
+          <div className="flex items-center gap-2">
             {headerActions}
             {actions}
           </div>
@@ -77,30 +78,40 @@ export function SharedNoteViewer({
           )}
           <div
             className={cn([
-              "text-color-muted flex min-w-0 flex-wrap items-center gap-2 text-xs",
+              "flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1 text-xs text-stone-500",
               showTitle ? "mt-3" : "mb-6",
             ])}
           >
-            <span className="surface border-color-subtle inline-flex min-h-8 items-center gap-1.5 rounded-full border px-3">
+            <span className="inline-flex min-h-7 items-center gap-1.5">
               <UsersRoundIcon className="size-3.5" aria-hidden="true" />
               {accessLabel}
             </span>
             <time
-              className="surface border-color-subtle inline-flex min-h-8 items-center gap-1.5 rounded-full border px-3"
+              className="inline-flex min-h-7 items-center gap-1.5"
               dateTime={snapshot.publishedAt}
+              title={`Published ${formatSharedNotePublishedAt(snapshot.publishedAt)}`}
             >
               <CalendarDaysIcon className="size-3.5" aria-hidden="true" />
-              {formatPublishedAt(snapshot.publishedAt)}
+              {formatSharedNotePublishedAt(snapshot.publishedAt)}
             </time>
           </div>
         </header>
 
         <div>
           {notice}
+          {featuredAudio ? (
+            <SharedNoteAudioPlayer
+              attachment={featuredAudio}
+              resolve={resolveAttachment}
+            />
+          ) : null}
           {documentContent ?? (
             <SharedNoteDocument
               attachments={snapshot.attachments}
               document={body}
+              excludedAttachmentIds={
+                featuredAudio ? [featuredAudio.id] : undefined
+              }
               resolveAttachment={resolveAttachment}
             />
           )}
@@ -199,26 +210,36 @@ function SharedNoteShell({
   children: React.ReactNode;
   topActions?: React.ReactNode;
 }) {
+  const headerHidden = useSyncExternalStore(
+    subscribeHeaderVisibility,
+    getHeaderHidden,
+    () => false,
+  );
+
   return (
-    <main className="bg-page text-color min-h-screen overflow-x-clip">
-      <header className="bg-page/95 border-color-subtle sticky top-0 z-40 flex h-14 items-center justify-between gap-4 border-b px-4 backdrop-blur-sm sm:px-6">
+    <main className="min-h-screen overflow-x-clip bg-white text-stone-900">
+      <header
+        className={cn([
+          "sticky top-0 z-40 flex h-14 items-center justify-between gap-4 border-b border-stone-200 bg-white/95 px-4 backdrop-blur-sm sm:px-6",
+          "transition-transform duration-200 will-change-transform motion-reduce:transition-none",
+          headerHidden && "-translate-y-full",
+        ])}
+      >
         <a
           href="/"
           aria-label="Anarlog home"
-          className="font-hand text-color text-2xl leading-none font-semibold"
+          className="font-hand text-[27px] leading-none font-semibold text-stone-900"
         >
           anarlog
         </a>
         {topActions ?? (
-          <span className="text-color-muted font-mono text-xs">
-            Shared with Anarlog
-          </span>
+          <span className="text-xs text-stone-500">Shared with Anarlog</span>
         )}
       </header>
       <div
         className={cn([
           "mx-auto w-full max-w-[720px] px-5 py-8 sm:px-8 sm:py-10",
-          "xl:has-[[data-comment-rail]]:max-w-[1028px] xl:has-[[data-comment-rail]]:pr-[308px]",
+          "xl:has-[[data-comment-rail]]:max-w-[1028px] xl:has-[[data-comment-rail]]:pr-[372px] xl:has-[[data-comment-rail]]:pl-0",
         ])}
       >
         {children}
@@ -227,11 +248,31 @@ function SharedNoteShell({
   );
 }
 
-function formatPublishedAt(value: string) {
-  return new Intl.DateTimeFormat("en-US", {
-    day: "numeric",
-    month: "short",
-    timeZone: "UTC",
-    year: "numeric",
-  }).format(new Date(value));
+let headerHidden = false;
+
+function subscribeHeaderVisibility(onChange: () => void) {
+  let lastScrollY = window.scrollY;
+  const handleScroll = () => {
+    const nextScrollY = window.scrollY;
+    const nextHidden =
+      nextScrollY > 80 &&
+      (nextScrollY > lastScrollY + 8
+        ? true
+        : nextScrollY < lastScrollY - 8
+          ? false
+          : headerHidden);
+    lastScrollY = nextScrollY;
+    if (nextHidden === headerHidden) return;
+    headerHidden = nextHidden;
+    onChange();
+  };
+  window.addEventListener("scroll", handleScroll, { passive: true });
+  return () => {
+    window.removeEventListener("scroll", handleScroll);
+    headerHidden = false;
+  };
+}
+
+function getHeaderHidden() {
+  return headerHidden;
 }

--- a/apps/web/src/components/shared-note-viewer.tsx
+++ b/apps/web/src/components/shared-note-viewer.tsx
@@ -249,27 +249,36 @@ function SharedNoteShell({
 }
 
 let headerHidden = false;
+let lastHeaderScrollY = 0;
+const headerVisibilityListeners = new Set<() => void>();
+
+function handleHeaderScroll() {
+  const nextScrollY = window.scrollY;
+  const nextHidden =
+    nextScrollY > 80 &&
+    (nextScrollY > lastHeaderScrollY + 8
+      ? true
+      : nextScrollY < lastHeaderScrollY - 8
+        ? false
+        : headerHidden);
+  lastHeaderScrollY = nextScrollY;
+  if (nextHidden === headerHidden) return;
+  headerHidden = nextHidden;
+  headerVisibilityListeners.forEach((listener) => listener());
+}
 
 function subscribeHeaderVisibility(onChange: () => void) {
-  let lastScrollY = window.scrollY;
-  const handleScroll = () => {
-    const nextScrollY = window.scrollY;
-    const nextHidden =
-      nextScrollY > 80 &&
-      (nextScrollY > lastScrollY + 8
-        ? true
-        : nextScrollY < lastScrollY - 8
-          ? false
-          : headerHidden);
-    lastScrollY = nextScrollY;
-    if (nextHidden === headerHidden) return;
-    headerHidden = nextHidden;
-    onChange();
-  };
-  window.addEventListener("scroll", handleScroll, { passive: true });
+  headerVisibilityListeners.add(onChange);
+  if (headerVisibilityListeners.size === 1) {
+    lastHeaderScrollY = window.scrollY;
+    window.addEventListener("scroll", handleHeaderScroll, { passive: true });
+  }
   return () => {
-    window.removeEventListener("scroll", handleScroll);
-    headerHidden = false;
+    headerVisibilityListeners.delete(onChange);
+    if (headerVisibilityListeners.size === 0) {
+      window.removeEventListener("scroll", handleHeaderScroll);
+      headerHidden = false;
+    }
   };
 }
 

--- a/apps/web/src/lib/shared-note-comment-threads.test.ts
+++ b/apps/web/src/lib/shared-note-comment-threads.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { AnchoredSharedNoteComment } from "./shared-note-comment-anchors.ts";
+import { groupSharedNoteCommentThreads } from "./shared-note-comment-threads.ts";
+
+function comment(commentId: string, from: number): AnchoredSharedNoteComment {
+  return {
+    commentId,
+    isAuthor: false,
+    body: commentId,
+    snapshotRevision: 1,
+    anchor: {
+      quoteExact: "same quote",
+      quotePrefix: "",
+      quoteSuffix: "",
+      fromHint: from,
+      toHint: from + 10,
+    },
+    range: { from, to: from + 10 },
+    createdAt: "2026-07-23T00:00:00Z",
+  };
+}
+
+test("groups comments on the same anchored text into one visual thread", () => {
+  const threads = groupSharedNoteCommentThreads([
+    comment("root", 10),
+    comment("reply", 10),
+    comment("other", 40),
+  ]);
+
+  assert.deepEqual(
+    threads.map((thread) => thread.comments.map(({ commentId }) => commentId)),
+    [["root", "reply"], ["other"]],
+  );
+});
+
+test("keeps unresolved comments in separate threads", () => {
+  const unresolved = { ...comment("first", 10), range: null };
+  assert.equal(
+    groupSharedNoteCommentThreads([
+      unresolved,
+      { ...unresolved, commentId: "second" },
+    ]).length,
+    2,
+  );
+});

--- a/apps/web/src/lib/shared-note-comment-threads.test.ts
+++ b/apps/web/src/lib/shared-note-comment-threads.test.ts
@@ -2,9 +2,16 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { AnchoredSharedNoteComment } from "./shared-note-comment-anchors.ts";
-import { groupSharedNoteCommentThreads } from "./shared-note-comment-threads.ts";
+import {
+  getSharedNoteCommentThreadAnchors,
+  groupSharedNoteCommentThreads,
+} from "./shared-note-comment-threads.ts";
 
-function comment(commentId: string, from: number): AnchoredSharedNoteComment {
+function comment(
+  commentId: string,
+  from: number,
+  createdAt = "2026-07-23T00:00:00Z",
+): AnchoredSharedNoteComment {
   return {
     commentId,
     isAuthor: false,
@@ -18,7 +25,7 @@ function comment(commentId: string, from: number): AnchoredSharedNoteComment {
       toHint: from + 10,
     },
     range: { from, to: from + 10 },
-    createdAt: "2026-07-23T00:00:00Z",
+    createdAt,
   };
 }
 
@@ -35,6 +42,19 @@ test("groups comments on the same anchored text into one visual thread", () => {
   );
 });
 
+test("orders thread roots and replies chronologically", () => {
+  const threads = groupSharedNoteCommentThreads([
+    comment("reply", 10, "2026-07-23T00:02:00Z"),
+    comment("other", 40, "2026-07-23T00:03:00Z"),
+    comment("root", 10, "2026-07-23T00:01:00Z"),
+  ]);
+
+  assert.deepEqual(
+    threads.map((thread) => thread.comments.map(({ commentId }) => commentId)),
+    [["root", "reply"], ["other"]],
+  );
+});
+
 test("keeps unresolved comments in separate threads", () => {
   const unresolved = { ...comment("first", 10), range: null };
   assert.equal(
@@ -43,5 +63,19 @@ test("keeps unresolved comments in separate threads", () => {
       { ...unresolved, commentId: "second" },
     ]).length,
     2,
+  );
+});
+
+test("creates one anchor per comment thread", () => {
+  assert.deepEqual(
+    getSharedNoteCommentThreadAnchors([
+      comment("reply", 10, "2026-07-23T00:02:00Z"),
+      comment("root", 10, "2026-07-23T00:01:00Z"),
+      comment("other", 40, "2026-07-23T00:03:00Z"),
+    ]),
+    [
+      { commentId: "root", from: 10, to: 20 },
+      { commentId: "other", from: 40, to: 50 },
+    ],
   );
 });

--- a/apps/web/src/lib/shared-note-comment-threads.ts
+++ b/apps/web/src/lib/shared-note-comment-threads.ts
@@ -1,0 +1,38 @@
+import type { AnchoredSharedNoteComment } from "@/lib/shared-note-comment-anchors";
+
+export type SharedNoteCommentThread = {
+  id: string;
+  comments: AnchoredSharedNoteComment[];
+};
+
+export function groupSharedNoteCommentThreads(
+  comments: readonly AnchoredSharedNoteComment[],
+) {
+  const threads: SharedNoteCommentThread[] = [];
+  const byAnchor = new Map<string, SharedNoteCommentThread>();
+
+  for (const comment of comments) {
+    const key = anchorKey(comment);
+    const existing = byAnchor.get(key);
+    if (existing) {
+      existing.comments.push(comment);
+      continue;
+    }
+    const thread = { id: comment.commentId, comments: [comment] };
+    byAnchor.set(key, thread);
+    threads.push(thread);
+  }
+
+  return threads;
+}
+
+function anchorKey(comment: AnchoredSharedNoteComment) {
+  if (!comment.anchor || !comment.range) return `comment:${comment.commentId}`;
+  return JSON.stringify([
+    comment.anchor.quoteExact,
+    comment.anchor.quotePrefix,
+    comment.anchor.quoteSuffix,
+    comment.range.from,
+    comment.range.to,
+  ]);
+}

--- a/apps/web/src/lib/shared-note-comment-threads.ts
+++ b/apps/web/src/lib/shared-note-comment-threads.ts
@@ -11,7 +11,11 @@ export function groupSharedNoteCommentThreads(
   const threads: SharedNoteCommentThread[] = [];
   const byAnchor = new Map<string, SharedNoteCommentThread>();
 
-  for (const comment of comments) {
+  const chronologicalComments = [...comments].sort(
+    (left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt),
+  );
+
+  for (const comment of chronologicalComments) {
     const key = anchorKey(comment);
     const existing = byAnchor.get(key);
     if (existing) {
@@ -24,6 +28,15 @@ export function groupSharedNoteCommentThreads(
   }
 
   return threads;
+}
+
+export function getSharedNoteCommentThreadAnchors(
+  comments: readonly AnchoredSharedNoteComment[],
+) {
+  return groupSharedNoteCommentThreads(comments).flatMap((thread) => {
+    const range = thread.comments[0]?.range;
+    return range ? [{ commentId: thread.id, ...range }] : [];
+  });
 }
 
 function anchorKey(comment: AnchoredSharedNoteComment) {

--- a/apps/web/src/lib/shared-note-presentation.test.ts
+++ b/apps/web/src/lib/shared-note-presentation.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSharedNoteWaveform,
+  findFeaturedSharedNoteAudio,
+  formatSharedNotePlaybackTime,
+} from "./shared-note-presentation.ts";
+
+test("finds the first playable shared audio attachment", () => {
+  const audio = {
+    id: "audio",
+    filename: "meeting.m4a",
+    contentType: "audio/mp4",
+    sizeBytes: 10,
+    sha256: "a".repeat(64),
+  };
+  assert.equal(
+    findFeaturedSharedNoteAudio([
+      { ...audio, id: "image", contentType: "image/png" },
+      audio,
+      { ...audio, id: "second" },
+    ]),
+    audio,
+  );
+});
+
+test("builds a stable bounded waveform", () => {
+  const first = createSharedNoteWaveform("abc", 12);
+  assert.deepEqual(first, createSharedNoteWaveform("abc", 12));
+  assert.equal(first.length, 12);
+  assert.ok(first.every((height) => height >= 18 && height <= 90));
+  assert.notDeepEqual(first, createSharedNoteWaveform("def", 12));
+});
+
+test("formats playback time without leaking invalid values", () => {
+  assert.equal(formatSharedNotePlaybackTime(0), "0:00");
+  assert.equal(formatSharedNotePlaybackTime(754.9), "12:34");
+  assert.equal(formatSharedNotePlaybackTime(Number.NaN), "0:00");
+});

--- a/apps/web/src/lib/shared-note-presentation.test.ts
+++ b/apps/web/src/lib/shared-note-presentation.test.ts
@@ -5,6 +5,8 @@ import {
   createSharedNoteWaveform,
   findFeaturedSharedNoteAudio,
   formatSharedNotePlaybackTime,
+  formatSharedNoteRelativeTime,
+  isSharedNoteAudioGrantExpiring,
 } from "./shared-note-presentation.ts";
 
 test("finds the first playable shared audio attachment", () => {
@@ -37,4 +39,28 @@ test("formats playback time without leaking invalid values", () => {
   assert.equal(formatSharedNotePlaybackTime(0), "0:00");
   assert.equal(formatSharedNotePlaybackTime(754.9), "12:34");
   assert.equal(formatSharedNotePlaybackTime(Number.NaN), "0:00");
+});
+
+test("formats shared note comment timestamps relative to a stable time", () => {
+  const now = Date.parse("2026-07-23T12:00:00Z");
+  assert.equal(
+    formatSharedNoteRelativeTime("2026-07-23T11:59:30Z", now),
+    "30 seconds ago",
+  );
+  assert.equal(
+    formatSharedNoteRelativeTime("2026-07-22T12:00:00Z", now),
+    "yesterday",
+  );
+});
+
+test("refreshes audio grants before they expire", () => {
+  const now = Date.parse("2026-07-23T12:00:00Z");
+  assert.equal(
+    isSharedNoteAudioGrantExpiring("2026-07-23T12:00:10Z", now),
+    true,
+  );
+  assert.equal(
+    isSharedNoteAudioGrantExpiring("2026-07-23T12:00:11Z", now),
+    false,
+  );
 });

--- a/apps/web/src/lib/shared-note-presentation.ts
+++ b/apps/web/src/lib/shared-note-presentation.ts
@@ -1,5 +1,17 @@
 import type { SharedNoteAttachment } from "@/lib/shared-notes";
 
+const RELATIVE_TIME_DIVISIONS: Array<
+  [amount: number, unit: Intl.RelativeTimeFormatUnit]
+> = [
+  [60, "second"],
+  [60, "minute"],
+  [24, "hour"],
+  [7, "day"],
+  [4.34524, "week"],
+  [12, "month"],
+  [Number.POSITIVE_INFINITY, "year"],
+];
+
 export function findFeaturedSharedNoteAudio(
   attachments: readonly SharedNoteAttachment[],
 ) {
@@ -28,6 +40,25 @@ export function formatSharedNotePlaybackTime(value: number) {
   const seconds = Math.floor(value);
   const minutes = Math.floor(seconds / 60);
   return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+export function formatSharedNoteRelativeTime(value: string, now = Date.now()) {
+  const formatter = new Intl.RelativeTimeFormat("en-US", { numeric: "auto" });
+  let duration = (Date.parse(value) - now) / 1000;
+  for (const [amount, unit] of RELATIVE_TIME_DIVISIONS) {
+    if (Math.abs(duration) < amount) {
+      return formatter.format(Math.round(duration), unit);
+    }
+    duration /= amount;
+  }
+  return "";
+}
+
+export function isSharedNoteAudioGrantExpiring(
+  expiresAt: string,
+  now = Date.now(),
+) {
+  return Date.parse(expiresAt) - now <= 10_000;
 }
 
 export function formatSharedNotePublishedAt(value: string) {

--- a/apps/web/src/lib/shared-note-presentation.ts
+++ b/apps/web/src/lib/shared-note-presentation.ts
@@ -1,0 +1,40 @@
+import type { SharedNoteAttachment } from "@/lib/shared-notes";
+
+export function findFeaturedSharedNoteAudio(
+  attachments: readonly SharedNoteAttachment[],
+) {
+  return attachments.find((attachment) =>
+    attachment.contentType.startsWith("audio/"),
+  );
+}
+
+export function createSharedNoteWaveform(seed: string, count = 96) {
+  let state = 2_166_136_261;
+  for (const character of seed) {
+    state ^= character.charCodeAt(0);
+    state = Math.imul(state, 16_777_619);
+  }
+
+  return Array.from({ length: count }, (_, index) => {
+    state ^= index + 1;
+    state = Math.imul(state, 2_246_822_519);
+    state ^= state >>> 13;
+    return 18 + (Math.abs(state) % 73);
+  });
+}
+
+export function formatSharedNotePlaybackTime(value: number) {
+  if (!Number.isFinite(value) || value < 0) return "0:00";
+  const seconds = Math.floor(value);
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+export function formatSharedNotePublishedAt(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(value));
+}

--- a/apps/web/src/lib/shared-notes.test.ts
+++ b/apps/web/src/lib/shared-notes.test.ts
@@ -7,6 +7,7 @@ import {
   buildSharedNoteWebPath,
   getSafeSharedNoteHref,
   getSharedNoteDescription,
+  isMatchingSharedNoteAttachmentDownload,
   parseAuthenticatedSharedNote,
   parseGatewaySharedNote,
   parseSessionAccessRequestState,
@@ -594,6 +595,31 @@ test("validates short-lived attachment downloads", () => {
       signedUrl: "http://project.supabase.co/file?token=secret",
     }),
   );
+});
+
+test("matches attachment downloads to their source attachment", () => {
+  const download = {
+    id: "00000000-0000-4000-8000-000000000002",
+    filename: "diagram.png",
+    contentType: "image/png",
+    sizeBytes: 4,
+    sha256: "a".repeat(64),
+    signedUrl: "https://example.com/diagram.png",
+    expiresAt: "2026-07-17T12:01:00Z",
+  };
+
+  assert.equal(
+    isMatchingSharedNoteAttachmentDownload(download, download),
+    true,
+  );
+  assert.equal(
+    isMatchingSharedNoteAttachmentDownload(
+      { ...download, sha256: "b".repeat(64) },
+      download,
+    ),
+    false,
+  );
+  assert.equal(isMatchingSharedNoteAttachmentDownload(download, null), false);
 });
 
 test("rejects unsafe links and accepts sanitized external links", () => {

--- a/apps/web/src/lib/shared-notes.ts
+++ b/apps/web/src/lib/shared-notes.ts
@@ -102,6 +102,20 @@ export type SharedNoteAttachmentDownload = SharedNoteAttachment & {
   expiresAt: string;
 };
 
+export function isMatchingSharedNoteAttachmentDownload(
+  attachment: SharedNoteAttachment,
+  download: SharedNoteAttachmentDownload | null | undefined,
+): download is SharedNoteAttachmentDownload {
+  return Boolean(
+    download &&
+    download.id === attachment.id &&
+    download.filename === attachment.filename &&
+    download.contentType === attachment.contentType &&
+    download.sizeBytes === attachment.sizeBytes &&
+    download.sha256 === attachment.sha256,
+  );
+}
+
 export type AuthenticatedSharedNote = {
   snapshot: SharedNoteSnapshot;
   capability: SharedNoteCapability;


### PR DESCRIPTION
Align shared link resolution with the public note layout to ensure consistent matching and display.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared-note reading, comment creation/replies, and signed attachment playback refresh; mostly UI with some collaboration behavior changes but no auth or API contract changes in this diff.
> 
> **Overview**
> Brings **shared link pages** in line with the public note layout: white shell, stone typography, a **scroll-hiding header**, and slimmer **Open in Anarlog** actions (no separate mobile download / create-account CTAs).
> 
> Adds a **featured audio** strip above the body for the first `audio/*` attachment via `SharedNoteAudioPlayer` (waveform, scrubber, signed-URL refresh before expiry). That attachment is **hidden** elsewhere in the document through `excludedAttachmentIds`.
> 
> **Comments** are grouped into **threads** on the same anchor (rail layout, one highlight per thread), with **inline replies** and a **header comments drawer** when collaboration is available. Shared helpers cover presentation (`formatSharedNoteRelativeTime`, etc.) and `isMatchingSharedNoteAttachmentDownload` in `shared-notes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2cb51c8c8d6dee81cef9cfc3c9ca7f17710d10f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->