### PR TITLE
Prepare the Anarlog 1.4.0 changelog

### DIFF
--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -1,0 +1,39 @@
+---
+date: "2026-07-27"
+summary: "Anarlog 1.4.0 brings one desktop version to macOS, Windows Preview, and Linux Beta with dedicated downloads for each platform."
+---
+
+<banner title="Windows Preview and Linux Beta" variant="info">
+Windows and Linux now ship alongside macOS with the same Anarlog version. Their
+virtual-machine release checks cover installation, launch, updates, sync, and
+basic audio capture; physical-device routing and echo-cancellation validation
+are still pending.
+</banner>
+
+## Desktop downloads
+
+- Download macOS builds for Apple Silicon and Intel, a Windows x64 installer,
+  or Linux AppImage and Debian packages for x64 and ARM64
+- Receive matching `1.4.0` application and updater versions on every supported
+  desktop platform
+
+## Windows Preview
+
+- Show native event reminders while hiding microphone-detection controls that
+  are not yet supported on Windows
+- Protect signed-in sessions with Windows user encryption and migrate older
+  plaintext session data
+- Stop stalled Cloud Sync requests cleanly so the app can recover without
+  hanging its local database
+
+## Linux Beta
+
+- Detect active microphone streams more reliably and stop the detector cleanly
+  when it is no longer needed
+- Make notification body, button, option, footer, dismiss, and timeout actions
+  work as expected
+
+## Transcription
+
+On-device transcription remains available on supported Apple Silicon Macs.
+Windows and Linux currently use cloud transcription or your own provider key.


### PR DESCRIPTION
Explain the shared desktop version, Windows Preview and Linux Beta scope, platform fixes, and transcription availability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog content with no application or infrastructure code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.0.md`** to publish the **1.4.0** release notes for the changelog site.
> 
> The entry frames **one shared desktop version** across macOS, **Windows Preview**, and **Linux Beta**, with an info banner on VM-based release validation scope and pending physical-device/echo-cancellation work. It documents **per-platform downloads** (macOS arch builds, Windows x64, Linux AppImage/deb for x64 and ARM64) and aligned **`1.4.0`** app/updater versions.
> 
> **Windows Preview** highlights native event reminders, hiding unsupported mic-detection UI, encrypted session storage with migration from plaintext, and cleaner recovery from stalled Cloud Sync. **Linux Beta** covers mic-stream detection lifecycle and notification action fixes. **Transcription** clarifies on-device availability on Apple Silicon Macs versus cloud or BYOK on Windows/Linux.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ecf2c81203ad643a7fd041488b8852e7b4ce4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->