### PR TITLE
Gate Linux candidates with virtual audio QA

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -47,14 +47,16 @@ macOS artifacts or Rust-only tests as cross-platform approval.
 sed -n '1,280p' .github/workflows/desktop_cd.yaml
 ```
 
-2. Check the version inputs that the workflow will use:
+2. Validate the explicit stable version requested by the user:
 
 ```bash
-doxxer --config doxxer.desktop.toml current
-doxxer --config doxxer.desktop.toml next patch
+VERSION=<version>
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+test -f "packages/changelog/content/$VERSION.md"
 ```
 
-Stable desktop releases use `next patch` unless the user explicitly asks for an override version.
+Stable desktop releases never infer a version. The workflow requires the exact
+stable semantic version and a matching changelog file.
 
 3. Identify the latest stable desktop tag and the commits that will ship:
 
@@ -71,7 +73,7 @@ Use read-only `git` commands for inspection. If the workspace is on `gitbutler/w
 The changelog is the release gate. Before releasing:
 
 1. Open `packages/changelog/content/AGENTS.md` and follow its instructions.
-2. Confirm `packages/changelog/content/<next-patch-version>.md` exists.
+2. Confirm `packages/changelog/content/<version>.md` exists.
 3. Compare the file against the desktop user-facing changes since the latest `desktop_v*` tag.
 4. If the changelog is missing or incomplete, update it before release.
 
@@ -120,17 +122,17 @@ Use actual IDs from `but diff` / `but status -fv`; do not invent IDs.
 ## Trigger Stable Release
 
 After the changelog merge and QA Gate pass on the same `main` SHA, verify
-`main` has not moved, then trigger the stable desktop workflow from `main`:
+`main` has not moved, then build the stable candidate without publishing:
 
 ```bash
 gh workflow run desktop_cd.yaml \
   --ref main \
   -f channel=stable \
-  -f publish=true \
-  -f version=
+  -f publish=false \
+  -f version=<version>
 ```
 
-Then watch the run:
+Watch the dry-run build:
 
 ```bash
 gh run list --workflow desktop_cd.yaml --branch main --limit 5
@@ -141,21 +143,38 @@ gh run watch <run-id>
 The run's `headSha` must equal the Dev/staging candidate SHA. A mismatch blocks
 acceptance even if the workflow succeeds.
 
-The stable workflow should:
+The dry-run workflow must:
 
-- compute the version from `doxxer --config doxxer.desktop.toml next patch` when no explicit version is supplied
+- use the exact explicit stable version
 - build both Apple Silicon and Intel macOS artifacts
-- draft, upload, and publish the CrabNebula release when `publish=true`
-- create or update `desktop_v<version>`
-- create the GitHub release pointing to `https://anarlog.so/changelog/<version>`
+- build the signed Windows and Linux artifacts for the same version and commit
+- upload a draft CrabNebula release without publishing it
+- upload `desktop-release-provenance-<version>-<sha>`, including the exact
+  artifact hashes and CrabNebula tool versions
+
+After the exact dry-run artifacts pass the required platform QA gates and
+`main` still points to the candidate SHA, publish only through the provenance
+workflow:
+
+```bash
+gh workflow run desktop_publish.yaml \
+  --ref main \
+  -f version=<version> \
+  -f candidate_sha=<40-character-main-sha> \
+  -f dry_run_id=<run-id>
+```
+
+Watch that workflow to completion. It must verify the dry-run run identity,
+artifact hashes, CrabNebula tool versions, current `main`, and the immutable
+tag before publishing.
 
 ## Final Checks
 
 Before reporting success, capture:
 
 - computed stable version
-- workflow run URL
-- workflow head SHA
+- dry-run workflow URL and head SHA
+- publish workflow URL and head SHA
 - `desktop_v<version>` tag
 - GitHub release URL
 - whether CrabNebula publish completed

--- a/.github/actions/cn_download/action.yaml
+++ b/.github/actions/cn_download/action.yaml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - id: get-assets
-      uses: crabnebula-dev/cloud-release@v0
+      uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       with:
         command: release show ${{ inputs.app }} ${{ inputs.version }} --channel ${{ inputs.channel }}
         api-key: ${{ inputs.key }}

--- a/.github/actions/cn_release/action.yaml
+++ b/.github/actions/cn_release/action.yaml
@@ -35,13 +35,13 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: crabnebula-dev/cloud-release@v0
+    - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       id: raw
       if: inputs.raw != ''
       with:
         command: ${{ inputs.raw }}
         api-key: ${{ inputs.key }}
-    - uses: crabnebula-dev/cloud-release@v0
+    - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       if: inputs.raw == '' && inputs.framework == 'tauri'
       with:
         command: >-
@@ -49,7 +49,7 @@ runs:
           --framework tauri${{ inputs.channel != '' && format(' --channel {0}', inputs.channel) || '' }}
         api-key: ${{ inputs.key }}
         working-directory: ${{ inputs.working-directory }}
-    - uses: crabnebula-dev/cloud-release@v0
+    - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       if: inputs.raw == '' && inputs.framework != 'tauri'
       with:
         command: >-

--- a/.github/actions/cn_release/action.yaml
+++ b/.github/actions/cn_release/action.yaml
@@ -41,6 +41,7 @@ runs:
       with:
         command: ${{ inputs.raw }}
         api-key: ${{ inputs.key }}
+        path: ${{ github.workspace }}
     - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       if: inputs.raw == '' && inputs.framework == 'tauri'
       with:
@@ -48,6 +49,7 @@ runs:
           release ${{ inputs.cmd }} ${{ inputs.app }}
           --framework tauri${{ inputs.channel != '' && format(' --channel {0}', inputs.channel) || '' }}
         api-key: ${{ inputs.key }}
+        path: ${{ github.workspace }}
         working-directory: ${{ inputs.working-directory }}
     - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       if: inputs.raw == '' && inputs.framework != 'tauri'
@@ -55,4 +57,5 @@ runs:
         command: >-
           release ${{ inputs.cmd }} ${{ inputs.app }} ${{ inputs.version }}${{ inputs.channel != '' && format(' --channel {0}', inputs.channel) || '' }}
         api-key: ${{ inputs.key }}
+        path: ${{ github.workspace }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/trigger-workflow/action.yml
+++ b/.github/actions/trigger-workflow/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Publish to Crabnebula and create GitHub release
     required: false
     default: "true"
+  version:
+    description: "Explicit stable version"
+    required: false
+    default: ""
   token:
     description: GitHub token
     required: true
@@ -37,12 +41,22 @@ runs:
     - id: trigger
       shell: bash
       env:
+        CHANNEL: ${{ inputs.channel }}
         GH_TOKEN: ${{ inputs.token }}
+        PUBLISH: ${{ inputs.publish }}
+        REF: ${{ inputs.ref }}
+        REPO: ${{ inputs.repo }}
+        VERSION: ${{ inputs.version }}
+        WORKFLOW: ${{ inputs.workflow }}
       run: |
-        gh workflow run ${{ inputs.workflow }} --repo ${{ inputs.repo }} --ref "${{ inputs.ref }}" -f channel=${{ inputs.channel }} -f publish=${{ inputs.publish }}
+        ARGS=(workflow run "$WORKFLOW" --repo "$REPO" --ref "$REF" -f "channel=$CHANNEL" -f "publish=$PUBLISH")
+        if [[ -n "$VERSION" ]]; then
+          ARGS+=(-f "version=$VERSION")
+        fi
+        gh "${ARGS[@]}"
         for i in $(seq 1 ${{ inputs.max_attempts }}); do
           sleep 5
-          RUN_ID=$(gh run list --workflow=${{ inputs.workflow }} --repo ${{ inputs.repo }} --branch="${{ inputs.ref }}" --json databaseId,createdAt --jq 'sort_by(.createdAt) | reverse | .[0].databaseId // empty')
+          RUN_ID=$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --branch="$REF" --json databaseId,createdAt --jq 'sort_by(.createdAt) | reverse | .[0].databaseId // empty')
           [ -n "$RUN_ID" ] && break
         done
         echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT

--- a/.github/workflows/command_dispatcher.yaml
+++ b/.github/workflows/command_dispatcher.yaml
@@ -27,16 +27,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       publish: ${{ steps.parse.outputs.publish }}
+      version: ${{ steps.parse.outputs.version }}
     steps:
       - id: parse
         env:
           COMMENT: ${{ github.event.comment.body }}
         run: |
+          if [[ ! "$COMMENT" =~ /stable[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+)($|[[:space:]]) ]]; then
+            echo "::error::Use /stable <version> [--no-publish], for example /stable 1.4.0"
+            exit 1
+          fi
+
+          VERSION="${BASH_REMATCH[1]}"
           PUBLISH="true"
           if [[ "$COMMENT" =~ --no-publish ]]; then
             PUBLISH="false"
           fi
           echo "publish=$PUBLISH" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   handle-stable:
     needs: [check-permission, parse-stable-options]
@@ -45,6 +53,7 @@ jobs:
     with:
       channel: stable
       publish: ${{ needs.parse-stable-options.outputs.publish == 'true' }}
+      version: ${{ needs.parse-stable-options.outputs.version }}
       issue_number: ${{ github.event.issue.number }}
       comment_id: ${{ github.event.comment.id }}
     secrets: inherit

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -14,15 +14,16 @@ on:
         type: boolean
         default: true
       version:
-        description: "Optional explicit version for stable releases"
+        description: "Explicit semantic version required for stable releases"
         required: false
         type: string
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.channel }}
-  cancel-in-progress: true
+  group: ${{ inputs.channel == 'stable' && 'desktop-stable-release' || format('{0}-{1}-{2}', github.workflow, github.ref, inputs.channel) }}
+  cancel-in-progress: ${{ inputs.channel != 'stable' }}
 env:
+  CN_ACTION_REF: "crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c"
   CN_APPLICATION: "fastrepl/hyprnote2"
   RELEASE_CHANNEL: ${{ inputs.channel }}
   TAURI_CONF_PATH: ./src-tauri/tauri.conf.${{ inputs.channel }}.json
@@ -55,13 +56,24 @@ jobs:
           fi
       - uses: ./.github/actions/doxxer_install
       - id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          RELEASE_CHANNEL: ${{ inputs.channel }}
         run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
