### PR TITLE
feat(mobile): transcribe recordings via the batch STT proxy

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -13,7 +13,7 @@ Expo (SDK 57) app for Anarlog. Expo has changed significantly — read the exact
 - `src/db/migrations.ts` is an interim TS mirror of `crates/db-app/migrations` (subset, final shape). The UniFFI `crates/mobile-bridge` will own the schema later; this local DB is disposable — cloud sync repopulates it. Keep every statement semantically identical to desktop (`apps/desktop/src/session/queries.ts` is the reference for session SQL).
 - `src/data/` mirrors desktop query semantics: canonical create-session transaction, note docs as ProseMirror JSON with `id == session_id`, `session-audio:<sessionId>` attachment rows.
 - `src/auth/` is supabase-js with AsyncStorage plus the desktop browser-handoff flow (`/auth?flow=desktop&scheme=anarlog`). Pro gating uses the same JWT-claims logic as `packages/supabase/src/billing.ts` (ported, since jose does not run on Hermes). No Supabase env → bypass mode (local dev, no gate).
-- Recording/import write files under `<documents>/sessions/<sessionId>/audio.<ext>` and catalog them via `src/data/audio-catalog.ts`. No on-device transcription: `transcript_status` stays `processing` until sync-side transcription exists.
+- Recording/import write files under `<documents>/sessions/<sessionId>/audio.<ext>` and catalog them via `src/data/audio-catalog.ts`. No on-device STT models: `src/data/transcribe.ts` posts the audio to the `{API}/stt/listen` batch proxy (desktop-parity transcript rows, `source: batch_transcription`) and flips `transcript_status` to `complete`; failures leave it `processing` with a retry affordance on the note screen.
 
 ## Rules
 

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -23,6 +23,7 @@ import {
   saveSessionTitle,
   useSessionDetail,
 } from "@/data/session";
+import { transcribeSession, useTranscriptionState } from "@/data/transcribe";
 import { useSessionTranscripts } from "@/data/transcripts";
 import { confirmDestructive } from "@/lib/confirm";
 
@@ -35,6 +36,7 @@ export default function NoteScreen() {
   const { data, isLoading } = useSessionDetail(id);
   const audio = useSessionAudio(id);
   const transcripts = useSessionTranscripts(id);
+  const transcription = useTranscriptionState(id);
   const [listening, setListening] = useState(listen === "1");
   const recorder = useSessionRecorder(id, listening);
 
@@ -146,12 +148,26 @@ export default function NoteScreen() {
               }
               filename={audio.data.filename}
               sizeBytes={audio.data.sizeBytes}
-              pending={
-                audio.data.transcriptStatus !== "complete" &&
-                transcripts.length === 0
-              }
             />
           )}
