### PR TITLE
Honor Linux notification actions

### DIFF
--- a/crates/notification-linux/src/callbacks.rs
+++ b/crates/notification-linux/src/callbacks.rs
@@ -1,0 +1,208 @@
+use std::sync::Mutex;
+
+type NotificationCallback = Mutex<Option<Box<dyn Fn(String) + Send + Sync>>>;
+type NotificationOptionCallback = Mutex<Option<Box<dyn Fn(String, i32) + Send + Sync>>>;
+
+static CONFIRM_CB: NotificationCallback = Mutex::new(None);
+static ACCEPT_CB: NotificationCallback = Mutex::new(None);
+static DISMISS_CB: NotificationCallback = Mutex::new(None);
+static TIMEOUT_CB: NotificationCallback = Mutex::new(None);
+static OPTION_SELECTED_CB: NotificationOptionCallback = Mutex::new(None);
+static FOOTER_ACTION_CB: NotificationCallback = Mutex::new(None);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PrimaryAction<'a> {
+    Accept { label: &'a str, destructive: bool },
+    Options(&'a [String]),
+}
+
+pub(crate) fn primary_action(
+    notification: &hypr_notification_interface::Notification,
+) -> PrimaryAction<'_> {
+    if let Some(options) = notification
+        .options
+        .as_deref()
+        .filter(|options| !options.is_empty())
+    {
+        return PrimaryAction::Options(options);
+    }
+
+    PrimaryAction::Accept {
+        label: notification
+            .action_label
+            .as_deref()
+            .unwrap_or("Open Anarlog"),
+        destructive: matches!(
+            notification.action_variant,
+            Some(hypr_notification_interface::NotificationActionVariant::Destructive)
+        ),
+    }
+}
+
+pub fn setup_notification_confirm_handler<F>(f: F)
+where
+    F: Fn(String) + Send + Sync + 'static,
+{
+    *CONFIRM_CB.lock().unwrap() = Some(Box::new(f));
+}
+
+pub fn setup_notification_accept_handler<F>(f: F)
+where
+    F: Fn(String) + Send + Sync + 'static,
+{
+    *ACCEPT_CB.lock().unwrap() = Some(Box::new(f));
+}
+
+pub fn setup_notification_dismiss_handler<F>(f: F)
+where
+    F: Fn(String) + Send + Sync + 'static,
+{
+    *DISMISS_CB.lock().unwrap() = Some(Box::new(f));
+}
+
+pub fn setup_notification_timeout_handler<F>(f: F)
+where
+    F: Fn(String) + Send + Sync + 'static,
+{
+    *TIMEOUT_CB.lock().unwrap() = Some(Box::new(f));
+}
+
+pub fn setup_notification_option_selected_handler<F>(f: F)
+where
+    F: Fn(String, i32) + Send + Sync + 'static,
+{
+    *OPTION_SELECTED_CB.lock().unwrap() = Some(Box::new(f));
+}
+
+pub fn setup_notification_footer_action_handler<F>(f: F)
+where
+    F: Fn(String) + Send + Sync + 'static,
+{
+    *FOOTER_ACTION_CB.lock().unwrap() = Some(Box::new(f));
+}
+
+pub(crate) fn confirm(key: String) {
+    if let Some(cb) = CONFIRM_CB.lock().unwrap().as_ref() {
+        cb(key);
+    }
+}
+
+pub(crate) fn accept(key: String) {
+    if let Some(cb) = ACCEPT_CB.lock().unwrap().as_ref() {
+        cb(key);
+    }
+}
+
+pub(crate) fn dismiss(key: String) {
+    if let Some(cb) = DISMISS_CB.lock().unwrap().as_ref() {
+        cb(key);
+    }
+}
+
+pub(crate) fn timeout(key: String) {
+    if let Some(cb) = TIMEOUT_CB.lock().unwrap().as_ref() {
+        cb(key);
+    }
+}
+
+pub(crate) fn option_selected(key: String, index: i32) {
+    if let Some(cb) = OPTION_SELECTED_CB.lock().unwrap().as_ref() {
+        cb(key, index);
+    }
+}
+
+pub(crate) fn footer_action(key: String) {
+    if let Some(cb) = FOOTER_ACTION_CB.lock().unwrap().as_ref() {
+        cb(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[test]
+    fn resolves_linux_primary_actions_from_the_shared_notification_contract() {
+        let default_action = hypr_notification_interface::Notification::builder()
+            .title("Upcoming event")
+            .message("Starting soon")
+            .build();
+        assert_eq!(
+            primary_action(&default_action),
+            PrimaryAction::Accept {
+                label: "Open Anarlog",
+                destructive: false,
+            }
+        );
+
+        let destructive_action = hypr_notification_interface::Notification::builder()
+            .title("Did your meeting end?")
+            .message("Anarlog will stop listening soon.")
+            .action_label("Stop")
+            .action_variant(hypr_notification_interface::NotificationActionVariant::Destructive)
+            .build();
+        assert_eq!(
+            primary_action(&destructive_action),
+            PrimaryAction::Accept {
+                label: "Stop",
+                destructive: true,
+            }
+        );
+
+        let options_action = hypr_notification_interface::Notification::builder()
+            .title("Choose a meeting")
+            .message("")
+            .action_label("Ignored when options are present")
+            .options(vec!["Design sync".to_string(), "Planning".to_string()])
+            .build();
+        assert_eq!(
+            primary_action(&options_action),
+            PrimaryAction::Options(&["Design sync".to_string(), "Planning".to_string()])
+        );
+    }
+
+    #[test]
+    fn routes_each_linux_notification_action_to_its_registered_handler() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        let record = |event: &'static str| {
+            let events = events.clone();
+            move |key: String| events.lock().unwrap().push(format!("{event}:{key}"))
+        };
+
+        setup_notification_confirm_handler(record("confirm"));
+        setup_notification_accept_handler(record("accept"));
+        setup_notification_dismiss_handler(record("dismiss"));
+        setup_notification_timeout_handler(record("timeout"));
+        setup_notification_footer_action_handler(record("footer"));
+
+        let option_events = events.clone();
+        setup_notification_option_selected_handler(move |key, index| {
+            option_events
+                .lock()
+                .unwrap()
+                .push(format!("option:{key}:{index}"));
+        });
+
+        confirm("meeting".to_string());
+        accept("meeting".to_string());
+        dismiss("meeting".to_string());
+        timeout("meeting".to_string());
+        option_selected("meeting".to_string(), 2);
+        footer_action("meeting".to_string());
+
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec![
+                "confirm:meeting".to_string(),
+                "accept:meeting".to_string(),
+                "dismiss:meeting".to_string(),
+                "timeout:meeting".to_string(),
+                "option:meeting:2".to_string(),
+                "footer:meeting".to_string(),
+            ]
+        );
+    }
+}