-          elif [[ "${{ inputs.channel }}" == "staging" ]]; then
+          if [[ "$RELEASE_CHANNEL" == "stable" ]]; then
+            if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Stable releases require an explicit semantic version such as 1.4.0"
+              exit 1
+            fi
+            VERSION="$INPUT_VERSION"
+            if [[ ! -f "packages/changelog/content/$VERSION.md" ]]; then
+              echo "::error::Missing changelog for stable version $VERSION"
+              exit 1
+            fi
+          elif [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="$INPUT_VERSION"
+          elif [[ "$RELEASE_CHANNEL" == "staging" ]]; then
             VERSION=$(doxxer --config doxxer.desktop.toml next dev)
-          elif [[ "${{ inputs.channel }}" == "stable" ]]; then
-            VERSION=$(doxxer --config doxxer.desktop.toml next patch)
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Computed version: $VERSION"
@@ -708,6 +720,31 @@ jobs:
             echo "::error::CrabNebula release $EXPECTED_VERSION has missing, duplicate, unsigned, or empty updater assets: ${INVALID_UPDATE_PLATFORMS[*]}"
             exit 1
           fi
+      - if: ${{ !inputs.publish }}
+        name: Record release provenance
+        env:
+          CN_ACTION_REF: ${{ env.CN_ACTION_REF }}
+          RELEASE: ${{ steps.release.outputs.raw }}
+          VERSION: ${{ needs.compute-version.outputs.version }}
+        run: |
+          mkdir -p release-provenance
+          printf '%s' "$RELEASE" > "$RUNNER_TEMP/crabnebula-release.json"
+          CN_VERSION=$("$GITHUB_WORKSPACE/cn" --version)
+          node scripts/desktop-release-provenance.mjs create \
+            --release "$RUNNER_TEMP/crabnebula-release.json" \
+            --output release-provenance/manifest.json \
+            --version "$VERSION" \
+            --candidate-sha "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --cn-version "$CN_VERSION" \
+            --cn-action-ref "$CN_ACTION_REF"
+      - if: ${{ !inputs.publish }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-release-provenance-${{ needs.compute-version.outputs.version }}-${{ github.sha }}
+          path: release-provenance/manifest.json
+          if-no-files-found: error
+          retention-days: 30
 
   create-tag:
     if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.verify-cn-release.result == 'success' }}
@@ -721,11 +758,18 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - run: |
+          git fetch origin main --no-tags
           git fetch --tags --force
 
           TAG="desktop_v${{ needs.compute-version.outputs.version }}"
           TARGET=$(git rev-parse HEAD)
+          MAIN=$(git rev-parse origin/main)
           EXISTING=$(git rev-parse -q --verify "refs/tags/$TAG" || true)
+
+          if [[ "$TARGET" != "$MAIN" ]]; then
+            echo "::error::Candidate moved before tagging (candidate=$TARGET, main=$MAIN)"
+            exit 1
+          fi
 
           if [[ -n "$EXISTING" ]]; then
             if [[ "$EXISTING" != "$TARGET" ]]; then
@@ -745,7 +789,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.compute-version.outputs.version }}"
+      - name: Verify candidate before publication
+        run: |
+          git fetch origin main --no-tags
+          git fetch --tags --force
+
+          TARGET=$(git rev-parse HEAD)
+          MAIN=$(git rev-parse origin/main)
+          TAG="desktop_v${{ needs.compute-version.outputs.version }}"
+          TAG_TARGET=$(git rev-parse "$TAG^{commit}")
+
+          if [[ "$TARGET" != "$MAIN" || "$TAG_TARGET" != "$TARGET" ]]; then
+            echo "::error::Candidate moved before publication (candidate=$TARGET, main=$MAIN, tag=$TAG_TARGET)"
+            exit 1
+          fi
       - uses: ./.github/actions/cn_release
         with:
           cmd: publish

--- a/.github/workflows/desktop_linux_audio_qa.yaml
+++ b/.github/workflows/desktop_linux_audio_qa.yaml
@@ -68,9 +68,21 @@ jobs:
           ref: ${{ needs.parse.outputs.candidate_sha }}
           fetch-depth: 0
       - env:
+          DISPATCH_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
           EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
           VERSION: ${{ needs.parse.outputs.version }}
         run: |
