### PR TITLE
feat(cli): ship Windows CLI and MCP

### DIFF
--- a/.github/workflows/cli_ci.yaml
+++ b/.github/workflows/cli_ci.yaml
@@ -125,3 +125,40 @@ jobs:
         working-directory: docs
         env:
           PUPPETEER_SKIP_DOWNLOAD: "true"
+
+  cli-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: ./.github/actions/rust_install
+        with:
+          platform: windows
+      - run: cargo test --locked -p anarlog-cli
+      - run: |
+          cargo clippy --locked \
+            -p anarlog-cli \
+            --all-targets \
+            --no-deps \
+            -- \
+            -D warnings
+        shell: bash
+      - run: cargo build --locked --release -p anarlog-cli
+      - run: |
+          target/release/anarlog.exe --help
+          target/release/anarlog.exe --version
+          target/release/anarlog.exe meetings --help
+          target/release/anarlog.exe mcp --help
+          if doctor_output="$(target/release/anarlog.exe --json --db-path "$RUNNER_TEMP/missing.db" doctor)"; then
+            echo "doctor unexpectedly reported a missing database as ready"
+            exit 1
+          fi
+          grep -q '"ready": false' <<<"$doctor_output"
+          if invalid_output="$(target/release/anarlog.exe --json meetings list --limit 0 2>&1)"; then
+            echo "invalid arguments unexpectedly succeeded"
+            exit 1
+          fi
+          grep -q '"code": "invalid_arguments"' <<<"$invalid_output"
+        shell: bash

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -163,6 +163,16 @@ jobs:
       - if: github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/pnpm_install
       - if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          cargo build --locked --release -p anarlog-cli --target x86_64-pc-windows-msvc
+          cp \
+            target/x86_64-pc-windows-msvc/release/anarlog.exe \
+            apps/desktop/src-tauri/resources/cli/anarlog-cli-x86_64-pc-windows-msvc.exe
+          ./scripts/sidecar.sh \
+            ./apps/desktop/src-tauri/tauri.conf.staging.json \
+            resources/cli/anarlog-cli
+      - if: github.event_name == 'workflow_dispatch'
         run: pnpm -F ui build
       - if: github.event_name == 'workflow_dispatch'
         run: pnpm -F desktop tauri build --ci --bundles nsis --no-sign --target x86_64-pc-windows-msvc --config ./src-tauri/tauri.conf.staging.json --features devtools --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4964,6 +4964,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "windows 0.62.2",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]

