### PR TITLE
Repair customer analytics reconciliation

### DIFF
--- a/.github/workflows/stripe_cd.yaml
+++ b/.github/workflows/stripe_cd.yaml
@@ -32,11 +32,11 @@ jobs:
           set -euo pipefail
 
           posthog_api_key="$(
-            infisical secrets get POSTHOG_API_KEY \
+            infisical secrets get VITE_POSTHOG_API_KEY \
               --token="$INFISICAL_TOKEN" \
               --env=prod \
               --projectId="$INFISICAL_PROJECT_ID" \
-              --path=/anarlog/ai \
+              --path=/anarlog/web \
               --output=json |
               python3 -c 'import json, sys; print(json.load(sys.stdin)[0]["secretValue"])'
           )"

--- a/apps/stripe/src/analytics-payload.ts
+++ b/apps/stripe/src/analytics-payload.ts
@@ -100,13 +100,18 @@ function invoicePayload(
 ): BillingAnalyticsPayload {
   return {
     event,
-    properties: {
-      plan: "pro",
-      amount_paid: invoice.amount_paid,
-      amount_due: invoice.amount_due,
-      currency: invoice.currency,
-      billing_reason: invoice.billing_reason,
-      attempt_count: invoice.attempt_count,
-    },
+    properties: getInvoiceAnalyticsProperties(invoice),
+  };
+}
+
+export function getInvoiceAnalyticsProperties(invoice: Stripe.Invoice) {
+  return {
+    plan: "pro",
+    amount_paid: invoice.amount_paid,
+    amount_due: invoice.amount_due,
+    currency: invoice.currency,
+    billing_reason: invoice.billing_reason,
+    attempt_count: invoice.attempt_count,
+    stripe_invoice_id: invoice.id,
   };
 }

