### PR TITLE
Make Linux setup architecture-safe

### DIFF
--- a/.github/reports/release-gates/linux.md
+++ b/.github/reports/release-gates/linux.md
@@ -62,6 +62,23 @@ both must exist before the beta ships. A VM result must remain labeled as VM evi
 Building release artifacts on Debian 12 or Ubuntu 22.04 for an older glibc baseline is a
 CI policy; it is not a substitute for the Ubuntu 24.04 runtime cells above.
 
+### Development setup
+
+The supported source-development setup is Debian or Ubuntu on x86_64 or ARM64. The setup
+script installs Node 22 when needed, selects Rust 1.94.0, pins pnpm 11.1.1, installs the
+native desktop dependencies, and downloads architecture-matched development tools:
+
+~~~bash
+bash scripts/setup-linux.sh
+exec "$SHELL" -l
+pnpm install --frozen-lockfile
+pnpm -F ui build
+pnpm -F @hypr/desktop tauri:dev
+~~~
+
+Release packages still use the older Debian 12 or Ubuntu 22.04 build baseline. Run the
+beta itself on the Ubuntu 24.04 environments listed above.
+
 ### Package matrix
 
 | Package ID             | Architecture | Package   | Release role                                      | Required | Current status | Evidence |
@@ -349,14 +366,12 @@ Confirm the path from the running sandbox rather than assuming the native-packag
 
 ### Optional source-build smoke
 
-The repository's current Linux setup and E2E path uses these commands. The setup scripts
-are Ubuntu-oriented and are not yet a clean ARM64 setup path; that remains tracked by
-ANLG-164. These commands are useful before packaging, but they do not replace tests of
-published AppImage and .deb artifacts:
+The repository's current Linux setup and E2E path uses these commands. These commands are
+useful before packaging, but they do not replace tests of published AppImage and .deb
+artifacts:
 
 ~~~bash
-bash scripts/setup-linux-tauri.sh
-bash scripts/setup-linux-others.sh
+bash scripts/setup-linux.sh
 pnpm -F ui build
 pnpm -F desktop typecheck
 cargo check -p desktop --target x86_64-unknown-linux-gnu

--- a/scripts/setup-devtools.sh
+++ b/scripts/setup-devtools.sh
@@ -4,15 +4,34 @@
 
 set -euo pipefail
 
-if ! command -v dprint &> /dev/null; then
+case "$(uname -m)" in
+  x86_64 | amd64)
+    RELEASE_ARCH=amd64
+    ;;
+  aarch64 | arm64)
+    RELEASE_ARCH=arm64
+    ;;
+  *)
+    echo "Error: development tools support x86_64 and ARM64 Linux only." >&2
+    exit 1
+    ;;
+esac
+
+if [[ -x "$HOME/.dprint/bin/dprint" ]]; then
+  export PATH="$HOME/.dprint/bin:$PATH"
+elif ! command -v dprint &> /dev/null; then
   curl -fsSL https://dprint.dev/install.sh | sh
   export PATH="$HOME/.dprint/bin:$PATH"
+fi
+if [[ -x "$HOME/.dprint/bin/dprint" ]]; then
+  sudo install -m 0755 "$HOME/.dprint/bin/dprint" /usr/local/bin/dprint
 fi
 
 if ! command -v supabase &> /dev/null; then
   TEMP_DIR=$(mktemp -d)
-  curl -fsSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz | tar -xz -C "$TEMP_DIR"
-  sudo mv "$TEMP_DIR/supabase" /usr/local/bin/supabase
+  curl -fsSL "https://github.com/supabase/cli/releases/latest/download/supabase_linux_${RELEASE_ARCH}.tar.gz" \
+    | tar -xz -C "$TEMP_DIR"
+  sudo install -m 0755 "$TEMP_DIR/supabase" /usr/local/bin/supabase
   rm -rf "$TEMP_DIR"
 fi
 
@@ -35,6 +54,9 @@ if ! command -v infisical &> /dev/null; then
 fi
 
 if ! command -v dasel &> /dev/null; then
-  curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
-  sudo mv ./dasel /usr/local/bin/dasel
+  TEMP_DIR=$(mktemp -d)
+  curl -fsSL "https://github.com/TomWright/dasel/releases/latest/download/dasel_linux_${RELEASE_ARCH}" \
+    -o "$TEMP_DIR/dasel"
+  sudo install -m 0755 "$TEMP_DIR/dasel" /usr/local/bin/dasel
+  rm -rf "$TEMP_DIR"
 fi

--- a/scripts/setup-linux-others.sh
+++ b/scripts/setup-linux-others.sh
@@ -5,8 +5,6 @@
 set -euo pipefail
 
 sudo apt update
