### PR TITLE
Build UI before native Dev QA

### DIFF
--- a/.agents/skills/qa-critical-ux/SKILL.md
+++ b/.agents/skills/qa-critical-ux/SKILL.md
@@ -37,7 +37,9 @@ waived by the user) before running the release-new-version skill.
    can contain enough old, provenance-tracked proc-macro dylibs for macOS
    assessment to stall `rustc` for minutes. Native builds use the full Xcode
    toolchain explicitly so Swift/MLX can invoke the Metal compiler instead of
-   inheriting Command Line Tools.
+   inheriting Command Line Tools. The helper also builds the workspace UI
+   package before Tauri, so a clean checkout does not depend on generated
+   `packages/ui/dist` output from an earlier build.
 
    A successful-build manifest fingerprints the complete app bundle, all
    desktop build inputs (including legacy crates), and the deployed public

--- a/.agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh
+++ b/.agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh
@@ -576,6 +576,11 @@ elif [[ $# -eq 0 ]]; then
   qa_source_fingerprint_before="$(source_fingerprint)"
   rm -f -- "$qa_manifest"
   (
+    cd "$qa_repo_root"
+    env -i "${qa_build_env[@]}" \
+      "$qa_pnpm_executable" -F ui build
+  )
+  (
     cd "$qa_repo_root/apps/desktop"
     env -i "${qa_build_env[@]}" \
       "$qa_pnpm_executable" exec tauri build \


### PR DESCRIPTION
Make clean-checkout native QA generate the shared UI stylesheet before the Tauri desktop build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> QA helper and documentation only; no runtime app, auth, or release pipeline logic changes.
> 
> **Overview**
> Native Dev QA now runs **`pnpm -F ui build`** at the repo root (same allowlisted build env as the Tauri step) **before** `tauri build`, so a fresh checkout does not assume **`packages/ui/dist`** already exists from a prior local build.
> 
> The **qa-critical-ux** skill text is updated to state that the helper builds the workspace UI package ahead of Tauri for that reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf87fb2cdf103f4221794b4b60172963e73f04e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->