### PR TITLE
Remove calendar disclaimer from landing pricing

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -491,11 +491,6 @@ function PricingSection() {
           Start with local meeting notes for free. Upgrade when you want hosted
           transcription, AI, sync, and sharing.
         </p>
-        <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-[#756b5d]">
-          Google Calendar access is read-only. It lets Anarlog show upcoming
-          events and associate them with your personal notes; Anarlog cannot
-          create, edit, or delete calendar events.
-        </p>
       </div>
 
       <div className="relative left-1/2 mt-8 grid w-screen max-w-[760px] -translate-x-1/2 grid-cols-1 gap-4 px-5 text-left md:grid-cols-2 md:px-8">


### PR DESCRIPTION
- Removed the calendar disclaimer from the landing pricing page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only removal on the marketing landing page with no logic, API, or permission behavior changes.
> 
> **Overview**
> **Removes** the secondary disclaimer under **Simple pricing** on the marketing homepage (`PricingSection` in `index.tsx`).
> 
> That paragraph explained that Google Calendar access is read-only, used to show upcoming events and link notes, and that Anarlog cannot create, edit, or delete calendar events. The main pricing blurb (free local notes vs. paid hosted features) and plan cards are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a850acc32f2e1bccc52d563cf42cbffee6e51c97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->