--- a/apps/stripe/src/analytics.ts
+++ b/apps/stripe/src/analytics.ts
@@ -45,8 +45,10 @@ export async function captureBillingEvent(event: Stripe.Event) {
   posthog.capture({
     distinctId: userId,
     event: payload.event,
+    timestamp: new Date(event.created * 1000),
     properties: {
       ...payload.properties,
+      $insert_id: `stripe-event:${event.id}`,
       source: "stripe",
       stripe_event_id: event.id,
     },

--- a/apps/stripe/src/billing-bridge.ts
+++ b/apps/stripe/src/billing-bridge.ts
@@ -1,5 +1,9 @@
 import Stripe from "stripe";
 
+import {
+  getCustomerIdentityMetadata,
+  getCustomerUserId,
+} from "./customer-metadata";
 import { stripe } from "./integration/stripe";
 import { supabaseAdmin } from "./integration/supabase";
 
@@ -32,6 +36,16 @@ export async function syncBillingBridge(event: Stripe.Event) {
 
   if (!userId) {
     return;
+  }
+
+  const identityMetadata = getCustomerIdentityMetadata(
+    customer.metadata,
+    userId,
+  );
+  if (identityMetadata) {
+    await stripe.customers.update(customerId, {
+      metadata: identityMetadata,
+    });
   }
 
   const { data, error } = await supabaseAdmin.rpc(
@@ -116,10 +130,4 @@ const isDeletedCustomer = (
 
 export const getUserIdFromCustomer = (
   customer: Stripe.Customer,
-): string | null => {
-  const metadata = customer.metadata ?? {};
-
-  return (
-    metadata["userId"] || metadata["user_id"] || metadata["userID"] || null
-  );
-};
+): string | null => getCustomerUserId(customer.metadata);

--- a/apps/stripe/src/customer-metadata.test.ts
+++ b/apps/stripe/src/customer-metadata.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+
+import {
+  getCustomerIdentityMetadata,
+  getCustomerUserId,
+} from "./customer-metadata";
+
+test("requires every Stripe owner alias to agree", () => {
+  expect(
+    getCustomerUserId({
+      userId: "owner-user",
+      user_id: "other-user",
+    }),
+  ).toBeNull();
+});
+
+test("returns the shared Stripe owner", () => {
+  expect(
+    getCustomerUserId({
+      userId: "owner-user",
+      user_id: "owner-user",
+    }),
+  ).toBe("owner-user");
+});
+
+test("repairs incomplete PostHog identity metadata", () => {
+  expect(
+    getCustomerIdentityMetadata({ userId: "owner-user" }, "owner-user"),
+  ).toEqual({
+    userId: "owner-user",
+    posthog_person_distinct_id: "owner-user",
+  });
+});
+
+test("does not rewrite complete identity metadata", () => {
+  expect(
+    getCustomerIdentityMetadata(
+      {
+        userId: "owner-user",
+        posthog_person_distinct_id: "owner-user",
+      },
+      "owner-user",
+    ),
+  ).toBeNull();
+});

--- a/apps/stripe/src/customer-metadata.ts
+++ b/apps/stripe/src/customer-metadata.ts
@@ -1,0 +1,33 @@
+const OWNER_METADATA_KEYS = ["userId", "user_id", "userID"] as const;
+
+export function getCustomerUserId(metadata: Record<string, string> | null) {
+  const ownerIds = OWNER_METADATA_KEYS.map((key) => metadata?.[key]).filter(
+    (ownerId): ownerId is string => Boolean(ownerId),
+  );
+
+  if (
+    ownerIds.length === 0 ||
+    ownerIds.some((ownerId) => ownerId !== ownerIds[0])
+  ) {
+    return null;
+  }
+
+  return ownerIds[0];
+}
+
+export function getCustomerIdentityMetadata(
+  metadata: Record<string, string> | null,
+  userId: string,
+) {
+  if (
+    metadata?.["userId"] === userId &&
+    metadata["posthog_person_distinct_id"] === userId
+  ) {
+    return null;
+  }
+
+  return {
+    userId,
+    posthog_person_distinct_id: userId,
+  };
+}

--- a/apps/stripe/src/scripts/stripe-backfill-billing-analytics.ts
+++ b/apps/stripe/src/scripts/stripe-backfill-billing-analytics.ts
@@ -1,0 +1,96 @@
+import { PostHog } from "posthog-node";
+import Stripe from "stripe";
+import { parseArgs } from "util";
+
+import { getInvoiceAnalyticsProperties } from "../analytics-payload";
+import { getCustomerUserId } from "../customer-metadata";
+
+const STRIPE_API_VERSION = "2026-02-25.clover";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    apply: { type: "boolean", default: false },
+  },
+  strict: true,
+  allowPositionals: false,
+});
+
+const apply = values.apply ?? false;
+const { POSTHOG_API_KEY, STRIPE_SECRET_KEY } = Bun.env;
+
+if (!POSTHOG_API_KEY || !STRIPE_SECRET_KEY) {
+  throw new Error("Missing POSTHOG_API_KEY or STRIPE_SECRET_KEY");
+}
+
+const stripe = new Stripe(STRIPE_SECRET_KEY, {
+  apiVersion: STRIPE_API_VERSION,
+});
+const posthog = apply
+  ? new PostHog(POSTHOG_API_KEY, {
+      host: "https://us.i.posthog.com",
+      flushAt: 100,
+      flushInterval: 0,
+    })
+  : null;
+
+const totals = {
+  scanned: 0,
+  captured: 0,
+  free: 0,
+  missingCustomer: 0,
+  missingUser: 0,
+};
+
+for await (const invoice of stripe.invoices.list({
+  status: "paid",
+  limit: 100,
+  expand: ["data.customer"],
+})) {
+  totals.scanned++;
+
+  if (invoice.amount_paid <= 0) {
+    totals.free++;
+    continue;
+  }
+
+  const customer = invoice.customer;
+  if (
+    !customer ||
+    typeof customer === "string" ||
+    ("deleted" in customer && customer.deleted)
+  ) {
+    totals.missingCustomer++;
+    continue;
+  }
+
+  const userId = getCustomerUserId(customer.metadata);
+  if (!userId) {
+    totals.missingUser++;
+    continue;
+  }
+
+  totals.captured++;
+  posthog?.capture({
+    distinctId: userId,
+    event: "subscription_payment_succeeded",
+    timestamp: new Date(
+      (invoice.status_transitions.paid_at ?? invoice.created) * 1000,
+    ),
+    properties: {
+      ...getInvoiceAnalyticsProperties(invoice),
+      $insert_id: `stripe-invoice:${invoice.id}`,
+      source: "stripe",
+      backfilled: true,
+    },
+  });
+}
+
+await posthog?.shutdown();
+
+console.log(
+  JSON.stringify({
+    mode: apply ? "apply" : "dry-run",
+    ...totals,
+  }),
+);

--- a/apps/stripe/src/scripts/stripe-backfill-posthog-identity.ts
+++ b/apps/stripe/src/scripts/stripe-backfill-posthog-identity.ts
@@ -74,6 +74,7 @@ const totals = {
   current: 0,
   updates: 0,
   deleted: 0,
+  missing: 0,
   conflicts: 0,
   errors: 0,
 };
@@ -117,7 +118,15 @@ for (let offset = 0; offset < profiles.length; offset += concurrency) {
             metadata,
           });
         }
