### PR TITLE
Track canonical account signup analytics

### DIFF
--- a/apps/web/netlify/functions/posthog-account-events.mts
+++ b/apps/web/netlify/functions/posthog-account-events.mts
@@ -1,0 +1,114 @@
+import { createClient } from "@supabase/supabase-js";
+
+import {
+  groupAccountAnalyticsEvents,
+  sendPostHogBatch,
+  type AccountAnalyticsEvent,
+} from "../../src/lib/account-analytics.ts";
+
+function requireEnvironmentVariable(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export default async () => {
+  const supabase = createClient(
+    requireEnvironmentVariable("SUPABASE_URL"),
+    requireEnvironmentVariable("SUPABASE_SERVICE_ROLE_KEY"),
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );
+  const projectToken = requireEnvironmentVariable("VITE_POSTHOG_API_KEY");
+  const host = process.env.VITE_POSTHOG_HOST ?? "https://us.i.posthog.com";
+
+  const { data: reconciliation, error: reconciliationError } =
+    await supabase.rpc("reconcile_account_analytics_events");
+  if (reconciliationError) {
+    throw reconciliationError;
+  }
+
+  const leaseId = crypto.randomUUID();
+  const { data, error: claimError } = await supabase.rpc(
+    "claim_account_analytics_events",
+    {
+      p_lease_id: leaseId,
+      p_limit: 500,
+      p_lease_seconds: 300,
+    },
+  );
+  if (claimError) {
+    throw claimError;
+  }
+
+  const events = (data ?? []) as AccountAnalyticsEvent[];
+  const failures: Error[] = [];
+  let delivered = 0;
+
+  for (const group of groupAccountAnalyticsEvents(events)) {
+    const eventIds = group.map((event) => event.id);
+
+    try {
+      await sendPostHogBatch({
+        events: group,
+        projectToken,
+        host,
+      });
+
+      const { data: completed, error: completionError } = await supabase.rpc(
+        "complete_account_analytics_events",
+        {
+          p_lease_id: leaseId,
+          p_event_ids: eventIds,
+        },
+      );
+      if (completionError) {
+        throw completionError;
+      }
+      if (completed !== eventIds.length) {
+        throw new Error(
+          `Completed ${completed} of ${eventIds.length} account analytics events`,
+        );
+      }
+      delivered += eventIds.length;
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      failures.push(failure);
+
+      const { error: failureError } = await supabase.rpc(
+        "fail_account_analytics_events",
+        {
+          p_lease_id: leaseId,
+          p_event_ids: eventIds,
+          p_error: failure.message,
+        },
+      );
+      if (failureError) {
+        failures.push(failureError);
+      }
+    }
+  }
+
+  console.log(
+    JSON.stringify({
+      reconciliation: reconciliation?.[0] ?? null,
+      claimed: events.length,
+      delivered,
+      failed: events.length - delivered,
+    }),
+  );
+
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Account analytics delivery failed");
+  }
+};
+
+export const config = {
+  schedule: "*/5 * * * *",
+};

