### PR TITLE
Respect selected STT model modes

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -75,6 +75,7 @@ import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { SettingsAlertToast } from "~/shared/ui/settings-alert";
 import {
   isConfiguredSttModel,
+  getSttModelTranscriptionMode,
   isHyprnoteLocalSttModel,
   isLiveTranscriptionSupported,
   isRealtimeLocalModel,
@@ -532,58 +533,6 @@ function getModelCategoryLabel(category?: ModelCategory) {
   return null;
 }
 
-function getProviderModelMode(
-  providerId: ProviderId,
-  model: string,
-): ModelEntry["mode"] {
-  if (providerId === "assemblyai") {
-    if (model === "universal-3-pro") {
-      return "batch";
-    }
-
-    if (model === "u3-rt-pro") {
-      return "realtime";
-    }
-  }
-
-  if (providerId === "elevenlabs") {
-    if (model === "scribe_v2") {
-      return "batch";
-    }
-
-    if (model === "scribe_v2_realtime") {
-      return "realtime";
-    }
-  }
-
-  if (providerId === "mistral") {
-    if (model === "voxtral-mini-2602" || model === "voxtral-mini-latest") {
-      return "batch";
-    }
-
-    if (model === "voxtral-mini-transcribe-realtime-2602") {
-      return "realtime";
-    }
-  }
-
-  if (providerId === "soniox") {
-    if (model === "stt-async-v5" || model === "stt-async-v4") {
-      return "batch";
-    }
-
-    if (
-      model === "stt-rt-v5" ||
-      model === "stt-rt-v4" ||
-      model === "stt-v5" ||
-      model === "stt-v4"
-    ) {
-      return "realtime";
-    }
-  }
-
-  return undefined;
-}
-
 function useConfiguredMapping(): {
   providers: Record<
     ProviderId,
@@ -672,11 +621,14 @@ function useConfiguredMapping(): {
         provider.id,
         {
           configured: true,
-          models: provider.models.map((model) => ({
-            id: model,
-            isDownloaded: true,
-            mode: getProviderModelMode(provider.id, model),
-          })),
+          models: provider.models.map((model) => {
+            const mode = getSttModelTranscriptionMode(provider.id, model);
+            return {
+              id: model,
+              isDownloaded: true,
+              mode: mode === "live" ? "realtime" : mode,
+            };
+          }),
         },
       ];
     }),

--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -17,6 +17,7 @@ import {
   getLiveTranscriptionConfig,
   getOnDeviceTranscriptionConfig,
   getOnDeviceTranscriptionMode,
+  getSttModelTranscriptionMode,
   getTranscriptionLanguages,
   isConfiguredSttModel,
   isSupportedLanguagesBatch,
@@ -57,6 +58,29 @@ describe("getOnDeviceTranscriptionMode", () => {
     expect(
       getOnDeviceTranscriptionMode("soniqo-parakeet-streaming", ["de"]),
     ).toBe("live");
+  });
+});
+
+describe("getSttModelTranscriptionMode", () => {
+  test("distinguishes external batch and realtime model variants", () => {
+    expect(getSttModelTranscriptionMode("elevenlabs", "scribe_v2")).toBe(
+      "batch",
+    );
+    expect(
+      getSttModelTranscriptionMode("elevenlabs", "scribe_v2_realtime"),
+    ).toBe("live");
+    expect(getSttModelTranscriptionMode("assemblyai", "universal-3-pro")).toBe(
+      "batch",
+    );
+    expect(getSttModelTranscriptionMode("mistral", "voxtral-mini-2602")).toBe(
+      "batch",
+    );
+  });
+
+  test("leaves models without an explicit mode to provider inference", () => {
+    expect(getSttModelTranscriptionMode("deepgram", "nova-3-general")).toBe(
+      undefined,
+    );
   });
 });
 