-      } catch {
+      } catch (error) {
+        if (
+          error instanceof Stripe.errors.StripeError &&
+          error.statusCode === 404
+        ) {
+          totals.missing++;
+          return;
+        }
+
         totals.errors++;
       }
     }),

--- a/apps/stripe/src/scripts/stripe-backfill-posthog-identity.ts
+++ b/apps/stripe/src/scripts/stripe-backfill-posthog-identity.ts
@@ -1,0 +1,144 @@
+import { createClient } from "@supabase/supabase-js";
+import Stripe from "stripe";
+import { parseArgs } from "util";
+
+import { getCustomerIdentityMetadata } from "../customer-metadata";
+
+const STRIPE_API_VERSION = "2026-02-25.clover";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    apply: { type: "boolean", default: false },
+    concurrency: { type: "string", default: "10" },
+    limit: { type: "string" },
+  },
+  strict: true,
+  allowPositionals: false,
+});
+
+const apply = values.apply ?? false;
+const concurrency = parsePositiveInteger(values.concurrency, "concurrency");
+const limit = values.limit ? parsePositiveInteger(values.limit, "limit") : null;
+const { STRIPE_SECRET_KEY, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_URL } = Bun.env;
+
+if (!STRIPE_SECRET_KEY || !SUPABASE_SERVICE_ROLE_KEY || !SUPABASE_URL) {
+  throw new Error(
+    "Missing STRIPE_SECRET_KEY, SUPABASE_SERVICE_ROLE_KEY, or SUPABASE_URL",
+  );
+}
+
+const stripe = new Stripe(STRIPE_SECRET_KEY, {
+  apiVersion: STRIPE_API_VERSION,
+});
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});
+
+const profiles: { id: string; stripe_customer_id: string }[] = [];
+const pageSize = 1000;
+
+for (
+  let offset = 0;
+  limit === null || profiles.length < limit;
+  offset += pageSize
+) {
+  const end =
+    offset +
+    Math.min(pageSize, limit === null ? pageSize : limit - profiles.length) -
+    1;
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id,stripe_customer_id")
+    .not("stripe_customer_id", "is", null)
+    .order("id")
+    .range(offset, end);
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = (data ?? []) as { id: string; stripe_customer_id: string }[];
+  profiles.push(...rows);
+
+  if (rows.length < pageSize || (limit !== null && profiles.length >= limit)) {
+    break;
+  }
+}
+
+const totals = {
+  scanned: 0,
+  current: 0,
+  updates: 0,
+  deleted: 0,
+  conflicts: 0,
+  errors: 0,
+};
+
+for (let offset = 0; offset < profiles.length; offset += concurrency) {
+  await Promise.all(
+    profiles.slice(offset, offset + concurrency).map(async (profile) => {
+      totals.scanned++;
+
+      try {
+        const customer = await stripe.customers.retrieve(
+          profile.stripe_customer_id,
+        );
+        if ("deleted" in customer && customer.deleted) {
+          totals.deleted++;
+          return;
+        }
+
+        const ownerIds = [
+          customer.metadata["userId"],
+          customer.metadata["user_id"],
+          customer.metadata["userID"],
+        ].filter((ownerId): ownerId is string => Boolean(ownerId));
+        if (ownerIds.some((ownerId) => ownerId !== profile.id)) {
+          totals.conflicts++;
+          return;
+        }
+
+        const metadata = getCustomerIdentityMetadata(
+          customer.metadata,
+          profile.id,
+        );
+        if (!metadata) {
+          totals.current++;
+          return;
+        }
+
+        totals.updates++;
+        if (apply) {
+          await stripe.customers.update(profile.stripe_customer_id, {
+            metadata,
+          });
+        }
+      } catch {
+        totals.errors++;
+      }
+    }),
+  );
+}
+
+console.log(
+  JSON.stringify({
+    mode: apply ? "apply" : "dry-run",
+    ...totals,
+  }),
+);
+
+if (totals.conflicts > 0 || totals.errors > 0) {
+  process.exitCode = 1;
+}
+
+function parsePositiveInteger(value: string, name: string) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}

