### PR TITLE
Clarify setup toast priorities

### DIFF
--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   warning: vi.fn(),
   loading: vi.fn(),
   dismiss: vi.fn(),
+  dismissedToastIds: new Set<string>(),
   sessionMode: "inactive",
   currentTab: {
     type: "empty",
@@ -111,7 +112,7 @@ vi.mock("~/stt/contexts", () => ({
 vi.mock("./useDismissedToasts", () => ({
   useDismissedToasts: () => ({
     dismissToast: mocks.dismissToast,
-    isDismissed: () => false,
+    isDismissed: (id: string) => mocks.dismissedToastIds.has(id),
   }),
 }));
 
@@ -127,6 +128,7 @@ describe("ToastNotifications", () => {
     mocks.warning.mockClear();
     mocks.loading.mockClear();
     mocks.dismiss.mockClear();
+    mocks.dismissedToastIds.clear();
     mocks.openNew.mockClear();
     mocks.updateSettingsTabState.mockClear();
     mocks.currentTab = { type: "empty" };
@@ -146,18 +148,18 @@ describe("ToastNotifications", () => {
     vi.useRealTimers();
   });
 
-  it("routes registry notifications through Sonner", () => {
+  it("routes the sign-in suggestion through Sonner", () => {
     render(<ToastNotifications />);
 
     act(() => vi.advanceTimersByTime(500));
 
     expect(mocks.message).toHaveBeenCalledWith(
-      "Pro features available",
+      "Sign in to get the most out of Anarlog",
       expect.objectContaining({
-        id: "upgrade-to-pro",
+        id: "sign-in-benefits",
         duration: Infinity,
         closeButton: true,
-        action: expect.objectContaining({ label: "Upgrade" }),
+        action: expect.objectContaining({ label: "Sign in" }),
       }),
     );
 
@@ -176,7 +178,7 @@ describe("ToastNotifications", () => {
 
     const options = mocks.message.mock.calls[0][1];
     options.onDismiss();
-    expect(mocks.dismissToast).toHaveBeenCalledWith("upgrade-to-pro");
+    expect(mocks.dismissToast).toHaveBeenCalledWith("sign-in-benefits");
   });
 
   it("uses a Sonner loading toast for model downloads", () => {
@@ -201,6 +203,7 @@ describe("ToastNotifications", () => {
   });
 
   it("uses the latest registry action while a toast remains visible", () => {
+    mocks.dismissedToastIds.add("sign-in-benefits");
     mocks.config.current_llm_provider = null;
     mocks.config.current_llm_model = null;
 

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -86,6 +86,30 @@ describe("sidebar toast registry", () => {
     expect(toast?.description).toBe("Transcription provider needed");
   });
 
+  it("keeps Pro providers usable while authentication is loading", () => {
+    const proSttToast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        isAuthenticated: false,
+        isAuthLoading: true,
+        hasProSttConfigured: true,
+      }),
+      () => false,
+    );
+    const proLlmToast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        isAuthenticated: false,
+        isAuthLoading: true,
+        hasProLlmConfigured: true,
+      }),
+      () => false,
+    );
+
+    expect(proSttToast).toBeNull();
+    expect(proLlmToast).toBeNull();
+  });
+
   it("hides local STT loading while the active transcript tab shows batch progress", () => {
     const toast = getToastToShow(
       createToastRegistry({

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -42,7 +42,7 @@ describe("sidebar toast registry", () => {
     expect(toast?.primaryAction?.label).toBe("Add");
   });
 
-  it("keeps the missing transcription model message short", () => {
+  it("keeps the missing transcription provider message short", () => {
     const toast = getToastToShow(
       createToastRegistry({
         ...baseParams,
@@ -52,8 +52,38 @@ describe("sidebar toast registry", () => {
     );
 
     expect(toast?.id).toBe("missing-stt");
-    expect(toast?.description).toBe("Transcription model needed");
+    expect(toast?.description).toBe("Transcription provider needed");
     expect(toast?.primaryAction?.label).toBe("Add");
+  });
+
+  it("suggests signing in before provider setup", () => {
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        isAuthenticated: false,
+        hasLLMConfigured: false,
+        hasSttConfigured: false,
+      }),
+      () => false,
+    );
+
+    expect(toast?.id).toBe("sign-in-benefits");
+    expect(toast?.description).toBe("Sign in to get the most out of Anarlog");
+    expect(toast?.primaryAction?.label).toBe("Sign in");
+  });
+
+  it("asks for a usable transcription provider after sign-in is dismissed", () => {
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        isAuthenticated: false,
+        hasProSttConfigured: true,
+      }),
+      (id) => id === "sign-in-benefits",
+    );
+
+    expect(toast?.id).toBe("missing-stt");
+    expect(toast?.description).toBe("Transcription provider needed");
   });
 
   it("hides local STT loading while the active transcript tab shows batch progress", () => {
@@ -105,7 +135,7 @@ describe("sidebar toast registry", () => {
         ...baseParams,
         isAuthenticated: false,
       }),
-      () => false,
+      (id) => id === "sign-in-benefits",
     );
     const previewToast = createDevtoolsToastPreview({
       preview: "pro",
@@ -137,6 +167,15 @@ describe("sidebar toast registry", () => {
     expect(languageModelToast.id).toBe("devtools-missing-llm");
     expect(languageModelToast.description).toBe("Language model needed");
     expect(languageModelToast.primaryAction?.label).toBe("Add");
+    const transcriptionModelToast = createDevtoolsToastPreview({
+      preview: "transcription-model",
+      onSignIn: vi.fn(),
+      onOpenLLMSettings: vi.fn(),
+      onOpenSTTSettings: vi.fn(),
+    });
+    expect(transcriptionModelToast.description).toBe(
+      "Transcription provider needed",
+    );
     expect(downloadToast.id).toBe("devtools-downloading-model");
     expect(downloadToast.loading).toBe(true);
   });

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -63,6 +63,10 @@ export function createToastRegistry({
     activeDownloads.length === 1 && downloadingModel
       ? `Downloading ${downloadingModel}`
       : `Downloading ${activeDownloads.length} models`;
+  const hasUsableSttConfigured =
+    hasSttConfigured && (isAuthenticated || !hasProSttConfigured);
+  const hasUsableLlmConfigured =
+    hasLLMConfigured && (isAuthenticated || !hasProLlmConfigured);
 
   // order matters
   return [
@@ -116,15 +120,34 @@ export function createToastRegistry({
     },
     {
       toast: {
+        id: "sign-in-benefits",
+        icon: (
+          <img
+            src={ANARLOG_ICON_SRC}
+            alt="Anarlog"
+            className="size-5 object-contain object-center"
+          />
+        ),
+        description: "Sign in to get the most out of Anarlog",
+        primaryAction: {
+          label: "Sign in",
+          onClick: onSignIn,
+        },
+        dismissible: true,
+      },
+      condition: () => !isAuthLoading && !isAuthenticated,
+    },
+    {
+      toast: {
         id: "missing-stt",
-        description: "Transcription model needed",
+        description: "Transcription provider needed",
         primaryAction: {
           label: "Add",
           onClick: onOpenSTTSettings,
         },
         dismissible: false,
       },
-      condition: () => !hasSttConfigured && !isAiTranscriptionTabActive,
+      condition: () => !hasUsableSttConfigured && !isAiTranscriptionTabActive,
     },
     {
       toast: {
@@ -137,30 +160,9 @@ export function createToastRegistry({
         dismissible: true,
       },
       condition: () =>
-        hasSttConfigured && !hasLLMConfigured && !isAiIntelligenceTabActive,
-    },
-    {
-      toast: {
-        id: "pro-requires-login",
-        icon: (
-          <img
-            src={ANARLOG_ICON_SRC}
-            alt="Anarlog Pro"
-            className="size-5 object-contain object-center"
-          />
-        ),
-        description: "Sign in required",
-        primaryAction: {
-          label: "Sign in",
-          onClick: onSignIn,
-        },
-        dismissible: true,
-      },
-      // suppress until auth resolves to avoid flash on startup
-      condition: () =>
-        !isAuthLoading &&
-        !isAuthenticated &&
-        (hasProSttConfigured || hasProLlmConfigured),
+        hasUsableSttConfigured &&
+        !hasUsableLlmConfigured &&
+        !isAiIntelligenceTabActive,
     },
     {
       toast: {
@@ -216,7 +218,7 @@ export function createDevtoolsToastPreview({
     case "transcription-model":
       return {
         id: "devtools-missing-stt",
-        description: "Transcription model needed",
+        description: "Transcription provider needed",
         primaryAction: {
           label: "Add",
           onClick: onOpenSTTSettings,

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -64,9 +64,11 @@ export function createToastRegistry({
       ? `Downloading ${downloadingModel}`
       : `Downloading ${activeDownloads.length} models`;
   const hasUsableSttConfigured =
-    hasSttConfigured && (isAuthenticated || !hasProSttConfigured);
+    hasSttConfigured &&
+    (isAuthLoading || isAuthenticated || !hasProSttConfigured);
   const hasUsableLlmConfigured =
-    hasLLMConfigured && (isAuthenticated || !hasProLlmConfigured);
+    hasLLMConfigured &&
+    (isAuthLoading || isAuthenticated || !hasProLlmConfigured);
 
   // order matters
   return [


### PR DESCRIPTION
Present sign-in as an optional benefit, then guide signed-out users to a usable transcription provider.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding toast ordering and copy only; no auth, sync, or transcription runtime changes.
> 
> **Overview**
> **Reorders sidebar setup toasts** so signed-out users see an optional **“Sign in to get the most out of Anarlog”** (`sign-in-benefits`) before missing-provider prompts, and removes the separate **“Sign in required”** toast for Pro STT/LLM.
> 
> **Treats Pro STT/LLM as usable only when signed in** (or while auth is still loading) via `hasUsableSttConfigured` / `hasUsableLlmConfigured`, so missing-STT/LLM nudges appear after dismissing sign-in when only Pro providers are selected. **Upgrade-to-pro** now follows that flow instead of competing with the old login gate.
> 
> Copy updates: missing STT uses **“Transcription provider needed”** (including devtools preview). Tests mock dismissed toasts and cover the new priority and auth-loading behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86d559091a9181cc11efa339df018337d0dd1e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->