### PR TITLE
QA for speakers

### DIFF
--- a/.agents/skills/qa-critical-ux/SKILL.md
+++ b/.agents/skills/qa-critical-ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-critical-ux
-description: QA-test the critical desktop user experience before a release — auth, CloudSync, calendar connect + notifications, note creation, recording, chat, and automated summaries across on-device, API-key, and Pro providers. Use before cutting a stable release, after changes to auth/CloudSync/STT/enhance/calendar/billing flows, or when asked to "QA the app".
+description: QA-test the critical desktop user experience before a release — auth, CloudSync, calendar connect + notifications, note creation, recording, speaker identification, chat, and automated summaries across on-device, API-key, and Pro providers. Use before cutting a stable release, after changes to auth/CloudSync/STT/enhance/calendar/billing flows, or when asked to "QA the app".
 ---
 
 # QA: Critical User Experience
@@ -99,8 +99,19 @@ waived by the user) before running the release-new-version skill.
    built-in speakers and microphone with no external audio device attached.
    The Dev helper fails before launch unless both macOS default devices use
    the built-in transport; do not bypass that preflight.
-6. Play at most three minutes of the Lex Fridman fixture from a long-lived terminal
-   command after recording starts:
+6. Create an untitled note, open its metadata through the UI, and add exactly
+   these two fixture participants before recording:
+
+   - **Lex Fridman**
+   - **George Hotz**
+
+   Do not seed participant rows directly in SQLite. The participant field must
+   show both names without an **Unknown** chip, and the two named mappings must
+   persist after the app restarts. In the fixture reference
+   `crates/data/src/english_10/pyannote.json`, `SPEAKER_01` is Lex Fridman and
+   `SPEAKER_00` is George Hotz.
+7. Play at most three minutes of the Lex Fridman/George Hotz fixture from a
+   long-lived terminal command after recording starts:
 
    ```bash
    /usr/bin/afplay -v 0.7 -t 180 \
@@ -109,6 +120,37 @@ waived by the user) before running the release-new-version skill.
 
    Let the three-minute cap finish naturally, or stop it earlier with Ctrl-C.
    Do not use QuickTime or Computer Use just to control fixture playback.
+
+## Known fixture ground truth
+
+The bundled audio is an excerpt from Lex Fridman Podcast #387 with George
+Hotz. Use the repo's time-aligned
+`crates/data/src/english_10/pyannote.json` as the transcription reference and
+the [official episode transcript](https://lexfridman.com/george-hotz-3-transcript)
+as the identity reference. Together they establish this canonical mapping:
+
+| Fixture speaker | Participant |
+| --- | --- |
+| `SPEAKER_01` | Lex Fridman |
+| `SPEAKER_00` | George Hotz |
+
+Validate at least these opening checkpoints after aligning to the first
+recognized fixture phrase. Fixture timestamps are audio-relative, not session
+wall-clock timestamps:
+
+| Fixture time | Expected participant | Semantic checkpoint |
+| --- | --- | --- |
+| 2.925-13.005 s | Lex Fridman | Asks what George thinks about Llama being open sourced |
+| 14.145-19.025 s | George Hotz | Says Mark Zuckerberg is the good guy |
+| 20.125-29.665 s | Lex Fridman | Asks whether open source is ultimately good |
+| 30.365-36.065 s | George Hotz | Answers "Undoubtedly" and begins discussing AI safety people |
+
+Use `turnLevelTranscription` for turn ownership and
+`wordLevelTranscription` only when finer alignment is needed. Provider wording
+and punctuation may differ, so compare the meaning and speaker ownership
+rather than requiring byte-identical text. The generic fixture IDs are valid
+only inside the reference file; they are not acceptable participant labels in
+the app.
 
 ## Release-candidate order
 
@@ -205,6 +247,17 @@ tests alone is not cross-platform evidence.
 - Also verify both microphone and system-audio inputs carry nonzero signal,
   AEC initializes without an error or fallback, and the transcript follows
   the podcast once rather than duplicating phrases from speaker leakage.
+- Speaker diarization and identity are separate release gates for this known
+  fixture. After the full recording settles, require exactly two RemoteParty
+  speaker clusters and compare their turns with the **Known fixture ground
+  truth** above. Every listed checkpoint must have the expected participant.
+- PASS speaker identification only when the live or settled transcript labels
+  those clusters **Lex Fridman** and **George Hotz** automatically. Generic
+  labels such as **Speaker 1**, swapped names, a third RemoteParty cluster, or
+  names that appear only after a tester manually assigns them are failures. A
+  transcript that names only the opening turns and later reverts to generic or
+  inconsistent labels also fails. Verify both named assignments and the
+  participant mappings survive app restart unchanged.
 - `audio_mic.wav` is the post-AEC, post-VAD microphone track, not the raw
   microphone. For a playback-only run, require all of:
   - `audio_mic.wav` and `audio_spk.wav` are readable mono 16 kHz WAVs whose
@@ -306,11 +359,17 @@ tests alone is not cross-platform evidence.
 - Useful signals: `sessions`, `transcripts`, and `session_documents`
   (kind = summary) tables via the app DB; console/log output from the
   dev server for stall-watchdog and enhance-task errors.
+- For the known two-speaker fixture, inspect `session_participants` and the
+  transcript's `speaker_hints_json` alongside the rendered UI. Count distinct
+  `provider_speaker_index` values per channel, but use the visible names to
+  gate identity attribution. Do not create `user_speaker_assignment` hints
+  before recording the automatic-identification result.
 
 ## Reporting
 
 Produce a table: checklist item × provider config → PASS/FAIL with a
 one-line note. Include the Dev manifest's Git SHA/dirty state, staging run
 URL and head SHA, staging artifact SHA-256, stable release URL and artifact
-SHA-256, app version, and any explicit waiver. Any FAIL or SHA mismatch blocks
-release; file or fix before cutting.
+SHA-256, app version, speaker-cluster count, speaker-name result, and any
+explicit waiver. Any FAIL or SHA mismatch blocks release; file or fix before
+cutting.

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/chip.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/chip.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ParticipantChip } from "./chip";
+
+import type { SessionParticipantRecord } from "~/session/queries";
+
+const mocks = vi.hoisted(() => ({
+  participant: null as SessionParticipantRecord | null,
+  removeSessionParticipant: vi.fn(),
+  removeHumanSpeakerAssignments: vi.fn(),
+}));
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children: ReactNode }) => children,
+  useLingui: () => ({ t: (value: string) => value }),
+}));
+
+vi.mock("~/session/queries", () => ({
+  removeSessionParticipant: mocks.removeSessionParticipant,
+  useSessionParticipant: () => mocks.participant,
+}));
+
+vi.mock("~/store/zustand/tabs/index", () => ({
+  useTabs: {
+    getState: () => ({ openNew: vi.fn() }),
+  },
+}));
+
+vi.mock("~/stt/queries", () => ({
+  removeHumanSpeakerAssignments: mocks.removeHumanSpeakerAssignments,
+}));
+
+function participant(
+  overrides: Partial<SessionParticipantRecord> = {},
+): SessionParticipantRecord {
+  return {
+    id: "mapping-1",
+    sessionId: "session-1",
+    humanId: "human-1",
+    source: "manual",
+    name: "Lex Fridman",
+    email: "",
+    jobTitle: "",
+    linkedinUsername: "",
+    organizationId: "",
+    organizationName: "",
+    ...overrides,
+  };
+}
+
+describe("ParticipantChip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.participant = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("hides participants without a name or email", () => {
+    mocks.participant = participant({ name: "", email: "" });
+
+    const { container } = render(<ParticipantChip mappingId="mapping-1" />);
+
+    expect(container.textContent).toBe("");
+    expect(screen.queryByText("Unknown")).toBeNull();
+  });
+
+  it("uses the email when a participant has no name", () => {
+    mocks.participant = participant({ name: "", email: "lex@example.com" });
+
+    render(<ParticipantChip mappingId="mapping-1" />);
+
+    expect(screen.getByText("lex@example.com")).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
@@ -52,7 +52,13 @@ export function ParticipantChip({
     return null;
   }
 
-  const { humanName } = details;
+  const { humanName, humanEmail } = details;
+  const displayName = humanName.trim() || humanEmail?.trim();
+
+  if (!displayName) {
+    return null;
+  }
+
   const isEnhancing = enhancingHumanId === assignedHumanId;
   const canEnhance = Boolean(onEnhanceContact && assignedHumanId);
 
@@ -71,12 +77,12 @@ export function ParticipantChip({
           className="animate-shimmer pointer-events-none absolute inset-0 -translate-x-full bg-linear-to-r from-transparent via-white/60 to-transparent"
         />
       )}
-      <span className="relative z-10">{humanName || "Unknown"}</span>
+      <span className="relative z-10">{displayName}</span>
       {canEnhance && (
         <EnhanceContactButton
           isEnhancing={isEnhancing}
           isDisabled={Boolean(enhancingHumanId)}
-          label={humanName || "contact"}
+          label={displayName}
           onClick={() => {
             if (assignedHumanId) {
               onEnhanceContact?.(assignedHumanId);

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
@@ -139,7 +139,7 @@ export function ParticipantInput({ sessionId }: { sessionId: string }) {
             variant="secondary"
             className="bg-foreground/10 flex items-center gap-1 px-2 py-0.5 text-xs opacity-60"
           >
-            <span>{pending.name || "Unknown"}</span>
+            <span>{pending.name}</span>
             <Loader2Icon className="size-2.5 animate-spin" aria-hidden="true" />
           </Badge>
         ))}
@@ -282,7 +282,11 @@ function useParticipantMutations(
       const key = ++pendingAddKeyRef.current;
       setPendingAdds((prev) => [
         ...prev,
-        { key, humanId: option.isNew ? null : option.id, name: option.name },
+        {
+          key,
+          humanId: option.isNew ? null : option.id,
+          name: option.name || option.email || "",
+        },
       ]);
 
       void (async () => {


### PR DESCRIPTION
- Add speaker identification to release QA.
- Require Lex Fridman and George Hotz fixture participants and gate automatic transcript identity labels.
- Hide unnamed participant chips.
- Preserve empty self-participant rows for speaker routing while hiding them from metadata and using email as the visible fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to QA documentation and participant chip display logic; no auth, sync, or recording pipeline code paths are modified in the diff.
> 
> **Overview**
> **Release QA** now treats **speaker identification** as a first-class gate alongside recording: setup requires adding **Lex Fridman** and **George Hotz** as note participants via the UI (not SQLite), documents **known fixture ground truth** from `english_10/pyannote.json`, and fails automatic ID unless transcript clusters map to those names without manual assignment. Reporting adds speaker-cluster count and speaker-name results; automation notes cover `session_participants` / `speaker_hints_json` inspection.
> 
> **Participant metadata UI** stops showing **Unknown** chips: `ParticipantChip` renders nothing when there is no trimmed name or email, otherwise shows name or **email** as the label (including enhance-contact copy). Pending add badges use `name || email` instead of a bare name or **Unknown**. Vitest covers hide-empty and email-fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fa46c3288100180dcc1d966b19d431d06d59b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->