### PR TITLE
Auto-complete the welcome demo recording

### DIFF
--- a/apps/desktop/src/onboarding/welcome-note.constants.ts
+++ b/apps/desktop/src/onboarding/welcome-note.constants.ts
@@ -1,2 +1,12 @@
 export const WELCOME_NOTE_DEMO_URL = "https://anarlog.so/onboarding-demo/";
 export const WELCOME_NOTE_TRACKING_ID = "anarlog-onboarding-demo-v1";
+export const WELCOME_NOTE_COMPLETE_PATH = "/onboarding-demo/complete";
+
+export function buildWelcomeNoteDemoUrl(meetingLink: string, port: number) {
+  const url = new URL(meetingLink);
+  url.searchParams.set(
+    "completion_url",
+    `http://127.0.0.1:${port}${WELCOME_NOTE_COMPLETE_PATH}`,
+  );
+  return url.toString();
+}

--- a/apps/desktop/src/onboarding/welcome-note.test.ts
+++ b/apps/desktop/src/onboarding/welcome-note.test.ts
@@ -3,6 +3,14 @@ import { beforeEach, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   createSession: vi.fn(),
   execute: vi.fn(),
+  listenerState: {
+    live: {
+      sessionId: null as string | null,
+      status: "inactive",
+      captureGenerationBySession: {} as Record<string, number>,
+    },
+    stop: vi.fn(),
+  },
 }));
 
 vi.mock("~/db", () => ({
@@ -13,9 +21,16 @@ vi.mock("~/session/queries", () => ({
   createSession: mocks.createSession,
 }));
 
+vi.mock("~/store/zustand/listener/instance", () => ({
+  listenerStore: {
+    getState: () => mocks.listenerState,
+  },
+}));
+
 import {
   getOrCreateWelcomeSession,
   setPendingWelcomeSession,
+  stopActiveWelcomeDemo,
   takePendingWelcomeSession,
 } from "./welcome-note";
 
@@ -27,6 +42,11 @@ beforeEach(() => {
     removeItem: (key: string) => values.delete(key),
     setItem: (key: string, value: string) => values.set(key, value),
   });
+  mocks.listenerState.live = {
+    sessionId: null,
+    status: "inactive",
+    captureGenerationBySession: {},
+  };
 });
 
 it("reuses an existing onboarding welcome note", async () => {
@@ -77,4 +97,72 @@ it("carries the welcome note across a one-time onboarding relaunch", () => {
 
   expect(takePendingWelcomeSession()).toBe("welcome-session");
   expect(takePendingWelcomeSession()).toBeNull();
+});
+
+it("stops an active welcome demo after its browser callback", async () => {
+  mocks.listenerState.live = {
+    sessionId: "welcome-session",
+    status: "active",
+    captureGenerationBySession: { "welcome-session": 1 },
+  };
+  mocks.execute.mockResolvedValueOnce([{ id: "welcome-session" }]);
+
+  await stopActiveWelcomeDemo();
+
+  expect(mocks.execute).toHaveBeenCalledWith(expect.any(String), [
+    "welcome-session",
+    "anarlog-onboarding-demo-v1",
+  ]);
+  expect(mocks.listenerState.stop).toHaveBeenCalledOnce();
+});
+
+it("ignores a demo callback while another session is active", async () => {
+  mocks.listenerState.live = {
+    sessionId: "regular-session",
+    status: "active",
+    captureGenerationBySession: { "regular-session": 1 },
+  };
+  mocks.execute.mockResolvedValueOnce([]);
+
+  await stopActiveWelcomeDemo();
+
+  expect(mocks.listenerState.stop).not.toHaveBeenCalled();
+});
+
+it("does not stop a newer capture of the welcome session", async () => {
+  mocks.listenerState.live = {
+    sessionId: "welcome-session",
+    status: "active",
+    captureGenerationBySession: { "welcome-session": 1 },
+  };
+  let finishQuery!: (rows: { id: string }[]) => void;
+  mocks.execute.mockReturnValueOnce(
+    new Promise((resolve) => {
+      finishQuery = resolve;
+    }),
+  );
+
+  const completion = stopActiveWelcomeDemo();
+  mocks.listenerState.live = {
+    sessionId: "welcome-session",
+    status: "active",
+    captureGenerationBySession: { "welcome-session": 2 },
+  };
+  finishQuery([{ id: "welcome-session" }]);
+  await completion;
+
+  expect(mocks.listenerState.stop).not.toHaveBeenCalled();
+});
+
+it("ignores a demo callback when listening already stopped", async () => {
+  mocks.listenerState.live = {
+    sessionId: "welcome-session",
+    status: "inactive",
+    captureGenerationBySession: {},
+  };
+
+  await stopActiveWelcomeDemo();
+
+  expect(mocks.execute).not.toHaveBeenCalled();
+  expect(mocks.listenerState.stop).not.toHaveBeenCalled();
 });

--- a/apps/desktop/src/onboarding/welcome-note.ts
+++ b/apps/desktop/src/onboarding/welcome-note.ts
@@ -8,6 +8,7 @@ import {
 } from "~/onboarding/welcome-note.constants";
 import { createSession } from "~/session/queries";
 import { DEFAULT_USER_ID } from "~/shared/utils";
+import { listenerStore } from "~/store/zustand/listener/instance";
 
 const PENDING_WELCOME_SESSION_KEY = "anarlog.pending-welcome-session";
 
@@ -20,7 +21,7 @@ This note is a quick way to see how Anarlog works.
 Click **Join & record** in the top-right corner. It will open a private, prerecorded demo meeting, so you don't have to worry about your camera or microphone. Anarlog will listen, transcribe the conversation, and turn it into notes just like a real meeting.
 
 
-When the video ends, come back here to review the transcript and notes.`;
+When the video ends, Anarlog will stop listening and start creating your summary automatically.`;
 
 let pendingWelcomeSession: Promise<string> | null = null;
 
@@ -45,6 +46,42 @@ export function takePendingWelcomeSession(): string | null {
   const sessionId = localStorage.getItem(PENDING_WELCOME_SESSION_KEY);
   localStorage.removeItem(PENDING_WELCOME_SESSION_KEY);
   return sessionId;
+}
+
+export async function stopActiveWelcomeDemo() {
+  const active = listenerStore.getState().live;
+  const sessionId = active.sessionId;
+  if (!sessionId || active.status !== "active") {
+    return;
+  }
+  const captureGeneration = active.captureGenerationBySession[sessionId];
+
+  const rows = await liveQueryClient.execute<{ id: string }>(
+    `
+      SELECT id
+      FROM sessions
+      WHERE id = ?
+        AND deleted_at IS NULL
+        AND CASE
+          WHEN json_valid(event_json)
+          THEN json_extract(event_json, '$.tracking_id')
+        END = ?
+      LIMIT 1
+    `,
+    [sessionId, WELCOME_NOTE_TRACKING_ID],
+  );
+  if (!rows[0]) {
+    return;
+  }
+
+  const current = listenerStore.getState();
+  if (
+    current.live.sessionId === sessionId &&
+    current.live.status === "active" &&
+    current.live.captureGenerationBySession[sessionId] === captureGeneration
+  ) {
+    current.stop();
+  }
 }
 
 async function findOrCreateWelcomeSession(): Promise<string> {

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -23,6 +23,8 @@ const mocks = vi.hoisted(() => ({
   sessionEvents: {} as Record<string, any>,
   nowMs: new Date("2026-06-05T09:50:00.000Z").getTime(),
   openUrl: vi.fn(),
+  startCallbackServer: vi.fn(),
+  getScheme: vi.fn(),
   startListening: vi.fn(),
   stopListening: vi.fn(),
   stopTranscription: vi.fn(),
@@ -85,6 +87,12 @@ vi.mock("@hypr/plugin-opener2", () => ({
   },
 }));
 
+vi.mock("@hypr/plugin-deeplink2", () => ({
+  commands: {
+    startCallbackServer: mocks.startCallbackServer,
+  },
+}));
+
 vi.mock("~/calendar/hooks", () => ({
   useNow: () => new Date(mocks.nowMs),
 }));
@@ -106,6 +114,11 @@ vi.mock("~/session/hooks/useSessionEvent", () => ({
 
 vi.mock("~/shared/config", () => ({
   useConfigValue: (key: string) => mocks.configValues[key],
+}));
+
+vi.mock("~/shared/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/shared/utils")>()),
+  getScheme: mocks.getScheme,
 }));
 
 vi.mock("~/store/zustand/tabs", () => ({
@@ -155,6 +168,13 @@ describe("OuterHeader", () => {
     mocks.sessionEvents = {};
     mocks.nowMs = new Date("2026-06-05T09:50:00.000Z").getTime();
     mocks.openUrl.mockClear();
+    mocks.startCallbackServer.mockReset();
+    mocks.startCallbackServer.mockResolvedValue({
+      status: "ok",
+      data: 43210,
+    });
+    mocks.getScheme.mockReset();
+    mocks.getScheme.mockResolvedValue("anarlog-dev");
     mocks.startListening.mockClear();
     mocks.stopListening.mockClear();
     mocks.stopTranscription.mockClear();
@@ -451,7 +471,7 @@ describe("OuterHeader", () => {
     expect(mocks.startListening).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the Anarlog logo for the welcome note meeting", () => {
+  it("opens the welcome demo with an automatic completion callback", async () => {
     mocks.sessionEvents = {
       "session-1": {
         tracking_id: "anarlog-onboarding-demo-v1",
@@ -469,8 +489,23 @@ describe("OuterHeader", () => {
     const joinButton = screen.getByRole("button", { name: "Join & record" });
     const logo = joinButton.querySelector("img");
 
+    fireEvent.click(joinButton);
+
     expect(logo?.getAttribute("src")).toBe("/assets/anarlog-icon.png");
     expect(logo?.getAttribute("alt")).toBe("");
+    expect(mocks.startListening).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(mocks.startCallbackServer).toHaveBeenCalledWith("anarlog-dev");
+      expect(mocks.openUrl).toHaveBeenCalledOnce();
+    });
+
+    const openedUrl = new URL(mocks.openUrl.mock.calls[0][0]);
+    expect(openedUrl.origin + openedUrl.pathname).toBe(
+      "https://anarlog.so/onboarding-demo/",
+    );
+    expect(openedUrl.searchParams.get("completion_url")).toBe(
+      "http://127.0.0.1:43210/onboarding-demo/complete",
+    );
   });
 
   it("shows the meeting countdown to the left of the header action", () => {

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -508,6 +508,49 @@ describe("OuterHeader", () => {
     );
   });
 
+  it("ignores repeated welcome demo joins while startup is in progress", async () => {
+    let resolveCallbackServer: (value: {
+      status: "ok";
+      data: number;
+    }) => void = () => {};
+    mocks.startCallbackServer.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCallbackServer = resolve;
+      }),
+    );
+    mocks.sessionEvents = {
+      "session-1": {
+        tracking_id: "anarlog-onboarding-demo-v1",
+        meeting_link: "https://anarlog.so/onboarding-demo/",
+      },
+    };
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+      />,
+    );
+
+    const joinButton = screen.getByRole("button", { name: "Join & record" });
+
+    fireEvent.click(joinButton);
+    fireEvent.click(joinButton);
+
+    expect(joinButton.hasAttribute("disabled")).toBe(true);
+    expect(mocks.startListening).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(mocks.startCallbackServer).toHaveBeenCalledOnce();
+    });
+
+    resolveCallbackServer({ status: "ok", data: 43210 });
+
+    await vi.waitFor(() => {
+      expect(mocks.openUrl).toHaveBeenCalledOnce();
+      expect(joinButton.hasAttribute("disabled")).toBe(false);
+    });
+  });
+
   it("shows the meeting countdown to the left of the header action", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-05T09:55:30.000Z"));

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -5,7 +5,7 @@ import {
   SquareIcon,
   VideoIcon,
 } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { commands as deeplinkCommands } from "@hypr/plugin-deeplink2";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
@@ -164,13 +164,15 @@ function HeaderMeetingActionPill({
   const { audioExists } = useAudioPlayer();
   const canResume = audioExists || hasTranscript;
   const { t } = useLingui();
-  const start = useCallback(() => {
+  const joiningMeetingRef = useRef(false);
+  const [joiningMeeting, setJoiningMeeting] = useState(false);
+  const start = useCallback(async () => {
     if (!isMainWebviewWindow()) {
-      void requestMainListenerControl("start", sessionId);
+      await requestMainListenerControl("start", sessionId);
       return;
     }
 
-    void startListening();
+    await startListening();
   }, [sessionId, startListening]);
   const openMeeting = useCallback(async () => {
     if (!meetingLink) {
@@ -195,21 +197,36 @@ function HeaderMeetingActionPill({
 
     void openerCommands.openUrl(url, null);
   }, [event?.tracking_id, meetingLink]);
+  const joinMeeting = useCallback(async () => {
+    if (joiningMeetingRef.current) {
+      return;
+    }
+
+    joiningMeetingRef.current = true;
+    setJoiningMeeting(true);
+    try {
+      await Promise.all([openMeeting(), start()]);
+    } finally {
+      joiningMeetingRef.current = false;
+      setJoiningMeeting(false);
+    }
+  }, [openMeeting, start]);
   const handleCountdownExpire = useCallback(() => {
     if (!autoStartScheduledMeetings || !canStartLiveSession) {
       return;
     }
 
     if (autoJoinScheduledMeetings && meetingLink) {
-      void openMeeting();
+      void joinMeeting();
+    } else {
+      void start();
     }
-    start();
   }, [
     autoJoinScheduledMeetings,
     autoStartScheduledMeetings,
     canStartLiveSession,
+    joinMeeting,
     meetingLink,
-    openMeeting,
     start,
   ]);
   const countdown = useEventCountdown(sessionId, {
@@ -255,8 +272,7 @@ function HeaderMeetingActionPill({
             getMeetingDisplay(remote.type).icon
           ) : undefined,
         onClick: () => {
-          void openMeeting();
-          start();
+          void joinMeeting();
         },
       };
     }
@@ -277,7 +293,7 @@ function HeaderMeetingActionPill({
       onClick: start,
     };
   })();
-  const disabled = sessionMode === "finalizing";
+  const disabled = sessionMode === "finalizing" || joiningMeeting;
   const showCountdown =
     Boolean(countdown.label) &&
     sessionMode !== "active" &&

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "lucide-react";
 import { useCallback } from "react";
 
+import { commands as deeplinkCommands } from "@hypr/plugin-deeplink2";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { cn, safeParseDate } from "@hypr/utils";
 
@@ -17,7 +18,10 @@ import { OverflowButton } from "./overflow";
 import { useAudioPlayer } from "~/audio-player";
 import { useNow } from "~/calendar/hooks";
 import { useShell } from "~/contexts/shell";
-import { WELCOME_NOTE_TRACKING_ID } from "~/onboarding/welcome-note.constants";
+import {
+  buildWelcomeNoteDemoUrl,
+  WELCOME_NOTE_TRACKING_ID,
+} from "~/onboarding/welcome-note.constants";
 import { SessionShareButton } from "~/session-sharing";
 import { useEventCountdown } from "~/session/hooks/useEventCountdown";
 import {
@@ -26,6 +30,7 @@ import {
 } from "~/session/hooks/useRemoteMeeting";
 import { useSessionEvent } from "~/session/hooks/useSessionEvent";
 import { useConfigValue } from "~/shared/config";
+import { getScheme } from "~/shared/utils";
 import type { EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
 import { useStartListening } from "~/stt/useStartListening";
@@ -167,13 +172,36 @@ function HeaderMeetingActionPill({
 
     void startListening();
   }, [sessionId, startListening]);
+  const openMeeting = useCallback(async () => {
+    if (!meetingLink) {
+      return;
+    }
+
+    let url = meetingLink;
+    if (event?.tracking_id === WELCOME_NOTE_TRACKING_ID) {
+      try {
+        const scheme = await getScheme();
+        const result = await deeplinkCommands.startCallbackServer(scheme);
+        if (result.status === "ok") {
+          url = buildWelcomeNoteDemoUrl(meetingLink, result.data);
+        }
+      } catch (error) {
+        console.error(
+          "[onboarding] failed to prepare demo completion callback",
+          error,
+        );
+      }
+    }
+
+    void openerCommands.openUrl(url, null);
+  }, [event?.tracking_id, meetingLink]);
   const handleCountdownExpire = useCallback(() => {
     if (!autoStartScheduledMeetings || !canStartLiveSession) {
       return;
     }
 
     if (autoJoinScheduledMeetings && meetingLink) {
-      void openerCommands.openUrl(meetingLink, null);
+      void openMeeting();
     }
     start();
   }, [
@@ -181,6 +209,7 @@ function HeaderMeetingActionPill({
     autoStartScheduledMeetings,
     canStartLiveSession,
     meetingLink,
+    openMeeting,
     start,
   ]);
   const countdown = useEventCountdown(sessionId, {
@@ -226,7 +255,7 @@ function HeaderMeetingActionPill({
             getMeetingDisplay(remote.type).icon
           ) : undefined,
         onClick: () => {
-          void openerCommands.openUrl(meetingLink, null);
+          void openMeeting();
           start();
         },
       };

--- a/apps/desktop/src/shared/hooks/useDeeplinkHandler.ts
+++ b/apps/desktop/src/shared/hooks/useDeeplinkHandler.ts
@@ -12,6 +12,7 @@ import { dismissInstruction } from "@hypr/plugin-windows";
 
 import { useAuth } from "~/auth";
 import { createAuthCallbackHandler } from "~/auth/deeplink";
+import { stopActiveWelcomeDemo } from "~/onboarding/welcome-note";
 import {
   allowReconnectedCalendarConnections,
   CALENDAR_SYNC_TASK_ID,
@@ -74,6 +75,10 @@ export function useDeeplinkHandler() {
       } else if (payload.to === "/billing/refresh") {
         void authRef.current.refreshSession();
         void dismissInstruction();
+      } else if (payload.to === "/onboarding-demo/complete") {
+        void stopActiveWelcomeDemo().catch((error) => {
+          console.error("[onboarding] failed to complete welcome demo", error);
+        });
       } else if (payload.to === "/integration/callback") {
         const {
           disconnected_connection_id,

--- a/apps/web/content/deeplinks/onboarding-demo-complete.mdx
+++ b/apps/web/content/deeplinks/onboarding-demo-complete.mdx
@@ -1,0 +1,6 @@
+---
+path: "/onboarding-demo/complete"
+description: null
+params: []
+---
+

--- a/apps/web/public/onboarding-demo/index.html
+++ b/apps/web/public/onboarding-demo/index.html
@@ -976,12 +976,45 @@
       const chatMessages = document.querySelector(".chat-messages");
       const avatarPhoto = document.querySelector(".avatar-photo");
       const params = new URLSearchParams(window.location.search);
-      const joiningUrl =
-        window.location.protocol === "file:"
-          ? "https://anarlog.so/onboarding-demo"
-          : window.location.href;
+      const completionUrl = getCompletionUrl(params.get("completion_url"));
+      const joiningUrl = getJoiningUrl();
 
       document.querySelector(".joining-url").textContent = joiningUrl;
+
+      function getJoiningUrl() {
+        if (window.location.protocol === "file:") {
+          return "https://anarlog.so/onboarding-demo";
+        }
+
+        const url = new URL(window.location.href);
+        url.searchParams.delete("completion_url");
+        return url.toString();
+      }
+
+      function getCompletionUrl(value) {
+        if (!value) return null;
+
+        try {
+          const url = new URL(value);
+          const validPort = /^[0-9]+$/.test(url.port);
+          const validPath = url.pathname === "/onboarding-demo/complete";
+          if (
+            url.protocol !== "http:" ||
+            url.hostname !== "127.0.0.1" ||
+            !validPort ||
+            !validPath ||
+            url.username ||
+            url.password ||
+            url.search ||
+            url.hash
+          ) {
+            return null;
+          }
+          return url.toString();
+        } catch {
+          return null;
+        }
+      }
 
       function updateTime() {
         document.querySelector(".current-time").textContent = new Intl.DateTimeFormat(
@@ -1122,7 +1155,11 @@
         }
       });
       video.addEventListener("ended", () => {
-        closeMeeting();
+        if (completionUrl) {
+          window.location.replace(completionUrl);
+        } else {
+          closeMeeting();
+        }
       });
       joinButton.addEventListener("click", playFromStart);
       chatButton.addEventListener("click", () => {

--- a/plugins/deeplink2/js/bindings.gen.ts
+++ b/plugins/deeplink2/js/bindings.gen.ts
@@ -67,9 +67,10 @@ shareOpenPendingEvent: "plugin:deeplink2:share-open-pending-event"
 
 export type AuthCallbackSearch = { access_token: string; refresh_token: string }
 export type BillingRefreshSearch = Record<string, never>
-export type DeepLink = { to: "/auth/callback"; search: AuthCallbackSearch } | { to: "/billing/refresh"; search: BillingRefreshSearch } | { to: "/integration/callback"; search: IntegrationCallbackSearch }
+export type DeepLink = { to: "/auth/callback"; search: AuthCallbackSearch } | { to: "/billing/refresh"; search: BillingRefreshSearch } | { to: "/integration/callback"; search: IntegrationCallbackSearch } | { to: "/onboarding-demo/complete"; search: OnboardingDemoCompleteSearch }
 export type DeepLinkEvent = DeepLink
 export type IntegrationCallbackSearch = { integration_id: string; status: string; disconnected_connection_id: string | null; return_to: string | null }
+export type OnboardingDemoCompleteSearch = Record<string, never>
 export type ShareOpenPendingEvent = { pending_id: string }
 export type ShareOpenRequest = { mode: "account"; share_id: string } | { mode: "handoff"; request_id: string }
 

--- a/plugins/deeplink2/src/lib.rs
+++ b/plugins/deeplink2/src/lib.rs
@@ -11,7 +11,7 @@ mod docs;
 pub use error::{Error, Result};
 pub use types::{
     AuthCallbackSearch, BillingRefreshSearch, DeepLink, DeepLinkEvent, IntegrationCallbackSearch,
-    ShareOpenPendingEvent, ShareOpenRequest,
+    OnboardingDemoCompleteSearch, ShareOpenPendingEvent, ShareOpenRequest,
 };
 
 use std::str::FromStr;

--- a/plugins/deeplink2/src/server/mod.rs
+++ b/plugins/deeplink2/src/server/mod.rs
@@ -122,6 +122,11 @@ fn ui_content(deep_link: &DeepLink) -> (bool, &'static str, &'static str) {
             "Connection failed",
             "Something went wrong. Please close this window and try again.",
         ),
+        DeepLink::OnboardingDemoComplete(_) => (
+            true,
+            "Demo complete",
+            "Anarlog is finishing your transcript and creating your summary.",
+        ),
     }
 }
 

--- a/plugins/deeplink2/src/types/mod.rs
+++ b/plugins/deeplink2/src/types/mod.rs
@@ -1,11 +1,13 @@
 mod auth_callback;
 mod billing_refresh;
 mod integration_callback;
+mod onboarding_demo_complete;
 mod share_open;
 
 pub use auth_callback::*;
 pub use billing_refresh::*;
 pub use integration_callback::*;
+pub use onboarding_demo_complete::*;
 pub use share_open::*;
 
 use serde::{Deserialize, Serialize};
@@ -34,6 +36,8 @@ pub enum DeepLink {
     BillingRefresh(BillingRefreshSearch),
     #[serde(rename = "/integration/callback")]
     IntegrationCallback(IntegrationCallbackSearch),
+    #[serde(rename = "/onboarding-demo/complete")]
+    OnboardingDemoComplete(OnboardingDemoCompleteSearch),
 }
 
 pub(crate) enum IncomingDeepLink {
@@ -100,6 +104,7 @@ impl DeepLink {
             DeepLink::AuthCallback(_) => "/auth/callback",
             DeepLink::BillingRefresh(_) => "/billing/refresh",
             DeepLink::IntegrationCallback(_) => "/integration/callback",
+            DeepLink::OnboardingDemoComplete(_) => "/onboarding-demo/complete",
         }
     }
 }
@@ -124,7 +129,23 @@ impl FromStr for DeepLink {
             "auth/callback" => Ok(DeepLink::AuthCallback(serde_qs::from_str(query)?)),
             "billing/refresh" => Ok(DeepLink::BillingRefresh(serde_qs::from_str(query)?)),
             "integration/callback" => Ok(DeepLink::IntegrationCallback(serde_qs::from_str(query)?)),
+            "onboarding-demo/complete" => {
+                Ok(DeepLink::OnboardingDemoComplete(serde_qs::from_str(query)?))
+            }
             _ => Err(crate::Error::UnknownPath(full_path)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_onboarding_demo_completion() {
+        assert!(matches!(
+            DeepLink::from_str("anarlog://onboarding-demo/complete").unwrap(),
+            DeepLink::OnboardingDemoComplete(_)
+        ));
     }
 }

--- a/plugins/deeplink2/src/types/onboarding_demo_complete.rs
+++ b/plugins/deeplink2/src/types/onboarding_demo_complete.rs
@@ -1,0 +1,5 @@
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct OnboardingDemoCompleteSearch {}


### PR DESCRIPTION
Stop the active welcome capture through a validated browser callback so normal transcript finalization and summary generation run automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live listening stop behavior and local HTTP callbacks for onboarding, but guards limit stops to the welcome session and matching capture generation.
> 
> **Overview**
> **Automatically ends the onboarding welcome demo** when the prerecorded video finishes, so transcript finalization and summary generation run without the user returning to the app manually.
> 
> On **Join & record** for the welcome session, the desktop app starts the local deeplink callback server and opens the demo with a `completion_url` pointing at `http://127.0.0.1:{port}/onboarding-demo/complete`. The public demo page only accepts that URL if it is loopback HTTP with the expected path; when playback ends it navigates there instead of closing the meeting UI.
> 
> The callback is wired through **deeplink2** as `/onboarding-demo/complete`. `useDeeplinkHandler` calls **`stopActiveWelcomeDemo`**, which stops the listener only when the active capture is the welcome session (matched by `tracking_id`), and skips stop if another session is active, listening already ended, or the capture generation changed mid-flight. Join is debounced while callback setup runs, and the welcome note text now describes automatic stop and summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe53d6638e252b5893e95590c2b624562c1f0fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->