### PR TITLE
Ship Linux release artifacts in CI

### DIFF
--- a/.github/reports/release-gates/linux.md
+++ b/.github/reports/release-gates/linux.md
@@ -65,8 +65,10 @@ different artifact hash.
 The x86_64 and ARM64 physical cells may be completed by trusted community testers, but
 both must exist before **HARDWARE-VALIDATED BETA SHIP**. A VM result must remain labeled
 as VM evidence.
-Building release artifacts on Debian 12 or Ubuntu 22.04 for an older glibc baseline is a
-CI policy; it is not a substitute for the Ubuntu 24.04 runtime cells above.
+Release artifacts are built on Ubuntu 24.04 runners. An older glibc build baseline such as
+Debian 12 or Ubuntu 22.04 is currently not available: the pipewire 0.9.2 crate needs
+PipeWire 0.3.65 or newer headers, and Ubuntu 22.04 ships 0.3.48. A green build is not a
+substitute for the Ubuntu 24.04 runtime cells above.
 
 ### Development setup
 
@@ -82,7 +84,7 @@ pnpm -F ui build
 pnpm -F @hypr/desktop tauri:dev
 ~~~
 
-Release packages still use the older Debian 12 or Ubuntu 22.04 build baseline. Run the
+Release packages are built on Ubuntu 24.04, so glibc 2.39 is the effective floor. Run the
 beta itself on the Ubuntu 24.04 environments listed above.
 
 ### Package matrix

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -305,7 +305,10 @@ jobs:
           bundles=("$appimage_dir"/* "$deb_dir"/*)
           for bundle in "${bundles[@]}"; do
             [[ -f "$bundle" && "$bundle" != *.sha256 ]] || continue
-            sha256sum "$bundle" > "$bundle.sha256"
+            # Record the basename, like the CI job does, so `sha256sum -c` works
+            # against the uploaded artifact instead of a CI-only path.
+            name=$(basename "$bundle")
+            (cd "$(dirname "$bundle")" && sha256sum "$name" > "$name.sha256")
           done
       - run: |
           deb=$(find "apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb" -maxdepth 1 -name '*.deb' -type f -print -quit)

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -210,14 +210,14 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-24.04-8
             target: x86_64-unknown-linux-gnu
             rust_platform: linux-x86_64
             artifact_name: x64
             debian_arch: amd64
             file_arch: x86-64
             docker_arch: amd64
-          - runner: depot-ubuntu-22.04-arm-8
+          - runner: depot-ubuntu-24.04-arm-8
             target: aarch64-unknown-linux-gnu
             rust_platform: linux-aarch64
             artifact_name: arm64
@@ -318,7 +318,7 @@ jobs:
             --volume "$PWD:/workspace:ro" \
             --env DEB_PATH="/workspace/$deb" \
             --env BINARY_PATH="/usr/bin/$binary_name" \
-            ubuntu:22.04 \
+            ubuntu:24.04 \
             bash -euxo pipefail -c '
               export DEBIAN_FRONTEND=noninteractive
               apt-get update

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -203,9 +203,179 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
 
+  build-linux:
+    needs: [compute-version, cn-draft]
+    if: ${{ !cancelled() && (needs.cn-draft.result == 'success' || needs.cn-draft.result == 'skipped') }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - runner: depot-ubuntu-22.04-8
+            target: x86_64-unknown-linux-gnu
+            rust_platform: linux-x86_64
+            artifact_name: x64
+            debian_arch: amd64
+            file_arch: x86-64
+            docker_arch: amd64
+          - runner: depot-ubuntu-22.04-arm-8
+            target: aarch64-unknown-linux-gnu
+            rust_platform: linux-aarch64
+            artifact_name: arm64
+            debian_arch: arm64
+            file_arch: ARM aarch64
+            docker_arch: arm64
+    runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: recursive
+      - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.compute-version.outputs.version }}"
+      - uses: ./.github/actions/install_desktop_deps
+        with:
+          target: linux
+      - uses: ./.github/actions/rust_install
+        with:
+          platform: ${{ matrix.rust_platform }}
+      - uses: ./.github/actions/pnpm_install
+      - run: pnpm -F ui build
+      - run: |
+          TAURI_ENV_TARGET_TRIPLE=${{ matrix.target }} cargo xtask prepare-binaries
+          ./scripts/sidecar.sh "./apps/desktop/${{ env.TAURI_CONF_PATH }}" "binaries/char-chrome-native-host"
+          ./scripts/sidecar.sh "./apps/desktop/${{ env.TAURI_CONF_PATH }}" "resources/cli/anarlog-cli"
+      - run: |
+          BUILD_ARGS=(
+            --ci
+            --bundles appimage,deb
+            --target "${{ matrix.target }}"
+            --config "${{ env.TAURI_CONF_PATH }}"
+            --verbose
+          )
+          if [[ "${{ inputs.channel }}" == "staging" ]]; then
+            BUILD_ARGS+=(--features devtools)
+          fi
+          pnpm -F desktop tauri build "${BUILD_ARGS[@]}"
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          VITE_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_HYPRNOTE_2 }}
+          APP_VERSION: ${{ needs.compute-version.outputs.version }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_APP_URL: https://anarlog.so
+          VITE_API_URL: https://api.anarlog.so
+          VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
+          VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
+      - run: |
+          shopt -s nullglob
+          appimage_dir="apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage"
+          deb_dir="apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb"
+          appimages=("$appimage_dir"/*.AppImage)
+          debs=("$deb_dir"/*.deb)
+          appimage_signatures=("$appimage_dir"/*.AppImage.sig)
+          deb_signatures=("$deb_dir"/*.deb.sig)
+
+          if [[ ${#appimages[@]} -ne 1 || ${#debs[@]} -ne 1 ]]; then
+            echo "Expected one AppImage and one .deb for ${{ matrix.target }}"
+            exit 1
+          fi
+          if [[ ${#appimage_signatures[@]} -ne 1 || ${#deb_signatures[@]} -ne 1 ]]; then
+            echo "Expected AppImage and .deb updater signatures for ${{ matrix.target }}"
+            exit 1
+          fi
+
+          package_arch=$(dpkg-deb --field "${debs[0]}" Architecture)
+          if [[ "$package_arch" != "${{ matrix.debian_arch }}" ]]; then
+            echo "Expected Debian architecture ${{ matrix.debian_arch }}, got $package_arch"
+            exit 1
+          fi
+          if ! file "${appimages[0]}" | grep -Fq "${{ matrix.file_arch }}"; then
+            file "${appimages[0]}"
+            echo "AppImage architecture does not match ${{ matrix.target }}"
+            exit 1
+          fi
+
+          bundles=("$appimage_dir"/* "$deb_dir"/*)
+          for bundle in "${bundles[@]}"; do
+            [[ -f "$bundle" && "$bundle" != *.sha256 ]] || continue
+            sha256sum "$bundle" > "$bundle.sha256"
+          done
+      - run: |
+          deb=$(find "apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb" -maxdepth 1 -name '*.deb' -type f -print -quit)
+          binary_name="${{ inputs.channel == 'staging' && 'anarlog-staging' || 'anarlog' }}"
+          docker run --rm \
+            --platform linux/${{ matrix.docker_arch }} \
+            --volume "$PWD:/workspace:ro" \
+            --env DEB_PATH="/workspace/$deb" \
+            --env BINARY_PATH="/usr/bin/$binary_name" \
+            ubuntu:22.04 \
+            bash -euxo pipefail -c '
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update
+              apt-get install -y "$DEB_PATH"
+              apt-get install -y dbus-x11 xvfb
+              set +e
+              timeout --signal=TERM 20s xvfb-run -a dbus-run-session -- "$BINARY_PATH" >/tmp/anarlog.log 2>&1
+              status=$?
+              set -e
+              cat /tmp/anarlog.log
+              if [[ $status -ne 124 ]]; then
+                echo "Anarlog exited before the smoke timeout with status $status"
+                exit 1
+              fi
+            '
+      - run: |
+          mkdir -p target/release
+          find target/${{ matrix.target }}/release/bundle/appimage target/${{ matrix.target }}/release/bundle/deb \
+            -maxdepth 1 -type f -exec cp {} target/release/ \;
+        working-directory: ./apps/desktop/src-tauri
+      - uses: actions/upload-artifact@v4
+        with:
+          name: anarlog-${{ inputs.channel }}-linux-${{ matrix.artifact_name }}
+          path: |
+            apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*
+            apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb/*
+          if-no-files-found: error
+          retention-days: 7
+      - if: ${{ inputs.channel != 'staging' }}
+        uses: ./.github/actions/cn_release
+        with:
+          cmd: upload
+          app: ${{ env.CN_APPLICATION }}
+          key: ${{ secrets.CN_API_KEY }}
+          channel: ${{ env.RELEASE_CHANNEL }}
+          framework: tauri
+          working-directory: ./apps/desktop
+      - if: ${{ inputs.channel == 'staging' }}
+        run: |
+          timestamp=$(date -u +"%Y%m%d%H%M%S")
+          commit_hash=$(git rev-parse --short HEAD)
+          prefix="anarlog-staging-${timestamp}-${commit_hash}-linux-${{ matrix.artifact_name }}"
+          upload_dir=$(mktemp -d)
+          for bundle_dir in appimage deb; do
+            for file in apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/$bundle_dir/*; do
+              cp "$file" "$upload_dir/${prefix}-$(basename "$file")"
+            done
+          done
+          aws s3 cp "$upload_dir/" \
+            s3://hyprnote-build/desktop/staging/ \
+            --recursive \
+            --endpoint-url ${{ secrets.CLOUDFLARE_R2_ENDPOINT_URL }} \
+            --region auto
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+
   create-tag:
-    if: ${{ inputs.channel != 'staging' && !cancelled() && needs.build-macos.result == 'success' }}
-    needs: [compute-version, build-macos]
+    if: ${{ inputs.channel != 'staging' && !cancelled() && needs.build-macos.result == 'success' && needs.build-linux.result == 'success' }}
+    needs: [compute-version, build-macos, build-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -231,7 +401,7 @@ jobs:
 
   cn-publish:
     if: ${{ inputs.channel != 'staging' && inputs.publish }}
-    needs: [compute-version, build-macos, create-tag]
+    needs: [compute-version, build-macos, build-linux, create-tag]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -246,8 +416,8 @@ jobs:
           working-directory: ./apps/desktop
 
   release:
-    if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.cn-publish.result == 'success' && needs.build-macos.result == 'success' }}
-    needs: [compute-version, build-macos, cn-publish]
+    if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.cn-publish.result == 'success' && needs.build-macos.result == 'success' && needs.build-linux.result == 'success' }}
+    needs: [compute-version, build-macos, build-linux, cn-publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -275,17 +445,65 @@ jobs:
           platform: dmg-x86_64
           output: hyprnote-macos-x86_64.dmg
           key: ${{ secrets.CN_API_KEY }}
+      - if: ${{ needs.build-linux.result == 'success' }}
+        uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.compute-version.outputs.version }}
+          channel: ${{ env.RELEASE_CHANNEL }}
+          platform: appimage-x86_64
+          output: anarlog-linux-x86_64.AppImage
+          key: ${{ secrets.CN_API_KEY }}
+      - if: ${{ needs.build-linux.result == 'success' }}
+        uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.compute-version.outputs.version }}
+          channel: ${{ env.RELEASE_CHANNEL }}
+          platform: debian-x86_64
+          output: anarlog-linux-x86_64.deb
+          key: ${{ secrets.CN_API_KEY }}
+      - if: ${{ needs.build-linux.result == 'success' }}
+        uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.compute-version.outputs.version }}
+          channel: ${{ env.RELEASE_CHANNEL }}
+          platform: appimage-aarch64
+          output: anarlog-linux-aarch64.AppImage
+          key: ${{ secrets.CN_API_KEY }}
+      - if: ${{ needs.build-linux.result == 'success' }}
+        uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.compute-version.outputs.version }}
+          channel: ${{ env.RELEASE_CHANNEL }}
+          platform: debian-aarch64
+          output: anarlog-linux-aarch64.deb
+          key: ${{ secrets.CN_API_KEY }}
       - id: checksums
         uses: ./.github/actions/generate_checksums
         with:
           files: |
             ${{ needs.build-macos.result == 'success' && 'hyprnote-macos-aarch64.dmg' || '' }}
             ${{ needs.build-macos.result == 'success' && 'hyprnote-macos-x86_64.dmg' || '' }}
+            ${{ needs.build-linux.result == 'success' && 'anarlog-linux-x86_64.AppImage' || '' }}
+            ${{ needs.build-linux.result == 'success' && 'anarlog-linux-x86_64.deb' || '' }}
+            ${{ needs.build-linux.result == 'success' && 'anarlog-linux-aarch64.AppImage' || '' }}
+            ${{ needs.build-linux.result == 'success' && 'anarlog-linux-aarch64.deb' || '' }}
       - id: artifacts
         run: |
           ARTIFACTS=""
           if [[ "${{ needs.build-macos.result }}" == "success" ]]; then
             ARTIFACTS="hyprnote-macos-aarch64.dmg,hyprnote-macos-x86_64.dmg"
+          fi
+          if [[ "${{ needs.build-linux.result }}" == "success" ]]; then
+            LINUX_ARTIFACTS="anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb"
+            if [[ -n "$ARTIFACTS" ]]; then
+              ARTIFACTS="$ARTIFACTS,$LINUX_ARTIFACTS"
+            else
+              ARTIFACTS="$LINUX_ARTIFACTS"
+            fi
           fi
           if [[ -z "$ARTIFACTS" ]]; then
             echo "No artifacts to release" >&2

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -211,7 +211,25 @@ jobs:
 
   linux_ci:
     if: ${{ !startsWith(github.head_ref || '', 'blog/') }}
-    runs-on: depot-ubuntu-24.04-8
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: depot-ubuntu-22.04-8
+            target: x86_64-unknown-linux-gnu
+            rust_platform: linux-x86_64
+            artifact_name: x64
+            debian_arch: amd64
+            file_arch: x86-64
+            docker_arch: amd64
+          - runner: depot-ubuntu-22.04-arm-8
+            target: aarch64-unknown-linux-gnu
+            rust_platform: linux-aarch64
+            artifact_name: arm64
+            debian_arch: arm64
+            file_arch: ARM aarch64
+            docker_arch: arm64
+    runs-on: ${{ matrix.runner }}
     defaults:
       run:
         shell: bash
@@ -225,22 +243,22 @@ jobs:
           target: linux
       - uses: ./.github/actions/rust_install
         with:
-          platform: linux
-      - run: cargo check --locked -p desktop
-      - run: cargo test --locked -p desktop embedded_cli --lib
-      - run: cargo test --locked -p cloudsync loads_bundled_cloudsync
+          platform: ${{ matrix.rust_platform }}
+      - run: cargo check --locked --target ${{ matrix.target }} -p desktop
+      - run: cargo test --locked --target ${{ matrix.target }} -p desktop embedded_cli --lib
+      - run: cargo test --locked --target ${{ matrix.target }} -p cloudsync loads_bundled_cloudsync
       - if: github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/pnpm_install
       - if: github.event_name == 'workflow_dispatch'
         run: |
-          TAURI_ENV_TARGET_TRIPLE=x86_64-unknown-linux-gnu cargo xtask prepare-binaries
+          TAURI_ENV_TARGET_TRIPLE=${{ matrix.target }} cargo xtask prepare-binaries
           ./scripts/sidecar.sh \
             ./apps/desktop/src-tauri/tauri.conf.staging.json \
             resources/cli/anarlog-cli
       - if: github.event_name == 'workflow_dispatch'
         run: pnpm -F ui build
       - if: github.event_name == 'workflow_dispatch'
-        run: pnpm -F desktop tauri build --ci --bundles appimage,deb --no-sign --target x86_64-unknown-linux-gnu --config ./src-tauri/tauri.conf.staging.json --features devtools --verbose
+        run: pnpm -F desktop tauri build --ci --bundles appimage,deb --target ${{ matrix.target }} --config ./src-tauri/tauri.conf.staging.json --features devtools --verbose
         env:
           POSTHOG_API_KEY: phc_linux_ci
           VITE_POSTHOG_API_KEY: phc_linux_ci
@@ -250,18 +268,41 @@ jobs:
           VITE_APP_URL: https://anarlog.so
           VITE_API_URL: https://api.anarlog.so
           VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
       - if: github.event_name == 'workflow_dispatch'
         run: |
           shopt -s nullglob
-          bundles=(
-            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
-            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
-          )
-          if [[ ${#bundles[@]} -eq 0 ]]; then
-            echo "No Linux bundles found"
+          appimage_dir="apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage"
+          deb_dir="apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb"
+          appimages=("$appimage_dir"/*.AppImage)
+          debs=("$deb_dir"/*.deb)
+          appimage_signatures=("$appimage_dir"/*.AppImage.sig)
+          deb_signatures=("$deb_dir"/*.deb.sig)
+
+          if [[ ${#appimages[@]} -ne 1 || ${#debs[@]} -ne 1 ]]; then
+            echo "Expected one AppImage and one .deb for ${{ matrix.target }}"
             exit 1
           fi
+          if [[ ${#appimage_signatures[@]} -ne 1 || ${#deb_signatures[@]} -ne 1 ]]; then
+            echo "Expected AppImage and .deb updater signatures for ${{ matrix.target }}"
+            exit 1
+          fi
+
+          package_arch=$(dpkg-deb --field "${debs[0]}" Architecture)
+          if [[ "$package_arch" != "${{ matrix.debian_arch }}" ]]; then
+            echo "Expected Debian architecture ${{ matrix.debian_arch }}, got $package_arch"
+            exit 1
+          fi
+          if ! file "${appimages[0]}" | grep -Fq "${{ matrix.file_arch }}"; then
+            file "${appimages[0]}"
+            echo "AppImage architecture does not match ${{ matrix.target }}"
+            exit 1
+          fi
+
+          bundles=("$appimage_dir"/* "$deb_dir"/*)
           for bundle in "${bundles[@]}"; do
+            [[ -f "$bundle" && "$bundle" != *.sha256 ]] || continue
             # Record the basename, like the Windows job does, so `sha256sum -c`
             # works next to the downloaded artifact rather than only inside the
             # CI directory layout.
@@ -269,14 +310,36 @@ jobs:
             (cd "$(dirname "$bundle")" && sha256sum "$name" > "$name.sha256")
           done
       - if: github.event_name == 'workflow_dispatch'
+        run: |
+          deb=$(find "apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb" -maxdepth 1 -name '*.deb' -type f -print -quit)
+          docker run --rm \
+            --platform linux/${{ matrix.docker_arch }} \
+            --volume "$PWD:/workspace:ro" \
+            --env DEB_PATH="/workspace/$deb" \
+            --env BINARY_PATH=/usr/bin/anarlog-staging \
+            ubuntu:22.04 \
+            bash -euxo pipefail -c '
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update
+              apt-get install -y "$DEB_PATH"
+              apt-get install -y dbus-x11 xvfb
+              set +e
+              timeout --signal=TERM 20s xvfb-run -a dbus-run-session -- "$BINARY_PATH" >/tmp/anarlog.log 2>&1
+              status=$?
+              set -e
+              cat /tmp/anarlog.log
+              if [[ $status -ne 124 ]]; then
+                echo "Anarlog exited before the smoke timeout with status $status"
+                exit 1
+              fi
+            '
+      - if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: anarlog-linux-x64-${{ github.sha }}
+          name: anarlog-linux-${{ matrix.artifact_name }}-${{ github.sha }}
           path: |
-            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
-            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.sha256
-            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
-            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.sha256
+            apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*
+            apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb/*
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -215,14 +215,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-24.04-8
             target: x86_64-unknown-linux-gnu
             rust_platform: linux-x86_64
             artifact_name: x64
             debian_arch: amd64
             file_arch: x86-64
             docker_arch: amd64
-          - runner: depot-ubuntu-22.04-arm-8
+          - runner: depot-ubuntu-24.04-arm-8
             target: aarch64-unknown-linux-gnu
             rust_platform: linux-aarch64
             artifact_name: arm64
@@ -317,7 +317,7 @@ jobs:
             --volume "$PWD:/workspace:ro" \
             --env DEB_PATH="/workspace/$deb" \
             --env BINARY_PATH=/usr/bin/anarlog-staging \
-            ubuntu:22.04 \
+            ubuntu:24.04 \
             bash -euxo pipefail -c '
               export DEBIAN_FRONTEND=noninteractive
               apt-get update

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -48,6 +48,10 @@ jobs:
           EXPECTED_PLATFORMS=(
             "dmg-aarch64"
             "dmg-x86_64"
+            "appimage-x86_64"
+            "debian-x86_64"
+            "appimage-aarch64"
+            "debian-aarch64"
           )
 
           MISSING_PLATFORMS=()
@@ -103,12 +107,52 @@ jobs:
           platform: dmg-x86_64
           output: char-macos-x86_64.dmg
           key: ${{ secrets.CN_API_KEY }}
+      - id: download-linux-x86_64-appimage
+        uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.parse.outputs.version }}
+          channel: ${{ needs.parse.outputs.channel }}
+          platform: appimage-x86_64
+          output: anarlog-linux-x86_64.AppImage
+          key: ${{ secrets.CN_API_KEY }}
+      - id: download-linux-x86_64-deb
+        uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.parse.outputs.version }}
+          channel: ${{ needs.parse.outputs.channel }}
+          platform: debian-x86_64
+          output: anarlog-linux-x86_64.deb
+          key: ${{ secrets.CN_API_KEY }}
+      - id: download-linux-aarch64-appimage
+        uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.parse.outputs.version }}
+          channel: ${{ needs.parse.outputs.channel }}
+          platform: appimage-aarch64
+          output: anarlog-linux-aarch64.AppImage
+          key: ${{ secrets.CN_API_KEY }}
+      - id: download-linux-aarch64-deb
+        uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.parse.outputs.version }}
+          channel: ${{ needs.parse.outputs.channel }}
+          platform: debian-aarch64
+          output: anarlog-linux-aarch64.deb
+          key: ${{ secrets.CN_API_KEY }}
       - id: checksums
         uses: ./.github/actions/generate_checksums
         with:
           files: |
             char-macos-aarch64.dmg
             char-macos-x86_64.dmg
+            anarlog-linux-x86_64.AppImage
+            anarlog-linux-x86_64.deb
+            anarlog-linux-aarch64.AppImage
+            anarlog-linux-aarch64.deb
       - id: release-body
         run: |
           echo "value=https://anarlog.so/changelog/${{ needs.parse.outputs.version }}" >> "$GITHUB_OUTPUT"
@@ -118,7 +162,7 @@ jobs:
           name: desktop_v${{ needs.parse.outputs.version }}
           body: ${{ steps.release-body.outputs.value }}
           prerelease: false
-          artifacts: char-macos-aarch64.dmg,char-macos-x86_64.dmg,${{ steps.checksums.outputs.checksum_files }}
+          artifacts: char-macos-aarch64.dmg,char-macos-x86_64.dmg,anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb,${{ steps.checksums.outputs.checksum_files }}
           allowUpdates: true
           makeLatest: true
           replacesArtifacts: true

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -31,6 +31,8 @@
     "linux": {
       "deb": {
         "depends": [
+          "libwebkit2gtk-4.1-0",
+          "libgtk-3-0",
           "libpipewire-0.3-0",
           "libpulse0",
           "libasound2",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -28,6 +28,21 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
+    "linux": {
+      "deb": {
+        "depends": [
+          "libpipewire-0.3-0",
+          "libpulse0",
+          "libasound2",
+          "libssl3",
+          "libstdc++6",
+          "ca-certificates",
+          "desktop-file-utils",
+          "xdg-utils",
+          "libayatana-appindicator3-1"
+        ]
+      }
+    },
     "externalBin": [],
     "icon": [
       "icons/stable/32x32.png",


### PR DESCRIPTION
Build and smoke-test signed x86_64 and ARM64 Linux packages with explicit runtime dependencies.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #6311
- <kbd>&nbsp;6&nbsp;</kbd> #6309
- <kbd>&nbsp;5&nbsp;</kbd> #6306
- <kbd>&nbsp;4&nbsp;</kbd> #6296
- <kbd>&nbsp;3&nbsp;</kbd> #6301
- <kbd>&nbsp;2&nbsp;</kbd> #6294
- <kbd>&nbsp;1&nbsp;</kbd> #6280 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release gating and signing for a new platform matrix; failures block tags/releases, but changes are mostly CI and packaging metadata rather than app runtime logic.
> 
> **Overview**
> Adds **end-to-end Linux packaging** for **x86_64 and ARM64**: CD gets a `build-linux` matrix on Ubuntu 24.04 runners that produces signed **AppImage** and **.deb** bundles, checks architecture and updater signatures, runs an **Ubuntu 24.04 Docker install/launch smoke** (xvfb), uploads to CrabNebula (and R2 for staging), and gates **tag/create, publish, and GitHub release** on Linux succeeding alongside macOS.
> 
> **Desktop CI** mirrors the same arch matrix for `workflow_dispatch`: cross-target `cargo check`/tests, signed Tauri bundles, bundle validation, and the Docker smoke test. **Publish** workflows now expect and attach all four Linux CrabNebula platforms to GitHub releases.
> 
> **`tauri.conf.json`** declares explicit **`.deb` runtime dependencies** (GTK, WebKit, PipeWire, Pulse, etc.). The **Linux release-gate doc** now states releases build on **Ubuntu 24.04** (glibc 2.39) because older distros lack PipeWire headers required by the `pipewire` crate—not as a substitute for manual Ubuntu 24.04 QA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f41be1097e71a2d2622c098eea2d1af5d18e9fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->