+          dispatch_sha=${DISPATCH_SHA,,}
+          if [[ "$DISPATCH_REF" != "refs/heads/main" ]]; then
+            echo "::error::Run this QA workflow from main, not $DISPATCH_REF"
+            exit 1
+          fi
+          if [[ "$dispatch_sha" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Workflow logic is from $dispatch_sha, not candidate $EXPECTED_SHA"
+            exit 1
+          fi
+
           git fetch origin main --no-tags
 
           checkout_sha=$(git rev-parse HEAD)

--- a/.github/workflows/desktop_linux_audio_qa.yaml
+++ b/.github/workflows/desktop_linux_audio_qa.yaml
@@ -1,0 +1,361 @@
+name: Desktop Linux Virtual Audio QA
+run-name: Linux audio QA v${{ inputs.version }} at ${{ inputs.candidate_sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable version whose CrabNebula DEBs should be tested
+        required: true
+        type: string
+      candidate_sha:
+        description: Exact 40-character current main commit for the candidate
+        required: true
+        type: string
+      dry_run_id:
+        description: Successful publish=false desktop CD run that built the candidate
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: desktop-linux-audio-qa-${{ inputs.version }}-${{ inputs.candidate_sha }}
+  cancel-in-progress: false
+
+env:
+  CN_APPLICATION: fastrepl/hyprnote2
+
+jobs:
+  parse:
+    runs-on: ubuntu-latest
+    outputs:
+      candidate_sha: ${{ steps.parse.outputs.candidate_sha }}
+      dry_run_id: ${{ steps.parse.outputs.dry_run_id }}
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - id: parse
+        env:
+          INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          INPUT_DRY_RUN_ID: ${{ inputs.dry_run_id }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must be a stable semantic version such as 1.4.0"
+            exit 1
+          fi
+          if [[ ! "$INPUT_CANDIDATE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::Candidate SHA must be a full 40-character commit SHA"
+            exit 1
+          fi
+          if [[ ! "$INPUT_DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Dry-run workflow ID must be a positive integer"
+            exit 1
+          fi
+
+          echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "candidate_sha=${INPUT_CANDIDATE_SHA,,}" >> "$GITHUB_OUTPUT"
+          echo "dry_run_id=$INPUT_DRY_RUN_ID" >> "$GITHUB_OUTPUT"
+
+  verify-candidate:
+    needs: parse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse.outputs.candidate_sha }}
+          fetch-depth: 0
+      - env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          git fetch origin main --no-tags
+
+          checkout_sha=$(git rev-parse HEAD)
+          main_sha=$(git rev-parse origin/main)
+          if [[ "$checkout_sha" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Checked out $checkout_sha instead of candidate $EXPECTED_SHA"
+            exit 1
+          fi
+          if [[ "$main_sha" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Candidate $EXPECTED_SHA is not current main ($main_sha)"
+            exit 1
+          fi
+
+          changelog="packages/changelog/content/$VERSION.md"
+          if [[ ! -s "$changelog" ]]; then
+            echo "::error::Missing or empty changelog $changelog at candidate $EXPECTED_SHA"
+            exit 1
+          fi
+
+          {
+            echo "### Linux virtual-audio candidate"
+            echo
+            echo "- Version: \`$VERSION\`"
+            echo "- Candidate: \`$EXPECTED_SHA\`"
+            echo "- Changelog SHA-256: \`$(sha256sum "$changelog" | cut -d' ' -f1)\`"
+            echo
+            echo "This gate uses \`NO_AEC=1\` and does not validate AEC."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  audio-qa:
+    needs: [parse, verify-candidate]
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: depot-ubuntu-24.04-8
+            artifact_arch: x64
+            public_platform: deb-x86_64
+            debian_arch: amd64
+          - runner: depot-ubuntu-24.04-arm-8
+            artifact_arch: arm64
+            public_platform: deb-aarch64
+            debian_arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.parse.outputs.candidate_sha }}
+          fetch-depth: 0
+          lfs: true
+      - env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+        run: |
+          git fetch origin main --no-tags
+          main_sha=$(git rev-parse origin/main)
+          checkout_sha=$(git rev-parse HEAD)
+          if [[ "$main_sha" != "$EXPECTED_SHA" || "$checkout_sha" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Candidate moved before QA (candidate=$EXPECTED_SHA, checkout=$checkout_sha, main=$main_sha)"
+            exit 1
+          fi
+      - env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          run=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID")
+          if ! jq -e \
+            --arg sha "$EXPECTED_SHA" \
+            --arg workflow ".github/workflows/desktop_cd.yaml" \
+            '
+              (.head_sha | ascii_downcase) == $sha
+              and .event == "workflow_dispatch"
+              and .conclusion == "success"
+              and (.path | split("@")[0]) == $workflow
+            ' <<< "$run" > /dev/null; then
+            echo "::error::Run $RUN_ID is not a successful desktop CD dry run for candidate $EXPECTED_SHA"
+            exit 1
+          fi
+
+          artifact_dir="$GITHUB_WORKSPACE/qa-artifacts/linux-${{ matrix.artifact_arch }}"
+          mkdir -p "$artifact_dir"
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "desktop-release-provenance-$VERSION-$EXPECTED_SHA" \
+            --dir "$artifact_dir/release-provenance"
+          manifest="$artifact_dir/release-provenance/manifest.json"
+          if ! jq -e \
+            --arg run_id "$RUN_ID" \
+            --arg sha "$EXPECTED_SHA" \
+            --arg version "$VERSION" \
+            '
+              .schemaVersion == 1
+              and .sourceWorkflow == ".github/workflows/desktop_cd.yaml"
+              and .workflowRunId == $run_id
+              and .candidateSha == $sha
+              and .version == $version
+              and .channel == "stable"
+              and .publish == false
+              and (.assets | type == "array" and length > 0)
+            ' "$manifest" > /dev/null; then
+            echo "::error::Dry-run provenance does not match this candidate"
+            exit 1
+          fi
+      - id: release
+        uses: ./.github/actions/cn_release
+        with:
+          raw: >-
+            release show ${{ env.CN_APPLICATION }} ${{ needs.parse.outputs.version }}
+            --channel stable
+          key: ${{ secrets.CN_API_KEY }}
+      - id: asset
+        env:
+          CANDIDATE_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          PLATFORM: ${{ matrix.public_platform }}
+          RELEASE: ${{ steps.release.outputs.raw }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          actual_version=$(jq -r '.version // empty' <<< "$RELEASE")
+          if [[ "$actual_version" != "$VERSION" ]]; then
+            echo "::error::Expected CrabNebula release $VERSION, got $actual_version"
+            exit 1
+          fi
+
+          asset=$(jq -cer --arg platform "$PLATFORM" '
+            [.assets[]?
+              | select(
+                  .publicPlatform == $platform
+                  and ((.size // 0) | tonumber) > 0
+                )
+            ]
+            | if length == 1 then .[0]
+              else error("expected exactly one nonempty asset for " + $platform)
+              end
+          ' <<< "$RELEASE")
+
+          asset_id=$(jq -r '.id' <<< "$asset")
+          asset_size=$(jq -r '.size | tonumber' <<< "$asset")
+          asset_filename=$(jq -r '.filename // empty' <<< "$asset")
+          if [[ -z "$asset_id" || -z "$asset_filename" ]]; then
+            echo "::error::CrabNebula asset metadata is incomplete"
+            exit 1
+          fi
+
+          artifact_dir="$GITHUB_WORKSPACE/qa-artifacts/linux-${{ matrix.artifact_arch }}"
+          manifest="$artifact_dir/release-provenance/manifest.json"
+          manifest_asset=$(jq -cer --arg id "$asset_id" '
+            [.assets[]? | select(.id == $id)]
+            | if length == 1 then .[0]
+              else error("expected one matching asset in dry-run provenance")
+              end
+          ' "$manifest")
+          expected_sha256=$(jq -r '.sha256 // empty' <<< "$manifest_asset")
+          if [[ ! "$expected_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::Dry-run provenance has no valid SHA-256 for asset $asset_id"
+            exit 1
+          fi
+          if ! jq -e \
+            --arg platform "$PLATFORM" \
+            --argjson size "$asset_size" \
+            '
+              .publicPlatform == $platform
+              and .size == $size
+            ' <<< "$manifest_asset" > /dev/null; then
+            echo "::error::CrabNebula asset metadata changed after the candidate dry run"
+            exit 1
+          fi
+
+          jq '{
+            id,
+            filename,
+            publicPlatform,
+            updatePlatform,
+            size,
+            createdAt,
+            updatedAt
+          }' <<< "$asset" > "$artifact_dir/crabnebula-asset.json"
+          jq -n \
+            --arg application "$CN_APPLICATION" \
+            --arg asset_id "$asset_id" \
+            --arg candidate_sha "$CANDIDATE_SHA" \
+            --arg platform "$PLATFORM" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --arg source_run_id "${{ needs.parse.outputs.dry_run_id }}" \
+            --arg version "$VERSION" \
+            --arg expected_sha256 "$expected_sha256" \
+            --argjson asset_size "$asset_size" \
+            '{
+              application: $application,
+              version: $version,
+              candidate_sha: $candidate_sha,
+              workflow_run_id: $run_id,
+              source_workflow_run_id: $source_run_id,
+              public_platform: $platform,
+              crabnebula_asset_id: $asset_id,
+              crabnebula_asset_size: $asset_size,
+              expected_sha256: $expected_sha256
+            }' > "$artifact_dir/provenance.json"
+
+          echo "id=$asset_id" >> "$GITHUB_OUTPUT"
+          echo "size=$asset_size" >> "$GITHUB_OUTPUT"
+          echo "sha256=$expected_sha256" >> "$GITHUB_OUTPUT"
+      - env:
+          ASSET_ID: ${{ steps.asset.outputs.id }}
+          EXPECTED_SIZE: ${{ steps.asset.outputs.size }}
+          EXPECTED_SHA256: ${{ steps.asset.outputs.sha256 }}
+        run: |
+          output="$GITHUB_WORKSPACE/candidate-linux-${{ matrix.artifact_arch }}.deb"
+          curl \
+            --fail \
+            --show-error \
+            --location \
+            --retry 3 \
+            --retry-all-errors \
+            "https://cdn.crabnebula.app/asset/$ASSET_ID" \
+            --output "$output"
+
+          actual_size=$(stat --format='%s' "$output")
+          if [[ "$actual_size" != "$EXPECTED_SIZE" ]]; then
+            echo "::error::Downloaded asset size $actual_size does not match CrabNebula metadata $EXPECTED_SIZE"
+            exit 1
+          fi
+
+          echo "$EXPECTED_SHA256  $output" | sha256sum --check
+          sha256sum "$output" \
+            | awk '{print $1 "  candidate-linux-${{ matrix.artifact_arch }}.deb"}' \
+            > "$GITHUB_WORKSPACE/qa-artifacts/linux-${{ matrix.artifact_arch }}/download.sha256"
+      - uses: ./.github/actions/rust_install
+        with:
+          platform: linux
+      - uses: ./.github/actions/pnpm_install
+      - run: |
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            alsa-utils \
+            dbus-x11 \
+            desktop-file-utils \
+            ffmpeg \
+            libasound2-plugins \
+            pipewire \
+            pipewire-pulse \
+            pulseaudio-utils \
+            webkit2gtk-driver \
+            wireplumber \
+            xvfb
+          ./scripts/setup-desktop-e2e.sh
+      - run: pnpm -F e2e-blackbox typecheck
+      - id: audio-qa
+        continue-on-error: true
+        env:
+          EXPECTED_DEBIAN_ARCH: ${{ matrix.debian_arch }}
+          EXPECTED_VERSION: ${{ needs.parse.outputs.version }}
+          QA_ARTIFACT_DIR: ${{ github.workspace }}/qa-artifacts/linux-${{ matrix.artifact_arch }}
+        run: |
+          ./scripts/qa/linux_virtual_audio_smoke.sh \
+            "$GITHUB_WORKSPACE/candidate-linux-${{ matrix.artifact_arch }}.deb"
+      - if: always()
+        env:
+          ARCH: ${{ matrix.artifact_arch }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          artifact_dir="$GITHUB_WORKSPACE/qa-artifacts/linux-$ARCH"
+          {
+            echo "### Linux $ARCH virtual-audio QA"
+            echo
+            echo "- Version: \`$VERSION\`"
+            echo "- Scope: packaged-app virtual routing, capture, separation, and persistence"
+            echo "- AEC: **not tested** (\`NO_AEC=1\`)"
+            if [[ -f "$artifact_dir/download.sha256" ]]; then
+              echo "- Download: \`$(cat "$artifact_dir/download.sha256")\`"
+            fi
+            if [[ -f "$artifact_dir/analysis.json" ]]; then
+              echo "- Result: \`$(jq -r '.status' "$artifact_dir/analysis.json")\`"
+              echo "- Alignment offset: \`$(jq -r '.metrics.alignment_offset_seconds // "n/a"' "$artifact_dir/analysis.json")s\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-audio-qa-${{ needs.parse.outputs.version }}-${{ matrix.artifact_arch }}
+          path: |
+            qa-artifacts/linux-${{ matrix.artifact_arch }}/
+            e2e/blackbox/videos/
+          if-no-files-found: warn
+          retention-days: 14
+      - if: steps.audio-qa.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -9,8 +9,17 @@ on:
         description: "Exact 40-character main commit used to build the candidate"
         required: true
         type: string
+      dry_run_id:
+        description: "Successful publish=false desktop CD run that built the candidate"
+        required: true
+        type: string
+
+concurrency:
+  group: desktop-stable-release
+  cancel-in-progress: false
 
 env:
+  CN_ACTION_REF: "crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c"
   CN_APPLICATION: "fastrepl/hyprnote2"
 
 jobs:
@@ -20,10 +29,12 @@ jobs:
       version: ${{ steps.parse.outputs.version }}
       channel: ${{ steps.parse.outputs.channel }}
       candidate_sha: ${{ steps.parse.outputs.candidate_sha }}
+      dry_run_id: ${{ steps.parse.outputs.dry_run_id }}
     steps:
       - id: parse
         env:
           INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          INPUT_DRY_RUN_ID: ${{ inputs.dry_run_id }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -35,12 +46,17 @@ jobs:
             echo "::error::Candidate SHA must be a full 40-character commit SHA"
             exit 1
           fi
+          if [[ ! "$INPUT_DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Dry-run workflow ID must be a positive integer"
+            exit 1
+          fi
 
           VERSION="$INPUT_VERSION"
           CANDIDATE_SHA="${INPUT_CANDIDATE_SHA,,}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "channel=stable" >> $GITHUB_OUTPUT
           echo "candidate_sha=$CANDIDATE_SHA" >> $GITHUB_OUTPUT
+          echo "dry_run_id=$INPUT_DRY_RUN_ID" >> $GITHUB_OUTPUT
 
   verify-candidate:
     needs: parse
@@ -140,6 +156,7 @@ jobs:
     needs: [parse, verify-candidate, verify-windows-signature]
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
       - uses: actions/checkout@v4
@@ -148,6 +165,31 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.parse.outputs.version }}"
+      - name: Download candidate provenance
+        env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID")
+          if ! echo "$RUN" | jq -e \
+            --arg sha "$EXPECTED_SHA" \
+            --arg workflow ".github/workflows/desktop_cd.yaml" \
+            '
+              (.head_sha | ascii_downcase) == $sha
+              and .event == "workflow_dispatch"
+              and .conclusion == "success"
+              and (.path | split("@")[0]) == $workflow
+            ' > /dev/null; then
+            echo "::error::Run $RUN_ID is not a successful desktop CD run for candidate $EXPECTED_SHA"
+            exit 1
+          fi
+
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "desktop-release-provenance-$VERSION-$EXPECTED_SHA" \
+            --dir release-provenance
       - id: release
         uses: ./.github/actions/cn_release
         with:
@@ -225,6 +267,24 @@ jobs:
               exit 1
               ;;
           esac
+      - name: Verify candidate provenance
+        env:
+          CN_ACTION_REF: ${{ env.CN_ACTION_REF }}
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          RELEASE: ${{ steps.release.outputs.raw }}
+          RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          printf '%s' "$RELEASE" > "$RUNNER_TEMP/crabnebula-release.json"
+          CN_VERSION=$("$GITHUB_WORKSPACE/cn" --version)
+          node scripts/desktop-release-provenance.mjs verify \
+            --release "$RUNNER_TEMP/crabnebula-release.json" \
+            --manifest release-provenance/manifest.json \
+            --version "$VERSION" \
+            --candidate-sha "$EXPECTED_SHA" \
+            --run-id "$RUN_ID" \
+            --cn-version "$CN_VERSION" \
+            --cn-action-ref "$CN_ACTION_REF"
       - name: Create immutable release tag
         env:
           EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
@@ -253,6 +313,22 @@ jobs:
           else
             git tag "$TAG" "$EXPECTED_SHA"
             git push origin "refs/tags/$TAG"
+          fi
+      - name: Verify candidate before publication
+        if: ${{ steps.publish-decision.outputs.publish_needed == 'true' }}
+        env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          git fetch origin main --no-tags
+          git fetch --tags --force
+
+          TARGET=$(git rev-parse HEAD)
+          MAIN=$(git rev-parse origin/main)
+          TAG_TARGET=$(git rev-parse "desktop_v$VERSION^{commit}")
+          if [[ "$TARGET" != "$EXPECTED_SHA" || "$MAIN" != "$EXPECTED_SHA" || "$TAG_TARGET" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Candidate moved before publication (candidate=$EXPECTED_SHA, checkout=$TARGET, main=$MAIN, tag=$TAG_TARGET)"
+            exit 1
           fi
       - uses: ./.github/actions/cn_release
         if: ${{ steps.publish-decision.outputs.publish_needed == 'true' }}
@@ -294,7 +370,7 @@ jobs:
           version: ${{ needs.parse.outputs.version }}
           channel: ${{ needs.parse.outputs.channel }}
           platform: dmg-aarch64
-          output: char-macos-aarch64.dmg
+          output: hyprnote-macos-aarch64.dmg
           key: ${{ secrets.CN_API_KEY }}
       - id: download-macos-x86_64
         uses: ./.github/actions/cn_download
@@ -303,7 +379,7 @@ jobs:
           version: ${{ needs.parse.outputs.version }}
           channel: ${{ needs.parse.outputs.channel }}
           platform: dmg-x86_64
-          output: char-macos-x86_64.dmg
+          output: hyprnote-macos-x86_64.dmg
           key: ${{ secrets.CN_API_KEY }}
       - id: download-linux-x86_64-appimage
         uses: ./.github/actions/cn_download
@@ -354,8 +430,8 @@ jobs:
         uses: ./.github/actions/generate_checksums
         with:
           files: |
-            char-macos-aarch64.dmg
-            char-macos-x86_64.dmg
+            hyprnote-macos-aarch64.dmg
+            hyprnote-macos-x86_64.dmg
             anarlog-linux-x86_64.AppImage
             anarlog-linux-x86_64.deb
             anarlog-linux-aarch64.AppImage
@@ -370,7 +446,7 @@ jobs:
           name: desktop_v${{ needs.parse.outputs.version }}
           body: ${{ steps.release-body.outputs.value }}
           prerelease: false
-          artifacts: char-macos-aarch64.dmg,char-macos-x86_64.dmg,anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb,anarlog-windows-x86_64-setup.exe,${{ steps.checksums.outputs.checksum_files }}
+          artifacts: hyprnote-macos-aarch64.dmg,hyprnote-macos-x86_64.dmg,anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb,anarlog-windows-x86_64-setup.exe,${{ steps.checksums.outputs.checksum_files }}
           allowUpdates: true
           makeLatest: true
           replacesArtifacts: true

--- a/.github/workflows/handle_release.yaml
+++ b/.github/workflows/handle_release.yaml
@@ -8,6 +8,9 @@ on:
         required: false
         type: boolean
         default: true
+      version:
+        required: true
+        type: string
       issue_number:
         required: true
         type: number
@@ -70,6 +73,7 @@ jobs:
           ref: ${{ steps.resolve.outputs.branch }}
           channel: ${{ inputs.channel }}
           publish: ${{ inputs.publish }}
+          version: ${{ inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
           max_attempts: "10"

--- a/apps/desktop/src-tauri/tauri.conf.stable.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable.json
@@ -3,6 +3,15 @@
   "productName": "Anarlog",
   "mainBinaryName": "anarlog",
   "identifier": "com.hyprnote.stable",
+  "bundle": {
+    "linux": {
+      "deb": {
+        "provides": ["char"],
+        "conflicts": ["char"],
+        "replaces": ["char"]
+      }
+    }
+  },
   "plugins": {
     "deep-link": {
       "desktop": { "schemes": ["anarlog", "hyprnote"] }
@@ -10,8 +19,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable",
-        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}/{{current_version}}?channel=stable"
+        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable"
       ]
     }
   }

--- a/e2e/blackbox/tests/linux-virtual-audio.spec.ts
+++ b/e2e/blackbox/tests/linux-virtual-audio.spec.ts
@@ -1,0 +1,179 @@
+import { $ } from "@wdio/globals";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+
+const virtualAudioEnabled = process.env.E2E_VIRTUAL_AUDIO === "1";
+const describeVirtualAudio = virtualAudioEnabled ? describe : describe.skip;
+
+describeVirtualAudio("Linux virtual audio capture", () => {
+  it("persists separated microphone and system-audio tracks", async function () {
+    this.timeout(180_000);
+
+    if (process.platform !== "linux") {
+      throw new Error("E2E_VIRTUAL_AUDIO is only supported on Linux");
+    }
+    if (process.env.NO_AEC !== "1") {
+      throw new Error("Linux virtual-audio QA must run with NO_AEC=1");
+    }
+
+    const micSignal = requiredEnvironmentPath("QA_MIC_SIGNAL");
+    const systemSignal = requiredEnvironmentPath("QA_SYSTEM_SIGNAL");
+    const phasesPath = requiredEnvironmentPath("QA_PHASES_PATH");
+    const micSink = process.env.QA_MIC_SINK ?? "qa_mic_bus";
+    const systemSink = process.env.QA_SYSTEM_SINK ?? "qa_system";
+
+    await mkdir(path.dirname(phasesPath), { recursive: true });
+    await closeChangelogIfVisible();
+
+    let startRecording = await $(
+      '//button[.//span[normalize-space()="Start Recording"]]',
+    );
+    await startRecording.waitForDisplayed({ timeout: 30_000 });
+    await startRecording.waitForEnabled({ timeout: 30_000 });
+    await closeChangelogIfVisible();
+    startRecording = await $(
+      '//button[.//span[normalize-space()="Start Recording"]]',
+    );
+    await startRecording.waitForDisplayed({ timeout: 30_000 });
+    await startRecording.waitForEnabled({ timeout: 30_000 });
+    await startRecording.click();
+
+    const stopListening = await $('button[title="Stop listening"]');
+    await stopListening.waitForDisplayed({ timeout: 30_000 });
+
+    const anchor = performance.now();
+    const phases: {
+      name: "mic_only" | "system_only" | "both";
+      start_seconds: number;
+      end_seconds: number;
+    }[] = [];
+
+    await pause(2_500);
+    phases.push(
+      await playPhase("mic_only", anchor, [
+        { sink: micSink, signal: micSignal },
+      ]),
+    );
+    await persistPhases(phasesPath, phases);
+
+    await pause(2_500);
+    phases.push(
+      await playPhase("system_only", anchor, [
+        { sink: systemSink, signal: systemSignal },
+      ]),
+    );
+    await persistPhases(phasesPath, phases);
+
+    await pause(2_500);
+    phases.push(
+      await playPhase("both", anchor, [
+        { sink: micSink, signal: micSignal },
+        { sink: systemSink, signal: systemSignal },
+      ]),
+    );
+    await persistPhases(phasesPath, phases);
+
+    await pause(2_500);
+    const recordingStopSeconds = (performance.now() - anchor) / 1000;
+    await stopListening.click();
+    await stopListening.waitForDisplayed({
+      timeout: 30_000,
+      reverse: true,
+    });
+    const settledControl = await $(
+      'button[title="Resume listening"]:not([disabled]), button[title="Record"]:not([disabled]), button[title="Stop transcription"]:not([disabled])',
+    );
+    await settledControl.waitForDisplayed({ timeout: 60_000 });
+    await persistPhases(phasesPath, phases, recordingStopSeconds);
+    await pause(1_000);
+  });
+});
+
+async function closeChangelogIfVisible() {
+  const closeChangelog = await $('button[aria-label="Close changelog"]');
+  if (
+    (await closeChangelog.isExisting()) &&
+    (await closeChangelog.isDisplayed())
+  ) {
+    await closeChangelog.click();
+  }
+}
+
+function requiredEnvironmentPath(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required for Linux virtual-audio QA`);
+  }
+  return path.resolve(value);
+}
+
+async function playPhase(
+  name: "mic_only" | "system_only" | "both",
+  anchor: number,
+  streams: { sink: string; signal: string }[],
+) {
+  const startSeconds = (performance.now() - anchor) / 1000;
+  await Promise.all(
+    streams.map(({ sink, signal }) =>
+      runProcess("paplay", [`--device=${sink}`, signal]),
+    ),
+  );
+  return {
+    name,
+    start_seconds: startSeconds,
+    end_seconds: (performance.now() - anchor) / 1000,
+  };
+}
+
+async function persistPhases(
+  phasesPath: string,
+  phases: {
+    name: "mic_only" | "system_only" | "both";
+    start_seconds: number;
+    end_seconds: number;
+  }[],
+  recordingStopSeconds?: number,
+) {
+  await writeFile(
+    phasesPath,
+    JSON.stringify(
+      {
+        schema_version: 1,
+        recording_anchor: "stop-listening control became visible",
+        no_aec: true,
+        scope:
+          "Virtual routing, capture, separation, and persistence only; this is not an AEC test.",
+        phases,
+        ...(recordingStopSeconds === undefined
+          ? {}
+          : { recording_stop_seconds: recordingStopSeconds }),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function runProcess(command: string, args: string[]) {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `${command} exited with ${code ?? `signal ${signal ?? "unknown"}`}`,
+        ),
+      );
+    });
+  });
+}
+
+async function pause(durationMs: number) {
+  await new Promise((resolve) => setTimeout(resolve, durationMs));
+}

--- a/e2e/blackbox/tests/linux-virtual-audio.spec.ts
+++ b/e2e/blackbox/tests/linux-virtual-audio.spec.ts
@@ -76,8 +76,8 @@ describeVirtualAudio("Linux virtual audio capture", () => {
     await persistPhases(phasesPath, phases);
 
     await pause(2_500);
-    const recordingStopSeconds = (performance.now() - anchor) / 1000;
     await stopListening.click();
+    const recordingStopSeconds = (performance.now() - anchor) / 1000;
     await stopListening.waitForDisplayed({
       timeout: 30_000,
       reverse: true,

--- a/scripts/desktop-release-provenance.mjs
+++ b/scripts/desktop-release-provenance.mjs
@@ -1,0 +1,317 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_ASSET_BASE_URL = "https://cdn.crabnebula.app/asset";
+const SOURCE_WORKFLOW = ".github/workflows/desktop_cd.yaml";
+const CN_ACTION_REPOSITORY = "crabnebula-dev/cloud-release";
+
+function invariant(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const args = {};
+
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index];
+    const value = rest[index + 1];
+    invariant(key?.startsWith("--") && value, `Invalid argument: ${key ?? ""}`);
+    args[key.slice(2)] = value;
+  }
+
+  return { command, args };
+}
+
+function normalizeSha(value) {
+  invariant(
+    typeof value === "string" && /^[0-9a-fA-F]{40}$/.test(value),
+    "Candidate SHA must contain 40 hexadecimal characters",
+  );
+  return value.toLowerCase();
+}
+
+function normalizeRunId(value) {
+  const runId = String(value);
+  invariant(
+    /^[1-9][0-9]*$/.test(runId),
+    "Workflow run ID must be a positive integer",
+  );
+  return runId;
+}
+
+function normalizeCnVersion(value) {
+  invariant(
+    typeof value === "string" &&
+      value.trim().length > 0 &&
+      value.trim().length <= 200 &&
+      !/[\r\n]/.test(value.trim()),
+    "CrabNebula CLI version must be one non-empty line",
+  );
+  return value.trim();
+}
+
+function normalizeCnActionRef(value) {
+  invariant(
+    typeof value === "string" &&
+      new RegExp(`^${CN_ACTION_REPOSITORY}@[0-9a-f]{40}$`).test(value),
+    "CrabNebula action ref must be pinned to a full commit SHA",
+  );
+  return value;
+}
+
+function normalizeAsset(asset) {
+  invariant(
+    typeof asset?.id === "string" && /^[A-Za-z0-9_-]+$/.test(asset.id),
+    "Every CrabNebula asset must have a safe ID",
+  );
+
+  const size = Number(asset.size);
+  invariant(
+    Number.isSafeInteger(size) && size > 0,
+    `Asset ${asset.id} has an invalid size`,
+  );
+
+  const publicPlatform = asset.publicPlatform ?? null;
+  const updatePlatform = asset.updatePlatform ?? null;
+  const signature = asset.signature ?? null;
+  invariant(
+    publicPlatform === null || typeof publicPlatform === "string",
+    `Asset ${asset.id} has an invalid public platform`,
+  );
+  invariant(
+    updatePlatform === null || typeof updatePlatform === "string",
+    `Asset ${asset.id} has an invalid update platform`,
+  );
+  invariant(
+    signature === null || typeof signature === "string",
+    `Asset ${asset.id} has an invalid signature`,
+  );
+
+  return {
+    id: asset.id,
+    publicPlatform,
+    updatePlatform,
+    size,
+    signature,
+  };
+}
+
+function normalizeAssets(release) {
+  invariant(
+    Array.isArray(release?.assets) && release.assets.length > 0,
+    "Release has no assets",
+  );
+
+  const assets = release.assets
+    .map(normalizeAsset)
+    .sort((left, right) => left.id.localeCompare(right.id));
+  invariant(
+    new Set(assets.map((asset) => asset.id)).size === assets.length,
+    "Release contains duplicate asset IDs",
+  );
+  return assets;
+}
+
+async function hashStream(stream) {
+  const hash = createHash("sha256");
+  let size = 0;
+
+  for await (const chunk of stream) {
+    hash.update(chunk);
+    size += chunk.length;
+  }
+
+  return { sha256: hash.digest("hex"), size };
+}
+
+async function hashAsset(asset, assetDir) {
+  const result = assetDir
+    ? await hashStream(createReadStream(path.join(assetDir, asset.id)))
+    : await hashRemoteAsset(asset.id);
+
+  invariant(
+    result.size === asset.size,
+    `Asset ${asset.id} has size ${result.size}, expected ${asset.size}`,
+  );
+  return result.sha256;
+}
+
+async function hashRemoteAsset(assetId) {
+  const baseUrl = process.env.CN_ASSET_BASE_URL ?? DEFAULT_ASSET_BASE_URL;
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}/${assetId}`);
+  invariant(
+    response.ok && response.body,
+    `Could not download asset ${assetId}: ${response.status}`,
+  );
+  return hashStream(response.body);
+}
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, "utf8"));
+}
+
+export async function createManifest({
+  release,
+  output,
+  version,
+  candidateSha,
+  workflowRunId,
+  cnVersion,
+  cnActionRef,
+  assetDir,
+}) {
+  invariant(
+    release?.version === version,
+    `Release version is ${release?.version}, expected ${version}`,
+  );
+  invariant(
+    String(release?.status ?? "").toLowerCase() === "draft",
+    "A provenance manifest can only be created from a draft release",
+  );
+
+  const assets = normalizeAssets(release);
+  const hashedAssets = [];
+  for (const asset of assets) {
+    hashedAssets.push({
+      ...asset,
+      sha256: await hashAsset(asset, assetDir),
+    });
+  }
+
+  const manifest = {
+    schemaVersion: 1,
+    sourceWorkflow: SOURCE_WORKFLOW,
+    workflowRunId: normalizeRunId(workflowRunId),
+    candidateSha: normalizeSha(candidateSha),
+    version,
+    channel: "stable",
+    publish: false,
+    tools: {
+      crabNebula: {
+        cliVersion: normalizeCnVersion(cnVersion),
+        actionRef: normalizeCnActionRef(cnActionRef),
+      },
+    },
+    assets: hashedAssets,
+  };
+
+  await writeFile(output, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+export async function verifyManifest({
+  release,
+  manifest,
+  version,
+  candidateSha,
+  workflowRunId,
+  cnVersion,
+  cnActionRef,
+  assetDir,
+}) {
+  invariant(
+    manifest?.schemaVersion === 1,
+    "Unsupported provenance manifest schema",
+  );
+  invariant(
+    manifest.sourceWorkflow === SOURCE_WORKFLOW,
+    "Unexpected source workflow",
+  );
+  invariant(
+    manifest.workflowRunId === normalizeRunId(workflowRunId),
+    "Workflow run ID mismatch",
+  );
+  invariant(
+    manifest.candidateSha === normalizeSha(candidateSha),
+    "Candidate SHA mismatch",
+  );
+  invariant(manifest.version === version, "Manifest version mismatch");
+  invariant(manifest.channel === "stable", "Manifest channel is not stable");
+  invariant(
+    manifest.publish === false,
+    "Provenance must come from a publish=false run",
+  );
+  invariant(
+    manifest.tools?.crabNebula?.cliVersion === normalizeCnVersion(cnVersion),
+    "CrabNebula CLI version mismatch",
+  );
+  invariant(
+    manifest.tools?.crabNebula?.actionRef === normalizeCnActionRef(cnActionRef),
+    "CrabNebula action ref mismatch",
+  );
+  invariant(
+    release?.version === version,
+    `Release version is ${release?.version}, expected ${version}`,
+  );
+
+  const currentAssets = normalizeAssets(release);
+  invariant(
+    Array.isArray(manifest.assets) &&
+      manifest.assets.length === currentAssets.length,
+    "Release asset count does not match the provenance manifest",
+  );
+
+  for (let index = 0; index < currentAssets.length; index += 1) {
+    const current = currentAssets[index];
+    const recorded = manifest.assets[index];
+    const { sha256, ...recordedMetadata } = recorded ?? {};
+    invariant(
+      JSON.stringify(recordedMetadata) === JSON.stringify(current),
+      `Asset metadata changed at index ${index}`,
+    );
+    invariant(
+      typeof sha256 === "string" && /^[0-9a-f]{64}$/.test(sha256),
+      `Asset ${current.id} has an invalid recorded SHA-256`,
+    );
+
+    const currentSha256 = await hashAsset(current, assetDir);
+    invariant(currentSha256 === sha256, `Asset ${current.id} SHA-256 changed`);
+  }
+}
+
+async function main() {
+  const { command, args } = parseArgs(process.argv.slice(2));
+  invariant(
+    command === "create" || command === "verify",
+    "Expected create or verify command",
+  );
+
+  const release = await readJson(args.release);
+  const common = {
+    release,
+    version: args.version,
+    candidateSha: args["candidate-sha"],
+    workflowRunId: args["run-id"],
+    cnVersion: args["cn-version"],
+    cnActionRef: args["cn-action-ref"],
+    assetDir: args["asset-dir"],
+  };
+
+  if (command === "create") {
+    invariant(args.output, "Missing --output");
+    await createManifest({ ...common, output: args.output });
+    console.log(`Wrote release provenance to ${args.output}`);
+    return;
+  }
+
+  invariant(args.manifest, "Missing --manifest");
+  await verifyManifest({ ...common, manifest: await readJson(args.manifest) });
+  console.log("Release provenance verified");
+}
+
+const isMain = process.argv[1]
+  ? import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+  : false;
+
+if (isMain) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createManifest,
+  verifyManifest,
+} from "./desktop-release-provenance.mjs";
+
+const candidateSha = "0123456789abcdef0123456789abcdef01234567";
+const cnActionRef =
+  "crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c";
+const cnVersion = "cn 0.21.0";
+
+test("binds every release asset to a candidate run and detects replacement", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "anarlog-release-provenance-"),
+  );
+  const assetDir = path.join(directory, "assets");
+  await mkdir(assetDir);
+
+  const contents = new Map([
+    ["asset-a", "macOS"],
+    ["asset-b", "Windows"],
+    ["asset-c", "Linux"],
+  ]);
+  for (const [id, content] of contents) {
+    await writeFile(path.join(assetDir, id), content);
+  }
+
+  const release = {
+    version: "1.4.0",
+    status: "draft",
+    assets: [
+      {
+        id: "asset-c",
+        publicPlatform: "appimage-x86_64",
+        updatePlatform: "linux-x86_64-appimage",
+        size: Buffer.byteLength(contents.get("asset-c")),
+        signature: "linux-signature",
+      },
+      {
+        id: "asset-a",
+        publicPlatform: "dmg-aarch64",
+        size: Buffer.byteLength(contents.get("asset-a")),
+      },
+      {
+        id: "asset-b",
+        publicPlatform: "nsis-x86_64",
+        updatePlatform: "windows-x86_64-nsis",
+        size: Buffer.byteLength(contents.get("asset-b")),
+        signature: "windows-signature",
+      },
+    ],
+  };
+  const output = path.join(directory, "manifest.json");
+
+  await createManifest({
+    release,
+    output,
+    version: "1.4.0",
+    candidateSha,
+    workflowRunId: "12345",
+    cnVersion,
+    cnActionRef,
+    assetDir,
+  });
+  const manifest = JSON.parse(await readFile(output, "utf8"));
+
+  assert.deepEqual(manifest.tools, {
+    crabNebula: { cliVersion: cnVersion, actionRef: cnActionRef },
+  });
+  assert.deepEqual(
+    manifest.assets.map((asset) => asset.id),
+    ["asset-a", "asset-b", "asset-c"],
+  );
+  await verifyManifest({
+    release,
+    manifest,
+    version: "1.4.0",
+    candidateSha,
+    workflowRunId: "12345",
+    cnVersion,
+    cnActionRef,
+    assetDir,
+  });
+
+  await assert.rejects(
+    verifyManifest({
+      release,
+      manifest,
+      version: "1.4.0",
+      candidateSha,
+      workflowRunId: "12345",
+      cnVersion: "cn 0.22.0",
+      cnActionRef,
+      assetDir,
+    }),
+    /CLI version mismatch/,
+  );
+
+  await assert.rejects(
+    verifyManifest({
+      release,
+      manifest,
+      version: "1.4.0",
+      candidateSha,
+      workflowRunId: "12345",
+      cnVersion,
+      cnActionRef:
+        "crabnebula-dev/cloud-release@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      assetDir,
+    }),
+    /action ref mismatch/,
+  );
+
+  await writeFile(path.join(assetDir, "asset-b"), "replaced");
+  await assert.rejects(
+    verifyManifest({
+      release,
+      manifest,
+      version: "1.4.0",
+      candidateSha,
+      workflowRunId: "12345",
+      cnVersion,
+      cnActionRef,
+      assetDir,
+    }),
+    /size .* expected|SHA-256 changed/,
+  );
+});

--- a/scripts/qa/linux_virtual_audio_smoke.sh
+++ b/scripts/qa/linux_virtual_audio_smoke.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <candidate.deb>" >&2
+  exit 2
+fi
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "Linux virtual-audio QA must run on Linux" >&2
+  exit 1
+fi
+
+script_path=$(realpath "$0")
+repo_root=$(cd "$(dirname "$script_path")/../.." && pwd)
+deb_path=$(realpath "$1")
+artifact_dir=$(realpath -m "${QA_ARTIFACT_DIR:-$repo_root/qa-artifacts/linux-audio}")
+
+expected_version=${EXPECTED_VERSION:?EXPECTED_VERSION is required}
+expected_debian_arch=${EXPECTED_DEBIAN_ARCH:?EXPECTED_DEBIAN_ARCH is required}
+
+mkdir -p "$artifact_dir"
+cat > "$artifact_dir/scope.txt" <<'EOF'
+This QA run uses NO_AEC=1. It proves virtual microphone/system routing,
+capture, separation, and persistence only. It does not validate acoustic echo
+cancellation, physical devices, drivers, or real-room acoustics.
+EOF
+
+if [[ "${ANARLOG_AUDIO_QA_IN_DBUS:-0}" != "1" ]]; then
+  for command in dbus-run-session dpkg-deb ffmpeg pnpm python3; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+      echo "Missing required command: $command" >&2
+      exit 1
+    fi
+  done
+
+  package_version=$(dpkg-deb --field "$deb_path" Version)
+  package_arch=$(dpkg-deb --field "$deb_path" Architecture)
+  package_name=$(dpkg-deb --field "$deb_path" Package)
+
+  if [[ "$package_version" != "$expected_version" ]]; then
+    echo "Expected Debian version $expected_version, got $package_version" >&2
+    exit 1
+  fi
+  if [[ "$package_arch" != "$expected_debian_arch" ]]; then
+    echo "Expected Debian architecture $expected_debian_arch, got $package_arch" >&2
+    exit 1
+  fi
+
+  sha256sum "$deb_path" | awk '{print $1 "  candidate.deb"}' \
+    > "$artifact_dir/candidate.deb.sha256"
+  {
+    echo "package=$package_name"
+    echo "version=$package_version"
+    echo "architecture=$package_arch"
+    echo "source=$deb_path"
+  } > "$artifact_dir/debian-package.txt"
+
+  sudo apt-get install -y "$deb_path" 2>&1 \
+    | tee "$artifact_dir/debian-install.log"
+
+  mapfile -t package_binaries < <(
+    dpkg-query -L "$package_name" \
+      | grep -E '^/usr/bin/anarlog(-staging)?$' \
+      | sort -u
+  )
+  if [[ ${#package_binaries[@]} -ne 1 ]]; then
+    printf "Expected one Anarlog executable, found: %s\n" \
+      "${package_binaries[*]:-none}" >&2
+    exit 1
+  fi
+  if [[ ! -x "${package_binaries[0]}" ]]; then
+    echo "Installed Anarlog executable is not runnable" >&2
+    exit 1
+  fi
+
+  qa_root=$(mktemp -d -t anarlog-linux-audio-qa.XXXXXXXX)
+  install -d -m 700 "$qa_root/runtime"
+  mkdir -p \
+    "$qa_root/cache" \
+    "$qa_root/config" \
+    "$qa_root/data" \
+    "$qa_root/state" \
+    "$qa_root/vault"
+
+  cat > "$qa_root/asound.conf" <<'EOF'
+pcm.!default {
+  type pulse
+}
+
+ctl.!default {
+  type pulse
+}
+EOF
+
+  export ALSA_CONFIG_PATH="$qa_root/asound.conf"
+  export ANARLOG_AUDIO_QA_IN_DBUS=1
+  export APP_BINARY_PATH="${package_binaries[0]}"
+  export CHAR_VAULT_BASE="$qa_root/vault"
+  export PULSE_SERVER="unix:$qa_root/runtime/pulse/native"
+  export PIPEWIRE_RUNTIME_DIR="$qa_root/runtime"
+  export QA_ARTIFACT_DIR="$artifact_dir"
+  export QA_ROOT="$qa_root"
+  export XDG_CACHE_HOME="$qa_root/cache"
+  export XDG_CONFIG_HOME="$qa_root/config"
+  export XDG_DATA_HOME="$qa_root/data"
+  export XDG_RUNTIME_DIR="$qa_root/runtime"
+  export XDG_STATE_HOME="$qa_root/state"
+
+  exec dbus-run-session -- "$script_path" "$deb_path"
+fi
+
+for command in arecord pactl paplay pipewire pipewire-pulse pw-cli wireplumber; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "Missing required audio command: $command" >&2
+    exit 1
+  fi
+done
+
+service_pids=()
+cleanup() {
+  for pid in "${service_pids[@]}"; do
+    kill "$pid" >/dev/null 2>&1 || true
+  done
+  for pid in "${service_pids[@]}"; do
+    wait "$pid" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+pipewire > "$artifact_dir/pipewire.log" 2>&1 &
+service_pids+=("$!")
+
+wait_for() {
+  local description=$1
+  shift
+  for _ in $(seq 1 100); do
+    if "$@" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "Timed out waiting for $description" >&2
+  return 1
+}
+
+wait_for "PipeWire core" pw-cli info 0
+
+wireplumber > "$artifact_dir/wireplumber.log" 2>&1 &
+service_pids+=("$!")
+pipewire-pulse > "$artifact_dir/pipewire-pulse.log" 2>&1 &
+service_pids+=("$!")
+
+wait_for "PipeWire Pulse server" pactl info
+
+system_module=$(pactl load-module module-null-sink \
+  sink_name=qa_system rate=48000 channels=1)
+mic_module=$(pactl load-module module-null-sink \
+  sink_name=qa_mic_bus rate=48000 channels=1)
+pactl set-default-sink qa_system
+pactl set-default-source qa_mic_bus.monitor
+
+{
+  echo "system_module=$system_module"
+  echo "mic_module=$mic_module"
+} > "$artifact_dir/virtual-audio-modules.txt"
+pactl info > "$artifact_dir/pactl-info.txt"
+pactl list short sinks > "$artifact_dir/pactl-sinks.txt"
+pactl list short sources > "$artifact_dir/pactl-sources.txt"
+pw-cli info 0 > "$artifact_dir/pipewire-core.txt"
+arecord -L > "$artifact_dir/alsa-pcms.txt"
+
+mic_signal="$QA_ROOT/mic-speech-with-523hz-pilot.wav"
+system_signal="$QA_ROOT/system-997hz-tone.wav"
+preflight_signal="$QA_ROOT/preflight-mic.wav"
+fixture="$repo_root/crates/aec/data/inputs/theo_mic.wav"
+
+ffmpeg -hide_banner -loglevel error -y \
+  -i "$fixture" \
+  -f lavfi -i "sine=frequency=523:sample_rate=48000:duration=10" \
+  -filter_complex \
+  "[0:a]atrim=duration=10,aresample=48000,volume=0.75[speech];[1:a]volume=0.02[pilot];[speech][pilot]amix=inputs=2:duration=shortest:normalize=0[out]" \
+  -map "[out]" -ar 48000 -ac 1 -c:a pcm_s16le "$mic_signal"
+ffmpeg -hide_banner -loglevel error -y \
+  -f lavfi -i "sine=frequency=997:sample_rate=48000:duration=10" \
+  -ar 48000 -ac 1 -c:a pcm_s16le "$system_signal"
+ffmpeg -hide_banner -loglevel error -y \
+  -i "$mic_signal" -t 3 -c:a pcm_s16le "$preflight_signal"
+
+arecord \
+  --device=default \
+  --format=S16_LE \
+  --rate=48000 \
+  --channels=1 \
+  --duration=4 \
+  "$artifact_dir/alsa-mic-preflight.wav" \
+  > "$artifact_dir/alsa-mic-preflight.log" 2>&1 &
+preflight_pid=$!
+sleep 0.25
+paplay --device=qa_mic_bus "$preflight_signal"
+wait "$preflight_pid"
+
+ffmpeg -hide_banner -nostats \
+  -i "$artifact_dir/alsa-mic-preflight.wav" \
+  -af volumedetect -f null - \
+  > /dev/null 2> "$artifact_dir/alsa-mic-preflight-volume.txt"
+preflight_mean_db=$(
+  awk '/mean_volume:/ {print $(NF - 1)}' \
+    "$artifact_dir/alsa-mic-preflight-volume.txt" \
+    | tail -n 1
+)
+if [[ -z "$preflight_mean_db" || "$preflight_mean_db" == "-inf" ]] \
+  || ! awk -v value="$preflight_mean_db" \
+    'BEGIN { exit !(value > -70.0) }'; then
+  echo "ALSA-to-Pulse microphone preflight was silent" >&2
+  exit 1
+fi
+
+export CI=1
+export E2E_VIRTUAL_AUDIO=1
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+export LISTENER_DEBUG=1
+export NO_AEC=1
+export ONBOARDING=0
+export QA_MIC_SIGNAL="$mic_signal"
+export QA_MIC_SINK=qa_mic_bus
+export QA_PHASES_PATH="$artifact_dir/phases.json"
+export QA_SYSTEM_SIGNAL="$system_signal"
+export QA_SYSTEM_SINK=qa_system
+export RUST_LOG="info,sqlx=warn,hyper=warn"
+
+set +e
+pnpm -F e2e-blackbox e2e 2>&1 | tee "$artifact_dir/e2e.log"
+e2e_status=${PIPESTATUS[0]}
+set -e
+
+mkdir -p "$artifact_dir/app-logs"
+while IFS= read -r -d '' log_path; do
+  relative_path=${log_path#"$QA_ROOT/"}
+  cp "$log_path" "$artifact_dir/app-logs/${relative_path//\//__}"
+done < <(
+  find "$QA_ROOT/data" "$QA_ROOT/state" \
+    -type f -name '*.log' -print0 2>/dev/null
+)
+
+for _ in $(seq 1 100); do
+  mic_candidate=$(find "$CHAR_VAULT_BASE" -type f -name audio_mic.wav -print -quit)
+  speaker_candidate=$(find "$CHAR_VAULT_BASE" -type f -name audio_spk.wav -print -quit)
+  if [[ -n "$mic_candidate" && -n "$speaker_candidate" ]] \
+    && ffprobe -v error "$mic_candidate" >/dev/null 2>&1 \
+    && ffprobe -v error "$speaker_candidate" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+
+mapfile -t mic_tracks < <(
+  find "$CHAR_VAULT_BASE" -type f -name audio_mic.wav -print
+)
+mapfile -t speaker_tracks < <(
+  find "$CHAR_VAULT_BASE" -type f -name audio_spk.wav -print
+)
+
+verification_status=0
+if [[ ${#mic_tracks[@]} -ne 1 || ${#speaker_tracks[@]} -ne 1 ]]; then
+  echo "Expected one persisted mic track and one persisted speaker track" \
+    | tee "$artifact_dir/track-discovery-error.txt"
+  find "$CHAR_VAULT_BASE" -maxdepth 5 -type f -print \
+    > "$artifact_dir/vault-files.txt"
+  verification_status=1
+else
+  cp "${mic_tracks[0]}" "$artifact_dir/audio_mic.wav"
+  cp "${speaker_tracks[0]}" "$artifact_dir/audio_spk.wav"
+
+  set +e
+  python3 "$repo_root/scripts/qa/verify_linux_audio_tracks.py" \
+    --mic "$artifact_dir/audio_mic.wav" \
+    --speaker "$artifact_dir/audio_spk.wav" \
+    --phases "$artifact_dir/phases.json" \
+    --output "$artifact_dir/analysis.json" \
+    2>&1 | tee "$artifact_dir/verification.log"
+  verification_status=${PIPESTATUS[0]}
+  set -e
+fi
+
+grep -R -E \
+  'capture_stream_failed|failed_to_send_audio_to_recorder|mic_queue_overflow|mic_stream_build_failed|mic_stream_error|mic_stream_start_failed|pipewire_capture_thread_failed|pipewire_stream_error|pulseaudio_capture_thread_failed|samples_dropped|source_stream_failed_stopping|speaker_queue_overflow' \
+  "$artifact_dir/e2e.log" "$artifact_dir/app-logs" \
+  > "$artifact_dir/capture-errors.txt" 2>/dev/null || true
+grep -R -E \
+  'pipewire_capture_initialized|pipewire_capture_unavailable|pulseaudio_capture_initialized' \
+  "$artifact_dir/e2e.log" "$artifact_dir/app-logs" \
+  > "$artifact_dir/capture-backend-events.txt" 2>/dev/null || true
+
+capture_log_status=0
+if [[ -s "$artifact_dir/capture-errors.txt" ]]; then
+  echo "Capture error events were present in application logs" >&2
+  capture_log_status=1
+fi
+if ! grep -q 'pipewire_capture_initialized' \
+  "$artifact_dir/capture-backend-events.txt"; then
+  echo "Application logs do not prove PipeWire capture initialized" >&2
+  capture_log_status=1
+fi
+if grep -Eq \
+  'pipewire_capture_unavailable|pulseaudio_capture_initialized' \
+  "$artifact_dir/capture-backend-events.txt"; then
+  echo "Application fell back from the required PipeWire capture backend" >&2
+  capture_log_status=1
+fi
+
+if [[ $e2e_status -ne 0 ]]; then
+  echo "Desktop E2E recording scenario failed with status $e2e_status" >&2
+fi
+if [[ $verification_status -ne 0 ]]; then
+  echo "Persisted audio verification failed" >&2
+fi
+
+if [[ $e2e_status -ne 0 || $verification_status -ne 0 || $capture_log_status -ne 0 ]]; then
+  exit 1
+fi

--- a/scripts/qa/verify_linux_audio_tracks.py
+++ b/scripts/qa/verify_linux_audio_tracks.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import math
+import struct
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class WavTrack:
+    sample_rate: int
+    samples: list[float]
+
+    @property
+    def duration_seconds(self) -> float:
+        return len(self.samples) / self.sample_rate
+
+
+THRESHOLDS = {
+    "duration_delta_seconds_max": 0.15,
+    "mic_active_rms_min": 0.0002,
+    "speaker_active_rms_min": 0.001,
+    "system_tone_amplitude_min": 0.0005,
+    "mic_pilot_amplitude_min": 0.0002,
+    "mic_isolation_db_min": 12.0,
+    "speaker_isolation_db_min": 15.0,
+    "system_tone_isolation_db_min": 18.0,
+    "mic_pilot_isolation_db_min": 6.0,
+    "cross_channel_isolation_db_min": 12.0,
+    "clipped_fraction_max": 0.001,
+    "recording_tail_tolerance_seconds": 0.5,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify Anarlog's persisted Linux mic/system tracks from the "
+            "virtual-audio QA scenario. This does not assess AEC."
+        )
+    )
+    parser.add_argument("--mic", type=Path, required=True)
+    parser.add_argument("--speaker", type=Path, required=True)
+    parser.add_argument("--phases", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def read_wav(path: Path) -> WavTrack:
+    data = path.read_bytes()
+    if len(data) < 12 or data[:4] != b"RIFF" or data[8:12] != b"WAVE":
+        raise ValueError(f"{path} is not a RIFF/WAVE file")
+
+    fmt: bytes | None = None
+    audio: bytes | None = None
+    cursor = 12
+    while cursor + 8 <= len(data):
+        chunk_id = data[cursor : cursor + 4]
+        chunk_size = struct.unpack_from("<I", data, cursor + 4)[0]
+        chunk_start = cursor + 8
+        chunk_end = chunk_start + chunk_size
+        if chunk_end > len(data):
+            raise ValueError(f"{path} has a truncated {chunk_id!r} chunk")
+        if chunk_id == b"fmt ":
+            fmt = data[chunk_start:chunk_end]
+        elif chunk_id == b"data":
+            audio = data[chunk_start:chunk_end]
+        cursor = chunk_end + (chunk_size % 2)
+
+    if fmt is None or len(fmt) < 16 or audio is None:
+        raise ValueError(f"{path} is missing required WAV chunks")
+
+    (
+        audio_format,
+        channels,
+        sample_rate,
+        _byte_rate,
+        block_align,
+        bits_per_sample,
+    ) = struct.unpack_from("<HHIIHH", fmt)
+    if audio_format == 0xFFFE and len(fmt) >= 40:
+        audio_format = struct.unpack_from("<H", fmt, 24)[0]
+
+    if channels != 1:
+        raise ValueError(f"{path} must be mono, got {channels} channels")
+    if block_align != bits_per_sample // 8:
+        raise ValueError(f"{path} has an unsupported WAV block alignment")
+
+    samples = decode_samples(audio, audio_format, bits_per_sample)
+    if not samples:
+        raise ValueError(f"{path} has no audio samples")
+    if not all(math.isfinite(sample) for sample in samples):
+        raise ValueError(f"{path} contains non-finite samples")
+
+    return WavTrack(sample_rate=sample_rate, samples=samples)
+
+
+def decode_samples(data: bytes, audio_format: int, bits_per_sample: int) -> list[float]:
+    if audio_format == 3 and bits_per_sample == 32:
+        if len(data) % 4:
+            raise ValueError("float WAV data is not sample-aligned")
+        return list(struct.unpack(f"<{len(data) // 4}f", data))
+
+    if audio_format != 1:
+        raise ValueError(
+            f"unsupported WAV format {audio_format} with {bits_per_sample} bits"
+        )
+
+    if bits_per_sample == 16:
+        if len(data) % 2:
+            raise ValueError("PCM16 WAV data is not sample-aligned")
+        return [
+            sample / 32768.0 for sample in struct.unpack(f"<{len(data) // 2}h", data)
+        ]
+    if bits_per_sample == 24:
+        if len(data) % 3:
+            raise ValueError("PCM24 WAV data is not sample-aligned")
+        samples = []
+        for offset in range(0, len(data), 3):
+            value = int.from_bytes(data[offset : offset + 3], "little", signed=False)
+            if value & 0x800000:
+                value -= 1 << 24
+            samples.append(value / 8388608.0)
+        return samples
+    if bits_per_sample == 32:
+        if len(data) % 4:
+            raise ValueError("PCM32 WAV data is not sample-aligned")
+        return [
+            sample / 2147483648.0
+            for sample in struct.unpack(f"<{len(data) // 4}i", data)
+        ]
+
+    raise ValueError(f"unsupported PCM bit depth {bits_per_sample}")
+
+
+def load_phases(path: Path) -> tuple[dict[str, dict[str, float]], float]:
+    payload = json.loads(path.read_text())
+    if payload.get("schema_version") != 1:
+        raise ValueError("unsupported phase schema")
+    if payload.get("no_aec") is not True:
+        raise ValueError("phase evidence must declare no_aec=true")
+
+    phases: dict[str, dict[str, float]] = {}
+    for phase in payload.get("phases", []):
+        name = phase.get("name")
+        if name not in {"mic_only", "system_only", "both"}:
+            continue
+        start = float(phase["start_seconds"])
+        end = float(phase["end_seconds"])
+        if end - start < 5.0:
+            raise ValueError(f"{name} phase is too short for deterministic analysis")
+        phases[name] = {"start": start, "end": end}
+
+    missing = {"mic_only", "system_only", "both"} - phases.keys()
+    if missing:
+        raise ValueError(f"missing phase evidence: {', '.join(sorted(missing))}")
+
+    recording_stop = float(payload.get("recording_stop_seconds", 0))
+    if recording_stop <= max(phase["end"] for phase in phases.values()):
+        raise ValueError("recording stop must follow every signal phase")
+    return phases, recording_stop
+
+
+def window(
+    track: WavTrack,
+    phase: dict[str, float],
+    offset_seconds: float,
+    trim_seconds: float = 1.25,
+) -> list[float]:
+    start = phase["start"] + offset_seconds + trim_seconds
+    end = phase["end"] + offset_seconds - trim_seconds
+    if end <= start:
+        raise ValueError("phase is too short after trimming")
+    start_index = round(start * track.sample_rate)
+    end_index = round(end * track.sample_rate)
+    if start_index < 0 or end_index > len(track.samples):
+        raise ValueError("phase window falls outside the persisted track")
+    return track.samples[start_index:end_index]
+
+
+def rms(samples: list[float]) -> float:
+    return math.sqrt(math.fsum(sample * sample for sample in samples) / len(samples))
+
+
+def goertzel_amplitude(
+    samples: list[float], sample_rate: int, frequency: float
+) -> float:
+    angular_frequency = 2.0 * math.pi * frequency / sample_rate
+    coefficient = 2.0 * math.cos(angular_frequency)
+    previous = 0.0
+    previous_previous = 0.0
+    for sample in samples:
+        current = sample + coefficient * previous - previous_previous
+        previous_previous = previous
+        previous = current
+    power = (
+        previous_previous * previous_previous
+        + previous * previous
+        - coefficient * previous * previous_previous
+    )
+    return 2.0 * math.sqrt(max(power, 0.0)) / len(samples)
+
+
+def ratio_db(active: float, quiet: float) -> float:
+    floor = 1e-12
+    return 20.0 * math.log10(max(active, floor) / max(quiet, floor))
+
+
+def find_alignment(speaker: WavTrack, phases: dict[str, dict[str, float]]) -> float:
+    candidates: list[tuple[float, float]] = []
+    for step in range(-20, 81):
+        offset = step / 10.0
+        try:
+            mic_only = window(speaker, phases["mic_only"], offset)
+            system_only = window(speaker, phases["system_only"], offset)
+            both = window(speaker, phases["both"], offset)
+        except ValueError:
+            continue
+
+        quiet_tone = goertzel_amplitude(mic_only, speaker.sample_rate, 997.0)
+        active_tone = min(
+            goertzel_amplitude(system_only, speaker.sample_rate, 997.0),
+            goertzel_amplitude(both, speaker.sample_rate, 997.0),
+        )
+        score = active_tone / max(quiet_tone, 1e-9)
+        candidates.append((score, offset))
+
+    if not candidates:
+        raise ValueError("could not align phase evidence with the persisted tracks")
+    best_score = max(score for score, _ in candidates)
+    plateau = [
+        offset
+        for score, offset in candidates
+        if score >= best_score * 0.98
+    ]
+    return (min(plateau) + max(plateau)) / 2.0
+
+
+def clipped_fraction(track: WavTrack) -> float:
+    return sum(1 for sample in track.samples if abs(sample) >= 0.999) / len(
+        track.samples
+    )
+
+
+def analyze(
+    mic: WavTrack,
+    speaker: WavTrack,
+    phases: dict[str, dict[str, float]],
+    recording_stop_seconds: float,
+) -> dict[str, Any]:
+    if mic.sample_rate != 16_000 or speaker.sample_rate != 16_000:
+        raise ValueError(
+            "debug tracks must both be 16 kHz "
+            f"(mic={mic.sample_rate}, speaker={speaker.sample_rate})"
+        )
+
+    alignment = find_alignment(speaker, phases)
+    mic_windows = {
+        name: window(mic, phase, alignment) for name, phase in phases.items()
+    }
+    speaker_windows = {
+        name: window(speaker, phase, alignment) for name, phase in phases.items()
+    }
+
+    metrics = {
+        "mic_duration_seconds": mic.duration_seconds,
+        "speaker_duration_seconds": speaker.duration_seconds,
+        "duration_delta_seconds": abs(mic.duration_seconds - speaker.duration_seconds),
+        "alignment_offset_seconds": alignment,
+        "recording_stop_seconds": recording_stop_seconds,
+        "aligned_recording_stop_seconds": recording_stop_seconds + alignment,
+        "mic_recording_tail_seconds": (
+            mic.duration_seconds - recording_stop_seconds - alignment
+        ),
+        "speaker_recording_tail_seconds": (
+            speaker.duration_seconds - recording_stop_seconds - alignment
+        ),
+        "mic_clipped_fraction": clipped_fraction(mic),
+        "speaker_clipped_fraction": clipped_fraction(speaker),
+        "mic_only_mic_rms": rms(mic_windows["mic_only"]),
+        "system_only_mic_rms": rms(mic_windows["system_only"]),
+        "both_mic_rms": rms(mic_windows["both"]),
+        "mic_only_speaker_rms": rms(speaker_windows["mic_only"]),
+        "system_only_speaker_rms": rms(speaker_windows["system_only"]),
+        "both_speaker_rms": rms(speaker_windows["both"]),
+        "mic_only_523hz_amplitude": goertzel_amplitude(
+            mic_windows["mic_only"], mic.sample_rate, 523.0
+        ),
+        "system_only_523hz_amplitude": goertzel_amplitude(
+            mic_windows["system_only"], mic.sample_rate, 523.0
+        ),
+        "both_523hz_amplitude": goertzel_amplitude(
+            mic_windows["both"], mic.sample_rate, 523.0
+        ),
+        "mic_only_997hz_amplitude": goertzel_amplitude(
+            speaker_windows["mic_only"], speaker.sample_rate, 997.0
+        ),
+        "system_only_997hz_amplitude": goertzel_amplitude(
+            speaker_windows["system_only"], speaker.sample_rate, 997.0
+        ),
+        "both_997hz_amplitude": goertzel_amplitude(
+            speaker_windows["both"], speaker.sample_rate, 997.0
+        ),
+        "both_mic_997hz_amplitude": goertzel_amplitude(
+            mic_windows["both"], mic.sample_rate, 997.0
+        ),
+        "both_speaker_523hz_amplitude": goertzel_amplitude(
+            speaker_windows["both"], speaker.sample_rate, 523.0
+        ),
+    }
+    metrics.update(
+        {
+            "mic_only_isolation_db": ratio_db(
+                metrics["mic_only_mic_rms"], metrics["system_only_mic_rms"]
+            ),
+            "both_mic_isolation_db": ratio_db(
+                metrics["both_mic_rms"], metrics["system_only_mic_rms"]
+            ),
+            "system_only_speaker_isolation_db": ratio_db(
+                metrics["system_only_speaker_rms"],
+                metrics["mic_only_speaker_rms"],
+            ),
+            "both_speaker_isolation_db": ratio_db(
+                metrics["both_speaker_rms"], metrics["mic_only_speaker_rms"]
+            ),
+            "system_tone_isolation_db": ratio_db(
+                min(
+                    metrics["system_only_997hz_amplitude"],
+                    metrics["both_997hz_amplitude"],
+                ),
+                metrics["mic_only_997hz_amplitude"],
+            ),
+            "mic_pilot_isolation_db": ratio_db(
+                min(
+                    metrics["mic_only_523hz_amplitude"],
+                    metrics["both_523hz_amplitude"],
+                ),
+                metrics["system_only_523hz_amplitude"],
+            ),
+            "both_system_to_mic_isolation_db": ratio_db(
+                metrics["both_997hz_amplitude"],
+                metrics["both_mic_997hz_amplitude"],
+            ),
+            "both_mic_to_speaker_isolation_db": ratio_db(
+                metrics["both_523hz_amplitude"],
+                metrics["both_speaker_523hz_amplitude"],
+            ),
+        }
+    )
+
+    failures = []
+    require_at_most(
+        failures,
+        "duration delta",
+        metrics["duration_delta_seconds"],
+        THRESHOLDS["duration_delta_seconds_max"],
+    )
+    require_at_least(
+        failures,
+        "mic recording tail",
+        metrics["mic_recording_tail_seconds"],
+        -THRESHOLDS["recording_tail_tolerance_seconds"],
+    )
+    require_at_least(
+        failures,
+        "speaker recording tail",
+        metrics["speaker_recording_tail_seconds"],
+        -THRESHOLDS["recording_tail_tolerance_seconds"],
+    )
+    require_at_most(
+        failures,
+        "mic clipped fraction",
+        metrics["mic_clipped_fraction"],
+        THRESHOLDS["clipped_fraction_max"],
+    )
+    require_at_most(
+        failures,
+        "speaker clipped fraction",
+        metrics["speaker_clipped_fraction"],
+        THRESHOLDS["clipped_fraction_max"],
+    )
+    for key in ("mic_only_mic_rms", "both_mic_rms"):
+        require_at_least(failures, key, metrics[key], THRESHOLDS["mic_active_rms_min"])
+    for key in ("system_only_speaker_rms", "both_speaker_rms"):
+        require_at_least(
+            failures, key, metrics[key], THRESHOLDS["speaker_active_rms_min"]
+        )
+    for key in ("system_only_997hz_amplitude", "both_997hz_amplitude"):
+        require_at_least(
+            failures,
+            key,
+            metrics[key],
+            THRESHOLDS["system_tone_amplitude_min"],
+        )
+    for key in ("mic_only_523hz_amplitude", "both_523hz_amplitude"):
+        require_at_least(
+            failures,
+            key,
+            metrics[key],
+            THRESHOLDS["mic_pilot_amplitude_min"],
+        )
+    for key in ("mic_only_isolation_db", "both_mic_isolation_db"):
+        require_at_least(
+            failures, key, metrics[key], THRESHOLDS["mic_isolation_db_min"]
+        )
+    for key in (
+        "system_only_speaker_isolation_db",
+        "both_speaker_isolation_db",
+    ):
+        require_at_least(
+            failures, key, metrics[key], THRESHOLDS["speaker_isolation_db_min"]
+        )
+    require_at_least(
+        failures,
+        "system_tone_isolation_db",
+        metrics["system_tone_isolation_db"],
+        THRESHOLDS["system_tone_isolation_db_min"],
+    )
+    require_at_least(
+        failures,
+        "mic_pilot_isolation_db",
+        metrics["mic_pilot_isolation_db"],
+        THRESHOLDS["mic_pilot_isolation_db_min"],
+    )
+    for key in (
+        "both_system_to_mic_isolation_db",
+        "both_mic_to_speaker_isolation_db",
+    ):
+        require_at_least(
+            failures,
+            key,
+            metrics[key],
+            THRESHOLDS["cross_channel_isolation_db_min"],
+        )
+
+    return {
+        "status": "pass" if not failures else "fail",
+        "scope": (
+            "Virtual microphone/system routing, capture, separation, and "
+            "persistence with NO_AEC=1. This result makes no AEC claim."
+        ),
+        "thresholds": THRESHOLDS,
+        "metrics": metrics,
+        "failures": failures,
+    }
+
+
+def require_at_least(
+    failures: list[str], name: str, actual: float, minimum: float
+) -> None:
+    if actual < minimum:
+        failures.append(f"{name} was {actual:.8g}, expected at least {minimum:.8g}")
+
+
+def require_at_most(
+    failures: list[str], name: str, actual: float, maximum: float
+) -> None:
+    if actual > maximum:
+        failures.append(f"{name} was {actual:.8g}, expected at most {maximum:.8g}")
+
+
+def write_result(path: Path, result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        phases, recording_stop_seconds = load_phases(args.phases)
+        result = analyze(
+            read_wav(args.mic),
+            read_wav(args.speaker),
+            phases,
+            recording_stop_seconds,
+        )
+    except Exception as error:
+        result = {
+            "status": "fail",
+            "scope": (
+                "Virtual microphone/system routing, capture, separation, and "
+                "persistence with NO_AEC=1. This result makes no AEC claim."
+            ),
+            "failures": [str(error)],
+        }
+
+    write_result(args.output, result)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/qa/verify_linux_audio_tracks.py
+++ b/scripts/qa/verify_linux_audio_tracks.py
@@ -232,11 +232,7 @@ def find_alignment(speaker: WavTrack, phases: dict[str, dict[str, float]]) -> fl
     if not candidates:
         raise ValueError("could not align phase evidence with the persisted tracks")
     best_score = max(score for score, _ in candidates)
-    plateau = [
-        offset
-        for score, offset in candidates
-        if score >= best_score * 0.98
-    ]
+    plateau = [offset for score, offset in candidates if score >= best_score * 0.98]
     return (min(plateau) + max(plateau)) / 2.0
 
 
@@ -370,6 +366,18 @@ def analyze(
         "speaker recording tail",
         metrics["speaker_recording_tail_seconds"],
         -THRESHOLDS["recording_tail_tolerance_seconds"],
+    )
+    require_at_most(
+        failures,
+        "mic recording tail",
+        metrics["mic_recording_tail_seconds"],
+        THRESHOLDS["recording_tail_tolerance_seconds"],
+    )
+    require_at_most(
+        failures,
+        "speaker recording tail",
+        metrics["speaker_recording_tail_seconds"],
+        THRESHOLDS["recording_tail_tolerance_seconds"],
     )
     require_at_most(
         failures,


### PR DESCRIPTION
Adds a manually dispatched x64/ARM64 gate that binds CrabNebula DEBs to the exact successful dry-run manifest, records artifact hashes, drives native PipeWire/Pulse plus ALSA-routed capture, and verifies persisted mic/system separation.

The gate runs with NO_AEC=1 and makes no AEC or physical-device claim.

Validation: E2E TypeScript typecheck, workflow YAML parse, shell/Python syntax, release-provenance unit test, real fixture VAD retention, and positive/leakage/truncation signal-analysis cases.

Stacked on #6306 for dry-run provenance manifests.

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #6311
- <kbd>&nbsp;6&nbsp;</kbd> #6309 👈 
- <kbd>&nbsp;5&nbsp;</kbd> #6306
- <kbd>&nbsp;4&nbsp;</kbd> #6296
- <kbd>&nbsp;3&nbsp;</kbd> #6301
- <kbd>&nbsp;2&nbsp;</kbd> #6294
- <kbd>&nbsp;1&nbsp;</kbd> #6280
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI/QA-only (new workflow, E2E test, and offline verification scripts); no production app or release-publish logic is modified.
> 
> **Overview**
> Adds a **manually dispatched** GitHub workflow that gates stable Linux **x64** and **ARM64** CrabNebula DEBs before release. Inputs pin **version**, **candidate SHA** (must be current `main`), and a successful **desktop CD dry-run** ID; jobs validate changelog presence, download the dry-run **release provenance** manifest, cross-check CrabNebula asset metadata and **SHA-256**, then fetch and checksum the DEB from CDN.
> 
> On Depot runners the workflow installs the candidate package, runs **`linux_virtual_audio_smoke.sh`** (isolated PipeWire/Pulse, virtual sinks, ALSA preflight), drives a new **`linux-virtual-audio.spec.ts`** E2E scenario with **`NO_AEC=1`**, and post-processes persisted **`audio_mic.wav` / `audio_spk.wav`** via **`verify_linux_audio_tracks.py`** (phase-aligned tone/RMS/isolation thresholds). It also asserts **PipeWire** capture in logs and uploads QA artifacts. **AEC and physical devices are explicitly out of scope.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907da3a8d7af798f9541ff7d7dc3b4045f811fbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->