### PR TITLE
Secure Linux auth sessions with Secret Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18173,6 +18173,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-settings",
+ "tauri-plugin-store2",
  "tauri-specta",
  "tempfile",
  "template-support",

--- a/crates/supabase-auth/src/client/store.rs
+++ b/crates/supabase-auth/src/client/store.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 /// In-memory state is the source of truth, not the file.
 /// This lets the session survive disk write failures.
 pub struct AuthStore {
-    path: PathBuf,
+    path: Option<PathBuf>,
     data: Mutex<HashMap<String, String>>,
 }
 
@@ -16,7 +16,14 @@ impl AuthStore {
 
     pub fn from_data(path: PathBuf, data: HashMap<String, String>) -> Self {
         Self {
-            path,
+            path: Some(path),
+            data: Mutex::new(data),
+        }
+    }
+
+    pub fn in_memory(data: HashMap<String, String>) -> Self {
+        Self {
+            path: None,
             data: Mutex::new(data),
         }
     }
@@ -36,18 +43,22 @@ impl AuthStore {
         // _removeSession() → SIGNED_OUT. Keeping the new token in memory lets the
         // current session survive; only a cold restart before a successful write
         // would be affected.
-        atomic_save(&self.path, &data)?;
+        if let Some(path) = &self.path {
+            atomic_save(path, &data)?;
+        }
         Ok(())
     }
 
     pub fn remove(&self, key: &str) -> super::Result<()> {
         let mut data = self.data.lock().unwrap();
         let old = data.remove(key);
-        if let Err(e) = atomic_save(&self.path, &data) {
-            if let Some(prev) = old {
-                data.insert(key.to_string(), prev);
+        if let Some(path) = &self.path {
+            if let Err(e) = atomic_save(path, &data) {
+                if let Some(prev) = old {
+                    data.insert(key.to_string(), prev);
+                }
+                return Err(e);
             }
-            return Err(e);
         }
         Ok(())
     }
@@ -55,10 +66,16 @@ impl AuthStore {
     pub fn clear(&self) -> super::Result<()> {
         let mut data = self.data.lock().unwrap();
         data.clear();
-        if self.path.exists() {
-            std::fs::remove_file(&self.path)?;
+        if let Some(path) = &self.path
+            && path.exists()
+        {
+            std::fs::remove_file(path)?;
         }
         Ok(())
+    }
+
+    pub fn replace(&self, data: HashMap<String, String>) {
+        *self.data.lock().unwrap() = data;
     }
 
     pub fn snapshot(&self) -> HashMap<String, String> {
@@ -77,4 +94,28 @@ fn atomic_save(path: &Path, data: &HashMap<String, String>) -> super::Result<()>
     let content = serde_json::to_string(data)?;
     hypr_storage::fs::atomic_write(path, &content)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_memory_store_supports_secure_persistence_adapters() {
+        let store = AuthStore::in_memory(HashMap::new());
+
+        store
+            .set("session".to_string(), "first".to_string())
+            .unwrap();
+        assert_eq!(store.get("session").as_deref(), Some("first"));
+
+        store.replace(HashMap::from([(
+            "session".to_string(),
+            "second".to_string(),
+        )]));
+        assert_eq!(store.get("session").as_deref(), Some("second"));
+
+        store.remove("session").unwrap();
+        assert!(store.snapshot().is_empty());
+    }
 }

--- a/plugins/auth/Cargo.toml
+++ b/plugins/auth/Cargo.toml
@@ -19,6 +19,7 @@ hypr-storage = { workspace = true }
 hypr-supabase-auth = { workspace = true, features = ["client"] }
 hypr-template-support = { workspace = true }
 tauri-plugin-settings = { workspace = true }
+tauri-plugin-store2 = { workspace = true }
 
 tauri = { workspace = true, features = ["test"] }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }

--- a/plugins/auth/src/commands.rs
+++ b/plugins/auth/src/commands.rs
@@ -25,25 +25,34 @@ pub(crate) fn get_item<R: tauri::Runtime>(
 
 #[tauri::command]
 #[specta::specta]
-pub(crate) fn set_item<R: tauri::Runtime>(
+pub(crate) async fn set_item<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     key: String,
     value: String,
 ) -> Result<(), String> {
-    app.set_item(key, value).map_err(|e| e.to_string())
+    tauri::async_runtime::spawn_blocking(move || app.set_item(key, value))
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 #[specta::specta]
-pub(crate) fn remove_item<R: tauri::Runtime>(
+pub(crate) async fn remove_item<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     key: String,
 ) -> Result<(), String> {
-    app.remove_item(key).map_err(|e| e.to_string())
+    tauri::async_runtime::spawn_blocking(move || app.remove_item(key))
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 #[specta::specta]
-pub(crate) fn clear<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), String> {
-    app.clear_auth().map_err(|e| e.to_string())
+pub(crate) async fn clear<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || app.clear_auth())
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())
 }

--- a/plugins/auth/src/error.rs
+++ b/plugins/auth/src/error.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Auth(#[from] hypr_supabase_auth::client::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error("{0}")]
+    Storage(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/plugins/auth/src/ext.rs
+++ b/plugins/auth/src/ext.rs
@@ -61,9 +61,11 @@ impl<R: tauri::Runtime, T: tauri::Manager<R>> AuthPluginExt<R> for T {
             let _guard = LINUX_AUTH_WRITE_LOCK.lock().unwrap();
             let mut data = store.snapshot();
             data.remove(&key);
-            crate::migrate::persist_linux_auth(self.app_handle(), &data)?;
+            // Apply the removal in memory even when the keyring refuses, so a
+            // reported failure cannot leave the value readable via get_item.
+            let result = crate::migrate::persist_linux_auth(self.app_handle(), &data);
             store.replace(data);
-            return Ok(());
+            return result;
         }
 
         #[cfg(any(not(target_os = "linux"), test))]
@@ -76,9 +78,12 @@ impl<R: tauri::Runtime, T: tauri::Manager<R>> AuthPluginExt<R> for T {
         #[cfg(all(target_os = "linux", not(test)))]
         {
             let _guard = LINUX_AUTH_WRITE_LOCK.lock().unwrap();
-            crate::migrate::clear_linux_auth(self.app_handle())?;
+            // Sign-out must drop the in-memory session even if the keyring is
+            // locked; callers that ignore the error would otherwise keep a
+            // readable session that returns once the keyring unlocks.
+            let result = crate::migrate::clear_linux_auth(self.app_handle());
             store.replace(HashMap::new());
-            return Ok(());
+            return result;
         }
 
         #[cfg(any(not(target_os = "linux"), test))]

--- a/plugins/auth/src/ext.rs
+++ b/plugins/auth/src/ext.rs
@@ -3,6 +3,9 @@ use std::collections::HashMap;
 use hypr_supabase_auth::{client::store::AuthStore, session::find_session};
 use hypr_template_support::AccountInfo;
 
+#[cfg(all(target_os = "linux", not(test)))]
+static LINUX_AUTH_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub(crate) fn parse_account_info(
     data: &HashMap<String, String>,
 ) -> Result<Option<AccountInfo>, crate::Error> {
@@ -37,15 +40,49 @@ impl<R: tauri::Runtime, T: tauri::Manager<R>> AuthPluginExt<R> for T {
     }
 
     fn set_item(&self, key: String, value: String) -> Result<(), crate::Error> {
-        self.state::<AuthStore>().set(key, value)
+        let store = self.state::<AuthStore>();
+
+        #[cfg(all(target_os = "linux", not(test)))]
+        {
+            let _guard = LINUX_AUTH_WRITE_LOCK.lock().unwrap();
+            store.set(key, value)?;
+            return crate::migrate::persist_linux_auth(self.app_handle(), &store.snapshot());
+        }
+
+        #[cfg(any(not(target_os = "linux"), test))]
+        store.set(key, value).map_err(Into::into)
     }
 
     fn remove_item(&self, key: String) -> Result<(), crate::Error> {
-        self.state::<AuthStore>().remove(&key)
+        let store = self.state::<AuthStore>();
+
+        #[cfg(all(target_os = "linux", not(test)))]
+        {
+            let _guard = LINUX_AUTH_WRITE_LOCK.lock().unwrap();
+            let mut data = store.snapshot();
+            data.remove(&key);
+            crate::migrate::persist_linux_auth(self.app_handle(), &data)?;
+            store.replace(data);
+            return Ok(());
+        }
+
+        #[cfg(any(not(target_os = "linux"), test))]
+        store.remove(&key).map_err(Into::into)
     }
 
     fn clear_auth(&self) -> Result<(), crate::Error> {
-        self.state::<AuthStore>().clear()
+        let store = self.state::<AuthStore>();
+
+        #[cfg(all(target_os = "linux", not(test)))]
+        {
+            let _guard = LINUX_AUTH_WRITE_LOCK.lock().unwrap();
+            crate::migrate::clear_linux_auth(self.app_handle())?;
+            store.replace(HashMap::new());
+            return Ok(());
+        }
+
+        #[cfg(any(not(target_os = "linux"), test))]
+        store.clear().map_err(Into::into)
     }
 
     fn get_account_info(&self) -> Result<Option<AccountInfo>, crate::Error> {

--- a/plugins/auth/src/lib.rs
+++ b/plugins/auth/src/lib.rs
@@ -1,9 +1,10 @@
 mod commands;
+mod error;
 mod ext;
 mod migrate;
 
+pub use error::{Error, Result};
 pub use ext::*;
-pub use hypr_supabase_auth::client::{Error, Result};
 use tauri::Manager;
 
 const PLUGIN_NAME: &str = "auth";
@@ -29,10 +30,18 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     tauri::plugin::Builder::new(PLUGIN_NAME)
         .invoke_handler(specta_builder.invoke_handler())
         .setup(|app, _api| {
-            let auth_path = migrate::auth_path(app)?;
-            app.manage(hypr_supabase_auth::client::store::AuthStore::load(
-                auth_path,
-            ));
+            #[cfg(all(target_os = "linux", not(test)))]
+            let auth_store = hypr_supabase_auth::client::store::AuthStore::in_memory(
+                migrate::load_linux_auth(app)?,
+            );
+
+            #[cfg(any(not(target_os = "linux"), test))]
+            let auth_store = {
+                let auth_path = migrate::auth_path(app)?;
+                hypr_supabase_auth::client::store::AuthStore::load(auth_path)
+            };
+
+            app.manage(auth_store);
             Ok(())
         })
         .build()

--- a/plugins/auth/src/migrate.rs
+++ b/plugins/auth/src/migrate.rs
@@ -7,18 +7,79 @@ use crate::PLUGIN_NAME;
 
 const FILENAME: &str = "auth.json";
 
-pub(crate) fn auth_path<R: tauri::Runtime>(
-    app: &tauri::AppHandle<R>,
-) -> std::result::Result<PathBuf, String> {
-    let new_auth_path = new_auth_path(app).map_err(|e| e.to_string())?;
-    let legacy_auth_path = legacy_auth_path(app).map_err(|e| e.to_string())?;
-    let legacy_store_json_path = legacy_store_json_path(app).map_err(|e| e.to_string())?;
+pub(crate) fn auth_path<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> crate::Result<PathBuf> {
+    let new_auth_path = new_auth_path(app)?;
+    let legacy_auth_path = legacy_auth_path(app)?;
+    let legacy_store_json_path = legacy_store_json_path(app)?;
 
     Ok(resolve_auth_path_from_paths(
         &legacy_auth_path,
         &legacy_store_json_path,
         &new_auth_path,
     ))
+}
+
+#[cfg(all(target_os = "linux", not(test)))]
+const AUTH_SCOPE: &str = "auth";
+#[cfg(all(target_os = "linux", not(test)))]
+const AUTH_KEY: &str = "supabase-storage";
+
+#[cfg(all(target_os = "linux", not(test)))]
+pub(crate) fn load_linux_auth<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> crate::Result<HashMap<String, String>> {
+    let auth_path = auth_path(app)?;
+    let secure_data = tauri_plugin_store2::read_secret_blocking(app, AUTH_SCOPE, AUTH_KEY)
+        .map_err(crate::Error::Storage)?;
+
+    if let Some(data) = secure_data {
+        remove_plaintext_auth(&auth_path)?;
+        return serde_json::from_str(&data).map_err(Into::into);
+    }
+
+    if !auth_path.is_file() {
+        return Ok(HashMap::new());
+    }
+
+    let data = std::fs::read_to_string(&auth_path)?;
+    let auth: HashMap<String, String> = serde_json::from_str(&data)?;
+    persist_linux_auth(app, &auth)?;
+    remove_plaintext_auth(&auth_path)?;
+    Ok(auth)
+}
+
+#[cfg(all(target_os = "linux", not(test)))]
+pub(crate) fn persist_linux_auth<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    auth: &HashMap<String, String>,
+) -> crate::Result<()> {
+    if auth.is_empty() {
+        return clear_linux_auth(app);
+    }
+
+    let data = serde_json::to_string(auth)?;
+    tauri_plugin_store2::write_secret_blocking(app, AUTH_SCOPE, AUTH_KEY, &data)
+        .map_err(crate::Error::Storage)
+}
+
+#[cfg(all(target_os = "linux", not(test)))]
+pub(crate) fn clear_linux_auth<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> crate::Result<()> {
+    tauri_plugin_store2::delete_secret_blocking(app, AUTH_SCOPE, AUTH_KEY)
+        .map_err(crate::Error::Storage)
+}
+
+#[cfg(all(target_os = "linux", not(test)))]
+fn remove_plaintext_auth(path: &Path) -> std::io::Result<()> {
+    if !path.is_file() {
+        return Ok(());
+    }
+
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)?;
+    file.sync_all()?;
+    std::fs::remove_file(path)
 }
 
 fn new_auth_path<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> std::io::Result<PathBuf> {

--- a/plugins/auth/src/migrate.rs
+++ b/plugins/auth/src/migrate.rs
@@ -57,12 +57,24 @@ pub(crate) fn load_linux_auth<R: tauri::Runtime>(
         return Ok(HashMap::new());
     }
 
-    let data = std::fs::read_to_string(&auth_path)?;
-    let auth: HashMap<String, String> = serde_json::from_str(&data)?;
+    let auth = match std::fs::read_to_string(&auth_path)
+        .map_err(crate::Error::Io)
+        .and_then(|data| Ok(serde_json::from_str::<HashMap<String, String>>(&data)?))
+    {
+        Ok(auth) => auth,
+        Err(error) => {
+            // Matches the keyring path: a corrupt or truncated auth.json costs the
+            // session, but must not stop the app from launching. Dropping it also
+            // breaks the loop where a half-removed file fails to parse every launch.
+            tracing::warn!(%error, "ignoring_unreadable_plaintext_auth");
+            discard_plaintext_auth(&auth_path);
+            return Ok(HashMap::new());
+        }
+    };
 
-    match persist_linux_auth(app, &auth) {
-        Ok(()) => discard_plaintext_auth(&auth_path),
-        Err(error) => tracing::warn!(%error, "failed_to_migrate_auth_to_secret_service"),
+    // persist_linux_auth drops the plaintext copy itself once the keyring owns it.
+    if let Err(error) = persist_linux_auth(app, &auth) {
+        tracing::warn!(%error, "failed_to_migrate_auth_to_secret_service");
     }
 
     Ok(auth)
@@ -79,13 +91,28 @@ pub(crate) fn persist_linux_auth<R: tauri::Runtime>(
 
     let data = serde_json::to_string(auth)?;
     tauri_plugin_store2::write_secret_blocking(app, AUTH_SCOPE, AUTH_KEY, &data)
-        .map_err(crate::Error::Storage)
+        .map_err(crate::Error::Storage)?;
+
+    drop_plaintext_auth_for(app);
+    Ok(())
 }
 
 #[cfg(all(target_os = "linux", not(test)))]
 pub(crate) fn clear_linux_auth<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> crate::Result<()> {
+    drop_plaintext_auth_for(app);
     tauri_plugin_store2::delete_secret_blocking(app, AUTH_SCOPE, AUTH_KEY)
         .map_err(crate::Error::Storage)
+}
+
+// The keyring is authoritative once it has been written or cleared, so a plaintext
+// copy left behind by a failed migration must not outlive it and silently restore
+// the session on the next launch.
+#[cfg(all(target_os = "linux", not(test)))]
+fn drop_plaintext_auth_for<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    match auth_path(app) {
+        Ok(path) => discard_plaintext_auth(&path),
+        Err(error) => tracing::warn!(%error, "failed_to_resolve_auth_path"),
+    }
 }
 
 // A leftover auth.json is less harmful than refusing a session the keyring already

--- a/plugins/auth/src/migrate.rs
+++ b/plugins/auth/src/migrate.rs
@@ -29,12 +29,28 @@ pub(crate) fn load_linux_auth<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
 ) -> crate::Result<HashMap<String, String>> {
     let auth_path = auth_path(app)?;
-    let secure_data = tauri_plugin_store2::read_secret_blocking(app, AUTH_SCOPE, AUTH_KEY)
-        .map_err(crate::Error::Storage)?;
+
+    // A locked or unavailable keyring must not abort plugin setup, otherwise the app
+    // cannot start and the plaintext session can never be migrated.
+    let secure_data = match tauri_plugin_store2::read_secret_blocking(app, AUTH_SCOPE, AUTH_KEY) {
+        Ok(data) => data,
+        Err(error) => {
+            tracing::warn!(%error, "failed_to_read_auth_from_secret_service");
+            None
+        }
+    };
 
     if let Some(data) = secure_data {
-        remove_plaintext_auth(&auth_path)?;
-        return serde_json::from_str(&data).map_err(Into::into);
+        match serde_json::from_str::<HashMap<String, String>>(&data) {
+            // Only drop the plaintext copy once the secure payload is known to be usable.
+            Ok(auth) => {
+                discard_plaintext_auth(&auth_path);
+                return Ok(auth);
+            }
+            Err(error) => {
+                tracing::warn!(%error, "ignoring_unreadable_secret_service_auth");
+            }
+        }
     }
 
     if !auth_path.is_file() {
@@ -43,8 +59,12 @@ pub(crate) fn load_linux_auth<R: tauri::Runtime>(
 
     let data = std::fs::read_to_string(&auth_path)?;
     let auth: HashMap<String, String> = serde_json::from_str(&data)?;
-    persist_linux_auth(app, &auth)?;
-    remove_plaintext_auth(&auth_path)?;
+
+    match persist_linux_auth(app, &auth) {
+        Ok(()) => discard_plaintext_auth(&auth_path),
+        Err(error) => tracing::warn!(%error, "failed_to_migrate_auth_to_secret_service"),
+    }
+
     Ok(auth)
 }
 
@@ -66,6 +86,19 @@ pub(crate) fn persist_linux_auth<R: tauri::Runtime>(
 pub(crate) fn clear_linux_auth<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> crate::Result<()> {
     tauri_plugin_store2::delete_secret_blocking(app, AUTH_SCOPE, AUTH_KEY)
         .map_err(crate::Error::Storage)
+}
+
+// A leftover auth.json is less harmful than refusing a session the keyring already
+// holds, so cleanup failures are reported rather than propagated.
+#[cfg(all(target_os = "linux", not(test)))]
+fn discard_plaintext_auth(path: &Path) {
+    if let Err(error) = remove_plaintext_auth(path) {
+        tracing::warn!(
+            path = %path.display(),
+            %error,
+            "failed_to_remove_plaintext_auth"
+        );
+    }
 }
 
 #[cfg(all(target_os = "linux", not(test)))]

--- a/plugins/auth/src/migrate.rs
+++ b/plugins/auth/src/migrate.rs
@@ -31,8 +31,12 @@ pub(crate) fn load_linux_auth<R: tauri::Runtime>(
     let auth_path = auth_path(app)?;
 
     // A locked or unavailable keyring must not abort plugin setup, otherwise the app
-    // cannot start and the plaintext session can never be migrated.
-    let secure_data = match tauri_plugin_store2::read_secret_blocking(app, AUTH_SCOPE, AUTH_KEY) {
+    // cannot start and the plaintext session can never be migrated. `Ok(None)` means
+    // there is no secret yet; `Err` only means it could not be read this time, which
+    // is a distinction the migration below depends on.
+    let secure_read = tauri_plugin_store2::read_secret_blocking(app, AUTH_SCOPE, AUTH_KEY);
+    let keyring_readable = secure_read.is_ok();
+    let secure_data = match secure_read {
         Ok(data) => data,
         Err(error) => {
             tracing::warn!(%error, "failed_to_read_auth_from_secret_service");
@@ -71,6 +75,12 @@ pub(crate) fn load_linux_auth<R: tauri::Runtime>(
             return Ok(HashMap::new());
         }
     };
+
+    // Writing now could clobber a secret that exists but could not be read, so an
+    // unreadable keyring keeps the plaintext copy and retries on a later launch.
+    if !keyring_readable {
+        return Ok(auth);
+    }
 
     // persist_linux_auth drops the plaintext copy itself once the keyring owns it.
     if let Err(error) = persist_linux_auth(app, &auth) {

--- a/plugins/store2/src/commands.rs
+++ b/plugins/store2/src/commands.rs
@@ -4,6 +4,12 @@ const SECURE_STORE_SUFFIX: &str = "secure-store";
 const NATIVE_SECRET_ACCOUNT_PREFIXES: &[&str] = &["e2ee:"];
 #[cfg(target_os = "macos")]
 const MACOS_KEYCHAIN_ACCESS_ERROR_PREFIX: &str = "macOS couldn't access your login Keychain.";
+#[cfg(target_os = "linux")]
+const LINUX_SECRET_SERVICE_ACCESS_ERROR: &str =
+    "Linux couldn't access Secret Service. Unlock your login keyring, then try again.";
+#[cfg(target_os = "linux")]
+const LINUX_SECRET_SERVICE_UNAVAILABLE_ERROR: &str =
+    "Linux Secret Service is unavailable. Start your desktop keyring service, then try again.";
 
 #[cfg(target_os = "macos")]
 const ERR_SEC_AUTH_FAILED: i32 = -25293;
@@ -54,6 +60,17 @@ fn secure_store_error(error: keyring::Error) -> String {
         return format!(
             "{MACOS_KEYCHAIN_ACCESS_ERROR_PREFIX} Use “Repair Keychain Access” below, then try again."
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    match error {
+        keyring::Error::NoStorageAccess(_) => {
+            return LINUX_SECRET_SERVICE_ACCESS_ERROR.to_string();
+        }
+        keyring::Error::PlatformFailure(_) => {
+            return LINUX_SECRET_SERVICE_UNAVAILABLE_ERROR.to_string();
+        }
+        _ => {}
     }
 
     error.to_string()
@@ -128,7 +145,7 @@ fn legacy_secret_entries<R: tauri::Runtime>(
     legacy_secret_locations(&app.config().identifier, scope, key)
         .into_iter()
         .map(|(service, account)| {
-            keyring::Entry::new(&service, &account).map_err(|error| error.to_string())
+            keyring::Entry::new(&service, &account).map_err(secure_store_error)
         })
         .collect()
 }
@@ -145,7 +162,7 @@ fn secret_entry<R: tauri::Runtime>(
     let identifier = &app.config().identifier;
     let service = secure_store_service(identifier);
     let account = secure_store_account(identifier, scope, key);
-    keyring::Entry::new(&service, &account).map_err(|error| error.to_string())
+    keyring::Entry::new(&service, &account).map_err(secure_store_error)
 }
 
 #[tauri::command]
@@ -279,6 +296,14 @@ pub async fn read_secret<R: tauri::Runtime>(
     read_secret_for(SecretCaller::Native, app, scope, key).await
 }
 
+pub fn read_secret_blocking<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    scope: &str,
+    key: &str,
+) -> Result<Option<String>, String> {
+    read_secret_blocking_for(SecretCaller::Native, app, scope, key)
+}
+
 async fn read_secret_for<R: tauri::Runtime>(
     caller: SecretCaller,
     app: tauri::AppHandle<R>,
@@ -287,29 +312,39 @@ async fn read_secret_for<R: tauri::Runtime>(
 ) -> Result<Option<String>, String> {
     validate_secret_coordinate(caller, &scope, &key)?;
     tauri::async_runtime::spawn_blocking(move || {
-        let entry = secret_entry(&app, &scope, &key)?;
-        match entry.get_password() {
-            Ok(secret) => Ok(Some(secret)),
-            Err(keyring::Error::NoEntry) => {
-                for legacy_entry in legacy_secret_entries(&app, &scope, &key)? {
-                    match legacy_entry.get_password() {
-                        Ok(secret) => {
-                            if entry.set_password(&secret).is_ok() {
-                                let _ = legacy_entry.delete_credential();
-                            }
-                            return Ok(Some(secret));
-                        }
-                        Err(keyring::Error::NoEntry | keyring::Error::PlatformFailure(_)) => {}
-                        Err(error) => return Err(secure_store_error(error)),
-                    }
-                }
-                Ok(None)
-            }
-            Err(error) => Err(secure_store_error(error)),
-        }
+        read_secret_blocking_for(caller, &app, &scope, &key)
     })
     .await
     .map_err(|error| error.to_string())?
+}
+
+fn read_secret_blocking_for<R: tauri::Runtime>(
+    caller: SecretCaller,
+    app: &tauri::AppHandle<R>,
+    scope: &str,
+    key: &str,
+) -> Result<Option<String>, String> {
+    validate_secret_coordinate(caller, scope, key)?;
+    let entry = secret_entry(app, scope, key)?;
+    match entry.get_password() {
+        Ok(secret) => Ok(Some(secret)),
+        Err(keyring::Error::NoEntry) => {
+            for legacy_entry in legacy_secret_entries(app, scope, key)? {
+                match legacy_entry.get_password() {
+                    Ok(secret) => {
+                        if entry.set_password(&secret).is_ok() {
+                            let _ = legacy_entry.delete_credential();
+                        }
+                        return Ok(Some(secret));
+                    }
+                    Err(keyring::Error::NoEntry | keyring::Error::PlatformFailure(_)) => {}
+                    Err(error) => return Err(secure_store_error(error)),
+                }
+            }
+            Ok(None)
+        }
+        Err(error) => Err(secure_store_error(error)),
+    }
 }
 
 #[tauri::command]
@@ -332,6 +367,15 @@ pub async fn write_secret<R: tauri::Runtime>(
     write_secret_for(SecretCaller::Native, app, scope, key, value).await
 }
 
+pub fn write_secret_blocking<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    scope: &str,
+    key: &str,
+    value: &str,
+) -> Result<(), String> {
+    write_secret_blocking_for(SecretCaller::Native, app, scope, key, value)
+}
+
 async fn write_secret_for<R: tauri::Runtime>(
     caller: SecretCaller,
     app: tauri::AppHandle<R>,
@@ -341,15 +385,26 @@ async fn write_secret_for<R: tauri::Runtime>(
 ) -> Result<(), String> {
     validate_secret_coordinate(caller, &scope, &key)?;
     tauri::async_runtime::spawn_blocking(move || {
-        let entry = secret_entry(&app, &scope, &key)?;
-        entry.set_password(&value).map_err(secure_store_error)?;
-        for legacy_entry in legacy_secret_entries(&app, &scope, &key)? {
-            let _ = legacy_entry.delete_credential();
-        }
-        Ok(())
+        write_secret_blocking_for(caller, &app, &scope, &key, &value)
     })
     .await
     .map_err(|error| error.to_string())?
+}
+
+fn write_secret_blocking_for<R: tauri::Runtime>(
+    caller: SecretCaller,
+    app: &tauri::AppHandle<R>,
+    scope: &str,
+    key: &str,
+    value: &str,
+) -> Result<(), String> {
+    validate_secret_coordinate(caller, scope, key)?;
+    let entry = secret_entry(app, scope, key)?;
+    entry.set_password(value).map_err(secure_store_error)?;
+    for legacy_entry in legacy_secret_entries(app, scope, key)? {
+        let _ = legacy_entry.delete_credential();
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -362,6 +417,14 @@ pub(crate) async fn delete_secret<R: tauri::Runtime>(
     delete_secret_for(SecretCaller::Renderer, app, scope, key).await
 }
 
+pub fn delete_secret_blocking<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    scope: &str,
+    key: &str,
+) -> Result<(), String> {
+    delete_secret_blocking_for(SecretCaller::Native, app, scope, key)
+}
+
 async fn delete_secret_for<R: tauri::Runtime>(
     caller: SecretCaller,
     app: tauri::AppHandle<R>,
@@ -370,21 +433,31 @@ async fn delete_secret_for<R: tauri::Runtime>(
 ) -> Result<(), String> {
     validate_secret_coordinate(caller, &scope, &key)?;
     tauri::async_runtime::spawn_blocking(move || {
-        for legacy_entry in legacy_secret_entries(&app, &scope, &key)? {
-            match legacy_entry.delete_credential() {
-                Ok(()) | Err(keyring::Error::NoEntry | keyring::Error::PlatformFailure(_)) => {}
-                Err(error) => return Err(secure_store_error(error)),
-            }
-        }
-        let entry = secret_entry(&app, &scope, &key)?;
-        match entry.delete_credential() {
-            Ok(()) | Err(keyring::Error::NoEntry) => {}
-            Err(error) => return Err(secure_store_error(error)),
-        }
-        Ok(())
+        delete_secret_blocking_for(caller, &app, &scope, &key)
     })
     .await
     .map_err(|error| error.to_string())?
+}
+
+fn delete_secret_blocking_for<R: tauri::Runtime>(
+    caller: SecretCaller,
+    app: &tauri::AppHandle<R>,
+    scope: &str,
+    key: &str,
+) -> Result<(), String> {
+    validate_secret_coordinate(caller, scope, key)?;
+    for legacy_entry in legacy_secret_entries(app, scope, key)? {
+        match legacy_entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry | keyring::Error::PlatformFailure(_)) => {}
+            Err(error) => return Err(secure_store_error(error)),
+        }
+    }
+    let entry = secret_entry(app, scope, key)?;
+    match entry.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => {}
+        Err(error) => return Err(secure_store_error(error)),
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -529,5 +602,24 @@ mod tests {
         let error = keyring::Error::PlatformFailure(Box::new(platform_error));
 
         assert_eq!(secure_store_error(error), expected);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn explains_locked_linux_secret_service() {
+        let error = keyring::Error::NoStorageAccess(Box::new(std::io::Error::other("locked")));
+
+        assert_eq!(secure_store_error(error), LINUX_SECRET_SERVICE_ACCESS_ERROR);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn explains_unavailable_linux_secret_service() {
+        let error = keyring::Error::PlatformFailure(Box::new(std::io::Error::other("unavailable")));
+
+        assert_eq!(
+            secure_store_error(error),
+            LINUX_SECRET_SERVICE_UNAVAILABLE_ERROR
+        );
     }
 }

--- a/plugins/store2/src/lib.rs
+++ b/plugins/store2/src/lib.rs
@@ -2,7 +2,9 @@ mod commands;
 mod error;
 mod ext;
 
-pub use commands::{read_secret, write_secret};
+pub use commands::{
+    delete_secret_blocking, read_secret, read_secret_blocking, write_secret, write_secret_blocking,
+};
 pub use error::*;
 pub use ext::*;
 


### PR DESCRIPTION
Migrate Supabase sessions out of plaintext auth.json, preserve in-memory auth on secure-write failures, and surface actionable Linux keyring errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how sessions are stored and migrated on Linux and touches sign-out/remove semantics when the keyring fails; mistakes could lose sessions or leave stale credentials readable.
> 
> **Overview**
> On **Linux**, Supabase auth stops persisting to plaintext `auth.json` and instead loads into an in-memory `AuthStore`, then reads/writes the session through **Secret Service** via `tauri-plugin-store2`. Startup migrates from legacy plaintext when the keyring is readable, drops the file only after a valid secure payload, and keeps plaintext if the keyring is locked so a later launch can retry without clobbering secrets.
> 
> **`AuthStore`** gains optional disk path (`in_memory`, `replace`) so Linux can treat memory as source of truth while secure storage handles durability; **`set`** still avoids rolling back memory on failed disk writes (unchanged intent, now skips file I/O when path is absent).
> 
> The auth plugin wires Linux `set_item` / `remove_item` / `clear` through `persist_linux_auth` / `clear_linux_auth` with a process-wide write lock, and updates in-memory state on remove/clear even when keyring operations fail. Mutating Tauri commands move to **`spawn_blocking`** async handlers. **`store2`** exposes blocking secret APIs and maps Linux keyring errors to user-facing messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccbc0d22c46b46835e77d660bbce2dc7b6f65d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->