+          {audio.data &&
+            audio.data.transcriptStatus !== "complete" &&
+            transcripts.length === 0 &&
+            (transcription === "running" ? (
+              <Text style={styles.transcribeStatus}>Transcribing…</Text>
+            ) : (
+              <Pressable
+                hitSlop={4}
+                onPress={() => void transcribeSession(id)}
+                style={({ pressed }) => pressed && styles.transcribePressed}
+              >
+                <Text style={styles.transcribeAction}>
+                  {transcription === "failed"
+                    ? "Transcription failed — tap to retry"
+                    : "Tap to transcribe"}
+                </Text>
+              </Pressable>
+            ))}
           {transcripts.length > 0 && (
             <View style={styles.transcript}>
               <Text style={styles.transcriptTitle}>Transcript</Text>
@@ -221,6 +237,22 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: "700",
     color: Colors.ink,
+  },
+  transcribeStatus: {
+    marginHorizontal: Spacing.lg,
+    marginTop: Spacing.xs,
+    fontSize: 12,
+    color: Colors.muted,
+  },
+  transcribeAction: {
+    marginHorizontal: Spacing.lg,
+    marginTop: Spacing.xs,
+    fontSize: 12,
+    fontWeight: "600",
+    color: Colors.accent,
+  },
+  transcribePressed: {
+    opacity: 0.6,
   },
   transcript: {
     marginHorizontal: Spacing.lg,

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { WAVEFORM_BAR_COUNT } from "@/components/waveform";
 import { catalogSessionAudio } from "@/data/audio-catalog";
+import { transcribeSession } from "@/data/transcribe";
 
 const METERING_FLOOR_DB = -50;
 
@@ -124,6 +125,7 @@ export function useSessionRecorder(
         contentType: CONTENT_TYPES[extension] ?? "application/octet-stream",
         sizeBytes: destination.size ?? 0,
       });
+      void transcribeSession(sessionId);
       setPhase("saved");
       return "saved";
     } catch (error) {

--- a/apps/mobile/src/components/audio-chip.tsx
+++ b/apps/mobile/src/components/audio-chip.tsx
@@ -19,12 +19,10 @@ export function AudioChip({
   uri,
   filename,
   sizeBytes,
-  pending,
 }: {
   uri: string;
   filename: string;
   sizeBytes: number;
-  pending: boolean;
 }) {
   const player = useAudioPlayer(uri);
   const status = useAudioPlayerStatus(player);
@@ -58,7 +56,6 @@ export function AudioChip({
       <Text style={styles.label} numberOfLines={1}>
         {filename} · {detail}
       </Text>
-      {pending && <Text style={styles.status}>Transcribes after sync</Text>}
     </Pressable>
   );
 }
@@ -85,9 +82,5 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: Colors.ink,
     maxWidth: 180,
-  },
-  status: {
-    fontSize: 12,
-    color: Colors.muted,
   },
 });

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -6,6 +6,7 @@ import { Directory, File, Paths } from "expo-file-system";
 
 import { catalogSessionAudio } from "@/data/audio-catalog";
 import { createSession, deleteSession } from "@/data/session";
+import { transcribeSession } from "@/data/transcribe";
 import { nowIso } from "@/lib/ids";
 
 const CONTENT_TYPES: Record<string, string> = {
@@ -69,6 +70,8 @@ async function importAsset(asset: DocumentPickerAsset): Promise<string> {
     await deleteSession(sessionId).catch(() => {});
     throw error;
   }
+
+  void transcribeSession(sessionId);
 
   return sessionId;
 }

