### PR TITLE
Protect Windows auth sessions with DPAPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18193,6 +18193,7 @@ dependencies = [
 name = "tauri-plugin-auth"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "serde",
  "serde_json",
  "specta",
@@ -18209,6 +18210,7 @@ dependencies = [
  "template-support",
  "thiserror 2.0.18",
  "tracing",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/plugins/auth/Cargo.toml
+++ b/plugins/auth/Cargo.toml
@@ -15,6 +15,7 @@ specta-typescript = { workspace = true }
 tempfile = { workspace = true }
 
 [dependencies]
+base64 = { workspace = true }
 hypr-storage = { workspace = true }
 hypr-supabase-auth = { workspace = true, features = ["client"] }
 hypr-template-support = { workspace = true }
@@ -31,3 +32,6 @@ strum = { workspace = true, features = ["derive"] }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { workspace = true, features = ["Win32_Foundation", "Win32_Security_Cryptography"] }

--- a/plugins/auth/src/ext.rs
+++ b/plugins/auth/src/ext.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use hypr_supabase_auth::{client::store::AuthStore, session::find_session};
 use hypr_template_support::AccountInfo;
 
-#[cfg(all(target_os = "linux", not(test)))]
-static LINUX_AUTH_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+#[cfg(all(any(target_os = "linux", target_os = "windows"), not(test)))]
+static SECURE_AUTH_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 pub(crate) fn parse_account_info(
     data: &HashMap<String, String>,
@@ -42,52 +42,74 @@ impl<R: tauri::Runtime, T: tauri::Manager<R>> AuthPluginExt<R> for T {
     fn set_item(&self, key: String, value: String) -> Result<(), crate::Error> {
         let store = self.state::<AuthStore>();
 
-        #[cfg(all(target_os = "linux", not(test)))]
+        #[cfg(all(any(target_os = "linux", target_os = "windows"), not(test)))]
         {
-            let _guard = LINUX_AUTH_WRITE_LOCK.lock().unwrap();
+            let _guard = SECURE_AUTH_WRITE_LOCK.lock().unwrap();
             store.set(key, value)?;
-            return crate::migrate::persist_linux_auth(self.app_handle(), &store.snapshot());
+
+            #[cfg(target_os = "linux")]
+            let result = crate::migrate::persist_linux_auth(self.app_handle(), &store.snapshot());
+
+            #[cfg(target_os = "windows")]
+            let result = crate::windows::persist_auth(self.app_handle(), &store.snapshot());
+
+            result
         }
 
-        #[cfg(any(not(target_os = "linux"), test))]
-        store.set(key, value).map_err(Into::into)
+        #[cfg(any(not(any(target_os = "linux", target_os = "windows")), test))]
+        {
+            store.set(key, value).map_err(Into::into)
+        }
     }
 
     fn remove_item(&self, key: String) -> Result<(), crate::Error> {
         let store = self.state::<AuthStore>();
 
-        #[cfg(all(target_os = "linux", not(test)))]
+        #[cfg(all(any(target_os = "linux", target_os = "windows"), not(test)))]
         {
-            let _guard = LINUX_AUTH_WRITE_LOCK.lock().unwrap();
+            let _guard = SECURE_AUTH_WRITE_LOCK.lock().unwrap();
             let mut data = store.snapshot();
             data.remove(&key);
-            // Apply the removal in memory even when the keyring refuses, so a
+            // Apply the removal in memory even when the secure store refuses, so a
             // reported failure cannot leave the value readable via get_item.
+            #[cfg(target_os = "linux")]
             let result = crate::migrate::persist_linux_auth(self.app_handle(), &data);
+
+            #[cfg(target_os = "windows")]
+            let result = crate::windows::persist_auth(self.app_handle(), &data);
+
             store.replace(data);
-            return result;
+            result
         }
 
-        #[cfg(any(not(target_os = "linux"), test))]
-        store.remove(&key).map_err(Into::into)
+        #[cfg(any(not(any(target_os = "linux", target_os = "windows")), test))]
+        {
+            store.remove(&key).map_err(Into::into)
+        }
     }
 
     fn clear_auth(&self) -> Result<(), crate::Error> {
         let store = self.state::<AuthStore>();
 
-        #[cfg(all(target_os = "linux", not(test)))]
+        #[cfg(all(any(target_os = "linux", target_os = "windows"), not(test)))]
         {
-            let _guard = LINUX_AUTH_WRITE_LOCK.lock().unwrap();
-            // Sign-out must drop the in-memory session even if the keyring is
-            // locked; callers that ignore the error would otherwise keep a
-            // readable session that returns once the keyring unlocks.
+            let _guard = SECURE_AUTH_WRITE_LOCK.lock().unwrap();
+            // Sign-out must drop the in-memory session even if secure persistence
+            // fails; callers that ignore the error must not retain readable auth.
+            #[cfg(target_os = "linux")]
             let result = crate::migrate::clear_linux_auth(self.app_handle());
+
+            #[cfg(target_os = "windows")]
+            let result = crate::windows::clear_auth(self.app_handle());
+
             store.replace(HashMap::new());
-            return result;
+            result
         }
 
-        #[cfg(any(not(target_os = "linux"), test))]
-        store.clear().map_err(Into::into)
+        #[cfg(any(not(any(target_os = "linux", target_os = "windows")), test))]
+        {
+            store.clear().map_err(Into::into)
+        }
     }
 
     fn get_account_info(&self) -> Result<Option<AccountInfo>, crate::Error> {

--- a/plugins/auth/src/lib.rs
+++ b/plugins/auth/src/lib.rs
@@ -2,6 +2,8 @@ mod commands;
 mod error;
 mod ext;
 mod migrate;
+#[cfg(any(target_os = "windows", test))]
+mod windows;
 
 pub use error::{Error, Result};
 pub use ext::*;
@@ -35,7 +37,11 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 migrate::load_linux_auth(app)?,
             );
 
-            #[cfg(any(not(target_os = "linux"), test))]
+            #[cfg(all(target_os = "windows", not(test)))]
+            let auth_store =
+                hypr_supabase_auth::client::store::AuthStore::in_memory(windows::load_auth(app)?);
+
+            #[cfg(any(not(any(target_os = "linux", target_os = "windows")), test))]
             let auth_store = {
                 let auth_path = migrate::auth_path(app)?;
                 hypr_supabase_auth::client::store::AuthStore::load(auth_path)

--- a/plugins/auth/src/migrate.rs
+++ b/plugins/auth/src/migrate.rs
@@ -125,10 +125,10 @@ fn drop_plaintext_auth_for<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     }
 }
 
-// A leftover auth.json is less harmful than refusing a session the keyring already
-// holds, so cleanup failures are reported rather than propagated.
-#[cfg(all(target_os = "linux", not(test)))]
-fn discard_plaintext_auth(path: &Path) {
+// A leftover auth.json is less harmful than refusing a session the secure store
+// already holds, so cleanup failures are reported rather than propagated.
+#[cfg(any(all(target_os = "linux", not(test)), target_os = "windows", test))]
+pub(crate) fn discard_plaintext_auth(path: &Path) {
     if let Err(error) = remove_plaintext_auth(path) {
         tracing::warn!(
             path = %path.display(),
@@ -138,8 +138,8 @@ fn discard_plaintext_auth(path: &Path) {
     }
 }
 
-#[cfg(all(target_os = "linux", not(test)))]
-fn remove_plaintext_auth(path: &Path) -> std::io::Result<()> {
+#[cfg(any(all(target_os = "linux", not(test)), target_os = "windows", test))]
+pub(crate) fn remove_plaintext_auth(path: &Path) -> std::io::Result<()> {
     if !path.is_file() {
         return Ok(());
     }
@@ -160,6 +160,13 @@ fn new_auth_path<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> std::io::Resul
         .join(FILENAME))
 }
 
+#[cfg(target_os = "windows")]
+pub(crate) fn windows_secure_auth_path<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> std::io::Result<PathBuf> {
+    Ok(new_auth_path(app)?.with_file_name("auth.dpapi"))
+}
+
 fn legacy_auth_path<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> std::io::Result<PathBuf> {
     Ok(legacy_base_path(app)?.join(FILENAME))
 }
@@ -168,6 +175,29 @@ fn legacy_store_json_path<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
 ) -> std::io::Result<PathBuf> {
     Ok(legacy_base_path(app)?.join("store.json"))
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn discard_windows_plaintext_auth<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    for path in [new_auth_path(app), legacy_auth_path(app)] {
+        match path {
+            Ok(path) => discard_plaintext_auth(&path),
+            Err(error) => tracing::warn!(%error, "failed_to_resolve_plaintext_auth_path"),
+        }
+    }
+
+    match legacy_store_json_path(app) {
+        Ok(path) => {
+            if let Err(error) = remove_auth_from_store_json(&path) {
+                tracing::warn!(
+                    path = %path.display(),
+                    %error,
+                    "failed_to_remove_auth_from_legacy_store"
+                );
+            }
+        }
+        Err(error) => tracing::warn!(%error, "failed_to_resolve_legacy_store_path"),
+    }
 }
 
 fn legacy_base_path<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> std::io::Result<PathBuf> {
@@ -251,6 +281,33 @@ fn migrate_from_store_json(store_json_path: &Path, auth_path: &Path) -> std::io:
     )?;
 
     Ok(())
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn remove_auth_from_store_json(store_json_path: &Path) -> std::io::Result<()> {
+    if !store_json_path.is_file() {
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(store_json_path)?;
+    let mut store: serde_json::Map<String, serde_json::Value> = match serde_json::from_str(&content)
+    {
+        Ok(store) => store,
+        Err(_) => {
+            // The legacy store is already unreadable. Replace it so a partial
+            // auth payload cannot survive after the encrypted store is authoritative.
+            return hypr_storage::fs::atomic_write(store_json_path, "{}");
+        }
+    };
+
+    if store.remove(PLUGIN_NAME).is_none() {
+        return Ok(());
+    }
+
+    hypr_storage::fs::atomic_write(
+        store_json_path,
+        &serde_json::to_string(&store).map_err(invalid_data)?,
+    )
 }
 
 fn invalid_data(e: impl std::fmt::Display) -> std::io::Error {
@@ -446,6 +503,52 @@ mod test {
             auth_json("legacy-token")
         );
         assert!(new_auth_path.is_dir());
+    }
+
+    #[test]
+    fn plaintext_removal_truncates_contents_before_unlinking() {
+        let temp = tempdir().unwrap();
+        let auth_path = temp.path().join(FILENAME);
+        let surviving_link = temp.path().join("auth-backup.json");
+        std::fs::write(&auth_path, auth_json("secret-token")).unwrap();
+        std::fs::hard_link(&auth_path, &surviving_link).unwrap();
+
+        remove_plaintext_auth(&auth_path).unwrap();
+
+        assert!(!auth_path.exists());
+        assert_eq!(std::fs::read(&surviving_link).unwrap(), b"");
+    }
+
+    #[test]
+    fn plaintext_cleanup_removes_auth_from_legacy_store() {
+        let temp = tempdir().unwrap();
+        let store_path = temp.path().join("store.json");
+        std::fs::write(
+            &store_path,
+            legacy_store_json(
+                &auth_json("secret-token"),
+                Some(("other", serde_json::json!("value"))),
+            ),
+        )
+        .unwrap();
+
+        remove_auth_from_store_json(&store_path).unwrap();
+
+        let store: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(store_path).unwrap()).unwrap();
+        assert!(store.get(PLUGIN_NAME).is_none());
+        assert_eq!(store.get("other"), Some(&serde_json::json!("value")));
+    }
+
+    #[test]
+    fn plaintext_cleanup_scrubs_unreadable_legacy_store() {
+        let temp = tempdir().unwrap();
+        let store_path = temp.path().join("store.json");
+        std::fs::write(&store_path, r#"{"auth":"partial-secret""#).unwrap();
+
+        remove_auth_from_store_json(&store_path).unwrap();
+
+        assert_eq!(std::fs::read_to_string(store_path).unwrap(), "{}");
     }
 
     fn auth_json(token: &str) -> String {

--- a/plugins/auth/src/windows.rs
+++ b/plugins/auth/src/windows.rs
@@ -238,6 +238,17 @@ mod tests {
         Ok(data.iter().map(|byte| byte ^ 0xa5).collect())
     }
 
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn dpapi_protects_and_round_trips_for_current_user() {
+        let plaintext = b"anarlog-windows-dpapi-round-trip";
+
+        let protected = protect(plaintext).unwrap();
+
+        assert_ne!(protected, plaintext);
+        assert_eq!(unprotect(&protected).unwrap(), plaintext);
+    }
+
     #[test]
     fn encrypted_auth_round_trips_sessions_larger_than_credential_manager_limit() {
         let temp = tempdir().unwrap();

--- a/plugins/auth/src/windows.rs
+++ b/plugins/auth/src/windows.rs
@@ -1,0 +1,348 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+
+const FORMAT_PREFIX: &str = "anarlog-auth-dpapi-v1:";
+
+#[cfg(target_os = "windows")]
+pub(crate) fn load_auth<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> crate::Result<HashMap<String, String>> {
+    let plaintext_path = crate::migrate::auth_path(app)?;
+    let secure_path = crate::migrate::windows_secure_auth_path(app)?;
+
+    if secure_path.is_file() {
+        let auth = match load_auth_file(&secure_path, unprotect) {
+            Ok(auth) => auth,
+            Err(error) => {
+                tracing::warn!(%error, "ignoring_unreadable_windows_auth");
+                HashMap::new()
+            }
+        };
+        crate::migrate::discard_windows_plaintext_auth(app);
+        return Ok(auth);
+    }
+
+    if !plaintext_path.is_file() {
+        return Ok(HashMap::new());
+    }
+
+    let auth = match read_plaintext_auth(&plaintext_path) {
+        Ok(auth) => auth,
+        Err(error) => {
+            tracing::warn!(%error, "ignoring_unreadable_plaintext_auth");
+            crate::migrate::discard_windows_plaintext_auth(app);
+            return Ok(HashMap::new());
+        }
+    };
+
+    if let Err(error) = persist_auth_file(&secure_path, &auth, protect, unprotect) {
+        tracing::warn!(%error, "failed_to_migrate_auth_to_windows_data_protection");
+        return Ok(auth);
+    }
+
+    crate::migrate::discard_windows_plaintext_auth(app);
+    Ok(auth)
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn persist_auth<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    auth: &HashMap<String, String>,
+) -> crate::Result<()> {
+    let secure_path = crate::migrate::windows_secure_auth_path(app)?;
+    persist_auth_file(&secure_path, auth, protect, unprotect)?;
+    crate::migrate::discard_windows_plaintext_auth(app);
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn clear_auth<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> crate::Result<()> {
+    let secure_path = crate::migrate::windows_secure_auth_path(app)?;
+    crate::migrate::discard_windows_plaintext_auth(app);
+
+    if !secure_path.is_file() {
+        return Ok(());
+    }
+
+    let overwrite_result = persist_auth_file(&secure_path, &HashMap::new(), protect, unprotect);
+    match std::fs::remove_file(&secure_path) {
+        Ok(()) => Ok(()),
+        Err(remove_error) => {
+            overwrite_result?;
+            Err(remove_error.into())
+        }
+    }
+}
+
+fn read_plaintext_auth(path: &Path) -> crate::Result<HashMap<String, String>> {
+    Ok(serde_json::from_str(&std::fs::read_to_string(path)?)?)
+}
+
+fn persist_auth_file(
+    path: &Path,
+    auth: &HashMap<String, String>,
+    protect: impl Fn(&[u8]) -> crate::Result<Vec<u8>>,
+    unprotect: impl Fn(&[u8]) -> crate::Result<Vec<u8>>,
+) -> crate::Result<()> {
+    let plaintext = serde_json::to_vec(auth)?;
+    let protected = protect(&plaintext)?;
+    let encoded = format!("{FORMAT_PREFIX}{}", STANDARD.encode(protected));
+    let previous = match std::fs::read_to_string(path) {
+        Ok(previous) => Some(previous),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
+    hypr_storage::fs::atomic_write(path, &encoded)?;
+
+    let verified = load_auth_file(path, unprotect)
+        .map(|persisted| persisted == *auth)
+        .unwrap_or(false);
+    if !verified {
+        match previous {
+            Some(previous) => hypr_storage::fs::atomic_write(path, &previous)?,
+            None => match std::fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            },
+        }
+        return Err(crate::Error::Storage(
+            "Windows encrypted auth verification failed".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn load_auth_file(
+    path: &Path,
+    unprotect: impl Fn(&[u8]) -> crate::Result<Vec<u8>>,
+) -> crate::Result<HashMap<String, String>> {
+    let encoded = std::fs::read_to_string(path)?;
+    let protected = encoded
+        .strip_prefix(FORMAT_PREFIX)
+        .ok_or_else(|| crate::Error::Storage("unsupported Windows auth format".to_string()))?;
+    let protected = STANDARD
+        .decode(protected)
+        .map_err(|_| crate::Error::Storage("invalid Windows auth encoding".to_string()))?;
+    let plaintext = unprotect(&protected)?;
+    Ok(serde_json::from_slice(&plaintext)?)
+}
+
+#[cfg(target_os = "windows")]
+fn protect(data: &[u8]) -> crate::Result<Vec<u8>> {
+    use windows::Win32::Security::Cryptography::{
+        CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptProtectData,
+    };
+    use windows::core::PCWSTR;
+
+    let input_len = u32::try_from(data.len())
+        .map_err(|_| crate::Error::Storage("Windows auth payload is too large".to_string()))?;
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: input_len,
+        pbData: data.as_ptr().cast_mut(),
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+
+    unsafe {
+        CryptProtectData(
+            &input,
+            PCWSTR::null(),
+            None,
+            None,
+            None,
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+        .map_err(data_protection_error)?;
+    }
+
+    Ok(copy_and_free(output, false))
+}
+
+#[cfg(target_os = "windows")]
+fn unprotect(data: &[u8]) -> crate::Result<Vec<u8>> {
+    use windows::Win32::Security::Cryptography::{
+        CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptUnprotectData,
+    };
+
+    let input_len = u32::try_from(data.len())
+        .map_err(|_| crate::Error::Storage("Windows auth payload is too large".to_string()))?;
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: input_len,
+        pbData: data.as_ptr().cast_mut(),
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+
+    unsafe {
+        CryptUnprotectData(
+            &input,
+            None,
+            None,
+            None,
+            None,
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+        .map_err(data_protection_error)?;
+    }
+
+    Ok(copy_and_free(output, true))
+}
+
+#[cfg(target_os = "windows")]
+fn copy_and_free(
+    output: windows::Win32::Security::Cryptography::CRYPT_INTEGER_BLOB,
+    clear_source: bool,
+) -> Vec<u8> {
+    use windows::Win32::Foundation::{HLOCAL, LocalFree};
+
+    if output.pbData.is_null() || output.cbData == 0 {
+        if !output.pbData.is_null() {
+            unsafe {
+                LocalFree(Some(HLOCAL(output.pbData.cast())));
+            }
+        }
+        return Vec::new();
+    }
+
+    let bytes =
+        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize) }.to_vec();
+    if clear_source {
+        unsafe {
+            std::ptr::write_bytes(output.pbData, 0, output.cbData as usize);
+        }
+    }
+    unsafe {
+        LocalFree(Some(HLOCAL(output.pbData.cast())));
+    }
+    bytes
+}
+
+#[cfg(target_os = "windows")]
+fn data_protection_error(error: windows::core::Error) -> crate::Error {
+    crate::Error::Storage(format!(
+        "Windows data protection failed ({:#010X})",
+        error.code().0
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn xor(data: &[u8]) -> crate::Result<Vec<u8>> {
+        Ok(data.iter().map(|byte| byte ^ 0xa5).collect())
+    }
+
+    #[test]
+    fn encrypted_auth_round_trips_sessions_larger_than_credential_manager_limit() {
+        let temp = tempdir().unwrap();
+        let secure_path = temp.path().join("auth.dpapi");
+        let auth = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            format!(r#"{{"access_token":"{}"}}"#, "token".repeat(2_000)),
+        )]);
+
+        persist_auth_file(&secure_path, &auth, xor, xor).unwrap();
+
+        assert_eq!(load_auth_file(&secure_path, xor).unwrap(), auth);
+        assert!(
+            !std::fs::read_to_string(secure_path)
+                .unwrap()
+                .contains("access_token")
+        );
+    }
+
+    #[test]
+    fn plaintext_migration_writes_verified_ciphertext_before_removal() {
+        let temp = tempdir().unwrap();
+        let plaintext_path = temp.path().join("auth.json");
+        let secure_path = temp.path().join("auth.dpapi");
+        let auth = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            r#"{"access_token":"secret"}"#.to_string(),
+        )]);
+        std::fs::write(&plaintext_path, serde_json::to_string(&auth).unwrap()).unwrap();
+
+        let loaded = read_plaintext_auth(&plaintext_path).unwrap();
+        persist_auth_file(&secure_path, &loaded, xor, xor).unwrap();
+        crate::migrate::discard_plaintext_auth(&plaintext_path);
+
+        assert!(!plaintext_path.exists());
+        assert_eq!(load_auth_file(&secure_path, xor).unwrap(), auth);
+    }
+
+    #[test]
+    fn failed_secure_write_leaves_plaintext_available_for_retry() {
+        let temp = tempdir().unwrap();
+        let plaintext_path = temp.path().join("auth.json");
+        let secure_path = temp.path().join("missing-parent").join("auth.dpapi");
+        let auth = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            r#"{"access_token":"secret"}"#.to_string(),
+        )]);
+        std::fs::write(&plaintext_path, serde_json::to_string(&auth).unwrap()).unwrap();
+
+        let result = persist_auth_file(
+            &secure_path,
+            &auth,
+            |_| Err(crate::Error::Storage("unavailable".to_string())),
+            xor,
+        );
+
+        assert!(result.is_err());
+        assert!(plaintext_path.is_file());
+    }
+
+    #[test]
+    fn failed_verification_does_not_leave_a_new_secure_file() {
+        let temp = tempdir().unwrap();
+        let secure_path = temp.path().join("auth.dpapi");
+        let auth = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            r#"{"access_token":"secret"}"#.to_string(),
+        )]);
+
+        let result = persist_auth_file(&secure_path, &auth, xor, |_| {
+            Err(crate::Error::Storage("unavailable".to_string()))
+        });
+
+        assert!(result.is_err());
+        assert!(!secure_path.exists());
+    }
+
+    #[test]
+    fn failed_verification_restores_previous_secure_file() {
+        let temp = tempdir().unwrap();
+        let secure_path = temp.path().join("auth.dpapi");
+        let first = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            r#"{"access_token":"first"}"#.to_string(),
+        )]);
+        let second = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            r#"{"access_token":"second"}"#.to_string(),
+        )]);
+        persist_auth_file(&secure_path, &first, xor, xor).unwrap();
+
+        let result = persist_auth_file(&secure_path, &second, xor, |_| {
+            Err(crate::Error::Storage("unavailable".to_string()))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(load_auth_file(&secure_path, xor).unwrap(), first);
+    }
+
+    #[test]
+    fn rejects_unversioned_encrypted_auth() {
+        let temp = tempdir().unwrap();
+        let secure_path = temp.path().join("auth.dpapi");
+        std::fs::write(&secure_path, STANDARD.encode(b"ciphertext")).unwrap();
+
+        assert!(load_auth_file(&secure_path, xor).is_err());
+    }
+}


