### PR TITLE
Personalize transactional email greetings

### DIFF
--- a/apps/stripe/src/trial-email-payload.test.ts
+++ b/apps/stripe/src/trial-email-payload.test.ts
@@ -16,6 +16,7 @@ const subscription = (overrides: Record<string, unknown> = {}) =>
 const customer = (overrides: Record<string, unknown> = {}) =>
   ({
     email: "user@example.com",
+    name: "Alex Morgan",
     invoice_settings: { default_payment_method: null },
     default_source: null,
     ...overrides,
@@ -32,10 +33,19 @@ describe("buildTrialEndingEmail", () => {
     expect(payload).toEqual({
       email: "user@example.com",
       dataVariables: {
-        daysRemaining: 3,
-        trialEndDate: "August 2, 2026",
+        firstName: "Alex",
       },
     });
+  });
+
+  it("uses a neutral greeting when the customer has no name", () => {
+    const payload = buildTrialEndingEmail({
+      subscription: subscription(),
+      customer: customer({ name: null }),
+      now: NOW,
+    });
+
+    expect(payload?.dataVariables).toEqual({ firstName: "there" });
   });
 
   it("skips card-backed trials", () => {

--- a/apps/stripe/src/trial-email-payload.ts
+++ b/apps/stripe/src/trial-email-payload.ts
@@ -1,7 +1,5 @@
 import type Stripe from "stripe";
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-
 export function buildTrialEndingEmail({
   subscription,
   customer,
@@ -33,11 +31,7 @@ export function buildTrialEndingEmail({
   return {
     email: customer.email,
     dataVariables: {
-      daysRemaining: Math.ceil((trialEndMs - now) / DAY_MS),
-      trialEndDate: new Intl.DateTimeFormat("en", {
-        dateStyle: "long",
-        timeZone: "UTC",
-      }).format(new Date(trialEndMs)),
+      firstName: customer.name?.trim().split(/\s+/)[0] || "there",
     },
   };
 }

--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -290,6 +290,7 @@ export const exchangeOAuthCode = createServerFn({ method: "POST" })
 export const doPasswordSignUp = createServerFn({ method: "POST" })
   .inputValidator(
     shared.extend({
+      name: z.string().trim().min(1).max(100),
       email: z.string().email(),
       password: z.string().min(6),
     }),
@@ -302,6 +303,10 @@ export const doPasswordSignUp = createServerFn({ method: "POST" })
       email: data.email,
       password: data.password,
       options: {
+        data: {
+          full_name: data.name,
+          name: data.name,
+        },
         emailRedirectTo: buildAuthCallbackUrl(params),
       },
     });

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -383,7 +383,7 @@ export const createCheckoutSession = createServerFn({ method: "POST" })
       const stripeCustomerId = await getStripeCustomerIdForUser(
         supabase,
         stripe,
-        { id: user.id, email: user.email },
+        user,
       );
 
       if (stripeCustomerId) {
@@ -408,10 +408,7 @@ export const createCheckoutSession = createServerFn({ method: "POST" })
 
       return await createCheckoutUrl({
         supabase,
-        user: {
-          id: user.id,
-          email: user.email,
-        },
+        user,
         period: data.period,
         scheme: data.scheme,
         trial: data.trial,
@@ -473,16 +470,13 @@ export const createPlanSwitchSession = createServerFn({ method: "POST" })
     const stripeCustomerId = await getStripeCustomerIdForUser(
       supabase,
       stripe,
-      { id: user.id, email: user.email },
+      user,
     );
 
     if (!stripeCustomerId) {
       return createCheckoutUrl({
         supabase,
-        user: {
-          id: user.id,
-          email: user.email,
-        },
+        user,
         period: data.targetPeriod,
         scheme: data.scheme,
       });
@@ -496,10 +490,7 @@ export const createPlanSwitchSession = createServerFn({ method: "POST" })
     if (!activeSubscription) {
       return createCheckoutUrl({
         supabase,
-        user: {
-          id: user.id,
-          email: user.email,
-        },
+        user,
         period: data.targetPeriod,
         scheme: data.scheme,
       });
@@ -508,10 +499,7 @@ export const createPlanSwitchSession = createServerFn({ method: "POST" })
     if (!activeSubscription.items.data[0]) {
       return createCheckoutUrl({
         supabase,
-        user: {
-          id: user.id,
-          email: user.email,
-        },
+        user,
         period: data.targetPeriod,
         scheme: data.scheme,
       });
@@ -564,7 +552,7 @@ export const createPortalSession = createServerFn({ method: "POST" })
     const stripeCustomerId = await getStripeCustomerIdForUser(
       supabase,
       stripe,
-      { id: user.id, email: user.email },
+      user,
     );
 
     if (!stripeCustomerId) {
@@ -594,7 +582,7 @@ export const syncAfterSuccess = createServerFn({ method: "POST" }).handler(
     const stripeCustomerId = await getStripeCustomerIdForUser(
       supabase,
       stripe,
-      { id: user.id, email: user.email },
+      user,
     );
 
     if (!stripeCustomerId) {

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -29,7 +29,24 @@ type SupabaseClient = ReturnType<typeof getSupabaseServerClient>;
 type AuthUser = {
   id: string;
   email?: string | null;
+  user_metadata?: {
+    full_name?: unknown;
+    name?: unknown;
+  };
 };
+
+function getAuthUserName(user: AuthUser) {
+  for (const value of [
+    user.user_metadata?.full_name,
+    user.user_metadata?.name,
+  ]) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return undefined;
+}
 
 class TrialCheckoutCreationError extends Error {
   constructor(readonly checkoutError: unknown) {
@@ -71,10 +88,18 @@ const getStripeCustomerIdForUser = async (
     throw new Error("Stripe customer does not belong to authenticated user");
   }
 
+  const updates: Stripe.CustomerUpdateParams = {};
   if (ownership === "claimable") {
-    await stripe.customers.update(stripeCustomerId, {
-      metadata: { userId: user.id },
-    });
+    updates.metadata = { userId: user.id };
+  }
+
+  const name = getAuthUserName(user);
+  if (!customer.name && name) {
+    updates.name = name;
+  }
+
+  if (Object.keys(updates).length > 0) {
+    await stripe.customers.update(stripeCustomerId, updates);
   }
 
   return stripeCustomerId;
@@ -133,6 +158,7 @@ async function ensureStripeCustomerId(
   const newCustomer = await stripe.customers.create(
     {
       email: user.email ?? undefined,
+      name: getAuthUserName(user),
       metadata: {
         userId: user.id,
         posthog_person_distinct_id: user.id,

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -323,6 +323,7 @@ function PasswordForm({
   scheme?: DesktopScheme;
   redirect?: string;
 }) {
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -363,7 +364,7 @@ function PasswordForm({
   const signUpMutation = useMutation({
     mutationFn: () =>
       doPasswordSignUp({
-        data: { email, password, flow, scheme, redirect },
+        data: { name, email, password, flow, scheme, redirect },
       }),
     onSuccess: (result) => {
       if (result && "error" in result && result.error) {
@@ -425,6 +426,17 @@ function PasswordForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      {isSignUp && (
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+          autoComplete="name"
+          required
+          className={authInputClassName}
+        />
+      )}
       <input
         type="email"
         value={email}
@@ -457,7 +469,10 @@ function PasswordForm({
       <button
         type="submit"
         disabled={
-          isPending || !email || !password || (isSignUp && !confirmPassword)
+          isPending ||
+          !email ||
+          !password ||
+          (isSignUp && (!name.trim() || !confirmPassword))
         }
         className={authPrimaryButtonClassName}
       >
@@ -469,6 +484,7 @@ function PasswordForm({
           onClick={() => {
             setIsSignUp(!isSignUp);
             setErrorMessage("");
+            setName("");
             setConfirmPassword("");
           }}
           className="cursor-pointer text-sm text-[#756b5d] transition-colors hover:text-[#181613] hover:underline"


### PR DESCRIPTION
Personalize transactional email greetings to use more tailored, recipient-specific messaging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signup validation and Stripe customer updates; trial email template variables are a breaking contract unless templates are updated in lockstep.
> 
> **Overview**
> Trial-ending transactional emails now send a **`firstName`** merge field (from the Stripe customer name, or **`there`** when missing) instead of **`daysRemaining`** / **`trialEndDate`**, so templates can use personalized greetings.
> 
> Password sign-up **requires a name**: the auth UI collects it, **`doPasswordSignUp`** stores it in Supabase **`user_metadata`**, and billing **propagates** that name onto Stripe customers when creating new customers or when an existing customer has no name yet (including batched updates with metadata claiming).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5396bc19822f7237d9bc1413481688f3082606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->