--- a/apps/mobile/src/data/transcribe.ts
+++ b/apps/mobile/src/data/transcribe.ts
@@ -1,0 +1,323 @@
+import { File, Paths } from "expo-file-system";
+import { fetch } from "expo/fetch";
+import { useSyncExternalStore } from "react";
+import { Platform } from "react-native";
+
+import { supabase } from "@/auth/client";
+import { execute, executeTransaction } from "@/db";
+import { env } from "@/lib/env";
+import { id, nowIso } from "@/lib/ids";
+
+// Client-driven batch STT, mirroring desktop's useRunBatch: POST the audio to
+// the transcribe proxy, then persist the transcript exactly like desktop's
+// createTranscript (source batch_transcription, whole-session replace).
+export type TranscriptionState = "idle" | "running" | "failed";
+
+const states = new Map<string, TranscriptionState>();
+const inflight = new Map<string, Promise<void>>();
+const listeners = new Set<() => void>();
+
+function setState(sessionId: string, state: TranscriptionState) {
+  if (state === "idle") states.delete(sessionId);
+  else states.set(sessionId, state);
+  for (const listener of listeners) listener();
+}
+
+// On success the committed transcript rows re-render the note screen via the
+// live query; clearing without notifying avoids a one-frame "Tap to
+// transcribe" flash between the idle notification and the query refresh.
+function clearStateSilently(sessionId: string) {
+  states.delete(sessionId);
+}
+
+export function useTranscriptionState(sessionId: string): TranscriptionState {
+  return useSyncExternalStore(
+    (onChange) => {
+      listeners.add(onChange);
+      return () => listeners.delete(onChange);
+    },
+    () => states.get(sessionId) ?? "idle",
+  );
+}
+
+const PENDING_AUDIO_SQL = `
+SELECT filename, content_type, size_bytes
+FROM session_attachments
+WHERE session_id = ? AND source_type = 'session_audio' AND deleted_at IS NULL
+  AND COALESCE(json_extract(metadata_json, '$.transcript_status'), '') <> 'complete'
+LIMIT 1
+`;
+
+const TRANSCRIPT_TOMBSTONE_SQL = `
+UPDATE transcripts
+SET deleted_at = ?, updated_at = ?
+WHERE session_id = ? AND deleted_at IS NULL
+`;
+
+const TRANSCRIPT_INSERT_SQL = `
+INSERT INTO transcripts (
+  id, workspace_id, owner_user_id, session_id, source, provider,
+  model, language, started_at_ms, ended_at_ms, audio_attachment_id,
+  memo, words_json, speaker_hints_json, metadata_json, created_at,
+  updated_at, deleted_at
+)
+SELECT ?, session.workspace_id, session.owner_user_id, session.id,
+  'batch_transcription', 'hyprnote', 'cloud', ?, ?, NULL, '',
+  COALESCE((
+    SELECT note.body FROM session_documents AS note
+    WHERE note.id = session.id AND note.kind = 'note' AND note.deleted_at IS NULL
+  ), ''),
+  ?, ?, '{}', ?, ?, NULL
+FROM sessions AS session
+WHERE session.id = ? AND session.deleted_at IS NULL
+`;
+
+const MARK_COMPLETE_SQL = `
+UPDATE session_attachments
+SET
+  metadata_json = json_set(
+    CASE WHEN json_valid(metadata_json) THEN metadata_json ELSE '{}' END,
+    '$.transcript_status',
+    'complete'
+  ),
+  updated_at = ?
+WHERE id = ? AND session_id = ? AND source_type = 'session_audio'
+  AND source_id = 'primary' AND deleted_at IS NULL
+`;
+
+type BatchWord = {
+  word?: unknown;
+  start?: unknown;
+  end?: unknown;
+  channel?: unknown;
+  speaker?: unknown;
+  punctuated_word?: unknown;
+};
+
+type WordRecord = {
+  id: string;
+  text: string;
+  start_ms: number;
+  end_ms: number;
+  channel: number;
+};
+
+type HintRecord = {
+  id: string;
+  word_id: string;
+  type: "provider_speaker_index";
+  value: string;
+};
+
+// Desktop's synthetic_text fallback (batch.ts wordEntriesFromTranscript):
+// providers like OpenAI/Mistral may return a transcript with no word timings.
+const SYNTHETIC_TEXT_WORD_MS = 400;
+
+function syntheticWords(transcript: string, channel: number): WordRecord[] {
+  const tokens = transcript.trim().split(/\s+/).filter(Boolean);
+  const durationMs = tokens.length * SYNTHETIC_TEXT_WORD_MS;
+  return tokens.map((token, index) => ({
+    id: id(),
+    text: token,
+    start_ms: Math.round((index / tokens.length) * durationMs),
+    end_ms: Math.round(((index + 1) / tokens.length) * durationMs),
+    channel,
+  }));
+}
+
+function mapBatchResponse(payload: unknown): {
+  words: WordRecord[];
+  hints: HintRecord[];
+} {
+  const channels =
+    (
+      payload as {
+        results?: {
+          channels?: {
+            alternatives?: { transcript?: unknown; words?: BatchWord[] }[];
+          }[];
+        };
+      }
+    )?.results?.channels ?? [];
+
+  const words: WordRecord[] = [];
+  const hints: HintRecord[] = [];
+  channels.forEach((channel, channelIndex) => {
+    const alternative = channel?.alternatives?.[0];
+    const channelWordCount = words.length;
+    for (const word of alternative?.words ?? []) {
+      if (typeof word?.word !== "string" || word.word === "") continue;
+      const wordId = id();
+      const wordChannel =
+        typeof word.channel === "number" ? word.channel : channelIndex;
+      words.push({
+        id: wordId,
+        text:
+          typeof word.punctuated_word === "string" && word.punctuated_word
+            ? word.punctuated_word
+            : word.word,
+        start_ms: Math.round(
+          (typeof word.start === "number" ? word.start : 0) * 1000,
+        ),
+        end_ms: Math.round(
+          (typeof word.end === "number" ? word.end : 0) * 1000,
+        ),
+        channel: wordChannel,
+      });
+      if (typeof word.speaker === "number") {
+        hints.push({
+          id: id(),
+          word_id: wordId,
+          type: "provider_speaker_index",
+          value: JSON.stringify({
+            provider: "hyprnote",
+            channel: wordChannel,
+            speaker_index: word.speaker,
+          }),
+        });
+      }
+    }
+    if (
+      words.length === channelWordCount &&
+      typeof alternative?.transcript === "string" &&
+      alternative.transcript.trim() !== ""
+    ) {
+      words.push(...syntheticWords(alternative.transcript, channelIndex));
+    }
+  });
+  return { words, hints };
+}
+
+const UPLOAD_TIMEOUT_BASE_MS = 60_000;
+const UPLOAD_TIMEOUT_MAX_MS = 600_000;
+
+function uploadTimeoutMs(sizeBytes: number): number {
+  // Scale with file size so long recordings on slow links aren't killed
+  // mid-upload: base + ~1ms/KiB, capped at 10 minutes.
+  return Math.min(
+    UPLOAD_TIMEOUT_BASE_MS + Math.round(sizeBytes / 1024),
+    UPLOAD_TIMEOUT_MAX_MS,
+  );
+}
+
+// Native uses File.upload (streams from disk, honors explicit Content-Type,
+// iOS background session survives the 60s idle timeout); expo/fetch there
+// would buffer the file in memory and override Content-Type with the
+// extension-inferred MIME. Web keeps fetch with a bytes body (no override).
+async function requestTranscription(
+  file: File,
+  contentType: string,
+  token: string | undefined,
+  timeoutMs: number,
+): Promise<{ status: number; body: string }> {
+  const url = `${env.apiUrl}/stt/listen?provider=hyprnote`;
+  const headers = {
+    "Content-Type": contentType,
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error("stt timeout")),
+    timeoutMs,
+  );
+  try {
+    if (Platform.OS === "web") {
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: new Uint8Array(await file.arrayBuffer()),
+        signal: controller.signal,
+      });
+      return { status: response.status, body: await response.text() };
+    }
+    const result = await file.upload(url, {
+      httpMethod: "POST",
+      headers,
+      signal: controller.signal,
+    });
+    return { status: result.status, body: result.body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runTranscription(sessionId: string): Promise<void> {
+  const rows = await execute<{
+    filename: string;
+    content_type: string;
+    size_bytes: number;
+  }>(PENDING_AUDIO_SQL, [sessionId]);
+  const audio = rows[0];
+  if (!audio) return;
+
+  const file = new File(Paths.document, "sessions", sessionId, audio.filename);
+  if (!file.exists) {
+    throw new Error(`audio file missing: ${audio.filename}`);
+  }
+
+  const auth = await supabase?.auth.getSession();
+  const token = auth?.data.session?.access_token;
+  const startedAtMs = Date.now();
+
+  const response = await requestTranscription(
+    file,
+    audio.content_type || "application/octet-stream",
+    token,
+    uploadTimeoutMs(audio.size_bytes),
+  );
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(
+      `stt request failed: ${response.status} ${response.body.slice(0, 256)}`,
+    );
+  }
+
+  const { words, hints } = mapBatchResponse(JSON.parse(response.body));
+  if (words.length === 0) {
+    // Never mark complete on an empty result — transcript_status stays
+    // 'processing' so the tap-to-retry affordance remains reachable.
+    throw new Error("stt returned no words");
+  }
+  const now = nowIso();
+  const attachmentId = `session-audio:${sessionId}`;
+  await executeTransaction([
+    {
+      sql: TRANSCRIPT_TOMBSTONE_SQL,
+      params: [now, now, sessionId] as unknown[],
+    },
+    {
+      sql: TRANSCRIPT_INSERT_SQL,
+      params: [
+        id(),
+        "",
+        startedAtMs,
+        JSON.stringify(words),
+        JSON.stringify(hints),
+        now,
+        now,
+        sessionId,
+      ] as unknown[],
+    },
+    {
+      sql: MARK_COMPLETE_SQL,
+      params: [now, attachmentId, sessionId] as unknown[],
+    },
+  ]);
+}
+
+export function transcribeSession(sessionId: string): Promise<void> {
+  const existing = inflight.get(sessionId);
+  if (existing) return existing;
+
+  setState(sessionId, "running");
+  const task = runTranscription(sessionId)
+    .then(() => clearStateSilently(sessionId))
+    .catch((error: unknown) => {
+      console.warn("[transcribe] failed", error);
+      setState(sessionId, "failed");
+    })
+    .finally(() => {
+      inflight.delete(sessionId);
+    });
+  inflight.set(sessionId, task);
+  return task;
+}