### PR DESCRIPTION
Persist Supabase sessions with current-user DPAPI and securely migrate legacy plaintext auth data.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6315
- <kbd>&nbsp;1&nbsp;</kbd> #6298 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how session tokens are stored and migrated on Windows; bugs could lose sessions, leave tokens on disk, or break sign-in/sign-out.
> 
> **Overview**
> Windows now persists Supabase auth like Linux: **in-memory `AuthStore`** with writes going through a shared **`SECURE_AUTH_WRITE_LOCK`**, instead of plain `auth.json` on disk.
> 
> A new **`windows`** module stores sessions in **`auth.dpapi`** using **current-user DPAPI** (`CryptProtectData` / `CryptUnprotectData`), with a versioned `anarlog-auth-dpapi-v1:` + base64 on-disk format. **Load** prefers the encrypted file, **migrates** readable legacy `auth.json` after a verified write, and **scrubs** plaintext `auth.json` (truncate-then-delete), legacy paths, and **`auth` entries in `store.json`**.
> 
> **`set_item` / `remove_item` / `clear_auth`** on Windows call **`persist_auth`** / **`clear_auth`** with the same “update memory even if persistence fails” behavior as Linux. **`migrate`** helpers for plaintext removal and legacy-store cleanup are shared with Windows and covered by new tests; **`windows.rs`** adds DPAPI round-trip and persistence failure/rollback tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9684aa122e955e02bcf559b2f2f9ae76ea38c7e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->