--- a/apps/web/netlify/functions/posthog-account-events.mts
+++ b/apps/web/netlify/functions/posthog-account-events.mts
@@ -15,6 +15,10 @@ function requireEnvironmentVariable(name: string) {
 }
 
 export default async () => {
+  if (process.env.CONTEXT !== "production") {
+    throw new Error("Account analytics delivery is production-only");
+  }
+
   const supabase = createClient(
     requireEnvironmentVariable("SUPABASE_URL"),
     requireEnvironmentVariable("SUPABASE_SERVICE_ROLE_KEY"),

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -21,7 +21,10 @@ import {
   sanitizeInternalReturnPath,
   toAbsoluteInternalReturnUrl,
 } from "@/lib/auth-redirect";
-import { getStripeCustomerOwnership } from "@/lib/stripe-customer";
+import {
+  getStripeCustomerIdentityMetadata,
+  getStripeCustomerOwnership,
+} from "@/lib/stripe-customer";
 import { WEB_TRIAL_CHECKOUT_FIELDS } from "@/lib/trial-policy";
 
 type SupabaseClient = ReturnType<typeof getSupabaseServerClient>;
@@ -89,8 +92,12 @@ const getStripeCustomerIdForUser = async (
   }
 
   const updates: Stripe.CustomerUpdateParams = {};
-  if (ownership === "claimable") {
-    updates.metadata = { userId: user.id };
+  const identityMetadata = getStripeCustomerIdentityMetadata(
+    customer.metadata,
+    user.id,
+  );
+  if (identityMetadata) {
+    updates.metadata = identityMetadata;
   }
 
   const name = getAuthUserName(user);

--- a/apps/web/src/lib/account-analytics.test.ts
+++ b/apps/web/src/lib/account-analytics.test.ts
@@ -44,7 +44,7 @@ test("sends stable distinct and insert IDs with original timestamps", async () =
     host: "https://us.i.posthog.com/",
     fetcher: async (url, init) => {
       request = { url: String(url), init };
-      return new Response(null, { status: 200 });
+      return Response.json({ status: "Ok" });
     },
   });
 
@@ -70,5 +70,17 @@ test("surfaces PostHog ingestion errors", async () => {
       fetcher: async () => new Response("invalid token", { status: 401 }),
     }),
     /PostHog batch rejected with 401: invalid token/,
+  );
+});
+
+test("rejects a malformed PostHog acknowledgement", async () => {
+  await assert.rejects(
+    sendPostHogBatch({
+      events: [events[0]],
+      projectToken: "project-token",
+      host: "https://us.i.posthog.com",
+      fetcher: async () => Response.json({ status: "Ignored" }),
+    }),
+    /PostHog batch returned an invalid acknowledgement/,
   );
 });

