### PR TITLE
Render ignored apps after settings hydration

### DIFF
--- a/apps/desktop/src/settings/general/notification.test.tsx
+++ b/apps/desktop/src/settings/general/notification.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clearNotifications: vi.fn(),
+  setSettingValues: vi.fn(),
+  useConfigValues: vi.fn(),
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  useLingui: () => ({
+    t: (input: TemplateStringsArray | string) =>
+      typeof input === "string" ? input : input.join(""),
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: mocks.useQuery,
+}));
+
+vi.mock("@hypr/plugin-detect", () => ({
+  commands: {
+    listDefaultIgnoredBundleIds: vi.fn(),
+    listInstalledApplications: vi.fn(),
+  },
+}));
+
+vi.mock("@hypr/plugin-notification", () => ({
+  commands: {
+    clearNotifications: mocks.clearNotifications,
+  },
+}));
+
+vi.mock("~/settings/queries", () => ({
+  useSetSettingValues: () => mocks.setSettingValues,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValues: mocks.useConfigValues,
+}));
+
+import { NotificationSettingsView } from "./notification";
+
+const baseConfig = {
+  notification_event: false,
+  notification_detect: true,
+  respect_dnd: false,
+  ignored_platforms: [],
+  included_platforms: [],
+  mic_active_threshold: 15,
+};
+
+describe("NotificationSettingsView", () => {
+  beforeEach(() => {
+    mocks.clearNotifications.mockReset();
+    mocks.setSettingValues.mockReset();
+    mocks.useConfigValues.mockReset();
+    mocks.useConfigValues.mockReturnValue(baseConfig);
+    mocks.useQuery.mockImplementation(
+      ({ queryKey }: { queryKey: readonly string[] }) => {
+        if (queryKey[1] === "all-installed-applications") {
+          return {
+            data: [{ id: "com.ting.aqua-bridge", name: "Ting Aqua Bridge" }],
+          };
+        }
+        return { data: [] };
+      },
+    );
+  });
+
+  afterEach(cleanup);
+
+  it("shows persisted ignored apps as soon as the form hydrates", async () => {
+    const { rerender } = render(<NotificationSettingsView />);
+
+    expect(screen.queryByText("Ting Aqua Bridge")).toBeNull();
+
+    mocks.useConfigValues.mockReturnValue({
+      ...baseConfig,
+      ignored_platforms: ["com.ting.aqua-bridge"],
+    });
+    rerender(<NotificationSettingsView />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Ting Aqua Bridge")).toBeTruthy(),
+    );
+  });
+});

--- a/apps/desktop/src/settings/general/notification.tsx
+++ b/apps/desktop/src/settings/general/notification.tsx
@@ -125,24 +125,11 @@ export function NotificationSettingsView() {
     },
   });
 