--- a/apps/web/src/lib/account-analytics.test.ts
+++ b/apps/web/src/lib/account-analytics.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  groupAccountAnalyticsEvents,
+  sendPostHogBatch,
+  type AccountAnalyticsEvent,
+} from "./account-analytics.ts";
+
+const events: AccountAnalyticsEvent[] = [
+  {
+    id: "event-live",
+    event_name: "account_created",
+    user_id: "user-live",
+    occurred_at: "2026-07-25T03:00:00.000Z",
+    properties: { source: "supabase_auth" },
+    historical: false,
+  },
+  {
+    id: "event-historical",
+    event_name: "account_confirmed",
+    user_id: "user-historical",
+    occurred_at: "2025-07-25T03:00:00.000Z",
+    properties: { source: "supabase_auth" },
+    historical: true,
+  },
+];
+
+test("groups live and historical events into separate batches", () => {
+  assert.deepEqual(
+    groupAccountAnalyticsEvents(events).map((group) =>
+      group.map((event) => event.id),
+    ),
+    [["event-live"], ["event-historical"]],
+  );
+});
+
+test("sends stable distinct and insert IDs with original timestamps", async () => {
+  let request: { url: string; init?: RequestInit } | undefined;
+
+  await sendPostHogBatch({
+    events: [events[1]],
+    projectToken: "project-token",
+    host: "https://us.i.posthog.com/",
+    fetcher: async (url, init) => {
+      request = { url: String(url), init };
+      return new Response(null, { status: 200 });
+    },
+  });
+
+  assert.equal(request?.url, "https://us.i.posthog.com/batch/");
+  const body = JSON.parse(String(request?.init?.body));
+
+  assert.equal(body.historical_migration, true);
+  assert.equal(body.batch[0].event, "account_confirmed");
+  assert.equal(body.batch[0].properties.distinct_id, "user-historical");
+  assert.equal(
+    body.batch[0].properties.$insert_id,
+    "account_confirmed:user-historical",
+  );
+  assert.equal(body.batch[0].timestamp, "2025-07-25T03:00:00.000Z");
+});
+
+test("surfaces PostHog ingestion errors", async () => {
+  await assert.rejects(
+    sendPostHogBatch({
+      events: [events[0]],
+      projectToken: "project-token",
+      host: "https://us.i.posthog.com",
+      fetcher: async () => new Response("invalid token", { status: 401 }),
+    }),
+    /PostHog batch rejected with 401: invalid token/,
+  );
+});

