### PR TITLE
Make Windows WASAPI manual smoke fail closed

### DIFF
--- a/crates/audio-actual/src/speaker/mod.rs
+++ b/crates/audio-actual/src/speaker/mod.rs
@@ -241,37 +241,54 @@ mod tests {
     #[cfg(target_os = "windows")]
     #[tokio::test]
     #[serial]
+    #[ignore = "requires Windows audio hardware and active system playback"]
     async fn test_windows() {
-        let input = match SpeakerInput::new() {
-            Ok(input) => input,
-            Err(e) => {
-                println!("Failed to create SpeakerInput: {}", e);
-                return;
-            }
-        };
+        println!("Play continuous audio through the Windows default output while this test runs");
 
-        let mut stream = match input.stream() {
-            Ok(stream) => stream,
-            Err(e) => {
-                println!("Failed to create speaker stream: {}", e);
-                return;
-            }
-        };
+        let input = SpeakerInput::new().expect("failed to create Windows WASAPI speaker input");
+        let mut stream = input
+            .stream()
+            .expect("failed to initialize Windows WASAPI loopback capture");
 
         let sample_rate = stream.sample_rate();
-        assert!(sample_rate > 0);
         println!("Windows speaker sample rate: {}", sample_rate);
+        assert!(sample_rate > 0);
 
-        let mut sample_count = 0;
-        while let Some(_sample) = stream.next().await {
-            sample_count += 1;
-            if sample_count > 100 {
-                break;
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        let mut samples = Vec::new();
+        let timeout = tokio::time::sleep(tokio::time::Duration::from_secs(5));
+        tokio::pin!(timeout);
+
+        loop {
+            tokio::select! {
+                _ = &mut timeout => {
+                    break;
+                }
+                sample = stream.next() => {
+                    match sample {
+                        Some(sample) => samples.push(sample),
+                        None => panic!("Windows WASAPI loopback capture ended unexpectedly"),
+                    }
+                    if samples.len() >= sample_rate as usize {
+                        break;
+                    }
+                }
             }
         }
 
-        assert!(sample_count > 0, "Should receive some audio samples");
-        println!("Received {} samples from Windows speaker", sample_count);
+        println!("Received {} Windows speaker samples", samples.len());
+        assert!(
+            !samples.is_empty(),
+            "Windows WASAPI loopback capture produced no samples"
+        );
+        let rms = (samples.iter().map(|sample| sample * sample).sum::<f32>()
+            / samples.len() as f32)
+            .sqrt();
+        assert!(
+            rms > 1e-4,
+            "Windows WASAPI loopback capture was silent; play audio through the default output while running this test"
+        );
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
Require the ignored Windows loopback test to initialize real hardware, finish within a bounded capture window, collect one second of playback, and reject silent RMS. This remains a manual VM hardware test and does not claim AEC coverage.

Verification:
- pnpm exec dprint fmt crates/audio-actual/src/speaker/mod.rs
- cargo test --locked -p audio-actual
- Windows-target cross-check attempted on macOS; blocked in ogg_next_sys because the MSVC C headers/toolchain are unavailable locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect an ignored, manual Windows integration test in `audio-actual`; no production audio path or CI default test behavior.
> 
> **Overview**
> The ignored **Windows WASAPI loopback** manual smoke test (`test_windows`) now **fails closed** instead of skipping when setup fails or capture is weak.
> 
> **Initialization** uses `expect` with explicit messages for `SpeakerInput` and stream creation (no early `return` on error). A **500ms** settle delay was added before capture, and the test collects samples until it has about **one second** of audio or hits a **5 second** timeout via `tokio::select!`. An unexpected end of the stream **panics**.
> 
> **Assertions** require a non-empty buffer and **RMS > 1e-4**, with guidance to play audio on the default output if capture is silent—aligned with the existing Linux manual loopback test. The `#[ignore]` reason now states that **hardware and active playback** are required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0ea6eaa64569985b8e44f78b41461314177bc91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->