--- a/apps/web/src/lib/account-analytics.test.ts
+++ b/apps/web/src/lib/account-analytics.test.ts
@@ -13,7 +13,10 @@ const events: AccountAnalyticsEvent[] = [
     event_name: "account_created",
     user_id: "user-live",
     occurred_at: "2026-07-25T03:00:00.000Z",
-    properties: { source: "supabase_auth" },
+    properties: {
+      source: "supabase_auth",
+      $set: { email: "live@example.com" },
+    },
     historical: false,
   },
   {
@@ -59,6 +62,12 @@ test("sends stable distinct and insert IDs with original timestamps", async () =
     "account_confirmed:user-historical",
   );
   assert.equal(body.batch[0].timestamp, "2025-07-25T03:00:00.000Z");
+
+  const liveRequest = await capturePostHogRequest(events[0]);
+  assert.deepEqual(liveRequest.batch[0].properties.$set, {
+    email: "live@example.com",
+    $email: "live@example.com",
+  });
 });
 
 test("surfaces PostHog ingestion errors", async () => {
@@ -84,3 +93,21 @@ test("rejects a malformed PostHog acknowledgement", async () => {
     /PostHog batch returned an invalid acknowledgement/,
   );
 });
+
+async function capturePostHogRequest(event: AccountAnalyticsEvent) {
+  let body: unknown;
+
+  await sendPostHogBatch({
+    events: [event],
+    projectToken: "project-token",
+    host: "https://us.i.posthog.com",
+    fetcher: async (_url, init) => {
+      body = JSON.parse(String(init?.body));
+      return Response.json({ status: "Ok" });
+    },
+  });
+
+  return body as {
+    batch: { properties: Record<string, unknown> }[];
+  };
+}

--- a/apps/web/src/lib/account-analytics.test.ts
+++ b/apps/web/src/lib/account-analytics.test.ts
@@ -13,10 +13,7 @@ const events: AccountAnalyticsEvent[] = [
     event_name: "account_created",
     user_id: "user-live",
     occurred_at: "2026-07-25T03:00:00.000Z",
-    properties: {
-      source: "supabase_auth",
-      $set: { email: "live@example.com" },
-    },
+    properties: { source: "supabase_auth" },
     historical: false,
   },
   {
@@ -62,12 +59,6 @@ test("sends stable distinct and insert IDs with original timestamps", async () =
     "account_confirmed:user-historical",
   );
   assert.equal(body.batch[0].timestamp, "2025-07-25T03:00:00.000Z");
-
-  const liveRequest = await capturePostHogRequest(events[0]);
-  assert.deepEqual(liveRequest.batch[0].properties.$set, {
-    email: "live@example.com",
-    $email: "live@example.com",
-  });
 });
 
 test("surfaces PostHog ingestion errors", async () => {
@@ -93,21 +84,3 @@ test("rejects a malformed PostHog acknowledgement", async () => {
     /PostHog batch returned an invalid acknowledgement/,
   );
 });
-
-async function capturePostHogRequest(event: AccountAnalyticsEvent) {
-  let body: unknown;
-
-  await sendPostHogBatch({
-    events: [event],
-    projectToken: "project-token",
-    host: "https://us.i.posthog.com",
-    fetcher: async (_url, init) => {
-      body = JSON.parse(String(init?.body));
-      return Response.json({ status: "Ok" });
-    },
-  });
-
-  return body as {
-    batch: { properties: Record<string, unknown> }[];
-  };
-}

--- a/apps/web/src/lib/account-analytics.ts
+++ b/apps/web/src/lib/account-analytics.ts
@@ -54,4 +54,9 @@ export async function sendPostHogBatch({
       `PostHog batch rejected with ${response.status}: ${await response.text()}`,
     );
   }
+
+  const result = (await response.json()) as { status?: unknown };
+  if (result.status !== "Ok") {
+    throw new Error("PostHog batch returned an invalid acknowledgement");
+  }
 }

--- a/apps/web/src/lib/account-analytics.ts
+++ b/apps/web/src/lib/account-analytics.ts
@@ -37,29 +37,15 @@ export async function sendPostHogBatch({
     body: JSON.stringify({
       api_key: projectToken,
       historical_migration: events.every((event) => event.historical),
-      batch: events.map((event) => {
-        const personProperties = event.properties["$set"] as
-          | Record<string, unknown>
-          | undefined;
-
-        return {
-          event: event.event_name,
-          properties: {
-            ...event.properties,
-            ...(personProperties?.["email"]
-              ? {
-                  $set: {
-                    ...personProperties,
-                    $email: personProperties["email"],
-                  },
-                }
-              : {}),
-            distinct_id: event.user_id,
-            $insert_id: `${event.event_name}:${event.user_id}`,
-          },
-          timestamp: event.occurred_at,
-        };
-      }),
+      batch: events.map((event) => ({
+        event: event.event_name,
+        properties: {
+          ...event.properties,
+          distinct_id: event.user_id,
+          $insert_id: `${event.event_name}:${event.user_id}`,
+        },
+        timestamp: event.occurred_at,
+      })),
     }),
   });
 

