### PR TITLE
fix(desktop): match sidebar gutter to platform chrome

### DIFF
--- a/apps/desktop/src/changelog/index.tsx
+++ b/apps/desktop/src/changelog/index.tsx
@@ -10,6 +10,7 @@ import { useChangelogContent } from "./data";
 
 import { useShell } from "~/contexts/shell";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
+import { useWindowControlsGutter } from "~/shared/hooks/useWindowControlsGutter";
 import { StandardContentWrapper } from "~/shared/main";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 
@@ -135,12 +136,14 @@ function ChangelogHeader({
   onClose: () => void;
 }) {
   const { t } = useLingui();
+  const showWindowControlsGutter = useWindowControlsGutter();
   return (
     <div
       data-tauri-drag-region
       className={cn([
         "relative flex h-12 w-full items-center",
-        showSidebarTimelineHeaderGutter && "pl-[156px]",
+        showSidebarTimelineHeaderGutter &&
+          (showWindowControlsGutter ? "pl-[156px]" : "pl-[80px]"),
       ])}
     >
       <div
@@ -150,7 +153,10 @@ function ChangelogHeader({
           showExpandedSidebarTimelineHeader
             ? "right-[70px] left-0 justify-start"
             : showSidebarTimelineHeaderGutter
-              ? "right-[70px] left-[104px] justify-start"
+              ? cn([
+                  "right-[70px] justify-start",
+                  showWindowControlsGutter ? "left-[104px]" : "left-[28px]",
+                ])
               : "left-1/2 w-[min(640px,calc(100%_-_160px))] -translate-x-1/2 justify-center",
         ])}
       >

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -44,6 +44,7 @@ import { useClassicMainShortcuts } from "./useShortcuts";
 import { useShell } from "~/contexts/shell";
 import { scrollElementByWheel } from "~/shared/dom/scroll-wheel";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
+import { useWindowControlsGutter } from "~/shared/hooks/useWindowControlsGutter";
 import {
   NOTE_SURFACE_MIN_WIDTH_PX,
   usesNoteSurfaceMinWidth,
@@ -100,6 +101,7 @@ export function ClassicMainBody() {
     useState(false);
   const [showDevtoolsPanelButton, setShowDevtoolsPanelButton] = useState(false);
   const [devtoolsPanelOpen, setDevtoolsPanelOpen] = useState(false);
+  const showWindowControlsGutter = useWindowControlsGutter();
   leftSidebarPanelConstraintsRef.current = leftSidebarPanelConstraints;
 
   useMountEffect(() => {
@@ -471,7 +473,10 @@ export function ClassicMainBody() {
     <div
       data-tauri-drag-region
       data-sidebar-timeline-header
-      className="flex h-9 shrink-0 items-start pt-[9px] pr-1 pl-[76px]"
+      className={cn([
+        "flex h-9 shrink-0 items-start pt-[9px] pr-1",
+        showWindowControlsGutter ? "pl-[76px]" : "pl-0",
+      ])}
       onWheelCapture={handleSidebarTimelineHeaderWheel}
     >
       {showSidebarTimeline ? (
@@ -510,7 +515,10 @@ export function ClassicMainBody() {
         >
           <div
             data-tauri-drag-region
-            className="flex h-full min-w-0 items-start pt-[9px] pr-1 pl-[76px]"
+            className={cn([
+              "flex h-full min-w-0 items-start pt-[9px] pr-1",
+              showWindowControlsGutter ? "pl-[76px]" : "pl-0",
+            ])}
           >
             <SidebarTimelineChromeWithUpcomingMeeting
               currentSessionId={currentSessionId}
@@ -537,7 +545,10 @@ export function ClassicMainBody() {
         <div data-tauri-drag-region className="relative h-10 shrink-0">
           <div
             data-tauri-drag-region
-            className="flex h-full min-w-0 items-start pt-1 pl-[76px]"
+            className={cn([
+              "flex h-full min-w-0 items-start pt-1",
+              showWindowControlsGutter ? "pl-[76px]" : "pl-0",
+            ])}
           />
         </div>
       )}
@@ -550,7 +561,10 @@ export function ClassicMainBody() {
         >
           <div
             data-tauri-drag-region
-            className="flex h-full min-w-0 items-start pt-[9px] pl-[76px]"
+            className={cn([
+              "flex h-full min-w-0 items-start pt-[9px]",
+              showWindowControlsGutter ? "pl-[76px]" : "pl-2",
+            ])}
           >
             <LeftSurfaceChromeButton
               ariaLabel="Go back"

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -41,6 +41,7 @@ const mocks = vi.hoisted(() => ({
     standaloneWindow?: boolean;
   }>,
   shareSessionIds: [] as string[],
+  windowControlsGutter: true,
 }));
 
 vi.mock("./metadata", () => ({
@@ -116,6 +117,10 @@ vi.mock("~/shared/config", () => ({
   useConfigValue: (key: string) => mocks.configValues[key],
 }));
 
+vi.mock("~/shared/hooks/useWindowControlsGutter", () => ({
+  useWindowControlsGutter: () => mocks.windowControlsGutter,
+}));
+
 vi.mock("~/shared/utils", async (importOriginal) => ({
   ...(await importOriginal<typeof import("~/shared/utils")>()),
   getScheme: mocks.getScheme,
@@ -188,6 +193,7 @@ describe("OuterHeader", () => {
     };
     mocks.overflowProps = [];
     mocks.shareSessionIds = [];
+    mocks.windowControlsGutter = true;
   });
 
   afterEach(() => {
@@ -433,6 +439,32 @@ describe("OuterHeader", () => {
     expect(titleSlot?.className).toContain("left-[76px]");
     expect(titleSlot?.className).toContain("right-[140px]");
   });
+
+  it.each([
+    ["expanded", true],
+    ["collapsed", false],
+  ])(
+    "drops the window controls inset in standalone windows without native chrome with the sidebar %s",
+    (_state, expanded) => {
+      mocks.leftsidebar.expanded = expanded;
+      mocks.windowControlsGutter = false;
+
+      render(
+        <OuterHeader
+          sessionId="session-1"
+          currentView={{ type: "raw" } as EditorView}
+          standaloneWindow
+          title={<span>Session title</span>}
+        />,
+      );
+
+      const title = screen.getByText("Session title");
+      const titleSlot = title.parentElement?.parentElement;
+
+      expect(titleSlot?.className).toContain("left-2");
+      expect(titleSlot?.className).not.toContain("left-[76px]");
+    },
+  );
 
   it("shows a join-and-record pill before a remote meeting with a video link", () => {
     mocks.sessionEvents = {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -78,7 +78,9 @@ export function OuterHeader({
             centerTitle && "justify-center",
             "right-[140px]",
             standaloneWindow
-              ? "left-[76px]"
+              ? showWindowControlsGutter
+                ? "left-[76px]"
+                : "left-2"
               : showSidebarTimelineHeaderGutter
                 ? showWindowControlsGutter
                   ? "left-[104px]"

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -30,6 +30,7 @@ import {
 } from "~/session/hooks/useRemoteMeeting";
 import { useSessionEvent } from "~/session/hooks/useSessionEvent";
 import { useConfigValue } from "~/shared/config";
+import { useWindowControlsGutter } from "~/shared/hooks/useWindowControlsGutter";
 import { getScheme } from "~/shared/utils";
 import type { EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
@@ -54,6 +55,7 @@ export function OuterHeader({
 }) {
   const { leftsidebar } = useShell();
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
+  const showWindowControlsGutter = useWindowControlsGutter();
   const showSidebarTimelineHeaderGutter =
     !standaloneWindow && !leftsidebar.expanded;
   const showExpandedSidebarTimelineHeader = leftsidebar.expanded;
@@ -64,7 +66,8 @@ export function OuterHeader({
       className={cn([
         "relative flex w-full items-center",
         "h-12",
-        showSidebarTimelineHeaderGutter && "pl-[156px]",
+        showSidebarTimelineHeaderGutter &&
+          (showWindowControlsGutter ? "pl-[156px]" : "pl-[80px]"),
       ])}
     >
       {title ? (
@@ -77,7 +80,9 @@ export function OuterHeader({
             standaloneWindow
               ? "left-[76px]"
               : showSidebarTimelineHeaderGutter
-                ? "left-[104px]"
+                ? showWindowControlsGutter
+                  ? "left-[104px]"
+                  : "left-[28px]"
                 : showExpandedSidebarTimelineHeader
                   ? "left-0"
                   : "left-[114px]",

--- a/apps/desktop/src/shared/hooks/useWindowControlsGutter.ts
+++ b/apps/desktop/src/shared/hooks/useWindowControlsGutter.ts
@@ -19,13 +19,10 @@ export function useWindowControlsGutter() {
     let unlistenResize: (() => void) | undefined;
     const appWindow = getCurrentWindow();
     const sync = async () => {
-      const [isMaximized, isFullscreen] = await Promise.all([
-        appWindow.isMaximized(),
-        appWindow.isFullscreen(),
-      ]).catch(() => [false, false]);
+      const isFullscreen = await appWindow.isFullscreen().catch(() => false);
 
       if (!cancelled) {
-        setVisible(!isMaximized && !isFullscreen);
+        setVisible(!isFullscreen);
       }
     };
 

--- a/apps/desktop/src/shared/hooks/useWindowControlsGutter.ts
+++ b/apps/desktop/src/shared/hooks/useWindowControlsGutter.ts
@@ -1,0 +1,54 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { platform } from "@tauri-apps/plugin-os";
+import { useState } from "react";
+
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+
+export function useWindowControlsGutter() {
+  const [visible, setVisible] = useState(
+    () => !isTauri() || platform() === "macos",
+  );
+
+  useMountEffect(() => {
+    if (!isTauri() || platform() !== "macos") {
+      return;
+    }
+
+    let cancelled = false;
+    let unlistenResize: (() => void) | undefined;
+    const appWindow = getCurrentWindow();
+    const sync = async () => {
+      const [isMaximized, isFullscreen] = await Promise.all([
+        appWindow.isMaximized(),
+        appWindow.isFullscreen(),
+      ]).catch(() => [false, false]);
+
+      if (!cancelled) {
+        setVisible(!isMaximized && !isFullscreen);
+      }
+    };
+
+    void sync();
+    void appWindow
+      .onResized(() => {
+        void sync();
+      })
+      .then((unlisten) => {
+        if (cancelled) {
+          unlisten();
+          return;
+        }
+
+        unlistenResize = unlisten;
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+      unlistenResize?.();
+    };
+  });
+
+  return visible;
+}

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -332,7 +332,7 @@ describe("ClassicMainBody", () => {
     ["expanded", true, "Hide sidebar"],
     ["collapsed", false, "Show sidebar"],
   ])(
-    "removes the window controls gutter while maximized with the sidebar %s",
+    "removes the window controls gutter in fullscreen with the sidebar %s",
     async (_state, expanded, toggleLabel) => {
       mocks.leftSidebarExpanded = expanded;
 
@@ -345,7 +345,7 @@ describe("ClassicMainBody", () => {
 
       expect(chromeFrame?.className).toContain("pl-[76px]");
 
-      mocks.isMaximized.mockResolvedValue(true);
+      mocks.isFullscreen.mockResolvedValue(true);
       act(() => {
         for (const listener of mocks.resizeListeners) {
           listener();
@@ -356,6 +356,36 @@ describe("ClassicMainBody", () => {
         expect(chromeFrame?.className).toContain("pl-0");
       });
       expect(chromeFrame?.className).not.toContain("pl-[76px]");
+    },
+  );
+
+  it.each([
+    ["expanded", true, "Hide sidebar"],
+    ["collapsed", false, "Show sidebar"],
+  ])(
+    "keeps the window controls gutter while maximized with the sidebar %s",
+    async (_state, expanded, toggleLabel) => {
+      mocks.leftSidebarExpanded = expanded;
+      mocks.isMaximized.mockResolvedValue(true);
+
+      render(<ClassicMainBody />);
+
+      const sidebarToggle = screen.getByRole("button", { name: toggleLabel });
+      const chromeFrame = expanded
+        ? document.querySelector<HTMLElement>("[data-sidebar-timeline-header]")
+        : sidebarToggle.parentElement?.parentElement?.parentElement;
+
+      act(() => {
+        for (const listener of mocks.resizeListeners) {
+          listener();
+        }
+      });
+
+      await waitFor(() => {
+        expect(mocks.isFullscreen).toHaveBeenCalled();
+      });
+      expect(chromeFrame?.className).toContain("pl-[76px]");
+      expect(chromeFrame?.className).not.toContain("pl-0");
     },
   );
 
@@ -405,7 +435,6 @@ describe("ClassicMainBody", () => {
         expect(chromeFrame?.className).toContain("pl-0");
       });
       expect(chromeFrame?.className).not.toContain("pl-[76px]");
-      expect(mocks.isMaximized).not.toHaveBeenCalled();
       expect(mocks.isFullscreen).not.toHaveBeenCalled();
       expect(mocks.resizeListeners).toHaveLength(0);
     },

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -1,8 +1,10 @@
 import {
+  act,
   cleanup,
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -16,6 +18,10 @@ const mocks = vi.hoisted(() => ({
   runEscapeShortcut: vi.fn(),
   toggleLeftSidebar: vi.fn(),
   isTauri: vi.fn(() => true),
+  isFullscreen: vi.fn().mockResolvedValue(false),
+  isMaximized: vi.fn().mockResolvedValue(false),
+  platform: "macos" as "linux" | "macos" | "windows",
+  resizeListeners: [] as Array<() => void>,
   startDragging: vi.fn().mockResolvedValue(undefined),
   devtoolsPanelActionListeners: [] as Array<
     (event: { payload: { action: string } }) => void
@@ -62,8 +68,22 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({
+    isFullscreen: mocks.isFullscreen,
+    isMaximized: mocks.isMaximized,
+    onResized: vi.fn(async (listener: () => void) => {
+      mocks.resizeListeners.push(listener);
+      return () => {
+        mocks.resizeListeners = mocks.resizeListeners.filter(
+          (candidate) => candidate !== listener,
+        );
+      };
+    }),
     startDragging: mocks.startDragging,
   }),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => mocks.platform,
 }));
 
 vi.mock("@hypr/plugin-windows", () => ({
@@ -177,6 +197,12 @@ describe("ClassicMainBody", () => {
     mocks.runEscapeShortcut.mockClear();
     mocks.toggleLeftSidebar.mockClear();
     mocks.isTauri.mockReturnValue(true);
+    mocks.isFullscreen.mockReset();
+    mocks.isFullscreen.mockResolvedValue(false);
+    mocks.isMaximized.mockReset();
+    mocks.isMaximized.mockResolvedValue(false);
+    mocks.platform = "macos";
+    mocks.resizeListeners = [];
     mocks.startDragging.mockClear();
     mocks.devtoolsPanelActionListeners = [];
     mocks.windowsCommands.devtoolsPanelHide.mockClear();
@@ -301,6 +327,89 @@ describe("ClassicMainBody", () => {
     expect(contentRow?.hasAttribute("data-tauri-drag-region")).toBe(false);
     expect(mocks.toggleLeftSidebar).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    ["expanded", true, "Hide sidebar"],
+    ["collapsed", false, "Show sidebar"],
+  ])(
+    "removes the window controls gutter while maximized with the sidebar %s",
+    async (_state, expanded, toggleLabel) => {
+      mocks.leftSidebarExpanded = expanded;
+
+      render(<ClassicMainBody />);
+
+      const sidebarToggle = screen.getByRole("button", { name: toggleLabel });
+      const chromeFrame = expanded
+        ? document.querySelector<HTMLElement>("[data-sidebar-timeline-header]")
+        : sidebarToggle.parentElement?.parentElement?.parentElement;
+
+      expect(chromeFrame?.className).toContain("pl-[76px]");
+
+      mocks.isMaximized.mockResolvedValue(true);
+      act(() => {
+        for (const listener of mocks.resizeListeners) {
+          listener();
+        }
+      });
+
+      await waitFor(() => {
+        expect(chromeFrame?.className).toContain("pl-0");
+      });
+      expect(chromeFrame?.className).not.toContain("pl-[76px]");
+    },
+  );
+
+  it.each([
+    {
+      expanded: true,
+      platform: "windows",
+      platformName: "Windows",
+      sidebarState: "expanded",
+      toggleLabel: "Hide sidebar",
+    },
+    {
+      expanded: false,
+      platform: "windows",
+      platformName: "Windows",
+      sidebarState: "collapsed",
+      toggleLabel: "Show sidebar",
+    },
+    {
+      expanded: true,
+      platform: "linux",
+      platformName: "Linux",
+      sidebarState: "expanded",
+      toggleLabel: "Hide sidebar",
+    },
+    {
+      expanded: false,
+      platform: "linux",
+      platformName: "Linux",
+      sidebarState: "collapsed",
+      toggleLabel: "Show sidebar",
+    },
+  ] as const)(
+    "does not reserve the window controls gutter on $platformName with the sidebar $sidebarState",
+    async ({ expanded, platform, toggleLabel }) => {
+      mocks.leftSidebarExpanded = expanded;
+      mocks.platform = platform;
+
+      render(<ClassicMainBody />);
+
+      const sidebarToggle = screen.getByRole("button", { name: toggleLabel });
+      const chromeFrame = expanded
+        ? document.querySelector<HTMLElement>("[data-sidebar-timeline-header]")
+        : sidebarToggle.parentElement?.parentElement?.parentElement;
+
+      await waitFor(() => {
+        expect(chromeFrame?.className).toContain("pl-0");
+      });
+      expect(chromeFrame?.className).not.toContain("pl-[76px]");
+      expect(mocks.isMaximized).not.toHaveBeenCalled();
+      expect(mocks.isFullscreen).not.toHaveBeenCalled();
+      expect(mocks.resizeListeners).toHaveLength(0);
+    },
+  );
 
   it("shows the update button in the expanded sidebar control group", () => {
     mocks.sidebarUpdateControl.status = "available";

--- a/apps/desktop/src/sidebar/custom-sidebar-header.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.tsx
@@ -5,6 +5,7 @@ import { type ReactNode, useCallback } from "react";
 import { cn } from "@hypr/utils";
 
 import { useShell } from "~/contexts/shell";
+import { useWindowControlsGutter } from "~/shared/hooks/useWindowControlsGutter";
 import { useTabs } from "~/store/zustand/tabs";
 
 export function CustomSidebarHeader({
@@ -16,6 +17,7 @@ export function CustomSidebarHeader({
 }) {
   const { t } = useLingui();
   const { chat } = useShell();
+  const showWindowControlsGutter = useWindowControlsGutter();
   const currentTab = useTabs((state) => state.currentTab);
   const tabs = useTabs((state) => state.tabs);
   const select = useTabs((state) => state.select);
@@ -43,7 +45,10 @@ export function CustomSidebarHeader({
   return (
     <div
       data-tauri-drag-region
-      className="-mt-11 flex h-12 shrink-0 items-start py-0 pt-[9px] pr-1 pl-[76px]"
+      className={cn([
+        "-mt-11 flex h-12 shrink-0 items-start py-0 pt-[9px] pr-1",
+        showWindowControlsGutter ? "pl-[76px]" : "pl-2",
+      ])}
     >
       <div
         data-tauri-drag-region


### PR DESCRIPTION
Reserve the left sidebar inset only when the platform chrome actually needs it, instead of always assuming macOS traffic lights.

- Add `useWindowControlsGutter`: the gutter applies only to restored macOS windows and turns off when maximized or fullscreen, and on Windows/Linux.
- Main shell, session outer header, changelog header, and custom sidebar header derive their padding from that flag instead of hardcoded `pl-[76px]` / `pl-[156px]`.
- Tests cover gutter removal on maximized macOS and no gutter on Windows/Linux.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only padding changes with platform/window-state detection; no auth, data, or business-logic impact.
> 
> **Overview**
> Desktop headers and sidebar chrome no longer always reserve space for macOS traffic lights. A new **`useWindowControlsGutter`** hook drives whether that left inset applies: **off** on Windows/Linux, **off** when the macOS window is fullscreen (via resize + `isFullscreen`), and **on** for normal macOS windows (including maximized).
> 
> **Main shell** (`body.tsx`), **session `OuterHeader`**, **changelog header**, and **custom sidebar header** switch from fixed `pl-[76px]` / `pl-[156px]` (and related title `left-*` offsets) to conditional padding when the gutter is hidden.
> 
> Tests cover fullscreen gutter removal, maximized gutter retention, non-macOS platforms, and standalone windows without native chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad5926c0302c79d3accacbaaf301464602830fba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->