### PR TITLE
Add 1.3.11 release notes

### DIFF
--- a/packages/changelog/content/1.3.11.md
+++ b/packages/changelog/content/1.3.11.md
@@ -1,0 +1,14 @@
+---
+date: "2026-07-26"
+summary: "Anarlog 1.3.11 adds dedicated Cloud Sync controls and automatically finishes the welcome demo recording."
+---
+
+## Cloud Sync
+
+- Manage Cloud Sync, end-to-end encryption, and manual syncing from a dedicated Sync settings page
+- Pause or resume syncing from the main status control, with clearer states for local saves, setup issues, and sync progress
+
+## Getting started
+
+- Finish the welcome demo recording automatically when its video ends, then finalize the transcript and start creating the summary
+- Prevent repeated clicks on **Join & record** from opening overlapping demo sessions


### PR DESCRIPTION
Summarize the new Cloud Sync controls and automatic welcome demo completion for the next desktop release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no application or infrastructure code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.3.11.md`** for the next desktop release, dated **2026-07-26**, in the same frontmatter + section format as prior entries (e.g. 1.3.10).
> 
> The notes document **Cloud Sync**: a dedicated Sync settings page for sync, E2E encryption, and manual sync, plus pause/resume from the main status control with clearer local-save, setup, and progress states. **Getting started** covers auto-finishing the welcome demo when the video ends (transcript finalize → summary) and blocking duplicate **Join & record** clicks from opening overlapping demo sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc1e202fcc157147380653ceaf5c21cae7685a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->