### PR TITLE
Gate unsupported floating overlays outside macOS

### DIFF
--- a/apps/desktop/src/meeting-float/host.component.test.tsx
+++ b/apps/desktop/src/meeting-float/host.component.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  platform: vi.fn(() => "macos"),
   settings: {
     current: {
       floating_bar_opacity: 0.78,
@@ -34,6 +35,10 @@ const mocks = vi.hoisted(() => ({
     stop: vi.fn(),
   },
   subscribeListener: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: mocks.platform,
 }));
 
 vi.mock("@hypr/plugin-windows", () => ({
@@ -83,6 +88,7 @@ import { FloatingMeetingWindowHost } from "./host";
 describe("FloatingMeetingWindowHost", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.platform.mockReturnValue("macos");
     mocks.settings.current = {
       floating_bar_opacity: 0.78,
       live_caption_opacity: 0.3,
@@ -120,5 +126,19 @@ describe("FloatingMeetingWindowHost", () => {
     });
     expect(mocks.floatingBarShow).toHaveBeenCalledOnce();
     expect(mocks.floatingBarHide).not.toHaveBeenCalled();
+  });
+
+  it("keeps unsupported floating overlays disabled outside macOS", async () => {
+    mocks.platform.mockReturnValue("linux");
+
+    render(<FloatingMeetingWindowHost />);
+
+    await waitFor(() => {
+      expect(mocks.floatingBarHide).toHaveBeenCalledOnce();
+      expect(mocks.liveCaptionHide).toHaveBeenCalledOnce();
+    });
+    expect(mocks.floatingBarShow).not.toHaveBeenCalled();
+    expect(mocks.floatingBarUpdate).not.toHaveBeenCalled();
+    expect(mocks.listen).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -1,3 +1,4 @@
+import { platform } from "@tauri-apps/plugin-os";
 import { useRef } from "react";
 
 import {
@@ -131,12 +132,17 @@ export function FloatingMeetingWindowHost() {
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
   const storedSettings = useConfigValues(FLOATING_OVERLAY_SETTING_KEYS);
   const overlaySettings = getFloatingOverlaySettings(storedSettings);
+  const floatingOverlaySupported = platform() === "macos";
 
   return (
     <>
-      <FloatingOverlaySettingsEventSync />
-      <LiveCaptionDefaultVisibilitySync />
-      {floatingBarEnabled ? (
+      {floatingOverlaySupported && (
+        <>
+          <FloatingOverlaySettingsEventSync />
+          <LiveCaptionDefaultVisibilitySync />
+        </>
+      )}
+      {floatingOverlaySupported && floatingBarEnabled ? (
         <FloatingMeetingWindowSync settings={overlaySettings} />
       ) : (
         <FloatingMeetingWindowDisabled />

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -23,6 +23,7 @@ const {
   useHasTranscriptMock,
   useListenerMock,
   useConfigValueMock,
+  platformMock,
   windowShowMock,
 } = vi.hoisted(() => ({
   uploadAudioMock: vi.fn(),
@@ -37,7 +38,12 @@ const {
   useHasTranscriptMock: vi.fn(),
   useListenerMock: vi.fn(),
   useConfigValueMock: vi.fn(),
+  platformMock: vi.fn(() => "macos"),
   windowShowMock: vi.fn(() => Promise.resolve({ status: "ok", data: null })),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: platformMock,
 }));
 
 vi.mock("@hypr/ui/components/ui/button", () => ({
@@ -146,6 +152,7 @@ describe("OverflowButton", () => {
     currentNoteContent.value = "";
     useHasTranscriptMock.mockReturnValue(true);
     useConfigValueMock.mockReturnValue(false);
+    platformMock.mockReturnValue("macos");
     useListenerMock.mockImplementation((selector) =>
       selector({
         getSessionMode: () => "inactive",
@@ -419,6 +426,27 @@ describe("OverflowButton", () => {
         enabled: true,
       }),
     );
+  });
+
+  it("hides the unsupported floating panel action outside macOS", () => {
+    platformMock.mockReturnValue("linux");
+    useConfigValueMock.mockReturnValue(true);
+    useListenerMock.mockImplementation((selector) =>
+      selector({
+        getSessionMode: () => "active",
+      }),
+    );
+
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Open floating panel" }),
+    ).toBeNull();
   });
 
   it("opens the current note in a standalone window", () => {

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/react/macro";
+import { platform } from "@tauri-apps/plugin-os";
 import {
   AudioLinesIcon,
   FileDownIcon,
@@ -62,6 +63,7 @@ export function OverflowButton({
   const regenerateTranscript = useRegenerateTranscript(sessionId);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
+  const floatingBarSupported = platform() === "macos";
   const isMeetingInProgress =
     sessionMode === "active" || sessionMode === "finalizing";
   const showListeningAction = allowListening;
@@ -74,7 +76,10 @@ export function OverflowButton({
     !currentNoteHasContent &&
     !isMeetingInProgress;
   const canOpenFloatingPanel =
-    allowListening && floatingBarEnabled && sessionMode === "active";
+    floatingBarSupported &&
+    allowListening &&
+    floatingBarEnabled &&
+    sessionMode === "active";
   const hasMeetingActions =
     showListeningAction ||
     showRetranscribeAction ||

--- a/apps/desktop/src/settings/general/app-settings.test.tsx
+++ b/apps/desktop/src/settings/general/app-settings.test.tsx
@@ -66,7 +66,7 @@ describe("AppSettingsView", () => {
     expect(screen.queryByText("Show live transcript overlay")).toBeNull();
   });
 
-  it("keeps the floating bar setting available", () => {
+  it("keeps the floating bar setting available on macOS", () => {
     renderAppSettings({ floatingBar: false });
 
     expect(screen.getByText("Show floating bar")).toBeTruthy();
@@ -86,6 +86,7 @@ describe("AppSettingsView", () => {
       screen.queryByText("Post recording disclosure in meeting chat"),
     ).toBeNull();
     expect(screen.queryByText("Capture meeting chat in Memos")).toBeNull();
+    expect(screen.queryByText("Show floating bar")).toBeNull();
     expect(screen.getByRole("switch", { name: "Show tray icon" })).toBeTruthy();
   });
 

--- a/apps/desktop/src/settings/general/app-settings.tsx
+++ b/apps/desktop/src/settings/general/app-settings.tsx
@@ -171,14 +171,18 @@ export function AppSettingsView({
               />
             </>
           )}
-          <SettingRow
-            title={<Trans>Show floating bar</Trans>}
-            description={
-              <Trans>Show the compact floating control while listening.</Trans>
-            }
-            checked={floatingBar.value}
-            onChange={floatingBar.onChange}
-          />
+          {isMacos && (
+            <SettingRow
+              title={<Trans>Show floating bar</Trans>}
+              description={
+                <Trans>
+                  Show the compact floating control while listening.
+                </Trans>
+              }
+              checked={floatingBar.value}
+              onChange={floatingBar.onChange}
+            />
+          )}
           <AudioRetentionRow
             value={audioRetention.value}
             onChange={audioRetention.onChange}


### PR DESCRIPTION
Hide Linux and Windows floating-overlay controls and keep the no-op native backend disabled while preserving the macOS experience.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6281 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6279 
- <kbd>&nbsp;1&nbsp;</kbd> #6266 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Platform-conditional UI and no-op overlay path; no auth or data changes, with test coverage for non-macOS behavior.
> 
> **Overview**
> **Floating meeting overlays** are now treated as **macOS-only** end to end: Linux and Windows no longer show controls or run overlay sync logic.
> 
> In **`FloatingMeetingWindowHost`**, overlay support is gated with `platform() === "macos"`. Off macOS, settings/event sync and live-caption default visibility are not mounted, and the disabled path runs so native **hide** is invoked without **show**, **update**, or event listeners.
> 
> The session overflow menu only offers **Open floating panel** when the platform is macOS (in addition to existing listening/config/session checks). General settings only render **Show floating bar** on macOS, alongside other macOS-only meeting options.
> 
> Tests mock `@tauri-apps/plugin-os` and cover non-macOS behavior for the host, overflow action, and settings visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e5be7256f098bd5225d05c4eeaa6e30d81b5b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->