--- a/apps/web/src/lib/account-analytics.ts
+++ b/apps/web/src/lib/account-analytics.ts
@@ -1,0 +1,57 @@
+export type AccountAnalyticsEvent = {
+  id: string;
+  event_name: "account_created" | "account_confirmed";
+  user_id: string;
+  occurred_at: string;
+  properties: Record<string, unknown>;
+  historical: boolean;
+};
+
+export function groupAccountAnalyticsEvents(events: AccountAnalyticsEvent[]) {
+  return [
+    events.filter((event) => !event.historical),
+    events.filter((event) => event.historical),
+  ].filter((group) => group.length > 0);
+}
+
+export async function sendPostHogBatch({
+  events,
+  projectToken,
+  host,
+  fetcher = fetch,
+}: {
+  events: AccountAnalyticsEvent[];
+  projectToken: string;
+  host: string;
+  fetcher?: typeof fetch;
+}) {
+  if (events.length === 0) {
+    return;
+  }
+
+  const response = await fetcher(`${host.replace(/\/+$/, "")}/batch/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      api_key: projectToken,
+      historical_migration: events.every((event) => event.historical),
+      batch: events.map((event) => ({
+        event: event.event_name,
+        properties: {
+          ...event.properties,
+          distinct_id: event.user_id,
+          $insert_id: `${event.event_name}:${event.user_id}`,
+        },
+        timestamp: event.occurred_at,
+      })),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `PostHog batch rejected with ${response.status}: ${await response.text()}`,
+    );
+  }
+}

--- a/supabase/migrations/20260725031456_account_analytics_outbox.sql
+++ b/supabase/migrations/20260725031456_account_analytics_outbox.sql
@@ -1,0 +1,442 @@
+CREATE TABLE private.account_analytics_outbox (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_name text NOT NULL,
+  user_id uuid NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  email text,
+  properties jsonb NOT NULL DEFAULT '{}'::jsonb,
+  historical boolean NOT NULL DEFAULT false,
+  attempt_count integer NOT NULL DEFAULT 0,
+  next_attempt_at timestamptz NOT NULL DEFAULT now(),
+  lease_id uuid,
+  lease_expires_at timestamptz,
+  delivered_at timestamptz,
+  last_error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT account_analytics_outbox_event_name_check CHECK (
+    event_name IN ('account_created', 'account_confirmed')
+  ),
+  CONSTRAINT account_analytics_outbox_event_user_key UNIQUE (
+    event_name,
+    user_id
+  )
+);
+
+CREATE INDEX account_analytics_outbox_claim_idx
+  ON private.account_analytics_outbox (
+    next_attempt_at,
+    occurred_at
+  )
+  WHERE delivered_at IS NULL;
+
+REVOKE ALL ON TABLE private.account_analytics_outbox
+  FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION private.enqueue_account_analytics_event(
+  p_event_name text,
+  p_user_id uuid,
+  p_occurred_at timestamptz,
+  p_email text,
+  p_auth_provider text,
+  p_historical boolean
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  person_properties jsonb;
+BEGIN
+  IF p_event_name NOT IN ('account_created', 'account_confirmed')
+    OR p_user_id IS NULL
+    OR p_occurred_at IS NULL
+  THEN
+    RAISE EXCEPTION 'invalid account analytics event'
+      USING ERRCODE = '22023';
+  END IF;
+
+  person_properties := jsonb_strip_nulls(
+    jsonb_build_object(
+      'email',
+      p_email,
+      CASE
+        WHEN p_event_name = 'account_created' THEN 'account_created_at'
+        ELSE 'account_confirmed_at'
+      END,
+      p_occurred_at
+    )
+  );
+
+  INSERT INTO private.account_analytics_outbox (
+    event_name,
+    user_id,
+    occurred_at,
+    email,
+    properties,
+    historical
+  )
+  VALUES (
+    p_event_name,
+    p_user_id,
+    p_occurred_at,
+    p_email,
+    jsonb_strip_nulls(
+      jsonb_build_object(
+        'source',
+        'supabase_auth',
+        'auth_provider',
+        p_auth_provider,
+        '$set',
+        person_properties
+      )
+    ),
+    p_historical
+  )
+  ON CONFLICT (event_name, user_id) DO UPDATE SET
+    email = COALESCE(EXCLUDED.email, private.account_analytics_outbox.email),
+    properties = private.account_analytics_outbox.properties
+      || EXCLUDED.properties,
+    updated_at = clock_timestamp();
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.handle_account_analytics_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  confirmation_time timestamptz;
+  provider text;
+BEGIN
+  IF COALESCE(NEW.is_anonymous, false) THEN
+    RETURN NEW;
+  END IF;
+
+  provider := COALESCE(NEW.raw_app_meta_data ->> 'provider', 'unknown');
+  confirmation_time := COALESCE(
+    NEW.confirmed_at,
+    NEW.email_confirmed_at,
+    NEW.phone_confirmed_at
+  );
+
+  IF TG_OP = 'INSERT' THEN
+    PERFORM private.enqueue_account_analytics_event(
+      'account_created',
+      NEW.id,
+      NEW.created_at,
+      NEW.email,
+      provider,
+      false
+    );
+  END IF;
+
+  IF confirmation_time IS NOT NULL THEN
+    PERFORM private.enqueue_account_analytics_event(
+      'account_confirmed',
+      NEW.id,
+      confirmation_time,
+      NEW.email,
+      provider,
+      false
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.enqueue_account_analytics_event(
+  text,
+  uuid,
+  timestamptz,
+  text,
+  text,
+  boolean
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.handle_account_analytics_user()
+  FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA private TO supabase_auth_admin;
+GRANT EXECUTE ON FUNCTION private.handle_account_analytics_user()
+  TO supabase_auth_admin;
+
+DROP TRIGGER IF EXISTS on_auth_user_account_analytics_created ON auth.users;
+CREATE TRIGGER on_auth_user_account_analytics_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION private.handle_account_analytics_user();
+
+DROP TRIGGER IF EXISTS on_auth_user_account_analytics_confirmed ON auth.users;
+CREATE TRIGGER on_auth_user_account_analytics_confirmed
+  AFTER UPDATE OF confirmed_at, email_confirmed_at, phone_confirmed_at
+  ON auth.users
+  FOR EACH ROW
+  WHEN (
+    COALESCE(
+      OLD.confirmed_at,
+      OLD.email_confirmed_at,
+      OLD.phone_confirmed_at
+    ) IS NULL
+    AND COALESCE(
+      NEW.confirmed_at,
+      NEW.email_confirmed_at,
+      NEW.phone_confirmed_at
+    ) IS NOT NULL
+  )
+  EXECUTE FUNCTION private.handle_account_analytics_user();
+
+CREATE OR REPLACE FUNCTION public.reconcile_account_analytics_events()
+RETURNS TABLE (
+  source_accounts bigint,
+  source_confirmed_accounts bigint,
+  queued_account_created bigint,
+  queued_account_confirmed bigint,
+  pending_events bigint,
+  delivered_events bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.enqueue_account_analytics_event(
+    'account_created',
+    account.id,
+    account.created_at,
+    account.email,
+    COALESCE(account.raw_app_meta_data ->> 'provider', 'unknown'),
+    account.created_at < clock_timestamp() - interval '10 minutes'
+  )
+  FROM auth.users AS account
+  WHERE COALESCE(account.is_anonymous, false) = false;
+
+  PERFORM private.enqueue_account_analytics_event(
+    'account_confirmed',
+    account.id,
+    confirmation.occurred_at,
+    account.email,
+    COALESCE(account.raw_app_meta_data ->> 'provider', 'unknown'),
+    confirmation.occurred_at < clock_timestamp() - interval '10 minutes'
+  )
+  FROM auth.users AS account
+  CROSS JOIN LATERAL (
+    SELECT COALESCE(
+      account.confirmed_at,
+      account.email_confirmed_at,
+      account.phone_confirmed_at
+    ) AS occurred_at
+  ) AS confirmation
+  WHERE COALESCE(account.is_anonymous, false) = false
+    AND confirmation.occurred_at IS NOT NULL;
+
+  RETURN QUERY
+  SELECT
+    (
+      SELECT count(*)
+      FROM auth.users AS account
+      WHERE COALESCE(account.is_anonymous, false) = false
+    ),
+    (
+      SELECT count(*)
+      FROM auth.users AS account
+      WHERE COALESCE(account.is_anonymous, false) = false
+        AND COALESCE(
+          account.confirmed_at,
+          account.email_confirmed_at,
+          account.phone_confirmed_at
+        ) IS NOT NULL
+    ),
+    count(*) FILTER (WHERE outbox.event_name = 'account_created'),
+    count(*) FILTER (WHERE outbox.event_name = 'account_confirmed'),
+    count(*) FILTER (WHERE outbox.delivered_at IS NULL),
+    count(*) FILTER (WHERE outbox.delivered_at IS NOT NULL)
+  FROM private.account_analytics_outbox AS outbox;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.claim_account_analytics_events(
+  p_lease_id uuid,
+  p_limit integer DEFAULT 500,
+  p_lease_seconds integer DEFAULT 300
+)
+RETURNS TABLE (
+  id uuid,
+  event_name text,
+  user_id uuid,
+  occurred_at timestamptz,
+  properties jsonb,
+  historical boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  current_time timestamptz := clock_timestamp();
+BEGIN
+  IF p_lease_id IS NULL
+    OR p_limit IS NULL
+    OR p_limit < 1
+    OR p_limit > 500
+    OR p_lease_seconds IS NULL
+    OR p_lease_seconds < 30
+    OR p_lease_seconds > 900
+  THEN
+    RAISE EXCEPTION 'invalid account analytics lease'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  WITH candidates AS (
+    SELECT outbox.id
+    FROM private.account_analytics_outbox AS outbox
+    WHERE outbox.delivered_at IS NULL
+      AND outbox.next_attempt_at <= current_time
+      AND outbox.attempt_count < 20
+      AND (
+        outbox.lease_expires_at IS NULL
+        OR outbox.lease_expires_at <= current_time
+      )
+    ORDER BY outbox.occurred_at, outbox.id
+    FOR UPDATE SKIP LOCKED
+    LIMIT p_limit
+  ), leased AS (
+    UPDATE private.account_analytics_outbox AS outbox
+    SET
+      attempt_count = outbox.attempt_count + 1,
+      lease_id = p_lease_id,
+      lease_expires_at = current_time
+        + make_interval(secs => p_lease_seconds),
+      updated_at = current_time
+    FROM candidates
+    WHERE outbox.id = candidates.id
+    RETURNING outbox.*
+  )
+  SELECT
+    leased.id,
+    leased.event_name,
+    leased.user_id,
+    leased.occurred_at,
+    leased.properties,
+    leased.historical
+  FROM leased
+  ORDER BY leased.occurred_at, leased.id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.complete_account_analytics_events(
+  p_lease_id uuid,
+  p_event_ids uuid[]
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  IF p_lease_id IS NULL
+    OR p_event_ids IS NULL
+    OR cardinality(p_event_ids) < 1
+    OR cardinality(p_event_ids) > 500
+  THEN
+    RAISE EXCEPTION 'invalid account analytics completion'
+      USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE private.account_analytics_outbox AS outbox
+  SET
+    delivered_at = clock_timestamp(),
+    lease_id = NULL,
+    lease_expires_at = NULL,
+    last_error = NULL,
+    updated_at = clock_timestamp()
+  WHERE outbox.id = ANY (p_event_ids)
+    AND outbox.lease_id = p_lease_id
+    AND outbox.delivered_at IS NULL;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fail_account_analytics_events(
+  p_lease_id uuid,
+  p_event_ids uuid[],
+  p_error text
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  IF p_lease_id IS NULL
+    OR p_event_ids IS NULL
+    OR cardinality(p_event_ids) < 1
+    OR cardinality(p_event_ids) > 500
+  THEN
+    RAISE EXCEPTION 'invalid account analytics failure'
+      USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE private.account_analytics_outbox AS outbox
+  SET
+    next_attempt_at = clock_timestamp()
+      + make_interval(
+        secs => LEAST(3600, power(2, LEAST(outbox.attempt_count, 10))::integer)
+      ),
+    lease_id = NULL,
+    lease_expires_at = NULL,
+    last_error = left(COALESCE(p_error, 'unknown error'), 2000),
+    updated_at = clock_timestamp()
+  WHERE outbox.id = ANY (p_event_ids)
+    AND outbox.lease_id = p_lease_id
+    AND outbox.delivered_at IS NULL;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.reconcile_account_analytics_events()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.claim_account_analytics_events(
+  uuid,
+  integer,
+  integer
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.complete_account_analytics_events(uuid, uuid[])
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.fail_account_analytics_events(
+  uuid,
+  uuid[],
+  text
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.reconcile_account_analytics_events()
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.claim_account_analytics_events(
+  uuid,
+  integer,
+  integer
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.complete_account_analytics_events(uuid, uuid[])
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.fail_account_analytics_events(
+  uuid,
+  uuid[],
+  text
+) TO service_role;
+
+DO $$
+BEGIN
+  PERFORM public.reconcile_account_analytics_events();
+END;
+$$;

--- a/supabase/migrations/20260725032204_make_account_analytics_reconciliation_insert_only.sql
+++ b/supabase/migrations/20260725032204_make_account_analytics_reconciliation_insert_only.sql
@@ -1,0 +1,64 @@
+CREATE OR REPLACE FUNCTION private.enqueue_account_analytics_event(
+  p_event_name text,
+  p_user_id uuid,
+  p_occurred_at timestamptz,
+  p_email text,
+  p_auth_provider text,
+  p_historical boolean
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  person_properties jsonb;
+BEGIN
+  IF p_event_name NOT IN ('account_created', 'account_confirmed')
+    OR p_user_id IS NULL
+    OR p_occurred_at IS NULL
+  THEN
+    RAISE EXCEPTION 'invalid account analytics event'
+      USING ERRCODE = '22023';
+  END IF;
+
+  person_properties := jsonb_strip_nulls(
+    jsonb_build_object(
+      'email',
+      p_email,
+      CASE
+        WHEN p_event_name = 'account_created' THEN 'account_created_at'
+        ELSE 'account_confirmed_at'
+      END,
+      p_occurred_at
+    )
+  );
+
+  INSERT INTO private.account_analytics_outbox (
+    event_name,
+    user_id,
+    occurred_at,
+    email,
+    properties,
+    historical
+  )
+  VALUES (
+    p_event_name,
+    p_user_id,
+    p_occurred_at,
+    p_email,
+    jsonb_strip_nulls(
+      jsonb_build_object(
+        'source',
+        'supabase_auth',
+        'auth_provider',
+        p_auth_provider,
+        '$set',
+        person_properties
+      )
+    ),
+    p_historical
+  )
+  ON CONFLICT (event_name, user_id) DO NOTHING;
+END;
+$$;

--- a/supabase/migrations/20260725032334_fix_account_analytics_lease_timestamp.sql
+++ b/supabase/migrations/20260725032334_fix_account_analytics_lease_timestamp.sql
@@ -1,0 +1,69 @@
+CREATE OR REPLACE FUNCTION public.claim_account_analytics_events(
+  p_lease_id uuid,
+  p_limit integer DEFAULT 500,
+  p_lease_seconds integer DEFAULT 300
+)
+RETURNS TABLE (
+  id uuid,
+  event_name text,
+  user_id uuid,
+  occurred_at timestamptz,
+  properties jsonb,
+  historical boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  lease_time timestamptz := clock_timestamp();
+BEGIN
+  IF p_lease_id IS NULL
+    OR p_limit IS NULL
+    OR p_limit < 1
+    OR p_limit > 500
+    OR p_lease_seconds IS NULL
+    OR p_lease_seconds < 30
+    OR p_lease_seconds > 900
+  THEN
+    RAISE EXCEPTION 'invalid account analytics lease'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  WITH candidates AS (
+    SELECT outbox.id
+    FROM private.account_analytics_outbox AS outbox
+    WHERE outbox.delivered_at IS NULL
+      AND outbox.next_attempt_at <= lease_time
+      AND outbox.attempt_count < 20
+      AND (
+        outbox.lease_expires_at IS NULL
+        OR outbox.lease_expires_at <= lease_time
+      )
+    ORDER BY outbox.occurred_at, outbox.id
+    FOR UPDATE SKIP LOCKED
+    LIMIT p_limit
+  ), leased AS (
+    UPDATE private.account_analytics_outbox AS outbox
+    SET
+      attempt_count = outbox.attempt_count + 1,
+      lease_id = p_lease_id,
+      lease_expires_at = lease_time
+        + make_interval(secs => p_lease_seconds),
+      updated_at = lease_time
+    FROM candidates
+    WHERE outbox.id = candidates.id
+    RETURNING outbox.*
+  )
+  SELECT
+    leased.id,
+    leased.event_name,
+    leased.user_id,
+    leased.occurred_at,
+    leased.properties,
+    leased.historical
+  FROM leased
+  ORDER BY leased.occurred_at, leased.id;
+END;
+$$;

--- a/supabase/tests/026-account-analytics-outbox.sql
+++ b/supabase/tests/026-account-analytics-outbox.sql
@@ -1,0 +1,220 @@
+begin;
+select plan(12);
+
+create temporary table account_analytics_test_users (
+  kind text primary key,
+  id uuid not null,
+  created_at timestamptz not null
+);
+
+insert into account_analytics_test_users (kind, id, created_at)
+values
+  (
+    'account',
+    gen_random_uuid(),
+    '2026-07-01 12:00:00+00'::timestamptz
+  ),
+  (
+    'anonymous',
+    gen_random_uuid(),
+    '2026-07-01 13:00:00+00'::timestamptz
+  );
+
+insert into auth.users (
+  id,
+  email,
+  raw_user_meta_data,
+  raw_app_meta_data,
+  is_anonymous,
+  created_at,
+  updated_at
+)
+select
+  id,
+  kind || '@example.com',
+  '{}'::jsonb,
+  jsonb_build_object('provider', 'email'),
+  kind = 'anonymous',
+  created_at,
+  created_at
+from account_analytics_test_users;
+
+select ok(
+  to_regclass('private.account_analytics_outbox') is not null,
+  'Account analytics outbox is private'
+);
+
+select ok(
+  not has_table_privilege(
+    'anon',
+    'private.account_analytics_outbox',
+    'SELECT'
+  )
+    and not has_table_privilege(
+      'authenticated',
+      'private.account_analytics_outbox',
+      'SELECT'
+    ),
+  'Client roles cannot read account analytics events'
+);
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    'public.reconcile_account_analytics_events()',
+    'EXECUTE'
+  )
+    and not has_function_privilege(
+      'authenticated',
+      'public.reconcile_account_analytics_events()',
+      'EXECUTE'
+    ),
+  'Only service code can reconcile account analytics'
+);
+
+select results_eq(
+  $$
+  select count(*)
+  from private.account_analytics_outbox
+  where user_id = (
+    select id from account_analytics_test_users where kind = 'account'
+  )
+    and event_name = 'account_created'
+  $$,
+  array[1::bigint],
+  'Permanent account creation is enqueued once'
+);
+
+select results_eq(
+  $$
+  select count(*)
+  from private.account_analytics_outbox
+  where user_id = (
+    select id from account_analytics_test_users where kind = 'anonymous'
+  )
+  $$,
+  array[0::bigint],
+  'Anonymous auth users are excluded'
+);
+
+select results_eq(
+  $$
+  select occurred_at
+  from private.account_analytics_outbox
+  where user_id = (
+    select id from account_analytics_test_users where kind = 'account'
+  )
+    and event_name = 'account_created'
+  $$,
+  array['2026-07-01 12:00:00+00'::timestamptz],
+  'Creation event keeps the source timestamp'
+);
+
+select results_eq(
+  $$
+  select properties ->> 'auth_provider'
+  from private.account_analytics_outbox
+  where user_id = (
+    select id from account_analytics_test_users where kind = 'account'
+  )
+    and event_name = 'account_created'
+  $$,
+  array['email'::text],
+  'Creation event records the auth provider'
+);
+
+update auth.users
+set email_confirmed_at = '2026-07-01 12:05:00+00'::timestamptz
+where id = (
+  select id from account_analytics_test_users where kind = 'account'
+);
+
+select results_eq(
+  $$
+  select count(*)
+  from private.account_analytics_outbox
+  where user_id = (
+    select id from account_analytics_test_users where kind = 'account'
+  )
+    and event_name = 'account_confirmed'
+  $$,
+  array[1::bigint],
+  'First confirmation is enqueued'
+);
+
+update auth.users
+set email_confirmed_at = email_confirmed_at + interval '1 minute'
+where id = (
+  select id from account_analytics_test_users where kind = 'account'
+);
+
+select results_eq(
+  $$
+  select count(*)
+  from private.account_analytics_outbox
+  where user_id = (
+    select id from account_analytics_test_users where kind = 'account'
+  )
+    and event_name = 'account_confirmed'
+  $$,
+  array[1::bigint],
+  'Later auth updates do not duplicate confirmation'
+);
+
+select public.reconcile_account_analytics_events();
+select public.reconcile_account_analytics_events();
+
+select results_eq(
+  $$
+  select count(*)
+  from private.account_analytics_outbox
+  where user_id = (
+    select id from account_analytics_test_users where kind = 'account'
+  )
+  $$,
+  array[2::bigint],
+  'Reconciliation is idempotent'
+);
+
+create temporary table account_analytics_test_lease (
+  id uuid primary key
+);
+
+insert into account_analytics_test_lease (id)
+values (gen_random_uuid());
+
+select results_eq(
+  $$
+  select count(*)
+  from public.claim_account_analytics_events(
+    (select id from account_analytics_test_lease),
+    500,
+    300
+  )
+  where user_id = (
+    select id from account_analytics_test_users where kind = 'account'
+  )
+  $$,
+  array[2::bigint],
+  'Pending account events can be leased'
+);
+
+select results_eq(
+  $$
+  select public.complete_account_analytics_events(
+    (select id from account_analytics_test_lease),
+    array(
+      select id
+      from private.account_analytics_outbox
+      where user_id = (
+        select id from account_analytics_test_users where kind = 'account'
+      )
+    )
+  )
+  $$,
+  array[2],
+  'Leased events can be completed'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Make Supabase Auth canonical for signup analytics and deliver account-created and confirmation events through an outbox. Add historical backfill, reconciliation tooling, and PostHog metric alignment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New triggers on `auth.users` and a service-role delivery path that sends PII (email) to PostHog; mitigated by private outbox, restricted RPC grants, and idempotent enqueue, but auth-path and analytics correctness warrant careful rollout monitoring.
> 
> **Overview**
> Adds **server-side canonical signup analytics** sourced from Supabase Auth: `account_created` and `account_confirmed` are written to a private outbox (triggers on `auth.users`, excluding anonymous users), with a one-time **reconciliation/backfill** that marks older rows as historical for PostHog migration batches.
> 
> A **scheduled Netlify function** (every 5 minutes) reconciles, **claims** pending rows with leases/retries, posts batches to PostHog (`historical_migration` split from live events, stable `$insert_id` and original timestamps), then **completes** or **fails** each batch. Follow-up migrations make enqueue **insert-only on conflict** (idempotent reconciliation) and fix lease timing to use a single `lease_time` snapshot.
> 
> Includes unit tests for batching/PostHog payload and pgTAP coverage for privacy, trigger behavior, idempotent reconcile, and claim/complete flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8c39b743faf8e51632d81dba468704f453bcab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->