### PR TITLE
Validate Linux audio capture initialization

### DIFF
--- a/crates/audio-actual/src/capture/stream.rs
+++ b/crates/audio-actual/src/capture/stream.rs
@@ -61,7 +61,7 @@ pub(crate) fn setup_mic_stream(
     mic_device: Option<String>,
 ) -> Result<ChunkStream, Error> {
     let mic = MicInput::new(mic_device).map_err(|_| Error::MicOpenFailed)?;
-    mic.stream()
+    mic.stream()?
         .resampled_chunks(sample_rate, chunk_size)
         .map(|stream| Box::pin(stream) as ChunkStream)
         .map_err(|_| Error::MicStreamSetupFailed)
@@ -71,10 +71,11 @@ pub(crate) fn setup_speaker_stream(
     sample_rate: u32,
     chunk_size: usize,
 ) -> Result<ChunkStream, Error> {
-    let speaker = SpeakerInput::new().map_err(|_| Error::SpeakerStreamSetupFailed)?;
+    let speaker = SpeakerInput::new()
+        .map_err(|error| Error::SpeakerStreamInitializationFailed(error.to_string()))?;
     speaker
         .stream()
-        .map_err(|_| Error::SpeakerStreamSetupFailed)?
+        .map_err(|error| Error::SpeakerStreamInitializationFailed(error.to_string()))?
         .resampled_chunks(sample_rate, chunk_size)
         .map(|stream| Box::pin(stream) as ChunkStream)
         .map_err(|_| Error::SpeakerStreamSetupFailed)

--- a/crates/audio-actual/src/lib.rs
+++ b/crates/audio-actual/src/lib.rs
@@ -161,19 +161,23 @@ impl AudioInput {
         }
     }
 
-    pub fn stream(&mut self) -> AudioStream {
-        match &self.source {
+    pub fn stream(&mut self) -> Result<AudioStream, Error> {
+        Ok(match &self.source {
             AudioSource::RealtimeMic => AudioStream::RealtimeMic {
-                mic: self.mic.as_ref().unwrap().stream(),
+                mic: self.mic.as_ref().unwrap().stream()?,
             },
-            AudioSource::RealtimeSpeaker => AudioStream::RealtimeSpeaker {
-                speaker: self.speaker.take().unwrap().stream().unwrap(),
-            },
+            AudioSource::RealtimeSpeaker => {
+                AudioStream::RealtimeSpeaker {
+                    speaker: self.speaker.take().unwrap().stream().map_err(|error| {
+                        Error::SpeakerStreamInitializationFailed(error.to_string())
+                    })?,
+                }
+            }
             AudioSource::Recorded => AudioStream::Recorded {
                 data: self.data.as_ref().unwrap().clone(),
                 position: 0,
             },
-        }
+        })
     }
 }
 
@@ -268,15 +272,16 @@ impl AudioProvider for ActualAudio {
 
     fn probe_mic(&self, device: Option<String>) -> Result<(), Error> {
         let mut input = AudioInput::from_mic(device)?;
-        let _stream = input.stream();
+        let _stream = input.stream()?;
         Ok(())
     }
 
     fn probe_speaker(&self) -> Result<(), Error> {
-        let speaker = SpeakerInput::new().map_err(|_| Error::SpeakerStreamSetupFailed)?;
+        let speaker = SpeakerInput::new()
+            .map_err(|error| Error::SpeakerStreamInitializationFailed(error.to_string()))?;
         let _stream = speaker
             .stream()
-            .map_err(|_| Error::SpeakerStreamSetupFailed)?;
+            .map_err(|error| Error::SpeakerStreamInitializationFailed(error.to_string()))?;
         Ok(())
     }
 }

--- a/crates/audio-actual/src/lib.rs
+++ b/crates/audio-actual/src/lib.rs
@@ -78,6 +78,9 @@ pub struct AudioInput {
     source: AudioSource,
     mic: Option<MicInput>,
     speaker: Option<SpeakerInput>,
+    // `SpeakerInput::stream` consumes the input, so the rate is cached up front to keep
+    // `sample_rate` answerable once the speaker has been handed off.
+    speaker_sample_rate: u32,
     data: Option<Vec<u8>>,
 }
 
@@ -94,7 +97,7 @@ impl AudioInput {
     pub fn sample_rate(&self) -> u32 {
         match &self.source {
             AudioSource::RealtimeMic => self.mic.as_ref().unwrap().sample_rate(),
-            AudioSource::RealtimeSpeaker => self.speaker.as_ref().unwrap().sample_rate(),
+            AudioSource::RealtimeSpeaker => self.speaker_sample_rate,
             AudioSource::Recorded => 16000,
         }
     }
@@ -140,17 +143,23 @@ impl AudioInput {
             source: AudioSource::RealtimeMic,
             mic: Some(mic),
             speaker: None,
+            speaker_sample_rate: 0,
             data: None,
         })
     }
 
