### PR TITLE
Prevent Stripe analytics token regressions

### DIFF
--- a/.github/workflows/stripe_cd.yaml
+++ b/.github/workflows/stripe_cd.yaml
@@ -31,23 +31,47 @@ jobs:
       - run: |
           set -euo pipefail
 
+          project_id="$(
+            python3 -c 'import json; print(json.load(open(".infisical.json"))["workspaceId"])'
+          )"
           posthog_api_key="$(
             infisical secrets get VITE_POSTHOG_API_KEY \
               --token="$INFISICAL_TOKEN" \
               --env=prod \
-              --projectId="$INFISICAL_PROJECT_ID" \
+              --projectId="$project_id" \
               --path=/anarlog/web \
               --output=json |
               python3 -c 'import json, sys; print(json.load(sys.stdin)[0]["secretValue"])'
           )"
+
+          echo "::add-mask::$posthog_api_key"
+          if [[ "$posthog_api_key" != phc_* || ${#posthog_api_key} -lt 20 ]]; then
+            echo "Invalid Anarlog PostHog project token" >&2
+            exit 1
+          fi
+
           flyctl secrets set POSTHOG_API_KEY="$posthog_api_key" --stage --app hyprnote-stripe
+
+          flyctl deploy \
+            --config apps/stripe/fly.toml \
+            --dockerfile apps/stripe/Dockerfile \
+            --remote-only
+
+          expected_hash="$(printf %s "$posthog_api_key" | sha256sum | cut -d " " -f 1)"
+          actual_hash="$(
+            flyctl ssh console \
+              --app hyprnote-stripe \
+              --command 'sh -lc '\''printf %s "$POSTHOG_API_KEY" | sha256sum | cut -d " " -f 1'\''' |
+              grep -Eo '[0-9a-f]{64}' |
+              tail -n 1
+          )"
+          if [[ "$actual_hash" != "$expected_hash" ]]; then
+            echo "Deployed Stripe service has the wrong PostHog project token" >&2
+            exit 1
+          fi
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
-          INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
-      - run: flyctl deploy --config apps/stripe/fly.toml --dockerfile apps/stripe/Dockerfile --remote-only
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   tag:
     needs: [compute-version, deploy]


### PR DESCRIPTION
Use the repository Infisical project for the Anarlog PostHog token, reject placeholder values, and verify the live service token after every deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the Stripe CD GitHub Actions workflow (secret resolution, validation, and deploy verification); no application runtime code is modified.
> 
> **Overview**
> The **Stripe Fly deploy workflow** now sources the Infisical **project ID** from the repo’s `.infisical.json` instead of the `INFISICAL_PROJECT_ID` GitHub secret, so the Anarlog `VITE_POSTHOG_API_KEY` is always fetched from the same project as the rest of the repo.
> 
> Before deploy, the job **masks** the token, **rejects** values that don’t look like a real PostHog key (`phc_*` and minimum length), then stages `POSTHOG_API_KEY` and runs **`flyctl deploy` in the same step**. After deploy, it **SSHs into `hyprnote-stripe`** and compares **SHA-256** of the live `POSTHOG_API_KEY` to the value from Infisical; a mismatch **fails the workflow**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62542897e086cca000b169b6f5a5b07f9069b5a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->