### PR TITLE
Keep Soniqo transcription macOS-only

### DIFF
--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -28,6 +28,7 @@ const {
   markSessionAudioTranscriptionCompleteMock,
   createTranscriptMock,
   idMock,
+  platformMock,
 } = vi.hoisted(() => ({
   startTranscriptionMock: vi.fn(),
   useListenerMock: vi.fn(),
@@ -44,6 +45,11 @@ const {
   markSessionAudioTranscriptionCompleteMock: vi.fn(),
   createTranscriptMock: vi.fn(),
   idMock: vi.fn(),
+  platformMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: platformMock,
 }));
 
 vi.mock("./contexts", () => ({
@@ -186,6 +192,7 @@ describe("getBatchFallbackTarget", () => {
         isPaid: true,
         accessToken: "token",
         apiBaseUrl: "https://api.test",
+        currentPlatform: "windows",
       }),
     ).toEqual({
       provider: "hyprnote",
@@ -202,6 +209,7 @@ describe("getBatchFallbackTarget", () => {
         isPaid: false,
         accessToken: null,
         apiBaseUrl: "https://api.test",
+        currentPlatform: "macos",
       }),
     ).toEqual({
       provider: "soniqo",
@@ -211,11 +219,26 @@ describe("getBatchFallbackTarget", () => {
       label: "Soniqo batch transcription",
     });
   });
+
+  test.each(["windows", "linux"] as const)(
+    "does not use local Soniqo on %s",
+    (currentPlatform) => {
+      expect(
+        getBatchFallbackTarget({
+          isPaid: false,
+          accessToken: null,
+          apiBaseUrl: "https://api.test",
+          currentPlatform,
+        }),
+      ).toBeNull();
+    },
+  );
 });
 
 describe("useRunBatch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    platformMock.mockReturnValue("macos");
 
     let nextId = 0;
     idMock.mockImplementation(() => `generated-${++nextId}`);
@@ -552,6 +575,34 @@ describe("useRunBatch", () => {
       }),
     );
   });
+
+  test.each(["windows", "linux"] as const)(
+    "does not invoke Soniqo as a batch fallback on %s",
+    async (currentPlatform) => {
+      platformMock.mockReturnValue(currentPlatform);
+      useSTTConnectionMock.mockReturnValue({
+        conn: {
+          provider: "custom",
+          model: "realtime-only",
+          baseUrl: "https://custom.test",
+          apiKey: "custom-key",
+        },
+      });
+
+      const { result } = renderHook(() => useRunBatch("session-1"));
+
+      await expect(
+        act(async () => {
+          await result.current("/tmp/session.wav");
+        }),
+      ).rejects.toThrow(
+        "realtime-only is not available for batch transcription on this platform",
+      );
+
+      expect(startTranscriptionMock).not.toHaveBeenCalled();
+      expect(sonnerToastWarningMock).not.toHaveBeenCalled();
+    },
+  );
 
   test("falls back to hosted cloud transcription for paid users", async () => {
     isSupportedLanguagesBatchMock.mockResolvedValue(false);

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -1,3 +1,4 @@
+import { platform } from "@tauri-apps/plugin-os";
 import { useCallback } from "react";
 
 import type { TranscriptionParams } from "@hypr/plugin-transcription";
@@ -113,11 +114,13 @@ export function getBatchFallbackTarget({
   isPaid,
   accessToken,
   apiBaseUrl,
+  currentPlatform = platform(),
 }: {
   isPaid: boolean;
   accessToken?: string | null;
   apiBaseUrl: string;
-}): BatchTarget {
+  currentPlatform?: ReturnType<typeof platform>;
+}): BatchTarget | null {
   if (isPaid && accessToken) {
     return {
       provider: "hyprnote",
@@ -128,7 +131,7 @@ export function getBatchFallbackTarget({
     };
   }
 
-  return LOCAL_SONIQO_BATCH_TARGET;
+  return currentPlatform === "macos" ? LOCAL_SONIQO_BATCH_TARGET : null;
 }
 
 async function canUseBatchTarget(
@@ -258,6 +261,7 @@ export const useRunBatch = (sessionId: string) => {
       const languages =
         options?.languages ??
         getTranscriptionLanguages(aiLanguage, spokenLanguages);
+      const currentPlatform = platform();
       const selectedModel = options?.model ?? conn?.model;
       const selectedProvider =
         conn && selectedModel
@@ -273,24 +277,33 @@ export const useRunBatch = (sessionId: string) => {
               label: selectedModel,
             }
           : null;
-      const selectedTargetSupported = selectedTarget
-        ? await canUseBatchTarget(
-            selectedTarget.provider,
-            selectedTarget.model,
-            languages,
-          )
-        : false;
+      const selectedTargetSupported =
+        selectedTarget &&
+        (selectedTarget.provider !== "soniqo" || currentPlatform === "macos")
+          ? await canUseBatchTarget(
+              selectedTarget.provider,
+              selectedTarget.model,
+              languages,
+            )
+          : false;
       const fallbackTarget = getBatchFallbackTarget({
         isPaid: billing.isPaid,
         accessToken: auth?.session?.access_token,
         apiBaseUrl: env.VITE_API_URL,
+        currentPlatform,
       });
       const shouldUseSelectedTarget =
         selectedTargetSupported ||
-        sameBatchTarget(selectedTarget, fallbackTarget);
+        (fallbackTarget && sameBatchTarget(selectedTarget, fallbackTarget));
       const target = shouldUseSelectedTarget
         ? (selectedTarget ?? fallbackTarget)
         : fallbackTarget;
+
+      if (!target) {
+        throw new Error(
+          `${selectedProviderLabel(conn, selectedModel)} is not available for batch transcription on this platform. Configure a batch-capable speech-to-text provider.`,
+        );
+      }
 
       if (!shouldUseSelectedTarget) {
         sonnerToast.warning("Using a batch transcription provider", {


### PR DESCRIPTION
Prevent Windows and Linux from selecting the local Soniqo batch fallback while preserving configured batch providers and Pro cloud transcription.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-capture batch provider selection on Windows/Linux for free users who relied on Soniqo fallback; paid cloud path is unchanged.
> 
> **Overview**
> **Batch STT** now treats local Soniqo as **macOS-only**: `getBatchFallbackTarget` returns Soniqo only on macOS and `null` on Windows/Linux for unpaid users without another fallback, and `useRunBatch` skips Soniqo as a selected or fallback target off macOS.
> 
> When no batch-capable target remains (e.g. realtime-only provider on Windows/Linux with no Pro cloud), batch transcription **fails with a clear error** instead of silently falling back to Soniqo. **Pro cloud** fallback for paid users is unchanged.
> 
> Tests mock `@tauri-apps/plugin-os` and cover platform-specific fallback and hook behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 282db63242332af62c5dacb1181c949865e14c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->