### PR TITLE
fix(desktop): align select widths in general settings

### DIFF
--- a/apps/desktop/src/settings/general/app-settings.tsx
+++ b/apps/desktop/src/settings/general/app-settings.tsx
@@ -301,7 +301,7 @@ function AudioRetentionRow({
         <SelectTrigger
           aria-labelledby={titleId}
           aria-describedby={descriptionId}
-          className="bg-card h-9 w-36 shadow-none focus:ring-0"
+          className="bg-card h-9 w-48 shadow-none focus:ring-0"
         >
           <SelectValue />
         </SelectTrigger>

--- a/apps/desktop/src/settings/general/theme.tsx
+++ b/apps/desktop/src/settings/general/theme.tsx
@@ -48,7 +48,7 @@ export function ThemeSelector() {
           setTheme(next);
         }}
       >
-        <SelectTrigger className="bg-card w-40 shadow-none focus:ring-0">
+        <SelectTrigger className="bg-card h-9 w-48 shadow-none focus:ring-0">
           <SelectValue placeholder={t`Select appearance`} />
         </SelectTrigger>
         <SelectContent>

--- a/apps/desktop/src/settings/general/week-start.tsx
+++ b/apps/desktop/src/settings/general/week-start.tsx
@@ -54,7 +54,7 @@ export function WeekStartSelector() {
         </p>
       </div>
       <Select value={displayValue} onValueChange={handleChange}>
-        <SelectTrigger className="bg-card w-40 shadow-none focus:ring-0">
+        <SelectTrigger className="bg-card h-9 w-48 shadow-none focus:ring-0">
           <SelectValue placeholder={t`Select day`} />
         </SelectTrigger>
         <SelectContent>


### PR DESCRIPTION
Audio retention, theme, and week-start select triggers each used a different
width (w-36/w-40), leaving the right column ragged next to the w-48 microphone,
language, and timezone selects. Standardize all of them on w-48 h-9, matching
the searchable-select button size.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind-only layout tweaks on settings UI with no behavior or data changes.
> 
> **Overview**
> **Aligns the right-column dropdowns** in General settings so audio retention, appearance, and week-start use the same **`h-9 w-48`** trigger sizing as microphone, language, and timezone controls.
> 
> Previously those three selects mixed **`w-36`** / **`w-40`** (and inconsistent height on appearance), which made the control column look uneven.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05d9ac9d7362649ed22a78fd6db85312b7d7506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->