--- a/crates/notification-linux/src/impl.rs
+++ b/crates/notification-linux/src/impl.rs
@@ -1,77 +1,17 @@
 use std::cell::RefCell;
-use std::sync::Mutex;
 use std::time::Duration;
 
 use gtk::prelude::*;
 use gtk::{
-    Align, Box as GtkBox, Button, CssProvider, Image, Label, Orientation, StyleContext, Window,
-    WindowType,
+    Align, Box as GtkBox, Button, CssProvider, EventBox, Image, Label, Menu, MenuButton, MenuItem,
+    Orientation, StyleContext, Window, WindowType,
 };
 use indexmap::IndexMap;
 
-type NotificationCallback = Mutex<Option<Box<dyn Fn(String) + Send + Sync>>>;
+use crate::callbacks;
 
 thread_local! {
     static NOTIFICATION_MANAGER: RefCell<NotificationManager> = RefCell::new(NotificationManager::new());
-}
-
-static CONFIRM_CB: NotificationCallback = Mutex::new(None);
-static ACCEPT_CB: NotificationCallback = Mutex::new(None);
-static DISMISS_CB: NotificationCallback = Mutex::new(None);
-static TIMEOUT_CB: NotificationCallback = Mutex::new(None);
-
-pub fn setup_notification_dismiss_handler<F>(f: F)
-where
-    F: Fn(String) + Send + Sync + 'static,
-{
-    *DISMISS_CB.lock().unwrap() = Some(Box::new(f));
-}
-
-pub fn setup_notification_confirm_handler<F>(f: F)
-where
-    F: Fn(String) + Send + Sync + 'static,
-{
-    *CONFIRM_CB.lock().unwrap() = Some(Box::new(f));
-}
-
-pub fn setup_notification_accept_handler<F>(f: F)
-where
-    F: Fn(String) + Send + Sync + 'static,
-{
-    *ACCEPT_CB.lock().unwrap() = Some(Box::new(f));
-}
-
-pub fn setup_notification_timeout_handler<F>(f: F)
-where
-    F: Fn(String) + Send + Sync + 'static,
-{
-    *TIMEOUT_CB.lock().unwrap() = Some(Box::new(f));
-}
-
-#[allow(dead_code)]
-fn call_confirm_handler(key: String) {
-    if let Some(cb) = CONFIRM_CB.lock().unwrap().as_ref() {
-        cb(key);
-    }
-}
-
-#[allow(dead_code)]
-fn call_accept_handler(key: String) {
-    if let Some(cb) = ACCEPT_CB.lock().unwrap().as_ref() {
-        cb(key);
-    }
-}
-
-fn call_dismiss_handler(key: String) {
-    if let Some(cb) = DISMISS_CB.lock().unwrap().as_ref() {
-        cb(key);
-    }
-}
-
-fn call_timeout_handler(key: String) {
-    if let Some(cb) = TIMEOUT_CB.lock().unwrap().as_ref() {
-        cb(key);
-    }
 }
 
 struct NotificationInstance {
@@ -97,17 +37,19 @@ impl NotificationInstance {
         let key = self.key.clone();
         let window = self.window.clone();
         let source = glib::timeout_add_seconds_local_once(timeout_seconds as u32, move || {
-            call_timeout_handler(key.clone());
-            Self::dismiss_window(&window, &key, false);
+            callbacks::timeout(key.clone());
+            Self::dismiss_window_inner(&window, &key, false);
+            NotificationManager::remove_notification_global(&key, false);
         });
         self.timeout_source = Some(source);
     }
 
     fn dismiss_window_inner(window: &Window, key: &str, user_action: bool) {
         if user_action {
-            call_dismiss_handler(key.to_string());
+            callbacks::dismiss(key.to_string());
         }
 
+        window.set_sensitive(false);
         window.set_opacity(1.0);
         let window_clone = window.clone();
         glib::timeout_add_local_once(Duration::from_millis(200), move || {
@@ -117,7 +59,7 @@ impl NotificationInstance {
 
     fn dismiss_window(window: &Window, key: &str, user_action: bool) {
         Self::dismiss_window_inner(window, key, user_action);
-        NotificationManager::remove_notification_global(key);
+        NotificationManager::remove_notification_global(key, true);
     }
 }
 
@@ -147,17 +89,23 @@ impl NotificationManager {
         }
     }
 
-    fn show(&mut self, key: String, title: String, message: String, timeout_seconds: f64) {
+    fn show(&mut self, notification: hypr_notification_interface::Notification) {
         if !self.ensure_gtk() {
             return;
         }
+
+        let key = notification
+            .key
+            .clone()
+            .unwrap_or_else(|| notification.title.clone());
+        let timeout_seconds = notification.timeout.map(|d| d.as_secs_f64()).unwrap_or(0.0);
 
         while self.active_notifications.len() >= self.max_notifications {
             if let Some((oldest_id, notif)) = self.active_notifications.get_index(0) {
                 let oldest_id = oldest_id.clone();
                 let window = notif.window.clone();
                 NotificationInstance::dismiss_window_inner(&window, &oldest_id, false);
-                self.remove_notification_locked(&oldest_id);
+                self.remove_notification_locked(&oldest_id, true);
             } else {
                 break;
             }
@@ -166,11 +114,18 @@ impl NotificationManager {
         let window = Window::new(WindowType::Toplevel);
         window.set_decorated(false);
         window.set_resizable(false);
-        window.set_default_size(360, 64);
+        window.set_default_size(
+            360,
+            if notification.footer.is_some() {
+                96
+            } else {
+                64
+            },
+        );
         window.set_keep_above(true);
 
         self.setup_window_style(&window);
-        self.create_notification_content(&window, &title, &message, &key);
+        self.create_notification_content(&window, &notification, &key);
         self.position_window(&window);
 
         window.show_all();
@@ -229,6 +184,21 @@ impl NotificationManager {
             .action-button:hover {
                 background-color: rgba(230, 230, 230, 0.9);
             }
+            .destructive-action-button {
+                background-color: rgba(196, 43, 28, 0.95);
+                color: white;
+            }
+            .destructive-action-button:hover {
+                background-color: rgba(166, 34, 23, 0.95);
+            }
+            .notification-footer {
+                border-top: 1px solid rgba(0, 0, 0, 0.1);
+                padding-top: 4px;
+            }
+            .notification-footer-label {
+                font-size: 10px;
+                color: #666666;
+            }
             "#,
         );
 
@@ -241,7 +211,12 @@ impl NotificationManager {
         }
     }
 
-    fn create_notification_content(&self, window: &Window, title: &str, message: &str, key: &str) {
+    fn create_notification_content(
+        &self,
+        window: &Window,
+        notification: &hypr_notification_interface::Notification,
+        key: &str,
+    ) {
         let main_box = GtkBox::new(Orientation::Horizontal, 8);
         main_box.set_margin_start(12);
         main_box.set_margin_end(12);
@@ -249,19 +224,20 @@ impl NotificationManager {
         main_box.set_margin_bottom(9);
         main_box.set_valign(Align::Center);
 
+        let content_box = GtkBox::new(Orientation::Horizontal, 8);
         let icon = Image::from_icon_name(Some("application-x-executable"), gtk::IconSize::Dnd);
-        main_box.pack_start(&icon, false, false, 0);
+        content_box.pack_start(&icon, false, false, 0);
 
         let text_box = GtkBox::new(Orientation::Vertical, 2);
         text_box.set_hexpand(true);
 
-        let title_label = Label::new(Some(title));
+        let title_label = Label::new(Some(&notification.title));
         title_label.set_halign(Align::Start);
         title_label.set_ellipsize(pango::EllipsizeMode::End);
         title_label.style_context().add_class("notification-title");
         text_box.pack_start(&title_label, false, false, 0);
 
-        let message_label = Label::new(Some(message));
+        let message_label = Label::new(Some(&notification.message));
         message_label.set_halign(Align::Start);
         message_label.set_ellipsize(pango::EllipsizeMode::End);
         message_label
@@ -269,7 +245,69 @@ impl NotificationManager {
             .add_class("notification-message");
         text_box.pack_start(&message_label, false, false, 0);
 
-        main_box.pack_start(&text_box, true, true, 0);
+        content_box.pack_start(&text_box, true, true, 0);
+
+        let content_event_box = EventBox::new();
+        content_event_box.set_visible_window(false);
+        content_event_box.add(&content_box);
+        let content_key = key.to_string();
+        let content_window = window.clone();
+        content_event_box.connect_button_press_event(move |_, _| {
+            callbacks::confirm(content_key.clone());
+            NotificationInstance::dismiss_window(&content_window, &content_key, false);
+            glib::Propagation::Stop
+        });
+        main_box.pack_start(&content_event_box, true, true, 0);
+
+        match callbacks::primary_action(notification) {
+            callbacks::PrimaryAction::Options(options) => {
+                let menu = Menu::new();
+                for (index, option) in options.iter().enumerate() {
+                    let menu_item = MenuItem::with_label(option);
+                    let option_key = key.to_string();
+                    let option_window = window.clone();
+                    menu_item.connect_activate(move |_| {
+                        callbacks::option_selected(option_key.clone(), index as i32);
+                        NotificationInstance::dismiss_window(&option_window, &option_key, false);
+                    });
+                    menu.append(&menu_item);
+                }
+
+                let create_new_item = MenuItem::with_label("Create New Note...");
+                let create_new_index = options.len() as i32;
+                let option_key = key.to_string();
+                let option_window = window.clone();
+                create_new_item.connect_activate(move |_| {
+                    callbacks::option_selected(option_key.clone(), create_new_index);
+                    NotificationInstance::dismiss_window(&option_window, &option_key, false);
+                });
+                menu.append(&create_new_item);
+                menu.show_all();
+
+                let menu_button = MenuButton::new();
+                menu_button.set_label("Options");
+                menu_button.style_context().add_class("action-button");
+                menu_button.set_popup(Some(&menu));
+                main_box.pack_start(&menu_button, false, false, 0);
+            }
+            callbacks::PrimaryAction::Accept { label, destructive } => {
+                let action_button = Button::with_label(label);
+                action_button.style_context().add_class("action-button");
+                if destructive {
+                    action_button
+                        .style_context()
+                        .add_class("destructive-action-button");
+                }
+
+                let action_key = key.to_string();
+                let action_window = window.clone();
+                action_button.connect_clicked(move |_| {
+                    callbacks::accept(action_key.clone());
+                    NotificationInstance::dismiss_window(&action_window, &action_key, false);
+                });
+                main_box.pack_start(&action_button, false, false, 0);
+            }
+        }
 
         let close_button = Button::new();
         close_button.set_label("×");
@@ -282,12 +320,38 @@ impl NotificationManager {
         close_button.connect_clicked(move |_| {
             NotificationInstance::dismiss_window(&window_clone, &key_clone, true);
         });
+        main_box.pack_start(&close_button, false, false, 0);
 
-        let overlay = gtk::Overlay::new();
-        overlay.add(&main_box);
-        overlay.add_overlay(&close_button);
+        let root_box = GtkBox::new(Orientation::Vertical, 0);
+        root_box.pack_start(&main_box, true, true, 0);
 
-        window.add(&overlay);
+        if let Some(footer) = &notification.footer {
+            let footer_box = GtkBox::new(Orientation::Horizontal, 8);
+            footer_box.set_margin_start(12);
+            footer_box.set_margin_end(12);
+            footer_box.set_margin_bottom(5);
+            footer_box.style_context().add_class("notification-footer");
+
+            let footer_label = Label::new(Some(&footer.text));
+            footer_label.set_halign(Align::Start);
+            footer_label.set_ellipsize(pango::EllipsizeMode::End);
+            footer_label
+                .style_context()
+                .add_class("notification-footer-label");
+            footer_box.pack_start(&footer_label, true, true, 0);
+
+            let footer_button = Button::with_label(&footer.action_label);
+            let footer_key = key.to_string();
+            let footer_window = window.clone();
+            footer_button.connect_clicked(move |_| {
+                callbacks::footer_action(footer_key.clone());
+                NotificationInstance::dismiss_window(&footer_window, &footer_key, false);
+            });
+            footer_box.pack_start(&footer_button, false, false, 0);
+            root_box.pack_start(&footer_box, false, false, 0);
+        }
+
+        window.add(&root_box);
     }
 
     fn position_window(&self, window: &Window) {
@@ -309,14 +373,21 @@ impl NotificationManager {
         // TODO: Reposition existing notifications once we implement a GTK4-compatible positioning strategy.
     }
 
-    fn remove_notification_locked(&mut self, key: &str) {
-        self.active_notifications.swap_remove(key);
+    fn remove_notification_locked(&mut self, key: &str, cancel_timeout: bool) {
+        if let Some(mut notification) = self.active_notifications.swap_remove(key)
+            && cancel_timeout
+            && let Some(source) = notification.timeout_source.take()
+        {
+            source.remove();
+        }
         self.reposition_notifications();
     }
 
-    fn remove_notification_global(key: &str) {
+    fn remove_notification_global(key: &str, cancel_timeout: bool) {
         NOTIFICATION_MANAGER.with(|manager| {
-            manager.borrow_mut().remove_notification_locked(key);
+            manager
+                .borrow_mut()
+                .remove_notification_locked(key, cancel_timeout);
         });
     }
 
@@ -326,26 +397,18 @@ impl NotificationManager {
             if let Some(notif) = self.active_notifications.get(&key) {
                 let window = notif.window.clone();
                 NotificationInstance::dismiss_window_inner(&window, &key, false);
-                self.remove_notification_locked(&key);
+                self.remove_notification_locked(&key, true);
             }
         }
     }
 }
 
 pub fn show(notification: &hypr_notification_interface::Notification) {
-    let key = notification
-        .key
-        .clone()
-        .unwrap_or_else(|| notification.title.clone());
-    let title = notification.title.clone();
-    let message = notification.message.clone();
-    let timeout_seconds = notification.timeout.map(|d| d.as_secs_f64()).unwrap_or(0.0);
+    let notification = notification.clone();
 
     glib::MainContext::default().invoke(move || {
         NOTIFICATION_MANAGER.with(|manager| {
-            manager
-                .borrow_mut()
-                .show(key, title, message, timeout_seconds);
+            manager.borrow_mut().show(notification);
         });
     });
 }
@@ -356,20 +419,4 @@ pub fn dismiss_all() {
             manager.borrow_mut().dismiss_all();
         });
     });
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_notification() {
-        let notification = hypr_notification_interface::Notification::builder()
-            .title("Test Title")
-            .message("Test message content")
-            .timeout(std::time::Duration::from_secs(3))
-            .build();
-
-        show(&notification);
-    }
 }

--- a/crates/notification-linux/src/lib.rs
+++ b/crates/notification-linux/src/lib.rs
@@ -1,10 +1,17 @@
 pub use hypr_notification_interface::*;
 
+#[cfg(any(target_os = "linux", test))]
+mod callbacks;
+
 #[cfg(target_os = "linux")]
 mod r#impl;
 
 #[cfg(target_os = "linux")]
-pub use r#impl::{
-    dismiss_all, setup_notification_accept_handler, setup_notification_confirm_handler,
-    setup_notification_dismiss_handler, setup_notification_timeout_handler, show,
+pub use callbacks::{
+    setup_notification_accept_handler, setup_notification_confirm_handler,
+    setup_notification_dismiss_handler, setup_notification_footer_action_handler,
+    setup_notification_option_selected_handler, setup_notification_timeout_handler,
 };
+
+#[cfg(target_os = "linux")]
+pub use r#impl::{dismiss_all, show};

--- a/crates/notification/src/lib.rs
+++ b/crates/notification/src/lib.rs
@@ -218,6 +218,14 @@ where
         });
     }
 
+    #[cfg(all(feature = "legacy", target_os = "linux"))]
+    {
+        let f = f.clone();
+        hypr_notification_linux::setup_notification_option_selected_handler(move |key, index| {
+            f(get_context(&key), index);
+        });
+    }
+
     let _ = f;
 }
 
@@ -231,6 +239,14 @@ where
     {
         let f = f.clone();
         hypr_notification_macos::setup_footer_action_handler(move |key, _tag| {
+            f(get_context(&key));
+        });
+    }
+
+    #[cfg(all(feature = "legacy", target_os = "linux"))]
+    {
+        let f = f.clone();
+        hypr_notification_linux::setup_notification_footer_action_handler(move |key| {
             f(get_context(&key));
         });
     }


### PR DESCRIPTION
Route body, primary, option, footer, dismiss, and timeout actions through the shared notification contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-visible notification UX and event routing on Linux; incorrect callback ordering or index handling for options could change meeting/note selection behavior.
> 
> **Overview**
> Linux GTK notifications now follow the same **shared notification contract** as macOS: body tap fires **confirm**, the primary control is either an **accept** button (custom/destructive labels) or an **options** menu (plus a hard-coded **Create New Note...** entry), and optional **footer** actions get their own button and taller window.
> 
> Callback wiring moves into a new **`callbacks`** module with handlers for confirm, accept, dismiss, timeout, option selection, and footer actions; **`notification`** registers Linux bridges for **option selected** and **footer action** so app-level handlers receive `NotificationContext`. Dismiss/timeout paths also avoid double-firing by controlling timeout source cancellation when windows close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca7a4cbc61d76b9be7d02b46f58c7b362cd9188d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->