### PR TITLE
Restore platform-aware hero downloads

### DIFF
--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  detectDesktopPlatform,
+  getOrderedDesktopDownloadSections,
+} from "./download.ts";
+
+test("detects supported desktop platforms from browser user agents", () => {
+  assert.equal(
+    detectDesktopPlatform(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+    ),
+    "windows",
+  );
+  assert.equal(
+    detectDesktopPlatform(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+    ),
+    "macos",
+  );
+  assert.equal(
+    detectDesktopPlatform("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"),
+    "linux",
+  );
+});
+
+test("falls back to macOS for unsupported and unknown platforms", () => {
+  assert.equal(
+    detectDesktopPlatform(
+      "Mozilla/5.0 (Linux; Android 16; Pixel 10) AppleWebKit/537.36",
+    ),
+    "macos",
+  );
+  assert.equal(detectDesktopPlatform("unknown"), "macos");
+});
+
+test("orders the detected platform first", () => {
+  assert.deepEqual(
+    getOrderedDesktopDownloadSections("windows").map(
+      (section) => section.platform,
+    ),
+    ["windows", "macos", "linux"],
+  );
+  assert.equal(
+    getOrderedDesktopDownloadSections("macos")[0].downloads[0].name,
+    "Apple Silicon",
+  );
+});

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -5,11 +5,14 @@ function getStableDownloadUrl(platform: string) {
   return `${latestStableDownloadUrl}/${platform}?channel=stable`;
 }
 
