### PR TITLE
Prevent reasoning leaks in generated titles

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -308,6 +308,28 @@ describe("Enhanced", () => {
     expect(screen.queryByText("Generating title...")).toBeNull();
   });
 
+  it("hides in-progress title reasoning while the summary is streaming", () => {
+    hoisted.enhanceTask = {
+      status: "generating",
+      error: undefined,
+      streamedText: "Streaming summary",
+      currentStep: undefined,
+      isGenerating: true,
+    };
+    hoisted.titleTask = {
+      status: "generating",
+      error: undefined,
+      streamedText: "We need to output a concise title.",
+      currentStep: undefined,
+      isGenerating: true,
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.queryByText("We need to output a concise title.")).toBeNull();
+    expect(screen.getByText("Generating title...")).not.toBeNull();
+  });
+
   it("renders the editor after an empty enhance task returns idle", () => {
     hoisted.enhanceTask = {
       status: "idle",

--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -43,9 +43,12 @@ export function StreamingView({
   const taskId = createTaskId(enhancedNoteId, "enhance");
   const { streamedText, isGenerating } = useAITaskTask(taskId, "enhance");
   const titleTaskId = createTaskId(sessionId, "title");
-  const { streamedText: streamedTitle } = useAITaskTask(titleTaskId, "title");
+  const { streamedText: streamedTitle, isGenerating: isGeneratingTitle } =
+    useAITaskTask(titleTaskId, "title");
   const title = sessionTitle.trim();
-  const generatedTitle = getPersistableGeneratedTitle(streamedTitle);
+  const generatedTitle = isGeneratingTitle
+    ? ""
+    : getPersistableGeneratedTitle(streamedTitle);
   const visibleTitle = title || generatedTitle;
 
   if (streamedText.trim().length === 0) {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
@@ -2,7 +2,11 @@ import type { LanguageModel } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TaskConfig } from ".";
-import { persistGeneratedTitle, titleSuccess } from "./title-success";
+import {
+  getPersistableGeneratedTitle,
+  persistGeneratedTitle,
+  titleSuccess,
+} from "./title-success";
 
 import { useLiveTitle } from "~/store/zustand/live-title";
 
@@ -99,6 +103,39 @@ describe("titleSuccess.onSuccess", () => {
     });
   });
 
+  it("persists only the final title when model reasoning leaks into text", async () => {
+    await titleSuccess.onSuccess?.(
+      createParams({
+        text: [
+          "We need to output a super concise title about the meeting.",
+          "The note discusses bore pit and wetland compliance.",
+          "",
+          "Bore Pit Wetland Compliance and Design Standards",
+        ].join("\n"),
+      }),
+    );
+
+    expect(mocks.applyGeneratedSessionTitle).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      currentTitle: "",
+      nextTitle: "Bore Pit Wetland Compliance and Design Standards",
+      documents: [
+        expect.objectContaining({
+          id: "session-1",
+          nextContent: expect.not.stringContaining(
+            "We need to output a super concise title",
+          ),
+        }),
+        expect.objectContaining({
+          id: "note-1",
+          nextContent: expect.not.stringContaining(
+            "We need to output a super concise title",
+          ),
+        }),
+      ],
+    });
+  });
+
   it("does not overwrite an existing session title", async () => {
     mocks.loadSessionContentSnapshot.mockResolvedValue(
       createSnapshot("Custom title"),
@@ -146,5 +183,20 @@ describe("titleSuccess.onSuccess", () => {
     await expect(titleSuccess.onSuccess?.(createParams())).rejects.toThrow(
       "unexpected rows affected",
     );
+  });
+});
+
+describe("getPersistableGeneratedTitle", () => {
+  it("normalizes common model response wrappers", () => {
+    expect(
+      getPersistableGeneratedTitle(
+        'Reasoning about the response\nFinal title: **"Weekly Design Review"**',
+      ),
+    ).toBe("Weekly Design Review");
+  });
+
+  it("rejects placeholders and oversized output", () => {
+    expect(getPersistableGeneratedTitle('"<EMPTY>"')).toBe("");
+    expect(getPersistableGeneratedTitle("x".repeat(161))).toBe("");
   });
 });

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
@@ -188,11 +188,19 @@ describe("titleSuccess.onSuccess", () => {
 
 describe("getPersistableGeneratedTitle", () => {
   it("normalizes common model response wrappers", () => {
-    expect(
-      getPersistableGeneratedTitle(
-        'Reasoning about the response\nFinal title: **"Weekly Design Review"**',
-      ),
-    ).toBe("Weekly Design Review");
+    const wrappedTitles = [
+      'Final title: **"Weekly Design Review"**',
+      '"**Weekly Design Review**"',
+      '"Final title: Weekly Design Review"',
+    ];
+
+    for (const wrappedTitle of wrappedTitles) {
+      expect(
+        getPersistableGeneratedTitle(
+          `Reasoning about the response\n${wrappedTitle}`,
+        ),
+      ).toBe("Weekly Design Review");
+    }
   });
 
   it("rejects placeholders and oversized output", () => {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.test.ts
@@ -203,6 +203,18 @@ describe("getPersistableGeneratedTitle", () => {
     }
   });
 
+  it("preserves unmatched and inline title markers", () => {
+    const titles = [
+      "__init__ design review",
+      'Review "quoted" results',
+      "Discuss **urgent** follow-up",
+    ];
+
+    for (const title of titles) {
+      expect(getPersistableGeneratedTitle(`Final title: ${title}`)).toBe(title);
+    }
+  });
+
   it("rejects placeholders and oversized output", () => {
     expect(getPersistableGeneratedTitle('"<EMPTY>"')).toBe("");
     expect(getPersistableGeneratedTitle("x".repeat(161))).toBe("");

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
@@ -110,13 +110,21 @@ export function getPersistableGeneratedTitle(text: string): string {
     .map((line) => line.trim())
     .filter(Boolean);
   const lastLine = lines[lines.length - 1] ?? "";
-  const title = lastLine
-    .replace(/^(?:(?:final\s+)?title|final answer)\s*:\s*/i, "")
-    .replace(/^(?:\d+[.)]|[-*]|#+)\s+/, "")
-    .replace(/^(?:\*\*|__)+|(?:\*\*|__)+$/g, "")
-    .replace(/^["'`]+|["'`]+$/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  let title = lastLine.replace(/\s+/g, " ").trim();
+
+  while (title) {
+    const unwrapped = title
+      .replace(/^(?:(?:final\s+)?title|final answer)\s*:\s*/i, "")
+      .replace(/^(?:\d+[.)]|[-*]|#+)\s+/, "")
+      .replace(/^(?:\*\*|__)+|(?:\*\*|__)+$/g, "")
+      .replace(/^["'`]+|["'`]+$/g, "")
+      .trim();
+
+    if (unwrapped === title) {
+      break;
+    }
+    title = unwrapped;
+  }
 
   if (
     !title ||

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
@@ -10,6 +10,8 @@ import { loadSessionContentSnapshot } from "~/session/content-queries";
 import { ensureFirstLineTitle } from "~/session/title-content";
 import { hasLiveSessionTitleDraft } from "~/store/zustand/live-title";
 
+const GENERATED_TITLE_MAX_LENGTH = 160;
+
 const onSuccess: NonNullable<TaskConfig<"title">["onSuccess"]> = async ({
   text,
   args,
@@ -103,8 +105,28 @@ function createTitledDocumentUpdate(
 }
 
 export function getPersistableGeneratedTitle(text: string): string {
-  const trimmed = text.trim();
-  return trimmed && trimmed !== "<EMPTY>" ? trimmed : "";
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const lastLine = lines[lines.length - 1] ?? "";
+  const title = lastLine
+    .replace(/^(?:(?:final\s+)?title|final answer)\s*:\s*/i, "")
+    .replace(/^(?:\d+[.)]|[-*]|#+)\s+/, "")
+    .replace(/^(?:\*\*|__)+|(?:\*\*|__)+$/g, "")
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (
+    !title ||
+    title === "<EMPTY>" ||
+    title.length > GENERATED_TITLE_MAX_LENGTH
+  ) {
+    return "";
+  }
+
+  return title;
 }
 
 export const titleSuccess: Pick<TaskConfig<"title">, "onSuccess"> = {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-success.ts
@@ -113,12 +113,12 @@ export function getPersistableGeneratedTitle(text: string): string {
   let title = lastLine.replace(/\s+/g, " ").trim();
 
   while (title) {
-    const unwrapped = title
+    const normalized = title
       .replace(/^(?:(?:final\s+)?title|final answer)\s*:\s*/i, "")
       .replace(/^(?:\d+[.)]|[-*]|#+)\s+/, "")
-      .replace(/^(?:\*\*|__)+|(?:\*\*|__)+$/g, "")
-      .replace(/^["'`]+|["'`]+$/g, "")
       .trim();
+    const wrapper = normalized.match(/^(\*\*|__|["'`])(.*)\1$/);
+    const unwrapped = (wrapper?.[2] ?? normalized).trim();
 
     if (unwrapped === title) {
       break;


### PR DESCRIPTION
Normalize generated title output to a safe final line before previewing or persisting it, with regression coverage for leaked model reasoning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped title parsing and preview gating with thorough tests; reduces bad title persistence rather than changing auth or core data paths.
> 
> **Overview**
> **Prevents model “reasoning” from appearing as session titles** during enhanced-note streaming and when titles are saved to SQLite.
> 
> `getPersistableGeneratedTitle` no longer treats the whole response as the title: it keeps the **last non-empty line**, strips common prefixes/wrappers (`Final title:`, quotes, bold), and drops placeholders and titles over **160** characters. `persistGeneratedTitle` / `titleSuccess` already route through this helper, so leaked multi-line output is not written into session or note first-line titles.
> 
> The **streaming summary UI** waits until the title task finishes (`isGeneratingTitle`) before showing a parsed title; while streaming it keeps the **“Generating title…”** placeholder instead of partial reasoning text.
> 
> Regression tests cover persistence with leaked reasoning, wrapper normalization, and the enhanced view behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2349efc96d68d62a95bdba2c3cedcac096064aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->