### PR TITLE
docs: correct editor stack description in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Tauri desktop note-taking app (`apps/desktop/`) with a web app (`apps/web/`).
 Uses pnpm workspaces.
-SQLite is the primary data store (schema and migrations in `crates/db-app/`, desktop transport in `plugins/db/`), Zustand is used for UI state, and TipTap powers the editor. Sessions are the core entity — all notes are backed by sessions.
+SQLite is the primary data store (schema and migrations in `crates/db-app/`, desktop transport in `plugins/db/`), Zustand is used for UI state, and ProseMirror powers the editor (`packages/editor`, via `@handlewithcare/react-prosemirror`); documents are stored as TipTap-dialect ProseMirror JSON (converters/validation in `crates/tiptap`). Sessions are the core entity — all notes are backed by sessions.
 
 ## Commands
 


### PR DESCRIPTION
The editor migrated from TipTap to raw ProseMirror
(@handlewithcare/react-prosemirror in packages/editor); TipTap survives
only as the stored document dialect and its converters (crates/tiptap).
Say so instead of claiming TipTap powers the editor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Updates the **AGENTS.md** overview so it matches the real editor stack: **ProseMirror** in `packages/editor` (via `@handlewithcare/react-prosemirror`) is described as what powers the editor, instead of TipTap.
> 
> TipTap is now called out only as the **on-disk document dialect** (TipTap-flavor ProseMirror JSON), with conversion/validation in `crates/tiptap`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ddc2c10da5565d97532742c647a711dde302951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->