### PR TITLE
Stabilize CloudSync teardown regression test

### DIFF
--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -588,7 +588,7 @@ mod test {
 
         runtime.suspend_cloudsync().await.unwrap();
         tokio::time::timeout(
-            Duration::from_millis(250),
+            Duration::from_millis(1_500),
             sqlx::query(
                 "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
                  VALUES ('after-sign-out-retry', '', '', 'Note')",


### PR DESCRIPTION
Increase the post-teardown connection deadline to the existing sign-out bound so slow CI runners still detect real hangs without producing false failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout tweak; no production CloudSync or pool behavior changes.
> 
> **Overview**
> **Extends the post-teardown assertion** in `sign_out_suspend_command_defers_busy_pool_teardown` so the timed local `INSERT` after `suspend_cloudsync()` waits up to **1.5s** instead of **250ms**.
> 
> That matches the **1.5s** deadline already used for the sign-out suspend step in the same test, reducing flaky failures on slow CI while still failing if the pool cannot accept writes after deferred teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95ccf645f9ea2a3484ebb41793a1d574fa78ef96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->