--- a/apps/cli/src/db.rs
+++ b/apps/cli/src/db.rs
@@ -36,7 +36,11 @@ fn resolve_default_path(data_dir: &Path) -> PathBuf {
 }
 
 fn resolve_default_path_for_command(data_dir: &Path, command_name: Option<&OsStr>) -> PathBuf {
-    let channel_identifier = match command_name.and_then(OsStr::to_str) {
+    let command_name = command_name
+        .and_then(OsStr::to_str)
+        .and_then(|name| Path::new(name).file_stem())
+        .and_then(OsStr::to_str);
+    let channel_identifier = match command_name {
         Some("anarlog-dev") => Some("com.hyprnote.dev"),
         Some("anarlog-staging") => Some("com.hyprnote.staging"),
         _ => None,
@@ -118,6 +122,14 @@ mod tests {
         );
         assert_eq!(
             resolve_default_path_for_command(dir.path(), Some(OsStr::new("anarlog-staging"))),
+            dir.path().join("com.hyprnote.staging/app.db")
+        );
+        assert_eq!(
+            resolve_default_path_for_command(dir.path(), Some(OsStr::new("anarlog-dev.exe"))),
+            dir.path().join("com.hyprnote.dev/app.db")
+        );
+        assert_eq!(
+            resolve_default_path_for_command(dir.path(), Some(OsStr::new("anarlog-staging.exe"))),
             dir.path().join("com.hyprnote.staging/app.db")
         );
     }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -118,5 +118,9 @@ automation = ["tauri-plugin-automation"]
 tauri-plugin-automation = { version = "0.1", optional = true }
 hypr-intercept = { workspace = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { workspace = true, features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
+windows-registry = "0.5.3"
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/apps/desktop/src-tauri/src/embedded_cli.rs
+++ b/apps/desktop/src-tauri/src/embedded_cli.rs
@@ -36,7 +36,14 @@ pub struct EmbeddedCliStatus {
 pub fn check<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -> EmbeddedCliStatus {
     let command_name = command_name_from_identifier(manager.config().identifier.as_ref());
     let Some(install_path) = install_path_for_command(command_name) else {
-        return unavailable_status(command_name, "Anarlog could not find your home directory.");
+        // Windows resolves the install path from local app data, not the home
+        // directory, so the two platforms cannot share one message.
+        #[cfg(target_os = "windows")]
+        let missing_dir = "Anarlog could not find your local application data directory.";
+        #[cfg(not(target_os = "windows"))]
+        let missing_dir = "Anarlog could not find your home directory.";
+
+        return unavailable_status(command_name, missing_dir);
     };
 
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
@@ -250,17 +257,25 @@ fn bundled_binary_name() -> Option<&'static str> {
 #[cfg(target_os = "windows")]
 fn classify_windows_status(command_name: &str, install_path: PathBuf) -> EmbeddedCliStatus {
     let state = match std::fs::symlink_metadata(&install_path) {
-        Ok(metadata) if metadata.is_file() => install_path
-            .parent()
-            .ok_or_else(|| "The CLI install directory is invalid.".to_string())
-            .and_then(windows_path_contains)
-            .map(|on_path| {
-                if on_path {
-                    EmbeddedCliState::Installed
-                } else {
-                    EmbeddedCliState::Missing
-                }
-            }),
+        Ok(metadata) if metadata.is_file() => {
+            // Reporting Conflict here would disable Install/Reinstall in settings,
+            // even though re-running the install is what repairs a missing or
+            // unreadable PATH entry.
+            let on_path = install_path
+                .parent()
+                .ok_or_else(|| "The CLI install directory is invalid.".to_string())
+                .and_then(windows_path_contains)
+                .unwrap_or_else(|error| {
+                    tracing::warn!(%error, "failed_to_check_windows_cli_path");
+                    false
+                });
+
+            Ok(if on_path {
+                EmbeddedCliState::Installed
+            } else {
+                EmbeddedCliState::Missing
+            })
+        }
         Ok(_) => Ok(EmbeddedCliState::Conflict),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(EmbeddedCliState::Missing),
         Err(error) => Err(format!(

--- a/apps/desktop/src-tauri/src/embedded_cli.rs
+++ b/apps/desktop/src-tauri/src/embedded_cli.rs
@@ -337,23 +337,47 @@ fn install_windows_cli(resource_path: &Path, install_path: &Path) -> Result<(), 
             temp_path.display()
         )
     })?;
-    if install_path.exists() {
-        std::fs::remove_file(install_path).map_err(|error| {
+    // Windows refuses to delete a running executable but still allows renaming it, so
+    // the old binary is moved aside rather than removed. Anything still running keeps
+    // its handle to the backup, which the next install clears once it is released.
+    let backup_path = install_path.with_file_name(format!(".{}.old", file_name.to_string_lossy()));
+    let _ = std::fs::remove_file(&backup_path);
+
+    let replaced = install_path.exists();
+    if replaced {
+        std::fs::rename(install_path, &backup_path).map_err(|error| {
+            let _ = std::fs::remove_file(&temp_path);
             format!(
                 "Could not replace the CLI at {}: {error}",
                 install_path.display()
             )
         })?;
     }
+
     if let Err(error) = std::fs::rename(&temp_path, install_path) {
         let _ = std::fs::remove_file(&temp_path);
+        if replaced {
+            let _ = std::fs::rename(&backup_path, install_path);
+        }
         return Err(format!(
             "Could not install the CLI at {}: {error}",
             install_path.display()
         ));
     }
 
+    let _ = std::fs::remove_file(&backup_path);
     Ok(())
+}
+
+// Treating an unreadable Path as empty would let the caller overwrite the user PATH
+// with only the install directory, so only a genuinely absent value reads as empty.
+#[cfg(target_os = "windows")]
+fn read_user_path(environment: &windows_registry::Key) -> Result<String, String> {
+    match environment.get_string("Path") {
+        Ok(path) => Ok(path),
+        Err(_) if environment.get_type("Path").is_err() => Ok(String::new()),
+        Err(error) => Err(format!("Could not read the user PATH: {error}")),
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -361,7 +385,7 @@ fn windows_path_contains(install_dir: &Path) -> Result<bool, String> {
     let environment = windows_registry::CURRENT_USER
         .open("Environment")
         .map_err(|error| format!("Could not read the user environment: {error}"))?;
-    let path = environment.get_string("Path").unwrap_or_default();
+    let path = read_user_path(&environment)?;
     Ok(path_list_contains(&path, install_dir))
 }
 
@@ -373,7 +397,7 @@ fn add_windows_cli_to_path(install_path: &Path) -> Result<(), String> {
     let environment = windows_registry::CURRENT_USER
         .create("Environment")
         .map_err(|error| format!("Could not open the user environment: {error}"))?;
-    let path = environment.get_string("Path").unwrap_or_default();
+    let path = read_user_path(&environment)?;
     if path_list_contains(&path, install_dir) {
         return Ok(());
     }

--- a/apps/desktop/src-tauri/src/embedded_cli.rs
+++ b/apps/desktop/src-tauri/src/embedded_cli.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "macos")]
 use std::os::unix::fs::PermissionsExt;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -39,7 +39,7 @@ pub fn check<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -> EmbeddedCl
         return unavailable_status(command_name, "Anarlog could not find your home directory.");
     };
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
         let _ = manager;
         return EmbeddedCliStatus {
@@ -47,8 +47,25 @@ pub fn check<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -> EmbeddedCl
             command_name: command_name.to_string(),
             install_path: install_path.display().to_string(),
             state: EmbeddedCliState::Unsupported,
-            details: Some("Bundled CLI installation is currently available on macOS.".to_string()),
+            details: Some(
+                "Bundled CLI installation is not yet available on this platform.".to_string(),
+            ),
         };
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let Some(_resource_path) = resolve_resource_path(manager) else {
+            return EmbeddedCliStatus {
+                supported: true,
+                command_name: command_name.to_string(),
+                install_path: install_path.display().to_string(),
+                state: EmbeddedCliState::ResourceMissing,
+                details: Some("The CLI is not included in this build of Anarlog.".to_string()),
+            };
+        };
+
+        classify_windows_status(command_name, install_path)
     }
 
     #[cfg(target_os = "macos")]
@@ -73,9 +90,32 @@ pub fn install<R: tauri::Runtime, T: tauri::Manager<R>>(
 ) -> Result<EmbeddedCliStatus, String> {
     let status = check(manager);
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
         Ok(status)
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        match status.state {
+            EmbeddedCliState::Unsupported | EmbeddedCliState::ResourceMissing => {
+                return Ok(status);
+            }
+            EmbeddedCliState::Conflict => {
+                return Err(format!(
+                    "Another file already exists at {}. Move it before installing the Anarlog CLI.",
+                    status.install_path
+                ));
+            }
+            EmbeddedCliState::Installed | EmbeddedCliState::Missing => {}
+        }
+
+        let resource_path = resolve_resource_path(manager)
+            .ok_or_else(|| "The bundled CLI could not be found.".to_string())?;
+        let install_path = PathBuf::from(&status.install_path);
+        install_windows_cli(&resource_path, &install_path)?;
+        add_windows_cli_to_path(&install_path)?;
+        Ok(classify_windows_status(&status.command_name, install_path))
     }
 
     #[cfg(target_os = "macos")]
@@ -128,16 +168,32 @@ fn command_name_from_identifier(identifier: &str) -> &'static str {
 }
 
 fn install_path_for_command(command_name: &str) -> Option<PathBuf> {
-    dirs::home_dir().map(|home| home.join(".local/bin").join(command_name))
+    #[cfg(target_os = "windows")]
+    {
+        return dirs::data_local_dir().map(|data_dir| {
+            data_dir
+                .join("Anarlog")
+                .join("bin")
+                .join(format!("{command_name}.exe"))
+        });
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        dirs::home_dir().map(|home| home.join(".local/bin").join(command_name))
+    }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn resolve_resource_path<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -> Option<PathBuf> {
     use tauri::path::BaseDirectory;
 
     if let Some(sidecar_path) = std::env::current_exe()
         .ok()
-        .and_then(|path| path.parent().map(|parent| parent.join("anarlog-cli")))
+        .and_then(|path| {
+            path.parent()
+                .map(|parent| parent.join(sidecar_binary_name()))
+        })
         .filter(|path| path.is_file())
     {
         return Some(sidecar_path);
@@ -161,20 +217,220 @@ fn resolve_resource_path<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -
     debug_path.exists().then_some(debug_path)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn sidecar_binary_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "anarlog-cli.exe"
+    } else {
+        "anarlog-cli"
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn bundled_binary_name() -> Option<&'static str> {
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        return Some("anarlog-cli-x86_64-pc-windows-msvc.exe");
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     {
         return Some("anarlog-cli-aarch64-apple-darwin");
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
     {
         return Some("anarlog-cli-x86_64-apple-darwin");
     }
 
     #[allow(unreachable_code)]
     None
+}
+
+#[cfg(target_os = "windows")]
+fn classify_windows_status(command_name: &str, install_path: PathBuf) -> EmbeddedCliStatus {
+    let state = match std::fs::symlink_metadata(&install_path) {
+        Ok(metadata) if metadata.is_file() => install_path
+            .parent()
+            .ok_or_else(|| "The CLI install directory is invalid.".to_string())
+            .and_then(windows_path_contains)
+            .map(|on_path| {
+                if on_path {
+                    EmbeddedCliState::Installed
+                } else {
+                    EmbeddedCliState::Missing
+                }
+            }),
+        Ok(_) => Ok(EmbeddedCliState::Conflict),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(EmbeddedCliState::Missing),
+        Err(error) => Err(format!(
+            "Failed to inspect {}: {error}",
+            install_path.display()
+        )),
+    };
+
+    match state {
+        Ok(state) => EmbeddedCliStatus {
+            supported: true,
+            command_name: command_name.to_string(),
+            install_path: install_path.display().to_string(),
+            state,
+            details: windows_details_for_state(state, &install_path),
+        },
+        Err(error) => EmbeddedCliStatus {
+            supported: true,
+            command_name: command_name.to_string(),
+            install_path: install_path.display().to_string(),
+            state: EmbeddedCliState::Conflict,
+            details: Some(error),
+        },
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_details_for_state(state: EmbeddedCliState, install_path: &Path) -> Option<String> {
+    match state {
+        EmbeddedCliState::Installed => Some(format!(
+            "Installed at {} and available in new terminals.",
+            install_path.display()
+        )),
+        EmbeddedCliState::Missing => Some(format!(
+            "Install the command at {} and add it to your user PATH.",
+            install_path.display()
+        )),
+        EmbeddedCliState::Conflict => Some(format!(
+            "Another file already exists at {}.",
+            install_path.display()
+        )),
+        EmbeddedCliState::Unsupported | EmbeddedCliState::ResourceMissing => None,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn install_windows_cli(resource_path: &Path, install_path: &Path) -> Result<(), String> {
+    let install_dir = install_path
+        .parent()
+        .ok_or_else(|| "The CLI install directory is invalid.".to_string())?;
+    std::fs::create_dir_all(install_dir)
+        .map_err(|error| format!("Could not create {}: {error}", install_dir.display()))?;
+
+    let file_name = install_path
+        .file_name()
+        .ok_or_else(|| "The CLI install path is invalid.".to_string())?;
+    let temp_path = install_path.with_file_name(format!(
+        ".{}.tmp-{}",
+        file_name.to_string_lossy(),
+        std::process::id()
+    ));
+    if std::fs::symlink_metadata(&temp_path).is_ok() {
+        std::fs::remove_file(&temp_path).map_err(|error| {
+            format!(
+                "Could not prepare the CLI update at {}: {error}",
+                temp_path.display()
+            )
+        })?;
+    }
+
+    std::fs::copy(resource_path, &temp_path).map_err(|error| {
+        format!(
+            "Could not copy the bundled CLI to {}: {error}",
+            temp_path.display()
+        )
+    })?;
+    if install_path.exists() {
+        std::fs::remove_file(install_path).map_err(|error| {
+            format!(
+                "Could not replace the CLI at {}: {error}",
+                install_path.display()
+            )
+        })?;
+    }
+    if let Err(error) = std::fs::rename(&temp_path, install_path) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(format!(
+            "Could not install the CLI at {}: {error}",
+            install_path.display()
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn windows_path_contains(install_dir: &Path) -> Result<bool, String> {
+    let environment = windows_registry::CURRENT_USER
+        .open("Environment")
+        .map_err(|error| format!("Could not read the user environment: {error}"))?;
+    let path = environment.get_string("Path").unwrap_or_default();
+    Ok(path_list_contains(&path, install_dir))
+}
+
+#[cfg(target_os = "windows")]
+fn add_windows_cli_to_path(install_path: &Path) -> Result<(), String> {
+    let install_dir = install_path
+        .parent()
+        .ok_or_else(|| "The CLI install directory is invalid.".to_string())?;
+    let environment = windows_registry::CURRENT_USER
+        .create("Environment")
+        .map_err(|error| format!("Could not open the user environment: {error}"))?;
+    let path = environment.get_string("Path").unwrap_or_default();
+    if path_list_contains(&path, install_dir) {
+        return Ok(());
+    }
+
+    let updated = if path.trim().is_empty() {
+        install_dir.display().to_string()
+    } else {
+        format!("{};{}", path.trim_end_matches(';'), install_dir.display())
+    };
+    let result = if environment.get_type("Path") == Ok(windows_registry::Type::ExpandString) {
+        environment
+            .set_expand_string("Path", updated)
+            .map_err(|error| format!("Could not update the user PATH: {error}"))
+    } else {
+        environment
+            .set_string("Path", updated)
+            .map_err(|error| format!("Could not update the user PATH: {error}"))
+    };
+    result?;
+    notify_windows_environment_changed();
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn notify_windows_environment_changed() {
+    use windows::Win32::Foundation::{LPARAM, WPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        HWND_BROADCAST, SMTO_ABORTIFHUNG, SendMessageTimeoutW, WM_SETTINGCHANGE,
+    };
+
+    unsafe {
+        let _ = SendMessageTimeoutW(
+            HWND_BROADCAST,
+            WM_SETTINGCHANGE,
+            WPARAM(0),
+            LPARAM(windows::core::w!("Environment").as_ptr() as isize),
+            SMTO_ABORTIFHUNG,
+            5_000,
+            None,
+        );
+    }
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn path_list_contains(path_list: &str, expected: &Path) -> bool {
+    let expected = expected
+        .to_string_lossy()
+        .trim_matches('"')
+        .trim_end_matches(['\\', '/'])
+        .to_string();
+    path_list.split(';').any(|entry| {
+        entry
+            .trim()
+            .trim_matches('"')
+            .trim_end_matches(['\\', '/'])
+            .eq_ignore_ascii_case(&expected)
+    })
 }
 
 #[cfg(target_os = "macos")]
@@ -496,6 +752,20 @@ mod tests {
         );
         assert_eq!(command_name_from_identifier(DEV_BUNDLE_ID), "anarlog-dev");
         assert_eq!(command_name_from_identifier("unknown"), "anarlog-dev");
+    }
+
+    #[test]
+    fn finds_windows_path_entries_case_insensitively() {
+        let expected = Path::new(r"C:\Users\Test\AppData\Local\Anarlog\bin");
+
+        assert!(path_list_contains(
+            r"C:\Windows;C:\USERS\TEST\APPDATA\LOCAL\ANARLOG\BIN\;C:\Tools",
+            expected
+        ));
+        assert!(!path_list_contains(
+            r"C:\Windows;C:\Users\Test\AppData\Local\Other\bin",
+            expected
+        ));
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Give Windows users the same `anarlog` CLI and MCP setup that ships on macOS, so channel installs work out of the box without manual PATH surgery.

- Bundle the CLI with the Windows installers and let the desktop app install it to `%LocalAppData%\Anarlog\bin\<channel>.exe`.
- Append that bin directory to the user `Path` in the registry (preserving expand-string type) and broadcast `WM_SETTINGCHANGE` so new terminals pick it up; installed status requires both the binary and the PATH entry.
- Strip `.exe` from the invoked binary name so channel builds like `anarlog-dev.exe` resolve to the same per-channel databases as on Unix.
- Add a `cli-windows` CI job (tests, clippy, release build, `doctor` smoke checks) and stage the x64 CLI resource in manual Windows desktop builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies user PATH via the registry and ships install/replace logic for executables; mistakes could break terminal PATH or overwrite conflicting binaries, though reads are guarded against treating unreadable PATH as empty.
> 
> **Overview**
> **Windows users get the same bundled `anarlog` CLI install flow as macOS**, driven from the desktop app’s existing embedded-CLI settings.
> 
> On Windows, install copies the bundled sidecar into `%LocalAppData%\Anarlog\bin\<channel>.exe`, updates the **user** `Path` in the registry (preserving expand-string type when present), and broadcasts `WM_SETTINGCHANGE` so new terminals see the change. **Installed** status requires both the binary and that directory on PATH; a binary without PATH stays **Missing** so reinstall can repair PATH.
> 
> The CLI now strips **`.exe`** when inferring channel from `argv[0]`, so `anarlog-dev.exe` / `anarlog-staging.exe` hit the same per-channel DB paths as on Unix.
> 
> CI adds a **`cli-windows`** job (test, clippy, release build, `doctor` / JSON error smoke checks) and manual Windows desktop builds stage the x64 CLI resource before Tauri packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce5175df32b25a0a92eb7f452c7a23020aea080a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #6280 
- <kbd>&nbsp;3&nbsp;</kbd> #6278 
- <kbd>&nbsp;2&nbsp;</kbd> #6277 
- <kbd>&nbsp;1&nbsp;</kbd> #6264 👈 
<!-- GitButler Footer Boundary Bottom -->