### PR TITLE
Remove clipped sync status focus ring

### DIFF
--- a/apps/desktop/src/main/sync-status.tsx
+++ b/apps/desktop/src/main/sync-status.tsx
@@ -254,7 +254,7 @@ export function SyncStatusIndicator() {
           className={cn([
             "fixed right-3 bottom-3 z-40",
             "border-border/60 bg-background/90 flex size-8 items-center justify-center rounded-xl border shadow-sm backdrop-blur",
-            "text-muted-foreground hover:text-foreground transition-colors",
+            "text-muted-foreground hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground outline-hidden transition-colors",
           ])}
         >
           {view.kind === "error" && (


### PR DESCRIPTION
Replace the oversized native outline with a contained background focus state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change to focus styling on a UI control; no sync, auth, or data logic affected.
> 
> **Overview**
> Updates the floating **cloud sync status** trigger button so keyboard focus no longer shows a clipped native outline.
> 
> On `:focus-visible`, the button now uses **`outline-hidden`** plus **`focus-visible:bg-accent`** and **`focus-visible:text-foreground`**, matching hover-like emphasis inside the rounded control instead of an oversized ring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f06e04c9f0bfb436fd190d81d13203eb2c8d4ee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->