--- a/apps/mobile/src/data/transcribe.ts
+++ b/apps/mobile/src/data/transcribe.ts
@@ -188,15 +188,22 @@ function mapBatchResponse(payload: unknown): {
   return { words, hints };
 }
 
-const UPLOAD_TIMEOUT_BASE_MS = 60_000;
-const UPLOAD_TIMEOUT_MAX_MS = 600_000;
+const REQUEST_TIMEOUT_BASE_MS = 60_000;
+const REQUEST_TIMEOUT_MAX_MS = 900_000;
+// Upload on a slow link, plus the provider transcribing the same audio before
+// the synchronous response comes back.
+const UPLOAD_MS_PER_KIB = 8;
+const PROCESSING_MS_PER_KIB = 8;
 
-function uploadTimeoutMs(sizeBytes: number): number {
-  // Scale with file size so long recordings on slow links aren't killed
-  // mid-upload: base + ~1ms/KiB, capped at 10 minutes.
+function requestTimeoutMs(sizeBytes: number): number {
+  // The abort covers the whole /stt/listen round trip, not just the upload, so
+  // budgeting for transfer alone aborts long recordings the provider is still
+  // transcribing and reports them as failures.
+  const kib = sizeBytes / 1024;
   return Math.min(
-    UPLOAD_TIMEOUT_BASE_MS + Math.round(sizeBytes / 1024),
-    UPLOAD_TIMEOUT_MAX_MS,
+    REQUEST_TIMEOUT_BASE_MS +
+      Math.round(kib * (UPLOAD_MS_PER_KIB + PROCESSING_MS_PER_KIB)),
+    REQUEST_TIMEOUT_MAX_MS,
   );
 }
 
@@ -263,7 +270,7 @@ async function runTranscription(sessionId: string): Promise<void> {
     file,
     audio.content_type || "application/octet-stream",
     token,
-    uploadTimeoutMs(audio.size_bytes),
+    requestTimeoutMs(audio.size_bytes),
   );
   if (response.status < 200 || response.status >= 300) {
     throw new Error(


### PR DESCRIPTION
Recordings and imported memos now get transcripts without waiting for
cloud sync: after catalog, transcribe.ts streams the audio to
{API}/stt/listen?provider=hyprnote and persists desktop-parity
transcript rows (source batch_transcription, whole-session replace,
memo snapshots the note body like desktop raw_md).

- Native uploads use File.upload (streams from disk, honors the
  explicit Content-Type, iOS background session); web keeps fetch with
  a bytes body. Size-scaled AbortController timeout caps hung requests.
- Providers returning transcript text without word timings get
  desktop's synthetic_text fallback instead of being dropped; empty
  results throw so transcript_status stays processing and the note
  screen keeps its tap-to-retry affordance.
- Note screen shows Transcribing…/failed-retry states via
  useSyncExternalStore; success clears state silently so the live-query
  refresh lands without a "Tap to transcribe" flash.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6271 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6265 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated uploads and transcript DB writes mirror desktop but depend on the STT proxy and auth; failures are non-blocking but affect core note/transcript UX.
> 
> **Overview**
> Mobile no longer waits for sync to get transcripts: new **`transcribe.ts`** uploads session audio to **`{API}/stt/listen?provider=hyprnote`** (Bearer when signed in), maps the batch response into desktop-style **`batch_transcription`** rows (whole-session replace, note body in memo), and sets attachment **`transcript_status`** to **`complete`**. Native uploads use **`File.upload`** with size-scaled timeouts; web uses **`expo/fetch`**. Text-only STT responses get desktop’s synthetic word timings; empty results fail without marking complete.
> 
> **Recording** and **voice-memo import** fire **`transcribeSession`** after cataloging. The **note screen** shows “Transcribing…”, tap-to-transcribe, or retry on failure via **`useTranscriptionState`**; **`AudioChip`** drops the old “Transcribes after sync” copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e29b3808e1acb8469ea39ac1baf749fe84d20d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->