### PR TITLE
Make Linux capability states actionable

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -2366,7 +2366,9 @@ msgstr "Trial"
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr "Trial activated - {trialDays} days of Pro"
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr "Try again"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -2366,7 +2366,9 @@ msgstr ""
 msgid "Trial activated - {trialDays} days of Pro"
 msgstr ""
 
+#: src/onboarding/permissions.tsx
 #: src/session-sharing/index.tsx
+#: src/settings/general/permissions.tsx
 msgid "Try again"
 msgstr ""
 

--- a/apps/desktop/src/onboarding/permissions.test.tsx
+++ b/apps/desktop/src/onboarding/permissions.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => {
     open: vi.fn(),
     request: vi.fn(),
     reset: vi.fn(),
+    error: null as string | null,
   });
   const permissions = {
     microphone: createPermission(),
@@ -55,6 +56,7 @@ describe("PermissionsSection", () => {
     Object.values(mocks.permissions).forEach((permission) => {
       permission.status = "denied";
       permission.isPending = false;
+      permission.error = null;
     });
   });
 
@@ -102,6 +104,37 @@ describe("PermissionsSection", () => {
     expect(screen.queryByText("Help Anarlog read meeting activity")).toBeNull();
     expect(mocks.usePermission).not.toHaveBeenCalledWith("accessibility");
     expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries denied runtime audio probes outside macOS", () => {
+    mocks.currentPlatform = "linux";
+    mocks.permissions.microphone.error = "microphone device unavailable";
+    mocks.permissions.systemAudio.error = "PipeWire source unavailable";
+
+    render(<PermissionsSection />);
+
+    expect(
+      screen
+        .getByRole("button", { name: "Try again: Microphone" })
+        .getAttribute("title"),
+    ).toBe("microphone device unavailable");
+    expect(
+      screen
+        .getByRole("button", { name: "Try again: System audio" })
+        .getAttribute("title"),
+    ).toBe("PipeWire source unavailable");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Try again: Microphone" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Try again: System audio" }),
+    );
+
+    expect(mocks.permissions.microphone.request).toHaveBeenCalledOnce();
+    expect(mocks.permissions.systemAudio.request).toHaveBeenCalledOnce();
+    expect(mocks.permissions.microphone.open).not.toHaveBeenCalled();
+    expect(mocks.permissions.systemAudio.open).not.toHaveBeenCalled();
   });
 
   it("requests denied Accessibility permission instead of opening Settings", () => {

--- a/apps/desktop/src/onboarding/permissions.tsx
+++ b/apps/desktop/src/onboarding/permissions.tsx
@@ -26,6 +26,7 @@ function PermissionBlock({
   status,
   isPending,
   onAction,
+  actionLabel,
   opensSettingsWhenDenied = true,
 }: {
   enabledLabel: string;
@@ -37,6 +38,7 @@ function PermissionBlock({
   status: PermissionStatus | undefined;
   isPending: boolean;
   onAction: () => void;
+  actionLabel?: string;
   opensSettingsWhenDenied?: boolean;
 }) {
   const { t } = useLingui();
@@ -63,7 +65,7 @@ function PermissionBlock({
       aria-label={
         opensSettings
           ? t`Open ${permissionName.toLowerCase()} settings`
-          : t`Enable ${permissionName.toLowerCase()}`
+          : (actionLabel ?? t`Enable ${permissionName.toLowerCase()}`)
       }
     >
       <div
@@ -114,9 +116,11 @@ function ContinueWhenComplete({
 function PermissionsSectionContent({
   onContinue,
   accessibility,
+  runtimeCapabilities = false,
 }: {
   onContinue?: () => void;
   accessibility?: ReturnType<typeof usePermission>;
+  runtimeCapabilities?: boolean;
 }) {
   const { t } = useLingui();
   const mic = usePermission("microphone");
@@ -128,8 +132,11 @@ function PermissionsSectionContent({
     systemAudio.status === "authorized" &&
     (!accessibility || accessibility.status === "authorized");
 
-  const handleAction = (perm: ReturnType<typeof usePermission>) => {
-    if (perm.status === "denied") {
+  const handleAction = (
+    perm: ReturnType<typeof usePermission>,
+    opensSettingsWhenDenied: boolean,
+  ) => {
+    if (opensSettingsWhenDenied && perm.status === "denied") {
       perm.open();
     } else {
       perm.request();
@@ -150,24 +157,38 @@ function PermissionsSectionContent({
           enabledLabel={t`Anarlog can hear your voice`}
           enableLabel={t`Help Anarlog listen to you`}
           enabledBody={t`Microphone access turned on`}
-          enableBody={t`Use your microphone to capture your voice`}
+          enableBody={mic.error ?? t`Use your microphone to capture your voice`}
           Icon={MicIcon}
           permissionName={t`Microphone`}
           status={mic.status}
           isPending={mic.isPending}
-          onAction={() => handleAction(mic)}
+          onAction={() => handleAction(mic, !runtimeCapabilities)}
+          actionLabel={
+            runtimeCapabilities && mic.status === "denied"
+              ? `${t`Try again`}: ${t`Microphone`}`
+              : undefined
+          }
+          opensSettingsWhenDenied={!runtimeCapabilities}
         />
 
         <PermissionBlock
           enabledLabel={t`Anarlog can hear others`}
           enableLabel={t`Help Anarlog listen to others`}
           enabledBody={t`System audio enabled`}
-          enableBody={t`Use system audio to capture other speakers`}
+          enableBody={
+            systemAudio.error ?? t`Use system audio to capture other speakers`
+          }
           Icon={Volume2Icon}
           permissionName={t`System audio`}
           status={systemAudio.status}
           isPending={systemAudio.isPending}
-          onAction={() => handleAction(systemAudio)}
+          onAction={() => handleAction(systemAudio, !runtimeCapabilities)}
+          actionLabel={
+            runtimeCapabilities && systemAudio.status === "denied"
+              ? `${t`Try again`}: ${t`System audio`}`
+              : undefined
+          }
+          opensSettingsWhenDenied={!runtimeCapabilities}
         />
 
         {accessibility && (
@@ -209,5 +230,7 @@ export function PermissionsSection({
     return <MacOSPermissionsSection onContinue={onContinue} />;
   }
 
-  return <PermissionsSectionContent onContinue={onContinue} />;
+  return (
+    <PermissionsSectionContent onContinue={onContinue} runtimeCapabilities />
+  );
 }

--- a/apps/desktop/src/settings/general/app-settings.test.tsx
+++ b/apps/desktop/src/settings/general/app-settings.test.tsx
@@ -82,6 +82,10 @@ describe("AppSettingsView", () => {
     expect(
       screen.queryByText("Keep Anarlog available from the menu bar."),
     ).toBeNull();
+    expect(
+      screen.queryByText("Post recording disclosure in meeting chat"),
+    ).toBeNull();
+    expect(screen.queryByText("Capture meeting chat in Memos")).toBeNull();
     expect(screen.getByRole("switch", { name: "Show tray icon" })).toBeTruthy();
   });
 

--- a/apps/desktop/src/settings/general/app-settings.tsx
+++ b/apps/desktop/src/settings/general/app-settings.tsx
@@ -142,31 +142,35 @@ export function AppSettingsView({
             checked={autoStopMeetings.value}
             onChange={autoStopMeetings.onChange}
           />
-          <SettingRow
-            title={<Trans>Post recording disclosure in meeting chat</Trans>}
-            description={
-              <Trans>
-                Automatically post a disclosure after listening starts when the
-                active meeting chat supports safe posting. Posting failure does
-                not stop listening. A disclosure does not confirm participant
-                consent.
-              </Trans>
-            }
-            checked={meetingDisclosureAutoPost.value}
-            onChange={meetingDisclosureAutoPost.onChange}
-          />
-          <SettingRow
-            title={<Trans>Capture meeting chat in Memos</Trans>}
-            description={
-              <Trans>
-                While listening, use Accessibility access to copy visible chat
-                from supported meeting apps and browser meetings into the active
-                note.
-              </Trans>
-            }
-            checked={captureMeetingChat.value}
-            onChange={captureMeetingChat.onChange}
-          />
+          {isMacos && (
+            <>
+              <SettingRow
+                title={<Trans>Post recording disclosure in meeting chat</Trans>}
+                description={
+                  <Trans>
+                    Automatically post a disclosure after listening starts when
+                    the active meeting chat supports safe posting. Posting
+                    failure does not stop listening. A disclosure does not
+                    confirm participant consent.
+                  </Trans>
+                }
+                checked={meetingDisclosureAutoPost.value}
+                onChange={meetingDisclosureAutoPost.onChange}
+              />
+              <SettingRow
+                title={<Trans>Capture meeting chat in Memos</Trans>}
+                description={
+                  <Trans>
+                    While listening, use Accessibility access to copy visible
+                    chat from supported meeting apps and browser meetings into
+                    the active note.
+                  </Trans>
+                }
+                checked={captureMeetingChat.value}
+                onChange={captureMeetingChat.onChange}
+              />
+            </>
+          )}
           <SettingRow
             title={<Trans>Show floating bar</Trans>}
             description={

--- a/apps/desktop/src/settings/general/permissions.test.tsx
+++ b/apps/desktop/src/settings/general/permissions.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Permission, PermissionStatus } from "@hypr/plugin-permissions";
 
 const mocks = vi.hoisted(() => ({
+  currentPlatform: "macos",
   permissions: new Map<
     Permission,
     {
@@ -12,12 +13,21 @@ const mocks = vi.hoisted(() => ({
       open: ReturnType<typeof vi.fn>;
       request: ReturnType<typeof vi.fn>;
       reset: ReturnType<typeof vi.fn>;
+      error: string | null;
     }
   >(),
+  usePermission: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => mocks.currentPlatform,
 }));
 
 vi.mock("~/shared/hooks/usePermissions", () => ({
-  usePermission: (permission: Permission) => mocks.permissions.get(permission),
+  usePermission: (permission: Permission) => {
+    mocks.usePermission(permission);
+    return mocks.permissions.get(permission);
+  },
 }));
 
 import { Permissions } from "./permissions";
@@ -29,6 +39,7 @@ function permission(status: PermissionStatus) {
     open: vi.fn(),
     request: vi.fn(),
     reset: vi.fn(),
+    error: null as string | null,
   };
 }
 
@@ -48,7 +59,9 @@ function renderPermissions(accessibilityStatus: PermissionStatus) {
 describe("Permissions", () => {
   afterEach(() => {
     cleanup();
+    mocks.currentPlatform = "macos";
     mocks.permissions.clear();
+    mocks.usePermission.mockClear();
   });
 
   it("explains what Accessibility enables and opens Settings when denied", () => {
@@ -79,5 +92,36 @@ describe("Permissions", () => {
 
     expect(accessibility.request).toHaveBeenCalledOnce();
     expect(accessibility.open).not.toHaveBeenCalled();
+  });
+
+  it("shows retryable audio capability checks outside macOS", () => {
+    mocks.currentPlatform = "linux";
+    const microphone = permission("denied");
+    const systemAudio = permission("denied");
+    microphone.error = "microphone device unavailable";
+    systemAudio.error = "PipeWire source unavailable";
+    mocks.permissions.set("microphone", microphone);
+    mocks.permissions.set("systemAudio", systemAudio);
+
+    render(<Permissions />);
+
+    expect(screen.queryByText("Accessibility")).toBeNull();
+    expect(screen.queryByText("Calendar")).toBeNull();
+    expect(screen.getByText("microphone device unavailable")).toBeTruthy();
+    expect(screen.getByText("PipeWire source unavailable")).toBeTruthy();
+    expect(mocks.usePermission).not.toHaveBeenCalledWith("accessibility");
+    expect(mocks.usePermission).not.toHaveBeenCalledWith("calendar");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Try again: Microphone" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Try again: System audio" }),
+    );
+
+    expect(microphone.request).toHaveBeenCalledOnce();
+    expect(systemAudio.request).toHaveBeenCalledOnce();
+    expect(microphone.open).not.toHaveBeenCalled();
+    expect(systemAudio.open).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/settings/general/permissions.tsx
+++ b/apps/desktop/src/settings/general/permissions.tsx
@@ -1,4 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import { platform } from "@tauri-apps/plugin-os";
 import { AlertCircleIcon, ArrowRightIcon, CheckIcon } from "lucide-react";
 
 import type { PermissionStatus } from "@hypr/plugin-permissions";
@@ -12,21 +13,30 @@ function PermissionRow({
   description,
   status,
   isPending,
+  error,
   onRequest,
   onOpen,
+  runtimeCapability = false,
 }: {
   title: string;
   description: string;
   status: PermissionStatus | undefined;
   isPending: boolean;
+  error?: string | null;
   onRequest: () => void;
   onOpen: () => void;
+  runtimeCapability?: boolean;
 }) {
   const { t } = useLingui();
   const isAuthorized = status === "authorized";
   const isDenied = status === "denied";
 
   const handleButtonClick = () => {
+    if (runtimeCapability) {
+      if (!isAuthorized) onRequest();
+      return;
+    }
+
     if (isAuthorized || isDenied) {
       onOpen();
     } else {
@@ -47,21 +57,30 @@ function PermissionRow({
           <h3 className="text-sm font-medium">{title}</h3>
         </div>
         <p className="text-muted-foreground text-xs">{description}</p>
+        {error && (
+          <p role="alert" className="mt-1 text-xs text-red-500">
+            {error}
+          </p>
+        )}
       </div>
       <Button
         variant={isAuthorized ? "ghost" : "default"}
         size="icon"
         onClick={handleButtonClick}
-        disabled={isPending}
+        disabled={isPending || (runtimeCapability && isAuthorized)}
         className={cn([
           "size-8",
           isAuthorized &&
             "text-green-600 hover:bg-transparent hover:text-green-600",
         ])}
         aria-label={
-          isAuthorized || isDenied
-            ? t`Open ${title.toLowerCase()} settings`
-            : t`Request ${title.toLowerCase()} permission`
+          runtimeCapability
+            ? isDenied
+              ? `${t`Try again`}: ${title}`
+              : title
+            : isAuthorized || isDenied
+              ? t`Open ${title.toLowerCase()} settings`
+              : t`Request ${title.toLowerCase()} permission`
         }
       >
         {isAuthorized ? (
@@ -92,32 +111,60 @@ function PermissionGroup({
 }
 
 export function Permissions() {
+  if (platform() === "macos") {
+    return <MacOSPermissions />;
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <AudioPermissions runtimeCapabilities />
+    </div>
+  );
+}
+
+function AudioPermissions({
+  runtimeCapabilities = false,
+}: {
+  runtimeCapabilities?: boolean;
+}) {
   const { t } = useLingui();
-  const calendar = usePermission("calendar");
   const mic = usePermission("microphone");
   const systemAudio = usePermission("systemAudio");
+
+  return (
+    <PermissionGroup title={<Trans>Audio</Trans>}>
+      <PermissionRow
+        title={t`Microphone`}
+        description={t`Required to record your voice during meetings and calls`}
+        status={mic.status}
+        isPending={mic.isPending}
+        error={mic.error}
+        onRequest={mic.request}
+        onOpen={mic.open}
+        runtimeCapability={runtimeCapabilities}
+      />
+      <PermissionRow
+        title={t`System audio`}
+        description={t`Required to capture other participants' voices in meetings`}
+        status={systemAudio.status}
+        isPending={systemAudio.isPending}
+        error={systemAudio.error}
+        onRequest={systemAudio.request}
+        onOpen={systemAudio.open}
+        runtimeCapability={runtimeCapabilities}
+      />
+    </PermissionGroup>
+  );
+}
+
+function MacOSPermissions() {
+  const { t } = useLingui();
+  const calendar = usePermission("calendar");
   const accessibility = usePermission("accessibility");
 
   return (
     <div className="flex flex-col gap-8">
-      <PermissionGroup title={<Trans>Audio</Trans>}>
-        <PermissionRow
-          title={t`Microphone`}
-          description={t`Required to record your voice during meetings and calls`}
-          status={mic.status}
-          isPending={mic.isPending}
-          onRequest={mic.request}
-          onOpen={mic.open}
-        />
-        <PermissionRow
-          title={t`System audio`}
-          description={t`Required to capture other participants' voices in meetings`}
-          status={systemAudio.status}
-          isPending={systemAudio.isPending}
-          onRequest={systemAudio.request}
-          onOpen={systemAudio.open}
-        />
-      </PermissionGroup>
+      <AudioPermissions />
 
       <PermissionRow
         title={t`Accessibility`}

--- a/apps/desktop/src/shared/hooks/usePermissions.test.tsx
+++ b/apps/desktop/src/shared/hooks/usePermissions.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  checkPermission: vi.fn(),
+  openPermission: vi.fn(),
+  requestPermission: vi.fn(),
+  resetPermission: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-permissions", () => ({
+  commands: mocks,
+}));
+
+import { usePermission } from "./usePermissions";
+
+describe("usePermission", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    mocks.checkPermission.mockResolvedValue({
+      status: "ok",
+      data: "denied",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    queryClient.clear();
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it("keeps a failed runtime probe denied and exposes its diagnostic", async () => {
+    mocks.requestPermission.mockResolvedValue({
+      status: "error",
+      error: "PipeWire source unavailable",
+    });
+
+    const { result } = renderHook(() => usePermission("systemAudio"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("denied"));
+
+    act(() => result.current.request());
+
+    await waitFor(() =>
+      expect(result.current.error).toBe("PipeWire source unavailable"),
+    );
+    expect(result.current.status).toBe("denied");
+  });
+});

--- a/apps/desktop/src/shared/hooks/usePermissions.test.tsx
+++ b/apps/desktop/src/shared/hooks/usePermissions.test.tsx
@@ -61,4 +61,51 @@ describe("usePermission", () => {
     );
     expect(result.current.status).toBe("denied");
   });
+
+  it("lets a later failing probe override an optimistic grant", async () => {
+    mocks.requestPermission.mockResolvedValue({ status: "ok", data: null });
+
+    const { result } = renderHook(() => usePermission("systemAudio"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("denied"));
+
+    act(() => result.current.request());
+
+    await waitFor(() => expect(result.current.status).toBe("authorized"));
+
+    await waitFor(() => expect(result.current.status).toBe("denied"), {
+      timeout: 5000,
+    });
+  });
+
+  it("drops a stale request error once the probe recovers", async () => {
+    mocks.requestPermission.mockResolvedValue({
+      status: "error",
+      error: "PipeWire source unavailable",
+    });
+
+    const { result } = renderHook(() => usePermission("microphone"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("denied"));
+
+    act(() => result.current.request());
+
+    await waitFor(() =>
+      expect(result.current.error).toBe("PipeWire source unavailable"),
+    );
+
+    mocks.checkPermission.mockResolvedValue({
+      status: "ok",
+      data: "authorized",
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("authorized"), {
+      timeout: 5000,
+    });
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/apps/desktop/src/shared/hooks/usePermissions.ts
+++ b/apps/desktop/src/shared/hooks/usePermissions.ts
@@ -16,9 +16,16 @@ function unwrap<T>(result: Result<T, string>): T {
   return result.data;
 }
 
+// macOS keeps reporting the old value for a moment after a grant, so an optimistic
+// status bridges that gap. It must expire, otherwise one lucky probe would pin the
+// row to authorized and disable the retry button forever.
+const OPTIMISTIC_GRACE_MS = 1000;
+
 export function usePermission(type: Permission) {
-  const [optimisticStatus, setOptimisticStatus] =
-    useState<PermissionStatus | null>(null);
+  const [optimistic, setOptimistic] = useState<{
+    status: PermissionStatus;
+    since: number;
+  } | null>(null);
   const statusQuery = useQuery({
     queryKey: [`${type}Permission`],
     queryFn: () => permissionsCommands.checkPermission(type),
@@ -31,20 +38,27 @@ export function usePermission(type: Permission) {
         ? "denied"
         : undefined;
 
+  const optimisticStatus =
+    optimistic &&
+    statusQuery.dataUpdatedAt <= optimistic.since + OPTIMISTIC_GRACE_MS
+      ? optimistic.status
+      : null;
+  const effectiveStatus = optimisticStatus ?? status;
+
   const requestMutation = useMutation({
     mutationFn: async () =>
       unwrap(await permissionsCommands.requestPermission(type)),
     onSuccess: async () => {
       if (type === "systemAudio" || type === "screenRecording") {
-        setOptimisticStatus("authorized");
+        setOptimistic({ status: "authorized", since: Date.now() });
         setTimeout(() => void statusQuery.refetch(), 1000);
         return;
       }
-      setOptimisticStatus(null);
+      setOptimistic(null);
       setTimeout(() => statusQuery.refetch(), 1000);
     },
     onError: () => {
-      setOptimisticStatus(null);
+      setOptimistic(null);
     },
   });
 
@@ -52,7 +66,7 @@ export function usePermission(type: Permission) {
     mutationFn: async () =>
       unwrap(await permissionsCommands.resetPermission(type)),
     onSuccess: () => {
-      setOptimisticStatus(null);
+      setOptimistic(null);
       setTimeout(() => statusQuery.refetch(), 1000);
     },
   });
@@ -72,15 +86,19 @@ export function usePermission(type: Permission) {
   };
 
   return {
-    status: optimisticStatus ?? status,
+    status: effectiveStatus,
     isPending,
+    // A recovered capability must not keep rendering the diagnostics of an older
+    // failed request.
     error:
-      requestMutation.error?.message ??
-      (statusQuery.data?.status === "error"
-        ? statusQuery.data.error
-        : statusQuery.error instanceof Error
-          ? statusQuery.error.message
-          : null),
+      effectiveStatus === "authorized"
+        ? null
+        : (requestMutation.error?.message ??
+          (statusQuery.data?.status === "error"
+            ? statusQuery.data.error
+            : statusQuery.error instanceof Error
+              ? statusQuery.error.message
+              : null)),
     open,
     request,
     reset,

--- a/apps/desktop/src/shared/hooks/usePermissions.ts
+++ b/apps/desktop/src/shared/hooks/usePermissions.ts
@@ -5,48 +5,62 @@ import {
   type Permission,
   commands as permissionsCommands,
   type PermissionStatus,
+  type Result,
 } from "@hypr/plugin-permissions";
+
+function unwrap<T>(result: Result<T, string>): T {
+  if (result.status === "error") {
+    throw new Error(result.error);
+  }
+
+  return result.data;
+}
 
 export function usePermission(type: Permission) {
   const [optimisticStatus, setOptimisticStatus] =
     useState<PermissionStatus | null>(null);
-  const status = useQuery({
+  const statusQuery = useQuery({
     queryKey: [`${type}Permission`],
     queryFn: () => permissionsCommands.checkPermission(type),
     refetchInterval: 1000,
-    select: (result): PermissionStatus => {
-      if (result.status === "error") {
-        return "denied";
-      }
-      return result.data;
-    },
   });
+  const status: PermissionStatus | undefined =
+    statusQuery.data?.status === "ok"
+      ? statusQuery.data.data
+      : statusQuery.data
+        ? "denied"
+        : undefined;
 
   const requestMutation = useMutation({
-    mutationFn: () => permissionsCommands.requestPermission(type),
+    mutationFn: async () =>
+      unwrap(await permissionsCommands.requestPermission(type)),
     onSuccess: async () => {
       if (type === "systemAudio" || type === "screenRecording") {
         setOptimisticStatus("authorized");
-        setTimeout(() => void status.refetch(), 1000);
+        setTimeout(() => void statusQuery.refetch(), 1000);
         return;
       }
       setOptimisticStatus(null);
-      setTimeout(() => status.refetch(), 1000);
+      setTimeout(() => statusQuery.refetch(), 1000);
+    },
+    onError: () => {
+      setOptimisticStatus(null);
     },
   });
 
   const resetMutation = useMutation({
-    mutationFn: () => permissionsCommands.resetPermission(type),
+    mutationFn: async () =>
+      unwrap(await permissionsCommands.resetPermission(type)),
     onSuccess: () => {
       setOptimisticStatus(null);
-      setTimeout(() => status.refetch(), 1000);
+      setTimeout(() => statusQuery.refetch(), 1000);
     },
   });
 
   const isPending = requestMutation.isPending || resetMutation.isPending;
 
   const open = async () => {
-    await permissionsCommands.openPermission(type);
+    unwrap(await permissionsCommands.openPermission(type));
   };
 
   const request = () => {
@@ -58,8 +72,15 @@ export function usePermission(type: Permission) {
   };
 
   return {
-    status: optimisticStatus ?? status.data,
+    status: optimisticStatus ?? status,
     isPending,
+    error:
+      requestMutation.error?.message ??
+      (statusQuery.data?.status === "error"
+        ? statusQuery.data.error
+        : statusQuery.error instanceof Error
+          ? statusQuery.error.message
+          : null),
     open,
     request,
     reset,


### PR DESCRIPTION
Hide macOS-only permission and meeting-chat controls, retry runtime audio probes, and surface native diagnostics without falsely authorizing failures.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6281 
- <kbd>&nbsp;2&nbsp;</kbd> #6279 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6266 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how recording capability is requested and displayed on Linux/Windows and tightens permission state handling; macOS recording settings are narrowed but core auth paths are unchanged.
> 
> **Overview**
> **Non-macOS** onboarding and **Permissions** settings treat microphone and system audio as **runtime capability checks** instead of OS permission dialogs: denied states show **Try again** actions that call `request` (not **Open settings**), and probe failures surface as **alert text** (e.g. PipeWire / device errors) in the row body.
> 
> `usePermission` now returns an **`error`** string from failed checks/requests, clears it once status is **authorized**, and uses a **time-limited optimistic grant** so a brief macOS lag cannot permanently lock a row as authorized.
> 
> **macOS-only** controls in app settings (**post recording disclosure**, **capture meeting chat in Memos**) render only when `platform() === "macos"`; non-macOS app-settings tests assert those strings are absent. Lingui catalogs gain extra **Try again** source references for the permission UIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76c123996a1dce7cbd8c07d14436262b504fbef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->