### PR TITLE
Ship matching cross-platform desktop releases

### DIFF
--- a/.github/actions/cn_download/action.yaml
+++ b/.github/actions/cn_download/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: "Release channel (stable)"
     required: true
   platform:
-    description: "Public platform (dmg-aarch64, dmg-x86_64, appimage-x86_64, debian-x86_64, appimage-aarch64, debian-aarch64)"
+    description: "CrabNebula public platform (for example dmg-aarch64, nsis-x86_64, appimage-x86_64, or deb-x86_64)"
     required: true
   output:
     description: "Output filename"
@@ -40,10 +40,12 @@ runs:
       run: |
         ASSET_ID=$(echo "$ASSETS" | jq -r --arg platform "$PLATFORM" '.assets[] | select(.publicPlatform == $platform) | .id')
         if [[ -z "$ASSET_ID" || "$ASSET_ID" == "null" ]]; then
-          echo "Asset not found for platform $PLATFORM"
+          echo "::error::Asset not found for platform $PLATFORM"
           echo "success=false" >> $GITHUB_OUTPUT
-          exit 0
+          exit 1
         fi
         echo "Downloading asset $ASSET_ID to $OUTPUT"
-        curl -L "https://cdn.crabnebula.app/asset/$ASSET_ID" -o "$OUTPUT"
+        curl --fail --show-error --location \
+          "https://cdn.crabnebula.app/asset/$ASSET_ID" \
+          --output "$OUTPUT"
         echo "success=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -146,6 +146,9 @@ jobs:
         working-directory: ./apps/desktop
       - run: |
           BUILD_ARGS=(--target "${{ matrix.target }}" --config "${{ env.TAURI_CONF_PATH }}" --verbose)
+          if [[ "${{ inputs.channel }}" == "stable" ]]; then
+            BUILD_ARGS+=(--config ./src-tauri/tauri.conf.stable-macos.json)
+          fi
           if [[ "${{ matrix.target }}" == "x86_64-apple-darwin" ]]; then
             BUILD_ARGS+=(--config ./src-tauri/tauri.conf.macos-intel.json)
           fi

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -734,7 +734,7 @@ jobs:
           fi
 
   cn-publish:
-    if: ${{ inputs.channel != 'staging' && inputs.publish }}
+    if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.verify-cn-release.result == 'success' && needs.create-tag.result == 'success' }}
     needs: [compute-version, verify-cn-release, create-tag]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -602,8 +602,11 @@ jobs:
           }
 
           $hash = (Get-FileHash -Algorithm SHA256 $installers[0].FullName).Hash.ToLowerInvariant()
-          "$hash  $($installers[0].Name)" |
-            Out-File "$($installers[0].FullName).sha256" -Encoding ascii
+          [System.IO.File]::WriteAllText(
+            "$($installers[0].FullName).sha256",
+            "$hash  $($installers[0].Name)`n",
+            [System.Text.Encoding]::ASCII
+          )
       - if: ${{ inputs.channel == 'stable' }}
         name: Verify Windows updater signature
         shell: bash

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -73,6 +73,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.compute-version.outputs.version }}"
+      - name: Verify stable signing credentials
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          missing=()
+          [[ -n "$WINDOWS_CERTIFICATE" ]] || missing+=("WINDOWS_CERTIFICATE")
+          [[ -n "$WINDOWS_CERTIFICATE_PASSWORD" ]] || missing+=("WINDOWS_CERTIFICATE_PASSWORD")
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::Stable Windows release signing is missing: ${missing[*]}"
+            exit 1
+          fi
       - uses: ./.github/actions/cn_release
         with:
           cmd: draft
@@ -163,6 +175,27 @@ jobs:
           VITE_API_URL: "https://api.anarlog.so"
           VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
           VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Verify macOS updater signature