+export type DesktopPlatform = "linux" | "macos" | "windows";
+
 export const appleSiliconDownloadUrl = getStableDownloadUrl("dmg-aarch64");
 export const appleIntelDownloadUrl = getStableDownloadUrl("dmg-x86_64");
 
 export const desktopDownloadSections = [
   {
+    platform: "macos",
     name: "macOS",
     description: "Choose the build that matches your Mac.",
     downloads: [
@@ -26,6 +29,7 @@ export const desktopDownloadSections = [
     ],
   },
   {
+    platform: "windows",
     name: "Windows",
     description:
       "Preview installer for 64-bit Windows PCs. Physical audio and AEC validation is pending.",
@@ -38,6 +42,7 @@ export const desktopDownloadSections = [
     ],
   },
   {
+    platform: "linux",
     name: "Linux",
     description:
       "Beta AppImage and Debian packages for x64 and ARM64. Physical audio and AEC validation is pending.",
@@ -65,3 +70,26 @@ export const desktopDownloadSections = [
     ],
   },
 ] as const;
+
+export function detectDesktopPlatform(userAgent: string): DesktopPlatform {
+  if (/Windows/i.test(userAgent)) return "windows";
+  if (/Macintosh|Mac OS X|iPhone|iPad|iPod/i.test(userAgent)) return "macos";
+  if (!/Android|CrOS/i.test(userAgent) && /Linux|X11/i.test(userAgent)) {
+    return "linux";
+  }
+
+  return "macos";
+}
+
+export function getOrderedDesktopDownloadSections(
+  preferredPlatform: DesktopPlatform,
+) {
+  return [
+    ...desktopDownloadSections.filter(
+      (section) => section.platform === preferredPlatform,
+    ),
+    ...desktopDownloadSections.filter(
+      (section) => section.platform !== preferredPlatform,
+    ),
+  ];
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -2,12 +2,13 @@ import { Icon } from "@iconify-icon/react";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import {
   ArrowRight,
+  ChevronDown,
   Cloud,
   Cpu,
   KeyRound,
   type LucideIcon,
 } from "lucide-react";
-import { type CSSProperties, useState } from "react";
+import { type CSSProperties, useRef, useState } from "react";
 import { z } from "zod";
 
 import {
@@ -27,6 +28,11 @@ import {
 } from "@/functions/desktop-flow";
 import { getGitHubStats } from "@/functions/github";
 import { useMountEffect } from "@/hooks/useMountEffect";
+import {
+  type DesktopPlatform,
+  detectDesktopPlatform,
+  getOrderedDesktopDownloadSections,
+} from "@/lib/download";
 import {
   ANARLOG_SITE_URL,
   ROOT_DESCRIPTION,
@@ -1282,13 +1288,133 @@ function HeroWorkflowDemo() {
 }
 
 function DownloadButton() {
+  const [open, setOpen] = useState(false);
+  const [preferredPlatform, setPreferredPlatform] =
+    useState<DesktopPlatform>("macos");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const orderedSections = getOrderedDesktopDownloadSections(preferredPlatform);
+  const preferredSection = orderedSections[0];
+  const preferredDownload = preferredSection.downloads[0];
+  const preferredLabel =
+    preferredSection.platform === "macos"
+      ? `Download for ${preferredDownload.name}`
+      : `Download for ${preferredSection.name}`;
+
+  useMountEffect(() => {
+    setPreferredPlatform(detectDesktopPlatform(navigator.userAgent));
+
+    const onPointerDown = (event: MouseEvent | TouchEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("touchstart", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("touchstart", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  });
+
   return (
-    <Link
-      to="/download/"
-      className="inline-flex items-center gap-2 rounded-full bg-[#181613] px-5 py-3 text-sm font-medium text-white"
+    <div
+      ref={containerRef}
+      className="relative inline-flex text-sm font-medium"
     >
-      <span>Download Anarlog</span>
-      <ArrowRight size={16} strokeWidth={2.2} aria-hidden="true" />
-    </Link>
+      <a
+        href={preferredDownload.url}
+        className="inline-flex items-center gap-1.5 rounded-l-full bg-[#181613] py-3 pr-2 pl-4 text-[13px] text-white sm:pl-5 sm:text-sm"
+      >
+        <Icon
+          icon={getPlatformIcon(preferredSection.platform)}
+          width={16}
+          height={16}
+          className="shrink-0"
+          aria-hidden="true"
+        />
+        <span>{preferredLabel}</span>
+      </a>
+      <button
+        type="button"
+        aria-label="Choose download platform"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={() => setOpen((previous) => !previous)}
+        className="inline-flex h-full cursor-pointer items-center rounded-r-full bg-[#181613] py-3 pr-3 pl-2 text-white"
+      >
+        <ChevronDown size={17} strokeWidth={2.2} aria-hidden="true" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="surface border-color-brand absolute top-[calc(100%+0.5rem)] left-0 z-10 w-72 max-w-[calc(100vw-2.5rem)] rounded-2xl border p-2 text-left shadow-[0_14px_40px_rgba(24,22,19,0.12)]"
+        >
+          {orderedSections.map((section) =>
+            section.downloads.map((download) => {
+              if (download.url === preferredDownload.url) return null;
+
+              return (
+                <a
+                  key={download.url}
+                  href={download.url}
+                  role="menuitem"
+                  onClick={() => setOpen(false)}
+                  className="text-color hover:surface-subtle flex items-center gap-3 rounded-xl px-3 py-2.5 transition-colors"
+                >
+                  <Icon
+                    icon={getPlatformIcon(section.platform)}
+                    width={20}
+                    height={20}
+                    className="shrink-0"
+                    aria-hidden="true"
+                  />
+                  <span className="min-w-0">
+                    <span className="block">
+                      {getDownloadOptionLabel(section.platform, download.name)}
+                    </span>
+                    <span className="text-color-muted block truncate text-xs font-normal">
+                      {download.detail}
+                    </span>
+                  </span>
+                </a>
+              );
+            }),
+          )}
+          <Link
+            to="/download/"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            className="text-color-muted hover:surface-subtle mt-1 flex items-center justify-between rounded-xl px-3 py-2.5 transition-colors"
+          >
+            <span>View all downloads</span>
+            <ArrowRight size={15} strokeWidth={2.2} aria-hidden="true" />
+          </Link>
+        </div>
+      )}
+    </div>
   );
+}
+
+function getPlatformIcon(platform: DesktopPlatform) {
+  if (platform === "windows") return "simple-icons:windows11";
+  if (platform === "linux") return "simple-icons:linux";
+  return "simple-icons:apple";
+}
+
+function getDownloadOptionLabel(
+  platform: DesktopPlatform,
+  downloadName: string,
+) {
+  if (platform === "macos" && downloadName === "Intel") return "Apple Intel";
+  if (platform === "linux") return `Linux ${downloadName}`;
+  return downloadName;
 }


### PR DESCRIPTION
Detect the visitor platform, order direct desktop downloads accordingly, and keep Apple Silicon as the fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-only UI and download URL selection; behavior is covered by unit tests with no auth or data changes.
> 
> **Overview**
> Restores **platform-aware downloads** on the marketing hero: the primary CTA is no longer a single link to `/download/` but a split control that starts one-click installs from stable CDN URLs.
> 
> On mount, **`detectDesktopPlatform`** reads `navigator.userAgent` (Windows / macOS / Linux desktop; Android and unknown → **macOS**, with Apple Silicon as the default mac build). **`getOrderedDesktopDownloadSections`** puts the detected OS first in the menu. The main segment links to that platform’s first artifact (e.g. Windows x64, Apple Silicon); the chevron opens a menu of alternate builds plus **View all downloads** to `/download/`.
> 
> **`download.ts`** gains a `platform` id on each section and the two helpers above; **`download.test.ts`** covers UA parsing and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653ee32cda835e0dc3a1585120e9200d4b49ad4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->