### PR TITLE
Support Windows notifications safely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10956,6 +10956,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "mac_address2"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11742,6 +11756,20 @@ dependencies = [
  "notify",
  "notify-types",
  "walkdir",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -18792,6 +18820,7 @@ dependencies = [
  "host",
  "intercept",
  "notification",
+ "notify-rust",
  "serde",
  "specta",
  "specta-typescript",
@@ -19510,6 +19539,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ legacy-db-user = { path = "legacy/db-user", package = "db-user" }
 posthog-rs = "0.5"
 progenitor-client = "0.13"
 
+notify-rust = "=4.11.7"
 openai-transcription = { path = "crates/openai-transcription", package = "openai-transcription" }
 owhisper-client = { path = "crates/owhisper-client", package = "owhisper-client" }
 owhisper-config = { path = "crates/owhisper-config", package = "owhisper-config" }

--- a/apps/desktop/src/settings/general/app-settings.test.tsx
+++ b/apps/desktop/src/settings/general/app-settings.test.tsx
@@ -87,6 +87,7 @@ describe("AppSettingsView", () => {
     ).toBeNull();
     expect(screen.queryByText("Capture meeting chat in Memos")).toBeNull();
     expect(screen.queryByText("Show floating bar")).toBeNull();
+    expect(screen.queryByText("Stop when meeting ends")).toBeNull();
     expect(screen.getByRole("switch", { name: "Show tray icon" })).toBeTruthy();
   });
 

--- a/apps/desktop/src/settings/general/app-settings.tsx
+++ b/apps/desktop/src/settings/general/app-settings.tsx
@@ -55,7 +55,9 @@ export function AppSettingsView({
   audioRetention,
   microphoneDevice,
 }: AppSettingsViewProps) {
-  const isMacos = platform() === "macos";
+  const currentPlatform = platform();
+  const isMacos = currentPlatform === "macos";
+  const supportsMicDetection = currentPlatform !== "windows";
 
   return (
     <div className="flex flex-col gap-8">
@@ -131,17 +133,19 @@ export function AppSettingsView({
             onChange={autoJoinScheduledMeetings.onChange}
             disabled={!autoStartScheduledMeetings.value}
           />
-          <SettingRow
-            title={<Trans>Stop when meeting ends</Trans>}
-            description={
-              <Trans>
-                Automatically stop listening when the meeting app releases the
-                microphone.
-              </Trans>
-            }
-            checked={autoStopMeetings.value}
-            onChange={autoStopMeetings.onChange}
-          />
+          {supportsMicDetection && (
+            <SettingRow
+              title={<Trans>Stop when meeting ends</Trans>}
+              description={
+                <Trans>
+                  Automatically stop listening when the meeting app releases the
+                  microphone.
+                </Trans>
+              }
+              checked={autoStopMeetings.value}
+              onChange={autoStopMeetings.onChange}
+            />
+          )}
           {isMacos && (
             <>
               <SettingRow

--- a/apps/desktop/src/settings/general/notification.test.tsx
+++ b/apps/desktop/src/settings/general/notification.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   clearNotifications: vi.fn(),
+  currentPlatform: "macos",
   setSettingValues: vi.fn(),
   useConfigValues: vi.fn(),
   useQuery: vi.fn(),
@@ -19,6 +20,10 @@ vi.mock("@lingui/react/macro", () => ({
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: mocks.useQuery,
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => mocks.currentPlatform,
 }));
 
 vi.mock("@hypr/plugin-detect", () => ({
@@ -56,6 +61,7 @@ const baseConfig = {
 describe("NotificationSettingsView", () => {
   beforeEach(() => {
     mocks.clearNotifications.mockReset();
+    mocks.currentPlatform = "macos";
     mocks.setSettingValues.mockReset();
     mocks.useConfigValues.mockReset();
     mocks.useConfigValues.mockReturnValue(baseConfig);
@@ -87,5 +93,15 @@ describe("NotificationSettingsView", () => {
     await waitFor(() =>
       expect(screen.getByText("Ting Aqua Bridge")).toBeTruthy(),
     );
+  });
+
+  it("hides unsupported microphone detection and DND controls on Windows", () => {
+    mocks.currentPlatform = "windows";
+
+    render(<NotificationSettingsView />);
+
+    expect(screen.getByText("Event notifications")).toBeTruthy();
+    expect(screen.queryByText("Microphone detection")).toBeNull();
+    expect(screen.queryByText("Respect Do-Not-Disturb mode")).toBeNull();
   });
 });

--- a/apps/desktop/src/settings/general/notification.tsx
+++ b/apps/desktop/src/settings/general/notification.tsx
@@ -1,6 +1,7 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
+import { platform } from "@tauri-apps/plugin-os";
 import { X } from "lucide-react";
 import { useState } from "react";
 
@@ -48,6 +49,9 @@ import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 export function NotificationSettingsView() {
   const { t } = useLingui();
+  const currentPlatform = platform();
+  const supportsMicDetection = currentPlatform !== "windows";
+  const supportsDoNotDisturb = currentPlatform === "macos";
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -70,6 +74,7 @@ export function NotificationSettingsView() {
   const { data: installedApps = [] } = useQuery({
     queryKey: ["settings", "all-installed-applications"],
     queryFn: detectCommands.listInstalledApplications,
+    enabled: supportsMicDetection,
     select: (result: Result<InstalledApp[], string>) => {
       if (result.status === "error") {
         throw new Error(result.error);
@@ -81,6 +86,7 @@ export function NotificationSettingsView() {
   const { data: defaultIgnoredBundleIds = [] } = useQuery({
     queryKey: ["settings", "default-ignored-bundle-ids"],
     queryFn: detectCommands.listDefaultIgnoredBundleIds,
+    enabled: supportsMicDetection,
     select: (result: Result<string[], string>) => {
       if (result.status === "error") {
         throw new Error(result.error);
@@ -174,257 +180,265 @@ export function NotificationSettingsView() {
         )}
       </form.Field>
 
-      <form.Field name="notification_detect">
-        {(field) => (
-          <div className="flex flex-col gap-4">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1">
-                <h3 className="mb-1 text-sm font-medium">
-                  <Trans>Microphone detection</Trans>
-                </h3>
-                <p className="text-muted-foreground text-xs">
-                  <Trans>
-                    Automatically detect when a meeting starts based on
-                    microphone activity.
-                  </Trans>
-                </p>
-              </div>
-              <Switch
-                checked={field.state.value}
-                onCheckedChange={field.handleChange}
-              />
-            </div>
-
-            {field.state.value && (
-              <div className={cn(["border-muted ml-3 border-l-2 pt-2 pl-4"])}>
-                <form.Field name="mic_active_threshold">
-                  {(thresholdField) => (
-                    <div className="mb-4 flex items-center justify-between gap-4">
-                      <div className="flex-1">
-                        <h4 className="text-sm font-medium">
-                          <Trans>Detection delay</Trans>
-                        </h4>
-                        <p className="text-muted-foreground text-xs">
-                          <Trans>
-                            How long the mic must be active before triggering
-                          </Trans>
-                        </p>
-                      </div>
-                      <Select
-                        value={String(thresholdField.state.value)}
-                        onValueChange={(v) =>
-                          thresholdField.handleChange(Number(v))
-                        }
-                      >
-                        <SelectTrigger className="w-[100px]">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent align="end">
-                          <SelectItem value="5">5 sec</SelectItem>
-                          <SelectItem value="10">10 sec</SelectItem>
-                          <SelectItem value="15">15 sec</SelectItem>
-                          <SelectItem value="30">30 sec</SelectItem>
-                          <SelectItem value="60">1 min</SelectItem>
-                          <SelectItem value="120">2 min</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  )}
-                </form.Field>
-
-                <div className="mb-3 flex flex-col gap-1">
-                  <h4 className="text-sm font-medium">
-                    <Trans>Exclude apps from detection</Trans>
-                  </h4>
+      {supportsMicDetection && (
+        <form.Field name="notification_detect">
+          {(field) => (
+            <div className="flex flex-col gap-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1">
+                  <h3 className="mb-1 text-sm font-medium">
+                    <Trans>Microphone detection</Trans>
+                  </h3>
                   <p className="text-muted-foreground text-xs">
                     <Trans>
-                      Search installed apps to exclude them. Click an excluded
-                      app to include it again.
+                      Automatically detect when a meeting starts based on
+                      microphone activity.
                     </Trans>
                   </p>
                 </div>
-                <form.Subscribe selector={(state) => state.values}>
-                  {(values) => {
-                    const ignoredPlatforms = values.ignored_platforms;
-                    const includedPlatforms = values.included_platforms;
-                    const ignorableApps = getIgnorableApps({
-                      installedApps,
-                      ignoredPlatforms,
-                      includedPlatforms,
-                      inputValue: searchQuery,
-                      defaultIgnoredBundleIds,
-                    });
-                    const ignoredBundleIds = getIgnoredBundleIds({
-                      installedApps,
-                      ignoredPlatforms,
-                      includedPlatforms,
-                      defaultIgnoredBundleIds,
-                    });
-
-                    return (
-                      <div className="flex flex-col gap-3">
-                        <Popover open={searchOpen} onOpenChange={setSearchOpen}>
-                          <PopoverTrigger asChild>
-                            <div
-                              role="button"
-                              tabIndex={0}
-                              aria-expanded={searchOpen}
-                              className={cn([
-                                "flex min-h-[38px] w-full cursor-text flex-wrap items-center gap-2 rounded-2xl border p-2",
-                                "focus-visible:ring-ring focus-visible:ring-1 focus-visible:outline-hidden",
-                              ])}
-                              onKeyDown={(event) => {
-                                if (
-                                  event.key === "Enter" ||
-                                  event.key === " "
-                                ) {
-                                  event.preventDefault();
-                                  setSearchOpen(true);
-                                }
-                              }}
-                            >
-                              {ignoredBundleIds.map((bundleId: string) => {
-                                const isDefault = isDefaultIgnored(bundleId);
-                                return (
-                                  <Badge
-                                    key={bundleId}
-                                    variant="secondary"
-                                    className={cn([
-                                      "flex items-center gap-1 px-2 py-0.5 text-xs",
-                                      isDefault
-                                        ? ["bg-accent text-muted-foreground"]
-                                        : ["bg-muted"],
-                                    ])}
-                                    title={isDefault ? "default" : undefined}
-                                  >
-                                    {bundleIdToName(bundleId)}
-                                    {isDefault && (
-                                      <span className="text-[10px] opacity-70">
-                                        <Trans>(default)</Trans>
-                                      </span>
-                                    )}
-                                    <Button
-                                      type="button"
-                                      variant="ghost"
-                                      size="sm"
-                                      className="ml-0.5 h-3 w-3 p-0 hover:bg-transparent"
-                                      onClick={(event) => {
-                                        event.stopPropagation();
-                                        handleToggleIgnoredApp(
-                                          bundleId,
-                                          ignoredPlatforms,
-                                          includedPlatforms,
-                                        );
-                                      }}
-                                    >
-                                      <X className="h-2.5 w-2.5" />
-                                    </Button>
-                                  </Badge>
-                                );
-                              })}
-                              <span className="text-muted-foreground text-sm">
-                                <Trans>Search installed apps...</Trans>
-                              </span>
-                            </div>
-                          </PopoverTrigger>
-                          <PopoverContent
-                            variant="app"
-                            align="start"
-                            style={{
-                              width: "var(--radix-popover-trigger-width)",
-                            }}
-                          >
-                            <AppFloatingPanel className="overflow-hidden">
-                              <Command className="rounded-[inherit] border-0 bg-transparent">
-                                <CommandInput
-                                  placeholder={t`Search installed apps...`}
-                                  value={searchQuery}
-                                  onValueChange={setSearchQuery}
-                                />
-                                <CommandEmpty>
-                                  <div className="text-muted-foreground px-2 py-1.5 text-sm">
-                                    <Trans>No apps found.</Trans>
-                                  </div>
-                                </CommandEmpty>
-                                <CommandList>
-                                  <CommandGroup className="max-h-[250px] overflow-y-auto">
-                                    {ignorableApps.map((app) => (
-                                      <CommandItem
-                                        key={app.id}
-                                        value={`${app.name} ${app.id}`}
-                                        onSelect={() =>
-                                          handleToggleIgnoredApp(
-                                            app.id,
-                                            ignoredPlatforms,
-                                            includedPlatforms,
-                                          )
-                                        }
-                                        className={cn([
-                                          "cursor-pointer",
-                                          "hover:bg-accent! focus:bg-accent! aria-selected:bg-transparent",
-                                        ])}
-                                      >
-                                        <span className="flex-1 truncate">
-                                          {app.name}
-                                        </span>
-                                      </CommandItem>
-                                    ))}
-                                  </CommandGroup>
-                                </CommandList>
-                              </Command>
-                            </AppFloatingPanel>
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    );
-                  }}
-                </form.Subscribe>
+                <Switch
+                  checked={field.state.value}
+                  onCheckedChange={field.handleChange}
+                />
               </div>
-            )}
-          </div>
-        )}
-      </form.Field>
 
-      <div className="flex flex-col gap-6">
-        <div className="flex items-center gap-4 pt-4 pb-2">
-          <div className="border-muted min-w-0 flex-1 border-t" />
-          <span className="text-muted-foreground shrink-0 text-xs font-medium">
-            <Trans>For enabled notifications</Trans>
-          </span>
-          <div className="border-muted min-w-0 flex-1 border-t" />
-        </div>
+              {field.state.value && (
+                <div className={cn(["border-muted ml-3 border-l-2 pt-2 pl-4"])}>
+                  <form.Field name="mic_active_threshold">
+                    {(thresholdField) => (
+                      <div className="mb-4 flex items-center justify-between gap-4">
+                        <div className="flex-1">
+                          <h4 className="text-sm font-medium">
+                            <Trans>Detection delay</Trans>
+                          </h4>
+                          <p className="text-muted-foreground text-xs">
+                            <Trans>
+                              How long the mic must be active before triggering
+                            </Trans>
+                          </p>
+                        </div>
+                        <Select
+                          value={String(thresholdField.state.value)}
+                          onValueChange={(v) =>
+                            thresholdField.handleChange(Number(v))
+                          }
+                        >
+                          <SelectTrigger className="w-[100px]">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent align="end">
+                            <SelectItem value="5">5 sec</SelectItem>
+                            <SelectItem value="10">10 sec</SelectItem>
+                            <SelectItem value="15">15 sec</SelectItem>
+                            <SelectItem value="30">30 sec</SelectItem>
+                            <SelectItem value="60">1 min</SelectItem>
+                            <SelectItem value="120">2 min</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
+                  </form.Field>
 
-        <form.Subscribe
-          selector={(state) =>
-            state.values.notification_event || state.values.notification_detect
-          }
-        >
-          {(anyNotificationEnabled) => (
-            <form.Field name="respect_dnd">
-              {(field) => (
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1">
-                    <h3 className="mb-1 text-sm font-medium">
-                      <Trans>Respect Do-Not-Disturb mode</Trans>
-                    </h3>
+                  <div className="mb-3 flex flex-col gap-1">
+                    <h4 className="text-sm font-medium">
+                      <Trans>Exclude apps from detection</Trans>
+                    </h4>
                     <p className="text-muted-foreground text-xs">
                       <Trans>
-                        Don't show notifications when Do-Not-Disturb is enabled
-                        on your system
+                        Search installed apps to exclude them. Click an excluded
+                        app to include it again.
                       </Trans>
                     </p>
                   </div>
-                  <Switch
-                    checked={field.state.value}
-                    onCheckedChange={field.handleChange}
-                    disabled={!anyNotificationEnabled}
-                  />
+                  <form.Subscribe selector={(state) => state.values}>
+                    {(values) => {
+                      const ignoredPlatforms = values.ignored_platforms;
+                      const includedPlatforms = values.included_platforms;
+                      const ignorableApps = getIgnorableApps({
+                        installedApps,
+                        ignoredPlatforms,
+                        includedPlatforms,
+                        inputValue: searchQuery,
+                        defaultIgnoredBundleIds,
+                      });
+                      const ignoredBundleIds = getIgnoredBundleIds({
+                        installedApps,
+                        ignoredPlatforms,
+                        includedPlatforms,
+                        defaultIgnoredBundleIds,
+                      });
+
+                      return (
+                        <div className="flex flex-col gap-3">
+                          <Popover
+                            open={searchOpen}
+                            onOpenChange={setSearchOpen}
+                          >
+                            <PopoverTrigger asChild>
+                              <div
+                                role="button"
+                                tabIndex={0}
+                                aria-expanded={searchOpen}
+                                className={cn([
+                                  "flex min-h-[38px] w-full cursor-text flex-wrap items-center gap-2 rounded-2xl border p-2",
+                                  "focus-visible:ring-ring focus-visible:ring-1 focus-visible:outline-hidden",
+                                ])}
+                                onKeyDown={(event) => {
+                                  if (
+                                    event.key === "Enter" ||
+                                    event.key === " "
+                                  ) {
+                                    event.preventDefault();
+                                    setSearchOpen(true);
+                                  }
+                                }}
+                              >
+                                {ignoredBundleIds.map((bundleId: string) => {
+                                  const isDefault = isDefaultIgnored(bundleId);
+                                  return (
+                                    <Badge
+                                      key={bundleId}
+                                      variant="secondary"
+                                      className={cn([
+                                        "flex items-center gap-1 px-2 py-0.5 text-xs",
+                                        isDefault
+                                          ? ["bg-accent text-muted-foreground"]
+                                          : ["bg-muted"],
+                                      ])}
+                                      title={isDefault ? "default" : undefined}
+                                    >
+                                      {bundleIdToName(bundleId)}
+                                      {isDefault && (
+                                        <span className="text-[10px] opacity-70">
+                                          <Trans>(default)</Trans>
+                                        </span>
+                                      )}
+                                      <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="sm"
+                                        className="ml-0.5 h-3 w-3 p-0 hover:bg-transparent"
+                                        onClick={(event) => {
+                                          event.stopPropagation();
+                                          handleToggleIgnoredApp(
+                                            bundleId,
+                                            ignoredPlatforms,
+                                            includedPlatforms,
+                                          );
+                                        }}
+                                      >
+                                        <X className="h-2.5 w-2.5" />
+                                      </Button>
+                                    </Badge>
+                                  );
+                                })}
+                                <span className="text-muted-foreground text-sm">
+                                  <Trans>Search installed apps...</Trans>
+                                </span>
+                              </div>
+                            </PopoverTrigger>
+                            <PopoverContent
+                              variant="app"
+                              align="start"
+                              style={{
+                                width: "var(--radix-popover-trigger-width)",
+                              }}
+                            >
+                              <AppFloatingPanel className="overflow-hidden">
+                                <Command className="rounded-[inherit] border-0 bg-transparent">
+                                  <CommandInput
+                                    placeholder={t`Search installed apps...`}
+                                    value={searchQuery}
+                                    onValueChange={setSearchQuery}
+                                  />
+                                  <CommandEmpty>
+                                    <div className="text-muted-foreground px-2 py-1.5 text-sm">
+                                      <Trans>No apps found.</Trans>
+                                    </div>
+                                  </CommandEmpty>
+                                  <CommandList>
+                                    <CommandGroup className="max-h-[250px] overflow-y-auto">
+                                      {ignorableApps.map((app) => (
+                                        <CommandItem
+                                          key={app.id}
+                                          value={`${app.name} ${app.id}`}
+                                          onSelect={() =>
+                                            handleToggleIgnoredApp(
+                                              app.id,
+                                              ignoredPlatforms,
+                                              includedPlatforms,
+                                            )
+                                          }
+                                          className={cn([
+                                            "cursor-pointer",
+                                            "hover:bg-accent! focus:bg-accent! aria-selected:bg-transparent",
+                                          ])}
+                                        >
+                                          <span className="flex-1 truncate">
+                                            {app.name}
+                                          </span>
+                                        </CommandItem>
+                                      ))}
+                                    </CommandGroup>
+                                  </CommandList>
+                                </Command>
+                              </AppFloatingPanel>
+                            </PopoverContent>
+                          </Popover>
+                        </div>
+                      );
+                    }}
+                  </form.Subscribe>
                 </div>
               )}
-            </form.Field>
+            </div>
           )}
-        </form.Subscribe>
-      </div>
+        </form.Field>
+      )}
+
+      {supportsDoNotDisturb && (
+        <div className="flex flex-col gap-6">
+          <div className="flex items-center gap-4 pt-4 pb-2">
+            <div className="border-muted min-w-0 flex-1 border-t" />
+            <span className="text-muted-foreground shrink-0 text-xs font-medium">
+              <Trans>For enabled notifications</Trans>
+            </span>
+            <div className="border-muted min-w-0 flex-1 border-t" />
+          </div>
+
+          <form.Subscribe
+            selector={(state) =>
+              state.values.notification_event ||
+              state.values.notification_detect
+            }
+          >
+            {(anyNotificationEnabled) => (
+              <form.Field name="respect_dnd">
+                {(field) => (
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1">
+                      <h3 className="mb-1 text-sm font-medium">
+                        <Trans>Respect Do-Not-Disturb mode</Trans>
+                      </h3>
+                      <p className="text-muted-foreground text-xs">
+                        <Trans>
+                          Don't show notifications when Do-Not-Disturb is
+                          enabled on your system
+                        </Trans>
+                      </p>
+                    </div>
+                    <Switch
+                      checked={field.state.value}
+                      onCheckedChange={field.handleChange}
+                      disabled={!anyNotificationEnabled}
+                    />
+                  </div>
+                )}
+              </form.Field>
+            )}
+          </form.Subscribe>
+        </div>
+      )}
     </div>
   );
 }

--- a/plugins/notification/Cargo.toml
+++ b/plugins/notification/Cargo.toml
@@ -37,3 +37,6 @@ tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 apalis = { workspace = true }
 apalis-cron = { workspace = true }
 chrono = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+notify-rust = { workspace = true }

--- a/plugins/notification/src/error.rs
+++ b/plugins/notification/src/error.rs
@@ -1,7 +1,11 @@
 use serde::{Serialize, ser::Serializer};
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {}
+pub enum Error {
+    #[cfg(target_os = "windows")]
+    #[error("failed to show Windows notification: {0}")]
+    WindowsNotification(#[from] notify_rust::error::Error),
+}
 
 impl Serialize for Error {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/plugins/notification/src/ext.rs
+++ b/plugins/notification/src/ext.rs
@@ -1,5 +1,18 @@
 use crate::error::Error;
 
+#[cfg(any(target_os = "windows", test))]
+use std::collections::HashMap;
+#[cfg(any(target_os = "windows", test))]
+use std::sync::{Mutex, OnceLock};
+#[cfg(any(target_os = "windows", test))]
+use std::time::{Duration, Instant};
+
+#[cfg(any(target_os = "windows", test))]
+static RECENT_WINDOWS_NOTIFICATIONS: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+
+#[cfg(any(target_os = "windows", test))]
+const WINDOWS_DEDUPE_WINDOW: Duration = Duration::from_mins(1);
+
 pub struct Notification<'a, R: tauri::Runtime, M: tauri::Manager<R>> {
     manager: &'a M,
     _runtime: std::marker::PhantomData<fn() -> R>,
@@ -8,8 +21,14 @@ pub struct Notification<'a, R: tauri::Runtime, M: tauri::Manager<R>> {
 impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Notification<'a, R, M> {
     #[tracing::instrument(skip(self))]
     pub fn show(&self, v: hypr_notification::Notification) -> Result<(), Error> {
-        let _ = self.manager;
+        #[cfg(target_os = "windows")]
+        if should_show_windows_notification(v.key.as_deref()) {
+            show_windows_notification(self.manager, &v)?;
+        }
+
+        #[cfg(not(target_os = "windows"))]
         hypr_notification::show(&v);
+
         Ok(())
     }
 
@@ -19,6 +38,66 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Notification<'a, R, M> {
         hypr_notification::clear();
         Ok(())
     }
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn should_show_windows_notification(key: Option<&str>) -> bool {
+    let Some(key) = key else {
+        return true;
+    };
+
+    let recent = RECENT_WINDOWS_NOTIFICATIONS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut recent = recent.lock().unwrap_or_else(|error| error.into_inner());
+    let now = Instant::now();
+    recent.retain(|_, timestamp| now.duration_since(*timestamp) < WINDOWS_DEDUPE_WINDOW);
+
+    if recent.contains_key(key) {
+        tracing::info!(key, "skipping_notification");
+        return false;
+    }
+
+    recent.insert(key.to_string(), now);
+    true
+}
+
+#[cfg(target_os = "windows")]
+fn show_windows_notification<R: tauri::Runtime, M: tauri::Manager<R>>(
+    manager: &M,
+    notification: &hypr_notification::Notification,
+) -> Result<(), Error> {
+    let mut toast = notify_rust::Notification::new();
+    toast
+        .summary(&notification.title)
+        .body(&notification.message)
+        .timeout(
+            notification
+                .timeout
+                .map(notify_rust::Timeout::from)
+                .unwrap_or(notify_rust::Timeout::Never),
+        );
+
+    if let Ok(exe) = tauri::utils::platform::current_exe()
+        && let Some(exe_dir) = exe.parent()
+    {
+        let current_dir = exe_dir.display().to_string();
+        let target_debug = format!(
+            "{}target{}debug",
+            std::path::MAIN_SEPARATOR,
+            std::path::MAIN_SEPARATOR
+        );
+        let target_release = format!(
+            "{}target{}release",
+            std::path::MAIN_SEPARATOR,
+            std::path::MAIN_SEPARATOR
+        );
+
+        if !current_dir.ends_with(&target_debug) && !current_dir.ends_with(&target_release) {
+            toast.app_id(&manager.config().identifier);
+        }
+    }
+
+    toast.show()?;
+    Ok(())
 }
 
 pub trait NotificationPluginExt<R: tauri::Runtime> {
@@ -36,5 +115,24 @@ impl<R: tauri::Runtime, T: tauri::Manager<R>> NotificationPluginExt<R> for T {
             manager: self,
             _runtime: std::marker::PhantomData,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_notifications_without_keys_are_not_deduplicated() {
+        assert!(should_show_windows_notification(None));
+        assert!(should_show_windows_notification(None));
+    }
+
+    #[test]
+    fn windows_notifications_with_duplicate_keys_are_suppressed() {
+        let key = "windows-notification-test-duplicate-key";
+
+        assert!(should_show_windows_notification(Some(key)));
+        assert!(!should_show_windows_notification(Some(key)));
     }
 }


### PR DESCRIPTION
Show basic native Windows toasts and hide microphone-detection controls whose Windows backend is not implemented.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Windows notification path and platform-gated settings affect user-visible behavior on Windows; dedupe and dev `app_id` logic need to behave correctly in production builds.
> 
> **Overview**
> Windows users now get **native toasts** via `notify-rust` in the notification plugin, with **1-minute deduplication** by notification key and **no `app_id`** when running from `target/debug` or `target/release` to avoid dev toast issues. Non-Windows platforms still use the existing `hypr_notification` path.
> 
> Desktop settings are gated by platform: **“Stop when meeting ends”** is hidden on Windows (mic-release detection not implemented), and notification settings hide **microphone detection** (and related installed-app queries) on Windows while **Do Not Disturb** stays **macOS-only**. Tests cover the Windows UI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a244178fe62fd94e936f0fd133af29810edade5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->