### PR TITLE
fix/slow-note-editor-keystrokes

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -35,6 +35,7 @@ import { initializeApplicationSettings } from "./settings/queries";
 import { initializeAppExitFlush } from "./shared/app-exit";
 import { useConfigValue } from "./shared/config";
 import { ErrorComponent, NotFoundComponent } from "./shared/control";
+import { startInteractionProfiler } from "./shared/perf/interaction-profiler";
 import { bootstrapThemeFromSettings } from "./shared/theme/apply";
 import { AppThemeProvider } from "./shared/theme/provider";
 import type { ThemePreference } from "./shared/theme/resolve";
@@ -135,6 +136,8 @@ async function enableReactScanInDev() {
   } catch (error) {
     console.warn("Failed to start React Scan:", error);
   }
+
+  startInteractionProfiler();
 }
 
 async function renderApp() {

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -132,6 +132,14 @@ const EnhancedEditorInner = forwardRef<
 
     const mentionConfig = useMentionConfig();
     const comments = useOwnedSessionComments(sessionId);
+    // Stable identity: NoteEditor keys whole-document memos off this.
+    const taskSource = useMemo(
+      () =>
+        persistChanges
+          ? ({ type: "enhanced_note", id: enhancedNoteId } as const)
+          : undefined,
+      [persistChanges, enhancedNoteId],
+    );
 
     return (
       <AudioDropTarget
@@ -153,11 +161,7 @@ const EnhancedEditorInner = forwardRef<
             onNavigateToTitle={onNavigateToTitle}
             onLinkOpen={openEditorLink}
             fileHandlerConfig={fileHandlerConfig}
-            taskSource={
-              persistChanges
-                ? { type: "enhanced_note", id: enhancedNoteId }
-                : undefined
-            }
+            taskSource={taskSource}
             extraNodeViews={extraNodeViews}
             commentAnchorsEnabled
             onCommentAnchorsEvent={comments.onCommentAnchorsEvent}

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -116,6 +116,14 @@ export const RawEditor = forwardRef<
 
     const mentionConfig = useMentionConfig();
     const commentAnchors = useSessionCommentAnchors(sessionId);
+    // Stable identity: NoteEditor keys whole-document memos off this.
+    const taskSource = useMemo(
+      () =>
+        syncTasks
+          ? ({ type: "session_raw_note", id: sessionId } as const)
+          : undefined,
+      [syncTasks, sessionId],
+    );
     return (
       <AudioDropTarget
         targetProps={audioDropTargetProps}
@@ -135,11 +143,7 @@ export const RawEditor = forwardRef<
             onNavigateToTitle={onNavigateToTitle}
             onLinkOpen={openEditorLink}
             fileHandlerConfig={fileHandlerConfig}
-            taskSource={
-              syncTasks
-                ? { type: "session_raw_note", id: sessionId }
-                : undefined
-            }
+            taskSource={taskSource}
             extraNodeViews={extraNodeViews}
             showFormatToolbar={showFormatToolbar}
             commentAnchorsEnabled

--- a/apps/desktop/src/shared/perf/interaction-profiler.ts
+++ b/apps/desktop/src/shared/perf/interaction-profiler.ts
@@ -1,0 +1,125 @@
+/**
+ * Dev-only attribution for slow interactions.
+ *
+ * React Scan reports *how much* time an interaction spent outside React
+ * rendering, but not *which* function burned it. Long Animation Frames carry
+ * per-script attribution (source URL, function name, char offset), which is
+ * what actually names the culprit.
+ *
+ * LoAF is Chromium-only, so on WebKit (macOS Tauri) this degrades to reporting
+ * which keystrokes blocked and for how long; use Safari Web Inspector's
+ * Timeline for attribution there.
+ */
+
+type LoafScript = PerformanceEntry & {
+  duration: number;
+  invoker?: string;
+  invokerType?: string;
+  sourceURL?: string;
+  sourceFunctionName?: string;
+  sourceCharPosition?: number;
+  forcedStyleAndLayoutDuration?: number;
+};
+
+type LoafEntry = PerformanceEntry & {
+  blockingDuration: number;
+  renderStart: number;
+  styleAndLayoutStart: number;
+  scripts: LoafScript[];
+};
+
+const SLOW_FRAME_MS = 100;
+const SLOW_KEYSTROKE_MS = 100;
+
+function observe(type: string, handle: (entries: PerformanceEntry[]) => void) {
+  try {
+    const observer = new PerformanceObserver((list) =>
+      handle(list.getEntries()),
+    );
+    observer.observe({ type, buffered: true } as PerformanceObserverInit);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function reportLongAnimationFrames(entries: PerformanceEntry[]) {
+  for (const entry of entries as LoafEntry[]) {
+    if (entry.duration < SLOW_FRAME_MS) continue;
+
+    const scripts = [...(entry.scripts ?? [])]
+      .sort((left, right) => right.duration - left.duration)
+      .slice(0, 8)
+      .map((script) => ({
+        ms: Math.round(script.duration),
+        forcedLayoutMs: Math.round(script.forcedStyleAndLayoutDuration ?? 0),
+        fn: script.sourceFunctionName || "(anonymous)",
+        source: `${script.sourceURL ?? "?"}:${script.sourceCharPosition ?? -1}`,
+        invoker: `${script.invokerType ?? "?"} ${script.invoker ?? ""}`.trim(),
+      }));
+
+    console.group(
+      `[perf] long frame ${Math.round(entry.duration)}ms (blocking ${Math.round(entry.blockingDuration)}ms)`,
+    );
+    console.table(scripts);
+    console.groupEnd();
+  }
+}
+
+function reportSlowEvents(entries: PerformanceEntry[]) {
+  for (const entry of entries as PerformanceEventTiming[]) {
+    console.warn(
+      `[perf] slow ${entry.name}: total ${Math.round(entry.duration)}ms, ` +
+        `handlers ${Math.round(entry.processingEnd - entry.processingStart)}ms, ` +
+        `input delay ${Math.round(entry.processingStart - entry.startTime)}ms`,
+      entry.target,
+    );
+  }
+}
+
+/** Fallback for engines without Long Animation Frames (WebKit). */
+function watchKeystrokes() {
+  window.addEventListener(
+    "keydown",
+    (event) => {
+      const start = performance.now();
+      requestAnimationFrame(() => {
+        const blocked = performance.now() - start;
+        if (blocked < SLOW_KEYSTROKE_MS) return;
+        console.warn(
+          `[perf] keydown "${event.key}" blocked ${Math.round(blocked)}ms before the next frame`,
+        );
+      });
+    },
+    { capture: true },
+  );
+}
+
+export function startInteractionProfiler() {
+  if (!import.meta.env.DEV) return;
+
+  const hasLoaf = observe("long-animation-frame", reportLongAnimationFrames);
+
+  try {
+    const observer = new PerformanceObserver((list) =>
+      reportSlowEvents(list.getEntries()),
+    );
+    observer.observe({
+      type: "event",
+      durationThreshold: SLOW_FRAME_MS,
+      buffered: true,
+    } as PerformanceObserverInit);
+  } catch {
+    // Event Timing unavailable; the keystroke watcher still reports blocking.
+  }
+
+  watchKeystrokes();
+
+  if (!hasLoaf) {
+    console.info(
+      "[perf] Long Animation Frames unsupported (WebKit). Slow keystrokes will be " +
+        "reported without attribution -- run `pnpm -F @hypr/desktop dev` in Chrome, " +
+        "or profile with Safari Web Inspector, to name the function.",
+    );
+  }
+}

--- a/crates/db-core/tests/write_coalescing.rs
+++ b/crates/db-core/tests/write_coalescing.rs
@@ -1,0 +1,70 @@
+use db_core::Db;
+
+async fn setup() -> Db {
+    let db = Db::connect_memory().await.unwrap();
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS probe (
+            id TEXT PRIMARY KEY NOT NULL,
+            body TEXT NOT NULL DEFAULT ''
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    db.cloudsync_init("probe", None, None).await.unwrap();
+    db
+}
+
+async fn pending(db: &Db) -> (u64, u64) {
+    let rows: Vec<(i64, i64)> =
+        sqlx::query_as("SELECT rows, payload_size FROM cloudsync_payload_chunks")
+            .fetch_all(db.pool())
+            .await
+            .unwrap();
+    rows.iter().fold((0u64, 0u64), |(r, b), (rows, bytes)| {
+        (r + *rows as u64, b + *bytes as u64)
+    })
+}
+
+#[tokio::test]
+async fn repeated_writes_to_one_row_do_not_multiply_the_sync_payload() {
+    let body = "x".repeat(20_000);
+
+    let once = setup().await;
+    sqlx::query("INSERT INTO probe (id, body) VALUES ('note', ?)")
+        .bind(&body)
+        .execute(once.pool())
+        .await
+        .unwrap();
+    let single = pending(&once).await;
+
+    let many = setup().await;
+    sqlx::query("INSERT INTO probe (id, body) VALUES ('note', '')")
+        .execute(many.pool())
+        .await
+        .unwrap();
+    for i in 0..50 {
+        sqlx::query("UPDATE probe SET body = ? WHERE id = 'note'")
+            .bind(format!("{body}{i}"))
+            .execute(many.pool())
+            .await
+            .unwrap();
+    }
+    let repeated = pending(&many).await;
+
+    // One pending row either way: the changeset carries the row's current
+    // value, not an entry per write. Debouncing local writes therefore cannot
+    // reduce what sync ships -- only the sync interval and the payload shape
+    // can.
+    assert_eq!(single.0, 1, "a single write should stage one row");
+    assert_eq!(
+        repeated.0, 1,
+        "51 writes to one row should still stage one row"
+    );
+    assert!(
+        repeated.1 < single.1 * 2,
+        "payload should not grow with write count: {} vs {}",
+        repeated.1,
+        single.1
+    );
+}

--- a/packages/editor/src/note/index.test.ts
+++ b/packages/editor/src/note/index.test.ts
@@ -215,6 +215,33 @@ describe("browser-safe editor controls", () => {
     expect(handleChange).toHaveBeenCalledWith(baseDoc);
   });
 
+  it("persists during uninterrupted typing instead of waiting for a pause", async () => {
+    const ref = createRef<NoteEditorRef>();
+    const handleChange = vi.fn();
+    render(
+      createElement(NoteEditor, {
+        ref,
+        initialContent: baseDoc,
+        handleChange,
+        enforceTitleHeading: false,
+      }),
+    );
+    await waitFor(() => expect(ref.current?.view).not.toBeNull());
+    vi.useFakeTimers();
+
+    // Keystrokes arrive faster than the debounce delay for 25s, so the
+    // trailing edge never fires and only maxWait can force a write.
+    for (let keystroke = 0; keystroke < 100; keystroke++) {
+      act(() => {
+        const view = ref.current?.view;
+        view?.dispatch(view.state.tr.insertText("a", 4));
+      });
+      await act(() => vi.advanceTimersByTimeAsync(250));
+    }
+
+    expect(handleChange).toHaveBeenCalled();
+  });
+
   it("cancels the original debounce after callback-changing rerenders", async () => {
     const ref = createRef<NoteEditorRef>();
     const handleChange = vi.fn();

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -210,6 +210,18 @@ const baseNodeViews = {
 
 const COMPOSITION_SYNC_GRACE_MS = 500;
 
+// Stretching this delay does not reduce upload volume -- CloudSync stages a
+// row's current value, not one entry per write, so a sync tick ships the note
+// once however often it was written (crates/db-core/tests/write_coalescing.rs).
+// maxWait is the part that matters: trailing-only never fires while keystrokes
+// keep arriving under the delay, so a fluent burst could persist nothing for as
+// long as it lasted, losing all of it on an unclean exit and going stale for
+// readers that query session_documents instead of calling flushPendingChanges().
+// Must stay module-level -- useDebounceCallback memoizes on the options
+// identity, and a fresh object each render would drop the pending timer.
+const CHANGE_FLUSH_DEBOUNCE_MS = 500;
+const CHANGE_FLUSH_OPTIONS = { maxWait: 10_000, trailing: true } as const;
+
 export type CompositionState = {
   active: boolean;
   endedAt: number;
@@ -663,7 +675,11 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       (doc: PMNode) => flushChangeRef.current(doc),
       [],
     );
-    const onUpdate = useDebounceCallback(flushLatestChange, 500);
+    const onUpdate = useDebounceCallback(
+      flushLatestChange,
+      CHANGE_FLUSH_DEBOUNCE_MS,
+      CHANGE_FLUSH_OPTIONS,
+    );
     const onUpdateRef = useRef(onUpdate);
     onUpdateRef.current = onUpdate;
 

--- a/packages/editor/src/plugins/task-identity.ts
+++ b/packages/editor/src/plugins/task-identity.ts
@@ -1,18 +1,30 @@
 import type { Node as PMNode } from "prosemirror-model";
-import { Plugin } from "prosemirror-state";
+import { Plugin, PluginKey } from "prosemirror-state";
 
 import { createTaskId, createTaskItemId } from "../tasks";
 import { hasChangedNodeOfType } from "./changed-ranges";
 
+const taskIdentityPluginKey = new PluginKey<boolean>("taskIdentity");
+
 export function taskIdentityPlugin() {
-  return new Plugin({
-    appendTransaction(transactions, _oldState, newState) {
+  return new Plugin<boolean>({
+    key: taskIdentityPluginKey,
+    // Documents arrive from storage, paste and import, so the whole doc has to
+    // be swept once for missing/duplicate ids. Editing can only introduce them
+    // inside a changed range, so the sweep runs on the first edit after a state
+    // is created and never again -- otherwise every keystroke walks every node.
+    state: {
+      init: () => false,
+      apply: (transaction, swept) => swept || transaction.docChanged,
+    },
+    appendTransaction(transactions, oldState, newState) {
       if (!transactions.some((transaction) => transaction.docChanged)) {
         return null;
       }
       if (
         !hasChangedNodeOfType(newState.doc, transactions, "taskItem") &&
-        !hasInvalidTaskIdentity(newState.doc)
+        (taskIdentityPluginKey.getState(oldState) === true ||
+          !hasInvalidTaskIdentity(newState.doc))
       ) {
         return null;
       }


### PR DESCRIPTION
- Stop repeatedly re-walking the entire note on every keystroke; restrict expensive task-identity validation to run once per `EditorState`, and rely on changed-range checks for later transactions.  
- Memoize task content–related computations in `NoteEditor` by removing unstable inline taskSource object identity that previously forced re-sync/hydration and repeated JSON/string comparisons on every render.  
- Add a dev-only profiler to attribute slow interactions/keystrokes using Long Animation Frame script attribution (and degraded reporting on WebKit/Safari).  
- Cap how long typing can go unpersisted by adding `maxWait` (10s) to the note persist debounce; add a test to ensure a write occurs after sustained typing without idling.  
- Pin CloudSync write coalescing behavior (sync stages the row’s current value), confirming sync bandwidth is unaffected by local write frequency when using the editor’s debounce strategy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches note persistence timing and task-id ProseMirror plugin behavior; incorrect identity or debounce logic could affect task sync or data loss on crash, but changes are targeted with new tests.
> 
> **Overview**
> Improves **note editor responsiveness** by cutting per-keystroke work and avoiding unnecessary React/editor re-sync.
> 
> **`taskIdentityPlugin`** now tracks whether the document has already had a full identity sweep: it still walks the whole doc once (load/paste/import), but after the first edit it relies on changed-range checks instead of re-scanning every node on each keystroke.
> 
> **Raw and enhanced session editors** memoize `taskSource` so `NoteEditor`’s `useMemo` dependencies stay stable—inline objects were forcing repeated task hydration and JSON comparisons on every parent render.
> 
> **Persist debounce** keeps a 500ms trailing delay but adds **`maxWait: 10s`** with module-level options so timers aren’t reset each render; continuous typing still flushes periodically instead of waiting forever for a pause. A **Vitest** case covers sustained keystrokes; **`write_coalescing`** documents that CloudSync stages one row value, so longer debounce doesn’t shrink sync payload.
> 
> **Dev-only**: `startInteractionProfiler()` (with React Scan) logs slow Long Animation Frames / events and a WebKit keystroke-blocking fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595bb4b5c75b1596e2e825f38553d0e68ecb3991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->