### PR TITLE
Visually balance update toolbar spacing

### DIFF
--- a/apps/desktop/src/main/update-banner.tsx
+++ b/apps/desktop/src/main/update-banner.tsx
@@ -351,7 +351,7 @@ export function SidebarTimelineUpdateButton({
       data-tauri-drag-region="false"
       disabled={isDownloading || update.downloadStarting || update.installing}
       className={cn([
-        "relative flex h-7 min-h-7 w-7 min-w-7 shrink-0 items-center justify-center rounded-full p-0",
+        "relative ml-2 flex h-7 min-h-7 w-7 min-w-7 shrink-0 items-center justify-center rounded-full p-0",
         "bg-blue-500 text-white shadow-sm transition-colors hover:bg-blue-600",
         "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
         "disabled:cursor-default disabled:bg-blue-500 disabled:text-white disabled:opacity-70 disabled:hover:bg-blue-500",


### PR DESCRIPTION
Add optical separation before the filled updater control so the titlebar actions read as evenly spaced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind spacing class on a desktop UI control; no behavior, auth, or data changes.
> 
> **Overview**
> Adds **`ml-2`** to the circular sidebar update control in `SidebarTimelineUpdateButton` so it sits slightly apart from neighboring titlebar actions and reads as more evenly spaced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08b0d8ce19c7af92aa99fd96172b0f6a41a75d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->