### PR TITLE
Hide non-streaming OpenAI Pro models

### DIFF
--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -35,6 +35,7 @@ import { listCloudflareWorkersAIModels } from "~/settings/ai/shared/list-cloudfl
 import {
   type InputModality,
   type ListModelsResult,
+  removeNonStreamingModels,
 } from "~/settings/ai/shared/list-common";
 import { listGoogleModels } from "~/settings/ai/shared/list-google";
 import { listLMStudioModels } from "~/settings/ai/shared/list-lmstudio";
@@ -509,7 +510,10 @@ export function getLlmProviderStatus({
       listModelsFunc = () => listGenericModels(baseUrl, apiKey);
   }
 
-  return { configured: true, listModels: listModelsFunc };
+  return {
+    configured: true,
+    listModels: async () => removeNonStreamingModels(await listModelsFunc()),
+  };
 }
 
 function useConfiguredMapping(): {

--- a/apps/desktop/src/settings/ai/shared/list-common.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.test.ts
@@ -1,6 +1,46 @@
 import { describe, expect, test } from "vitest";
 
-import { isOldModel, sortModelsByRecency } from "./list-common";
+import {
+  isNonStreamingModel,
+  isOldModel,
+  removeNonStreamingModels,
+  sortModelsByRecency,
+} from "./list-common";
+
+describe("isNonStreamingModel", () => {
+  test("filters GPT Pro models without hiding streaming-capable models", () => {
+    expect(isNonStreamingModel("gpt-5.4-pro")).toBe(true);
+    expect(isNonStreamingModel("openai/gpt-5.5-pro")).toBe(true);
+    expect(isNonStreamingModel("gpt-5.5-pro-2026-04-23")).toBe(true);
+
+    expect(isNonStreamingModel("gpt-5.5")).toBe(false);
+    expect(isNonStreamingModel("gemini-3.1-pro-preview")).toBe(false);
+  });
+});
+
+describe("removeNonStreamingModels", () => {
+  test("removes non-streaming models from provider API results", () => {
+    expect(
+      removeNonStreamingModels({
+        models: ["openai/gpt-5.5-pro", "openai/gpt-5.5"],
+        ignored: [
+          { id: "gpt-5.4-pro", reasons: ["date_snapshot"] },
+          { id: "gpt-5.4-mini", reasons: ["date_snapshot"] },
+        ],
+        metadata: {
+          "openai/gpt-5.5-pro": { input_modalities: ["text", "image"] },
+          "openai/gpt-5.5": { input_modalities: ["text", "image"] },
+        },
+      }),
+    ).toEqual({
+      models: ["openai/gpt-5.5"],
+      ignored: [{ id: "gpt-5.4-mini", reasons: ["date_snapshot"] }],
+      metadata: {
+        "openai/gpt-5.5": { input_modalities: ["text", "image"] },
+      },
+    });
+  });
+});
 
 describe("isOldModel", () => {
   test("filters older OpenAI chat families while keeping current models", () => {

--- a/apps/desktop/src/settings/ai/shared/list-common.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.ts
@@ -51,11 +51,9 @@ const commonIgnoreKeywords = [
 ] as const;
 
 const modelPriorityPatterns = [
-  /(?:^|\/)gpt-5\.5-pro$/,
   /(?:^|\/)gpt-5\.5$/,
   /(?:^|\/)(?:chat-latest|gpt-chat-latest)$/,
   /(?:^|\/)claude-sonnet-(?:5|latest)$/,
-  /(?:^|\/)gpt-5\.4-pro$/,
   /(?:^|\/)gpt-5\.4$/,
   /(?:^|\/)gpt-5\.4-mini$/,
   /(?:^|\/)gpt-5\.4-nano$/,
@@ -112,6 +110,25 @@ export const isNonChatModel = (id: string): boolean => {
   if (/^nano-banana/.test(name)) return true;
 
   return false;
+};
+
+export const isNonStreamingModel = (id: string): boolean => {
+  const name = id.toLowerCase().split("/").pop()!;
+  return /^gpt-\d+(?:\.\d+)*-pro(?:$|-)/.test(name);
+};
+
+export const removeNonStreamingModels = (
+  result: ListModelsResult,
+): ListModelsResult => {
+  return {
+    models: result.models.filter((id) => !isNonStreamingModel(id)),
+    ignored: result.ignored.filter(({ id }) => !isNonStreamingModel(id)),
+    metadata: Object.fromEntries(
+      Object.entries(result.metadata).filter(
+        ([id]) => !isNonStreamingModel(id),
+      ),
+    ),
+  };
 };
 
 export const isOldModel = (id: string): boolean => {


### PR DESCRIPTION
Remove GPT-5.4 Pro and GPT-5.5 Pro from direct OpenAI model choices and cover the capability filter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI and model-list filtering only; no changes to chat, auth, or API calls beyond what models appear in the picker.
> 
> **Overview**
> **OpenAI GPT `*-pro` models are excluded from LLM model lists** because they do not support streaming in this app.
> 
> New helpers in `list-common` identify IDs matching `gpt-<version>-pro` (including provider-prefixed and dated snapshots) and strip them from `models`, `ignored`, and `metadata` on every configured provider’s `listModels` path in the LLM settings selector. **GPT-5.4 Pro and GPT-5.5 Pro** are no longer boosted in recency sort patterns since they are removed from lists. Unit tests cover detection and list cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e28c61c82f3855415287de7dc409a2361c723a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->