### PR TITLE
Detect Linux microphone stream activity

### DIFF
--- a/crates/detect/src/error.rs
+++ b/crates/detect/src/error.rs
@@ -13,4 +13,7 @@ pub enum Error {
     #[cfg(target_os = "linux")]
     #[error("failed to connect to pulseaudio")]
     PulseConnect,
+    #[cfg(target_os = "linux")]
+    #[error("pulseaudio operation failed: {0}")]
+    PulseOperation(String),
 }

--- a/crates/detect/src/list/linux.rs
+++ b/crates/detect/src/list/linux.rs
@@ -1,7 +1,16 @@
 use super::InstalledApp;
+use libpulse_binding as pulse;
+use libpulse_binding::context::{Context, FlagSet as ContextFlagSet};
+use libpulse_binding::mainloop::standard::{IterateResult, Mainloop};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+const PULSE_OPERATION_TIMEOUT: Duration = Duration::from_secs(2);
+const PULSE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 pub fn list_installed_apps() -> Vec<InstalledApp> {
     let desktop_dirs = get_desktop_file_dirs();
@@ -26,15 +35,7 @@ pub fn list_installed_apps() -> Vec<InstalledApp> {
 }
 
 pub fn list_mic_using_apps() -> Result<Vec<InstalledApp>, crate::Error> {
-    use libpulse_binding::context::{Context, FlagSet as ContextFlagSet};
-    use libpulse_binding::mainloop::standard::{IterateResult, Mainloop};
-    use std::cell::RefCell;
-    use std::rc::Rc;
-
-    let mut apps = Vec::new();
-
     let mut mainloop = Mainloop::new().ok_or(crate::Error::PulseMainloop)?;
-
     let mut context =
         Context::new(&mainloop, "hyprnote-detect").ok_or(crate::Error::PulseContext)?;
 
@@ -42,48 +43,158 @@ pub fn list_mic_using_apps() -> Result<Vec<InstalledApp>, crate::Error> {
         .connect(None, ContextFlagSet::NOFLAGS, None)
         .map_err(|_| crate::Error::PulseConnect)?;
 
-    let apps_rc: Rc<RefCell<Vec<InstalledApp>>> = Rc::new(RefCell::new(Vec::new()));
-    let apps_clone = apps_rc.clone();
-
-    let introspect = context.introspect();
-    introspect.get_source_output_info_list(move |result| {
-        use libpulse_binding::callbacks::ListResult;
-
-        if let ListResult::Item(info) = result {
-            let props = &info.proplist;
-            let app_name = props
-                .get_str("application.name")
-                .or_else(|| props.get_str("application.process.binary"))
-                .unwrap_or_default();
-
-            let app_id = props
-                .get_str("application.process.binary")
-                .or_else(|| props.get_str("application.name"))
-                .unwrap_or_default();
-
-            if !app_name.is_empty() && !app_id.is_empty() {
-                apps_clone.borrow_mut().push(InstalledApp {
-                    id: app_id,
-                    name: app_name,
-                });
-            }
-        }
-    });
-
-    for _ in 0..100 {
-        match mainloop.iterate(false) {
-            IterateResult::Quit(_) | IterateResult::Err(_) => break,
-            IterateResult::Success(_) => {}
-        }
+    if let Err(error) = wait_for_context_ready(&mut mainloop, &context) {
+        context.disconnect();
+        return Err(error);
     }
 
-    context.disconnect();
+    let query = Rc::new(RefCell::new(SourceOutputQuery::default()));
+    let query_for_callback = query.clone();
+    let mut operation =
+        context
+            .introspect()
+            .get_source_output_info_list(move |result| match result {
+                pulse::callbacks::ListResult::Item(info) => {
+                    if info.corked {
+                        return;
+                    }
 
-    apps = apps_rc.borrow().clone();
+                    let props = &info.proplist;
+                    let name = props
+                        .get_str("application.name")
+                        .or_else(|| props.get_str("application.process.binary"))
+                        .unwrap_or_default();
+                    let id = props
+                        .get_str("application.process.binary")
+                        .or_else(|| props.get_str("application.name"))
+                        .unwrap_or_default();
+
+                    if !name.is_empty() && !id.is_empty() {
+                        query_for_callback
+                            .borrow_mut()
+                            .apps
+                            .push(InstalledApp { id, name });
+                    }
+                }
+                pulse::callbacks::ListResult::End => {
+                    query_for_callback.borrow_mut().completed = true;
+                }
+                pulse::callbacks::ListResult::Error => {
+                    let mut query = query_for_callback.borrow_mut();
+                    query.failed = true;
+                    query.completed = true;
+                }
+            });
+
+    let query_result = wait_for_source_output_query(&mut mainloop, &query);
+    if query_result.is_err() && !query.borrow().completed {
+        operation.cancel();
+    }
+    drop(operation);
+    context.disconnect();
+    query_result?;
+
+    let mut apps = query.borrow().apps.clone();
     apps.sort_by(|a, b| a.id.cmp(&b.id));
     apps.dedup_by(|a, b| a.id == b.id);
     apps.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(apps)
+}
+
+#[derive(Default)]
+struct SourceOutputQuery {
+    apps: Vec<InstalledApp>,
+    completed: bool,
+    failed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContextReadiness {
+    Pending,
+    Ready,
+    Failed,
+}
+
+fn context_readiness(state: pulse::context::State) -> ContextReadiness {
+    match state {
+        pulse::context::State::Ready => ContextReadiness::Ready,
+        pulse::context::State::Failed | pulse::context::State::Terminated => {
+            ContextReadiness::Failed
+        }
+        _ => ContextReadiness::Pending,
+    }
+}
+
+fn wait_for_context_ready(mainloop: &mut Mainloop, context: &Context) -> Result<(), crate::Error> {
+    let deadline = Instant::now() + PULSE_OPERATION_TIMEOUT;
+
+    loop {
+        match context_readiness(context.get_state()) {
+            ContextReadiness::Ready => return Ok(()),
+            ContextReadiness::Failed => {
+                return Err(crate::Error::PulseOperation(
+                    "context failed before becoming ready".to_string(),
+                ));
+            }
+            ContextReadiness::Pending => {}
+        }
+
+        if Instant::now() >= deadline {
+            return Err(crate::Error::PulseOperation(
+                "timed out waiting for context readiness".to_string(),
+            ));
+        }
+
+        iterate_mainloop(mainloop, "waiting for context readiness")?;
+    }
+}
+
+fn wait_for_source_output_query(
+    mainloop: &mut Mainloop,
+    query: &Rc<RefCell<SourceOutputQuery>>,
+) -> Result<(), crate::Error> {
+    let deadline = Instant::now() + PULSE_OPERATION_TIMEOUT;
+
+    loop {
+        let query = query.borrow();
+        if query.completed {
+            return if query.failed {
+                Err(crate::Error::PulseOperation(
+                    "source-output introspection failed".to_string(),
+                ))
+            } else {
+                Ok(())
+            };
+        }
+        drop(query);
+
+        if Instant::now() >= deadline {
+            return Err(crate::Error::PulseOperation(
+                "timed out waiting for source-output introspection".to_string(),
+            ));
+        }
+
+        iterate_mainloop(mainloop, "enumerating source outputs")?;
+    }
+}
+
+fn iterate_mainloop(mainloop: &mut Mainloop, operation: &str) -> Result<(), crate::Error> {
+    match mainloop.iterate(false) {
+        IterateResult::Success(0) => std::thread::sleep(PULSE_POLL_INTERVAL),
+        IterateResult::Success(_) => {}
+        IterateResult::Quit(retval) => {
+            return Err(crate::Error::PulseOperation(format!(
+                "mainloop quit while {operation}: {retval:?}"
+            )));
+        }
+        IterateResult::Err(error) => {
+            return Err(crate::Error::PulseOperation(format!(
+                "mainloop failed while {operation}: {error:?}"
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 fn get_desktop_file_dirs() -> Vec<PathBuf> {
@@ -172,6 +283,26 @@ fn parse_desktop_file(path: &std::path::Path) -> Option<InstalledApp> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn context_readiness_requires_ready_state() {
+        use pulse::context::State;
+
+        for state in [
+            State::Unconnected,
+            State::Connecting,
+            State::Authorizing,
+            State::SettingName,
+        ] {
+            assert_eq!(context_readiness(state), ContextReadiness::Pending);
+        }
+        assert_eq!(context_readiness(State::Ready), ContextReadiness::Ready);
+        assert_eq!(context_readiness(State::Failed), ContextReadiness::Failed);
+        assert_eq!(
+            context_readiness(State::Terminated),
+            ContextReadiness::Failed
+        );
+    }
 
     #[test]
     #[ignore]

--- a/crates/detect/src/mic/linux.rs
+++ b/crates/detect/src/mic/linux.rs
@@ -1,15 +1,16 @@
 use libpulse_binding as pulse;
 use libpulse_binding::context::{Context, FlagSet as ContextFlagSet};
 use libpulse_binding::mainloop::threaded::Mainloop;
+use std::collections::HashSet;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
     mpsc::{Receiver, SyncSender, sync_channel},
 };
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use crate::DetectEvent;
+use crate::{DetectEvent, InstalledApp};
 
 #[derive(Default)]
 pub struct Detector {
@@ -24,21 +25,40 @@ struct Worker {
 
 #[derive(Default)]
 struct DetectorState {
-    last_state: bool,
+    active_apps: Vec<InstalledApp>,
 }
 
 impl DetectorState {
-    fn seed(&mut self, state: bool) {
-        self.last_state = state;
+    fn seed(&mut self, apps: Vec<InstalledApp>) {
+        self.active_apps = apps;
     }
 
-    fn transition(&mut self, new_state: bool) -> Option<bool> {
-        if new_state == self.last_state {
-            return None;
-        }
+    fn reconcile(&mut self, current_apps: Vec<InstalledApp>) -> Vec<DetectEvent> {
+        let previous_ids: HashSet<_> = self.active_apps.iter().map(|app| &app.id).collect();
+        let current_ids: HashSet<_> = current_apps.iter().map(|app| &app.id).collect();
 
-        self.last_state = new_state;
-        Some(new_state)
+        let started = current_apps
+            .iter()
+            .filter(|app| !previous_ids.contains(&app.id))
+            .cloned()
+            .collect::<Vec<_>>();
+        let stopped = self
+            .active_apps
+            .iter()
+            .filter(|app| !current_ids.contains(&app.id))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        self.active_apps = current_apps;
+
+        let mut events = Vec::with_capacity(2);
+        if !started.is_empty() {
+            events.push(DetectEvent::MicStarted(started));
+        }
+        if !stopped.is_empty() {
+            events.push(DetectEvent::MicStopped(stopped));
+        }
+        events
     }
 }
 
@@ -173,8 +193,9 @@ fn run_detector(
     mainloop.unlock();
 
     let mut detector_state = DetectorState::default();
-    if let Some(initial_state) = check_mic_in_use(&mut mainloop, &context, &shutdown) {
-        detector_state.seed(initial_state);
+    match crate::list_mic_using_apps() {
+        Ok(active_apps) => detector_state.seed(active_apps),
+        Err(error) => tracing::warn!(?error, "failed_to_seed_linux_mic_apps"),
     }
 
     while !shutdown.load(Ordering::SeqCst) {
@@ -182,10 +203,16 @@ fn run_detector(
             break;
         }
 
-        if let Some(mic_in_use) = check_mic_in_use(&mut mainloop, &context, &shutdown)
-            && let Some(new_state) = detector_state.transition(mic_in_use)
-        {
-            emit_transition(&callback, new_state);
+        match crate::list_mic_using_apps() {
+            Ok(current_apps) => {
+                for event in detector_state.reconcile(current_apps) {
+                    tracing::info!(event = ?event, "detected");
+                    callback(event);
+                }
+            }
+            Err(error) => {
+                tracing::warn!(?error, "failed_to_refresh_linux_mic_apps");
+            }
         }
     }
 
@@ -241,83 +268,6 @@ fn is_source_output_event(
     )
 }
 
-fn check_mic_in_use(
-    mainloop: &mut Mainloop,
-    context: &Context,
-    shutdown: &AtomicBool,
-) -> Option<bool> {
-    let result = Arc::new(AtomicBool::new(false));
-    let query_done = Arc::new(AtomicBool::new(false));
-    let query_failed = Arc::new(AtomicBool::new(false));
-
-    let result_for_callback = result.clone();
-    let done_for_callback = query_done.clone();
-    let failed_for_callback = query_failed.clone();
-
-    mainloop.lock();
-    let mut operation = context
-        .introspect()
-        .get_source_output_info_list(move |list_result| match list_result {
-            pulse::callbacks::ListResult::Item(info) => {
-                if !info.corked {
-                    result_for_callback.store(true, Ordering::SeqCst);
-                }
-            }
-            pulse::callbacks::ListResult::End => {
-                done_for_callback.store(true, Ordering::SeqCst);
-            }
-            pulse::callbacks::ListResult::Error => {
-                failed_for_callback.store(true, Ordering::SeqCst);
-                done_for_callback.store(true, Ordering::SeqCst);
-            }
-        });
-    mainloop.unlock();
-
-    let deadline = Instant::now() + Duration::from_secs(1);
-    while !query_done.load(Ordering::SeqCst)
-        && !shutdown.load(Ordering::SeqCst)
-        && Instant::now() < deadline
-    {
-        std::thread::sleep(Duration::from_millis(10));
-    }
-
-    mainloop.lock();
-    let completed = query_done.load(Ordering::SeqCst);
-    let failed = query_failed.load(Ordering::SeqCst);
-    if !completed {
-        operation.cancel();
-    }
-    drop(operation);
-    mainloop.unlock();
-
-    if !completed {
-        if !shutdown.load(Ordering::SeqCst) {
-            tracing::warn!("pulseaudio_source_output_query_timed_out");
-        }
-        return None;
-    }
-
-    if failed {
-        tracing::warn!("pulseaudio_source_output_query_failed");
-        return None;
-    }
-
-    Some(result.load(Ordering::SeqCst))
-}
-
-fn emit_transition(callback: &crate::DetectCallback, mic_in_use: bool) {
-    let event = if mic_in_use {
-        let apps = crate::list_mic_using_apps().unwrap_or_default();
-        tracing::info!("mic_started_detected: {:?}", apps);
-        DetectEvent::MicStarted(apps)
-    } else {
-        DetectEvent::MicStopped(vec![])
-    };
-
-    tracing::info!(event = ?event, "detected");
-    callback(event);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,18 +297,57 @@ mod tests {
         assert!(!is_source_output_event(Some(Facility::SourceOutput), None));
     }
 
+    fn app(id: &str, name: &str) -> InstalledApp {
+        InstalledApp {
+            id: id.to_string(),
+            name: name.to_string(),
+        }
+    }
+
     #[test]
-    fn detector_state_emits_only_real_transitions() {
+    fn detector_state_emits_only_per_app_changes() {
         let mut state = DetectorState::default();
+        let zoom = app("us.zoom.xos", "Zoom");
+        let slack = app("com.tinyspeck.slackmacgap", "Slack");
 
-        assert_eq!(state.transition(false), None);
-        assert_eq!(state.transition(true), Some(true));
-        assert_eq!(state.transition(true), None);
-        assert_eq!(state.transition(false), Some(false));
+        assert!(state.reconcile(vec![]).is_empty());
 
-        state.seed(true);
-        assert_eq!(state.transition(true), None);
-        assert_eq!(state.transition(false), Some(false));
+        let events = state.reconcile(vec![zoom.clone()]);
+        assert!(matches!(
+            events.as_slice(),
+            [DetectEvent::MicStarted(apps)]
+                if apps.len() == 1 && apps[0].id.as_str() == zoom.id.as_str()
+        ));
+        assert!(state.reconcile(vec![zoom.clone()]).is_empty());
+
+        let events = state.reconcile(vec![zoom.clone(), slack.clone()]);
+        assert!(matches!(
+            events.as_slice(),
+            [DetectEvent::MicStarted(apps)]
+                if apps.len() == 1 && apps[0].id.as_str() == slack.id.as_str()
+        ));
+
+        let events = state.reconcile(vec![slack]);
+        assert!(matches!(
+            events.as_slice(),
+            [DetectEvent::MicStopped(apps)]
+                if apps.len() == 1 && apps[0].id.as_str() == zoom.id.as_str()
+        ));
+    }
+
+    #[test]
+    fn detector_state_retains_identity_for_final_stop() {
+        let mut state = DetectorState::default();
+        let zoom = app("us.zoom.xos", "Zoom");
+
+        state.seed(vec![zoom.clone()]);
+
+        let events = state.reconcile(vec![]);
+        assert!(matches!(
+            events.as_slice(),
+            [DetectEvent::MicStopped(apps)]
+                if apps.len() == 1 && apps[0].id.as_str() == zoom.id.as_str()
+        ));
     }
 
     #[test]

--- a/crates/detect/src/mic/linux.rs
+++ b/crates/detect/src/mic/linux.rs
@@ -1,258 +1,321 @@
 use libpulse_binding as pulse;
 use libpulse_binding::context::{Context, FlagSet as ContextFlagSet};
 use libpulse_binding::mainloop::threaded::Mainloop;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+    mpsc::{Receiver, SyncSender, sync_channel},
+};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
-use crate::{BackgroundTask, DetectEvent};
+use crate::DetectEvent;
 
 #[derive(Default)]
 pub struct Detector {
-    background: BackgroundTask,
+    worker: Option<Worker>,
 }
 
+struct Worker {
+    shutdown: Arc<AtomicBool>,
+    wake_tx: SyncSender<()>,
+    handle: JoinHandle<()>,
+}
+
+#[derive(Default)]
 struct DetectorState {
     last_state: bool,
-    last_change: Instant,
-    debounce_duration: Duration,
 }
 
 impl DetectorState {
-    fn new() -> Self {
-        Self {
-            last_state: false,
-            last_change: Instant::now(),
-            debounce_duration: Duration::from_millis(500),
-        }
+    fn seed(&mut self, state: bool) {
+        self.last_state = state;
     }
 
-    fn should_trigger(&mut self, new_state: bool) -> bool {
-        let now = Instant::now();
-
+    fn transition(&mut self, new_state: bool) -> Option<bool> {
         if new_state == self.last_state {
-            return false;
-        }
-        if now.duration_since(self.last_change) < self.debounce_duration {
-            return false;
+            return None;
         }
 
         self.last_state = new_state;
-        self.last_change = now;
-        true
+        Some(new_state)
+    }
+}
+
+impl Worker {
+    fn shutdown(self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.wake_tx.try_send(());
+
+        if self.handle.thread().id() == std::thread::current().id() {
+            return;
+        }
+
+        if self.handle.join().is_err() {
+            tracing::error!("pulseaudio_detector_thread_panicked");
+        }
+    }
+}
+
+impl Detector {
+    fn stop_worker(&mut self) {
+        if let Some(worker) = self.worker.take() {
+            worker.shutdown();
+        }
     }
 }
 
 impl crate::Observer for Detector {
     fn start(&mut self, f: crate::DetectCallback) {
-        self.background.start(|running, mut rx| async move {
-            let (tx, mut notify_rx) = tokio::sync::mpsc::channel(1);
+        if self
+            .worker
+            .as_ref()
+            .is_some_and(|worker| !worker.handle.is_finished())
+        {
+            return;
+        }
 
-            std::thread::spawn(move || {
-                let callback = Arc::new(Mutex::new(f));
-                let detector_state = Arc::new(Mutex::new(DetectorState::new()));
+        self.stop_worker();
 
-                let mut mainloop = match Mainloop::new() {
-                    Some(m) => m,
-                    None => {
-                        tracing::error!("failed_to_create_pulseaudio_mainloop");
-                        return;
-                    }
-                };
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let (wake_tx, wake_rx) = sync_channel(1);
+        let thread_shutdown = shutdown.clone();
+        let thread_wake_tx = wake_tx.clone();
 
-                let mut context = match Context::new(&mainloop, "hyprnote-mic-detector") {
-                    Some(c) => c,
-                    None => {
-                        tracing::error!("failed_to_create_pulseaudio_context");
-                        return;
-                    }
-                };
-
-                let callback_for_subscribe = callback.clone();
-                let detector_state_for_subscribe = detector_state.clone();
-
-                context.set_subscribe_callback(Some(Box::new(
-                    move |facility, operation, _index| {
-                        if let Some(pulse::context::subscribe::Facility::Source) = facility
-                            && let Some(pulse::context::subscribe::Operation::Changed) = operation
-                            && let Ok(mut state) = detector_state_for_subscribe.lock()
-                        {
-                            let mic_in_use = check_mic_in_use();
-
-                            if state.should_trigger(mic_in_use) {
-                                if mic_in_use {
-                                    let cb = callback_for_subscribe.clone();
-                                    std::thread::spawn(move || {
-                                        let apps = crate::list_mic_using_apps().unwrap_or_default();
-                                        tracing::info!("mic_started_detected: {:?}", apps);
-
-                                        if let Ok(guard) = cb.lock() {
-                                            let event = DetectEvent::MicStarted(apps);
-                                            tracing::info!(event = ?event, "detected");
-                                            (*guard)(event);
-                                        }
-                                    });
-                                } else if let Ok(guard) = callback_for_subscribe.lock() {
-                                    let event = DetectEvent::MicStopped(vec![]);
-                                    tracing::info!(event = ?event, "detected");
-                                    (*guard)(event);
-                                }
-                            }
-                        }
-                    },
-                )));
-
-                if context
-                    .connect(None, ContextFlagSet::NOFLAGS, None)
-                    .is_err()
-                {
-                    tracing::error!("failed_to_connect_to_pulseaudio");
-                    return;
-                }
-
-                if mainloop.start().is_err() {
-                    tracing::error!("failed_to_start_mainloop");
-                    return;
-                }
-
-                mainloop.lock();
-                loop {
-                    match context.get_state() {
-                        pulse::context::State::Ready => break,
-                        pulse::context::State::Failed | pulse::context::State::Terminated => {
-                            mainloop.unlock();
-                            tracing::error!("pulseaudio_context_connection_failed");
-                            return;
-                        }
-                        _ => {
-                            mainloop.wait();
-                        }
-                    }
-                }
-                mainloop.unlock();
-
-                tracing::info!("pulseaudio_context_connected");
-
-                context.subscribe(
-                    pulse::context::subscribe::InterestMaskSet::SOURCE,
-                    |success| {
-                        if success {
-                            tracing::info!("subscribed_to_pulseaudio_source_events");
-                        } else {
-                            tracing::error!("failed_to_subscribe_to_pulseaudio_events");
-                        }
-                    },
-                );
-
-                let initial_mic_state = check_mic_in_use();
-                if let Ok(mut state) = detector_state.lock() {
-                    state.last_state = initial_mic_state;
-                }
-
-                let _ = tx.blocking_send(());
-
-                loop {
-                    std::thread::park();
-                }
-            });
-
-            let _ = notify_rx.recv().await;
-
-            loop {
-                tokio::select! {
-                    _ = &mut rx => {
-                        break;
-                    }
-                    _ = tokio::time::sleep(tokio::time::Duration::from_millis(500)) => {
-                        if !running.load(std::sync::atomic::Ordering::SeqCst) {
-                            break;
-                        }
-                    }
-                }
+        match std::thread::Builder::new()
+            .name("pulseaudio-mic-detector".to_string())
+            .spawn(move || run_detector(f, thread_shutdown, thread_wake_tx, wake_rx))
+        {
+            Ok(handle) => {
+                self.worker = Some(Worker {
+                    shutdown,
+                    wake_tx,
+                    handle,
+                });
             }
-        });
+            Err(error) => {
+                tracing::error!(?error, "failed_to_spawn_pulseaudio_detector");
+            }
+        }
     }
 
     fn stop(&mut self) {
-        self.background.stop();
+        self.stop_worker();
     }
 }
 
-fn check_mic_in_use() -> bool {
+impl Drop for Detector {
+    fn drop(&mut self) {
+        self.stop_worker();
+    }
+}
+
+fn run_detector(
+    callback: crate::DetectCallback,
+    shutdown: Arc<AtomicBool>,
+    wake_tx: SyncSender<()>,
+    wake_rx: Receiver<()>,
+) {
     let mut mainloop = match Mainloop::new() {
         Some(m) => m,
-        None => return false,
+        None => {
+            tracing::error!("failed_to_create_pulseaudio_mainloop");
+            return;
+        }
     };
 
-    let mut context = match Context::new(&mainloop, "hyprnote-mic-check") {
+    let mut context = match Context::new(&mainloop, "hyprnote-mic-detector") {
         Some(c) => c,
-        None => return false,
+        None => {
+            tracing::error!("failed_to_create_pulseaudio_context");
+            return;
+        }
     };
-
-    let result = Arc::new(Mutex::new(false));
-    let result_clone = result.clone();
 
     if context
         .connect(None, ContextFlagSet::NOFLAGS, None)
         .is_err()
     {
-        return false;
+        tracing::error!("failed_to_connect_to_pulseaudio");
+        return;
     }
 
     if mainloop.start().is_err() {
-        return false;
+        tracing::error!("failed_to_start_pulseaudio_mainloop");
+        context.disconnect();
+        return;
+    }
+
+    if !wait_for_context(&mut mainloop, &context, &shutdown) {
+        shutdown_context(&mut mainloop, &mut context);
+        return;
+    }
+
+    tracing::info!("pulseaudio_context_connected");
+
+    let event_wake_tx = wake_tx.clone();
+    mainloop.lock();
+    context.set_subscribe_callback(Some(Box::new(move |facility, operation, _index| {
+        if is_source_output_event(facility, operation) {
+            let _ = event_wake_tx.try_send(());
+        }
+    })));
+    let subscribe_operation = context.subscribe(
+        pulse::context::subscribe::InterestMaskSet::SOURCE_OUTPUT,
+        |success| {
+            if success {
+                tracing::info!("subscribed_to_pulseaudio_source_output_events");
+            } else {
+                tracing::error!("failed_to_subscribe_to_pulseaudio_source_output_events");
+            }
+        },
+    );
+    mainloop.unlock();
+
+    let mut detector_state = DetectorState::default();
+    if let Some(initial_state) = check_mic_in_use(&mut mainloop, &context, &shutdown) {
+        detector_state.seed(initial_state);
+    }
+
+    while !shutdown.load(Ordering::SeqCst) {
+        if wake_rx.recv().is_err() || shutdown.load(Ordering::SeqCst) {
+            break;
+        }
+
+        if let Some(mic_in_use) = check_mic_in_use(&mut mainloop, &context, &shutdown)
+            && let Some(new_state) = detector_state.transition(mic_in_use)
+        {
+            emit_transition(&callback, new_state);
+        }
     }
 
     mainloop.lock();
-    loop {
-        match context.get_state() {
-            pulse::context::State::Ready => break,
+    context.set_subscribe_callback(None);
+    drop(subscribe_operation);
+    context.disconnect();
+    mainloop.unlock();
+    mainloop.stop();
+}
+
+fn wait_for_context(mainloop: &mut Mainloop, context: &Context, shutdown: &AtomicBool) -> bool {
+    while !shutdown.load(Ordering::SeqCst) {
+        mainloop.lock();
+        let state = context.get_state();
+        mainloop.unlock();
+
+        match state {
+            pulse::context::State::Ready => return true,
             pulse::context::State::Failed | pulse::context::State::Terminated => {
-                mainloop.unlock();
+                tracing::error!("pulseaudio_context_connection_failed");
                 return false;
             }
-            _ => {
-                mainloop.wait();
-            }
+            _ => std::thread::sleep(Duration::from_millis(10)),
         }
     }
+
+    false
+}
+
+fn shutdown_context(mainloop: &mut Mainloop, context: &mut Context) {
+    mainloop.lock();
+    context.set_subscribe_callback(None);
+    context.disconnect();
+    mainloop.unlock();
+    mainloop.stop();
+}
+
+fn is_source_output_event(
+    facility: Option<pulse::context::subscribe::Facility>,
+    operation: Option<pulse::context::subscribe::Operation>,
+) -> bool {
+    matches!(
+        (facility, operation),
+        (
+            Some(pulse::context::subscribe::Facility::SourceOutput),
+            Some(
+                pulse::context::subscribe::Operation::New
+                    | pulse::context::subscribe::Operation::Changed
+                    | pulse::context::subscribe::Operation::Removed
+            )
+        )
+    )
+}
+
+fn check_mic_in_use(
+    mainloop: &mut Mainloop,
+    context: &Context,
+    shutdown: &AtomicBool,
+) -> Option<bool> {
+    let result = Arc::new(AtomicBool::new(false));
+    let query_done = Arc::new(AtomicBool::new(false));
+    let query_failed = Arc::new(AtomicBool::new(false));
+
+    let result_for_callback = result.clone();
+    let done_for_callback = query_done.clone();
+    let failed_for_callback = query_failed.clone();
+
+    mainloop.lock();
+    let mut operation = context
+        .introspect()
+        .get_source_output_info_list(move |list_result| match list_result {
+            pulse::callbacks::ListResult::Item(info) => {
+                if !info.corked {
+                    result_for_callback.store(true, Ordering::SeqCst);
+                }
+            }
+            pulse::callbacks::ListResult::End => {
+                done_for_callback.store(true, Ordering::SeqCst);
+            }
+            pulse::callbacks::ListResult::Error => {
+                failed_for_callback.store(true, Ordering::SeqCst);
+                done_for_callback.store(true, Ordering::SeqCst);
+            }
+        });
     mainloop.unlock();
 
-    let introspector = context.introspect();
-    let done = Arc::new(Mutex::new(false));
-    let done_clone = done.clone();
-
-    introspector.get_source_output_info_list(move |list_result| match list_result {
-        pulse::callbacks::ListResult::Item(info) => {
-            if !info.corked
-                && let Ok(mut r) = result_clone.lock()
-            {
-                *r = true;
-            }
-        }
-        pulse::callbacks::ListResult::End => {
-            if let Ok(mut d) = done_clone.lock() {
-                *d = true;
-            }
-        }
-        pulse::callbacks::ListResult::Error => {
-            if let Ok(mut d) = done_clone.lock() {
-                *d = true;
-            }
-        }
-    });
-
-    for _ in 0..100 {
-        if let Ok(d) = done.lock()
-            && *d
-        {
-            break;
-        }
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !query_done.load(Ordering::SeqCst)
+        && !shutdown.load(Ordering::SeqCst)
+        && Instant::now() < deadline
+    {
         std::thread::sleep(Duration::from_millis(10));
     }
 
-    mainloop.stop();
+    mainloop.lock();
+    let completed = query_done.load(Ordering::SeqCst);
+    let failed = query_failed.load(Ordering::SeqCst);
+    if !completed {
+        operation.cancel();
+    }
+    drop(operation);
+    mainloop.unlock();
 
-    result.lock().map(|r| *r).unwrap_or(false)
+    if !completed {
+        if !shutdown.load(Ordering::SeqCst) {
+            tracing::warn!("pulseaudio_source_output_query_timed_out");
+        }
+        return None;
+    }
+
+    if failed {
+        tracing::warn!("pulseaudio_source_output_query_failed");
+        return None;
+    }
+
+    Some(result.load(Ordering::SeqCst))
+}
+
+fn emit_transition(callback: &crate::DetectCallback, mic_in_use: bool) {
+    let event = if mic_in_use {
+        let apps = crate::list_mic_using_apps().unwrap_or_default();
+        tracing::info!("mic_started_detected: {:?}", apps);
+        DetectEvent::MicStarted(apps)
+    } else {
+        DetectEvent::MicStopped(vec![])
+    };
+
+    tracing::info!(event = ?event, "detected");
+    callback(event);
 }
 
 #[cfg(test)]
@@ -260,7 +323,69 @@ mod tests {
     use super::*;
     use crate::{Observer, new_callback};
 
+    #[test]
+    fn source_output_lifecycle_events_request_state_refresh() {
+        use pulse::context::subscribe::{Facility, Operation};
+
+        for operation in [Operation::New, Operation::Changed, Operation::Removed] {
+            assert!(is_source_output_event(
+                Some(Facility::SourceOutput),
+                Some(operation)
+            ));
+        }
+    }
+
+    #[test]
+    fn source_device_events_do_not_request_state_refresh() {
+        use pulse::context::subscribe::{Facility, Operation};
+
+        assert!(!is_source_output_event(
+            Some(Facility::Source),
+            Some(Operation::Changed)
+        ));
+        assert!(!is_source_output_event(None, Some(Operation::New)));
+        assert!(!is_source_output_event(Some(Facility::SourceOutput), None));
+    }
+
+    #[test]
+    fn detector_state_emits_only_real_transitions() {
+        let mut state = DetectorState::default();
+
+        assert_eq!(state.transition(false), None);
+        assert_eq!(state.transition(true), Some(true));
+        assert_eq!(state.transition(true), None);
+        assert_eq!(state.transition(false), Some(false));
+
+        state.seed(true);
+        assert_eq!(state.transition(true), None);
+        assert_eq!(state.transition(false), Some(false));
+    }
+
+    #[test]
+    fn worker_shutdown_wakes_and_joins_thread() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let thread_shutdown = shutdown.clone();
+        let exited = Arc::new(AtomicBool::new(false));
+        let thread_exited = exited.clone();
+        let (wake_tx, wake_rx) = sync_channel(1);
+        let handle = std::thread::spawn(move || {
+            wake_rx.recv().unwrap();
+            assert!(thread_shutdown.load(Ordering::SeqCst));
+            thread_exited.store(true, Ordering::SeqCst);
+        });
+
+        Worker {
+            shutdown,
+            wake_tx,
+            handle,
+        }
+        .shutdown();
+
+        assert!(exited.load(Ordering::SeqCst));
+    }
+
     #[tokio::test]
+    #[ignore = "requires a live PulseAudio server and microphone client"]
     async fn test_detector() {
         let mut detector = Detector::default();
         detector.start(new_callback(|v| {


### PR DESCRIPTION
Track PulseAudio source-output lifecycle changes and shut down the detector worker cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral change to Linux mic detection and PulseAudio async handling; failures surface as new errors but core app logic is isolated to the detect crate with added tests.
> 
> **Overview**
> **Linux mic detection** now tracks **per-app** microphone use via PulseAudio **source-output** lifecycle events instead of a debounced on/off flag tied to generic source changes.
> 
> `list_mic_using_apps` waits for a ready PulseAudio context, completes source-output introspection with **timeouts and explicit errors** (`PulseOperation`), skips **corked** streams, and **deduplicates** apps. The mic **detector** runs on a dedicated worker thread: it subscribes to source-output new/changed/removed events, seeds state from an initial listing, **reconciles** app sets into `MicStarted` / `MicStopped` with app identity on stop, and **shuts down** cleanly (wake, unsubscribe, disconnect, join). Unit tests cover readiness mapping, event filtering, reconcile behavior, and worker shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb7fe197038edec0fbea5efc48ab045a8ba9afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->