### PR TITLE
Bound live transcript memory growth

### DIFF
--- a/.agents/skills/qa-critical-ux/SKILL.md
+++ b/.agents/skills/qa-critical-ux/SKILL.md
@@ -73,7 +73,13 @@ waived by the user) before running the release-new-version skill.
    without rebuilding.
 
    A newly rebuilt ad-hoc Dev bundle can prompt for access to the E2EE recovery
-   key because its code-signing hash changed. Approve **Always Allow** once;
+   key because its code-signing hash changed. When the login Keychain prompt
+   appears, use Computer Use to enter the password explicitly supplied by the
+   user for that QA machine, then click **Always Allow**. Fetch fresh app state
+   and verify the prompt has disappeared before continuing. If the app or
+   SecurityAgent prompt closes first, record the step as incomplete and
+   relaunch the exact same bundle until it succeeds. Never place the password
+   in commands, logs, screenshots, reports, or repository files.
    `--launch-only` keeps the same binary and avoids another prompt. Staging and
    stable use a persistent Developer ID identity and do not have this Dev-only
    behavior.

--- a/apps/desktop/src/session/components/note-input/transcript/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/index.test.tsx
@@ -47,7 +47,12 @@ vi.mock("./screens/listening", () => ({
 }));
 
 vi.mock("./renderer", () => ({
-  TranscriptViewer: () => <div data-testid="transcript-viewer" />,
+  TranscriptViewer: ({ captureGeneration }: { captureGeneration: number }) => (
+    <div
+      data-testid="transcript-viewer"
+      data-capture-generation={captureGeneration}
+    />
+  ),
 }));
 
 vi.mock("~/stt/useUploadFile", () => ({
@@ -70,6 +75,8 @@ describe("Transcript", () => {
     getSessionMode: (id: string) => "inactive" | "active" | "finalizing";
     batch: Record<string, { error?: string | null }>;
     live: {
+      captureGenerationCounter: number;
+      captureGenerationBySession: Record<string, number>;
       degraded: null;
       requestedLiveTranscription: boolean;
       liveTranscriptionActive: boolean;
@@ -91,6 +98,11 @@ describe("Transcript", () => {
       getSessionMode: () => "active",
       batch: {},
       live: {
+        captureGenerationCounter: 2,
+        captureGenerationBySession: {
+          [sessionId]: 1,
+          "session-2": 2,
+        },
         degraded: null,
         requestedLiveTranscription: true,
         liveTranscriptionActive: true,
@@ -119,7 +131,11 @@ describe("Transcript", () => {
 
     view.rerender(<Transcript sessionId={sessionId} scrollRef={scrollRef} />);
 
-    expect(screen.queryByTestId("transcript-viewer")).not.toBeNull();
+    expect(
+      screen
+        .getByTestId("transcript-viewer")
+        .getAttribute("data-capture-generation"),
+    ).toBe("1");
   });
 
   it("keeps existing transcript content unobstructed while finalizing", () => {

--- a/apps/desktop/src/session/components/note-input/transcript/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/index.tsx
@@ -62,6 +62,7 @@ export function Transcript({
           transcriptIds={screen.transcriptIds}
           liveSegments={screen.liveSegments}
           currentActive={screen.currentActive}
+          captureGeneration={screen.captureGeneration}
           scrollRef={scrollRef}
         />
       )}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.integration.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.integration.test.tsx
@@ -1,0 +1,107 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useRenderedTranscriptData } from "./data-hooks";
+
+const mocks = vi.hoisted(() => ({
+  request: null as unknown,
+  renderTranscriptSegments: vi.fn(async (request: unknown) => {
+    const transcript = request as {
+      transcripts: Array<{ words: Array<{ id: string }> }>;
+    };
+    const id = transcript.transcripts[0]?.words[0]?.id ?? "empty";
+
+    return [
+      {
+        end_ms: 1,
+        id,
+        key: { channel: "DirectMic" },
+        start_ms: 0,
+        text: id,
+        words: [],
+      },
+    ];
+  }),
+}));
+
+vi.mock("../render-request-hooks", () => ({
+  useTranscriptRenderData: () => ({ request: mocks.request }),
+}));
+
+vi.mock("~/stt/queries", () => ({
+  useSessionTranscripts: vi.fn(() => []),
+  useTranscript: vi.fn(() => null),
+}));
+
+vi.mock("~/stt/render-transcript", () => ({
+  getRenderTranscriptRequestKey: vi.fn(() => "request-key"),
+  renderTranscriptSegments: mocks.renderTranscriptSegments,
+}));
+
+function requestWithWord(id: string) {
+  return {
+    humans: [],
+    participant_human_ids: [],
+    self_human_id: null,
+    transcripts: [
+      {
+        assignments: [],
+        started_at: null,
+        words: [{ id }],
+      },
+    ],
+  };
+}
+
+describe("useRenderedTranscriptData cache lifecycle", () => {
+  it("reuses one capture baseline across remounts and rotates it for the next capture", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const firstRequest = requestWithWord("word-a");
+    const nextRequest = requestWithWord("word-b");
+    mocks.request = firstRequest;
+    mocks.renderTranscriptSegments.mockClear();
+
+    const firstMount = renderHook(
+      () => useRenderedTranscriptData("transcript-1", true, 1),
+      { wrapper },
+    );
+    await waitFor(() =>
+      expect(firstMount.result.current.segments[0]?.id).toBe("word-a"),
+    );
+    expect(mocks.renderTranscriptSegments).toHaveBeenCalledTimes(1);
+    firstMount.unmount();
+
+    mocks.request = nextRequest;
+    const sameCaptureRemount = renderHook(
+      () => useRenderedTranscriptData("transcript-1", true, 1),
+      { wrapper },
+    );
+    await waitFor(() =>
+      expect(sameCaptureRemount.result.current.segments[0]?.id).toBe("word-a"),
+    );
+    expect(mocks.renderTranscriptSegments).toHaveBeenCalledTimes(1);
+    sameCaptureRemount.unmount();
+
+    const nextCaptureMount = renderHook(
+      () => useRenderedTranscriptData("transcript-1", true, 2),
+      { wrapper },
+    );
+    await waitFor(() =>
+      expect(nextCaptureMount.result.current.segments[0]?.id).toBe("word-b"),
+    );
+    expect(mocks.renderTranscriptSegments).toHaveBeenCalledTimes(2);
+    expect(mocks.renderTranscriptSegments).toHaveBeenLastCalledWith(
+      nextRequest,
+    );
+
+    nextCaptureMount.unmount();
+    queryClient.clear();
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
@@ -5,7 +5,7 @@ import { TRANSCRIPT_RENDER_CACHE_TIME_MS } from "../cache";
 import { useRenderedTranscriptData } from "./data-hooks";
 
 const mocks = vi.hoisted(() => ({
-  getRenderTranscriptRequestKey: vi.fn(() => "request-key"),
+  getRenderTranscriptRequestKey: vi.fn((_request: unknown) => "request-key"),
   renderTranscriptSegments: vi.fn(),
   useQuery: vi.fn(),
   useTranscriptRenderData: vi.fn(),
@@ -31,6 +31,7 @@ vi.mock("~/stt/render-transcript", () => ({
 
 describe("useRenderedTranscriptData", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mocks.useQuery.mockReturnValue({ data: [] });
     mocks.useTranscriptRenderData.mockReturnValue({
       request: {
@@ -42,7 +43,7 @@ describe("useRenderedTranscriptData", () => {
     });
   });
 
-  it("keeps rendered transcript data cached across short tab remounts", () => {
+  it("keeps settled transcript data cached across short tab remounts", () => {
     renderHook(() => useRenderedTranscriptData("transcript-1"));
 
     expect(mocks.useQuery).toHaveBeenCalledWith(
@@ -50,6 +51,7 @@ describe("useRenderedTranscriptData", () => {
         queryKey: [
           "rendered-transcript-segments",
           "transcript-1",
+          "settled",
           "request-key",
         ],
         enabled: true,
@@ -57,5 +59,153 @@ describe("useRenderedTranscriptData", () => {
         gcTime: TRANSCRIPT_RENDER_CACHE_TIME_MS,
       }),
     );
+  });
+
+  it("keeps one reusable render baseline while the transcript is active", () => {
+    renderHook(() => useRenderedTranscriptData("transcript-1", true));
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [
+          "rendered-transcript-segments",
+          "transcript-1",
+          "volatile",
+          "baseline",
+        ],
+        enabled: true,
+        staleTime: Number.POSITIVE_INFINITY,
+        gcTime: TRANSCRIPT_RENDER_CACHE_TIME_MS,
+      }),
+    );
+  });
+
+  it("keeps one persisted baseline while exposing current active data", async () => {
+    const requestA = {
+      humans: [],
+      participant_human_ids: [],
+      self_human_id: null,
+      transcripts: [
+        {
+          assignments: [],
+          started_at: null,
+          words: [{ id: "word-a" }],
+        },
+      ],
+    };
+    const requestB = {
+      humans: [],
+      participant_human_ids: [],
+      self_human_id: null,
+      transcripts: [
+        {
+          assignments: [],
+          started_at: null,
+          words: [{ id: "word-b" }],
+        },
+      ],
+    };
+    const assignment = {
+      human_id: "human-1",
+      scope: { channel: "MixedCapture", kind: "channel" },
+    };
+    const requestC = {
+      ...requestB,
+      humans: [{ human_id: "human-1", name: "Ada" }],
+      transcripts: [{ ...requestB.transcripts[0], assignments: [assignment] }],
+    };
+    const requestD = {
+      ...requestC,
+      transcripts: [
+        {
+          ...requestC.transcripts[0],
+          assignments: [
+            {
+              human_id: "human-1",
+              scope: {
+                kind: "words",
+                word_ids: ["word-b", "word-c"],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    mocks.getRenderTranscriptRequestKey.mockImplementation((request) => {
+      if (request === requestA) return "baseline-a";
+      if (request === requestB) return "request-b";
+      if (request === requestC) return "request-c";
+      if (request === requestD) return "request-d";
+      return "empty";
+    });
+    mocks.useTranscriptRenderData.mockReturnValue({ request: null });
+
+    const { rerender, result } = renderHook(
+      ({ currentActive }) =>
+        useRenderedTranscriptData("transcript-1", currentActive),
+      { initialProps: { currentActive: true } },
+    );
+
+    expect(mocks.useQuery.mock.lastCall?.[0].enabled).toBe(false);
+
+    mocks.useTranscriptRenderData.mockReturnValue({ request: requestA });
+    rerender({ currentActive: true });
+    mocks.useTranscriptRenderData.mockReturnValue({ request: requestB });
+    rerender({ currentActive: true });
+
+    const activeQuery = mocks.useQuery.mock.lastCall?.[0];
+    expect(activeQuery.queryKey).toEqual([
+      "rendered-transcript-segments",
+      "transcript-1",
+      "volatile",
+      "baseline",
+    ]);
+    await activeQuery.queryFn();
+    expect(mocks.renderTranscriptSegments).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        transcripts: [
+          expect.objectContaining({
+            assignments: [],
+            words: requestA.transcripts[0]?.words,
+          }),
+        ],
+      }),
+    );
+
+    mocks.useTranscriptRenderData.mockReturnValue({ request: requestC });
+    rerender({ currentActive: true });
+    mocks.useTranscriptRenderData.mockReturnValue({ request: requestD });
+    rerender({ currentActive: true });
+
+    const updatedActiveQuery = mocks.useQuery.mock.lastCall?.[0];
+    expect(updatedActiveQuery.queryKey).toEqual([
+      "rendered-transcript-segments",
+      "transcript-1",
+      "volatile",
+      "baseline",
+    ]);
+    await updatedActiveQuery.queryFn();
+    expect(mocks.renderTranscriptSegments).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        transcripts: [
+          expect.objectContaining({
+            assignments: [],
+            words: requestA.transcripts[0]?.words,
+          }),
+        ],
+      }),
+    );
+    expect(result.current.request).toBe(requestD);
+
+    rerender({ currentActive: false });
+
+    const settledQuery = mocks.useQuery.mock.lastCall?.[0];
+    expect(settledQuery.queryKey).toEqual([
+      "rendered-transcript-segments",
+      "transcript-1",
+      "settled",
+      "request-d",
+    ]);
+    await settledQuery.queryFn();
+    expect(mocks.renderTranscriptSegments).toHaveBeenLastCalledWith(requestD);
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
@@ -70,7 +70,7 @@ describe("useRenderedTranscriptData", () => {
           "rendered-transcript-segments",
           "transcript-1",
           "volatile",
-          "baseline",
+          "baseline:0",
         ],
         enabled: true,
         staleTime: Number.POSITIVE_INFINITY,
@@ -140,24 +140,28 @@ describe("useRenderedTranscriptData", () => {
     mocks.useTranscriptRenderData.mockReturnValue({ request: null });
 
     const { rerender, result } = renderHook(
-      ({ currentActive }) =>
-        useRenderedTranscriptData("transcript-1", currentActive),
-      { initialProps: { currentActive: true } },
+      ({ currentActive, captureGeneration }) =>
+        useRenderedTranscriptData(
+          "transcript-1",
+          currentActive,
+          captureGeneration,
+        ),
+      { initialProps: { currentActive: true, captureGeneration: 1 } },
     );
 
     expect(mocks.useQuery.mock.lastCall?.[0].enabled).toBe(false);
 
     mocks.useTranscriptRenderData.mockReturnValue({ request: requestA });
-    rerender({ currentActive: true });
+    rerender({ currentActive: true, captureGeneration: 1 });
     mocks.useTranscriptRenderData.mockReturnValue({ request: requestB });
-    rerender({ currentActive: true });
+    rerender({ currentActive: true, captureGeneration: 1 });
 
     const activeQuery = mocks.useQuery.mock.lastCall?.[0];
     expect(activeQuery.queryKey).toEqual([
       "rendered-transcript-segments",
       "transcript-1",
       "volatile",
-      "baseline",
+      "baseline:1",
     ]);
     await activeQuery.queryFn();
     expect(mocks.renderTranscriptSegments).toHaveBeenLastCalledWith(
@@ -172,16 +176,16 @@ describe("useRenderedTranscriptData", () => {
     );
 
     mocks.useTranscriptRenderData.mockReturnValue({ request: requestC });
-    rerender({ currentActive: true });
+    rerender({ currentActive: true, captureGeneration: 1 });
     mocks.useTranscriptRenderData.mockReturnValue({ request: requestD });
-    rerender({ currentActive: true });
+    rerender({ currentActive: true, captureGeneration: 1 });
 
     const updatedActiveQuery = mocks.useQuery.mock.lastCall?.[0];
     expect(updatedActiveQuery.queryKey).toEqual([
       "rendered-transcript-segments",
       "transcript-1",
       "volatile",
-      "baseline",
+      "baseline:1",
     ]);
     await updatedActiveQuery.queryFn();
     expect(mocks.renderTranscriptSegments).toHaveBeenLastCalledWith(
@@ -196,7 +200,7 @@ describe("useRenderedTranscriptData", () => {
     );
     expect(result.current.request).toBe(requestD);
 
-    rerender({ currentActive: false });
+    rerender({ currentActive: false, captureGeneration: 1 });
 
     const settledQuery = mocks.useQuery.mock.lastCall?.[0];
     expect(settledQuery.queryKey).toEqual([
@@ -206,6 +210,18 @@ describe("useRenderedTranscriptData", () => {
       "request-d",
     ]);
     await settledQuery.queryFn();
+    expect(mocks.renderTranscriptSegments).toHaveBeenLastCalledWith(requestD);
+
+    rerender({ currentActive: true, captureGeneration: 2 });
+
+    const nextCaptureQuery = mocks.useQuery.mock.lastCall?.[0];
+    expect(nextCaptureQuery.queryKey).toEqual([
+      "rendered-transcript-segments",
+      "transcript-1",
+      "volatile",
+      "baseline:2",
+    ]);
+    await nextCaptureQuery.queryFn();
     expect(mocks.renderTranscriptSegments).toHaveBeenLastCalledWith(requestD);
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -23,6 +23,7 @@ export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
 export function useRenderedTranscriptData(
   transcriptId: string,
   currentActive = false,
+  captureGeneration = 0,
 ): {
   maxSpeakerNumber?: number;
   request: RenderTranscriptRequest | null;
@@ -32,6 +33,7 @@ export function useRenderedTranscriptData(
   // Recovery needs the persisted prefix. The active key stays stable across
   // word and assignment writes so tab remounts reuse the same native render.
   const activeBaselineRef = useRef<{
+    captureGeneration: number;
     transcriptId: string;
     request: typeof request;
   } | null>(null);
@@ -39,16 +41,24 @@ export function useRenderedTranscriptData(
     activeBaselineRef.current = null;
   } else if (
     activeBaselineRef.current?.transcriptId !== transcriptId ||
+    activeBaselineRef.current.captureGeneration !== captureGeneration ||
     activeBaselineRef.current.request === null
   ) {
-    activeBaselineRef.current = { transcriptId, request };
+    activeBaselineRef.current = {
+      captureGeneration,
+      transcriptId,
+      request,
+    };
   }
   const activeBaselineRequest = currentActive
     ? (activeBaselineRef.current?.request ?? null)
     : request;
   const requestKey = useMemo(
-    () => (currentActive ? "baseline" : getRenderTranscriptRequestKey(request)),
-    [currentActive, request],
+    () =>
+      currentActive
+        ? `baseline:${captureGeneration}`
+        : getRenderTranscriptRequestKey(request),
+    [captureGeneration, currentActive, request],
   );
 
   // eslint-disable-next-line @tanstack/query/exhaustive-deps -- active input is frozen and reconciled with current SQLite state in JavaScript.

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
+
+import type { RenderTranscriptRequest } from "@hypr/plugin-transcription";
 
 import { TRANSCRIPT_RENDER_CACHE_TIME_MS } from "../cache";
 import { useTranscriptRenderData } from "../render-request-hooks";
@@ -18,27 +20,53 @@ export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
   return useRenderedTranscriptData(transcriptId).segments;
 }
 
-export function useRenderedTranscriptData(transcriptId: string): {
+export function useRenderedTranscriptData(
+  transcriptId: string,
+  currentActive = false,
+): {
   maxSpeakerNumber?: number;
+  request: RenderTranscriptRequest | null;
   segments: Segment[];
 } {
   const { request } = useTranscriptRenderData(transcriptId);
+  // Recovery needs the persisted prefix. The active key stays stable across
+  // word and assignment writes so tab remounts reuse the same native render.
+  const activeBaselineRef = useRef<{
+    transcriptId: string;
+    request: typeof request;
+  } | null>(null);
+  if (!currentActive) {
+    activeBaselineRef.current = null;
+  } else if (
+    activeBaselineRef.current?.transcriptId !== transcriptId ||
+    activeBaselineRef.current.request === null
+  ) {
+    activeBaselineRef.current = { transcriptId, request };
+  }
+  const activeBaselineRequest = currentActive
+    ? (activeBaselineRef.current?.request ?? null)
+    : request;
   const requestKey = useMemo(
-    () => getRenderTranscriptRequestKey(request),
-    [request],
+    () => (currentActive ? "baseline" : getRenderTranscriptRequestKey(request)),
+    [currentActive, request],
   );
 
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- requestKey is the canonical hash of the complete render request.
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- active input is frozen and reconciled with current SQLite state in JavaScript.
   const { data = [] } = useQuery({
-    queryKey: ["rendered-transcript-segments", transcriptId, requestKey],
+    queryKey: [
+      "rendered-transcript-segments",
+      transcriptId,
+      currentActive ? "volatile" : "settled",
+      requestKey,
+    ],
     queryFn: async () => {
-      if (!request) {
+      if (!activeBaselineRequest) {
         return [];
       }
 
-      return renderTranscriptSegments(request);
+      return renderTranscriptSegments(activeBaselineRequest);
     },
-    enabled: !!request,
+    enabled: !!activeBaselineRequest,
     staleTime: Number.POSITIVE_INFINITY,
     gcTime: TRANSCRIPT_RENDER_CACHE_TIME_MS,
   });
@@ -54,7 +82,7 @@ export function useRenderedTranscriptData(transcriptId: string): {
     [request],
   );
 
-  return { maxSpeakerNumber, segments: data };
+  return { maxSpeakerNumber, request, segments: data };
 }
 
 export function useTranscriptOffset(transcriptId: string): number {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -46,14 +46,17 @@ vi.mock("./transcript", () => ({
     shouldScrollToEnd,
     transcriptId,
     currentActive,
+    captureGeneration,
   }: {
     liveSegments: unknown[];
     shouldScrollToEnd: boolean;
     transcriptId: string;
     currentActive: boolean;
+    captureGeneration?: number;
   }) => (
     <div
       data-testid="render-transcript"
+      data-capture-generation={String(captureGeneration ?? 0)}
       data-current-active={String(currentActive)}
       data-live-segment-count={String(liveSegments.length)}
       data-should-scroll-to-end={String(shouldScrollToEnd)}
@@ -108,6 +111,7 @@ describe("TranscriptViewer", () => {
         transcriptIds={["transcript-1"]}
         liveSegments={[]}
         currentActive
+        captureGeneration={7}
         scrollRef={createRef()}
       />,
     );
@@ -117,6 +121,11 @@ describe("TranscriptViewer", () => {
         .getByTestId("render-transcript")
         .getAttribute("data-should-scroll-to-end"),
     ).toBe("true");
+    expect(
+      screen
+        .getByTestId("render-transcript")
+        .getAttribute("data-capture-generation"),
+    ).toBe("7");
   });
 
   it("keeps active transcript sessions pinned near the exact bottom edge", () => {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -45,13 +45,16 @@ vi.mock("./transcript", () => ({
     liveSegments,
     shouldScrollToEnd,
     transcriptId,
+    currentActive,
   }: {
     liveSegments: unknown[];
     shouldScrollToEnd: boolean;
     transcriptId: string;
+    currentActive: boolean;
   }) => (
     <div
       data-testid="render-transcript"
+      data-current-active={String(currentActive)}
       data-live-segment-count={String(liveSegments.length)}
       data-should-scroll-to-end={String(shouldScrollToEnd)}
       data-transcript-id={transcriptId}
@@ -160,6 +163,32 @@ describe("TranscriptViewer", () => {
     expect(transcript.getAttribute("data-transcript-id")).toBe(
       "__live-transcript__",
     );
+  });
+
+  it("keeps prior transcript rows settled during an active capture", () => {
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1", "transcript-2"]}
+        liveSegments={[
+          {
+            end_ms: 1000,
+            id: "segment-1",
+            key: { channel: "DirectMic" },
+            start_ms: 0,
+            text: "hello",
+            words: [],
+          },
+        ]}
+        currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    const transcripts = screen.getAllByTestId("render-transcript");
+    expect(transcripts[0]?.getAttribute("data-current-active")).toBe("false");
+    expect(transcripts[0]?.getAttribute("data-live-segment-count")).toBe("0");
+    expect(transcripts[1]?.getAttribute("data-current-active")).toBe("true");
+    expect(transcripts[1]?.getAttribute("data-live-segment-count")).toBe("1");
   });
 
   it("does not show scroll controls when the transcript cannot scroll", () => {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -119,26 +119,28 @@ export function TranscriptViewer({
           "pb-[calc(4rem+env(safe-area-inset-bottom))]",
         ])}
       >
-        {visibleTranscriptIds.map((transcriptId, index) => (
-          <div key={transcriptId} className="flex flex-col gap-8">
-            <RenderTranscript
-              scrollElement={scrollElement}
-              isLastTranscript={index === visibleTranscriptIds.length - 1}
-              shouldScrollToEnd={shouldScrollLastTranscriptToEnd}
-              transcriptId={transcriptId}
-              liveSegments={
-                index === visibleTranscriptIds.length - 1 && currentActive
-                  ? liveSegments
-                  : []
-              }
-              currentMs={deferredCurrentMs}
-              seek={seek}
-              startPlayback={start}
-              audioExists={audioExists}
-            />
-            {index < visibleTranscriptIds.length - 1 && <TranscriptSeparator />}
-          </div>
-        ))}
+        {visibleTranscriptIds.map((transcriptId, index) => {
+          const isLastTranscript = index === visibleTranscriptIds.length - 1;
+          const isActiveTranscript = currentActive && isLastTranscript;
+
+          return (
+            <div key={transcriptId} className="flex flex-col gap-8">
+              <RenderTranscript
+                scrollElement={scrollElement}
+                isLastTranscript={isLastTranscript}
+                shouldScrollToEnd={shouldScrollLastTranscriptToEnd}
+                transcriptId={transcriptId}
+                currentActive={isActiveTranscript}
+                liveSegments={isActiveTranscript ? liveSegments : []}
+                currentMs={deferredCurrentMs}
+                seek={seek}
+                startPlayback={start}
+                audioExists={audioExists}
+              />
+              {!isLastTranscript && <TranscriptSeparator />}
+            </div>
+          );
+        })}
 
         <SelectionMenu
           containerRef={containerRef}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -29,11 +29,13 @@ export function TranscriptViewer({
   transcriptIds,
   liveSegments,
   currentActive,
+  captureGeneration = 0,
   scrollRef,
 }: {
   transcriptIds: string[];
   liveSegments: Segment[];
   currentActive: boolean;
+  captureGeneration?: number;
   scrollRef: RefObject<HTMLDivElement | null>;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -131,6 +133,7 @@ export function TranscriptViewer({
                 shouldScrollToEnd={shouldScrollLastTranscriptToEnd}
                 transcriptId={transcriptId}
                 currentActive={isActiveTranscript}
+                captureGeneration={isActiveTranscript ? captureGeneration : 0}
                 liveSegments={isActiveTranscript ? liveSegments : []}
                 currentMs={deferredCurrentMs}
                 seek={seek}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.test.tsx
@@ -5,31 +5,14 @@ import { SegmentHeader } from "./segment-header";
 
 import type { Segment } from "~/stt/live-segment";
 
-const labelState = vi.hoisted(() => ({
-  names: {} as Record<string, string>,
-  participantIds: [] as string[],
-  selfId: undefined as string | undefined,
-}));
-
 vi.mock("./speaker-assign", () => ({
   SpeakerAssignPopover: ({ label }: { label: string }) => (
     <button type="button">{label}</button>
   ),
 }));
 
-vi.mock("~/stt/queries", () => ({
-  useTranscriptLabelContext: () => ({
-    getSelfHumanId: () => labelState.selfId,
-    getHumanName: (humanId: string) => labelState.names[humanId],
-    getParticipantHumanIds: () => labelState.participantIds,
-  }),
-}));
-
 beforeEach(() => {
   cleanup();
-  labelState.names = {};
-  labelState.participantIds = [];
-  labelState.selfId = undefined;
 });
 
 describe("SegmentHeader", () => {
@@ -37,6 +20,8 @@ describe("SegmentHeader", () => {
     render(
       <SegmentHeader
         transcriptId="transcript-1"
+        sessionId="session-1"
+        label="Speaker 3"
         segment={createRemoteSegment(2)}
       />,
     );
@@ -46,13 +31,11 @@ describe("SegmentHeader", () => {
   });
 
   it("labels remote live segments as the unique other participant", () => {
-    labelState.selfId = "self";
-    labelState.participantIds = ["self", "remote"];
-    labelState.names = { self: "John", remote: "Artem" };
-
     render(
       <SegmentHeader
         transcriptId="transcript-1"
+        sessionId="session-1"
+        label="Artem"
         segment={createRemoteSegment(0)}
       />,
     );
@@ -61,23 +44,26 @@ describe("SegmentHeader", () => {
   });
 
   it("updates cached remote labels when session participants change", () => {
-    labelState.selfId = "self";
-    labelState.participantIds = ["self", "remote"];
-    labelState.names = { self: "John", remote: "Artem" };
     const segment = createRemoteSegment(0);
     const { rerender } = render(
-      <SegmentHeader transcriptId="transcript-1" segment={segment} />,
+      <SegmentHeader
+        transcriptId="transcript-1"
+        sessionId="session-1"
+        label="Artem"
+        segment={segment}
+      />,
     );
 
     expect(screen.getByRole("button", { name: "Artem" })).toBeTruthy();
 
-    labelState.participantIds = ["self", "remote", "remote-2"];
-    labelState.names = {
-      self: "John",
-      remote: "Artem",
-      "remote-2": "Taylor",
-    };
-    rerender(<SegmentHeader transcriptId="transcript-1" segment={segment} />);
+    rerender(
+      <SegmentHeader
+        transcriptId="transcript-1"
+        sessionId="session-1"
+        label="Speaker 1"
+        segment={segment}
+      />,
+    );
 
     expect(screen.getByRole("button", { name: "Speaker 1" })).toBeTruthy();
   });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -1,25 +1,22 @@
-import { useMemo } from "react";
-
 import { cn } from "@hypr/utils";
 
 import { SpeakerAssignPopover } from "./speaker-assign";
 import { useSegmentColorVars } from "./utils";
 
 import type { Segment } from "~/stt/live-segment";
-import { SegmentKeyUtils, SpeakerLabelManager } from "~/stt/live-segment";
-import { useTranscriptLabelContext } from "~/stt/queries";
 
 export function SegmentHeader({
   segment,
   transcriptId,
-  speakerLabelManager,
+  sessionId,
+  label,
 }: {
   segment: Segment;
   transcriptId: string;
-  speakerLabelManager?: SpeakerLabelManager;
+  sessionId?: string;
+  label: string;
 }) {
   const colorVars = useSegmentColorVars(segment.key);
-  const label = useSpeakerLabel(segment.key, transcriptId, speakerLabelManager);
   const headerClassName = cn([
     "bg-card sticky top-0 z-20",
     "-mx-3 px-3 py-1",
@@ -34,22 +31,10 @@ export function SegmentHeader({
       <SpeakerAssignPopover
         segment={segment}
         transcriptId={transcriptId}
+        sessionId={sessionId}
         color="var(--segment-color)"
         label={label}
       />
     </div>
-  );
-}
-
-function useSpeakerLabel(
-  key: Segment["key"],
-  transcriptId: string,
-  manager?: SpeakerLabelManager,
-) {
-  const labelContext = useTranscriptLabelContext(transcriptId);
-
-  return useMemo(
-    () => SegmentKeyUtils.renderLabel(key, labelContext, manager),
-    [key, labelContext, manager],
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment.test.tsx
@@ -46,6 +46,7 @@ describe("SegmentRenderer", () => {
         segment={segment}
         offsetMs={0}
         transcriptId="transcript-1"
+        speakerLabel="Speaker 1"
         currentMs={0}
         seekAndPlay={seekAndPlay}
         audioExists
@@ -64,6 +65,7 @@ describe("SegmentRenderer", () => {
         segment={segment}
         offsetMs={0}
         transcriptId="transcript-1"
+        speakerLabel="Speaker 1"
         currentMs={500}
         seekAndPlay={seekAndPlay}
         audioExists
@@ -78,6 +80,7 @@ describe("SegmentRenderer", () => {
         segment={segment}
         offsetMs={0}
         transcriptId="transcript-1"
+        speakerLabel="Speaker 1"
         currentMs={700}
         seekAndPlay={seekAndPlay}
         audioExists
@@ -96,6 +99,7 @@ describe("SegmentRenderer", () => {
         segment={segment}
         offsetMs={0}
         transcriptId="transcript-1"
+        speakerLabel="Speaker 1"
         currentMs={500}
         seekAndPlay={seekAndPlay}
         audioExists
@@ -110,6 +114,7 @@ describe("SegmentRenderer", () => {
         segment={segment}
         offsetMs={0}
         transcriptId="transcript-1"
+        speakerLabel="Speaker 1"
         currentMs={1500}
         seekAndPlay={seekAndPlay}
         audioExists
@@ -129,6 +134,7 @@ describe("SegmentRenderer", () => {
         segment={segment}
         offsetMs={0}
         transcriptId="transcript-1"
+        speakerLabel="Speaker 1"
         currentMs={0}
         seekAndPlay={seekAndPlay}
         audioExists
@@ -143,6 +149,7 @@ describe("SegmentRenderer", () => {
         segment={segment}
         offsetMs={0}
         transcriptId="transcript-1"
+        speakerLabel="Speaker 1"
         currentMs={0}
         seekAndPlay={seekAndPlay}
         audioExists
@@ -161,6 +168,7 @@ describe("SegmentRenderer", () => {
         segment={segment}
         offsetMs={0}
         transcriptId="transcript-1"
+        speakerLabel="Speaker 1"
         currentMs={0}
         seekAndPlay={seekAndPlay}
         audioExists
@@ -175,10 +183,45 @@ describe("SegmentRenderer", () => {
         segment={segment}
         offsetMs={0}
         transcriptId="transcript-1"
+        speakerLabel="Speaker 1"
         currentMs={0}
         seekAndPlay={seekAndPlay}
         audioExists
         search={createSearch("word-3")}
+      />,
+    );
+
+    expect(mocks.wordSpan).toHaveBeenCalledTimes(8);
+  });
+
+  it("rerenders when the computed speaker label changes", () => {
+    const segment = createSegment();
+    const seekAndPlay = vi.fn();
+    const view = render(
+      <SegmentRenderer
+        segment={segment}
+        offsetMs={0}
+        transcriptId="transcript-1"
+        speakerLabel="Speaker 1"
+        currentMs={0}
+        seekAndPlay={seekAndPlay}
+        audioExists
+        search={EMPTY_TRANSCRIPT_SEARCH}
+      />,
+    );
+
+    expect(mocks.wordSpan).toHaveBeenCalledTimes(4);
+
+    view.rerender(
+      <SegmentRenderer
+        segment={segment}
+        offsetMs={0}
+        transcriptId="transcript-1"
+        speakerLabel="Alice"
+        currentMs={0}
+        seekAndPlay={seekAndPlay}
+        audioExists
+        search={EMPTY_TRANSCRIPT_SEARCH}
       />,
     );
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
@@ -12,7 +12,6 @@ import { WordSpan } from "./word-span";
 
 import { createHighlightSegments } from "~/session/components/note-input/search/matching";
 import type { Segment, SegmentWord } from "~/stt/live-segment";
-import { SpeakerLabelManager } from "~/stt/live-segment";
 
 export type TranscriptSearchRenderState = {
   query: string;
@@ -45,7 +44,8 @@ export const SegmentRenderer = memo(
     segment,
     offsetMs,
     transcriptId,
-    speakerLabelManager,
+    sessionId,
+    speakerLabel,
     currentMs,
     seekAndPlay,
     audioExists,
@@ -54,7 +54,8 @@ export const SegmentRenderer = memo(
     segment: Segment;
     offsetMs: number;
     transcriptId: string;
-    speakerLabelManager?: SpeakerLabelManager;
+    sessionId?: string;
+    speakerLabel: string;
     currentMs: number;
     seekAndPlay: (word: SegmentWord) => void;
     audioExists: boolean;
@@ -90,7 +91,8 @@ export const SegmentRenderer = memo(
         <SegmentHeader
           segment={segment}
           transcriptId={transcriptId}
-          speakerLabelManager={speakerLabelManager}
+          sessionId={sessionId}
+          label={speakerLabel}
         />
 
         <div
@@ -147,7 +149,8 @@ export const SegmentRenderer = memo(
       prev.segment !== next.segment ||
       prev.offsetMs !== next.offsetMs ||
       prev.transcriptId !== next.transcriptId ||
-      prev.speakerLabelManager !== next.speakerLabelManager ||
+      prev.sessionId !== next.sessionId ||
+      prev.speakerLabel !== next.speakerLabel ||
       prev.audioExists !== next.audioExists ||
       prev.seekAndPlay !== next.seekAndPlay
     ) {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
@@ -134,7 +134,6 @@ vi.mock("~/session/queries", () => ({
 
 vi.mock("~/stt/queries", () => ({
   assignTranscriptSpeaker: assignTranscriptSpeakerMock,
-  useTranscript: () => ({ sessionId: "session-1" }),
 }));
 
 beforeEach(() => {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -20,13 +20,14 @@ import {
   useSessionParticipants,
 } from "~/session/queries";
 import type { Segment } from "~/stt/live-segment";
-import { assignTranscriptSpeaker, useTranscript } from "~/stt/queries";
+import { assignTranscriptSpeaker } from "~/stt/queries";
 
 type AssignmentMode = "all" | "segment";
 
 export function SpeakerAssignPopover({
   segment,
   transcriptId,
+  sessionId,
   color,
   label,
   className,
@@ -34,13 +35,13 @@ export function SpeakerAssignPopover({
 }: {
   segment: Segment;
   transcriptId: string;
+  sessionId?: string;
   color: string;
   label: string;
   className?: string;
   onAssigned?: (humanId: string) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const sessionId = useTranscript(transcriptId)?.sessionId;
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen);

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.test.tsx
@@ -83,6 +83,7 @@ describe("RenderTranscript", () => {
         shouldScrollToEnd={false}
         transcriptId="transcript-1"
         currentActive
+        captureGeneration={7}
         liveSegments={createSegments(500)}
         currentMs={0}
         seek={vi.fn()}
@@ -96,6 +97,7 @@ describe("RenderTranscript", () => {
     expect(mocks.useRenderedTranscriptData).toHaveBeenCalledWith(
       "transcript-1",
       true,
+      7,
     );
     expect(mocks.useTranscript).toHaveBeenCalledTimes(1);
     expect(mocks.useTranscript).toHaveBeenCalledWith("transcript-1");
@@ -166,6 +168,7 @@ describe("RenderTranscript", () => {
     expect(mocks.useRenderedTranscriptData).toHaveBeenCalledWith(
       "transcript-1",
       false,
+      0,
     );
     expect(document.querySelectorAll("section")).toHaveLength(1);
   });
@@ -195,6 +198,7 @@ describe("RenderTranscript", () => {
     expect(mocks.useRenderedTranscriptData).toHaveBeenCalledWith(
       "transcript-1",
       true,
+      0,
     );
     expect(document.querySelectorAll("section")).toHaveLength(1);
   });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.test.tsx
@@ -1,0 +1,311 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  IdentityAssignment,
+  RenderTranscriptRequest,
+} from "@hypr/plugin-transcription";
+
+import { RenderTranscript } from "./transcript";
+
+import type { RenderLabelContext, Segment } from "~/stt/live-segment";
+
+const mocks = vi.hoisted(() => ({
+  assignTranscriptSpeaker: vi.fn(),
+  useRenderedTranscriptData: vi.fn(),
+  useTranscript: vi.fn(),
+  useTranscriptLabelContext: vi.fn(),
+  useTranscriptOffset: vi.fn(() => 0),
+}));
+
+vi.mock("../../search/context", () => ({
+  useSearch: () => null,
+}));
+
+vi.mock("./data-hooks", () => ({
+  useRenderedTranscriptData: mocks.useRenderedTranscriptData,
+  useTranscriptOffset: mocks.useTranscriptOffset,
+}));
+
+vi.mock("./word-span", () => ({
+  WordSpan: ({ displayText }: { displayText: string }) => (
+    <span>{displayText}</span>
+  ),
+}));
+
+vi.mock("@hypr/ui/components/ui/popover", () => ({
+  AppFloatingPanel: () => null,
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: () => null,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("~/calendar/queries", () => ({
+  useSessionEventParticipants: () => [],
+}));
+
+vi.mock("~/contacts/queries", () => ({
+  createHuman: vi.fn(),
+  useHumans: () => [],
+}));
+
+vi.mock("~/session/queries", () => ({
+  addSessionParticipant: vi.fn(),
+  useSession: () => null,
+  useSessionParticipants: () => [],
+}));
+
+vi.mock("~/stt/queries", () => ({
+  assignTranscriptSpeaker: mocks.assignTranscriptSpeaker,
+  useTranscript: mocks.useTranscript,
+  useTranscriptLabelContext: mocks.useTranscriptLabelContext,
+}));
+
+describe("RenderTranscript", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mocks.useRenderedTranscriptData.mockReturnValue({
+      maxSpeakerNumber: undefined,
+      request: createRenderRequest(createSegments(500)),
+      segments: createSegments(500),
+    });
+    mocks.useTranscript.mockReturnValue({ sessionId: "session-1" });
+    mocks.useTranscriptLabelContext.mockReturnValue(labelContext);
+  });
+
+  it("loads transcript metadata once instead of once per rendered segment", () => {
+    render(
+      <RenderTranscript
+        scrollElement={null}
+        isLastTranscript
+        shouldScrollToEnd={false}
+        transcriptId="transcript-1"
+        currentActive
+        liveSegments={createSegments(500)}
+        currentMs={0}
+        seek={vi.fn()}
+        startPlayback={vi.fn()}
+        audioExists
+      />,
+    );
+
+    expect(document.querySelectorAll("section")).toHaveLength(500);
+    expect(mocks.useRenderedTranscriptData).toHaveBeenCalledOnce();
+    expect(mocks.useRenderedTranscriptData).toHaveBeenCalledWith(
+      "transcript-1",
+      true,
+    );
+    expect(mocks.useTranscript).toHaveBeenCalledTimes(1);
+    expect(mocks.useTranscript).toHaveBeenCalledWith("transcript-1");
+    expect(mocks.useTranscriptLabelContext).toHaveBeenCalledTimes(1);
+    expect(mocks.useTranscriptLabelContext).toHaveBeenCalledWith(
+      "transcript-1",
+    );
+  });
+
+  it("preserves persisted history when a recovered live preview only has the tail", () => {
+    const prefix = createSegment("persisted", 0);
+    const live = createSegment("live", 1);
+    mocks.useRenderedTranscriptData.mockReturnValue({
+      maxSpeakerNumber: undefined,
+      request: createRenderRequest([prefix, live]),
+      segments: [
+        {
+          ...prefix,
+          end_ms: live.end_ms,
+          text: `${prefix.text} ${live.text}`,
+          words: [...prefix.words, ...live.words],
+        },
+      ],
+    });
+
+    render(
+      <RenderTranscript
+        scrollElement={null}
+        isLastTranscript
+        shouldScrollToEnd={false}
+        transcriptId="transcript-1"
+        currentActive
+        liveSegments={[live]}
+        currentMs={0}
+        seek={vi.fn()}
+        startPlayback={vi.fn()}
+        audioExists
+      />,
+    );
+
+    expect(document.querySelectorAll("section")).toHaveLength(2);
+    expect(document.body.textContent).toContain("word-persisted");
+    expect(document.body.textContent).toContain("word-live");
+  });
+
+  it("switches back to the persisted renderer after capture stops", () => {
+    mocks.useRenderedTranscriptData.mockReturnValue({
+      maxSpeakerNumber: undefined,
+      request: createRenderRequest(createSegments(1)),
+      segments: createSegments(1),
+    });
+
+    render(
+      <RenderTranscript
+        scrollElement={null}
+        isLastTranscript
+        shouldScrollToEnd={false}
+        transcriptId="transcript-1"
+        currentActive={false}
+        liveSegments={[]}
+        currentMs={0}
+        seek={vi.fn()}
+        startPlayback={vi.fn()}
+        audioExists
+      />,
+    );
+
+    expect(mocks.useRenderedTranscriptData).toHaveBeenCalledWith(
+      "transcript-1",
+      false,
+    );
+    expect(document.querySelectorAll("section")).toHaveLength(1);
+  });
+
+  it("uses the volatile persisted fallback before live segments arrive", () => {
+    mocks.useRenderedTranscriptData.mockReturnValue({
+      maxSpeakerNumber: undefined,
+      request: createRenderRequest(createSegments(1)),
+      segments: createSegments(1),
+    });
+
+    render(
+      <RenderTranscript
+        scrollElement={null}
+        isLastTranscript
+        shouldScrollToEnd={false}
+        transcriptId="transcript-1"
+        currentActive
+        liveSegments={[]}
+        currentMs={0}
+        seek={vi.fn()}
+        startPlayback={vi.fn()}
+        audioExists
+      />,
+    );
+
+    expect(mocks.useRenderedTranscriptData).toHaveBeenCalledWith(
+      "transcript-1",
+      true,
+    );
+    expect(document.querySelectorAll("section")).toHaveLength(1);
+  });
+
+  it("applies current SQLite speaker assignments to visible live segments", () => {
+    const live = createSegment("live", 0);
+    const assignments: IdentityAssignment[] = [
+      {
+        human_id: "human-1",
+        scope: {
+          kind: "channel_speaker",
+          channel: "MixedCapture",
+          speaker_index: 0,
+        },
+      },
+    ];
+    mocks.useRenderedTranscriptData.mockReturnValue({
+      maxSpeakerNumber: undefined,
+      request: createRenderRequest([live], assignments),
+      segments: [],
+    });
+    mocks.useTranscriptLabelContext.mockReturnValue({
+      ...labelContext,
+      getHumanName: (humanId: string) =>
+        humanId === "human-1" ? "Ada" : undefined,
+    });
+
+    render(
+      <RenderTranscript
+        scrollElement={null}
+        isLastTranscript
+        shouldScrollToEnd={false}
+        transcriptId="transcript-1"
+        currentActive
+        liveSegments={[live]}
+        currentMs={0}
+        seek={vi.fn()}
+        startPlayback={vi.fn()}
+        audioExists
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Ada" })).toBeTruthy();
+  });
+});
+
+const labelContext: RenderLabelContext = {
+  getSelfHumanId: () => "self",
+  getHumanName: () => undefined,
+  getParticipantHumanIds: () => [],
+};
+
+function createSegments(count: number): Segment[] {
+  return Array.from({ length: count }, (_, index) =>
+    createSegment(String(index), index),
+  );
+}
+
+function createSegment(id: string, index: number): Segment {
+  return {
+    id: `segment-${id}`,
+    key: {
+      channel: "MixedCapture",
+      speaker_index: index % 2,
+      speaker_human_id: null,
+    },
+    start_ms: index * 100,
+    end_ms: index * 100 + 100,
+    text: `word ${index}`,
+    words: [
+      {
+        id: `word-${id}`,
+        text: `word-${id}`,
+        start_ms: index * 100,
+        end_ms: index * 100 + 100,
+        channel: "MixedCapture",
+        is_final: true,
+      },
+    ],
+  };
+}
+
+function createRenderRequest(
+  segments: Segment[],
+  assignments: IdentityAssignment[] = [],
+): RenderTranscriptRequest {
+  return {
+    humans: [],
+    participant_human_ids: [],
+    self_human_id: null,
+    transcripts: [
+      {
+        assignments,
+        started_at: null,
+        words: segments.flatMap((segment) =>
+          segment.words.flatMap((word) =>
+            word.id
+              ? [
+                  {
+                    id: word.id,
+                    text: word.text,
+                    start_ms: word.start_ms,
+                    end_ms: word.end_ms,
+                    channel: 2,
+                    speaker_index: segment.key.speaker_index,
+                  },
+                ]
+              : [],
+          ),
+        ),
+      },
+    ],
+  };
+}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
@@ -34,6 +34,7 @@ export function RenderTranscript({
   shouldScrollToEnd,
   transcriptId,
   currentActive,
+  captureGeneration = 0,
   liveSegments,
   currentMs,
   seek,
@@ -45,6 +46,7 @@ export function RenderTranscript({
   shouldScrollToEnd: boolean;
   transcriptId: string;
   currentActive: boolean;
+  captureGeneration?: number;
   liveSegments: Segment[];
   currentMs: number;
   seek: (sec: number) => void;
@@ -56,6 +58,7 @@ export function RenderTranscript({
       scrollElement={scrollElement}
       transcriptId={transcriptId}
       currentActive={currentActive}
+      captureGeneration={captureGeneration}
       liveSegments={liveSegments}
       shouldScrollToEnd={isLastTranscript && shouldScrollToEnd}
       currentMs={currentMs}
@@ -70,6 +73,7 @@ function PersistedTranscript({
   scrollElement,
   transcriptId,
   currentActive,
+  captureGeneration,
   liveSegments,
   shouldScrollToEnd,
   currentMs,
@@ -80,6 +84,7 @@ function PersistedTranscript({
   scrollElement: HTMLDivElement | null;
   transcriptId: string;
   currentActive: boolean;
+  captureGeneration: number;
   liveSegments: Segment[];
   shouldScrollToEnd: boolean;
   currentMs: number;
@@ -91,7 +96,7 @@ function PersistedTranscript({
     maxSpeakerNumber,
     request,
     segments: storedSegments,
-  } = useRenderedTranscriptData(transcriptId, currentActive);
+  } = useRenderedTranscriptData(transcriptId, currentActive, captureGeneration);
   const mergedSegments = useMemo(() => {
     const merged = mergeRenderedAndLiveSegments(
       storedSegments,

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
@@ -16,11 +16,15 @@ import {
 } from "./segment-hooks";
 
 import {
+  applyRenderRequestIdentitiesToSegments,
+  getMaxSpeakerNumberForParticipants,
   mergeRenderedAndLiveSegments,
+  SegmentKeyUtils,
+  type RenderLabelContext,
   type Segment,
   type SegmentWord,
 } from "~/stt/live-segment";
-import { useTranscriptLabelContext } from "~/stt/queries";
+import { useTranscript, useTranscriptLabelContext } from "~/stt/queries";
 import { SpeakerLabelManager } from "~/stt/segment/shared";
 import { isTranscriptWordSeekable } from "~/stt/timing";
 
@@ -29,6 +33,7 @@ export function RenderTranscript({
   isLastTranscript,
   shouldScrollToEnd,
   transcriptId,
+  currentActive,
   liveSegments,
   currentMs,
   seek,
@@ -39,20 +44,105 @@ export function RenderTranscript({
   isLastTranscript: boolean;
   shouldScrollToEnd: boolean;
   transcriptId: string;
+  currentActive: boolean;
   liveSegments: Segment[];
   currentMs: number;
   seek: (sec: number) => void;
   startPlayback: () => void;
   audioExists: boolean;
 }) {
-  const { maxSpeakerNumber, segments: storedSegments } =
-    useRenderedTranscriptData(transcriptId);
-  const mergedSegments = useMemo(
-    () => mergeRenderedAndLiveSegments(storedSegments, liveSegments),
-    [liveSegments, storedSegments],
+  return (
+    <PersistedTranscript
+      scrollElement={scrollElement}
+      transcriptId={transcriptId}
+      currentActive={currentActive}
+      liveSegments={liveSegments}
+      shouldScrollToEnd={isLastTranscript && shouldScrollToEnd}
+      currentMs={currentMs}
+      seek={seek}
+      startPlayback={startPlayback}
+      audioExists={audioExists}
+    />
   );
-  const segments = useStableSegments(mergedSegments);
+}
+
+function PersistedTranscript({
+  scrollElement,
+  transcriptId,
+  currentActive,
+  liveSegments,
+  shouldScrollToEnd,
+  currentMs,
+  seek,
+  startPlayback,
+  audioExists,
+}: {
+  scrollElement: HTMLDivElement | null;
+  transcriptId: string;
+  currentActive: boolean;
+  liveSegments: Segment[];
+  shouldScrollToEnd: boolean;
+  currentMs: number;
+  seek: (sec: number) => void;
+  startPlayback: () => void;
+  audioExists: boolean;
+}) {
+  const {
+    maxSpeakerNumber,
+    request,
+    segments: storedSegments,
+  } = useRenderedTranscriptData(transcriptId, currentActive);
+  const mergedSegments = useMemo(() => {
+    const merged = mergeRenderedAndLiveSegments(
+      storedSegments,
+      liveSegments,
+      currentActive ? request : null,
+    );
+    return currentActive
+      ? applyRenderRequestIdentitiesToSegments(merged, request)
+      : merged;
+  }, [currentActive, liveSegments, request, storedSegments]);
+
+  return (
+    <TranscriptSegments
+      segments={mergedSegments}
+      scrollElement={scrollElement}
+      transcriptId={transcriptId}
+      shouldScrollToEnd={shouldScrollToEnd}
+      currentMs={currentMs}
+      seek={seek}
+      startPlayback={startPlayback}
+      audioExists={audioExists}
+      maxSpeakerNumber={maxSpeakerNumber}
+    />
+  );
+}
+
+function TranscriptSegments({
+  segments: rawSegments,
+  scrollElement,
+  transcriptId,
+  shouldScrollToEnd,
+  currentMs,
+  seek,
+  startPlayback,
+  audioExists,
+  maxSpeakerNumber,
+}: {
+  segments: Segment[];
+  scrollElement: HTMLDivElement | null;
+  transcriptId: string;
+  shouldScrollToEnd: boolean;
+  currentMs: number;
+  seek: (sec: number) => void;
+  startPlayback: () => void;
+  audioExists: boolean;
+  maxSpeakerNumber?: number;
+}) {
+  const segments = useStableSegments(rawSegments);
   const offsetMs = useTranscriptOffset(transcriptId);
+  const transcript = useTranscript(transcriptId);
+  const labelContext = useTranscriptLabelContext(transcriptId);
 
   if (segments.length === 0) {
     return null;
@@ -63,8 +153,10 @@ export function RenderTranscript({
       segments={segments}
       scrollElement={scrollElement}
       transcriptId={transcriptId}
+      sessionId={transcript?.sessionId}
+      labelContext={labelContext}
       offsetMs={offsetMs}
-      shouldScrollToEnd={isLastTranscript && shouldScrollToEnd}
+      shouldScrollToEnd={shouldScrollToEnd}
       currentMs={currentMs}
       seek={seek}
       startPlayback={startPlayback}
@@ -79,6 +171,8 @@ const SegmentsList = memo(
     segments,
     scrollElement,
     transcriptId,
+    sessionId,
+    labelContext,
     offsetMs,
     shouldScrollToEnd,
     currentMs,
@@ -90,6 +184,8 @@ const SegmentsList = memo(
     segments: Segment[];
     scrollElement: HTMLDivElement | null;
     transcriptId: string;
+    sessionId?: string;
+    labelContext?: RenderLabelContext;
     offsetMs: number;
     shouldScrollToEnd: boolean;
     currentMs: number;
@@ -98,17 +194,38 @@ const SegmentsList = memo(
     audioExists: boolean;
     maxSpeakerNumber?: number;
   }) => {
-    const labelContext = useTranscriptLabelContext(transcriptId);
     const search = useSearch();
+    const inferredMaxSpeakerNumber = labelContext
+      ? getMaxSpeakerNumberForParticipants(
+          labelContext.getParticipantHumanIds?.() ?? [],
+          labelContext.getSelfHumanId(),
+        )
+      : undefined;
+    const resolvedMaxSpeakerNumber =
+      maxSpeakerNumber ?? inferredMaxSpeakerNumber;
     const speakerLabelManager = useMemo(() => {
       return labelContext
         ? SpeakerLabelManager.fromSegments(
             segments,
             labelContext,
-            maxSpeakerNumber,
+            resolvedMaxSpeakerNumber,
           )
-        : new SpeakerLabelManager();
-    }, [labelContext, maxSpeakerNumber, segments]);
+        : new SpeakerLabelManager(resolvedMaxSpeakerNumber);
+    }, [labelContext, resolvedMaxSpeakerNumber, segments]);
+    const speakerLabels = useMemo(() => {
+      const labels = new Map<Segment, string>();
+      for (const segment of segments) {
+        labels.set(
+          segment,
+          SegmentKeyUtils.renderLabel(
+            segment.key,
+            labelContext,
+            speakerLabelManager,
+          ),
+        );
+      }
+      return labels;
+    }, [labelContext, segments, speakerLabelManager]);
     const transcriptSearch = useMemo<TranscriptSearchRenderState>(() => {
       const query = search?.query.trim() ?? "";
       if (!search?.isVisible || !query) {
@@ -163,7 +280,11 @@ const SegmentsList = memo(
               segment={segment}
               offsetMs={offsetMs}
               transcriptId={transcriptId}
-              speakerLabelManager={speakerLabelManager}
+              sessionId={sessionId}
+              speakerLabel={
+                speakerLabels.get(segment) ??
+                SegmentKeyUtils.renderLabel(segment.key)
+              }
               currentMs={currentMs}
               seekAndPlay={seekAndPlay}
               audioExists={audioExists}
@@ -177,6 +298,8 @@ const SegmentsList = memo(
   (prevProps, nextProps) => {
     return (
       prevProps.transcriptId === nextProps.transcriptId &&
+      prevProps.sessionId === nextProps.sessionId &&
+      prevProps.labelContext === nextProps.labelContext &&
       prevProps.scrollElement === nextProps.scrollElement &&
       prevProps.offsetMs === nextProps.offsetMs &&
       prevProps.shouldScrollToEnd === nextProps.shouldScrollToEnd &&

--- a/apps/desktop/src/session/components/note-input/transcript/state.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/state.ts
@@ -35,6 +35,7 @@ export type TranscriptScreen =
       transcriptIds: string[];
       liveSegments: Segment[];
       currentActive: boolean;
+      captureGeneration: number;
     };
 
 export function useTranscriptScreen({
@@ -96,6 +97,7 @@ export function useTranscriptScreen({
     transcriptIds,
     liveSegments,
     currentActive,
+    captureGeneration: live.captureGenerationBySession[sessionId] ?? 0,
   };
 }
 

--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -24,10 +24,12 @@ import {
   type GeneralState,
   type LiveIntervalId,
   markLiveActive,
+  markLiveCaptureStarted,
   markLiveFinalizing,
   markLiveInactive,
   markLiveStartFailed,
   noteLiveTranscriptActivity,
+  releaseLiveCaptureGeneration,
   setLiveState,
   tickTranscriptionStallWatchdog,
   updateLiveAmplitude,
@@ -208,6 +210,7 @@ const createSessionEventHandlers = <T extends LiveStore>(
     setLiveState(set, (live) => {
       delete live.eventUnlistenersBySession[targetSessionId];
       delete live.finalizingBySession[targetSessionId];
+      releaseLiveCaptureGeneration(live, targetSessionId);
       if (onStopped) {
         live.postStopProcessingBySession[targetSessionId] = true;
       }
@@ -393,9 +396,7 @@ export const startLiveSession = <T extends LiveStore>(
     yield* startSessionEffect(params);
 
     setLiveState(set, (live) => {
-      live.status = "active";
-      live.loading = false;
-      live.sessionId = targetSessionId;
+      markLiveCaptureStarted(live, targetSessionId);
     });
   });
 
@@ -494,8 +495,7 @@ export const attachLiveSession = <T extends LiveStore>(
         const isAttached =
           (snapshot.state === "active" &&
             snapshot.activeSessionId === targetSessionId) ||
-          (snapshot.state === "finalizing" &&
-            snapshot.finalizingSessionIds.includes(targetSessionId));
+          snapshot.finalizingSessionIds.includes(targetSessionId);
         if (!isAttached) {
           clearAttachedCallbacks();
         }
@@ -557,8 +557,7 @@ export const attachLiveSession = <T extends LiveStore>(
     const isAttached =
       (snapshot.state === "active" &&
         snapshot.activeSessionId === targetSessionId) ||
-      (snapshot.state === "finalizing" &&
-        snapshot.finalizingSessionIds.includes(targetSessionId));
+      snapshot.finalizingSessionIds.includes(targetSessionId);
     if (!isAttached) {
       clearAttachedCallbacks();
     }
@@ -629,10 +628,7 @@ function applyCaptureSnapshot<T extends GeneralState>(
     return;
   }
 
-  if (
-    snapshot.state === "finalizing" &&
-    snapshot.finalizingSessionIds.includes(targetSessionId)
-  ) {
+  if (snapshot.finalizingSessionIds.includes(targetSessionId)) {
     setLiveState(set, (live) => {
       if (!live.sessionId) {
         live.sessionId = targetSessionId;
@@ -644,6 +640,9 @@ function applyCaptureSnapshot<T extends GeneralState>(
 
   setLiveState(set, (live) => {
     if (live.sessionId === targetSessionId && live.status === "inactive") {
+      if (!live.loading) {
+        releaseLiveCaptureGeneration(live, targetSessionId);
+      }
       live.loading = false;
       live.sessionId = null;
     }

--- a/apps/desktop/src/store/zustand/listener/general-shared.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general-shared.test.ts
@@ -3,24 +3,67 @@ import { describe, expect, it } from "vitest";
 import {
   type GeneralState,
   initialGeneralState,
+  markLiveCaptureStarted,
+  markLiveFinalizing,
+  markLiveStartRequested,
   noteLiveTranscriptActivity,
+  releaseLiveCaptureGeneration,
   TRANSCRIPTION_FINAL_STALL_AUDIBLE_SECONDS,
   TRANSCRIPTION_STALL_AUDIBLE_SECONDS,
   tickTranscriptionStallWatchdog,
 } from "./general-shared";
 
-function createActiveLive(): GeneralState["live"] {
+function createLive(): GeneralState["live"] {
   return {
     ...initialGeneralState.live,
+    captureGenerationBySession: {},
+    finalizingBySession: {},
+    eventUnlistenersBySession: {},
+  };
+}
+
+function createActiveLive(): GeneralState["live"] {
+  return {
+    ...createLive(),
     status: "active",
     sessionId: "session-1",
     requestedLiveTranscription: true,
     liveTranscriptionActive: true,
     amplitude: { mic: 0.4, speaker: 0.4 },
-    finalizingBySession: {},
-    eventUnlistenersBySession: {},
   };
 }
+
+describe("markLiveCaptureStarted", () => {
+  it("keeps one generation per capture across lifecycle observations", () => {
+    const live = createLive();
+
+    markLiveStartRequested(live, "session-1");
+    expect(live.captureGenerationBySession["session-1"]).toBe(1);
+    markLiveCaptureStarted(live, "session-1");
+    expect(live.captureGenerationBySession["session-1"]).toBe(1);
+    markLiveCaptureStarted(live, "session-1");
+    markLiveFinalizing(live, "session-1");
+    expect(live.captureGenerationBySession["session-1"]).toBe(1);
+
+    releaseLiveCaptureGeneration(live, "session-1");
+    markLiveStartRequested(live, "session-1");
+    expect(live.captureGenerationBySession["session-1"]).toBe(2);
+  });
+
+  it("keeps a finalizing session stable while another capture starts", () => {
+    const live = createLive();
+
+    markLiveStartRequested(live, "session-a");
+    markLiveCaptureStarted(live, "session-a");
+    markLiveFinalizing(live, "session-a");
+    markLiveStartRequested(live, "session-b");
+
+    expect(live.captureGenerationBySession).toEqual({
+      "session-a": 1,
+      "session-b": 2,
+    });
+  });
+});
 
 describe("tickTranscriptionStallWatchdog", () => {
   it("flags a stalled live transcription after sustained audible silence", () => {

--- a/apps/desktop/src/store/zustand/listener/general-shared.ts
+++ b/apps/desktop/src/store/zustand/listener/general-shared.ts
@@ -38,6 +38,8 @@ export type GeneralState = {
     status: LiveSessionStatus;
     amplitude: { mic: number; speaker: number };
     seconds: number;
+    captureGenerationCounter: number;
+    captureGenerationBySession: Record<string, number>;
     intervalId?: LiveIntervalId;
     sessionId: string | null;
     muted: boolean;
@@ -68,6 +70,8 @@ const initialLiveState: LiveState = {
   loadingPhase: "idle",
   amplitude: { mic: 0, speaker: 0 },
   seconds: 0,
+  captureGenerationCounter: 0,
+  captureGenerationBySession: {},
   sessionId: null,
   muted: false,
   lastError: null,
@@ -141,7 +145,29 @@ export const setLiveState = <T extends GeneralState>(
   );
 };
 
+const ensureLiveCaptureGeneration = (live: LiveState, sessionId: string) => {
+  if (live.captureGenerationBySession[sessionId] === undefined) {
+    live.captureGenerationCounter += 1;
+    live.captureGenerationBySession[sessionId] = live.captureGenerationCounter;
+  }
+};
+
+export const releaseLiveCaptureGeneration = (
+  live: LiveState,
+  sessionId: string,
+) => {
+  delete live.captureGenerationBySession[sessionId];
+};
+
+export const markLiveCaptureStarted = (live: LiveState, sessionId: string) => {
+  ensureLiveCaptureGeneration(live, sessionId);
+  live.status = "active";
+  live.loading = false;
+  live.sessionId = sessionId;
+};
+
 export const markLiveStartRequested = (live: LiveState, sessionId: string) => {
+  ensureLiveCaptureGeneration(live, sessionId);
   live.loading = true;
   live.status = "inactive";
   live.sessionId = sessionId;
@@ -162,12 +188,10 @@ export const markLiveActive = (
   liveTranscriptionActive: boolean,
   degraded: DegradedError | null,
 ) => {
-  live.status = "active";
-  live.loading = false;
+  markLiveCaptureStarted(live, sessionId);
   live.loadingPhase = "idle";
   live.seconds = 0;
   live.intervalId = intervalId;
-  live.sessionId = sessionId;
   live.degraded = degraded;
   live.requestedLiveTranscription = requestedLiveTranscription;
   live.liveTranscriptionActive = liveTranscriptionActive;
@@ -187,6 +211,7 @@ export const markLiveFinalizing = (live: LiveState, sessionId: string) => {
     live.sessionId === sessionId
       ? live.needsBatchRepair
       : (existing?.needsBatchRepair ?? false);
+  ensureLiveCaptureGeneration(live, sessionId);
   if (live.sessionId === sessionId) {
     live.status = "finalizing";
     live.loading = true;
@@ -219,6 +244,9 @@ export const markLiveInactive = (live: LiveState, error: string | null) => {
 };
 
 export const markLiveStartFailed = (live: LiveState) => {
+  if (live.sessionId) {
+    releaseLiveCaptureGeneration(live, live.sessionId);
+  }
   live.intervalId = undefined;
   live.loading = false;
   live.loadingPhase = "idle";

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -699,9 +699,69 @@ describe("General Listener Slice", () => {
       expect(store.getState().getSessionMode("session-a")).toBe("active");
       expect(store.getState().live.sessionId).toBe("session-a");
       expect(store.getState().live.liveTranscriptionActive).toBe(true);
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(1);
       expect(listenCaptureLifecycleMock).toHaveBeenCalledTimes(1);
       expect(listenCaptureStatusMock).toHaveBeenCalledTimes(1);
       expect(listenCaptureDataMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("attached windows advance once for each observed native capture", async () => {
+      let lifecycleHandler:
+        | ((event: { payload: Record<string, unknown> }) => void)
+        | undefined;
+      listenCaptureLifecycleMock.mockImplementation((handler) => {
+        lifecycleHandler = handler;
+        return Promise.resolve(() => {});
+      });
+
+      await store.getState().attachLiveSession("session-a");
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBeUndefined();
+
+      const started = {
+        type: "started",
+        session_id: "session-a",
+        requested_live_transcription: true,
+        live_transcription_active: true,
+        degraded: null,
+      };
+      const stopped = {
+        type: "stopped",
+        session_id: "session-a",
+        audio_path: "/tmp/session.wav",
+        requested_live_transcription: true,
+        live_transcription_active: true,
+        error: null,
+      };
+
+      lifecycleHandler?.({ payload: started });
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(1);
+      lifecycleHandler?.({ payload: started });
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(1);
+      lifecycleHandler?.({
+        payload: { type: "finalizing", session_id: "session-a" },
+      });
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(1);
+      lifecycleHandler?.({ payload: stopped });
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBeUndefined();
+
+      await store.getState().attachLiveSession("session-a");
+      lifecycleHandler?.({ payload: started });
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(2);
+      lifecycleHandler?.({ payload: stopped });
     });
 
     test("attachLiveSession restores transcript and stop callbacks for an active native capture", async () => {
@@ -1196,6 +1256,37 @@ describe("General Listener Slice", () => {
       expect(store.getState().live.sessionId).toBeNull();
     });
 
+    test("attachLiveSession keeps a finalizing target attached while another capture is active", async () => {
+      const handlePersist = vi.fn();
+      const onStopped = vi.fn();
+      getCaptureSnapshotMock.mockResolvedValueOnce({
+        status: "ok",
+        data: {
+          activeSessionId: "session-b",
+          finalizingSessionIds: ["session-a"],
+          liveTranscriptionActive: true,
+          requestedLiveTranscription: true,
+          state: "active",
+        },
+      });
+
+      await expect(
+        store.getState().attachLiveSession("session-a", {
+          handlePersist,
+          onStopped,
+        }),
+      ).resolves.toBe("attached");
+
+      expect(store.getState().getSessionMode("session-a")).toBe("finalizing");
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(1);
+      expect(store.getState().handlePersistBySession["session-a"]).toBe(
+        handlePersist,
+      );
+      expect(store.getState().onStoppedBySession["session-a"]).toBe(onStopped);
+    });
+
     test("attachLiveSession hydrates finalizing native capture for the same session", async () => {
       let dataHandler:
         | ((event: {
@@ -1225,6 +1316,9 @@ describe("General Listener Slice", () => {
 
       expect(store.getState().live.sessionId).toBe("session-a");
       expect(store.getState().getSessionMode("session-a")).toBe("finalizing");
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(1);
 
       dataHandler?.({
         payload: {
@@ -1372,6 +1466,129 @@ describe("General Listener Slice", () => {
       await expect(start).resolves.toBe(true);
       await queued;
       expect(nextOperation).toHaveBeenCalledOnce();
+    });
+
+    test("releases a failed start generation before retrying", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const params = {
+        session_id: "session-a",
+        languages: [],
+        onboarding: false,
+        model: "test-model",
+        base_url: "http://localhost",
+        api_key: "test-key",
+        keywords: [],
+      };
+      startCaptureMock.mockResolvedValueOnce({
+        status: "error",
+        error: "capture unavailable",
+      });
+
+      await expect(store.getState().start(params)).resolves.toBe(false);
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBeUndefined();
+      expect(store.getState().live.captureGenerationCounter).toBe(1);
+
+      await expect(store.getState().start(params)).resolves.toBe(true);
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(2);
+      consoleError.mockRestore();
+    });
+
+    test("keeps the capture generation when stop command delivery fails", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const intervalId = setInterval(() => {}, 1000);
+      store.setState((state) =>
+        mutate(state, (draft) => {
+          markLiveActive(draft.live, "session-a", intervalId, true, true, null);
+        }),
+      );
+      stopCaptureMock.mockResolvedValueOnce({
+        status: "error",
+        error: "stop unavailable",
+      });
+
+      store.getState().stop();
+
+      await vi.waitFor(() =>
+        expect(store.getState().live.status).toBe("active"),
+      );
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(1);
+      clearInterval(store.getState().live.intervalId);
+      consoleError.mockRestore();
+    });
+
+    test("deduplicates capture generation across native start event ordering", async () => {
+      let lifecycleHandler:
+        | ((event: { payload: Record<string, unknown> }) => void)
+        | undefined;
+      let resolveStart:
+        | ((value: { status: "ok"; data: null }) => void)
+        | undefined;
+      listenCaptureLifecycleMock.mockImplementation((handler) => {
+        lifecycleHandler = handler;
+        return Promise.resolve(() => {});
+      });
+      startCaptureMock.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveStart = resolve;
+        }),
+      );
+      const params = {
+        session_id: "session-a",
+        languages: [],
+        onboarding: false,
+        model: "test-model",
+        base_url: "http://localhost",
+        api_key: "test-key",
+        keywords: [],
+      };
+      const started = {
+        type: "started",
+        session_id: "session-a",
+        requested_live_transcription: true,
+        live_transcription_active: true,
+        degraded: null,
+      };
+      const stopped = {
+        type: "stopped",
+        session_id: "session-a",
+        audio_path: "/tmp/session.wav",
+        requested_live_transcription: true,
+        live_transcription_active: true,
+        error: null,
+      };
+
+      const firstStart = store.getState().start(params);
+      await vi.waitFor(() => expect(startCaptureMock).toHaveBeenCalledOnce());
+      lifecycleHandler?.({ payload: started });
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(1);
+      resolveStart?.({ status: "ok", data: null });
+      await expect(firstStart).resolves.toBe(true);
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(1);
+      lifecycleHandler?.({ payload: stopped });
+
+      await expect(store.getState().start(params)).resolves.toBe(true);
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(2);
+      lifecycleHandler?.({ payload: started });
+      expect(
+        store.getState().live.captureGenerationBySession["session-a"],
+      ).toBe(2);
+      lifecycleHandler?.({ payload: stopped });
     });
 
     test("getSessionMode returns finalizing for non-active finalizing sessions", () => {

--- a/apps/desktop/src/stt/live-segment.test.ts
+++ b/apps/desktop/src/stt/live-segment.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  IdentityAssignment,
+  RenderTranscriptRequest,
+} from "@hypr/plugin-transcription";
 
 import {
+  applyRenderRequestIdentitiesToSegments,
   getMaxSpeakerNumberForParticipants,
+  mergeRenderedAndLiveSegments,
   SegmentKeyUtils,
   SpeakerLabelManager,
   type RenderLabelContext,
@@ -89,3 +96,295 @@ describe("SegmentKeyUtils", () => {
     expect(getMaxSpeakerNumberForParticipants([], "self")).toBeUndefined();
   });
 });
+
+describe("mergeRenderedAndLiveSegments", () => {
+  it("preserves persisted words that share a segment with the live tail", () => {
+    const persisted = createSegment("persisted", [
+      { id: "word-prefix", startMs: 0 },
+      { id: "word-tail", startMs: 100 },
+    ]);
+    const live = createSegment("live", [{ id: "word-tail", startMs: 100 }]);
+
+    const merged = mergeRenderedAndLiveSegments([persisted], [live]);
+
+    expect(
+      merged.flatMap((segment) => segment.words.map((word) => word.id)),
+    ).toEqual(["word-prefix", "word-tail"]);
+  });
+
+  it("keeps split persisted fragments in timestamp order", () => {
+    const persisted = createSegment("persisted", [
+      { id: "word-before", startMs: 0 },
+      { id: "word-live", startMs: 100 },
+      { id: "word-after", startMs: 200 },
+    ]);
+    const live = createSegment("live", [{ id: "word-live", startMs: 100 }]);
+
+    const merged = mergeRenderedAndLiveSegments([persisted], [live]);
+
+    expect(merged.map((segment) => segment.words[0]?.id)).toEqual([
+      "word-before",
+      "word-live",
+      "word-after",
+    ]);
+  });
+
+  it("preserves the persisted prefix beside an id-less live partial", () => {
+    const persisted = createSegment("persisted", [
+      { id: "word-prefix", startMs: 0 },
+    ]);
+    const live = createSegment("live", [{ startMs: 100 }]);
+
+    const merged = mergeRenderedAndLiveSegments([persisted], [live]);
+
+    expect(merged).toEqual([persisted, live]);
+  });
+
+  it("replaces a frozen word before its new id reaches SQLite", () => {
+    const persisted = createSegment("persisted", [
+      { id: "word-old", startMs: 100 },
+    ]);
+    const live = createSegment("live", [
+      { id: "word-replacement", startMs: 100 },
+    ]);
+    const request = createRequest(["word-old"]);
+
+    const merged = mergeRenderedAndLiveSegments([persisted], [live], request);
+
+    expect(
+      merged.flatMap((segment) => segment.words.map((word) => word.id)),
+    ).toEqual(["word-replacement"]);
+  });
+
+  it("removes frozen words that SQLite has already replaced", () => {
+    const persisted = createSegment("persisted", [
+      { id: "word-old", startMs: 100 },
+    ]);
+    const live = createSegment("live", [
+      { id: "word-replacement", startMs: 100 },
+    ]);
+    const request = createRequest(["word-replacement"]);
+
+    const merged = mergeRenderedAndLiveSegments([persisted], [live], request);
+
+    expect(
+      merged.flatMap((segment) => segment.words.map((word) => word.id)),
+    ).toEqual(["word-replacement"]);
+  });
+
+  it("indexes pending replacements instead of scanning the full live tail", () => {
+    const persisted = createSegment(
+      "persisted",
+      Array.from({ length: 1_000 }, (_, index) => ({
+        id: `persisted-${index}`,
+        startMs: index * 100,
+      })),
+    );
+    const live = createSegment(
+      "live",
+      Array.from({ length: 1_000 }, (_, index) => ({
+        id: `live-${index}`,
+        startMs: 100_000 + index * 100,
+      })),
+    );
+    const request = createRequest(
+      [...persisted.words, ...live.words].flatMap((word) =>
+        word.id ? [word.id] : [],
+      ),
+    );
+    const hasSpy = vi.spyOn(Set.prototype, "has");
+
+    try {
+      mergeRenderedAndLiveSegments([persisted], [live], request);
+      expect(hasSpy.mock.calls.length).toBeLessThan(10_000);
+    } finally {
+      hasSpy.mockRestore();
+    }
+  });
+});
+
+describe("applyRenderRequestIdentitiesToSegments", () => {
+  it("applies a speaker assignment to current and future matching segments", () => {
+    const current = createSegment("current", [
+      { id: "word-current", startMs: 0 },
+    ]);
+    const future = createSegment("future", [
+      { id: "word-future", startMs: 100 },
+    ]);
+    const other = createSegment("other", [{ id: "word-other", startMs: 200 }]);
+    current.key.speaker_index = 1;
+    future.key.speaker_index = 1;
+    other.key.speaker_index = 2;
+    const request = createRequest(
+      ["word-current", "word-future", "word-other"],
+      [
+        {
+          human_id: "human-1",
+          scope: {
+            kind: "channel_speaker",
+            channel: "MixedCapture",
+            speaker_index: 1,
+          },
+        },
+      ],
+    );
+
+    const result = applyRenderRequestIdentitiesToSegments(
+      [current, future, other],
+      request,
+    );
+
+    expect(result.map((segment) => segment.key.speaker_human_id)).toEqual([
+      "human-1",
+      "human-1",
+      null,
+    ]);
+  });
+
+  it("splits word-scoped assignments and carries them into a trailing partial", () => {
+    const segment = createSegment("live", [
+      { id: "word-before", startMs: 0 },
+      { id: "word-assigned", startMs: 100 },
+      { startMs: 200 },
+    ]);
+    segment.key.speaker_index = 1;
+    const request = createRequest(
+      ["word-before", "word-assigned"],
+      [
+        {
+          human_id: "speaker-human",
+          scope: {
+            kind: "channel_speaker",
+            channel: "MixedCapture",
+            speaker_index: 1,
+          },
+        },
+        {
+          human_id: "word-human",
+          scope: { kind: "words", word_ids: ["word-assigned"] },
+        },
+      ],
+    );
+
+    const result = applyRenderRequestIdentitiesToSegments([segment], request);
+
+    expect(result).toHaveLength(2);
+    expect(
+      result.map((current) => ({
+        humanId: current.key.speaker_human_id,
+        wordIds: current.words.map((word) => word.id),
+      })),
+    ).toEqual([
+      { humanId: "speaker-human", wordIds: ["word-before"] },
+      {
+        humanId: "word-human",
+        wordIds: ["word-assigned", undefined],
+      },
+    ]);
+  });
+
+  it("gives word assignments precedence over channel speaker assignments", () => {
+    const segment = createSegment("live", [
+      { id: "word-a", startMs: 0 },
+      { id: "word-b", startMs: 100 },
+    ]);
+    segment.key.speaker_index = 1;
+    const request = createRequest(
+      ["word-a", "word-b"],
+      [
+        {
+          human_id: "speaker-human",
+          scope: {
+            kind: "channel_speaker",
+            channel: "MixedCapture",
+            speaker_index: 1,
+          },
+        },
+        {
+          human_id: "word-human",
+          scope: { kind: "words", word_ids: ["word-b"] },
+        },
+      ],
+    );
+
+    const result = applyRenderRequestIdentitiesToSegments([segment], request);
+
+    expect(result.map((current) => current.key.speaker_human_id)).toEqual([
+      "speaker-human",
+      "word-human",
+    ]);
+  });
+
+  it("keeps participant identity ahead of complete-channel assignments", () => {
+    const segment = createSegment("live", [{ id: "word-a", startMs: 0 }]);
+    segment.key = {
+      channel: "DirectMic",
+      speaker_index: null,
+      speaker_human_id: "self",
+    };
+    const request = createRequest(
+      ["word-a"],
+      [
+        {
+          human_id: "other-human",
+          scope: { kind: "channel", channel: "DirectMic" },
+        },
+      ],
+    );
+    request.self_human_id = "self";
+
+    const result = applyRenderRequestIdentitiesToSegments([segment], request);
+
+    expect(result[0]?.key.speaker_human_id).toBe("self");
+  });
+});
+
+function createSegment(
+  id: string,
+  words: Array<{ id?: string; startMs: number }>,
+): Segment {
+  return {
+    id,
+    key: {
+      channel: "MixedCapture",
+      speaker_index: null,
+      speaker_human_id: null,
+    },
+    start_ms: words[0]?.startMs ?? 0,
+    end_ms: (words[words.length - 1]?.startMs ?? 0) + 100,
+    text: words.map((word) => ` word-${word.id ?? "partial"}`).join(""),
+    words: words.map((word) => ({
+      id: word.id,
+      text: ` word-${word.id ?? "partial"}`,
+      start_ms: word.startMs,
+      end_ms: word.startMs + 100,
+      channel: "MixedCapture",
+      is_final: Boolean(word.id),
+    })),
+  };
+}
+
+function createRequest(
+  wordIds: string[],
+  assignments: IdentityAssignment[] = [],
+): RenderTranscriptRequest {
+  return {
+    humans: [],
+    participant_human_ids: [],
+    self_human_id: null,
+    transcripts: [
+      {
+        assignments,
+        started_at: null,
+        words: wordIds.map((id, index) => ({
+          id,
+          text: id,
+          start_ms: index * 100,
+          end_ms: index * 100 + 100,
+          channel: 2,
+          speaker_index: null,
+        })),
+      },
+    ],
+  };
+}

--- a/apps/desktop/src/stt/live-segment.ts
+++ b/apps/desktop/src/stt/live-segment.ts
@@ -1,6 +1,7 @@
 import type {
   ChannelProfile as BoundChannelProfile,
   LiveTranscriptSegment,
+  RenderTranscriptRequest,
   RenderedTranscriptSegment,
   SegmentKey as BoundSegmentKey,
   SegmentWord as BoundSegmentWord,
@@ -58,6 +59,8 @@ export type Segment =
   | SegmentWithWordMetadata<LiveTranscriptSegment>
   | SegmentWithWordMetadata<RenderedTranscriptSegment>;
 export type SegmentChannelProfile = BoundChannelProfile;
+
+const REPLACEMENT_TIME_BUCKET_MS = 1_000;
 
 export class SpeakerLabelManager {
   private unknownSpeakerMap: Map<string, number> = new Map();
@@ -199,15 +202,8 @@ export function getMaxSpeakerNumberForParticipants(
 export function mergeRenderedAndLiveSegments(
   renderedSegments: Segment[],
   liveSegments: Segment[],
+  currentRequest?: RenderTranscriptRequest | null,
 ): Segment[] {
-  if (liveSegments.length === 0) {
-    return renderedSegments;
-  }
-
-  if (renderedSegments.length === 0) {
-    return liveSegments;
-  }
-
   const liveSegmentIds = new Set(
     liveSegments
       .map((segment) => segment.id)
@@ -220,13 +216,288 @@ export function mergeRenderedAndLiveSegments(
         .filter((id): id is string => typeof id === "string" && id.length > 0),
     ),
   );
-  const renderedOnlySegments = renderedSegments.filter((segment) => {
+  const currentWordIds = currentRequest
+    ? new Set(
+        currentRequest.transcripts.flatMap((transcript) =>
+          transcript.words.map((word) => word.id),
+        ),
+      )
+    : null;
+  const pendingReplacementIndex = indexPendingLiveReplacements(
+    liveSegments,
+    currentWordIds,
+  );
+  const renderedOnlySegments = renderedSegments.flatMap((segment) => {
     if (segment.id && liveSegmentIds.has(segment.id)) {
-      return false;
+      return [];
     }
 
-    return !segment.words.some((word) => word.id && liveWordIds.has(word.id));
+    return filterSegmentWords(
+      segment,
+      (word) =>
+        !(
+          (word.id && liveWordIds.has(word.id)) ||
+          (word.id && currentWordIds && !currentWordIds.has(word.id)) ||
+          isPendingLiveReplacement(segment.key, word, pendingReplacementIndex)
+        ),
+      "persisted",
+    );
   });
 
-  return [...renderedOnlySegments, ...liveSegments];
+  return [...renderedOnlySegments, ...liveSegments].sort(
+    (a, b) => a.start_ms - b.start_ms || a.end_ms - b.end_ms,
+  );
+}
+
+export function applyRenderRequestIdentitiesToSegments(
+  segments: Segment[],
+  request?: RenderTranscriptRequest | null,
+): Segment[] {
+  if (!request || segments.length === 0) {
+    return segments;
+  }
+
+  const assignments = request.transcripts.flatMap(
+    (transcript) => transcript.assignments,
+  );
+  if (assignments.length === 0) {
+    return segments;
+  }
+
+  const completeChannels = getCompleteChannels(request);
+  const assignmentsByWordId = new Map<string, string>();
+  const assignmentsByChannel = new Map<SegmentChannelProfile, string>();
+  const assignmentsByChannelSpeaker = new Map<string, string>();
+
+  for (const assignment of assignments) {
+    if (!assignment.human_id) {
+      continue;
+    }
+
+    if (assignment.scope.kind === "words") {
+      for (const wordId of assignment.scope.word_ids) {
+        assignmentsByWordId.set(wordId, assignment.human_id);
+      }
+    } else if (assignment.scope.kind === "channel_speaker") {
+      assignmentsByChannelSpeaker.set(
+        channelSpeakerKey(
+          assignment.scope.channel,
+          assignment.scope.speaker_index,
+        ),
+        assignment.human_id,
+      );
+    } else if (completeChannels.has(assignment.scope.channel)) {
+      assignmentsByChannel.set(assignment.scope.channel, assignment.human_id);
+    }
+  }
+
+  return segments.flatMap((segment) => {
+    const scopedHumanId =
+      (typeof segment.key.speaker_index === "number"
+        ? assignmentsByChannelSpeaker.get(
+            channelSpeakerKey(segment.key.channel, segment.key.speaker_index),
+          )
+        : undefined) ??
+      segment.key.speaker_human_id ??
+      assignmentsByChannel.get(segment.key.channel) ??
+      null;
+    const runs: Array<{ humanId: string | null; words: SegmentWord[] }> = [];
+    let previousHumanId = scopedHumanId;
+
+    for (const word of segment.words) {
+      let humanId =
+        (word.id ? assignmentsByWordId.get(word.id) : undefined) ??
+        scopedHumanId;
+      if (!word.id && !word.is_final) {
+        humanId = previousHumanId;
+      }
+
+      const run = runs[runs.length - 1];
+      if (run?.humanId === humanId) {
+        run.words.push(word);
+      } else {
+        runs.push({ humanId, words: [word] });
+      }
+      previousHumanId = humanId;
+    }
+
+    if (runs.length === 0) {
+      return [segment];
+    }
+
+    if (runs.length === 1) {
+      const humanId = runs[0]!.humanId;
+      if ((segment.key.speaker_human_id ?? null) === humanId) {
+        return [segment];
+      }
+
+      return [
+        {
+          ...segment,
+          key: { ...segment.key, speaker_human_id: humanId },
+        },
+      ];
+    }
+
+    return runs.map(({ humanId, words }) => ({
+      ...createSegmentFragment(
+        segment,
+        words,
+        `identity:${humanId ?? "unassigned"}`,
+      ),
+      key: { ...segment.key, speaker_human_id: humanId },
+    }));
+  });
+}
+
+function getCompleteChannels(
+  request: RenderTranscriptRequest,
+): Set<SegmentChannelProfile> {
+  const participantHumanIds = new Set(
+    request.participant_human_ids.filter(Boolean),
+  );
+  if (request.self_human_id) {
+    participantHumanIds.add(request.self_human_id);
+  }
+
+  return new Set([
+    "DirectMic",
+    ...(participantHumanIds.size === 2 ? (["RemoteParty"] as const) : []),
+  ]);
+}
+
+function channelSpeakerKey(
+  channel: SegmentChannelProfile,
+  speakerIndex: number,
+): string {
+  return `${channel}:${speakerIndex}`;
+}
+
+function isPendingLiveReplacement(
+  renderedKey: SegmentKey,
+  renderedWord: SegmentWord,
+  pendingReplacementIndex: Map<string, SegmentWord[]>,
+): boolean {
+  if (!renderedWord.id || renderedWord.end_ms <= renderedWord.start_ms) {
+    return false;
+  }
+
+  const [startBucket, endBucket] = getReplacementBucketRange(renderedWord);
+  for (let bucket = startBucket; bucket <= endBucket; bucket += 1) {
+    const candidates = pendingReplacementIndex.get(
+      replacementBucketKey(renderedKey, bucket),
+    );
+    if (
+      candidates?.some((word) => {
+        const overlap =
+          Math.min(renderedWord.end_ms, word.end_ms) -
+          Math.max(renderedWord.start_ms, word.start_ms);
+        const shorterDuration = Math.min(
+          renderedWord.end_ms - renderedWord.start_ms,
+          word.end_ms - word.start_ms,
+        );
+        return overlap > 0 && overlap / shorterDuration >= 0.8;
+      })
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function indexPendingLiveReplacements(
+  liveSegments: Segment[],
+  currentWordIds: Set<string> | null,
+): Map<string, SegmentWord[]> {
+  const index = new Map<string, SegmentWord[]>();
+  if (!currentWordIds) {
+    return index;
+  }
+
+  for (const segment of liveSegments) {
+    for (const word of segment.words) {
+      if (!word.id || currentWordIds.has(word.id)) {
+        continue;
+      }
+
+      const [startBucket, endBucket] = getReplacementBucketRange(word);
+      for (let bucket = startBucket; bucket <= endBucket; bucket += 1) {
+        const key = replacementBucketKey(segment.key, bucket);
+        const words = index.get(key);
+        if (words) {
+          words.push(word);
+        } else {
+          index.set(key, [word]);
+        }
+      }
+    }
+  }
+
+  return index;
+}
+
+function getReplacementBucketRange(
+  word: SegmentWord,
+): [start: number, end: number] {
+  const start = Math.floor(word.start_ms / REPLACEMENT_TIME_BUCKET_MS);
+  const inclusiveEnd = Math.max(word.start_ms, word.end_ms - 1);
+  return [start, Math.floor(inclusiveEnd / REPLACEMENT_TIME_BUCKET_MS)];
+}
+
+function replacementBucketKey(key: SegmentKey, bucket: number): string {
+  return `${key.channel}:${key.speaker_index ?? "none"}:${bucket}`;
+}
+
+function filterSegmentWords(
+  segment: Segment,
+  keepWord: (word: SegmentWord) => boolean,
+  fragmentKind: string,
+): Segment[] {
+  if (segment.words.every(keepWord)) {
+    return [segment];
+  }
+
+  const fragments: Segment[] = [];
+  let words: SegmentWord[] = [];
+  const flushFragment = () => {
+    if (words.length > 0) {
+      fragments.push(createSegmentFragment(segment, words, fragmentKind));
+      words = [];
+    }
+  };
+
+  for (const word of segment.words) {
+    if (keepWord(word)) {
+      words.push(word);
+    } else {
+      flushFragment();
+    }
+  }
+  flushFragment();
+  return fragments;
+}
+
+function createSegmentFragment(
+  segment: Segment,
+  words: SegmentWord[],
+  fragmentKind: string,
+): Segment {
+  const first = words[0]!;
+  const last = words[words.length - 1]!;
+  return {
+    ...segment,
+    id: [
+      segment.id || "segment",
+      fragmentKind,
+      first.id ?? first.start_ms,
+      last.id ?? last.end_ms,
+    ].join(":"),
+    start_ms: first.start_ms,
+    end_ms: last.end_ms,
+    text: words
+      .map((word) => word.text)
+      .join("")
+      .trim(),
+    words,
+  };
 }

--- a/crates/db-core/src/cloudsync/ops.rs
+++ b/crates/db-core/src/cloudsync/ops.rs
@@ -1951,7 +1951,7 @@ mod tests {
 
         drop(held_connection);
         tokio::time::timeout(
-            Duration::from_millis(250),
+            Duration::from_millis(1_500),
             sqlx::query("INSERT INTO sessions (id, title) VALUES ('after-timeout', 'Note')")
                 .execute(db.pool()),
         )

--- a/packages/changelog/content/1.3.10.md
+++ b/packages/changelog/content/1.3.10.md
@@ -7,6 +7,7 @@ summary: "Anarlog 1.3.10 adds microphone selection and makes recording, Cloud Sy
 
 - Choose and remember a preferred microphone, with automatic fallback when that device is unavailable
 - Recover interrupted recordings and retain repairable audio until transcript work finishes safely
+- Keep long live transcripts responsive without hiding earlier words as recording continues
 - Improve echo cancellation for larger speaker and microphone timing differences
 
 ## Chat & AI

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -577,7 +577,7 @@ mod test {
 
         drop(held_connection);
         let mut replacement =
-            tokio::time::timeout(Duration::from_millis(250), runtime.pool().acquire())
+            tokio::time::timeout(Duration::from_millis(1_500), runtime.pool().acquire())
                 .await
                 .expect("pool did not open a replacement after deferred teardown")
                 .unwrap();


### PR DESCRIPTION
Render active captures directly from live segments, remove per-segment transcript subscriptions, and isolate volatile render caches. Adds full-descendant regression coverage for 500 segments and active-to-settled rendering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core live recording, transcript integrity, and caching during capture; regressions could drop or duplicate words or mis-label speakers, though coverage is extensive.
> 
> **Overview**
> Introduces **per-session capture generations** in the listener store so each recording gets a stable identity from start through finalizing, with retries and attach/detach edge cases covered by new tests.
> 
> **Active transcript rendering** now uses a frozen native-render **baseline** keyed by capture generation (`volatile` vs `settled` React Query caches), so live word and speaker-assignment writes no longer trigger a full re-segment on every SQLite update. The UI threads `captureGeneration` into the viewer; only the **last** transcript row stays active with live segments while earlier rows render settled.
> 
> **Live/persisted merge** gains reconciliation helpers: preserve prefixes when the live tail overlaps persisted segments, drop stale frozen words when IDs rotate, and apply current assignments to visible live segments in JS. Speaker labels are computed once per transcript list instead of per segment header.
> 
> Docs/changelog note long-session responsiveness; QA skill adds Keychain **Computer Use** steps. CloudSync integration test pool-drain timeouts increase from 250ms to 1500ms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5885ee2defa78e1866086f3c8cdaccc7e8f71f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->