@@ -116,6 +140,33 @@ describe("getOnDeviceTranscriptionConfig", () => {
 });
 
 describe("getLiveTranscriptionConfig", () => {
+  test("forces ElevenLabs Scribe V2 into after-recording batch mode", async () => {
+    await expect(
+      getLiveTranscriptionConfig({
+        provider: "elevenlabs",
+        model: "scribe_v2",
+        languages: ["en"],
+      }),
+    ).resolves.toEqual({
+      languages: ["en"],
+      transcriptionMode: "batch",
+    });
+    expect(isSupportedLanguagesLiveMock).not.toHaveBeenCalled();
+  });
+
+  test("keeps ElevenLabs Scribe V2 Realtime in live mode", async () => {
+    await expect(
+      getLiveTranscriptionConfig({
+        provider: "elevenlabs",
+        model: "scribe_v2_realtime",
+        languages: ["en"],
+      }),
+    ).resolves.toEqual({
+      languages: ["en"],
+      transcriptionMode: "live",
+    });
+  });
+
   test("keeps all languages when the selected provider supports them live", async () => {
     const config = await getLiveTranscriptionConfig({
       provider: "deepgram",

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -82,6 +82,42 @@ export function isRealtimeLocalModel(model?: string | null) {
   return model === "soniqo-parakeet-streaming";
 }
 
+export function getSttModelTranscriptionMode(
+  provider?: string | null,
+  model?: string | null,
+): TranscriptionMode | undefined {
+  if (provider === "assemblyai") {
+    if (model === "universal-3-pro") return "batch";
+    if (model === "u3-rt-pro") return "live";
+  }
+
+  if (provider === "elevenlabs") {
+    if (model === "scribe_v2") return "batch";
+    if (model === "scribe_v2_realtime") return "live";
+  }
+
+  if (provider === "mistral") {
+    if (model === "voxtral-mini-2602" || model === "voxtral-mini-latest") {
+      return "batch";
+    }
+    if (model === "voxtral-mini-transcribe-realtime-2602") return "live";
+  }
+
+  if (provider === "soniox") {
+    if (model === "stt-async-v5" || model === "stt-async-v4") return "batch";
+    if (
+      model === "stt-rt-v5" ||
+      model === "stt-rt-v4" ||
+      model === "stt-v5" ||
+      model === "stt-v4"
+    ) {
+      return "live";
+    }
+  }
+
+  return undefined;
+}
+
 function baseLanguageCode(language: string) {
   return language.split(/[-_]/)[0]?.toLowerCase() ?? "";
 }
@@ -197,10 +233,14 @@ export async function getLiveTranscriptionConfig({
 
   const config = {
     languages: [...languages],
-    transcriptionMode: undefined as TranscriptionMode | undefined,
+    transcriptionMode: getSttModelTranscriptionMode(provider, model),
   } satisfies LiveTranscriptionConfig;
 
-  if (!provider || languages.length <= 1) {
+  if (
+    !provider ||
+    config.transcriptionMode === "batch" ||
+    languages.length <= 1
+  ) {
     return config;
   }
 


### PR DESCRIPTION
Share provider model mode classification between settings and recording startup so batch models run only after capture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recording-time transcription mode selection for several cloud providers; incorrect mappings could wrongly enable or disable live STT during meetings.
> 
> **Overview**
> **Centralizes** which external STT models are **live** vs **after-recording (batch)** in `getSttModelTranscriptionMode` in `capabilities.ts`, replacing duplicated provider-specific logic in the STT settings picker.
> 
> The STT model dropdown still shows **Live** / **After recording** badges via the shared helper (`live` is mapped to `realtime` in the UI). **`getLiveTranscriptionConfig`** now sets `transcriptionMode` from that helper and **returns early for batch models** (skipping live language-capability checks), so models like ElevenLabs `scribe_v2` are not treated as live during capture—aligned with `event-listeners` skipping live updates when mode is `batch`.
> 
> Tests cover the classifier and ElevenLabs batch vs realtime live-config behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f2384f8ce71156c15d7802292f0bbf5d0a570e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->