### PR TITLE
Add desktop 1.3.9 changelog

### DIFF
--- a/packages/changelog/content/1.3.9.md
+++ b/packages/changelog/content/1.3.9.md
@@ -1,0 +1,20 @@
+---
+date: "2026-07-25"
+summary: "Anarlog 1.3.9 keeps transcription behavior consistent, improves call detection, and cleans up generated titles and setup guidance."
+---
+
+## Recording & transcription
+
+- Run batch transcription models after recording instead of attempting live transcription
+- Identify FaceTime and iPhone calls reliably even after switching to another app
+- Keep floating meeting controls on the display where they opened
+
+## Notes & setup
+
+- Remove leaked model reasoning and formatting wrappers from generated note titles
+- Get clearer setup guidance that prioritizes a usable transcription provider while keeping sign-in optional
+
+## Account & Cloud Sync
+
+- Open sign-in, integration, billing, and shared-note links directly in Anarlog while retaining compatibility with older links
+- Show sync status only when Pro Cloud Sync is enabled


### PR DESCRIPTION
Document the user-facing desktop changes shipping from origin/main and gate the stable 1.3.9 release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog content with no application or release-pipeline code changes in the diff.
> 
> **Overview**
> Adds **`packages/changelog/content/1.3.9.md`** so the stable **1.3.9** desktop release is documented in the changelog index (dated **2026-07-25** with a one-line preview summary).
> 
> The entry groups user-facing changes under **Recording & transcription** (post-recording batch transcription, FaceTime/iPhone call detection after app switches, floating controls staying on the opening display), **Notes & setup** (cleaner generated titles, clearer optional sign-in setup), and **Account & Cloud Sync** (in-app deep links with legacy link support, sync status shown only when Pro Cloud Sync is on).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe8d192e28fbe71fd3873c01eae8b51a13f8c44f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->