-sudo add-apt-repository -y ppa:pipewire-debian/pipewire-upstream
-sudo apt update
 sudo apt-get install -y \
   libgtk-3-dev \
   libgtk-4-dev \
@@ -19,6 +17,6 @@ sudo apt-get install -y \
   patchelf \
   cmake \
   curl \
-  libcurl4-openssl-dev
-
-curl -fsSL https://get.pnpm.io/install.sh | sh -
+  jq \
+  libcurl4-openssl-dev \
+  unzip

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -5,8 +5,76 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NODE_MAJOR=22
+RUST_VERSION=1.94.0
+PNPM_VERSION=11.1.1
+
+setup_toolchains() {
+  if ! command -v apt-get &> /dev/null || [[ ! -f /etc/os-release ]]; then
+    echo "Error: Linux setup currently supports Debian and Ubuntu." >&2
+    exit 1
+  fi
+
+  . /etc/os-release
+  case "${ID:-}" in
+    debian | ubuntu) ;;
+    *)
+      echo "Error: Linux setup currently supports Debian and Ubuntu, not ${ID:-unknown}." >&2
+      exit 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64 | amd64 | aarch64 | arm64) ;;
+    *)
+      echo "Error: Linux setup supports x86_64 and ARM64 only." >&2
+      exit 1
+      ;;
+  esac
+
+  sudo apt-get update
+  sudo apt-get install -y ca-certificates curl libatomic1
+
+  local installed_node_major=0
+  if command -v node &> /dev/null; then
+    installed_node_major="$(node --version)"
+    installed_node_major="${installed_node_major#v}"
+    installed_node_major="${installed_node_major%%.*}"
+  fi
+
+  if ((installed_node_major < NODE_MAJOR)); then
+    local nodesource_setup
+    nodesource_setup="$(mktemp)"
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" -o "$nodesource_setup"
+    sudo -E bash "$nodesource_setup"
+    rm -f "$nodesource_setup"
+    sudo apt-get install -y nodejs
+  fi
+
+  local cargo_home="${CARGO_HOME:-$HOME/.cargo}"
+  if [[ -f "$cargo_home/env" ]]; then
+    . "$cargo_home/env"
+  else
+    export PATH="$cargo_home/bin:$PATH"
+  fi
+  if ! command -v rustup &> /dev/null; then
+    curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+      | sh -s -- -y --profile minimal --default-toolchain "$RUST_VERSION"
+  fi
+  rustup toolchain install "$RUST_VERSION" --profile minimal
+
+  export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+  export PATH="$PNPM_HOME/bin:$PATH"
+  if ! command -v pnpm &> /dev/null || [[ "$(pnpm --version)" != "$PNPM_VERSION" ]]; then
+    curl -fsSL https://get.pnpm.io/install.sh \
+      | env PNPM_VERSION="$PNPM_VERSION" SHELL="${SHELL:-/bin/bash}" sh -
+  fi
+
+  echo "Node $(node --version), Rust $(rustc --version), pnpm $(pnpm --version)"
+}
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  setup_toolchains
   bash "$SCRIPT_DIR/setup-linux-others.sh"
   bash "$SCRIPT_DIR/setup-linux-tauri.sh"
   bash "$SCRIPT_DIR/setup-devtools.sh"


### PR DESCRIPTION
Pin the supported toolchains and use native x86_64 or ARM64 development tool downloads without the Ubuntu-only PipeWire PPA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect local/CI developer setup scripts and documentation only, not runtime app code or release packaging behavior.
> 
> **Overview**
> **Linux developer onboarding** is consolidated into a single `scripts/setup-linux.sh` entry point that now bootstraps **Node 22**, **Rust 1.94.0**, and **pnpm 11.1.1**, restricts support to **Debian/Ubuntu on x86_64 or ARM64**, then runs the existing native-deps and devtools sub-scripts.
> 
> `setup-linux-others.sh` **drops the Ubuntu-only PipeWire PPA** and no longer installs pnpm there (pnpm moves to the main script); it adds **`jq`** and **`unzip`** to the apt package list. `setup-devtools.sh` selects **`amd64` vs `arm64`** from `uname` and uses matching **Supabase CLI** and **dasel** artifacts instead of hardcoded amd64 downloads, with clearer **dprint** install/`/usr/local/bin` handling.
> 
> The **Linux beta release gate** doc gains a **Development setup** section describing the one-command flow and updates optional source-build smoke to **`bash scripts/setup-linux.sh`**, removing the prior note that setup was Ubuntu-oriented and that a clean ARM64 path was still tracked by ANLG-164.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76ac212e351935c65df904ffb2b53f7851c40bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->