-  const ignoredPlatforms = form.getFieldValue("ignored_platforms");
-  const includedPlatforms = form.getFieldValue("included_platforms");
-
-  const ignorableApps = getIgnorableApps({
-    installedApps,
-    ignoredPlatforms,
-    includedPlatforms,
-    inputValue: searchQuery,
-    defaultIgnoredBundleIds,
-  });
-  const ignoredBundleIds = getIgnoredBundleIds({
-    installedApps: installedApps,
-    ignoredPlatforms,
-    includedPlatforms,
-    defaultIgnoredBundleIds,
-  });
-
-  const handleToggleIgnoredApp = (bundleId: string) => {
+  const handleToggleIgnoredApp = (
+    bundleId: string,
+    ignoredPlatforms: string[],
+    includedPlatforms: string[],
+  ) => {
     if (!bundleId) {
       return;
     }
@@ -256,107 +243,142 @@ export function NotificationSettingsView() {
                     </Trans>
                   </p>
                 </div>
-                <div className="flex flex-col gap-3">
-                  <Popover open={searchOpen} onOpenChange={setSearchOpen}>
-                    <PopoverTrigger asChild>
-                      <div
-                        role="button"
-                        tabIndex={0}
-                        aria-expanded={searchOpen}
-                        className={cn([
-                          "flex min-h-[38px] w-full cursor-text flex-wrap items-center gap-2 rounded-2xl border p-2",
-                          "focus-visible:ring-ring focus-visible:ring-1 focus-visible:outline-hidden",
-                        ])}
-                        onKeyDown={(event) => {
-                          if (event.key === "Enter" || event.key === " ") {
-                            event.preventDefault();
-                            setSearchOpen(true);
-                          }
-                        }}
-                      >
-                        {ignoredBundleIds.map((bundleId: string) => {
-                          const isDefault = isDefaultIgnored(bundleId);
-                          return (
-                            <Badge
-                              key={bundleId}
-                              variant="secondary"
+                <form.Subscribe selector={(state) => state.values}>
+                  {(values) => {
+                    const ignoredPlatforms = values.ignored_platforms;
+                    const includedPlatforms = values.included_platforms;
+                    const ignorableApps = getIgnorableApps({
+                      installedApps,
+                      ignoredPlatforms,
+                      includedPlatforms,
+                      inputValue: searchQuery,
+                      defaultIgnoredBundleIds,
+                    });
+                    const ignoredBundleIds = getIgnoredBundleIds({
+                      installedApps,
+                      ignoredPlatforms,
+                      includedPlatforms,
+                      defaultIgnoredBundleIds,
+                    });
+
+                    return (
+                      <div className="flex flex-col gap-3">
+                        <Popover open={searchOpen} onOpenChange={setSearchOpen}>
+                          <PopoverTrigger asChild>
+                            <div
+                              role="button"
+                              tabIndex={0}
+                              aria-expanded={searchOpen}
                               className={cn([
-                                "flex items-center gap-1 px-2 py-0.5 text-xs",
-                                isDefault
-                                  ? ["bg-accent text-muted-foreground"]
-                                  : ["bg-muted"],
+                                "flex min-h-[38px] w-full cursor-text flex-wrap items-center gap-2 rounded-2xl border p-2",
+                                "focus-visible:ring-ring focus-visible:ring-1 focus-visible:outline-hidden",
                               ])}
-                              title={isDefault ? "default" : undefined}
+                              onKeyDown={(event) => {
+                                if (
+                                  event.key === "Enter" ||
+                                  event.key === " "
+                                ) {
+                                  event.preventDefault();
+                                  setSearchOpen(true);
+                                }
+                              }}
                             >
-                              {bundleIdToName(bundleId)}
-                              {isDefault && (
-                                <span className="text-[10px] opacity-70">
-                                  <Trans>(default)</Trans>
-                                </span>
-                              )}
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                className="ml-0.5 h-3 w-3 p-0 hover:bg-transparent"
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  handleToggleIgnoredApp(bundleId);
-                                }}
-                              >
-                                <X className="h-2.5 w-2.5" />
-                              </Button>
-                            </Badge>
-                          );
-                        })}
-                        <span className="text-muted-foreground text-sm">
-                          <Trans>Search installed apps...</Trans>
-                        </span>
-                      </div>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      variant="app"
-                      align="start"
-                      style={{ width: "var(--radix-popover-trigger-width)" }}
-                    >
-                      <AppFloatingPanel className="overflow-hidden">
-                        <Command className="rounded-[inherit] border-0 bg-transparent">
-                          <CommandInput
-                            placeholder={t`Search installed apps...`}
-                            value={searchQuery}
-                            onValueChange={setSearchQuery}
-                          />
-                          <CommandEmpty>
-                            <div className="text-muted-foreground px-2 py-1.5 text-sm">
-                              <Trans>No apps found.</Trans>
+                              {ignoredBundleIds.map((bundleId: string) => {
+                                const isDefault = isDefaultIgnored(bundleId);
+                                return (
+                                  <Badge
+                                    key={bundleId}
+                                    variant="secondary"
+                                    className={cn([
+                                      "flex items-center gap-1 px-2 py-0.5 text-xs",
+                                      isDefault
+                                        ? ["bg-accent text-muted-foreground"]
+                                        : ["bg-muted"],
+                                    ])}
+                                    title={isDefault ? "default" : undefined}
+                                  >
+                                    {bundleIdToName(bundleId)}
+                                    {isDefault && (
+                                      <span className="text-[10px] opacity-70">
+                                        <Trans>(default)</Trans>
+                                      </span>
+                                    )}
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="sm"
+                                      className="ml-0.5 h-3 w-3 p-0 hover:bg-transparent"
+                                      onClick={(event) => {
+                                        event.stopPropagation();
+                                        handleToggleIgnoredApp(
+                                          bundleId,
+                                          ignoredPlatforms,
+                                          includedPlatforms,
+                                        );
+                                      }}
+                                    >
+                                      <X className="h-2.5 w-2.5" />
+                                    </Button>
+                                  </Badge>
+                                );
+                              })}
+                              <span className="text-muted-foreground text-sm">
+                                <Trans>Search installed apps...</Trans>
+                              </span>
                             </div>
-                          </CommandEmpty>
-                          <CommandList>
-                            <CommandGroup className="max-h-[250px] overflow-y-auto">
-                              {ignorableApps.map((app) => (
-                                <CommandItem
-                                  key={app.id}
-                                  value={`${app.name} ${app.id}`}
-                                  onSelect={() =>
-                                    handleToggleIgnoredApp(app.id)
-                                  }
-                                  className={cn([
-                                    "cursor-pointer",
-                                    "hover:bg-accent! focus:bg-accent! aria-selected:bg-transparent",
-                                  ])}
-                                >
-                                  <span className="flex-1 truncate">
-                                    {app.name}
-                                  </span>
-                                </CommandItem>
-                              ))}
-                            </CommandGroup>
-                          </CommandList>
-                        </Command>
-                      </AppFloatingPanel>
-                    </PopoverContent>
-                  </Popover>
-                </div>
+                          </PopoverTrigger>
+                          <PopoverContent
+                            variant="app"
+                            align="start"
+                            style={{
+                              width: "var(--radix-popover-trigger-width)",
+                            }}
+                          >
+                            <AppFloatingPanel className="overflow-hidden">
+                              <Command className="rounded-[inherit] border-0 bg-transparent">
+                                <CommandInput
+                                  placeholder={t`Search installed apps...`}
+                                  value={searchQuery}
+                                  onValueChange={setSearchQuery}
+                                />
+                                <CommandEmpty>
+                                  <div className="text-muted-foreground px-2 py-1.5 text-sm">
+                                    <Trans>No apps found.</Trans>
+                                  </div>
+                                </CommandEmpty>
+                                <CommandList>
+                                  <CommandGroup className="max-h-[250px] overflow-y-auto">
+                                    {ignorableApps.map((app) => (
+                                      <CommandItem
+                                        key={app.id}
+                                        value={`${app.name} ${app.id}`}
+                                        onSelect={() =>
+                                          handleToggleIgnoredApp(
+                                            app.id,
+                                            ignoredPlatforms,
+                                            includedPlatforms,
+                                          )
+                                        }
+                                        className={cn([
+                                          "cursor-pointer",
+                                          "hover:bg-accent! focus:bg-accent! aria-selected:bg-transparent",
+                                        ])}
+                                      >
+                                        <span className="flex-1 truncate">
+                                          {app.name}
+                                        </span>
+                                      </CommandItem>
+                                    ))}
+                                  </CommandGroup>
+                                </CommandList>
+                              </Command>
+                            </AppFloatingPanel>
+                          </PopoverContent>
+                        </Popover>
+                      </div>
+                    );
+                  }}
+                </form.Subscribe>
               </div>
             )}
           </div>


### PR DESCRIPTION
Subscribe the app picker to form values and cover delayed persisted settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized notification settings UI and form subscription behavior; no auth, persistence format, or detection pipeline changes beyond display timing.
> 
> **Overview**
> Fixes **excluded app badges** staying empty when persisted `ignored_platforms` loads after the notification settings view first renders.
> 
> The exclude-apps UI now derives `ignored_platforms` / `included_platforms` inside **`form.Subscribe`** on `state.values`, so ignored bundle IDs and search results update when the TanStack form picks up hydrated config—not only on the initial render from `getFieldValue`. **`handleToggleIgnoredApp`** now receives the current platform lists from that subscribe scope so toggles use the same source of truth.
> 
> Adds a **`NotificationSettingsView`** test that simulates delayed `useConfigValues` hydration and asserts the resolved app name appears once ignored platforms are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6136007dabc9b7cb361b28a610327f8ff9e4a2c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->