### PR TITLE
fix/windows-sidebar-gutter

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -454,7 +454,7 @@ describe("ClassicMainBody", () => {
       { state: { selectedMineId: null, selectedWebIndex: null } },
     ],
   ] as const)(
-    "uses compact %s spacing for the %s back button",
+    "uses the 8px %s fallback gutter for the %s back button",
     (runtimePlatform, type, extraTabState) => {
       mocks.runtimePlatform = runtimePlatform;
       mocks.currentTab = {

--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { commands } from "~/types/tauri.gen";
 
 const mocks = vi.hoisted(() => ({
+  runtimePlatform: null as "windows" | "linux" | null,
   currentTab: {
     active: true,
     pinned: false,
@@ -57,6 +58,16 @@ const mocks = vi.hoisted(() => ({
     | ((
         status: null | { itemKey: string; label: string; title: string },
       ) => void),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => {
+    if (mocks.runtimePlatform === null) {
+      throw new Error("Tauri runtime unavailable");
+    }
+
+    return mocks.runtimePlatform;
+  },
 }));
 
 vi.mock("@hypr/ui/components/ui/resizable", () => ({
@@ -259,6 +270,7 @@ function rectWithWidth(width: number) {
 describe("ClassicMainBody", () => {
   beforeEach(() => {
     cleanup();
+    mocks.runtimePlatform = null;
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
       value: 1600,
@@ -423,6 +435,43 @@ describe("ClassicMainBody", () => {
       "12.5%",
     );
   });
+
+  it.each([
+    ["windows", "settings", { state: { tab: "app" } }],
+    ["windows", "calendar", {}],
+    ["windows", "contacts", { state: { selected: null } }],
+    [
+      "windows",
+      "templates",
+      { state: { selectedMineId: null, selectedWebIndex: null } },
+    ],
+    ["linux", "settings", { state: { tab: "app" } }],
+    ["linux", "calendar", {}],
+    ["linux", "contacts", { state: { selected: null } }],
+    [
+      "linux",
+      "templates",
+      { state: { selectedMineId: null, selectedWebIndex: null } },
+    ],
+  ] as const)(
+    "uses compact %s spacing for the %s back button",
+    (runtimePlatform, type, extraTabState) => {
+      mocks.runtimePlatform = runtimePlatform;
+      mocks.currentTab = {
+        active: true,
+        pinned: false,
+        slotId: `slot-${type}`,
+        type,
+        ...extraTabState,
+      };
+
+      render(<ClassicMainBody />);
+
+      const backButton = screen.getByRole("button", { name: "Go back" });
+      expect(backButton.parentElement?.className).toContain("pl-2");
+      expect(backButton.parentElement?.className).not.toContain("pl-[76px]");
+    },
+  );
 
   it("settles the startup left sidebar default against the rendered body width", async () => {
     let bodyWidth = 1000;

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -475,7 +475,7 @@ export function ClassicMainBody() {
       data-sidebar-timeline-header
       className={cn([
         "flex h-9 shrink-0 items-start pt-[9px] pr-1",
-        showWindowControlsGutter ? "pl-[76px]" : "pl-0",
+        showWindowControlsGutter ? "pl-[76px]" : "pl-2",
       ])}
       onWheelCapture={handleSidebarTimelineHeaderWheel}
     >
@@ -517,7 +517,7 @@ export function ClassicMainBody() {
             data-tauri-drag-region
             className={cn([
               "flex h-full min-w-0 items-start pt-[9px] pr-1",
-              showWindowControlsGutter ? "pl-[76px]" : "pl-0",
+              showWindowControlsGutter ? "pl-[76px]" : "pl-2",
             ])}
           >
             <SidebarTimelineChromeWithUpcomingMeeting
@@ -547,7 +547,7 @@ export function ClassicMainBody() {
             data-tauri-drag-region
             className={cn([
               "flex h-full min-w-0 items-start pt-1",
-              showWindowControlsGutter ? "pl-[76px]" : "pl-0",
+              showWindowControlsGutter ? "pl-[76px]" : "pl-2",
             ])}
           />
         </div>

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -353,7 +353,7 @@ describe("ClassicMainBody", () => {
       });
 
       await waitFor(() => {
-        expect(chromeFrame?.className).toContain("pl-0");
+        expect(chromeFrame?.className).toContain("pl-2");
       });
       expect(chromeFrame?.className).not.toContain("pl-[76px]");
     },
@@ -385,7 +385,7 @@ describe("ClassicMainBody", () => {
         expect(mocks.isFullscreen).toHaveBeenCalled();
       });
       expect(chromeFrame?.className).toContain("pl-[76px]");
-      expect(chromeFrame?.className).not.toContain("pl-0");
+      expect(chromeFrame?.className).not.toContain("pl-2");
     },
   );
 
@@ -419,7 +419,7 @@ describe("ClassicMainBody", () => {
       toggleLabel: "Show sidebar",
     },
   ] as const)(
-    "does not reserve the window controls gutter on $platformName with the sidebar $sidebarState",
+    "uses the 8px fallback gutter on $platformName with the sidebar $sidebarState",
     async ({ expanded, platform, toggleLabel }) => {
       mocks.leftSidebarExpanded = expanded;
       mocks.platform = platform;
@@ -432,7 +432,7 @@ describe("ClassicMainBody", () => {
         : sidebarToggle.parentElement?.parentElement?.parentElement;
 
       await waitFor(() => {
-        expect(chromeFrame?.className).toContain("pl-0");
+        expect(chromeFrame?.className).toContain("pl-2");
       });
       expect(chromeFrame?.className).not.toContain("pl-[76px]");
       expect(mocks.isFullscreen).not.toHaveBeenCalled();


### PR DESCRIPTION
- Remove the macOS-specific sidebar gutter behavior on Windows.
- Detect the runtime platform without relying on a missing Tauri marker, adding coverage for Windows, Linux, macOS, and browser fallbacks.
- Add a compact 8px left inset gutter for desktop Chrome across expanded, collapsed, and custom sidebar surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only Tailwind padding changes in desktop chrome with updated unit tests; no auth, data, or business-logic impact.
> 
> **Overview**
> When the main shell is **not** reserving space for native window controls (`showWindowControlsGutter` is false), left sidebar chrome no longer uses **zero** left padding. It now applies **`pl-2`** (8px) on the timeline header, collapsed sidebar chrome, empty top drag strip, and custom left-surface back-button row in `ClassicMainBody`.
> 
> Tests now expect **`pl-2`** instead of **`pl-0`** for fullscreen chrome and for Windows/Linux (expanded and collapsed). **`main/body.test.tsx`** mocks `@tauri-apps/plugin-os` and adds cases that the back button row uses the 8px fallback on Windows/Linux for settings, calendar, contacts, and templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81904bdcb29a04bf05f6cc167efa399c450fd89e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->