### PR TITLE
Prevent summary finalization race

### DIFF
--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -346,6 +346,78 @@ describe("EnhancerService", () => {
     expect(queueSpy).not.toHaveBeenCalled();
   });
 
+  it("does not replace an attachment-only summary", async () => {
+    snapshot = createSnapshot({
+      notes: [
+        createNote({
+          content: JSON.stringify({
+            type: "doc",
+            content: [
+              {
+                type: "heading",
+                attrs: { level: 1 },
+                content: [{ type: "text", text: "Planning" }],
+              },
+              {
+                type: "fileAttachment",
+                attrs: {
+                  attachmentId: "attachment-1",
+                  name: "notes.pdf",
+                },
+              },
+            ],
+          }),
+        }),
+      ],
+      wordCount: 40,
+    });
+    const service = new EnhancerService(createDeps());
+    const queueSpy = vi.spyOn(service, "queueAutoEnhance");
+
+    await expect(
+      service.queueAutoEnhanceIfSummaryEmpty("session-1"),
+    ).resolves.toEqual({ type: "summary_exists", noteId: "note-1" });
+    expect(mocks.ensurePendingAutoEnhanceDocument).not.toHaveBeenCalled();
+    expect(queueSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats a synthesized session title as an empty summary", async () => {
+    snapshot = createSnapshot({
+      notes: [
+        createNote({
+          content: JSON.stringify({
+            type: "doc",
+            content: [
+              {
+                type: "heading",
+                attrs: { level: 1 },
+                content: [{ type: "text", text: "Planning" }],
+              },
+              { type: "paragraph" },
+            ],
+          }),
+        }),
+      ],
+      wordCount: 40,
+    });
+    const service = new EnhancerService(createDeps());
+    const queueSpy = vi
+      .spyOn(service, "queueAutoEnhance")
+      .mockImplementation(() => {});
+
+    await expect(
+      service.queueAutoEnhanceIfSummaryEmpty("session-1"),
+    ).resolves.toEqual({ type: "queued" });
+    expect(mocks.ensurePendingAutoEnhanceDocument).toHaveBeenCalledWith(
+      "session-1",
+      undefined,
+    );
+    expect(queueSpy).toHaveBeenCalledWith(
+      "session-1",
+      expect.objectContaining({ noteId: "note-1" }),
+    );
+  });
+
   it("creates a visible empty summary when a short transcript cannot enhance", async () => {
     snapshot = createSnapshot({ wordCount: 2 });
     const service = new EnhancerService(createDeps());

--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -418,6 +418,41 @@ describe("EnhancerService", () => {
     );
   });
 
+  it("preserves formatting applied to a synthesized session title", async () => {
+    snapshot = createSnapshot({
+      notes: [
+        createNote({
+          content: JSON.stringify({
+            type: "doc",
+            content: [
+              {
+                type: "heading",
+                attrs: { level: 1 },
+                content: [
+                  {
+                    type: "text",
+                    text: "Planning",
+                    marks: [{ type: "bold" }],
+                  },
+                ],
+              },
+              { type: "paragraph" },
+            ],
+          }),
+        }),
+      ],
+      wordCount: 40,
+    });
+    const service = new EnhancerService(createDeps());
+    const queueSpy = vi.spyOn(service, "queueAutoEnhance");
+
+    await expect(
+      service.queueAutoEnhanceIfSummaryEmpty("session-1"),
+    ).resolves.toEqual({ type: "summary_exists", noteId: "note-1" });
+    expect(mocks.ensurePendingAutoEnhanceDocument).not.toHaveBeenCalled();
+    expect(queueSpy).not.toHaveBeenCalled();
+  });
+
   it("creates a visible empty summary when a short transcript cannot enhance", async () => {
     snapshot = createSnapshot({ wordCount: 2 });
     const service = new EnhancerService(createDeps());

--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -418,6 +418,55 @@ describe("EnhancerService", () => {
     );
   });
 
+  it("treats empty text containers as an empty summary", async () => {
+    snapshot = createSnapshot({
+      notes: [
+        createNote({
+          content: JSON.stringify({
+            type: "doc",
+            content: [
+              {
+                type: "heading",
+                attrs: { level: 1 },
+                content: [{ type: "text", text: "Planning" }],
+              },
+              {
+                type: "bulletList",
+                content: [
+                  {
+                    type: "listItem",
+                    content: [{ type: "paragraph" }],
+                  },
+                ],
+              },
+              {
+                type: "blockquote",
+                content: [{ type: "paragraph" }],
+              },
+            ],
+          }),
+        }),
+      ],
+      wordCount: 40,
+    });
+    const service = new EnhancerService(createDeps());
+    const queueSpy = vi
+      .spyOn(service, "queueAutoEnhance")
+      .mockImplementation(() => {});
+
+    await expect(
+      service.queueAutoEnhanceIfSummaryEmpty("session-1"),
+    ).resolves.toEqual({ type: "queued" });
+    expect(mocks.ensurePendingAutoEnhanceDocument).toHaveBeenCalledWith(
+      "session-1",
+      undefined,
+    );
+    expect(queueSpy).toHaveBeenCalledWith(
+      "session-1",
+      expect.objectContaining({ noteId: "note-1" }),
+    );
+  });
+
   it("preserves formatting applied to a synthesized session title", async () => {
     snapshot = createSnapshot({
       notes: [

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -67,19 +67,35 @@ const ISO_TITLE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
 const PENDING_AUTO_ENHANCE_RECOVERY_INTERVAL_MS = 5_000;
 
 type TiptapNode = {
+  type?: string;
+  attrs?: Record<string, unknown>;
   content?: TiptapNode[];
   text?: string;
 };
 
-function hasTiptapText(node: TiptapNode): boolean {
+function hasMeaningfulTiptapContent(node: TiptapNode): boolean {
   if (typeof node.text === "string" && node.text.trim()) {
     return true;
   }
 
-  return node.content?.some(hasTiptapText) ?? false;
+  if (
+    node.type !== "doc" &&
+    node.type !== "heading" &&
+    node.type !== "paragraph" &&
+    node.type !== "text"
+  ) {
+    return true;
+  }
+
+  return node.content?.some(hasMeaningfulTiptapContent) ?? false;
 }
 
-function hasSummaryContent(value: unknown): boolean {
+function collectTiptapText(node: TiptapNode): string {
+  const text = typeof node.text === "string" ? node.text : "";
+  return text + (node.content?.map(collectTiptapText).join("") ?? "");
+}
+
+function hasSummaryContent(value: unknown, sessionTitle?: string): boolean {
   if (typeof value !== "string") {
     return false;
   }
@@ -100,7 +116,20 @@ function hasSummaryContent(value: unknown): boolean {
       parsed !== null &&
       (parsed as { type?: unknown }).type === "doc"
     ) {
-      return hasTiptapText(parsed);
+      const document = parsed as TiptapNode;
+      const blocks = document.content ?? [];
+      const firstBlock = blocks[0];
+      const synthesizedTitle =
+        sessionTitle?.trim() &&
+        firstBlock?.type === "heading" &&
+        firstBlock.attrs?.level === 1 &&
+        collectTiptapText(firstBlock).trim() === sessionTitle.trim() &&
+        !firstBlock.content?.some(
+          (child) => child.type !== "text" || !child.text?.trim(),
+        );
+      return (synthesizedTitle ? blocks.slice(1) : blocks).some(
+        hasMeaningfulTiptapContent,
+      );
     }
     return true;
   } catch {
@@ -224,7 +253,10 @@ export class EnhancerService {
       const templateId = this.deps.getSelectedTemplateId();
       const existingNote = getAutoEnhancedNote(snapshot, templateId);
 
-      if (existingNote && hasSummaryContent(existingNote.content)) {
+      if (
+        existingNote &&
+        hasSummaryContent(existingNote.content, snapshot.title)
+      ) {
         return { type: "summary_exists", noteId: existingNote.id };
       }
 
@@ -449,7 +481,10 @@ export class EnhancerService {
       };
     }
 
-    if (existingTask?.status === "success" && hasSummaryContent(note.content)) {
+    if (
+      existingTask?.status === "success" &&
+      hasSummaryContent(note.content, snapshot.title)
+    ) {
       return { type: "already_active", noteId: note.id };
     }
 

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -65,6 +65,17 @@ const UUID_TITLE_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const ISO_TITLE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
 const PENDING_AUTO_ENHANCE_RECOVERY_INTERVAL_MS = 5_000;
+const TEXT_CONTAINER_TYPES = new Set([
+  "doc",
+  "heading",
+  "paragraph",
+  "text",
+  "codeBlock",
+  "blockquote",
+  "bulletList",
+  "orderedList",
+  "listItem",
+]);
 
 type TiptapNode = {
   type?: string;
@@ -79,12 +90,7 @@ function hasMeaningfulTiptapContent(node: TiptapNode): boolean {
     return true;
   }
 
-  if (
-    node.type !== "doc" &&
-    node.type !== "heading" &&
-    node.type !== "paragraph" &&
-    node.type !== "text"
-  ) {
+  if (!node.type || !TEXT_CONTAINER_TYPES.has(node.type)) {
     return true;
   }
 

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -70,6 +70,7 @@ type TiptapNode = {
   type?: string;
   attrs?: Record<string, unknown>;
   content?: TiptapNode[];
+  marks?: Array<{ type?: string; attrs?: Record<string, unknown> }>;
   text?: string;
 };
 
@@ -119,13 +120,18 @@ function hasSummaryContent(value: unknown, sessionTitle?: string): boolean {
       const document = parsed as TiptapNode;
       const blocks = document.content ?? [];
       const firstBlock = blocks[0];
+      const firstBlockAttrs = firstBlock?.attrs ?? {};
       const synthesizedTitle =
         sessionTitle?.trim() &&
         firstBlock?.type === "heading" &&
-        firstBlock.attrs?.level === 1 &&
+        firstBlockAttrs.level === 1 &&
+        Object.keys(firstBlockAttrs).length === 1 &&
         collectTiptapText(firstBlock).trim() === sessionTitle.trim() &&
         !firstBlock.content?.some(
-          (child) => child.type !== "text" || !child.text?.trim(),
+          (child) =>
+            child.type !== "text" ||
+            !child.text?.trim() ||
+            Boolean(child.marks?.length),
         );
       return (synthesizedTitle ? blocks.slice(1) : blocks).some(
         hasMeaningfulTiptapContent,

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -255,6 +255,36 @@ describe("EnhancedEditor", () => {
     expect(hoisted.persistContent).not.toHaveBeenCalled();
   });
 
+  it("does not persist a synthesized session title for a new summary", () => {
+    hoisted.content = "";
+    hoisted.sessionTitle = "Weekly sync";
+
+    render(
+      <EnhancedEditor
+        sessionId="session-1"
+        enhancedNoteId="note-1"
+        content={hoisted.content}
+      />,
+    );
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const input = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Weekly sync" }],
+        },
+        { type: "paragraph" },
+      ],
+    };
+
+    (props?.handleChange as (input: unknown) => void)(input);
+
+    expect(hoisted.persistContent).not.toHaveBeenCalled();
+  });
+
   it("persists clearing an existing summary", () => {
     hoisted.content = JSON.stringify({
       type: "doc",

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -34,7 +34,10 @@ vi.mock("@tauri-apps/api/window", () => ({
 }));
 
 vi.mock("@hypr/editor/markdown", () => ({
-  parseJsonContent: (value: string) => JSON.parse(value),
+  parseJsonContent: (value: string) =>
+    value
+      ? JSON.parse(value)
+      : { type: "doc", content: [{ type: "paragraph" }] },
 }));
 
 vi.mock("@hypr/editor/note", () => ({
@@ -223,6 +226,102 @@ describe("EnhancedEditor", () => {
     expect(hoisted.persistContent).toHaveBeenCalledWith(
       JSON.stringify(input),
       "Edited title",
+    );
+  });
+
+  it("does not persist the empty title layout for a new summary", () => {
+    hoisted.content = "";
+    hoisted.sessionTitle = "";
+
+    render(
+      <EnhancedEditor
+        sessionId="session-1"
+        enhancedNoteId="note-1"
+        content={hoisted.content}
+      />,
+    );
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const input = {
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 1 } },
+        { type: "paragraph" },
+      ],
+    };
+
+    (props?.handleChange as (input: unknown) => void)(input);
+
+    expect(hoisted.persistContent).not.toHaveBeenCalled();
+  });
+
+  it("persists clearing an existing summary", () => {
+    hoisted.content = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Existing summary" }],
+        },
+      ],
+    });
+    hoisted.sessionTitle = "";
+
+    render(
+      <EnhancedEditor
+        sessionId="session-1"
+        enhancedNoteId="note-1"
+        content={hoisted.content}
+      />,
+    );
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const input = {
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 1 } },
+        { type: "paragraph" },
+      ],
+    };
+
+    (props?.handleChange as (input: unknown) => void)(input);
+
+    expect(hoisted.persistContent).toHaveBeenCalledWith(
+      JSON.stringify(input),
+      "",
+    );
+  });
+
+  it("persists an attachment added to a new summary", () => {
+    hoisted.content = "";
+    hoisted.sessionTitle = "";
+
+    render(
+      <EnhancedEditor
+        sessionId="session-1"
+        enhancedNoteId="note-1"
+        content={hoisted.content}
+      />,
+    );
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const input = {
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 1 } },
+        {
+          type: "fileAttachment",
+          attrs: { attachmentId: "attachment-1", name: "notes.pdf" },
+        },
+      ],
+    };
+
+    (props?.handleChange as (input: unknown) => void)(input);
+
+    expect(hoisted.persistContent).toHaveBeenCalledWith(
+      JSON.stringify(input),
+      undefined,
     );
   });
 

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -285,6 +285,45 @@ describe("EnhancedEditor", () => {
     expect(hoisted.persistContent).not.toHaveBeenCalled();
   });
 
+  it("persists formatting applied to a synthesized session title", () => {
+    hoisted.content = "";
+    hoisted.sessionTitle = "Weekly sync";
+
+    render(
+      <EnhancedEditor
+        sessionId="session-1"
+        enhancedNoteId="note-1"
+        content={hoisted.content}
+      />,
+    );
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    const input = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [
+            {
+              type: "text",
+              text: "Weekly sync",
+              marks: [{ type: "bold" }],
+            },
+          ],
+        },
+        { type: "paragraph" },
+      ],
+    };
+
+    (props?.handleChange as (input: unknown) => void)(input);
+
+    expect(hoisted.persistContent).toHaveBeenCalledWith(
+      JSON.stringify(input),
+      "Weekly sync",
+    );
+  });
+
   it("persists clearing an existing summary", () => {
     hoisted.content = JSON.stringify({
       type: "doc",

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -32,14 +32,25 @@ import {
 
 const extraNodeViews = { appLink: AppLinkView, session: SessionNodeView };
 
-function isCanonicalEmptyDocument(content: JSONContent): boolean {
+function isCanonicalEmptyDocument(
+  content: JSONContent,
+  sessionTitle: string,
+): boolean {
   const [title, body, ...rest] = content.content ?? [];
+  const expectedTitle = sessionTitle.trim();
+  const titleContent = title?.content ?? [];
+  const hasExpectedTitle = expectedTitle
+    ? titleContent.length === 1 &&
+      titleContent[0]?.type === "text" &&
+      titleContent[0].text === expectedTitle &&
+      !titleContent[0].marks?.length
+    : titleContent.length === 0;
   return (
     content.type === "doc" &&
     rest.length === 0 &&
     title?.type === "heading" &&
     title.attrs?.level === 1 &&
-    !title.content?.length &&
+    hasExpectedTitle &&
     body?.type === "paragraph" &&
     !body.content?.length
   );
@@ -95,7 +106,10 @@ const EnhancedEditorInner = forwardRef<
     const handleChange = useCallback(
       (input: JSONContent) => {
         const portableInput = normalizePortableAttachmentUrls(input);
-        if (content === "" && isCanonicalEmptyDocument(portableInput)) {
+        if (
+          content === "" &&
+          isCanonicalEmptyDocument(portableInput, sessionTitle)
+        ) {
           return;
         }
         const title = extractFirstLineTitle(portableInput);
@@ -109,7 +123,7 @@ const EnhancedEditorInner = forwardRef<
           },
         );
       },
-      [content, updateContent],
+      [content, sessionTitle, updateContent],
     );
 
     const mentionConfig = useMentionConfig();

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -32,6 +32,19 @@ import {
 
 const extraNodeViews = { appLink: AppLinkView, session: SessionNodeView };
 
+function isCanonicalEmptyDocument(content: JSONContent): boolean {
+  const [title, body, ...rest] = content.content ?? [];
+  return (
+    content.type === "doc" &&
+    rest.length === 0 &&
+    title?.type === "heading" &&
+    title.attrs?.level === 1 &&
+    !title.content?.length &&
+    body?.type === "paragraph" &&
+    !body.content?.length
+  );
+}
+
 const EnhancedEditorInner = forwardRef<
   NoteEditorRef,
   {
@@ -82,6 +95,9 @@ const EnhancedEditorInner = forwardRef<
     const handleChange = useCallback(
       (input: JSONContent) => {
         const portableInput = normalizePortableAttachmentUrls(input);
+        if (content === "" && isCanonicalEmptyDocument(portableInput)) {
+          return;
+        }
         const title = extractFirstLineTitle(portableInput);
         const nextTitle =
           title !== null || hasStoredNoteContent(content)

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -39,6 +39,8 @@ function isCanonicalEmptyDocument(
   const [title, body, ...rest] = content.content ?? [];
   const expectedTitle = sessionTitle.trim();
   const titleContent = title?.content ?? [];
+  const titleAttrs = title?.attrs ?? {};
+  const bodyAttrs = body?.attrs ?? {};
   const hasExpectedTitle = expectedTitle
     ? titleContent.length === 1 &&
       titleContent[0]?.type === "text" &&
@@ -49,9 +51,11 @@ function isCanonicalEmptyDocument(
     content.type === "doc" &&
     rest.length === 0 &&
     title?.type === "heading" &&
-    title.attrs?.level === 1 &&
+    titleAttrs.level === 1 &&
+    Object.keys(titleAttrs).length === 1 &&
     hasExpectedTitle &&
     body?.type === "paragraph" &&
+    Object.keys(bodyAttrs).length === 0 &&
     !body.content?.length
   );
 }

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -839,6 +839,7 @@ describe("useStartListening", () => {
   });
 
   test("flushes canonical note persistence before releasing the capture sync lease", async () => {
+    useSessionHasTranscriptMock.mockReturnValue(true);
     let finishEditorFlush: (() => void) | undefined;
     flushCanonicalSessionEditorChangesMock.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -867,11 +868,15 @@ describe("useStartListening", () => {
     });
     expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
     expect(endCloudsyncActivityMock).not.toHaveBeenCalled();
+    expect(queueAutoEnhanceIfSummaryEmptyMock).not.toHaveBeenCalled();
 
     finishEditorFlush?.();
     await act(async () => {
       await stopped;
     });
+    expect(flushCanonicalSessionEditorChangesMock).toHaveBeenCalledBefore(
+      queueAutoEnhanceIfSummaryEmptyMock,
+    );
     expect(flushCanonicalSessionEditorChangesMock).toHaveBeenCalledBefore(
       clearCaptureLifecycleMarkerMock,
     );

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -625,6 +625,17 @@ function useCaptureLifecycle(sessionId: string) {
           return;
         }
 
+        try {
+          await flushCanonicalSessionEditorChanges(sessionId);
+        } catch (error) {
+          console.error(
+            "[listener] failed to flush session notes before completing capture",
+            error,
+          );
+          await requestRecovery();
+          return;
+        }
+
         const hasTranscriptEvidence =
           Boolean(pendingSummaryMode) ||
           preserveExistingTranscript ||
@@ -685,17 +696,6 @@ function useCaptureLifecycle(sessionId: string) {
           (!details.audioPath && !transcriptWriteError) ||
           (transcriptIsComplete && summaryScheduled);
         if (!recoveryComplete) {
-          await requestRecovery();
-          return;
-        }
-
-        try {
-          await flushCanonicalSessionEditorChanges(sessionId);
-        } catch (error) {
-          console.error(
-            "[listener] failed to flush session notes before completing capture",
-            error,
-          );
           await requestRecovery();
           return;
         }


### PR DESCRIPTION
Flush editor writes before scheduling auto-summary generation and ignore the one empty editor normalization that invalidated the pending generation marker. Add regression coverage for summary ordering, clearing content, and attachment-only edits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-capture finalization ordering and summary emptiness heuristics; mistakes could skip needed auto-enhance or persist stale editor state, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes a **post-capture race** where the summary editor could persist a default empty layout (heading + blank paragraph, sometimes mirroring the session title) after stop, which made durable state look “non-empty” and interfered with pending auto-enhance.
> 
> **Capture stop ordering:** `flushCanonicalSessionEditorChanges` now runs **before** `requestAutoEnhance` / `queueAutoEnhanceIfSummaryEmpty`, right after transcript completion is confirmed and the finalizing marker is written—so in-flight editor writes land in SQLite before emptiness checks and pending-generation markers.
> 
> **Enhanced summary editor:** `handleChange` no-ops when stored content is still empty and the document matches the canonical empty template (`isCanonicalEmptyDocument`), while real edits (clearing an existing note, attachments, bold on the title, etc.) still persist.
> 
> **Enhancer emptiness:** `hasSummaryContent` ignores a plain synthesized H1 that matches `snapshot.title`, treats attachment-only and empty list/blockquote shells appropriately via `hasMeaningfulTiptapContent`, and still counts formatted title text as real content so auto-enhance is not re-queued incorrectly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17127934c061af3f941c5f5113a2137ed7b33d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->