### PR TITLE
Fix chat in standalone notes

### DIFF
--- a/apps/desktop/src/routes/app/-note.$sessionId.test.tsx
+++ b/apps/desktop/src/routes/app/-note.$sessionId.test.tsx
@@ -1,10 +1,21 @@
-import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resetTabsStore } from "~/store/zustand/tabs/test-utils";
 
 const mocks = vi.hoisted(() => ({
   attachLiveSession: vi.fn(),
+  chatMode: "FloatingClosed" as
+    | "FloatingClosed"
+    | "FloatingOpen"
+    | "RightPanelOpen",
   close: vi.fn(),
   listenerState: {
     attachLiveSession: vi.fn(),
@@ -12,6 +23,7 @@ const mocks = vi.hoisted(() => ({
       eventUnlistenersBySession: {} as Record<string, (() => void)[]>,
     },
   },
+  sendEvent: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/window", () => ({
@@ -20,12 +32,64 @@ vi.mock("@tauri-apps/api/window", () => ({
   }),
 }));
 
+vi.mock("~/main/layout", () => ({
+  ClassicMainLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    chat: {
+      mode: mocks.chatMode,
+      sendEvent: mocks.sendEvent,
+    },
+  }),
+}));
+
+vi.mock("~/session", () => ({
+  TabContentNote: ({ standaloneWindow }: { standaloneWindow?: boolean }) => (
+    <div
+      data-testid="standalone-note"
+      data-standalone-window={standaloneWindow}
+    />
+  ),
+}));
+
+vi.mock("~/shared/main", () => ({
+  MainChatPanels: ({
+    autoSaveId,
+    children,
+    leftSidebarAvailable,
+    noteSurfaceMinWidth,
+  }: {
+    autoSaveId?: string;
+    children: React.ReactNode;
+    leftSidebarAvailable?: boolean;
+    noteSurfaceMinWidth?: number;
+  }) => (
+    <div
+      data-auto-save-id={autoSaveId}
+      data-left-sidebar-available={leftSidebarAvailable}
+      data-note-surface-min-width={noteSurfaceMinWidth}
+      data-testid="standalone-chat-panels"
+    >
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("~/shared/window-shell", () => ({
+  StandaloneWindowShell: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
 vi.mock("~/stt/contexts", () => ({
   useListener: (selector: (state: typeof mocks.listenerState) => unknown) =>
     selector(mocks.listenerState),
 }));
 
 import {
+  Route,
+  StandaloneNoteWindow,
   useAttachStandaloneNoteToLiveSession,
   useCloseStandaloneNoteWindowOnEscape,
   useStandaloneNoteTab,
@@ -37,19 +101,24 @@ describe("standalone note window route", () => {
   beforeEach(() => {
     mocks.listenerState.attachLiveSession = mocks.attachLiveSession;
     mocks.listenerState.live.eventUnlistenersBySession = {};
+    mocks.chatMode = "FloatingClosed";
     mocks.attachLiveSession.mockClear();
     mocks.close.mockClear();
+    mocks.sendEvent.mockClear();
     resetTabsStore();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
   });
 
   it("closes the standalone note window on escape", () => {
+    vi.useFakeTimers();
     renderHook(() => useCloseStandaloneNoteWindowOnEscape());
 
     const event = dispatchKeyDown("Escape");
+    act(() => vi.runOnlyPendingTimers());
 
     expect(event.defaultPrevented).toBe(true);
     expect(mocks.close).toHaveBeenCalledTimes(1);
@@ -62,6 +131,70 @@ describe("standalone note window route", () => {
 
     expect(event.defaultPrevented).toBe(false);
     expect(mocks.close).not.toHaveBeenCalled();
+  });
+
+  it("closes chat before closing the standalone note window", () => {
+    vi.useFakeTimers();
+    mocks.chatMode = "FloatingOpen";
+    renderHook(() => useCloseStandaloneNoteWindowOnEscape());
+
+    const event = dispatchKeyDown("Escape");
+    act(() => vi.runOnlyPendingTimers());
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mocks.sendEvent).toHaveBeenCalledWith({ type: "CLOSE" });
+    expect(mocks.close).not.toHaveBeenCalled();
+  });
+
+  it("lets an overlay consume escape before closing chat", () => {
+    vi.useFakeTimers();
+    mocks.chatMode = "FloatingOpen";
+    const overlay = document.createElement("button");
+    overlay.addEventListener("keydown", (event) => event.preventDefault());
+    document.body.append(overlay);
+    renderHook(() => useCloseStandaloneNoteWindowOnEscape());
+
+    const event = dispatchKeyDown("Escape", overlay);
+    act(() => vi.runOnlyPendingTimers());
+    overlay.remove();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mocks.sendEvent).not.toHaveBeenCalled();
+    expect(mocks.close).not.toHaveBeenCalled();
+  });
+
+  it("mounts chat panels around the standalone note", () => {
+    vi.spyOn(Route, "useParams").mockReturnValue({
+      sessionId: "session-1",
+    });
+
+    render(<StandaloneNoteWindow />);
+
+    expect(
+      screen
+        .getByTestId("standalone-chat-panels")
+        .contains(screen.getByTestId("standalone-note")),
+    ).toBe(true);
+    expect(
+      screen
+        .getByTestId("standalone-note")
+        .getAttribute("data-standalone-window"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByTestId("standalone-chat-panels")
+        .getAttribute("data-left-sidebar-available"),
+    ).toBe("false");
+    expect(
+      screen
+        .getByTestId("standalone-chat-panels")
+        .getAttribute("data-note-surface-min-width"),
+    ).toBe("420");
+    expect(
+      screen
+        .getByTestId("standalone-chat-panels")
+        .getAttribute("data-auto-save-id"),
+    ).toBe("standalone-note-chat");
   });
 
   it("returns the subscribed standalone note tab after tab state updates", async () => {
@@ -112,12 +245,12 @@ describe("standalone note window route", () => {
   });
 });
 
-function dispatchKeyDown(key: string) {
+function dispatchKeyDown(key: string, target: EventTarget = window) {
   const event = new KeyboardEvent("keydown", {
     bubbles: true,
     cancelable: true,
     key,
   });
-  window.dispatchEvent(event);
+  target.dispatchEvent(event);
   return event;
 }

--- a/apps/desktop/src/routes/app/note.$sessionId.tsx
+++ b/apps/desktop/src/routes/app/note.$sessionId.tsx
@@ -2,30 +2,51 @@ import { createFileRoute } from "@tanstack/react-router";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useLayoutEffect, useMemo } from "react";
 
+import { useShell } from "~/contexts/shell";
 import { ClassicMainLayout } from "~/main/layout";
 import { TabContentNote } from "~/session";
+import { MainChatPanels } from "~/shared/main";
+import {
+  getEscapeShortcutContext,
+  shouldSkipEscapeShortcut,
+} from "~/shared/useMainShortcuts";
 import { StandaloneWindowShell } from "~/shared/window-shell";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 
+const STANDALONE_NOTE_SURFACE_MIN_WIDTH_PX = 420;
+
 export const Route = createFileRoute("/app/note/$sessionId")({
-  component: Component,
+  component: StandaloneNoteWindow,
 });
 
-function Component() {
+export function StandaloneNoteWindow() {
   const { sessionId } = Route.useParams();
+
+  return (
+    <ClassicMainLayout includeServices={false}>
+      <StandaloneNoteContent sessionId={sessionId} />
+    </ClassicMainLayout>
+  );
+}
+
+function StandaloneNoteContent({ sessionId }: { sessionId: string }) {
   useCloseStandaloneNoteWindowOnEscape();
   useAttachStandaloneNoteToLiveSession(sessionId);
   const tab = useStandaloneNoteTab(sessionId);
 
   return (
-    <ClassicMainLayout includeServices={false}>
-      <StandaloneWindowShell topDragRegion={false}>
-        <div className="bg-background h-screen w-screen">
+    <StandaloneWindowShell topDragRegion={false}>
+      <div className="bg-background flex h-screen w-screen">
+        <MainChatPanels
+          autoSaveId="standalone-note-chat"
+          leftSidebarAvailable={false}
+          noteSurfaceMinWidth={STANDALONE_NOTE_SURFACE_MIN_WIDTH_PX}
+        >
           <TabContentNote tab={tab} standaloneWindow />
-        </div>
-      </StandaloneWindowShell>
-    </ClassicMainLayout>
+        </MainChatPanels>
+      </div>
+    </StandaloneWindowShell>
   );
 }
 
@@ -84,19 +105,33 @@ export function useStandaloneNoteTab(sessionId: string) {
 }
 
 export function useCloseStandaloneNoteWindowOnEscape() {
+  const { chat } = useShell();
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") {
         return;
       }
 
-      event.preventDefault();
-      void getCurrentWindow().close();
+      const escapeContext = getEscapeShortcutContext(event.target);
+      window.setTimeout(() => {
+        if (shouldSkipEscapeShortcut(event, escapeContext)) {
+          return;
+        }
+
+        event.preventDefault();
+        if (chat.mode !== "FloatingClosed") {
+          chat.sendEvent({ type: "CLOSE" });
+          return;
+        }
+
+        void getCurrentWindow().close();
+      });
     };
 
     window.addEventListener("keydown", handleKeyDown, { capture: true });
     return () => {
       window.removeEventListener("keydown", handleKeyDown, { capture: true });
     };
-  }, []);
+  }, [chat.mode, chat.sendEvent]);
 }

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -31,13 +31,22 @@ vi.mock("@hypr/plugin-windows", () => ({
 
 vi.mock("@hypr/ui/components/ui/resizable", () => ({
   ResizablePanelGroup: ({
+    autoSaveId,
     children,
+    "data-main-chat-panel-group": mainChatPanelGroup,
     direction,
   }: {
+    autoSaveId?: string;
     children: React.ReactNode;
+    "data-main-chat-panel-group"?: boolean;
     direction: string;
   }) => (
-    <div data-direction={direction} data-testid="panel-group">
+    <div
+      data-auto-save-id={autoSaveId}
+      data-direction={direction}
+      data-main-chat-panel-group={mainChatPanelGroup}
+      data-testid="panel-group"
+    >
       {children}
     </div>
   ),
@@ -169,6 +178,9 @@ describe("MainChatPanels", () => {
     expect(screen.getByTestId("panel-group").dataset.direction).toBe(
       "horizontal",
     );
+    expect(screen.getByTestId("panel-group").dataset.autoSaveId).toBe(
+      "main-chat",
+    );
     expect(screen.queryByTestId("resize-handle")).toBeNull();
     expect(screen.getAllByTestId("panel")).toHaveLength(1);
     expect(screen.queryByRole("dialog")).toBeNull();
@@ -227,6 +239,56 @@ describe("MainChatPanels", () => {
     );
 
     expect(screen.getAllByTestId("panel")[0]?.dataset.minWidth).toBe("700");
+  });
+
+  it("uses the standalone note minimum without reserving a sidebar", () => {
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = true;
+
+    render(
+      <MainChatPanels
+        autoSaveId="standalone-note-chat"
+        leftSidebarAvailable={false}
+        noteSurfaceMinWidth={420}
+      >
+        <div data-testid="main-content" />
+      </MainChatPanels>,
+    );
+
+    expect(screen.getAllByTestId("panel")[0]?.dataset.minWidth).toBe("420");
+    expect(screen.getByTestId("panel-group").dataset.autoSaveId).toBe(
+      "standalone-note-chat",
+    );
+  });
+
+  it("expands a standalone note for docked chat without collapsing a sidebar", () => {
+    mocks.chatMode = "RightPanelOpen";
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = true;
+    mockPanelWidths({
+      bodyPanelWidth: 420,
+      leftSidebarWidth: 200,
+      panelGroupWidth: 720,
+      rightPanelWidth: 320,
+    });
+
+    render(
+      <MainChatPanels leftSidebarAvailable={false} noteSurfaceMinWidth={420}>
+        <div data-left-sidebar-chrome />
+        <div data-chat-floating-anchor>
+          <div data-session-surface />
+        </div>
+      </MainChatPanels>,
+    );
+
+    expect(mocks.setLeftSidebarExpanded).not.toHaveBeenCalled();
+    expect(mocks.windowExpandWidth).toHaveBeenCalledWith(
+      20,
+      null,
+      false,
+      false,
+      true,
+    );
   });
 
   it("expands left when opening the sidebar would make a note surface narrower than 500px", () => {
@@ -454,6 +516,7 @@ describe("MainChatPanels", () => {
 function mockPanelWidths(widths: {
   bodyPanelWidth: number;
   leftSidebarWidth: number;
+  panelGroupWidth?: number;
   rightPanelWidth?: number;
 }) {
   restorePanelWidths?.();
@@ -462,6 +525,10 @@ function mockPanelWidths(widths: {
     .mockImplementation(function getBoundingClientRectMock(this: HTMLElement) {
       if (this.hasAttribute("data-main-body-panel-container")) {
         return rectWithWidth(widths.bodyPanelWidth);
+      }
+
+      if (this.hasAttribute("data-main-chat-panel-group")) {
+        return rectWithWidth(widths.panelGroupWidth ?? 0);
       }
 
       if (this.hasAttribute("data-left-sidebar-chrome")) {

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -21,25 +21,38 @@ import { type Tab, useTabs } from "~/store/zustand/tabs";
 const RIGHT_CHAT_PANEL_MIN_WIDTH_PX = 320;
 const LEFT_SIDEBAR_MIN_WIDTH_PX = 200;
 
-export function MainChatPanels({ children }: { children: React.ReactNode }) {
+export function MainChatPanels({
+  autoSaveId = "main-chat",
+  children,
+  leftSidebarAvailable = true,
+  noteSurfaceMinWidth = NOTE_SURFACE_MIN_WIDTH_PX,
+}: {
+  autoSaveId?: string;
+  children: React.ReactNode;
+  leftSidebarAvailable?: boolean;
+  noteSurfaceMinWidth?: number;
+}) {
   const { chat, leftsidebar } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
   const bodyPanelContainerRef = useRef<HTMLDivElement>(null);
   const isRightPanelOpen = chat.mode === "RightPanelOpen";
+  const leftSidebarExpanded = leftSidebarAvailable && leftsidebar.expanded;
   const reserveNoteSurfaceMinWidth = usesNoteSurfaceMinWidth(currentTab);
   const collapseLeftSidebar = useCallback(() => {
     leftsidebar.setExpanded(false);
   }, [leftsidebar.setExpanded]);
   const bodyMinWidth = getMainBodyMinWidth({
     currentTab,
-    leftSidebarExpanded: leftsidebar.expanded,
+    leftSidebarExpanded,
+    noteSurfaceMinWidth,
   });
 
   useNoteSurfaceWindowWidthGuard({
     bodyPanelContainerRef,
     enabled: reserveNoteSurfaceMinWidth,
-    leftPanelOpen: leftsidebar.expanded,
+    leftPanelOpen: leftSidebarExpanded,
     collapseLeftPanel: collapseLeftSidebar,
+    noteSurfaceMinWidth,
     rightPanelOpen: isRightPanelOpen,
   });
 
@@ -48,7 +61,8 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
       {(sessionProps) => (
         <>
           <ResizablePanelGroup
-            autoSaveId="main-chat"
+            autoSaveId={autoSaveId}
+            data-main-chat-panel-group
             direction="horizontal"
             className="flex min-h-0 flex-1 overflow-hidden"
           >
@@ -102,17 +116,18 @@ export function MainChatPanels({ children }: { children: React.ReactNode }) {
 function getMainBodyMinWidth({
   currentTab,
   leftSidebarExpanded,
+  noteSurfaceMinWidth,
 }: {
   currentTab: Tab | null;
   leftSidebarExpanded: boolean;
+  noteSurfaceMinWidth: number;
 }) {
   if (!usesNoteSurfaceMinWidth(currentTab)) {
     return undefined;
   }
 
   return (
-    NOTE_SURFACE_MIN_WIDTH_PX +
-    (leftSidebarExpanded ? LEFT_SIDEBAR_MIN_WIDTH_PX : 0)
+    noteSurfaceMinWidth + (leftSidebarExpanded ? LEFT_SIDEBAR_MIN_WIDTH_PX : 0)
   );
 }
 
@@ -121,12 +136,14 @@ function useNoteSurfaceWindowWidthGuard({
   collapseLeftPanel,
   enabled,
   leftPanelOpen,
+  noteSurfaceMinWidth,
   rightPanelOpen,
 }: {
   bodyPanelContainerRef: React.RefObject<HTMLDivElement | null>;
   collapseLeftPanel: () => void;
   enabled: boolean;
   leftPanelOpen: boolean;
+  noteSurfaceMinWidth: number;
   rightPanelOpen: boolean;
 }) {
   const restorableExpansionCountRef = useRef(0);
@@ -184,7 +201,7 @@ function useNoteSurfaceWindowWidthGuard({
       rightPanelJustOpened &&
       leftPanelOpen &&
       leftSidebarWidth > 0 &&
-      bodyWidth - leftSidebarWidth < NOTE_SURFACE_MIN_WIDTH_PX;
+      bodyWidth - leftSidebarWidth < noteSurfaceMinWidth;
 
     if (shouldCollapseLeftPanelForRightPanel) {
       collapseLeftPanel();
@@ -195,7 +212,7 @@ function useNoteSurfaceWindowWidthGuard({
       return;
     }
 
-    const requiredBodyWidth = NOTE_SURFACE_MIN_WIDTH_PX + leftSidebarWidth;
+    const requiredBodyWidth = noteSurfaceMinWidth + leftSidebarWidth;
     const requiredTotalWidth =
       requiredBodyWidth + (rightPanelOpen ? RIGHT_CHAT_PANEL_MIN_WIDTH_PX : 0);
     const visibleTotalWidth = bodyWidth + rightPanelWidth;
@@ -230,6 +247,7 @@ function useNoteSurfaceWindowWidthGuard({
     collapseLeftPanel,
     enabled,
     leftPanelOpen,
+    noteSurfaceMinWidth,
     restoreWidthExpansions,
     rightPanelOpen,
   ]);
@@ -251,6 +269,7 @@ function useNoteSurfaceWindowWidthGuard({
         bodyPanel,
         collapseLeftPanel,
         lastVisibleBodyWidthRef,
+        noteSurfaceMinWidth,
       });
     };
 
@@ -279,6 +298,7 @@ function useNoteSurfaceWindowWidthGuard({
     collapseLeftPanel,
     enabled,
     leftPanelOpen,
+    noteSurfaceMinWidth,
     rightPanelOpen,
   ]);
 
@@ -289,10 +309,12 @@ function collapseLeftPanelIfNoteSurfaceWouldShrink({
   bodyPanel,
   collapseLeftPanel,
   lastVisibleBodyWidthRef,
+  noteSurfaceMinWidth,
 }: {
   bodyPanel: HTMLElement;
   collapseLeftPanel: () => void;
   lastVisibleBodyWidthRef: React.MutableRefObject<number | null>;
+  noteSurfaceMinWidth: number;
 }) {
   const visibleBodyWidth = getVisibleBodyWidth(bodyPanel);
   if (visibleBodyWidth <= 0) {
@@ -312,36 +334,39 @@ function collapseLeftPanelIfNoteSurfaceWouldShrink({
   const leftSidebarWidth = getLeftSidebarWidth(bodyPanel, true);
   const noteSurfaceWidth = visibleBodyWidth - leftSidebarWidth;
 
-  if (noteSurfaceWidth < NOTE_SURFACE_MIN_WIDTH_PX) {
+  if (noteSurfaceWidth < noteSurfaceMinWidth) {
     collapseLeftPanel();
   }
 }
 
 function getVisibleBodyWidth(bodyPanel: HTMLElement) {
   const bodyWidth = bodyPanel.getBoundingClientRect().width;
-  const shell = bodyPanel.closest<HTMLElement>(
-    "[data-testid='main-app-shell']",
-  );
-  if (!shell) {
+  const widthContainer =
+    bodyPanel.closest<HTMLElement>("[data-main-chat-panel-group]") ??
+    bodyPanel.closest<HTMLElement>("[data-testid='main-app-shell']");
+  if (!widthContainer) {
     return bodyWidth;
   }
 
-  const shellWidth = shell.getBoundingClientRect().width;
-  if (shellWidth <= 0) {
+  const containerWidth = widthContainer.getBoundingClientRect().width;
+  if (containerWidth <= 0) {
     return bodyWidth;
   }
 
-  const rightPanel = shell.querySelector<HTMLElement>(
+  const rightPanel = widthContainer.querySelector<HTMLElement>(
     "[data-chat-right-panel]",
   );
   const rightPanelWidth = rightPanel?.getBoundingClientRect().width ?? 0;
-  const visibleShellBodyWidth = Math.max(0, shellWidth - rightPanelWidth);
+  const visibleContainerBodyWidth = Math.max(
+    0,
+    containerWidth - rightPanelWidth,
+  );
 
   if (bodyWidth <= 0) {
-    return visibleShellBodyWidth;
+    return visibleContainerBodyWidth;
   }
 
-  return Math.min(bodyWidth, visibleShellBodyWidth);
+  return Math.min(bodyWidth, visibleContainerBodyWidth);
 }
 
 function getRightPanelWidth(bodyPanel: HTMLElement, rightPanelOpen: boolean) {

--- a/apps/desktop/src/shared/useMainShortcuts.tsx
+++ b/apps/desktop/src/shared/useMainShortcuts.tsx
@@ -25,25 +25,11 @@ export function useMainShortcuts() {
         return;
       }
 
-      const fromProseMirrorEditor = isFromProseMirrorEditor(event.target);
-      const fromSessionTitleInput = isFromSessionTitleInput(event.target);
-      const fromSessionSurface = isFromSessionSurface(event.target);
-      const hadEditorEscapeConsumer =
-        fromProseMirrorEditor &&
-        document.querySelector("[data-editor-escape-consumer]") !== null;
-      const hadMeaningfulFocus = hasMeaningfulFocus(event.target);
+      const escapeContext = getEscapeShortcutContext(event.target);
       const hadOpenChat = chatRef.current.mode !== "FloatingClosed";
 
       window.setTimeout(() => {
-        if (
-          shouldSkipEscapeShortcut(event, {
-            fromProseMirrorEditor,
-            fromSessionTitleInput,
-            fromSessionSurface,
-            hadEditorEscapeConsumer,
-            hadMeaningfulFocus,
-          })
-        ) {
+        if (shouldSkipEscapeShortcut(event, escapeContext)) {
           return;
         }
 
@@ -146,7 +132,21 @@ export function useMainEscapeShortcutAction() {
   }, [chat.mode, chat.sendEvent]);
 }
 
-function shouldSkipEscapeShortcut(
+export function getEscapeShortcutContext(target: EventTarget | null) {
+  const fromProseMirrorEditor = isFromProseMirrorEditor(target);
+
+  return {
+    fromProseMirrorEditor,
+    fromSessionTitleInput: isFromSessionTitleInput(target),
+    fromSessionSurface: isFromSessionSurface(target),
+    hadEditorEscapeConsumer:
+      fromProseMirrorEditor &&
+      document.querySelector("[data-editor-escape-consumer]") !== null,
+    hadMeaningfulFocus: hasMeaningfulFocus(target),
+  };
+}
+
+export function shouldSkipEscapeShortcut(
   event: KeyboardEvent,
   {
     fromProseMirrorEditor,

--- a/packages/changelog/content/1.3.10.md
+++ b/packages/changelog/content/1.3.10.md
@@ -11,6 +11,7 @@ summary: "Anarlog 1.3.10 adds microphone selection and makes recording, Cloud Sy
 
 ## Chat & AI
 
+- Open and use chat from standalone note windows
 - Keep streaming responses visible while respecting manual scrolling
 - Preserve the previous answer when regeneration is canceled or fails, replacing it only after the new response is saved
 - Hide OpenAI Pro models that do not support streaming from model pickers


### PR DESCRIPTION
Mount the shared chat panels in standalone note windows so Ask Anarlog becomes visible after opening it. Add regression coverage for the route layout.

Verification:
- pnpm -F @hypr/desktop exec vitest run "src/routes/app/-note.$sessionId.test.tsx"
- pnpm -F @hypr/desktop typecheck
- pnpm exec dprint check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches window resize/expansion logic and global Escape handling reused across main and standalone windows; behavior is well covered by new tests but layout edge cases could still differ from the main shell.
> 
> **Overview**
> Standalone note windows now mount **`MainChatPanels`** around the note so floating and docked chat (Ask Anarlog) actually renders, with a dedicated **`autoSaveId`**, **no left sidebar**, and a **420px** note minimum instead of the main app’s 500px + sidebar rules.
> 
> **`MainChatPanels`** accepts optional **`leftSidebarAvailable`**, **`noteSurfaceMinWidth`**, and **`autoSaveId`**; width guards and min-body math use those values, and visible-width measurement prefers **`data-main-chat-panel-group`** so Tauri window expansion works outside the main shell.
> 
> Escape in standalone notes matches the main app: shared **`getEscapeShortcutContext`** / **`shouldSkipEscapeShortcut`**, deferred handling—**close chat first**, then close the window—and respect overlays that consume Escape. Changelog notes chat from standalone note windows; tests cover layout, escape order, and standalone panel sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a28fd3cf440b74dc1f88714b108fcb7af8f09452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->