### PR TITLE
fix(desktop): show native window controls and platform labels

### DIFF
--- a/apps/desktop/src/composer/index.tsx
+++ b/apps/desktop/src/composer/index.tsx
@@ -1,3 +1,4 @@
+import { platform } from "@tauri-apps/plugin-os";
 import {
   ArrowUpIcon,
   ArrowUpRightIcon,
@@ -186,6 +187,7 @@ function ComposerInput({
     onSendMessage,
   });
   const mentionConfig = useMentionConfig();
+  const primaryModifier = platform() === "macos" ? "⌘" : "Ctrl";
 
   useAutoFocusEditor({
     editorRef,
@@ -258,7 +260,7 @@ function ComposerInput({
             Esc to dismiss
           </span>
           <span className="bg-primary-foreground/8 rounded-full px-2 py-1">
-            ⌘ ↩ to send
+            {primaryModifier} ↩ to send
           </span>
         </div>
 

--- a/apps/desktop/src/main/empty.test.tsx
+++ b/apps/desktop/src/main/empty.test.tsx
@@ -2,6 +2,14 @@ import { cleanup, render, screen } from "@testing-library/react";
 import type React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({
+  platform: vi.fn(() => "macos"),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: mocks.platform,
+}));
+
 vi.mock("~/shared/main", () => ({
   StandardContentWrapper: ({
     children,
@@ -43,6 +51,7 @@ import { TabContentEmpty } from "./empty";
 describe("TabContentEmpty", () => {
   afterEach(() => {
     cleanup();
+    mocks.platform.mockReturnValue("macos");
   });
 
   it("shows the home actions and global chat FAB", () => {
@@ -61,6 +70,28 @@ describe("TabContentEmpty", () => {
     expect(
       screen.getByRole("button", { name: "Ask Anarlog anything" }),
     ).toBeTruthy();
+  });
+
+  it("shows Windows shortcut modifiers", () => {
+    mocks.platform.mockReturnValue("windows");
+
+    render(
+      <TabContentEmpty
+        tab={{
+          active: true,
+          pinned: false,
+          slotId: "slot-home",
+          type: "empty",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /New Note/ }).textContent,
+    ).toContain("Ctrl N");
+    expect(
+      screen.getByRole("button", { name: /Start Recording/ }).textContent,
+    ).toContain("Ctrl ⇧ N");
   });
 
   it("centers actions in a draggable empty surface while keeping actions clickable", () => {

--- a/apps/desktop/src/main/empty.tsx
+++ b/apps/desktop/src/main/empty.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/react/macro";
+import { platform } from "@tauri-apps/plugin-os";
 import { useCallback } from "react";
 
 import { Kbd } from "@hypr/ui/components/ui/kbd";
@@ -25,6 +26,7 @@ function EmptyView() {
   const newNote = useNewNote({ behavior: "current" });
   const newNoteAndListen = useNewNoteAndListen({ behavior: "current" });
   const openCurrent = useTabs((state) => state.openCurrent);
+  const primaryModifier = platform() === "macos" ? "⌘" : "Ctrl";
 
   const openSettings = useCallback(
     () => openCurrent({ type: "settings" }),
@@ -39,18 +41,18 @@ function EmptyView() {
       <div className="flex min-w-[280px] flex-col gap-1 text-center">
         <ActionItem
           label={<Trans>New Note</Trans>}
-          shortcut={["⌘", "N"]}
+          shortcut={[primaryModifier, "N"]}
           onClick={newNote}
         />
         <ActionItem
           label={<Trans>Start Recording</Trans>}
-          shortcut={["⌘", "⇧", "N"]}
+          shortcut={[primaryModifier, "⇧", "N"]}
           onClick={newNoteAndListen}
         />
         <div className="bg-accent my-1 h-px" />
         <ActionItem
           label={<Trans>Settings</Trans>}
-          shortcut={["⌘", ","]}
+          shortcut={[primaryModifier, ","]}
           onClick={openSettings}
         />
       </div>

--- a/apps/desktop/src/session/components/note-input/search/bar.test.tsx
+++ b/apps/desktop/src/session/components/note-input/search/bar.test.tsx
@@ -3,6 +3,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   setSearch: vi.fn(),
+  platform: vi.fn(() => "macos"),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: hoisted.platform,
 }));
 
 vi.mock("@lingui/react/macro", () => ({
@@ -50,6 +55,7 @@ import { SearchBar } from "./bar";
 
 afterEach(() => {
   hoisted.setSearch.mockClear();
+  hoisted.platform.mockReturnValue("macos");
 });
 
 describe("SearchBar", () => {
@@ -67,5 +73,20 @@ describe("SearchBar", () => {
 
     expect(hoisted.setSearch).toHaveBeenCalledOnce();
     expect(hoisted.setSearch).toHaveBeenCalledWith("", false);
+  });
+
+  it("shows the Windows shortcut modifier", () => {
+    hoisted.platform.mockReturnValue("windows");
+    const editorRef = {
+      current: {
+        commands: {
+          setSearch: hoisted.setSearch,
+        },
+      },
+    } as any;
+
+    const { container } = render(<SearchBar editorRef={editorRef} />);
+
+    expect(container.textContent).toContain("Ctrl H");
   });
 });

--- a/apps/desktop/src/session/components/note-input/search/bar.tsx
+++ b/apps/desktop/src/session/components/note-input/search/bar.tsx
@@ -1,4 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import { platform } from "@tauri-apps/plugin-os";
 import {
   ALargeSmallIcon,
   ChevronDownIcon,
@@ -101,6 +102,7 @@ export function SearchBar({
 }) {
   const { t } = useLingui();
   const search = useSearch();
+  const primaryModifier = platform() === "macos" ? "⌘" : "Ctrl";
   const searchInputRef = useRef<HTMLInputElement>(null);
   const replaceInputRef = useRef<HTMLInputElement>(null);
 
@@ -237,7 +239,7 @@ export function SearchBar({
                 <span>
                   <Trans>Replace</Trans>
                 </span>
-                <Kbd className="animate-kbd-press">⌘ H</Kbd>
+                <Kbd className="animate-kbd-press">{primaryModifier} H</Kbd>
               </>
             }
           >
@@ -324,7 +326,7 @@ export function SearchBar({
                   <span>
                     <Trans>Replace all</Trans>
                   </span>
-                  <Kbd className="animate-kbd-press">⌘ ↵</Kbd>
+                  <Kbd className="animate-kbd-press">{primaryModifier} ↵</Kbd>
                 </>
               }
             >

--- a/apps/desktop/src/settings/general/app-settings.test.tsx
+++ b/apps/desktop/src/settings/general/app-settings.test.tsx
@@ -1,6 +1,14 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({
+  platform: vi.fn(() => "macos"),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: mocks.platform,
+}));
+
 import { AppSettingsView } from "./app-settings";
 
 function setting(value = true) {
@@ -49,6 +57,7 @@ function renderAppSettings({
 describe("AppSettingsView", () => {
   afterEach(() => {
     cleanup();
+    mocks.platform.mockReturnValue("macos");
   });
 
   it("does not expose a separate live transcript overlay setting", () => {
@@ -61,6 +70,19 @@ describe("AppSettingsView", () => {
     renderAppSettings({ floatingBar: false });
 
     expect(screen.getByText("Show floating bar")).toBeTruthy();
+  });
+
+  it("hides macOS-only Dock controls outside macOS", () => {
+    mocks.platform.mockReturnValue("windows");
+    renderAppSettings();
+
+    expect(
+      screen.queryByRole("switch", { name: "Show app in Dock" }),
+    ).toBeNull();
+    expect(
+      screen.queryByText("Keep Anarlog available from the menu bar."),
+    ).toBeNull();
+    expect(screen.getByRole("switch", { name: "Show tray icon" })).toBeTruthy();
   });
 
   it("toggles automatic updates", () => {

--- a/apps/desktop/src/settings/general/app-settings.tsx
+++ b/apps/desktop/src/settings/general/app-settings.tsx
@@ -1,4 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import { platform } from "@tauri-apps/plugin-os";
 import { type ReactNode, useId } from "react";
 
 import {
@@ -54,6 +55,8 @@ export function AppSettingsView({
   audioRetention,
   microphoneDevice,
 }: AppSettingsViewProps) {
+  const isMacos = platform() === "macos";
+
   return (
     <div className="flex flex-col gap-8">
       <section>
@@ -77,18 +80,22 @@ export function AppSettingsView({
             checked={automaticUpdates.value}
             onChange={automaticUpdates.onChange}
           />
-          <SettingRow
-            title={<Trans>Show app in Dock</Trans>}
-            description={
-              <Trans>Show Anarlog in the Dock and app switcher.</Trans>
-            }
-            checked={showAppInDock.value}
-            onChange={showAppInDock.onChange}
-          />
+          {isMacos && (
+            <SettingRow
+              title={<Trans>Show app in Dock</Trans>}
+              description={
+                <Trans>Show Anarlog in the Dock and app switcher.</Trans>
+              }
+              checked={showAppInDock.value}
+              onChange={showAppInDock.onChange}
+            />
+          )}
           <SettingRow
             title={<Trans>Show tray icon</Trans>}
             description={
-              <Trans>Keep Anarlog available from the menu bar.</Trans>
+              isMacos ? (
+                <Trans>Keep Anarlog available from the menu bar.</Trans>
+              ) : undefined
             }
             checked={showTrayIcon.value}
             onChange={showTrayIcon.onChange}
@@ -333,7 +340,7 @@ function SettingRow({
   disabled = false,
 }: {
   title: ReactNode;
-  description: ReactNode;
+  description?: ReactNode;
   checked: boolean;
   onChange: (checked: boolean) => void;
   disabled?: boolean;
@@ -347,16 +354,18 @@ function SettingRow({
         <h3 id={titleId} className="mb-1 text-sm font-medium">
           {title}
         </h3>
-        <p id={descriptionId} className="text-muted-foreground text-xs">
-          {description}
-        </p>
+        {description && (
+          <p id={descriptionId} className="text-muted-foreground text-xs">
+            {description}
+          </p>
+        )}
       </div>
       <Switch
         checked={checked}
         onCheckedChange={onChange}
         disabled={disabled}
         aria-labelledby={titleId}
-        aria-describedby={descriptionId}
+        aria-describedby={description ? descriptionId : undefined}
       />
     </div>
   );

--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -104,14 +104,9 @@ impl AppWindow {
                 .title_bar_style(tauri::TitleBarStyle::Overlay);
         }
 
-        #[cfg(target_os = "windows")]
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
         {
-            builder = builder.decorations(false);
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            builder = builder.decorations(false);
+            builder = builder.decorations(true);
         }
 
         builder

--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -166,6 +166,9 @@ impl WindowImpl for AppWindow {
             }
         };
 
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        window.set_decorations(true)?;
+
         Ok(window)
     }
 


### PR DESCRIPTION
Make the desktop app feel native on Windows and Linux instead of assuming macOS chrome and conventions.

- Restore OS-provided title-bar decorations on Windows and Linux (`decorations(true)` instead of frameless chrome).
- Show Ctrl instead of ⌘ in shortcut hints (composer send, empty-tab actions, note search/replace tooltips) using `platform()` from `@tauri-apps/plugin-os`.
- Hide the macOS-only "Show app in Dock" setting off macOS and drop the menu-bar helper text on the tray toggle.
- Tests cover Windows shortcut copy and non-macOS Dock hiding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and window chrome only; no auth, data, or core business-logic changes beyond conditional settings visibility.
> 
> **Overview**
> Makes the desktop app feel native on **Windows and Linux** by restoring **OS title-bar decorations** (`decorations(true)` in the windows plugin, including after note windows are created) instead of frameless chrome.
> 
> Shortcut hints now use **`platform()`** to show **Ctrl** off macOS and **⌘** on macOS in the composer send hint, empty-tab actions, and note search/replace tooltips. **General settings** hide the Dock toggle outside macOS, omit menu-bar helper text on the tray switch on other platforms, and allow optional row descriptions.
> 
> Tests mock `@tauri-apps/plugin-os` for Windows shortcut copy and non-macOS Dock hiding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c5c2793d328c3270afbeda7ab3cf53ad61563c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6281 
- <kbd>&nbsp;2&nbsp;</kbd> #6279 
- <kbd>&nbsp;1&nbsp;</kbd> #6266 👈 
<!-- GitButler Footer Boundary Bottom -->