+        run: |
+          shopt -s nullglob
+          updater_dir="apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/macos"
+          apps=("$updater_dir"/*.app)
+          artifacts=("$updater_dir"/*.app.tar.gz)
+          signatures=("$updater_dir"/*.app.tar.gz.sig)
+          if [[ ${#apps[@]} -ne 1 || ${#artifacts[@]} -ne 1 || ${#signatures[@]} -ne 1 ]]; then
+            echo "Expected one macOS app, updater artifact, and signature for ${{ matrix.target }}"
+            exit 1
+          fi
+          app_version=$(plutil -extract CFBundleShortVersionString raw -o - "${apps[0]}/Contents/Info.plist")
+          if [[ "$app_version" != "${{ needs.compute-version.outputs.version }}" ]]; then
+            echo "Expected macOS app version ${{ needs.compute-version.outputs.version }}, got $app_version"
+            exit 1
+          fi
+          cargo run --locked -p updater-core --bin verify-updater-signature -- \
+            "${artifacts[0]}" \
+            "${signatures[0]}" \
+            apps/desktop/src-tauri/tauri.conf.json
       - id: find-dmg
         shell: bash
         run: |
@@ -307,10 +340,29 @@ jobs:
             echo "Expected Debian architecture ${{ matrix.debian_arch }}, got $package_arch"
             exit 1
           fi
+          package_version=$(dpkg-deb --field "${debs[0]}" Version)
+          if [[ "$package_version" != "${{ needs.compute-version.outputs.version }}" ]]; then
+            echo "Expected Debian version ${{ needs.compute-version.outputs.version }}, got $package_version"
+            exit 1
+          fi
+          if [[ "$(basename "${appimages[0]}")" != *"${{ needs.compute-version.outputs.version }}"* ]]; then
+            echo "AppImage filename does not contain version ${{ needs.compute-version.outputs.version }}"
+            exit 1
+          fi
           if ! file "${appimages[0]}" | grep -Fq "${{ matrix.file_arch }}"; then
             file "${appimages[0]}"
             echo "AppImage architecture does not match ${{ matrix.target }}"
             exit 1
+          fi
+          if [[ "${{ inputs.channel }}" == "stable" ]]; then
+            cargo run --locked -p updater-core --bin verify-updater-signature -- \
+              "${appimages[0]}" \
+              "${appimage_signatures[0]}" \
+              apps/desktop/src-tauri/tauri.conf.json
+            cargo run --locked -p updater-core --bin verify-updater-signature -- \
+              "${debs[0]}" \
+              "${deb_signatures[0]}" \
+              apps/desktop/src-tauri/tauri.conf.json
           fi
 
           bundles=("$appimage_dir"/* "$deb_dir"/*)
@@ -468,6 +520,8 @@ jobs:
 
           "WINDOWS_SIGNING_CONFIG=$($signingConfigPath.Replace('\', '/'))" |
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "WINDOWS_SIGNING_THUMBPRINT=$($certificate.Thumbprint)" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - shell: bash
         run: |
           BUILD_ARGS=(
@@ -532,12 +586,32 @@ jobs:
               if ($signature.Status -ne "Valid") {
                 throw "Invalid Authenticode signature for $signedFile`: $($signature.Status)"
               }
+              if (
+                -not $signature.SignerCertificate -or
+                $signature.SignerCertificate.Thumbprint -ne $env:WINDOWS_SIGNING_THUMBPRINT
+              ) {
+                throw "Authenticode signer does not match the imported release certificate for $signedFile"
+              }
+              if (-not $signature.TimeStamperCertificate) {
+                throw "Authenticode signature is missing a trusted timestamp for $signedFile"
+              }
             }
           }
 
           $hash = (Get-FileHash -Algorithm SHA256 $installers[0].FullName).Hash.ToLowerInvariant()
           "$hash  $($installers[0].Name)" |
             Out-File "$($installers[0].FullName).sha256" -Encoding ascii
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Verify Windows updater signature
+        shell: bash
+        run: |
+          shopt -s nullglob
+          bundle_dir="apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis"
+          installers=("$bundle_dir"/*.exe)
+          cargo run --locked -p updater-core --bin verify-updater-signature -- \
+            "${installers[0]}" \
+            "${installers[0]}.sig" \
+            apps/desktop/src-tauri/tauri.conf.json
       - shell: pwsh
         run: |
           $source = "apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis"

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -42,6 +42,17 @@ jobs:
       - run: |
           git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
           git fetch --tags --force
+      - if: ${{ inputs.channel == 'stable' }}
+        run: |
+          git fetch origin main --no-tags
+
+          TARGET=$(git rev-parse HEAD)
+          MAIN=$(git rev-parse origin/main)
+
+          if [[ "$TARGET" != "$MAIN" ]]; then
+            echo "::error::Stable releases must run from the current main commit ($MAIN), got $TARGET"
+            exit 1
+          fi
       - uses: ./.github/actions/doxxer_install
       - id: version
         run: |
@@ -376,9 +387,251 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
 
+  build-windows:
+    needs: [compute-version, cn-draft]
+    if: ${{ !cancelled() && (needs.cn-draft.result == 'success' || needs.cn-draft.result == 'skipped') }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: recursive
+      - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.compute-version.outputs.version }}"
+        shell: bash
+      - uses: ./.github/actions/rust_install
+        with:
+          platform: windows
+      - uses: ./.github/actions/pnpm_install
+      - run: pnpm -F ui build
+      - shell: bash
+        run: |
+          cargo build --locked --release -p anarlog-cli --target x86_64-pc-windows-msvc
+          cp \
+            target/x86_64-pc-windows-msvc/release/anarlog.exe \
+            apps/desktop/src-tauri/resources/cli/anarlog-cli-x86_64-pc-windows-msvc.exe
+          ./scripts/sidecar.sh \
+            "./apps/desktop/${{ env.TAURI_CONF_PATH }}" \
+            resources/cli/anarlog-cli
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Import Windows signing certificate
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          if (
+            [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE) -or
+            [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)
+          ) {
+            throw "Stable Windows releases require WINDOWS_CERTIFICATE and WINDOWS_CERTIFICATE_PASSWORD"
+          }
+
+          $encodedCertificate = Join-Path $env:RUNNER_TEMP "anarlog-windows-certificate.txt"
+          $certificatePath = Join-Path $env:RUNNER_TEMP "anarlog-windows-certificate.pfx"
+          Set-Content -Path $encodedCertificate -Value $env:WINDOWS_CERTIFICATE
+          certutil -decode $encodedCertificate $certificatePath
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not decode the Windows signing certificate"
+          }
+
+          $password = ConvertTo-SecureString `
+            -String $env:WINDOWS_CERTIFICATE_PASSWORD `
+            -Force `
+            -AsPlainText
+          $certificate = @(
+            Import-PfxCertificate `
+              -FilePath $certificatePath `
+              -CertStoreLocation Cert:\CurrentUser\My `
+              -Password $password
+          ) |
+            Where-Object { $_.HasPrivateKey } |
+            Select-Object -First 1
+          if (-not $certificate) {
+            throw "Could not import the Windows signing certificate"
+          }
+          Remove-Item $encodedCertificate, $certificatePath -Force
+
+          $signingConfigPath = Join-Path $env:RUNNER_TEMP "tauri.windows-signing.json"
+          @{
+            bundle = @{
+              windows = @{
+                certificateThumbprint = $certificate.Thumbprint
+                digestAlgorithm = "sha256"
+                timestampUrl = "http://timestamp.digicert.com"
+              }
+            }
+          } |
+            ConvertTo-Json -Depth 4 |
+            Set-Content -Path $signingConfigPath -Encoding utf8
+
+          "WINDOWS_SIGNING_CONFIG=$($signingConfigPath.Replace('\', '/'))" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - shell: bash
+        run: |
+          BUILD_ARGS=(
+            --ci
+            --bundles nsis
+            --target x86_64-pc-windows-msvc
+            --config "${{ env.TAURI_CONF_PATH }}"
+            --verbose
+          )
+          if [[ "${{ inputs.channel }}" == "staging" ]]; then
+            BUILD_ARGS+=(--features devtools --no-sign)
+          else
+            BUILD_ARGS+=(--config "$WINDOWS_SIGNING_CONFIG")
+          fi
+          pnpm -F desktop tauri build "${BUILD_ARGS[@]}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          VITE_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_HYPRNOTE_2 }}
+          APP_VERSION: ${{ needs.compute-version.outputs.version }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_APP_URL: https://anarlog.so
+          VITE_API_URL: https://api.anarlog.so
+          VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
+          VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
+      - shell: pwsh
+        env:
+          EXPECTED_VERSION: ${{ needs.compute-version.outputs.version }}
+          RELEASE_CHANNEL: ${{ inputs.channel }}
+        run: |
+          $config = Get-Content "apps/desktop/src-tauri/tauri.conf.json" | ConvertFrom-Json
+          if ($config.version -ne $env:EXPECTED_VERSION) {
+            throw "Expected app version $env:EXPECTED_VERSION, got $($config.version)"
+          }
+
+          $bundleDir = "apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis"
+          $installers = @(Get-ChildItem $bundleDir -Filter "*.exe")
+          if ($installers.Count -ne 1) {
+            throw "Expected one NSIS installer in $bundleDir, found $($installers.Count)"
+          }
+          if ($installers[0].Name -notmatch [regex]::Escape($env:EXPECTED_VERSION)) {
+            throw "Installer filename does not contain version $env:EXPECTED_VERSION"
+          }
+
+          if ($env:RELEASE_CHANNEL -eq "stable") {
+            $updaterSignatures = @(Get-ChildItem $bundleDir -Filter "*.exe.sig")
+            $expectedUpdaterSignature = "$($installers[0].FullName).sig"
+            if (
+              $updaterSignatures.Count -ne 1 -or
+              $updaterSignatures[0].FullName -ne $expectedUpdaterSignature
+            ) {
+              throw "Expected the NSIS installer and its updater signature for the stable release"
+            }
+
+            $appBinary = "apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/anarlog.exe"
+            foreach ($signedFile in @($appBinary, $installers[0].FullName)) {
+              $signature = Get-AuthenticodeSignature $signedFile
+              if ($signature.Status -ne "Valid") {
+                throw "Invalid Authenticode signature for $signedFile`: $($signature.Status)"
+              }
+            }
+          }
+
+          $hash = (Get-FileHash -Algorithm SHA256 $installers[0].FullName).Hash.ToLowerInvariant()
+          "$hash  $($installers[0].Name)" |
+            Out-File "$($installers[0].FullName).sha256" -Encoding ascii
+      - shell: pwsh
+        run: |
+          $source = "apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis"
+          $destination = "apps/desktop/src-tauri/target/release"
+          New-Item -ItemType Directory -Force -Path $destination | Out-Null
+          Copy-Item "$source/*" $destination
+      - uses: actions/upload-artifact@v4
+        with:
+          name: anarlog-${{ inputs.channel }}-windows-x64
+          path: apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*
+          if-no-files-found: error
+          retention-days: 7
+      - if: ${{ inputs.channel != 'staging' }}
+        uses: ./.github/actions/cn_release
+        with:
+          cmd: upload
+          app: ${{ env.CN_APPLICATION }}
+          key: ${{ secrets.CN_API_KEY }}
+          channel: ${{ env.RELEASE_CHANNEL }}
+          framework: tauri
+          working-directory: ./apps/desktop
+
+  verify-cn-release:
+    if: ${{ inputs.channel != 'staging' && !cancelled() && needs.build-macos.result == 'success' && needs.build-windows.result == 'success' && needs.build-linux.result == 'success' }}
+    needs: [compute-version, build-macos, build-windows, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: release
+        uses: ./.github/actions/cn_release
+        with:
+          raw: >-
+            release show ${{ env.CN_APPLICATION }} ${{ needs.compute-version.outputs.version }}
+            --channel ${{ env.RELEASE_CHANNEL }}
+          key: ${{ secrets.CN_API_KEY }}
+      - env:
+          EXPECTED_VERSION: ${{ needs.compute-version.outputs.version }}
+          RELEASE: ${{ steps.release.outputs.raw }}
+        run: |
+          ACTUAL_VERSION=$(echo "$RELEASE" | jq -r '.version // empty')
+          if [[ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::Expected CrabNebula release $EXPECTED_VERSION, got $ACTUAL_VERSION"
+            exit 1
+          fi
+
+          EXPECTED_PLATFORMS=(
+            "dmg-aarch64"
+            "dmg-x86_64"
+            "nsis-x86_64"
+            "appimage-x86_64"
+            "deb-x86_64"
+            "appimage-aarch64"
+            "deb-aarch64"
+          )
+
+          INVALID_PLATFORMS=()
+          for platform in "${EXPECTED_PLATFORMS[@]}"; do
+            if ! echo "$RELEASE" | jq -e --arg platform "$platform" \
+              '[.assets[]? | select(.publicPlatform == $platform and ((.size // 0) | tonumber) > 0)] | length == 1' > /dev/null; then
+              INVALID_PLATFORMS+=("$platform")
+            fi
+          done
+
+          if [[ "${#INVALID_PLATFORMS[@]}" -gt 0 ]]; then
+            echo "::error::CrabNebula release $EXPECTED_VERSION has missing, duplicate, or empty download assets: ${INVALID_PLATFORMS[*]}"
+            exit 1
+          fi
+
+          EXPECTED_UPDATE_PLATFORMS=(
+            "darwin-aarch64"
+            "darwin-x86_64"
+            "windows-x86_64-nsis"
+            "linux-x86_64-appimage"
+            "linux-x86_64-deb"
+            "linux-aarch64-appimage"
+            "linux-aarch64-deb"
+          )
+
+          INVALID_UPDATE_PLATFORMS=()
+          for platform in "${EXPECTED_UPDATE_PLATFORMS[@]}"; do
+            if ! echo "$RELEASE" | jq -e --arg platform "$platform" \
+              '[.assets[]? | select(.updatePlatform == $platform and ((.signature // "") | length) > 0 and ((.size // 0) | tonumber) > 0)] | length == 1' > /dev/null; then
+              INVALID_UPDATE_PLATFORMS+=("$platform")
+            fi
+          done
+
+          if [[ "${#INVALID_UPDATE_PLATFORMS[@]}" -gt 0 ]]; then
+            echo "::error::CrabNebula release $EXPECTED_VERSION has missing, duplicate, unsigned, or empty updater assets: ${INVALID_UPDATE_PLATFORMS[*]}"
+            exit 1
+          fi
+
   create-tag:
-    if: ${{ inputs.channel != 'staging' && !cancelled() && needs.build-macos.result == 'success' && needs.build-linux.result == 'success' }}
-    needs: [compute-version, build-macos, build-linux]
+    if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.verify-cn-release.result == 'success' }}
+    needs: [compute-version, verify-cn-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -394,17 +647,21 @@ jobs:
           TARGET=$(git rev-parse HEAD)
           EXISTING=$(git rev-parse -q --verify "refs/tags/$TAG" || true)
 
-          if [[ -n "$EXISTING" && -z "${{ inputs.version }}" ]]; then
-            echo "::error::Tag $TAG already exists"
-            exit 1
-          fi
+          if [[ -n "$EXISTING" ]]; then
+            if [[ "$EXISTING" != "$TARGET" ]]; then
+              echo "::error::Tag $TAG points to $EXISTING instead of candidate $TARGET"
+              exit 1
+            fi
 
-          git tag -f "$TAG" "$TARGET"
-          git push origin "refs/tags/$TAG" --force
+            echo "Tag $TAG already points to candidate $TARGET"
+          else
+            git tag "$TAG" "$TARGET"
+            git push origin "refs/tags/$TAG"
+          fi
 
   cn-publish:
     if: ${{ inputs.channel != 'staging' && inputs.publish }}
-    needs: [compute-version, build-macos, build-linux, create-tag]
+    needs: [compute-version, verify-cn-release, create-tag]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -419,8 +676,14 @@ jobs:
           working-directory: ./apps/desktop
 
   release:
-    if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.cn-publish.result == 'success' && needs.build-macos.result == 'success' && needs.build-linux.result == 'success' }}
-    needs: [compute-version, build-macos, build-linux, cn-publish]
+    if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.cn-publish.result == 'success' && needs.build-macos.result == 'success' && needs.build-windows.result == 'success' && needs.build-linux.result == 'success' }}
+    needs: [
+      compute-version,
+      build-macos,
+      build-windows,
+      build-linux,
+      cn-publish,
+    ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -463,7 +726,7 @@ jobs:
           app: ${{ env.CN_APPLICATION }}
           version: ${{ needs.compute-version.outputs.version }}
           channel: ${{ env.RELEASE_CHANNEL }}
-          platform: debian-x86_64
+          platform: deb-x86_64
           output: anarlog-linux-x86_64.deb
           key: ${{ secrets.CN_API_KEY }}
       - if: ${{ needs.build-linux.result == 'success' }}
@@ -481,8 +744,17 @@ jobs:
           app: ${{ env.CN_APPLICATION }}
           version: ${{ needs.compute-version.outputs.version }}
           channel: ${{ env.RELEASE_CHANNEL }}
-          platform: debian-aarch64
+          platform: deb-aarch64
           output: anarlog-linux-aarch64.deb
+          key: ${{ secrets.CN_API_KEY }}
+      - if: ${{ needs.build-windows.result == 'success' }}
+        uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.compute-version.outputs.version }}
+          channel: ${{ env.RELEASE_CHANNEL }}
+          platform: nsis-x86_64
+          output: anarlog-windows-x86_64-setup.exe
           key: ${{ secrets.CN_API_KEY }}
       - id: checksums
         uses: ./.github/actions/generate_checksums
@@ -494,6 +766,7 @@ jobs:
             ${{ needs.build-linux.result == 'success' && 'anarlog-linux-x86_64.deb' || '' }}
             ${{ needs.build-linux.result == 'success' && 'anarlog-linux-aarch64.AppImage' || '' }}
             ${{ needs.build-linux.result == 'success' && 'anarlog-linux-aarch64.deb' || '' }}
+            ${{ needs.build-windows.result == 'success' && 'anarlog-windows-x86_64-setup.exe' || '' }}
       - id: artifacts
         run: |
           ARTIFACTS=""
@@ -506,6 +779,14 @@ jobs:
               ARTIFACTS="$ARTIFACTS,$LINUX_ARTIFACTS"
             else
               ARTIFACTS="$LINUX_ARTIFACTS"
+            fi
+          fi
+          if [[ "${{ needs.build-windows.result }}" == "success" ]]; then
+            WINDOWS_ARTIFACT="anarlog-windows-x86_64-setup.exe"
+            if [[ -n "$ARTIFACTS" ]]; then
+              ARTIFACTS="$ARTIFACTS,$WINDOWS_ARTIFACT"
+            else
+              ARTIFACTS="$WINDOWS_ARTIFACT"
             fi
           fi
           if [[ -z "$ARTIFACTS" ]]; then

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -888,3 +888,5 @@ jobs:
           prerelease: false
           makeLatest: true
           artifacts: ${{ steps.artifacts.outputs.list }}
+          allowUpdates: true
+          replacesArtifacts: true

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -178,7 +178,7 @@ jobs:
       - run: cargo check --locked -p desktop
       - run: cargo test --locked -p desktop --no-run
       - run: cargo test --locked -p cloudsync
-      - run: "cargo test --locked -p db-core 'cloudsync::'"
+      - run: "cargo test --locked -p db-core 'cloudsync::' -- --test-threads=1"
       - if: github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/pnpm_install
       - if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -177,7 +177,6 @@ jobs:
           retention-days: 7
       - run: cargo check --locked -p desktop
       - run: cargo test --locked -p desktop --no-run
-      - run: cargo test --locked -p tauri-plugin-auth
       - run: cargo test --locked -p cloudsync
       - run: "cargo test --locked -p db-core 'cloudsync::'"
       - if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -177,6 +177,7 @@ jobs:
           retention-days: 7
       - run: cargo check --locked -p desktop
       - run: cargo test --locked -p desktop --no-run
+      - run: cargo test --locked -p tauri-plugin-auth
       - run: cargo test --locked -p cloudsync
       - run: "cargo test --locked -p db-core 'cloudsync::'"
       - if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -91,10 +91,49 @@ jobs:
           output: anarlog-windows-x86_64-setup.exe
           key: ${{ secrets.CN_API_KEY }}
       - shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
         run: |
+          if (
+            [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE) -or
+            [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)
+          ) {
+            throw "Windows signature verification requires WINDOWS_CERTIFICATE and WINDOWS_CERTIFICATE_PASSWORD"
+          }
+
+          $encodedCertificate = Join-Path $env:RUNNER_TEMP "anarlog-windows-certificate.txt"
+          $certificatePath = Join-Path $env:RUNNER_TEMP "anarlog-windows-certificate.pfx"
+          Set-Content -Path $encodedCertificate -Value $env:WINDOWS_CERTIFICATE
+          certutil -decode $encodedCertificate $certificatePath
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not decode the Windows signing certificate"
+          }
+
+          $password = ConvertTo-SecureString `
+            -String $env:WINDOWS_CERTIFICATE_PASSWORD `
+            -Force `
+            -AsPlainText
+          $expectedCertificate = @(
+            (Get-PfxData -FilePath $certificatePath -Password $password).EndEntityCertificates
+          ) | Select-Object -First 1
+          Remove-Item $encodedCertificate, $certificatePath -Force
+          if (-not $expectedCertificate) {
+            throw "Could not read the Windows signing certificate"
+          }
+
           $signature = Get-AuthenticodeSignature "anarlog-windows-x86_64-setup.exe"
           if ($signature.Status -ne "Valid") {
             throw "Invalid Windows Authenticode signature: $($signature.Status)"
+          }
+          if (
+            -not $signature.SignerCertificate -or
+            $signature.SignerCertificate.Thumbprint -ne $expectedCertificate.Thumbprint
+          ) {
+            throw "Windows Authenticode signer does not match the release certificate"
+          }
+          if (-not $signature.TimeStamperCertificate) {
+            throw "Windows Authenticode signature is missing a trusted timestamp"
           }
 
   cn-publish:

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -5,6 +5,10 @@ on:
         description: "Version to publish (e.g., 1.0.2)"
         required: true
         type: string
+      candidate_sha:
+        description: "Exact 40-character main commit used to build the candidate"
+        required: true
+        type: string
 
 env:
   CN_APPLICATION: "fastrepl/hyprnote2"
@@ -15,21 +19,97 @@ jobs:
     outputs:
       version: ${{ steps.parse.outputs.version }}
       channel: ${{ steps.parse.outputs.channel }}
+      candidate_sha: ${{ steps.parse.outputs.candidate_sha }}
     steps:
       - id: parse
+        env:
+          INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
+          if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must be a stable semantic version such as 1.4.0"
+            exit 1
+          fi
+
+          if [[ ! "$INPUT_CANDIDATE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::Candidate SHA must be a full 40-character commit SHA"
+            exit 1
+          fi
+
+          VERSION="$INPUT_VERSION"
+          CANDIDATE_SHA="${INPUT_CANDIDATE_SHA,,}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "channel=stable" >> $GITHUB_OUTPUT
+          echo "candidate_sha=$CANDIDATE_SHA" >> $GITHUB_OUTPUT
 
-  cn-publish:
+  verify-candidate:
     needs: parse
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse.outputs.candidate_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+      - env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          git fetch origin main --no-tags
+
+          TARGET=$(git rev-parse HEAD)
+          MAIN=$(git rev-parse origin/main)
+
+          if [[ "$TARGET" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Checked out $TARGET instead of candidate $EXPECTED_SHA"
+            exit 1
+          fi
+
+          if [[ "$MAIN" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Candidate $EXPECTED_SHA is not the current main commit ($MAIN)"
+            exit 1
+          fi
+
+          if [[ ! -f "packages/changelog/content/$VERSION.md" ]]; then
+            echo "::error::Missing changelog for $VERSION at candidate $EXPECTED_SHA"
+            exit 1
+          fi
+
+  verify-windows-signature:
+    needs: [parse, verify-candidate]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse.outputs.candidate_sha }}
+      - uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.parse.outputs.version }}
+          channel: ${{ needs.parse.outputs.channel }}
+          platform: nsis-x86_64
+          output: anarlog-windows-x86_64-setup.exe
+          key: ${{ secrets.CN_API_KEY }}
+      - shell: pwsh
+        run: |
+          $signature = Get-AuthenticodeSignature "anarlog-windows-x86_64-setup.exe"
+          if ($signature.Status -ne "Valid") {
+            throw "Invalid Windows Authenticode signature: $($signature.Status)"
+          }
+
+  cn-publish:
+    needs: [parse, verify-candidate, verify-windows-signature]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse.outputs.candidate_sha }}
+          fetch-depth: 0
+          fetch-tags: true
       - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.parse.outputs.version }}"
-      - id: existing-release
-        continue-on-error: true
+      - id: release
         uses: ./.github/actions/cn_release
         with:
           raw: >-
@@ -38,36 +118,103 @@ jobs:
           key: ${{ secrets.CN_API_KEY }}
       - id: publish-decision
         env:
-          ASSETS: ${{ steps.existing-release.outputs.raw }}
+          RELEASE: ${{ steps.release.outputs.raw }}
+          EXPECTED_VERSION: ${{ needs.parse.outputs.version }}
         run: |
-          if [[ "${{ steps.existing-release.outcome }}" != "success" ]]; then
-            echo "publish_needed=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          ACTUAL_VERSION=$(echo "$RELEASE" | jq -r '.version // empty')
+          if [[ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::Expected CrabNebula release $EXPECTED_VERSION, got $ACTUAL_VERSION"
+            exit 1
           fi
 
           EXPECTED_PLATFORMS=(
             "dmg-aarch64"
             "dmg-x86_64"
+            "nsis-x86_64"
             "appimage-x86_64"
-            "debian-x86_64"
+            "deb-x86_64"
             "appimage-aarch64"
-            "debian-aarch64"
+            "deb-aarch64"
           )
 
-          MISSING_PLATFORMS=()
+          INVALID_PLATFORMS=()
           for platform in "${EXPECTED_PLATFORMS[@]}"; do
-            if ! echo "$ASSETS" | jq -e --arg platform "$platform" '.assets[] | select(.publicPlatform == $platform)' > /dev/null; then
-              MISSING_PLATFORMS+=("$platform")
+            if ! echo "$RELEASE" | jq -e --arg platform "$platform" \
+              '[.assets[]? | select(.publicPlatform == $platform and ((.size // 0) | tonumber) > 0)] | length == 1' > /dev/null; then
+              INVALID_PLATFORMS+=("$platform")
             fi
           done
 
-          if [[ "${#MISSING_PLATFORMS[@]}" -gt 0 ]]; then
-            echo "publish_needed=true" >> "$GITHUB_OUTPUT"
-            echo "missing_platforms=${MISSING_PLATFORMS[*]}" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ "${#INVALID_PLATFORMS[@]}" -gt 0 ]]; then
+            echo "::error::CrabNebula release $EXPECTED_VERSION has missing, duplicate, or empty download assets: ${INVALID_PLATFORMS[*]}"
+            exit 1
           fi
 
-          echo "publish_needed=false" >> "$GITHUB_OUTPUT"
+          EXPECTED_UPDATE_PLATFORMS=(
+            "darwin-aarch64"
+            "darwin-x86_64"
+            "windows-x86_64-nsis"
+            "linux-x86_64-appimage"
+            "linux-x86_64-deb"
+            "linux-aarch64-appimage"
+            "linux-aarch64-deb"
+          )
+
+          INVALID_UPDATE_PLATFORMS=()
+          for platform in "${EXPECTED_UPDATE_PLATFORMS[@]}"; do
+            if ! echo "$RELEASE" | jq -e --arg platform "$platform" \
+              '[.assets[]? | select(.updatePlatform == $platform and ((.signature // "") | length) > 0 and ((.size // 0) | tonumber) > 0)] | length == 1' > /dev/null; then
+              INVALID_UPDATE_PLATFORMS+=("$platform")
+            fi
+          done
+
+          if [[ "${#INVALID_UPDATE_PLATFORMS[@]}" -gt 0 ]]; then
+            echo "::error::CrabNebula release $EXPECTED_VERSION has missing, duplicate, unsigned, or empty updater assets: ${INVALID_UPDATE_PLATFORMS[*]}"
+            exit 1
+          fi
+
+          STATUS=$(echo "$RELEASE" | jq -r '.status // empty | ascii_downcase')
+          case "$STATUS" in
+            draft)
+              echo "publish_needed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            published)
+              echo "publish_needed=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unexpected CrabNebula release status: $STATUS"
+              exit 1
+              ;;
+          esac
+      - name: Create immutable release tag
+        env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          git fetch origin main --no-tags
+          git fetch --tags --force
+
+          TARGET=$(git rev-parse HEAD)
+          MAIN=$(git rev-parse origin/main)
+          TAG="desktop_v$VERSION"
+          EXISTING=$(git rev-parse -q --verify "refs/tags/$TAG" || true)
+
+          if [[ "$TARGET" != "$EXPECTED_SHA" || "$MAIN" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Candidate moved before publication (candidate=$EXPECTED_SHA, checkout=$TARGET, main=$MAIN)"
+            exit 1
+          fi
+
+          if [[ -n "$EXISTING" ]]; then
+            if [[ "$EXISTING" != "$EXPECTED_SHA" ]]; then
+              echo "::error::Tag $TAG points to $EXISTING instead of candidate $EXPECTED_SHA"
+              exit 1
+            fi
+
+            echo "Tag $TAG already points to candidate $EXPECTED_SHA"
+          else
+            git tag "$TAG" "$EXPECTED_SHA"
+            git push origin "refs/tags/$TAG"
+          fi
       - uses: ./.github/actions/cn_release
         if: ${{ steps.publish-decision.outputs.publish_needed == 'true' }}
         with:
@@ -86,9 +233,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ needs.parse.outputs.candidate_sha }}
           fetch-depth: 0
           fetch-tags: true
-      - run: git fetch --tags --force
+      - env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          git fetch --tags --force
+
+          TAG="desktop_v$VERSION"
+          TAG_TARGET=$(git rev-parse "$TAG^{commit}")
+          if [[ "$TAG_TARGET" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Tag $TAG points to $TAG_TARGET instead of candidate $EXPECTED_SHA"
+            exit 1
+          fi
       - id: download-macos-aarch64
         uses: ./.github/actions/cn_download
         with:
@@ -122,7 +281,7 @@ jobs:
           app: ${{ env.CN_APPLICATION }}
           version: ${{ needs.parse.outputs.version }}
           channel: ${{ needs.parse.outputs.channel }}
-          platform: debian-x86_64
+          platform: deb-x86_64
           output: anarlog-linux-x86_64.deb
           key: ${{ secrets.CN_API_KEY }}
       - id: download-linux-aarch64-appimage
@@ -140,8 +299,17 @@ jobs:
           app: ${{ env.CN_APPLICATION }}
           version: ${{ needs.parse.outputs.version }}
           channel: ${{ needs.parse.outputs.channel }}
-          platform: debian-aarch64
+          platform: deb-aarch64
           output: anarlog-linux-aarch64.deb
+          key: ${{ secrets.CN_API_KEY }}
+      - id: download-windows-x86_64
+        uses: ./.github/actions/cn_download
+        with:
+          app: ${{ env.CN_APPLICATION }}
+          version: ${{ needs.parse.outputs.version }}
+          channel: ${{ needs.parse.outputs.channel }}
+          platform: nsis-x86_64
+          output: anarlog-windows-x86_64-setup.exe
           key: ${{ secrets.CN_API_KEY }}
       - id: checksums
         uses: ./.github/actions/generate_checksums
@@ -153,6 +321,7 @@ jobs:
             anarlog-linux-x86_64.deb
             anarlog-linux-aarch64.AppImage
             anarlog-linux-aarch64.deb
+            anarlog-windows-x86_64-setup.exe
       - id: release-body
         run: |
           echo "value=https://anarlog.so/changelog/${{ needs.parse.outputs.version }}" >> "$GITHUB_OUTPUT"
@@ -162,7 +331,7 @@ jobs:
           name: desktop_v${{ needs.parse.outputs.version }}
           body: ${{ steps.release-body.outputs.value }}
           prerelease: false
-          artifacts: char-macos-aarch64.dmg,char-macos-x86_64.dmg,anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb,${{ steps.checksums.outputs.checksum_files }}
+          artifacts: char-macos-aarch64.dmg,char-macos-x86_64.dmg,anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb,anarlog-windows-x86_64-setup.exe,${{ steps.checksums.outputs.checksum_files }}
           allowUpdates: true
           makeLatest: true
           replacesArtifacts: true

--- a/apps/desktop/src-tauri/tauri.conf.stable-macos.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable-macos.json
@@ -1,0 +1,9 @@
+{
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}/{{current_version}}?channel=stable"
+      ]
+    }
+  }
+}

--- a/apps/desktop/src-tauri/tauri.conf.stable.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable.json
@@ -10,6 +10,7 @@
     "updater": {
       "active": true,
       "endpoints": [
+        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable",
         "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}/{{current_version}}?channel=stable"
       ]
     }

--- a/crates/db-core/src/cloudsync/ops.rs
+++ b/crates/db-core/src/cloudsync/ops.rs
@@ -660,7 +660,7 @@ pub(crate) async fn interruptible_cleanup(
 async fn rollback_cleanup_savepoint(
     connection: &mut SqliteConnection,
 ) -> Result<(), hypr_cloudsync::Error> {
-    sqlx::query("ROLLBACK TO cloudsync_cleanup; RELEASE cloudsync_cleanup")
+    sqlx::raw_sql("ROLLBACK TO cloudsync_cleanup; RELEASE cloudsync_cleanup")
         .execute(connection)
         .await?;
     Ok(())

--- a/crates/db-core/src/cloudsync/ops.rs
+++ b/crates/db-core/src/cloudsync/ops.rs
@@ -2020,8 +2020,15 @@ mod tests {
         .execute(db.pool())
         .await
         .unwrap();
-        db.cloudsync_init("sessions", None, None).await.unwrap();
-        let held_connection = db.pool().acquire().await.unwrap();
+        db.cloudsync_init_enabled_tables(&[CloudsyncTableSpec {
+            table_name: "sessions".to_string(),
+            crdt_algo: None,
+            init_flags: None,
+            enabled: true,
+        }])
+        .await
+        .unwrap();
+        let mut held_connection = db.pool().acquire().await.unwrap();
 
         let started_at = std::time::Instant::now();
         let error = tokio::time::timeout(Duration::from_millis(1_500), db.cloudsync_suspend())
@@ -2031,7 +2038,7 @@ mod tests {
         assert!(matches!(error, CloudsyncRuntimeError::LocalStatusBusy));
         assert!(started_at.elapsed() < Duration::from_millis(1_500));
 
-        drop(held_connection);
+        held_connection.return_to_pool().await;
         tokio::time::timeout(
             Duration::from_millis(1_500),
             sqlx::query("INSERT INTO sessions (id, title) VALUES ('after-timeout', 'Note')")
@@ -2083,7 +2090,7 @@ mod tests {
         .execute(db.pool())
         .await
         .unwrap();
-        let held_connection = db.pool().acquire().await.unwrap();
+        let mut held_connection = db.pool().acquire().await.unwrap();
 
         let error = tokio::time::timeout(Duration::from_millis(1_500), db.cloudsync_suspend())
             .await
@@ -2091,7 +2098,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(error, CloudsyncRuntimeError::LocalStatusBusy));
 
-        drop(held_connection);
+        held_connection.return_to_pool().await;
         db.cloudsync_suspend().await.unwrap();
         tokio::time::timeout(
             Duration::from_millis(250),

--- a/crates/updater-core/src/bin/verify-updater-signature.rs
+++ b/crates/updater-core/src/bin/verify-updater-signature.rs
@@ -1,0 +1,31 @@
+use std::{env, fs};
+
+use updater_core::verify_signature;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args_os().skip(1);
+    let artifact_path = args
+        .next()
+        .ok_or("usage: verify-updater-signature <artifact> <signature> <tauri-config>")?;
+    let signature_path = args
+        .next()
+        .ok_or("usage: verify-updater-signature <artifact> <signature> <tauri-config>")?;
+    let config_path = args
+        .next()
+        .ok_or("usage: verify-updater-signature <artifact> <signature> <tauri-config>")?;
+    if args.next().is_some() {
+        return Err("usage: verify-updater-signature <artifact> <signature> <tauri-config>".into());
+    }
+
+    let artifact = fs::read(artifact_path)?;
+    let signature = fs::read_to_string(signature_path)?;
+    let config: serde_json::Value = serde_json::from_slice(&fs::read(config_path)?)?;
+    let pubkey = config
+        .pointer("/plugins/updater/pubkey")
+        .and_then(serde_json::Value::as_str)
+        .ok_or("Tauri config is missing plugins.updater.pubkey")?;
+
+    verify_signature(&artifact, signature.trim(), pubkey)?;
+    println!("Updater signature verified");
+    Ok(())
+}

--- a/crates/updater-core/src/lib.rs
+++ b/crates/updater-core/src/lib.rs
@@ -339,7 +339,7 @@ fn replace_url_tokens(
     Ok(replaced.parse()?)
 }
 
-fn verify_signature(data: &[u8], release_signature: &str, pubkey: &str) -> Result<()> {
+pub fn verify_signature(data: &[u8], release_signature: &str, pubkey: &str) -> Result<()> {
     let pubkey_decoded = base64_to_utf8(pubkey)?;
     let public_key = PublicKey::decode(&pubkey_decoded)?;
     let signature_decoded = base64_to_utf8(release_signature)?;


### PR DESCRIPTION
Build and Authenticode-verify Windows NSIS packages, require one complete CrabNebula version across macOS, Windows, and Linux, and mirror every installer to GitHub releases.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6322 
- <kbd>&nbsp;1&nbsp;</kbd> #6296 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect production release and signing pipelines (Windows Authenticode, updater keys, immutable tags); mistakes could block releases or ship incomplete artifacts, but scope is mostly CI and verification rather than app runtime logic.
> 
> **Overview**
> Adds **Windows NSIS** builds to desktop CD (Authenticode signing on stable, staging unsigned), includes the installer in CrabNebula uploads and GitHub releases, and tightens **stable** so the workflow must run from **current `main`**, signing secrets are checked early, and **tag/publish** wait on a new **`verify-cn-release`** job that asserts one non-empty asset per platform (including `nsis-x86_64`) plus signed updater payloads for every update platform.
> 
> **Publish path** (`desktop_publish`) now requires a **`candidate_sha`**, validates that commit is still `main` with a changelog, re-checks Windows Authenticode on the CrabNebula installer, and enforces the same complete-release asset rules before publishing or tagging.
> 
> Build jobs gain **version and updater checks** on stable (macOS app version + `verify-updater-signature`, Linux package/filename version + signatures). Stable Tauri config adds a **bundle-type updater URL** and a macOS-only stable updater override. **`cn_download`** fails hard on missing assets; Linux deb platform ids move to **`deb-*`**.
> 
> Small supporting changes: **`updater-core`** exposes signature verification for CI via a CLI; **`db-core`** uses `sqlx::raw_sql` for cleanup rollback and stabilizes cloudsync pool-drain tests; Windows **`db-core`** cloudsync tests run single-threaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b53a7be50068523ddaa39c25c799fb557c571ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->