### PR TITLE
fix(desktop): make sign out read as a destructive action

### DIFF
--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -146,12 +146,9 @@ export function SettingsAccount() {
         description={auth.session?.user.email ?? t`Signed in`}
         action={
           <Button
-            variant="outline"
+            variant="destructive"
             onClick={() => signOutMutation.mutate()}
             disabled={signOutMutation.isPending}
-            className={cn([
-              "border-alert-border text-alert-foreground hover:bg-alert hover:text-alert-foreground",
-            ])}
           >
             {signOutMutation.isPending ? t`Signing out...` : t`Sign out`}
           </Button>


### PR DESCRIPTION
The Sign out button used the outline variant with alert-* overrides, which
rendered as a neutral button and gave no signal that it ends the session.
Switch it to the design system's destructive variant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic button styling only in account settings; sign-out behavior is unchanged.
> 
> **Overview**
> **Account settings** Sign out is now styled with the shared `Button` **`destructive`** variant instead of **`outline`** plus custom `alert-*` border/text/hover classes.
> 
> The click handler, pending state, and copy are unchanged; only visual treatment updates so ending the session reads as a consequential action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb7fe0e3897ea8575c0c77b78fc9e1045cfc978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->