### PR TITLE
chore(desktop): simplify account layout classes

### DIFF
--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -481,7 +481,7 @@ function PlanTierList({
   return (
     <div ref={containerRef}>
       {isWide ? (
-        <div className="divide-border border-border grid grid-cols-2 divide-x border-t">
+        <div className="divide-border grid grid-cols-2 divide-x">
           {PLAN_TIERS.map((tier) => {
             const isCurrent = tier.id === currentTier;
             const action = getActionForTier(
@@ -606,7 +606,7 @@ function Container({
   children?: ReactNode;
 }) {
   return (
-    <section className="border-border border-b pb-4 last:border-b-0">
+    <section>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex min-w-0 flex-1 flex-col gap-2">
           <h3 className="text-sm font-medium">{title}</h3>


### PR DESCRIPTION
Remove unnecessary border-related Tailwind classes from the account
settings layout. This reduces redundant styling while keeping the
grid and spacing structure intact for the wide tier selector and
the account section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind-only changes in account settings with no logic or data impact; the only reviewer note is a possible subtle visual shift where borders/padding were removed.
> 
> **Overview**
> **Account settings layout** in the desktop app drops extra border styling so spacing and dividers come from the parent layout instead of duplicated rules.
> 
> The wide **plan tier** grid keeps its two-column `divide-x` split but no longer applies a top border on the wrapper. The reusable **`Container`** sections lose bottom borders and section-level bottom padding (`border-b`, `pb-4`, `last:border-b-0`), so vertical rhythm is driven by the existing `gap-8` on the page rather than per-section rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66e7bd68604d6267c21a59aa7796d1e3de7fb33d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->