--- a/apps/web/src/lib/account-analytics.ts
+++ b/apps/web/src/lib/account-analytics.ts
@@ -37,15 +37,29 @@ export async function sendPostHogBatch({
     body: JSON.stringify({
       api_key: projectToken,
       historical_migration: events.every((event) => event.historical),
-      batch: events.map((event) => ({
-        event: event.event_name,
-        properties: {
-          ...event.properties,
-          distinct_id: event.user_id,
-          $insert_id: `${event.event_name}:${event.user_id}`,
-        },
-        timestamp: event.occurred_at,
-      })),
+      batch: events.map((event) => {
+        const personProperties = event.properties["$set"] as
+          | Record<string, unknown>
+          | undefined;
+
+        return {
+          event: event.event_name,
+          properties: {
+            ...event.properties,
+            ...(personProperties?.["email"]
+              ? {
+                  $set: {
+                    ...personProperties,
+                    $email: personProperties["email"],
+                  },
+                }
+              : {}),
+            distinct_id: event.user_id,
+            $insert_id: `${event.event_name}:${event.user_id}`,
+          },
+          timestamp: event.occurred_at,
+        };
+      }),
     }),
   });
 

--- a/apps/web/src/lib/stripe-customer.test.ts
+++ b/apps/web/src/lib/stripe-customer.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getStripeCustomerOwnership } from "./stripe-customer.ts";
+import {
+  getStripeCustomerIdentityMetadata,
+  getStripeCustomerOwnership,
+} from "./stripe-customer.ts";
 
 test("Stripe metadata must belong to the authenticated user", () => {
   assert.equal(
@@ -68,5 +71,28 @@ test("empty aliases do not hide a conflicting owner", () => {
       { id: "owner-user", email: "owner@example.com" },
     ),
     "claimable",
+  );
+});
+
+test("repairs missing Stripe identity metadata", () => {
+  assert.deepEqual(
+    getStripeCustomerIdentityMetadata({ user_id: "owner-user" }, "owner-user"),
+    {
+      userId: "owner-user",
+      posthog_person_distinct_id: "owner-user",
+    },
+  );
+});
+
+test("leaves complete Stripe identity metadata unchanged", () => {
+  assert.equal(
+    getStripeCustomerIdentityMetadata(
+      {
+        userId: "owner-user",
+        posthog_person_distinct_id: "owner-user",
+      },
+      "owner-user",
+    ),
+    null,
   );
 });

--- a/apps/web/src/lib/stripe-customer.ts
+++ b/apps/web/src/lib/stripe-customer.ts
@@ -27,3 +27,20 @@ export function getStripeCustomerOwnership(
     ? "claimable"
     : "unowned";
 }
+
+export function getStripeCustomerIdentityMetadata(
+  metadata: Record<string, string> | null | undefined,
+  userId: string,
+) {
+  if (
+    metadata?.["userId"] === userId &&
+    metadata["posthog_person_distinct_id"] === userId
+  ) {
+    return null;
+  }
+
+  return {
+    userId,
+    posthog_person_distinct_id: userId,
+  };
+}

--- a/crates/api-subscription/src/stripe.rs
+++ b/crates/api-subscription/src/stripe.rs
@@ -180,6 +180,31 @@ fn customer_ownership(
     }
 }
 
+fn customer_identity_metadata(
+    metadata: Option<&HashMap<String, String>>,
+    user_id: &str,
+) -> Option<HashMap<String, String>> {
+    if metadata.is_some_and(|values| {
+        values.get("userId").is_some_and(|value| value == user_id)
+            && values
+                .get("posthog_person_distinct_id")
+                .is_some_and(|value| value == user_id)
+    }) {
+        return None;
+    }
+
+    Some(
+        [
+            ("userId".to_string(), user_id.to_string()),
+            (
+                "posthog_person_distinct_id".to_string(),
+                user_id.to_string(),
+            ),
+        ]
+        .into(),
+    )
+}
+
 async fn verify_customer_ownership(
     stripe: &stripe::Client,
     customer_id: &str,
@@ -196,33 +221,28 @@ async fn verify_customer_ownership(
         ));
     };
 
