### PR TITLE
Add cross-platform download page

### DIFF
--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -13,6 +13,9 @@ export function SiteFooter() {
         <span>© 2026</span>
       </a>
       <nav className="flex flex-wrap gap-x-5 gap-y-2">
+        <Link to="/download/" className="hover:text-[#181613]">
+          Download
+        </Link>
         <a
           href="https://github.com/fastrepl/anarlog"
           className="hover:text-[#181613]"

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -1,5 +1,65 @@
-export const appleSiliconDownloadUrl =
-  "https://cdn.crabnebula.app/download/fastrepl/hyprnote2/latest/platform/dmg-aarch64?channel=stable";
+const latestStableDownloadUrl =
+  "https://cdn.crabnebula.app/download/fastrepl/hyprnote2/latest/platform";
 
-export const appleIntelDownloadUrl =
-  "https://cdn.crabnebula.app/download/fastrepl/hyprnote2/latest/platform/dmg-x86_64?channel=stable";
+function getStableDownloadUrl(platform: string) {
+  return `${latestStableDownloadUrl}/${platform}?channel=stable`;
+}
+
+export const appleSiliconDownloadUrl = getStableDownloadUrl("dmg-aarch64");
+export const appleIntelDownloadUrl = getStableDownloadUrl("dmg-x86_64");
+
+export const desktopDownloadSections = [
+  {
+    name: "macOS",
+    description: "Choose the build that matches your Mac.",
+    downloads: [
+      {
+        name: "Apple Silicon",
+        detail: "M-series Mac · DMG",
+        url: appleSiliconDownloadUrl,
+      },
+      {
+        name: "Intel",
+        detail: "Intel-based Mac · DMG",
+        url: appleIntelDownloadUrl,
+      },
+    ],
+  },
+  {
+    name: "Windows",
+    description: "Installer for 64-bit Windows PCs.",
+    downloads: [
+      {
+        name: "Windows x64",
+        detail: "NSIS installer · EXE",
+        url: getStableDownloadUrl("nsis-x86_64"),
+      },
+    ],
+  },
+  {
+    name: "Linux",
+    description: "Portable AppImage and Debian packages for x64 and ARM64.",
+    downloads: [
+      {
+        name: "AppImage x64",
+        detail: "Intel or AMD 64-bit · AppImage",
+        url: getStableDownloadUrl("appimage-x86_64"),
+      },
+      {
+        name: "Debian x64",
+        detail: "Debian or Ubuntu · DEB",
+        url: getStableDownloadUrl("deb-x86_64"),
+      },
+      {
+        name: "AppImage ARM64",
+        detail: "64-bit ARM · AppImage",
+        url: getStableDownloadUrl("appimage-aarch64"),
+      },
+      {
+        name: "Debian ARM64",
+        detail: "Debian or Ubuntu on 64-bit ARM · DEB",
+        url: getStableDownloadUrl("deb-aarch64"),
+      },
+    ],
+  },
+] as const;

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -27,7 +27,8 @@ export const desktopDownloadSections = [
   },
   {
     name: "Windows",
-    description: "Installer for 64-bit Windows PCs.",
+    description:
+      "Preview installer for 64-bit Windows PCs. Physical audio and AEC validation is pending.",
     downloads: [
       {
         name: "Windows x64",
@@ -38,7 +39,8 @@ export const desktopDownloadSections = [
   },
   {
     name: "Linux",
-    description: "Portable AppImage and Debian packages for x64 and ARM64.",
+    description:
+      "Beta AppImage and Debian packages for x64 and ARM64. Physical audio and AEC validation is pending.",
     downloads: [
       {
         name: "AppImage x64",

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -53,8 +53,8 @@ export function getSoftwareApplicationJsonLd({
     url,
     description,
     applicationCategory: "ProductivityApplication",
-    operatingSystem: "macOS",
-    downloadUrl: ANARLOG_SITE_URL,
+    operatingSystem: ["macOS", "Windows", "Linux"],
+    downloadUrl: `${ANARLOG_SITE_URL}/download`,
     publisher: getOrganizationJsonLd(),
     ...(featureList ? { featureList } : {}),
     ...(aggregateOffer

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as ApiTemplatesRouteImport } from './routes/api/templates'
 import { Route as ApiShortcutsRouteImport } from './routes/api/shortcuts'
 import { Route as ApiMediaUploadRouteImport } from './routes/api/media-upload'
 import { Route as ViewAppRouteRouteImport } from './routes/_view/app/route'
+import { Route as ViewDownloadIndexRouteImport } from './routes/_view/download/index'
 import { Route as ViewAppIndexRouteImport } from './routes/_view/app/index'
 import { Route as SharePublicPublicSlugRouteImport } from './routes/share/public/$publicSlug'
 import { Route as ShareLinkShareIdRouteImport } from './routes/share/link/$shareId'
@@ -165,6 +166,11 @@ const ApiMediaUploadRoute = ApiMediaUploadRouteImport.update({
 const ViewAppRouteRoute = ViewAppRouteRouteImport.update({
   id: '/app',
   path: '/app',
+  getParentRoute: () => ViewRouteRoute,
+} as any)
+const ViewDownloadIndexRoute = ViewDownloadIndexRouteImport.update({
+  id: '/download/',
+  path: '/download/',
   getParentRoute: () => ViewRouteRoute,
 } as any)
 const ViewAppIndexRoute = ViewAppIndexRouteImport.update({
@@ -462,6 +468,7 @@ export interface FileRoutesByFullPath {
   '/share/link/$shareId': typeof ShareLinkShareIdRoute
   '/share/public/$publicSlug': typeof SharePublicPublicSlugRoute
   '/app/': typeof ViewAppIndexRoute
+  '/download/': typeof ViewDownloadIndexRoute
   '/api/admin/blog/upload-image': typeof ApiAdminBlogUploadImageRoute
   '/api/admin/content/audit': typeof ApiAdminContentAuditRoute
   '/api/admin/content/create': typeof ApiAdminContentCreateRoute
@@ -530,6 +537,7 @@ export interface FileRoutesByTo {
   '/share/link/$shareId': typeof ShareLinkShareIdRoute
   '/share/public/$publicSlug': typeof SharePublicPublicSlugRoute
   '/app': typeof ViewAppIndexRoute
+  '/download': typeof ViewDownloadIndexRoute
   '/api/admin/blog/upload-image': typeof ApiAdminBlogUploadImageRoute
   '/api/admin/content/audit': typeof ApiAdminContentAuditRoute
   '/api/admin/content/create': typeof ApiAdminContentCreateRoute
@@ -601,6 +609,7 @@ export interface FileRoutesById {
   '/share/link/$shareId': typeof ShareLinkShareIdRoute
   '/share/public/$publicSlug': typeof SharePublicPublicSlugRoute
   '/_view/app/': typeof ViewAppIndexRoute
+  '/_view/download/': typeof ViewDownloadIndexRoute
   '/api/admin/blog/upload-image': typeof ApiAdminBlogUploadImageRoute
   '/api/admin/content/audit': typeof ApiAdminContentAuditRoute
   '/api/admin/content/create': typeof ApiAdminContentCreateRoute
@@ -672,6 +681,7 @@ export interface FileRouteTypes {
     | '/share/link/$shareId'
     | '/share/public/$publicSlug'
     | '/app/'
+    | '/download/'
     | '/api/admin/blog/upload-image'
     | '/api/admin/content/audit'
     | '/api/admin/content/create'
@@ -740,6 +750,7 @@ export interface FileRouteTypes {
     | '/share/link/$shareId'
     | '/share/public/$publicSlug'
     | '/app'
+    | '/download'
     | '/api/admin/blog/upload-image'
     | '/api/admin/content/audit'
     | '/api/admin/content/create'
@@ -810,6 +821,7 @@ export interface FileRouteTypes {
     | '/share/link/$shareId'
     | '/share/public/$publicSlug'
     | '/_view/app/'
+    | '/_view/download/'
     | '/api/admin/blog/upload-image'
     | '/api/admin/content/audit'
     | '/api/admin/content/create'
@@ -1028,6 +1040,13 @@ declare module '@tanstack/react-router' {
       path: '/app'
       fullPath: '/app'
       preLoaderRoute: typeof ViewAppRouteRouteImport
+      parentRoute: typeof ViewRouteRoute
+    }
+    '/_view/download/': {
+      id: '/_view/download/'
+      path: '/download'
+      fullPath: '/download/'
+      preLoaderRoute: typeof ViewDownloadIndexRouteImport
       parentRoute: typeof ViewRouteRoute
     }
     '/_view/app/': {
@@ -1413,6 +1432,7 @@ interface ViewRouteRouteChildren {
   ViewCallbackSignoutRoute: typeof ViewCallbackSignoutRoute
   ViewDownloadAppleIntelRoute: typeof ViewDownloadAppleIntelRoute
   ViewDownloadAppleSiliconRoute: typeof ViewDownloadAppleSiliconRoute
+  ViewDownloadIndexRoute: typeof ViewDownloadIndexRoute
 }
 
 const ViewRouteRouteChildren: ViewRouteRouteChildren = {
@@ -1423,6 +1443,7 @@ const ViewRouteRouteChildren: ViewRouteRouteChildren = {
   ViewCallbackSignoutRoute: ViewCallbackSignoutRoute,
   ViewDownloadAppleIntelRoute: ViewDownloadAppleIntelRoute,
   ViewDownloadAppleSiliconRoute: ViewDownloadAppleSiliconRoute,
+  ViewDownloadIndexRoute: ViewDownloadIndexRoute,
 }
 
 const ViewRouteRouteWithChildren = ViewRouteRoute._addFileChildren(

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -14,7 +14,7 @@ export const Route = createFileRoute("/_view/download/")({
       {
         name: "description",
         content:
-          "Download the latest stable Anarlog desktop app for macOS, Windows, or Linux.",
+          "Download Anarlog for macOS, Windows, or Linux. Every desktop build uses the same release version.",
       },
       { property: "og:title", content: "Download Anarlog" },
       { property: "og:url", content: `${ANARLOG_SITE_URL}/download` },
@@ -37,8 +37,8 @@ function Component() {
             Download Anarlog
           </h1>
           <p className="text-color-secondary mt-6 max-w-2xl text-xl leading-9">
-            Get the latest stable desktop release. macOS, Windows, and Linux
-            ship together with the same version.
+            macOS, Windows Preview, and Linux Beta ship together with the same
+            desktop version.
           </p>
         </section>
 

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -1,0 +1,99 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Download } from "lucide-react";
+
+import { SiteFooter } from "@/components/site-footer";
+import { desktopDownloadSections } from "@/lib/download";
+import { ANARLOG_SITE_URL } from "@/lib/seo";
+
+export const Route = createFileRoute("/_view/download/")({
+  component: Component,
+  head: () => ({
+    links: [{ rel: "canonical", href: `${ANARLOG_SITE_URL}/download` }],
+    meta: [
+      { title: "Download Anarlog" },
+      {
+        name: "description",
+        content:
+          "Download the latest stable Anarlog desktop app for macOS, Windows, or Linux.",
+      },
+      { property: "og:title", content: "Download Anarlog" },
+      { property: "og:url", content: `${ANARLOG_SITE_URL}/download` },
+    ],
+  }),
+});
+
+function Component() {
+  return (
+    <main className="surface text-color min-h-screen">
+      <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
+        <header>
+          <Link to="/" aria-label="Anarlog home">
+            <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
+          </Link>
+        </header>
+
+        <section className="pt-24 pb-16 md:pt-32">
+          <h1 className="font-hand text-color text-6xl leading-[0.98] font-semibold tracking-normal text-balance md:text-8xl">
+            Download Anarlog
+          </h1>
+          <p className="text-color-secondary mt-6 max-w-2xl text-xl leading-9">
+            Get the latest stable desktop release. macOS, Windows, and Linux
+            ship together with the same version.
+          </p>
+        </section>
+
+        <div className="grid gap-14 pb-12">
+          {desktopDownloadSections.map((section) => {
+            const headingId = `${section.name.toLowerCase()}-downloads`;
+
+            return (
+              <section key={section.name} aria-labelledby={headingId}>
+                <div className="mb-5">
+                  <h2
+                    id={headingId}
+                    className="font-mono text-2xl font-semibold"
+                  >
+                    {section.name}
+                  </h2>
+                  <p className="text-color-secondary mt-2 leading-7">
+                    {section.description}
+                  </p>
+                </div>
+
+                <ul className="border-color-subtle divide-y divide-[var(--color-border-subtle)] border-y">
+                  {section.downloads.map((download) => (
+                    <li key={download.name}>
+                      <a
+                        href={download.url}
+                        className="hover:bg-surface-subtle flex items-center justify-between gap-6 px-1 py-5 transition-colors"
+                      >
+                        <span className="min-w-0">
+                          <span className="block font-medium">
+                            {download.name}
+                          </span>
+                          <span className="text-color-secondary mt-1 block text-sm">
+                            {download.detail}
+                          </span>
+                        </span>
+                        <span className="inline-flex shrink-0 items-center gap-2 font-mono text-sm font-medium">
+                          Download
+                          <Download
+                            size={16}
+                            strokeWidth={2}
+                            aria-hidden="true"
+                          />
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+      </div>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -13,7 +13,6 @@ import {
 
 import { mdxComponents } from "@/components/mdx-components";
 import { SiteFooter } from "@/components/site-footer";
-import { appleSiliconDownloadUrl } from "@/lib/download";
 import { ANARLOG_SITE_URL, getBlogOgImageUrl } from "@/lib/seo";
 
 const blogMdxComponents = {
@@ -237,13 +236,13 @@ function BlogArticleCta() {
             Try Anarlog for private, local-first meeting notes on your Mac.
           </p>
         </div>
-        <a
-          href={appleSiliconDownloadUrl}
+        <Link
+          to="/download/"
           className="inline-flex h-12 shrink-0 items-center justify-center gap-2 rounded-full bg-[#181613] px-5 text-sm font-semibold text-white transition-colors hover:bg-[#363029]"
         >
           Try for free
           <ArrowRight size={17} strokeWidth={2.2} aria-hidden="true" />
-        </a>
+        </Link>
       </div>
     </aside>
   );

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -233,7 +233,7 @@ function BlogArticleCta() {
             Take notes without inviting a bot
           </p>
           <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-            Try Anarlog for private, local-first meeting notes on your Mac.
+            Try Anarlog for private, local-first meeting notes on your desktop.
           </p>
         </div>
         <Link

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,14 +1,13 @@
 import { Icon } from "@iconify-icon/react";
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import {
   ArrowRight,
-  ChevronDown,
   Cloud,
   Cpu,
   KeyRound,
   type LucideIcon,
 } from "lucide-react";
-import { type CSSProperties, useEffect, useRef, useState } from "react";
+import { type CSSProperties, useState } from "react";
 import { z } from "zod";
 
 import {
@@ -28,7 +27,6 @@ import {
 } from "@/functions/desktop-flow";
 import { getGitHubStats } from "@/functions/github";
 import { useMountEffect } from "@/hooks/useMountEffect";
-import { appleIntelDownloadUrl, appleSiliconDownloadUrl } from "@/lib/download";
 import {
   ANARLOG_SITE_URL,
   ROOT_DESCRIPTION,
@@ -554,8 +552,8 @@ function PricingCard({ plan }: { plan: MarketingPlanData }) {
       </div>
 
       <div className="mt-auto pt-6">
-        <a
-          href={appleSiliconDownloadUrl}
+        <Link
+          to="/download/"
           className={cn([
             "flex h-11 w-full items-center justify-center rounded-full text-sm font-medium transition-all hover:scale-[102%] active:scale-[98%]",
             plan.popular
@@ -566,7 +564,7 @@ function PricingCard({ plan }: { plan: MarketingPlanData }) {
           {plan.price
             ? `Download and start your ${PRO_TRIAL_DAYS}-day Pro trial`
             : "Download for free"}
-        </a>
+        </Link>
       </div>
     </article>
   );
@@ -582,19 +580,13 @@ function FinalCtaSection() {
         <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-[#4f4940]">
           Try Anarlog today and be present in meetings.
         </p>
-        <a
-          href={appleSiliconDownloadUrl}
+        <Link
+          to="/download/"
           className="mt-8 inline-flex items-center gap-2 rounded-full bg-[#181613] px-5 py-3 text-sm font-medium text-white"
         >
-          <Icon
-            icon="simple-icons:apple"
-            width={16}
-            height={16}
-            className="shrink-0"
-            aria-hidden="true"
-          />
           <span>Download for free</span>
-        </a>
+          <ArrowRight size={16} strokeWidth={2.2} aria-hidden="true" />
+        </Link>
       </div>
     </section>
   );
@@ -772,13 +764,13 @@ function TestimonialsSection() {
             Try for yourself.
           </p>
           <div className="mt-6 flex items-center justify-center">
-            <a
-              href={appleSiliconDownloadUrl}
+            <Link
+              to="/download/"
               className="inline-flex items-center gap-2 rounded-full bg-[#181613] px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-[#4f4940]"
             >
               Start using for free
               <ArrowRight size={16} strokeWidth={2.2} aria-hidden="true" />
-            </a>
+            </Link>
           </div>
         </div>
 
@@ -1290,80 +1282,13 @@ function HeroWorkflowDemo() {
 }
 
 function DownloadButton() {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const onPointerDown = (event: MouseEvent | TouchEvent) => {
-      if (!containerRef.current) return;
-      if (!containerRef.current.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-
-    document.addEventListener("mousedown", onPointerDown);
-    document.addEventListener("touchstart", onPointerDown);
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", onPointerDown);
-      document.removeEventListener("touchstart", onPointerDown);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [open]);
-
   return (
-    <div
-      ref={containerRef}
-      className="relative inline-flex text-sm font-medium"
+    <Link
+      to="/download/"
+      className="inline-flex items-center gap-2 rounded-full bg-[#181613] px-5 py-3 text-sm font-medium text-white"
     >
-      <a
-        href={appleSiliconDownloadUrl}
-        className="inline-flex items-center gap-1 rounded-l-full bg-[#181613] py-3 pr-1 pl-4 text-[13px] text-white sm:pl-5 sm:text-sm"
-      >
-        <Icon
-          icon="simple-icons:apple"
-          width={16}
-          height={16}
-          className="shrink-0"
-          aria-hidden="true"
-        />
-        <span>Download for Apple Silicon</span>
-      </a>
-      <button
-        type="button"
-        aria-label="Choose download platform"
-        aria-expanded={open}
-        aria-haspopup="menu"
-        onClick={() => setOpen((prev) => !prev)}
-        className="inline-flex h-full cursor-pointer items-center rounded-r-full bg-[#181613] py-3 pr-3 pl-2 text-white"
-      >
-        <ChevronDown size={17} strokeWidth={2.2} aria-hidden="true" />
-      </button>
-      {open && (
-        <div
-          role="menu"
-          className="absolute top-[calc(100%+0.5rem)] left-0 z-10 w-full max-w-[calc(100vw-2.5rem)] rounded-2xl border border-[#d8d0c5] bg-white p-2 shadow-[0_14px_40px_rgba(24,22,19,0.12)]"
-        >
-          <a
-            href={appleIntelDownloadUrl}
-            className="flex items-center gap-3 rounded-xl px-3 py-3 text-[#181613] transition-colors hover:bg-[#f7f4ef]"
-          >
-            <Icon
-              icon="simple-icons:apple"
-              width={20}
-              height={20}
-              className="shrink-0"
-              aria-hidden="true"
-            />
-            <span>Apple Intel</span>
-          </a>
-        </div>
-      )}
-    </div>
+      <span>Download Anarlog</span>
+      <ArrowRight size={16} strokeWidth={2.2} aria-hidden="true" />
+    </Link>
   );
 }

--- a/apps/web/src/utils/sitemap.ts
+++ b/apps/web/src/utils/sitemap.ts
@@ -51,6 +51,10 @@ export function getSitemap(): Sitemap<TRoutes> {
         priority: 0.7,
         changeFrequency: "weekly",
       },
+      "/download/": {
+        priority: 0.9,
+        changeFrequency: "weekly",
+      },
       "/changelog/$version": changelogVersions.map((version) => ({
         path: `/changelog/${version}`,
         priority: 0.5,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,6 +24,8 @@ const config = defineConfig(() => ({
         filter: ({ path }) => {
           return [
             "/",
+            "/download",
+            "/download/",
             "/blog",
             "/blog/",
             "/blog/char-is-now-anarlog",


### PR DESCRIPTION
List the latest stable macOS, Windows, and Linux builds by section, route generic download calls-to-action through the page, and include it in SEO and prerender output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-site routing and outbound download links only; no auth, billing, or app runtime changes. Main user-facing risk is CTAs no longer defaulting to immediate Mac Silicon download.
> 
> **Overview**
> Adds a **`/download/`** marketing page that lists stable CrabNebula builds for **macOS**, **Windows (preview)**, and **Linux (beta)**, driven by a shared `desktopDownloadSections` config in `download.ts`.
> 
> **Download URLs** are built through a single `getStableDownloadUrl` helper (existing Mac DMG exports are preserved for the legacy `/download/apple-*` redirect routes).
> 
> Site-wide **download CTAs** on the homepage, pricing cards, blog sidebar, and footer now link to `/download/` instead of jumping straight to the Apple Silicon CDN URL; the hero **Mac-only split button / platform dropdown** is removed in favor of one “Download Anarlog” link.
> 
> **SEO and discoverability**: structured data now advertises macOS/Windows/Linux and points `downloadUrl` at `/download`; the sitemap gives `/download/` high priority and prerender includes that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81e516f4542f820181f234b947f8ea56f43bded8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->