-    pub fn from_speaker() -> Self {
-        Self {
+    pub fn from_speaker() -> Result<Self, Error> {
+        let speaker = SpeakerInput::new()
+            .map_err(|error| Error::SpeakerStreamInitializationFailed(error.to_string()))?;
+        let speaker_sample_rate = speaker.sample_rate();
+
+        Ok(Self {
             source: AudioSource::RealtimeSpeaker,
             mic: None,
-            speaker: Some(SpeakerInput::new().unwrap()),
+            speaker: Some(speaker),
+            speaker_sample_rate,
             data: None,
-        }
+        })
     }
 
     pub fn device_name(&self) -> String {
@@ -167,11 +176,14 @@ impl AudioInput {
                 mic: self.mic.as_ref().unwrap().stream()?,
             },
             AudioSource::RealtimeSpeaker => {
-                AudioStream::RealtimeSpeaker {
-                    speaker: self.speaker.take().unwrap().stream().map_err(|error| {
-                        Error::SpeakerStreamInitializationFailed(error.to_string())
-                    })?,
-                }
+                let speaker = self
+                    .speaker
+                    .take()
+                    .ok_or(Error::SpeakerStreamSetupFailed)?
+                    .stream()
+                    .map_err(|error| Error::SpeakerStreamInitializationFailed(error.to_string()))?;
+
+                AudioStream::RealtimeSpeaker { speaker }
             }
             AudioSource::Recorded => AudioStream::Recorded {
                 data: self.data.as_ref().unwrap().clone(),

--- a/crates/audio-actual/src/mic.rs
+++ b/crates/audio-actual/src/mic.rs
@@ -127,10 +127,11 @@ impl MicInput {
 }
 
 impl MicInput {
-    pub fn stream(&self) -> MicStream {
+    pub fn stream(&self) -> Result<MicStream, crate::Error> {
         let config = self.config.clone();
         let device = self.device.clone();
         let (drop_tx, drop_rx) = std::sync::mpsc::channel();
+        let (init_tx, init_rx) = std::sync::mpsc::channel();
 
         let rb = HeapRb::<f32>::new(MIC_BUFFER_SIZE);
         let (producer, consumer) = rb.split();
@@ -187,7 +188,7 @@ impl MicInput {
                 )
             }
 
-            let start_stream = || {
+            let start_stream = || -> Result<cpal::Stream, String> {
                 let stream = match config.sample_format() {
                     cpal::SampleFormat::I8 => build_stream::<i8>(
                         &device,
@@ -227,45 +228,62 @@ impl MicInput {
                     ),
                     sample_format => {
                         tracing::error!(sample_format = ?sample_format, "unsupported");
-                        return None;
+                        return Err(format!(
+                            "unsupported microphone sample format: {sample_format:?}"
+                        ));
                     }
                 };
 
-                let stream = match stream {
-                    Ok(stream) => stream,
-                    Err(err) => {
-                        tracing::error!("Error starting stream: {}", err);
-                        return None;
-                    }
-                };
+                let stream = stream.map_err(|err| {
+                    tracing::error!(error = %err, "mic_stream_build_failed");
+                    format!("failed to build microphone stream: {err}")
+                })?;
 
-                if let Err(err) = stream.play() {
-                    tracing::error!("Error playing stream: {}", err);
-                    return None;
-                }
+                stream.play().map_err(|err| {
+                    tracing::error!(error = %err, "mic_stream_start_failed");
+                    format!("failed to start microphone stream: {err}")
+                })?;
 
-                Some(stream)
+                Ok(stream)
             };
 
             let stream = match start_stream() {
-                Some(stream) => stream,
-                None => {
+                Ok(stream) => stream,
+                Err(error) => {
+                    let _ = init_tx.send(Err(error));
                     alive_for_thread.store(false, Ordering::Release);
                     waker_for_thread.wake();
                     return;
                 }
             };
 
-            // Wait for the stream to be dropped
+            let _ = init_tx.send(Ok(()));
             let _ = drop_rx.recv();
 
-            // Then drop the stream
             alive_for_thread.store(false, Ordering::Release);
             waker_for_thread.wake();
             drop(stream);
         });
 
-        MicStream {
+        match init_rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                return Err(crate::Error::MicStreamInitializationFailed(error));
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                let _ = drop_tx.send(());
+                return Err(crate::Error::MicStreamInitializationFailed(
+                    "timed out while starting the microphone stream".to_string(),
+                ));
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(crate::Error::MicStreamInitializationFailed(
+                    "microphone capture stopped during initialization".to_string(),
+                ));
+            }
+        }
+
+        Ok(MicStream {
             drop_tx,
             config: self.config.clone(),
             reader: RingbufAsyncReader::new(
@@ -276,7 +294,7 @@ impl MicInput {
             )
             .with_alive(alive)
             .with_dropped_samples(dropped_samples, "mic_samples_dropped"),
-        }
+        })
     }
 }
 
@@ -319,21 +337,40 @@ mod tests {
     use super::*;
     use futures_util::StreamExt;
 
+    fn rms(samples: &[f32]) -> f32 {
+        (samples.iter().map(|sample| sample * sample).sum::<f32>() / samples.len() as f32).sqrt()
+    }
+
     #[tokio::test]
-    #[ignore = "requires audio hardware"]
+    #[ignore = "requires audio hardware and speech near the microphone"]
     async fn test_mic() {
         let mic = MicInput::new(None).unwrap();
-        let mut stream = mic.stream();
+        let mut stream = mic.stream().unwrap();
 
         let mut buffer = Vec::new();
-        while let Some(sample) = stream.next().await {
-            buffer.push(sample);
-            if buffer.len() > 6000 {
-                break;
+        let timeout = tokio::time::sleep(tokio::time::Duration::from_secs(5));
+        tokio::pin!(timeout);
+
+        loop {
+            tokio::select! {
+                _ = &mut timeout => break,
+                sample = stream.next() => {
+                    match sample {
+                        Some(sample) => buffer.push(sample),
+                        None => panic!("microphone stream ended unexpectedly"),
+                    }
+                    if buffer.len() >= mic.sample_rate() as usize {
+                        break;
+                    }
+                }
             }
         }
 
-        assert!(buffer.iter().any(|x| *x != 0.0));
+        assert!(!buffer.is_empty(), "microphone produced no samples");
+        assert!(
+            rms(&buffer) > 1e-4,
+            "microphone capture was silent; speak while running this test"
+        );
     }
 
     #[tokio::test]
@@ -350,7 +387,7 @@ mod tests {
         let chunk_size = chunk_size_for_stt(target_rate);
         println!("target_rate: {}, chunk_size: {}", target_rate, chunk_size);
 
-        let stream = mic.stream();
+        let stream = mic.stream().unwrap();
         let mut resampled = stream.resampled_chunks(target_rate, chunk_size).unwrap();
 
         let mut chunks_received = 0;

--- a/crates/audio-actual/src/mic.rs
+++ b/crates/audio-actual/src/mic.rs
@@ -146,7 +146,7 @@ impl MicInput {
         let alive_for_thread = alive.clone();
         let dropped_for_thread = dropped_samples.clone();
 
-        std::thread::spawn(move || {
+        let capture_thread = std::thread::spawn(move || {
             fn build_stream<S: ToSample<f32> + SizedSample>(
                 device: &cpal::Device,
                 config: &cpal::SupportedStreamConfig,
@@ -267,16 +267,24 @@ impl MicInput {
 
         match init_rx.recv_timeout(std::time::Duration::from_secs(5)) {
             Ok(Ok(())) => {}
+            // The thread returns right after reporting a failure, so joining here is
+            // immediate and guarantees the cpal stream is dropped before we return.
             Ok(Err(error)) => {
+                let _ = capture_thread.join();
                 return Err(crate::Error::MicStreamInitializationFailed(error));
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                // Deliberately not joined: a timeout means the thread is still inside
+                // build_input_stream, and waiting on it would reintroduce exactly the
+                // block this timeout exists to avoid. The drop signal is queued, so it
+                // tears down as soon as the driver returns.
                 let _ = drop_tx.send(());
                 return Err(crate::Error::MicStreamInitializationFailed(
                     "timed out while starting the microphone stream".to_string(),
                 ));
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                let _ = capture_thread.join();
                 return Err(crate::Error::MicStreamInitializationFailed(
                     "microphone capture stopped during initialization".to_string(),
                 ));

--- a/crates/audio-actual/src/speaker/linux.rs
+++ b/crates/audio-actual/src/speaker/linux.rs
@@ -240,6 +240,40 @@ fn pipewire_capture_loop(
     shutdown_rx: pw::channel::Receiver<()>,
     init_tx: std::sync::mpsc::Sender<Result<()>>,
 ) -> Result<()> {
+    // `init_tx` moves into the listener's user data partway through setup, so any
+    // failure would otherwise just drop the sender and reach the parent as a bare
+    // "stopped during initialization". This clone carries the real error instead.
+    // After a successful init the receiver is gone and the send is a no-op.
+    let setup_err_tx = init_tx.clone();
+
+    let result = pipewire_capture_setup(
+        producer,
+        waker,
+        wake_pending,
+        alive,
+        current_sample_rate,
+        dropped_samples,
+        shutdown_rx,
+        init_tx,
+    );
+
+    if let Err(error) = &result {
+        let _ = setup_err_tx.send(Err(anyhow::anyhow!(error.to_string())));
+    }
+
+    result
+}
+
+fn pipewire_capture_setup(
+    producer: HeapProd<f32>,
+    waker: Arc<AtomicWaker>,
+    wake_pending: Arc<AtomicBool>,
+    alive: Arc<AtomicBool>,
+    current_sample_rate: Arc<AtomicU32>,
+    dropped_samples: Arc<AtomicUsize>,
+    shutdown_rx: pw::channel::Receiver<()>,
+    init_tx: std::sync::mpsc::Sender<Result<()>>,
+) -> Result<()> {
     pw::init();
     let _deinit_guard = PipeWireDeinitGuard;
 

--- a/crates/audio-actual/src/speaker/linux.rs
+++ b/crates/audio-actual/src/speaker/linux.rs
@@ -15,10 +15,7 @@ use pulse::sample::{Format, Spec};
 use pulse::stream::{FlagSet as StreamFlagSet, Stream as PaStream};
 use pw::properties::properties;
 use pw::spa::utils::Direction;
-use ringbuf::{
-    HeapCons, HeapProd, HeapRb,
-    traits::{Producer, Split},
-};
+use ringbuf::{HeapCons, HeapProd, HeapRb, traits::Split};
 
 use crate::async_ring::RingbufAsyncReader;
 use crate::rt_ring::push_f32le_bytes_first_channel_to_ringbuf;
@@ -51,6 +48,7 @@ enum BackendControl {
 
 struct PipeWireUserData {
     format: pw::spa::param::audio::AudioInfoRaw,
+    init_tx: Option<std::sync::mpsc::Sender<Result<()>>>,
     producer: HeapProd<f32>,
     waker: Arc<AtomicWaker>,
     wake_pending: Arc<AtomicBool>,
@@ -133,10 +131,14 @@ impl SpeakerStream {
                 let _ = capture_thread.join();
                 return Err(err);
             }
-            Err(_) => {
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                 let _ = shutdown_tx.send(());
                 let _ = capture_thread.join();
                 anyhow::bail!("Timed out initializing PipeWire speaker capture");
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                let _ = capture_thread.join();
+                anyhow::bail!("PipeWire speaker capture stopped during initialization");
             }
         }
 
@@ -200,10 +202,14 @@ impl SpeakerStream {
                 let _ = capture_thread.join();
                 return Err(err);
             }
-            Err(_) => {
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                 running.store(false, Ordering::Release);
                 let _ = capture_thread.join();
                 anyhow::bail!("Timed out initializing PulseAudio speaker capture");
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                let _ = capture_thread.join();
+                anyhow::bail!("PulseAudio speaker capture stopped during initialization");
             }
         }
 
@@ -265,6 +271,7 @@ fn pipewire_capture_loop(
     let _listener = stream
         .add_local_listener_with_user_data(PipeWireUserData {
             format: Default::default(),
+            init_tx: Some(init_tx),
             producer,
             waker,
             wake_pending,
@@ -274,10 +281,15 @@ fn pipewire_capture_loop(
         })
         .state_changed({
             let mainloop = mainloop.clone();
-            move |_, _, old, new| {
+            move |_, user_data, old, new| {
                 tracing::debug!(?old, ?new, "pipewire_stream_state_changed");
                 if let pw::stream::StreamState::Error(error) = new {
                     tracing::error!(error = %error, "pipewire_stream_error");
+                    if let Some(init_tx) = user_data.init_tx.take() {
+                        let _ = init_tx.send(Err(anyhow::anyhow!(
+                            "PipeWire stream entered an error state: {error}"
+                        )));
+                    }
                     mainloop.quit();
                 }
             }
@@ -308,6 +320,9 @@ fn pipewire_capture_loop(
                         hyprnote.audio.sample_rate_hz = rate,
                         "pipewire_capture_initialized"
                     );
+                    if let Some(init_tx) = user_data.init_tx.take() {
+                        let _ = init_tx.send(Ok(()));
+                    }
                 }
             }
         })
@@ -383,7 +398,6 @@ fn pipewire_capture_loop(
         )
         .context("Failed to connect PipeWire capture stream")?;
 
-    let _ = init_tx.send(Ok(()));
     mainloop.run();
 
     alive.store(false, Ordering::Release);

--- a/crates/audio-actual/src/speaker/mod.rs
+++ b/crates/audio-actual/src/speaker/mod.rs
@@ -277,30 +277,17 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[tokio::test]
     #[serial]
-    #[ignore = "requires audio hardware"]
+    #[ignore = "requires Linux audio hardware and active system playback"]
     async fn test_linux() {
-        let input = match SpeakerInput::new() {
-            Ok(input) => input,
-            Err(e) => {
-                println!("Failed to create SpeakerInput: {}", e);
-                println!(
-                    "This is expected if PulseAudio is not running or no audio devices are available"
-                );
-                return;
-            }
-        };
+        let input = SpeakerInput::new().expect("failed to create Linux speaker input");
 
         let sample_rate = input.sample_rate();
         println!("Linux speaker sample rate: {}", sample_rate);
         assert!(sample_rate > 0);
 
-        let mut stream = match input.stream() {
-            Ok(stream) => stream,
-            Err(e) => {
-                println!("Failed to create speaker stream: {}", e);
-                return;
-            }
-        };
+        let mut stream = input
+            .stream()
+            .expect("failed to initialize Linux system audio capture");
 
         let stream_sample_rate = stream.sample_rate();
         println!("Linux speaker stream sample rate: {}", stream_sample_rate);
@@ -308,33 +295,38 @@ mod tests {
 
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-        let mut sample_count = 0;
-        let timeout = tokio::time::sleep(tokio::time::Duration::from_secs(2));
+        let mut samples = Vec::new();
+        let timeout = tokio::time::sleep(tokio::time::Duration::from_secs(5));
         tokio::pin!(timeout);
 
         loop {
             tokio::select! {
                 _ = &mut timeout => {
-                    println!("Timeout reached after collecting {} samples", sample_count);
                     break;
                 }
                 sample = stream.next() => {
-                    if let Some(_s) = sample {
-                        sample_count += 1;
-                        if sample_count >= 1000 {
-                            break;
-                        }
-                    } else {
+                    match sample {
+                        Some(sample) => samples.push(sample),
+                        None => panic!("Linux system audio capture ended unexpectedly"),
+                    }
+                    if samples.len() >= stream_sample_rate as usize {
                         break;
                     }
                 }
             }
         }
 
-        println!("Received {} samples from Linux speaker", sample_count);
+        println!("Received {} samples from Linux speaker", samples.len());
         assert!(
-            sample_count > 0,
-            "Should receive audio samples from speaker monitor"
+            !samples.is_empty(),
+            "system audio capture produced no samples"
+        );
+        let rms = (samples.iter().map(|sample| sample * sample).sum::<f32>()
+            / samples.len() as f32)
+            .sqrt();
+        assert!(
+            rms > 1e-4,
+            "system audio capture was silent; play audio while running this test"
         );
     }
 }

--- a/crates/audio/src/lib.rs
+++ b/crates/audio/src/lib.rs
@@ -12,8 +12,12 @@ pub enum Error {
     MicOpenFailed,
     #[error("mic_stream_setup_failed")]
     MicStreamSetupFailed,
+    #[error("microphone capture initialization failed: {0}")]
+    MicStreamInitializationFailed(String),
     #[error("speaker_stream_setup_failed")]
     SpeakerStreamSetupFailed,
+    #[error("system audio capture initialization failed: {0}")]
+    SpeakerStreamInitializationFailed(String),
     #[error("mic_resample_failed")]
     MicResampleFailed,
     #[error("speaker_resample_failed")]


### PR DESCRIPTION
Wait for mic startup and PipeWire format negotiation, preserve actionable setup errors, and require non-silent hardware diagnostics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes synchronous initialization and error propagation on all mic/speaker open paths; mic init timeout intentionally avoids joining a stuck driver thread, which affects cleanup behavior on failure.
> 
> **Overview**
> Capture setup now **fails fast with descriptive errors** instead of returning streams that never produce audio or panicking on speaker open.
> 
> **Microphone:** `MicInput::stream()` returns `Result` and blocks up to 5s on an init handshake from the cpal capture thread (build/play failures, unsupported formats, timeout, or early thread exit). Callers such as `AudioInput::stream`, capture setup, and `probe_mic` propagate `MicStreamInitializationFailed`.
> 
> **Linux system audio (PipeWire):** readiness is signaled only after **format negotiation** sets a valid sample rate (or on stream error), with a backup path so setup failures are not reported as a generic disconnect. Init wait paths distinguish timeout vs disconnect.
> 
> **API / errors:** `AudioInput::from_speaker()` and `stream()` are `Result`-based; speaker probe and capture map backend errors to `SpeakerStreamInitializationFailed`. Speaker sample rate is cached on `AudioInput` because `stream()` consumes the input.
> 
> **Tests:** ignored hardware tests require ~1s of non-silent audio (RMS threshold) rather than any non-zero sample.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4431090e36f69df65d97f8457f923ee57d737d06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->