-    match customer_ownership(
+    let ownership = customer_ownership(
         customer.metadata.as_ref(),
         customer.email.as_deref(),
         user_id,
         user_email,
-    ) {
-        CustomerOwnership::Owned => {}
-        CustomerOwnership::Claimable => {
-            let metadata: HashMap<String, String> = [
-                ("userId".to_string(), user_id.to_string()),
-                (
-                    "posthog_person_distinct_id".to_string(),
-                    user_id.to_string(),
-                ),
-            ]
-            .into();
-            UpdateCustomer::new(customer_id)
-                .metadata(metadata)
-                .send(stripe)
-                .await
-                .map_err(|e: stripe::StripeError| SubscriptionError::Stripe(e.to_string()))?;
-        }
+    );
+
+    match ownership {
+        CustomerOwnership::Owned | CustomerOwnership::Claimable => {}
         CustomerOwnership::Unowned => {
             return Err(SubscriptionError::Stripe(
                 "Stripe customer does not belong to authenticated user".to_string(),
             ));
         }
+    }
+
+    if let Some(metadata) = customer_identity_metadata(customer.metadata.as_ref(), user_id) {
+        UpdateCustomer::new(customer_id)
+            .metadata(metadata)
+            .send(stripe)
+            .await
+            .map_err(|e: stripe::StripeError| SubscriptionError::Stripe(e.to_string()))?;
     }
 
     Ok(())
@@ -300,8 +320,8 @@ mod tests {
     use crate::trial::pro_trial_days;
 
     use super::{
-        CustomerOwnership, build_trial_subscription, customer_ownership,
-        trial_subscription_idempotency_key,
+        CustomerOwnership, build_trial_subscription, customer_identity_metadata,
+        customer_ownership, trial_subscription_idempotency_key,
     };
 
     #[test]
@@ -354,6 +374,43 @@ mod tests {
                 Some("owner@example.com"),
             ),
             CustomerOwnership::Claimable
+        );
+    }
+
+    #[test]
+    fn incomplete_customer_identity_metadata_is_repaired() {
+        let metadata: HashMap<String, String> =
+            [("userId".to_string(), "owner-user".to_string())].into();
+
+        assert_eq!(
+            customer_identity_metadata(Some(&metadata), "owner-user"),
+            Some(
+                [
+                    ("userId".to_string(), "owner-user".to_string()),
+                    (
+                        "posthog_person_distinct_id".to_string(),
+                        "owner-user".to_string(),
+                    ),
+                ]
+                .into()
+            )
+        );
+    }
+
+    #[test]
+    fn complete_customer_identity_metadata_is_unchanged() {
+        let metadata: HashMap<String, String> = [
+            ("userId".to_string(), "owner-user".to_string()),
+            (
+                "posthog_person_distinct_id".to_string(),
+                "owner-user".to_string(),
+            ),
+        ]
+        .into();
+
+        assert_eq!(
+            customer_identity_metadata(Some(&metadata), "owner-user"),
+            None
         );
     }
 


### PR DESCRIPTION
Verify PostHog acknowledgements and restrict delivery to the production worker. Keep Stripe customer identity metadata synchronized across web, API, and webhook paths, with a controlled backfill command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing customer metadata updates and analytics pipelines across multiple services; incorrect metadata repair could affect ownership reconciliation, though changes are guarded by tests and dry-run backfills.
> 
> **Overview**
> Aligns **Stripe customer metadata** with PostHog by standardizing owner resolution (`userId` / `user_id` / `userID` must agree) and **repairing** `userId` plus `posthog_person_distinct_id` on the web billing path, Rust subscription API, and Stripe webhook billing bridge—not only when “claiming” a customer.
> 
> **Stripe → PostHog billing events** now use the Stripe event time, dedupe via `$insert_id`, and include `stripe_invoice_id` on invoice payloads. A **dry-run/apply backfill** replays paid invoices as `subscription_payment_succeeded`; a separate script backfills missing identity metadata from Supabase profiles.
> 
> **Account analytics delivery** is **production-only** on the Netlify worker, and batch uploads **fail unless PostHog returns `{ status: "Ok" }`**. Stripe deploy pulls the PostHog key from the web Infisical path (`VITE_POSTHOG_API_KEY`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141df95d5b6165548ac0d98d4283164f0caba1b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->