### PR TITLE
Use square main surfaces on Windows and Linux

### DIFF
--- a/apps/desktop/src/shared/main/index.test.tsx
+++ b/apps/desktop/src/shared/main/index.test.tsx
@@ -2,6 +2,14 @@ import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({
+  platform: "macos" as "linux" | "macos" | "windows",
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => mocks.platform,
+}));
+
 vi.mock("@hypr/ui/components/ui/resizable", () => {
   return {
     ResizablePanelGroup: ({
@@ -45,6 +53,7 @@ import { StandardContentWrapper } from "./index";
 describe("StandardContentWrapper", () => {
   beforeEach(() => {
     cleanup();
+    mocks.platform = "macos";
   });
 
   it("renders a single full-height main panel", () => {
@@ -65,6 +74,23 @@ describe("StandardContentWrapper", () => {
       document.querySelector("[data-chat-floating-anchor]")?.className,
     ).toContain("rounded-xl");
   });
+
+  it.each(["windows", "linux"] as const)(
+    "uses square main panel corners on %s",
+    (currentPlatform) => {
+      mocks.platform = currentPlatform;
+
+      render(
+        <StandardContentWrapper>
+          <div data-testid="main-area" />
+        </StandardContentWrapper>,
+      );
+
+      expect(
+        document.querySelector("[data-chat-floating-anchor]")?.className,
+      ).not.toContain("rounded-xl");
+    },
+  );
 
   it("renders the floating button inside the main surface", () => {
     render(

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -1,3 +1,5 @@
+import { platform } from "@tauri-apps/plugin-os";
+
 import {
   ResizablePanel,
   ResizablePanelGroup,
@@ -47,6 +49,8 @@ function MainPanel({
   floatingButton?: React.ReactNode;
   noBorder: boolean;
 }) {
+  const isMacos = platform() === "macos";
+
   return (
     <div
       className={cn([
@@ -58,7 +62,7 @@ function MainPanel({
         data-chat-floating-anchor
         className={cn([
           "bg-card @container relative flex min-h-0 flex-1 flex-col overflow-hidden",
-          "rounded-xl",
+          isMacos && "rounded-xl",
           !noBorder && "border-border border",
         ])}
       >

--- a/apps/desktop/src/shared/main/shell-scaffold.test.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.test.tsx
@@ -3,6 +3,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   currentTab: { type: "empty" } as { type: string } | null,
+  platform: "macos" as "linux" | "macos" | "windows",
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => mocks.platform,
 }));
 
 vi.mock("~/calendar/components/context", () => ({
@@ -23,6 +28,7 @@ describe("MainShellScaffold", () => {
   afterEach(() => {
     cleanup();
     mocks.currentTab = { type: "empty" };
+    mocks.platform = "macos";
   });
 
   it("keeps the top border for regular top chrome", () => {
@@ -56,4 +62,26 @@ describe("MainShellScaffold", () => {
     );
     expect(shell.className).not.toContain("pl-1");
   });
+
+  it.each([
+    ["windows", "left", "rounded-l-xl"],
+    ["windows", "top", "rounded-t-xl"],
+    ["linux", "left", "rounded-l-xl"],
+    ["linux", "top", "rounded-t-xl"],
+  ] as const)(
+    "does not add %s main surface rounding for %s chrome",
+    (currentPlatform, mainSurfaceChrome, roundedClass) => {
+      mocks.platform = currentPlatform;
+
+      render(
+        <MainShellScaffold mainSurfaceChrome={mainSurfaceChrome}>
+          <div data-chat-floating-anchor data-testid="main-surface" />
+        </MainShellScaffold>,
+      );
+
+      expect(screen.getByTestId("main-app-shell").className).not.toContain(
+        roundedClass,
+      );
+    },
+  );
 });

--- a/apps/desktop/src/shared/main/shell-scaffold.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.tsx
@@ -1,3 +1,4 @@
+import { platform } from "@tauri-apps/plugin-os";
 import { Fragment } from "react";
 
 import { cn } from "@hypr/utils";
@@ -18,6 +19,7 @@ export function MainShellScaffold({
 }) {
   const currentTab = useTabs((state) => state.currentTab);
   const isCalendarMode = currentTab?.type === "calendar";
+  const isMacos = platform() === "macos";
   const SyncWrapper = isCalendarMode ? SyncProvider : Fragment;
   const resolvedMainSurfaceChrome =
     mainSurfaceChrome ?? (edgeToEdge ? "top" : "default");
@@ -32,7 +34,7 @@ export function MainShellScaffold({
           "bg-background flex h-full gap-1 overflow-hidden",
           !hasTopMainSurfaceChrome && "pl-1",
           hasTopMainSurfaceChrome && [
-            "[&_[data-chat-floating-anchor]]:rounded-t-xl",
+            isMacos && "[&_[data-chat-floating-anchor]]:rounded-t-xl",
             "[&_[data-chat-floating-anchor]]:rounded-b-none",
             "[&_[data-chat-floating-anchor]]:border-x-0",
             resolvedMainSurfaceChrome === "top"
@@ -41,7 +43,7 @@ export function MainShellScaffold({
             "[&_[data-chat-floating-anchor]]:border-b-0",
           ],
           resolvedMainSurfaceChrome === "left" && [
-            "[&_[data-chat-floating-anchor]]:rounded-l-xl",
+            isMacos && "[&_[data-chat-floating-anchor]]:rounded-l-xl",
             "[&_[data-chat-floating-anchor]]:rounded-r-none",
             "[&_[data-chat-floating-anchor]]:border-y-0",
             "[&_[data-chat-floating-anchor]]:border-r-0",


### PR DESCRIPTION
Keep rounded main chrome on macOS while removing it on Windows and Linux.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic className changes in desktop shell layout with no auth, data, or API impact; behavior is covered by new platform-specific tests.
> 
> **Overview**
> **Main content chrome is now platform-aware:** rounded corners on the main surface (`data-chat-floating-anchor`) apply only on **macOS**; **Windows** and **Linux** get square edges.
> 
> `StandardContentWrapper` / `MainPanel` applies `rounded-xl` only when `platform() === "macos"`. `MainShellScaffold` gates `rounded-t-xl` and `rounded-l-xl` shell overrides the same way for top and left chrome modes.
> 
> Tests mock `@tauri-apps/plugin-os` and assert macOS keeps rounding while Windows/Linux omit the rounded classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d606f5084e80b5d7d26c5ccc02ceaa8d7b339ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->