### PR TITLE
Style download platform headings

### DIFF
--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -1,9 +1,16 @@
+import { Icon } from "@iconify-icon/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Download } from "lucide-react";
 
 import { SiteFooter } from "@/components/site-footer";
 import { desktopDownloadSections } from "@/lib/download";
 import { ANARLOG_SITE_URL } from "@/lib/seo";
+
+const platformIcons = {
+  macOS: "simple-icons:apple",
+  Windows: "simple-icons:windows",
+  Linux: "simple-icons:linux",
+} as const;
 
 export const Route = createFileRoute("/_view/download/")({
   component: Component,
@@ -51,8 +58,13 @@ function Component() {
                 <div className="mb-5">
                   <h2
                     id={headingId}
-                    className="font-mono text-2xl font-semibold"
+                    className="font-hand flex items-center gap-2.5 text-3xl leading-none font-semibold tracking-normal"
                   >
+                    <Icon
+                      icon={platformIcons[section.name]}
+                      className="text-2xl"
+                      aria-hidden="true"
+                    />
                     {section.name}
                   </h2>
                   <p className="text-color-secondary mt-2 leading-7">


### PR DESCRIPTION
Pair each platform name with its native icon and the handwritten display font.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes on the marketing download route; no download URLs, routing, or data logic touched.
> 
> **Overview**
> The download page **platform section headings** (macOS, Windows, Linux) are restyled to match the page hero: **`font-hand`** instead of mono, larger type, and a **leading platform icon** from Iconify (`simple-icons` for Apple, Windows, and Linux).
> 
> Icons are mapped via a small `platformIcons` constant keyed by `section.name` from `desktopDownloadSections`; the icon is decorative (`aria-hidden`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d334886583265a6ec00e588f4323f8e7c5727677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->