### PR TITLE
Ship Linux CLI and MCP

### DIFF
--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -207,6 +207,73 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  desktop_linux:
+    if: ${{ !startsWith(github.head_ref || '', 'blog/') }}
+    runs-on: depot-ubuntu-24.04-8
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: ./.github/actions/install_desktop_deps
+        with:
+          target: linux
+      - uses: ./.github/actions/rust_install
+        with:
+          platform: linux
+      - run: cargo check --locked -p desktop
+      - run: cargo test --locked -p desktop embedded_cli --lib
+      - run: cargo test --locked -p cloudsync loads_bundled_cloudsync
+      - if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/pnpm_install
+      - if: github.event_name == 'workflow_dispatch'
+        run: |
+          TAURI_ENV_TARGET_TRIPLE=x86_64-unknown-linux-gnu cargo xtask prepare-binaries
+          ./scripts/sidecar.sh \
+            ./apps/desktop/src-tauri/tauri.conf.staging.json \
+            resources/cli/anarlog-cli
+      - if: github.event_name == 'workflow_dispatch'
+        run: pnpm -F ui build
+      - if: github.event_name == 'workflow_dispatch'
+        run: pnpm -F desktop tauri build --ci --bundles appimage,deb --no-sign --target x86_64-unknown-linux-gnu --config ./src-tauri/tauri.conf.staging.json --features devtools --verbose
+        env:
+          POSTHOG_API_KEY: phc_linux_ci
+          VITE_POSTHOG_API_KEY: phc_linux_ci
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_HYPRNOTE_2 }}
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_APP_URL: https://anarlog.so
+          VITE_API_URL: https://api.anarlog.so
+          VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
+      - if: github.event_name == 'workflow_dispatch'
+        run: |
+          shopt -s nullglob
+          bundles=(
+            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
+            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
+          )
+          if [[ ${#bundles[@]} -eq 0 ]]; then
+            echo "No Linux bundles found"
+            exit 1
+          fi
+          for bundle in "${bundles[@]}"; do
+            sha256sum "$bundle" > "$bundle.sha256"
+          done
+      - if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: anarlog-linux-x64-${{ github.sha }}
+          path: |
+            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
+            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.sha256
+            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
+            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.sha256
+          if-no-files-found: error
+          retention-days: 7
+
   desktop_i18n:
     if: ${{ !startsWith(github.head_ref || '', 'blog/') }}
     runs-on: ubuntu-latest
@@ -233,7 +300,13 @@ jobs:
 
   ci:
     if: always()
-    needs: [desktop_ci, desktop_windows, desktop_i18n, desktop_swift]
+    needs: [
+      desktop_ci,
+      desktop_windows,
+      desktop_linux,
+      desktop_i18n,
+      desktop_swift,
+    ]
     runs-on: ubuntu-latest
     steps:
       - run: exit 1

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -260,7 +260,11 @@ jobs:
             exit 1
           fi
           for bundle in "${bundles[@]}"; do
-            sha256sum "$bundle" > "$bundle.sha256"
+            # Record the basename, like the Windows job does, so `sha256sum -c`
+            # works next to the downloaded artifact rather than only inside the
+            # CI directory layout.
+            name=$(basename "$bundle")
+            (cd "$(dirname "$bundle")" && sha256sum "$name" > "$name.sha256")
           done
       - if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4

--- a/apps/desktop/src-tauri/src/embedded_cli.rs
+++ b/apps/desktop/src-tauri/src/embedded_cli.rs
@@ -1,13 +1,13 @@
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::os::unix::fs::PermissionsExt;
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 use std::path::Path;
 use std::path::PathBuf;
 
 use serde::Serialize;
 
 const DEV_BUNDLE_ID: &str = "com.hyprnote.dev";
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 const MANAGED_CLI_DIR: &str = ".anarlog-cli";
 const STABLE_BUNDLE_ID: &str = "com.hyprnote.stable";
 const STAGING_BUNDLE_ID: &str = "com.hyprnote.staging";
@@ -46,7 +46,7 @@ pub fn check<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -> EmbeddedCl
         return unavailable_status(command_name, missing_dir);
     };
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
         let _ = manager;
         return EmbeddedCliStatus {
@@ -75,7 +75,7 @@ pub fn check<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -> EmbeddedCl
         classify_windows_status(command_name, install_path)
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
         let Some(_resource_path) = resolve_resource_path(manager) else {
             return EmbeddedCliStatus {
@@ -97,7 +97,7 @@ pub fn install<R: tauri::Runtime, T: tauri::Manager<R>>(
 ) -> Result<EmbeddedCliStatus, String> {
     let status = check(manager);
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
         Ok(status)
     }
@@ -125,7 +125,7 @@ pub fn install<R: tauri::Runtime, T: tauri::Manager<R>>(
         Ok(classify_windows_status(&status.command_name, install_path))
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
         match status.state {
             EmbeddedCliState::Unsupported | EmbeddedCliState::ResourceMissing => {
@@ -191,7 +191,7 @@ fn install_path_for_command(command_name: &str) -> Option<PathBuf> {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn resolve_resource_path<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -> Option<PathBuf> {
     use tauri::path::BaseDirectory;
 
@@ -224,7 +224,7 @@ fn resolve_resource_path<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -
     debug_path.exists().then_some(debug_path)
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn sidecar_binary_name() -> &'static str {
     if cfg!(target_os = "windows") {
         "anarlog-cli.exe"
@@ -233,7 +233,7 @@ fn sidecar_binary_name() -> &'static str {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn bundled_binary_name() -> Option<&'static str> {
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
     {
@@ -248,6 +248,16 @@ fn bundled_binary_name() -> Option<&'static str> {
     #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
     {
         return Some("anarlog-cli-x86_64-apple-darwin");
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        return Some("anarlog-cli-x86_64-unknown-linux-gnu");
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        return Some("anarlog-cli-aarch64-unknown-linux-gnu");
     }
 
     #[allow(unreachable_code)]
@@ -472,7 +482,7 @@ fn path_list_contains(path_list: &str, expected: &Path) -> bool {
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn classify_status(
     command_name: &str,
     install_path: PathBuf,
@@ -499,7 +509,7 @@ fn classify_status(
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn classify_installation(
     install_path: &Path,
     managed_path: &Path,
@@ -555,12 +565,22 @@ fn classify_installation(
     Ok(EmbeddedCliState::Installed)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn is_replaceable_symlink_target(target: &Path, managed_path: &Path) -> bool {
-    managed_path
+    if managed_path
         .parent()
         .is_some_and(|managed_dir| target.parent() == Some(managed_dir))
-        || is_legacy_app_cli_target(target)
+    {
+        return true;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return is_legacy_app_cli_target(target);
+    }
+
+    #[cfg(target_os = "linux")]
+    false
 }
 
 #[cfg(target_os = "macos")]
@@ -601,7 +621,7 @@ fn is_legacy_app_cli_target(target: &Path) -> bool {
     )
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn details_for_state(state: EmbeddedCliState, install_path: &Path) -> Option<String> {
     match state {
         EmbeddedCliState::Installed => Some(format!(
@@ -621,7 +641,7 @@ fn details_for_state(state: EmbeddedCliState, install_path: &Path) -> Option<Str
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn managed_binary_path(
     install_path: &Path,
     command_name: &str,
@@ -637,7 +657,7 @@ fn managed_binary_path(
         .join(app_version))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn install_managed_cli(
     resource_path: &Path,
     managed_path: &Path,
@@ -699,7 +719,7 @@ fn install_managed_cli(
     install_symlink(managed_path, install_path)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn install_symlink(managed_path: &Path, install_path: &Path) -> Result<(), String> {
     let install_dir = install_path
         .parent()
@@ -745,7 +765,7 @@ fn install_symlink(managed_path: &Path, install_path: &Path) -> Result<(), Strin
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn ensure_install_path_replaceable(install_path: &Path, managed_path: &Path) -> Result<(), String> {
     let metadata = match std::fs::symlink_metadata(install_path) {
         Ok(metadata) => metadata,
@@ -779,7 +799,7 @@ fn ensure_install_path_replaceable(install_path: &Path, managed_path: &Path) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     use std::os::unix::fs::PermissionsExt;
 
     #[test]
@@ -791,6 +811,26 @@ mod tests {
         );
         assert_eq!(command_name_from_identifier(DEV_BUNDLE_ID), "anarlog-dev");
         assert_eq!(command_name_from_identifier("unknown"), "anarlog-dev");
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    #[test]
+    fn resolves_linux_x64_bundled_binary() {
+        assert_eq!(
+            bundled_binary_name(),
+            Some("anarlog-cli-x86_64-unknown-linux-gnu")
+        );
+        assert_eq!(sidecar_binary_name(), "anarlog-cli");
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    #[test]
+    fn resolves_linux_arm64_bundled_binary() {
+        assert_eq!(
+            bundled_binary_name(),
+            Some("anarlog-cli-aarch64-unknown-linux-gnu")
+        );
+        assert_eq!(sidecar_binary_name(), "anarlog-cli");
     }
 
     #[test]
@@ -807,7 +847,7 @@ mod tests {
         ));
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn classifies_missing_install() {
         let dir = tempfile::tempdir().unwrap();
@@ -818,7 +858,7 @@ mod tests {
         assert_eq!(state, EmbeddedCliState::Missing);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn classifies_installed_symlink() {
         let dir = tempfile::tempdir().unwrap();
@@ -832,7 +872,7 @@ mod tests {
         assert_eq!(state, EmbeddedCliState::Installed);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn classifies_non_executable_managed_cli_as_missing() {
         let dir = tempfile::tempdir().unwrap();
@@ -848,7 +888,7 @@ mod tests {
         );
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn classifies_stale_symlinks_as_missing() {
         let dir = tempfile::tempdir().unwrap();
@@ -926,7 +966,7 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&install_path).unwrap(), "new cli");
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn classifies_foreign_symlink_as_conflict() {
         let dir = tempfile::tempdir().unwrap();
@@ -940,7 +980,7 @@ mod tests {
         );
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn installer_refuses_to_replace_foreign_symlink() {
         let dir = tempfile::tempdir().unwrap();
@@ -955,7 +995,7 @@ mod tests {
         assert_eq!(std::fs::read_link(&install_path).unwrap(), foreign_target);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn installed_cli_survives_bundled_resource_move() {
         let dir = tempfile::tempdir().unwrap();
@@ -984,7 +1024,7 @@ mod tests {
         );
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn app_update_requires_installing_the_new_cli_version() {
         let dir = tempfile::tempdir().unwrap();
@@ -1010,7 +1050,7 @@ mod tests {
         );
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn classifies_regular_file_as_conflict() {
         let dir = tempfile::tempdir().unwrap();

--- a/scripts/setup-linux-others.sh
+++ b/scripts/setup-linux-others.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 
 sudo apt update
 sudo apt-get install -y \
+  clang \
+  libclang-dev \
   libgtk-3-dev \
   libgtk-4-dev \
   libasound2-dev \
@@ -15,6 +17,7 @@ sudo apt-get install -y \
   libgraphene-1.0-dev \
   pkg-config \
   patchelf \
+  xdg-utils \
   cmake \
   curl \
   jq \


### PR DESCRIPTION
Add upgrade-safe CLI installation, native Linux package CI, and target-OS validation for the desktop and bundled CloudSync library.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #6280 
- <kbd>&nbsp;3&nbsp;</kbd> #6278 
- <kbd>&nbsp;2&nbsp;</kbd> #6277 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6264 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the desktop installs CLI binaries on user machines (symlinks under `~/.local/bin`) and adds a new required CI gate; release-path risk is limited to workflow_dispatch artifacts unless dispatch is used in release flows.
> 
> **Overview**
> **Adds Linux support for the bundled Anarlog CLI** using the same upgrade-safe, version-managed install flow as macOS (`~/.local/bin` symlink into `.anarlog-cli/<command>/<version>`), including Linux x86_64 and aarch64 bundled sidecar names. macOS-only legacy app-bundle symlink targets stay macOS-specific; foreign symlinks on Linux are not auto-replaced.
> 
> **Introduces a `desktop_linux` CI job** that runs locked `cargo check`, `embedded_cli` unit tests, and `loads_bundled_cloudsync`, and on manual dispatch builds staging AppImage and `.deb` bundles (with basename `sha256` sidecars) as upload artifacts. The aggregate `ci` job now depends on `desktop_linux`.
> 
> **Expands Linux dev setup** with `clang`, `libclang-dev`, and `xdg-utils` for native/desktop builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a472c1a97c1787e77cdab03ab392f761625e428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->