### PR TITLE
Remove macOS sidebar gutter on Windows

### DIFF
--- a/apps/desktop/src/shared/hooks/useWindowControlsGutter.test.tsx
+++ b/apps/desktop/src/shared/hooks/useWindowControlsGutter.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCurrentWindow: vi.fn(),
+  isFullscreen: vi.fn(),
+  onResized: vi.fn(),
+  platform: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: mocks.getCurrentWindow,
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: mocks.platform,
+}));
+
+import { useWindowControlsGutter } from "./useWindowControlsGutter";
+
+describe("useWindowControlsGutter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isFullscreen.mockResolvedValue(false);
+    mocks.onResized.mockResolvedValue(vi.fn());
+    mocks.getCurrentWindow.mockReturnValue({
+      isFullscreen: mocks.isFullscreen,
+      onResized: mocks.onResized,
+    });
+  });
+
+  afterEach(cleanup);
+
+  it.each(["windows", "linux"])(
+    "does not reserve macOS window controls on %s",
+    (runtimePlatform) => {
+      mocks.platform.mockReturnValue(runtimePlatform);
+
+      const { result } = renderHook(() => useWindowControlsGutter());
+
+      expect(result.current).toBe(false);
+      expect(mocks.getCurrentWindow).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps the preview gutter when the runtime platform is unavailable", () => {
+    mocks.platform.mockImplementation(() => {
+      throw new Error("Tauri runtime unavailable");
+    });
+
+    const { result } = renderHook(() => useWindowControlsGutter());
+
+    expect(result.current).toBe(true);
+    expect(mocks.getCurrentWindow).not.toHaveBeenCalled();
+  });
+
+  it("keeps the macOS gutter outside fullscreen", async () => {
+    mocks.platform.mockReturnValue("macos");
+
+    const { result } = renderHook(() => useWindowControlsGutter());
+
+    expect(result.current).toBe(true);
+    await waitFor(() => expect(mocks.isFullscreen).toHaveBeenCalledOnce());
+    expect(result.current).toBe(true);
+  });
+
+  it("removes the macOS gutter in fullscreen", async () => {
+    mocks.platform.mockReturnValue("macos");
+    mocks.isFullscreen.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useWindowControlsGutter());
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+});

--- a/apps/desktop/src/shared/hooks/useWindowControlsGutter.ts
+++ b/apps/desktop/src/shared/hooks/useWindowControlsGutter.ts
@@ -1,4 +1,3 @@
-import { isTauri } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { platform } from "@tauri-apps/plugin-os";
 import { useState } from "react";
@@ -6,12 +5,14 @@ import { useState } from "react";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 export function useWindowControlsGutter() {
-  const [visible, setVisible] = useState(
-    () => !isTauri() || platform() === "macos",
-  );
+  const [visible, setVisible] = useState(() => {
+    const runtimePlatform = getRuntimePlatform();
+
+    return runtimePlatform === null || runtimePlatform === "macos";
+  });
 
   useMountEffect(() => {
-    if (!isTauri() || platform() !== "macos") {
+    if (getRuntimePlatform() !== "macos") {
       return;
     }
 
@@ -48,4 +49,12 @@ export function useWindowControlsGutter() {
   });
 
   return visible;
+}
+
+function getRuntimePlatform() {
+  try {
+    return platform();
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
Detect the runtime platform without relying on the missing Tauri marker and cover Windows, Linux, macOS, and browser fallbacks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout-only change in the desktop app with explicit tests; no auth, data, or backend impact.
> 
> **Overview**
> Fixes **incorrect macOS-style left padding on Windows/Linux** by stopping use of `isTauri()` and instead reading the OS via `platform()` inside a safe `getRuntimePlatform()` helper.
> 
> **Gutter visibility** is now: **off** on `windows` and `linux`, **on** on `macos` (hidden in fullscreen via existing resize listener), and **on** when `platform()` throws (e.g. browser preview without Tauri).
> 
> Adds **unit tests** for those platform and fullscreen behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b79d6a84be09eaff3046c86188745059b2f3049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->