### PR TITLE
Require Linux audio QA before desktop publication

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -143,6 +143,10 @@ gh run watch <run-id>
 The run's `headSha` must equal the Dev/staging candidate SHA. A mismatch blocks
 acceptance even if the workflow succeeds.
 
+Do not use GitHub's rerun button for a failed stable candidate or Linux audio
+gate. Dispatch a fresh run instead; publication only accepts first-attempt run
+IDs so evidence cannot be mixed across attempts.
+
 The dry-run workflow must:
 
 - use the exact explicit stable version
@@ -150,23 +154,41 @@ The dry-run workflow must:
 - build the signed Windows and Linux artifacts for the same version and commit
 - upload a draft CrabNebula release without publishing it
 - upload `desktop-release-provenance-<version>-<sha>`, including the exact
-  artifact hashes and CrabNebula tool versions
+  artifact hashes and pinned CrabNebula CLI version, asset ID, and SHA-256
 
-After the exact dry-run artifacts pass the required platform QA gates and
-`main` still points to the candidate SHA, publish only through the provenance
-workflow:
+Run the Linux virtual-audio gate against that exact dry-run candidate:
+
+```bash
+gh workflow run desktop_linux_audio_qa.yaml \
+  --ref main \
+  -f version=<version> \
+  -f candidate_sha=<40-character-main-sha> \
+  -f dry_run_id=<dry-run-id>
+```
+
+Watch the run and verify its head SHA is still the candidate SHA. It must
+produce passing `linux-audio-qa-<version>-x64` and
+`linux-audio-qa-<version>-arm64` evidence artifacts. This gate proves virtual
+microphone/system routing, capture, separation, and persistence with
+`NO_AEC=1`; it does not waive physical-device or AEC validation.
+
+After the exact dry-run artifacts and Linux audio QA run pass the required
+platform gates and `main` still points to the candidate SHA, publish only
+through the provenance workflow:
 
 ```bash
 gh workflow run desktop_publish.yaml \
   --ref main \
   -f version=<version> \
   -f candidate_sha=<40-character-main-sha> \
-  -f dry_run_id=<run-id>
+  -f dry_run_id=<dry-run-id> \
+  -f audio_qa_run_id=<linux-audio-qa-run-id>
 ```
 
 Watch that workflow to completion. It must verify the dry-run run identity,
-artifact hashes, CrabNebula tool versions, current `main`, and the immutable
-tag before publishing.
+artifact hashes, both Linux audio evidence artifacts, CrabNebula tool
+identity and hash, current `main`, and the immutable tag before publishing. It
+must also verify every file mirrored to GitHub against the provenance manifest.
 
 ## Final Checks
 
@@ -174,6 +196,7 @@ Before reporting success, capture:
 
 - computed stable version
 - dry-run workflow URL and head SHA
+- Linux audio QA workflow URL, head SHA, and x64/ARM64 evidence artifacts
 - publish workflow URL and head SHA
 - `desktop_v<version>` tag
 - GitHub release URL

--- a/.github/actions/cn_download/action.yaml
+++ b/.github/actions/cn_download/action.yaml
@@ -1,3 +1,6 @@
+name: Download CrabNebula release asset
+description: Resolve and download one exact public-platform release asset
+
 inputs:
   app:
     description: "Fully qualified application slug (e.g., fastrepl/hyprnote2)"
@@ -22,30 +25,50 @@ outputs:
   success:
     description: "Whether the download succeeded"
     value: ${{ steps.download.outputs.success }}
+  asset_id:
+    description: "Exact downloaded CrabNebula asset ID"
+    value: ${{ steps.download.outputs.asset_id }}
+  cli-version:
+    description: "Verified CrabNebula CLI version"
+    value: ${{ steps.get-assets.outputs.cli-version }}
+  cli-asset-id:
+    description: "Immutable CrabNebula CLI asset ID"
+    value: ${{ steps.get-assets.outputs.cli-asset-id }}
+  cli-sha256:
+    description: "Verified CrabNebula CLI SHA-256"
+    value: ${{ steps.get-assets.outputs.cli-sha256 }}
 
 runs:
   using: "composite"
   steps:
     - id: get-assets
-      uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
+      uses: ./.github/actions/cn_release
       with:
-        command: release show ${{ inputs.app }} ${{ inputs.version }} --channel ${{ inputs.channel }}
-        api-key: ${{ inputs.key }}
+        raw: >-
+          release show ${{ inputs.app }} ${{ inputs.version }}
+          --channel ${{ inputs.channel }}
+        key: ${{ inputs.key }}
     - id: download
       shell: bash
       env:
-        ASSETS: ${{ steps.get-assets.outputs.stdout }}
+        ASSETS: ${{ steps.get-assets.outputs.raw }}
         PLATFORM: ${{ inputs.platform }}
         OUTPUT: ${{ inputs.output }}
       run: |
-        ASSET_ID=$(echo "$ASSETS" | jq -r --arg platform "$PLATFORM" '.assets[] | select(.publicPlatform == $platform) | .id')
-        if [[ -z "$ASSET_ID" || "$ASSET_ID" == "null" ]]; then
-          echo "::error::Asset not found for platform $PLATFORM"
+        ASSET=$(echo "$ASSETS" | jq -cer \
+          --arg platform "$PLATFORM" \
+          '[.assets[] | select(.publicPlatform == $platform and ((.size // 0) | tonumber) > 0)] | if length == 1 then .[0] else error("expected exactly one nonempty asset for " + $platform) end')
+        ASSET_ID=$(echo "$ASSET" | jq -r '.id')
+        if [[ ! "$ASSET_ID" =~ ^[A-Za-z0-9_-]+$ ]]; then
+          echo "::error::Invalid asset ID for platform $PLATFORM"
           echo "success=false" >> $GITHUB_OUTPUT
           exit 1
         fi
         echo "Downloading asset $ASSET_ID to $OUTPUT"
         curl --fail --show-error --location \
+          --proto "=https" \
+          --proto-redir "=https" \
           "https://cdn.crabnebula.app/asset/$ASSET_ID" \
           --output "$OUTPUT"
         echo "success=true" >> $GITHUB_OUTPUT
+        echo "asset_id=$ASSET_ID" >> $GITHUB_OUTPUT

--- a/.github/actions/cn_install/action.yaml
+++ b/.github/actions/cn_install/action.yaml
@@ -1,0 +1,106 @@
+name: Install CrabNebula CLI
+description: Install the project-pinned CrabNebula CLI after verifying its size and SHA-256
+
+outputs:
+  path:
+    description: Absolute path to the verified CrabNebula CLI
+    value: ${{ steps.install.outputs.path }}
+  version:
+    description: Verified CrabNebula CLI version
+    value: ${{ steps.install.outputs.version }}
+  asset-id:
+    description: Immutable CrabNebula CDN asset ID
+    value: ${{ steps.install.outputs.asset-id }}
+  sha256:
+    description: Verified CrabNebula CLI SHA-256
+    value: ${{ steps.install.outputs.sha256 }}
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      env:
+        RUNNER_ARCHITECTURE: ${{ runner.arch }}
+        RUNNER_OPERATING_SYSTEM: ${{ runner.os }}
+      run: |
+        # CrabNebula does not publish checksums, so these project-maintained
+        # pins are verified against its immutable asset-ID URLs before use.
+        case "$RUNNER_OPERATING_SYSTEM/$RUNNER_ARCHITECTURE" in
+          Linux/X64)
+            ASSET_ID="01KVDB8KPSKMQ5X3SJ0ANF6943"
+            EXPECTED_SIZE="5731704"
+            EXPECTED_SHA256="760b11d1ab9326dc78068ac8ef450685ea116e329903b14d94a5133641a54128"
+            EXECUTABLE="cn"
+            ;;
+          Linux/ARM64)
+            ASSET_ID="01KVDB8P8EA4FM154BZ58Q8M2T"
+            EXPECTED_SIZE="5035936"
+            EXPECTED_SHA256="d37aa11eee8694cc431c06f221d7dd10ad9c843a4dfd5dc62117fd979954f6da"
+            EXECUTABLE="cn"
+            ;;
+          macOS/X64|macOS/ARM64)
+            ASSET_ID="01KVDB8RX4NMKPZY5JG93MCDA3"
+            EXPECTED_SIZE="10949552"
+            EXPECTED_SHA256="cad269fc9fb56c43bb9e03277261ebdeeb0a3345539b5e799adf2222441dde81"
+            EXECUTABLE="cn"
+            ;;
+          Windows/X64)
+            ASSET_ID="01KVDB8VNES8V1M6PQJEN5D2MQ"
+            EXPECTED_SIZE="5623160"
+            EXPECTED_SHA256="30d5dfc5fdf64a8364fe1b847d39341c453844f16a8bced586488ba454b6c840"
+            EXECUTABLE="cn.exe"
+            ;;
+          *)
+            echo "::error::Unsupported CrabNebula CLI runner: $RUNNER_OPERATING_SYSTEM/$RUNNER_ARCHITECTURE"
+            exit 1
+            ;;
+        esac
+
+        INSTALL_DIR="$RUNNER_TEMP/anarlog-cn-cli-0.13.2-$ASSET_ID"
+        CLI_PATH="$INSTALL_DIR/$EXECUTABLE"
+        mkdir -p "$INSTALL_DIR"
+
+        verify_binary() {
+          local file="$1"
+          local metadata
+          metadata=$(node -e '
+            const crypto = require("node:crypto");
+            const fs = require("node:fs");
+            const file = process.argv[1];
+            const bytes = fs.readFileSync(file);
+            process.stdout.write(`${bytes.length} ${crypto.createHash("sha256").update(bytes).digest("hex")}`);
+          ' "$file")
+          [[ "$metadata" == "$EXPECTED_SIZE $EXPECTED_SHA256" ]]
+        }
+
+        if [[ ! -f "$CLI_PATH" ]] || ! verify_binary "$CLI_PATH"; then
+          DOWNLOAD_PATH="$CLI_PATH.download"
+          curl \
+            --fail \
+            --location \
+            --proto "=https" \
+            --proto-redir "=https" \
+            --show-error \
+            --silent \
+            --tlsv1.2 \
+            "https://cdn.crabnebula.app/asset/$ASSET_ID" \
+            --output "$DOWNLOAD_PATH"
+          if ! verify_binary "$DOWNLOAD_PATH"; then
+            echo "::error::CrabNebula CLI size or SHA-256 did not match the project pin"
+            exit 1
+          fi
+          mv -f "$DOWNLOAD_PATH" "$CLI_PATH"
+        fi
+
+        chmod +x "$CLI_PATH"
+        ACTUAL_VERSION=$("$CLI_PATH" --version | tr -d '\r')
+        if [[ "$ACTUAL_VERSION" != "cn 0.13.2" ]]; then
+          echo "::error::Expected CrabNebula CLI cn 0.13.2, got $ACTUAL_VERSION"
+          exit 1
+        fi
+
+        echo "path=$CLI_PATH" >> "$GITHUB_OUTPUT"
+        echo "version=$ACTUAL_VERSION" >> "$GITHUB_OUTPUT"
+        echo "asset-id=$ASSET_ID" >> "$GITHUB_OUTPUT"
+        echo "sha256=$EXPECTED_SHA256" >> "$GITHUB_OUTPUT"

--- a/.github/actions/cn_release/action.yaml
+++ b/.github/actions/cn_release/action.yaml
@@ -1,3 +1,6 @@
+name: Run CrabNebula release command
+description: Run the project-pinned CrabNebula CLI for a release operation
+
 inputs:
   raw:
     description: "raw"
@@ -31,31 +34,65 @@ outputs:
   raw:
     description: "Output from raw command"
     value: ${{ steps.raw.outputs.stdout }}
+  cli-version:
+    description: "Verified CrabNebula CLI version"
+    value: ${{ steps.install.outputs.version }}
+  cli-asset-id:
+    description: "Immutable CrabNebula CLI asset ID"
+    value: ${{ steps.install.outputs.asset-id }}
+  cli-sha256:
+    description: "Verified CrabNebula CLI SHA-256"
+    value: ${{ steps.install.outputs.sha256 }}
 
 runs:
   using: "composite"
   steps:
-    - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
-      id: raw
+    - id: install
+      uses: ./.github/actions/cn_install
+    - id: raw
       if: inputs.raw != ''
-      with:
-        command: ${{ inputs.raw }}
-        api-key: ${{ inputs.key }}
-        path: ${{ github.workspace }}
-    - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
-      if: inputs.raw == '' && inputs.framework == 'tauri'
-      with:
-        command: >-
-          release ${{ inputs.cmd }} ${{ inputs.app }}
-          --framework tauri${{ inputs.channel != '' && format(' --channel {0}', inputs.channel) || '' }}
-        api-key: ${{ inputs.key }}
-        path: ${{ github.workspace }}
-        working-directory: ${{ inputs.working-directory }}
-    - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
-      if: inputs.raw == '' && inputs.framework != 'tauri'
-      with:
-        command: >-
-          release ${{ inputs.cmd }} ${{ inputs.app }} ${{ inputs.version }}${{ inputs.channel != '' && format(' --channel {0}', inputs.channel) || '' }}
-        api-key: ${{ inputs.key }}
-        path: ${{ github.workspace }}
-        working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      env:
+        CLI_PATH: ${{ steps.install.outputs.path }}
+        CN_API_KEY: ${{ inputs.key }}
+        RAW_COMMAND: ${{ inputs.raw }}
+      run: |
+        read -r -a arguments <<< "$RAW_COMMAND"
+        stdout=$("$CLI_PATH" "${arguments[@]}")
+        printf '%s\n' "$stdout"
+        {
+          echo "stdout<<CN_OUTPUT_EOF"
+          printf '%s\n' "$stdout"
+          echo "CN_OUTPUT_EOF"
+        } >> "$GITHUB_OUTPUT"
+    - if: inputs.raw == '' && inputs.framework == 'tauri'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        APP: ${{ inputs.app }}
+        CHANNEL: ${{ inputs.channel }}
+        CLI_PATH: ${{ steps.install.outputs.path }}
+        CMD: ${{ inputs.cmd }}
+        CN_API_KEY: ${{ inputs.key }}
+      run: |
+        arguments=(release "$CMD" "$APP" --framework tauri)
+        if [[ -n "$CHANNEL" ]]; then
+          arguments+=(--channel "$CHANNEL")
+        fi
+        "$CLI_PATH" "${arguments[@]}"
+    - if: inputs.raw == '' && inputs.framework != 'tauri'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        APP: ${{ inputs.app }}
+        CHANNEL: ${{ inputs.channel }}
+        CLI_PATH: ${{ steps.install.outputs.path }}
+        CMD: ${{ inputs.cmd }}
+        CN_API_KEY: ${{ inputs.key }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        arguments=(release "$CMD" "$APP" "$VERSION")
+        if [[ -n "$CHANNEL" ]]; then
+          arguments+=(--channel "$CHANNEL")
+        fi
+        "$CLI_PATH" "${arguments[@]}"

--- a/.github/actions/trigger-workflow/action.yml
+++ b/.github/actions/trigger-workflow/action.yml
@@ -1,5 +1,5 @@
 name: Trigger Workflow
-description: Trigger a workflow and poll for run ID
+description: Trigger a workflow and return its exact run ID
 
 inputs:
   workflow:
@@ -12,9 +12,9 @@ inputs:
     description: Channel input for the workflow
     required: true
   publish:
-    description: Publish to Crabnebula and create GitHub release
+    description: Legacy desktop CD compatibility input
     required: false
-    default: "true"
+    default: "false"
   version:
     description: "Explicit stable version"
     required: false
@@ -25,11 +25,6 @@ inputs:
   repo:
     description: Repository (owner/repo)
     required: true
-  max_attempts:
-    description: Max polling attempts
-    required: false
-    default: "10"
-
 outputs:
   run_id:
     description: The triggered workflow run ID
@@ -49,14 +44,19 @@ runs:
         VERSION: ${{ inputs.version }}
         WORKFLOW: ${{ inputs.workflow }}
       run: |
-        ARGS=(workflow run "$WORKFLOW" --repo "$REPO" --ref "$REF" -f "channel=$CHANNEL" -f "publish=$PUBLISH")
+        ARGS=(
+          --method POST
+          -H "X-GitHub-Api-Version: 2026-03-10"
+          "repos/$REPO/actions/workflows/$WORKFLOW/dispatches"
+          -f "ref=$REF"
+          -f "inputs[channel]=$CHANNEL"
+          -F "inputs[publish]=$PUBLISH"
+        )
         if [[ -n "$VERSION" ]]; then
-          ARGS+=(-f "version=$VERSION")
+          ARGS+=(-f "inputs[version]=$VERSION")
         fi
-        gh "${ARGS[@]}"
-        for i in $(seq 1 ${{ inputs.max_attempts }}); do
-          sleep 5
-          RUN_ID=$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --branch="$REF" --json databaseId,createdAt --jq 'sort_by(.createdAt) | reverse | .[0].databaseId // empty')
-          [ -n "$RUN_ID" ] && break
-        done
+        RESPONSE=$(gh api "${ARGS[@]}")
+        RUN_ID=$(jq -er \
+          '.workflow_run_id | numbers | select(. > 0)' \
+          <<< "$RESPONSE")
         echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT

--- a/.github/actions/trigger-workflow/action.yml
+++ b/.github/actions/trigger-workflow/action.yml
@@ -51,6 +51,7 @@ runs:
           -f "ref=$REF"
           -f "inputs[channel]=$CHANNEL"
           -F "inputs[publish]=$PUBLISH"
+          -F "return_run_details=true"
         )
         if [[ -n "$VERSION" ]]; then
           ARGS+=(-f "inputs[version]=$VERSION")

--- a/.github/actions/trigger-workflow/action.yml
+++ b/.github/actions/trigger-workflow/action.yml
@@ -8,6 +8,9 @@ inputs:
   ref:
     description: Git ref to run on
     required: true
+  sha:
+    description: Immutable commit SHA to check out
+    required: true
   channel:
     description: Channel input for the workflow
     required: true
@@ -41,6 +44,7 @@ runs:
         PUBLISH: ${{ inputs.publish }}
         REF: ${{ inputs.ref }}
         REPO: ${{ inputs.repo }}
+        SHA: ${{ inputs.sha }}
         VERSION: ${{ inputs.version }}
         WORKFLOW: ${{ inputs.workflow }}
       run: |
@@ -50,6 +54,7 @@ runs:
           "repos/$REPO/actions/workflows/$WORKFLOW/dispatches"
           -f "ref=$REF"
           -f "inputs[channel]=$CHANNEL"
+          -f "inputs[candidate_sha]=$SHA"
           -F "inputs[publish]=$PUBLISH"
           -F "return_run_details=true"
         )

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,4 +4,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "pass"
+      - uses: actions/checkout@v4
+      - run: >-
+          node --test
+          scripts/desktop-release-provenance.test.mjs
+          scripts/verify-linux-audio-qa-run.test.mjs
+          scripts/verify-linux-audio-qa-evidence.test.mjs

--- a/.github/workflows/command_dispatcher.yaml
+++ b/.github/workflows/command_dispatcher.yaml
@@ -26,7 +26,6 @@ jobs:
     if: needs.check-permission.outputs.allowed == 'true' && contains(github.event.comment.body, '/stable')
     runs-on: ubuntu-latest
     outputs:
-      publish: ${{ steps.parse.outputs.publish }}
       version: ${{ steps.parse.outputs.version }}
     steps:
       - id: parse
@@ -34,16 +33,11 @@ jobs:
           COMMENT: ${{ github.event.comment.body }}
         run: |
           if [[ ! "$COMMENT" =~ /stable[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+)($|[[:space:]]) ]]; then
-            echo "::error::Use /stable <version> [--no-publish], for example /stable 1.4.0"
+            echo "::error::Use /stable <version>, for example /stable 1.4.0"
             exit 1
           fi
 
           VERSION="${BASH_REMATCH[1]}"
-          PUBLISH="true"
-          if [[ "$COMMENT" =~ --no-publish ]]; then
-            PUBLISH="false"
-          fi
-          echo "publish=$PUBLISH" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   handle-stable:
@@ -52,7 +46,7 @@ jobs:
     uses: ./.github/workflows/handle_release.yaml
     with:
       channel: stable
-      publish: ${{ needs.parse-stable-options.outputs.publish == 'true' }}
+      publish: false
       version: ${{ needs.parse-stable-options.outputs.version }}
       issue_number: ${{ github.event.issue.number }}
       comment_id: ${{ github.event.comment.id }}

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -9,6 +9,11 @@ on:
         options:
           - staging
           - stable
+      candidate_sha:
+        description: "Immutable candidate commit to check out"
+        required: false
+        type: string
+        default: ""
       publish:
         description: "Legacy compatibility input; stable publication must use desktop_publish"
         type: boolean
@@ -36,6 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.candidate_sha || github.sha }}
           lfs: true
           fetch-depth: 0
           fetch-tags: true
@@ -88,6 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.candidate_sha || github.sha }}
       - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.compute-version.outputs.version }}"
       - name: Verify stable signing credentials
         env:
@@ -126,6 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.candidate_sha || github.sha }}
           lfs: true
           fetch-depth: 0
           fetch-tags: true
@@ -291,6 +300,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.candidate_sha || github.sha }}
           lfs: true
           fetch-depth: 0
           fetch-tags: true
@@ -462,6 +472,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.candidate_sha || github.sha }}
           lfs: true
           fetch-depth: 0
           fetch-tags: true
@@ -656,6 +667,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.candidate_sha || github.sha }}
       - id: release
         uses: ./.github/actions/cn_release
         with:

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -10,9 +10,9 @@ on:
           - staging
           - stable
       publish:
-        description: "Publish to Crabnebula and create GitHub release (ignored for staging)"
+        description: "Legacy compatibility input; stable publication must use desktop_publish"
         type: boolean
-        default: true
+        default: false
       version:
         description: "Explicit semantic version required for stable releases"
         required: false
@@ -23,7 +23,6 @@ concurrency:
   group: ${{ inputs.channel == 'stable' && 'desktop-stable-release' || format('{0}-{1}-{2}', github.workflow, github.ref, inputs.channel) }}
   cancel-in-progress: ${{ inputs.channel != 'stable' }}
 env:
-  CN_ACTION_REF: "crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c"
   CN_APPLICATION: "fastrepl/hyprnote2"
   RELEASE_CHANNEL: ${{ inputs.channel }}
   TAURI_CONF_PATH: ./src-tauri/tauri.conf.${{ inputs.channel }}.json
@@ -45,6 +44,11 @@ jobs:
           git fetch --tags --force
       - if: ${{ inputs.channel == 'stable' }}
         run: |
+          if [[ "${{ inputs.publish }}" == "true" ]]; then
+            echo "::error::desktop_cd only builds stable candidates; publish through desktop_publish after QA"
+            exit 1
+          fi
+
           git fetch origin main --no-tags
 
           TARGET=$(git rev-parse HEAD)
@@ -158,9 +162,6 @@ jobs:
         working-directory: ./apps/desktop
       - run: |
           BUILD_ARGS=(--target "${{ matrix.target }}" --config "${{ env.TAURI_CONF_PATH }}" --verbose)
-          if [[ "${{ inputs.channel }}" == "stable" ]]; then
-            BUILD_ARGS+=(--config ./src-tauri/tauri.conf.stable-macos.json)
-          fi
           if [[ "${{ matrix.target }}" == "x86_64-apple-darwin" ]]; then
             BUILD_ARGS+=(--config ./src-tauri/tauri.conf.macos-intel.json)
           fi
@@ -614,11 +615,8 @@ jobs:
           }
 
           $hash = (Get-FileHash -Algorithm SHA256 $installers[0].FullName).Hash.ToLowerInvariant()
-          [System.IO.File]::WriteAllText(
-            "$($installers[0].FullName).sha256",
-            "$hash  $($installers[0].Name)`n",
-            [System.Text.Encoding]::ASCII
-          )
+          "$hash  $($installers[0].Name)" |
+            Out-File "$($installers[0].FullName).sha256" -Encoding ascii
       - if: ${{ inputs.channel == 'stable' }}
         name: Verify Windows updater signature
         shell: bash
@@ -720,16 +718,16 @@ jobs:
             echo "::error::CrabNebula release $EXPECTED_VERSION has missing, duplicate, unsigned, or empty updater assets: ${INVALID_UPDATE_PLATFORMS[*]}"
             exit 1
           fi
-      - if: ${{ !inputs.publish }}
-        name: Record release provenance
+      - name: Record release provenance
         env:
-          CN_ACTION_REF: ${{ env.CN_ACTION_REF }}
+          CN_ASSET_ID: ${{ steps.release.outputs.cli-asset-id }}
+          CN_SHA256: ${{ steps.release.outputs.cli-sha256 }}
+          CN_VERSION: ${{ steps.release.outputs.cli-version }}
           RELEASE: ${{ steps.release.outputs.raw }}
           VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           mkdir -p release-provenance
           printf '%s' "$RELEASE" > "$RUNNER_TEMP/crabnebula-release.json"
-          CN_VERSION=$("$GITHUB_WORKSPACE/cn" --version)
           node scripts/desktop-release-provenance.mjs create \
             --release "$RUNNER_TEMP/crabnebula-release.json" \
             --output release-provenance/manifest.json \
@@ -737,217 +735,11 @@ jobs:
             --candidate-sha "$GITHUB_SHA" \
             --run-id "$GITHUB_RUN_ID" \
             --cn-version "$CN_VERSION" \
-            --cn-action-ref "$CN_ACTION_REF"
-      - if: ${{ !inputs.publish }}
-        uses: actions/upload-artifact@v4
+            --cn-asset-id "$CN_ASSET_ID" \
+            --cn-sha256 "$CN_SHA256"
+      - uses: actions/upload-artifact@v4
         with:
           name: desktop-release-provenance-${{ needs.compute-version.outputs.version }}-${{ github.sha }}
           path: release-provenance/manifest.json
           if-no-files-found: error
           retention-days: 30
-
-  create-tag:
-    if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.verify-cn-release.result == 'success' }}
-    needs: [compute-version, verify-cn-release]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - run: |
-          git fetch origin main --no-tags
-          git fetch --tags --force
-
-          TAG="desktop_v${{ needs.compute-version.outputs.version }}"
-          TARGET=$(git rev-parse HEAD)
-          MAIN=$(git rev-parse origin/main)
-          EXISTING=$(git rev-parse -q --verify "refs/tags/$TAG" || true)
-
-          if [[ "$TARGET" != "$MAIN" ]]; then
-            echo "::error::Candidate moved before tagging (candidate=$TARGET, main=$MAIN)"
-            exit 1
-          fi
-
-          if [[ -n "$EXISTING" ]]; then
-            if [[ "$EXISTING" != "$TARGET" ]]; then
-              echo "::error::Tag $TAG points to $EXISTING instead of candidate $TARGET"
-              exit 1
-            fi
-
-            echo "Tag $TAG already points to candidate $TARGET"
-          else
-            git tag "$TAG" "$TARGET"
-            git push origin "refs/tags/$TAG"
-          fi
-
-  cn-publish:
-    if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.verify-cn-release.result == 'success' && needs.create-tag.result == 'success' }}
-    needs: [compute-version, verify-cn-release, create-tag]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.compute-version.outputs.version }}"
-      - name: Verify candidate before publication
-        run: |
-          git fetch origin main --no-tags
-          git fetch --tags --force
-
-          TARGET=$(git rev-parse HEAD)
-          MAIN=$(git rev-parse origin/main)
-          TAG="desktop_v${{ needs.compute-version.outputs.version }}"
-          TAG_TARGET=$(git rev-parse "$TAG^{commit}")
-
-          if [[ "$TARGET" != "$MAIN" || "$TAG_TARGET" != "$TARGET" ]]; then
-            echo "::error::Candidate moved before publication (candidate=$TARGET, main=$MAIN, tag=$TAG_TARGET)"
-            exit 1
-          fi
-      - uses: ./.github/actions/cn_release
-        with:
-          cmd: publish
-          app: ${{ env.CN_APPLICATION }}
-          key: ${{ secrets.CN_API_KEY }}
-          channel: ${{ env.RELEASE_CHANNEL }}
-          framework: tauri
-          working-directory: ./apps/desktop
-
-  release:
-    if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.cn-publish.result == 'success' && needs.build-macos.result == 'success' && needs.build-windows.result == 'success' && needs.build-linux.result == 'success' }}
-    needs: [
-      compute-version,
-      build-macos,
-      build-windows,
-      build-linux,
-      cn-publish,
-    ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - run: git fetch --tags --force
-      - if: ${{ needs.build-macos.result == 'success' }}
-        uses: ./.github/actions/cn_download
-        with:
-          app: ${{ env.CN_APPLICATION }}
-          version: ${{ needs.compute-version.outputs.version }}
-          channel: ${{ env.RELEASE_CHANNEL }}
-          platform: dmg-aarch64
-          output: hyprnote-macos-aarch64.dmg
-          key: ${{ secrets.CN_API_KEY }}
-      - if: ${{ needs.build-macos.result == 'success' }}
-        uses: ./.github/actions/cn_download
-        with:
-          app: ${{ env.CN_APPLICATION }}
-          version: ${{ needs.compute-version.outputs.version }}
-          channel: ${{ env.RELEASE_CHANNEL }}
-          platform: dmg-x86_64
-          output: hyprnote-macos-x86_64.dmg
-          key: ${{ secrets.CN_API_KEY }}
-      - if: ${{ needs.build-linux.result == 'success' }}
-        uses: ./.github/actions/cn_download
-        with:
-          app: ${{ env.CN_APPLICATION }}
-          version: ${{ needs.compute-version.outputs.version }}
-          channel: ${{ env.RELEASE_CHANNEL }}
-          platform: appimage-x86_64
-          output: anarlog-linux-x86_64.AppImage
-          key: ${{ secrets.CN_API_KEY }}
-      - if: ${{ needs.build-linux.result == 'success' }}
-        uses: ./.github/actions/cn_download
-        with:
-          app: ${{ env.CN_APPLICATION }}
-          version: ${{ needs.compute-version.outputs.version }}
-          channel: ${{ env.RELEASE_CHANNEL }}
-          platform: deb-x86_64
-          output: anarlog-linux-x86_64.deb
-          key: ${{ secrets.CN_API_KEY }}
-      - if: ${{ needs.build-linux.result == 'success' }}
-        uses: ./.github/actions/cn_download
-        with:
-          app: ${{ env.CN_APPLICATION }}
-          version: ${{ needs.compute-version.outputs.version }}
-          channel: ${{ env.RELEASE_CHANNEL }}
-          platform: appimage-aarch64
-          output: anarlog-linux-aarch64.AppImage
-          key: ${{ secrets.CN_API_KEY }}
-      - if: ${{ needs.build-linux.result == 'success' }}
-        uses: ./.github/actions/cn_download
-        with:
-          app: ${{ env.CN_APPLICATION }}
-          version: ${{ needs.compute-version.outputs.version }}
-          channel: ${{ env.RELEASE_CHANNEL }}
-          platform: deb-aarch64
-          output: anarlog-linux-aarch64.deb
-          key: ${{ secrets.CN_API_KEY }}
-      - if: ${{ needs.build-windows.result == 'success' }}
-        uses: ./.github/actions/cn_download
-        with:
-          app: ${{ env.CN_APPLICATION }}
-          version: ${{ needs.compute-version.outputs.version }}
-          channel: ${{ env.RELEASE_CHANNEL }}
-          platform: nsis-x86_64
-          output: anarlog-windows-x86_64-setup.exe
-          key: ${{ secrets.CN_API_KEY }}
-      - id: checksums
-        uses: ./.github/actions/generate_checksums
-        with:
-          files: |
-            ${{ needs.build-macos.result == 'success' && 'hyprnote-macos-aarch64.dmg' || '' }}
-            ${{ needs.build-macos.result == 'success' && 'hyprnote-macos-x86_64.dmg' || '' }}
-            ${{ needs.build-linux.result == 'success' && 'anarlog-linux-x86_64.AppImage' || '' }}
-            ${{ needs.build-linux.result == 'success' && 'anarlog-linux-x86_64.deb' || '' }}
-            ${{ needs.build-linux.result == 'success' && 'anarlog-linux-aarch64.AppImage' || '' }}
-            ${{ needs.build-linux.result == 'success' && 'anarlog-linux-aarch64.deb' || '' }}
-            ${{ needs.build-windows.result == 'success' && 'anarlog-windows-x86_64-setup.exe' || '' }}
-      - id: artifacts
-        run: |
-          ARTIFACTS=""
-          if [[ "${{ needs.build-macos.result }}" == "success" ]]; then
-            ARTIFACTS="hyprnote-macos-aarch64.dmg,hyprnote-macos-x86_64.dmg"
-          fi
-          if [[ "${{ needs.build-linux.result }}" == "success" ]]; then
-            LINUX_ARTIFACTS="anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb"
-            if [[ -n "$ARTIFACTS" ]]; then
-              ARTIFACTS="$ARTIFACTS,$LINUX_ARTIFACTS"
-            else
-              ARTIFACTS="$LINUX_ARTIFACTS"
-            fi
-          fi
-          if [[ "${{ needs.build-windows.result }}" == "success" ]]; then
-            WINDOWS_ARTIFACT="anarlog-windows-x86_64-setup.exe"
-            if [[ -n "$ARTIFACTS" ]]; then
-              ARTIFACTS="$ARTIFACTS,$WINDOWS_ARTIFACT"
-            else
-              ARTIFACTS="$WINDOWS_ARTIFACT"
-            fi
-          fi
-          if [[ -z "$ARTIFACTS" ]]; then
-            echo "No artifacts to release" >&2
-            exit 1
-          fi
-          if [[ -n "${{ steps.checksums.outputs.checksum_files }}" ]]; then
-            ARTIFACTS="$ARTIFACTS,${{ steps.checksums.outputs.checksum_files }}"
-          fi
-          echo "list=$ARTIFACTS" >> $GITHUB_OUTPUT
-      - id: release-body
-        run: |
-          echo "value=https://anarlog.so/changelog/${{ needs.compute-version.outputs.version }}" >> "$GITHUB_OUTPUT"
-      - uses: ncipollo/release-action@v1
-        with:
-          tag: desktop_v${{ needs.compute-version.outputs.version }}
-          name: desktop_v${{ needs.compute-version.outputs.version }}
-          body: ${{ steps.release-body.outputs.value }}
-          prerelease: false
-          makeLatest: true
-          artifacts: ${{ steps.artifacts.outputs.list }}
-          allowUpdates: true
-          replacesArtifacts: true

--- a/.github/workflows/desktop_linux_audio_qa.yaml
+++ b/.github/workflows/desktop_linux_audio_qa.yaml
@@ -152,15 +152,22 @@ jobs:
         run: |
           run=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID")
           if ! jq -e \
+            --arg repo "$GITHUB_REPOSITORY" \
             --arg sha "$EXPECTED_SHA" \
             --arg workflow ".github/workflows/desktop_cd.yaml" \
+            --argjson run_id "$RUN_ID" \
             '
-              (.head_sha | ascii_downcase) == $sha
-              and .event == "workflow_dispatch"
+              .id == $run_id
+              and .status == "completed"
               and .conclusion == "success"
+              and .run_attempt == 1
+              and .event == "workflow_dispatch"
+              and (.head_sha | ascii_downcase) == $sha
+              and .repository.full_name == $repo
+              and .head_repository.full_name == $repo
               and (.path | split("@")[0]) == $workflow
             ' <<< "$run" > /dev/null; then
-            echo "::error::Run $RUN_ID is not a successful desktop CD dry run for candidate $EXPECTED_SHA"
+            echo "::error::Run $RUN_ID is not an unrerun, successful desktop CD dry run for candidate $EXPECTED_SHA"
             exit 1
           fi
 
@@ -367,7 +374,7 @@ jobs:
           path: |
             qa-artifacts/linux-${{ matrix.artifact_arch }}/
             e2e/blackbox/videos/
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14
       - if: steps.audio-qa.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - id: parse
         env:
+          EXECUTION_REF: ${{ github.ref }}
+          EXECUTION_SHA: ${{ github.sha }}
           INPUT_AUDIO_QA_RUN_ID: ${{ inputs.audio_qa_run_id }}
           INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha }}
           INPUT_DRY_RUN_ID: ${{ inputs.dry_run_id }}
@@ -62,6 +64,15 @@ jobs:
 
           VERSION="$INPUT_VERSION"
           CANDIDATE_SHA="${INPUT_CANDIDATE_SHA,,}"
+          if [[ "$EXECUTION_REF" != "refs/heads/main" ]]; then
+            echo "::error::Stable publication must run from refs/heads/main, not $EXECUTION_REF"
+            exit 1
+          fi
+          if [[ "${EXECUTION_SHA,,}" != "$CANDIDATE_SHA" ]]; then
+            echo "::error::Executing workflow SHA $EXECUTION_SHA does not match candidate $CANDIDATE_SHA"
+            exit 1
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "channel=stable" >> $GITHUB_OUTPUT
           echo "candidate_sha=$CANDIDATE_SHA" >> $GITHUB_OUTPUT
@@ -275,6 +286,10 @@ jobs:
             echo "::error::Expected CrabNebula release $EXPECTED_VERSION, got $ACTUAL_VERSION"
             exit 1
           fi
+
+          printf '%s' "$RELEASE" > "$RUNNER_TEMP/crabnebula-release.json"
+          node scripts/desktop-release-provenance.mjs verify-platforms \
+            --release "$RUNNER_TEMP/crabnebula-release.json"
 
           EXPECTED_PLATFORMS=(
             "dmg-aarch64"

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -540,9 +540,28 @@ jobs:
           copy_asset "$LINUX_ARM64_DEB_ID" "anarlog-linux-aarch64.deb"
           copy_asset "$WINDOWS_X64_ID" "anarlog-windows-x86_64-setup.exe"
 
+          PLATFORM_ASSET_IDS=$(jq -cn \
+            --arg dmg_aarch64 "$MACOS_ARM64_ID" \
+            --arg dmg_x86_64 "$MACOS_X64_ID" \
+            --arg appimage_x86_64 "$LINUX_X64_APPIMAGE_ID" \
+            --arg deb_x86_64 "$LINUX_X64_DEB_ID" \
+            --arg appimage_aarch64 "$LINUX_ARM64_APPIMAGE_ID" \
+            --arg deb_aarch64 "$LINUX_ARM64_DEB_ID" \
+            --arg nsis_x86_64 "$WINDOWS_X64_ID" \
+            '{
+              "dmg-aarch64": $dmg_aarch64,
+              "dmg-x86_64": $dmg_x86_64,
+              "appimage-x86_64": $appimage_x86_64,
+              "deb-x86_64": $deb_x86_64,
+              "appimage-aarch64": $appimage_aarch64,
+              "deb-aarch64": $deb_aarch64,
+              "nsis-x86_64": $nsis_x86_64
+            }')
+
           node scripts/desktop-release-provenance.mjs verify-assets \
             --manifest release-provenance/manifest.json \
             --asset-dir "$ASSET_DIR" \
+            --platform-asset-ids "$PLATFORM_ASSET_IDS" \
             --version "$VERSION" \
             --candidate-sha "$EXPECTED_SHA" \
             --run-id "$RUN_ID" \

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -13,13 +13,16 @@ on:
         description: "Successful publish=false desktop CD run that built the candidate"
         required: true
         type: string
+      audio_qa_run_id:
+        description: "Successful desktop Linux virtual-audio QA run for the candidate"
+        required: true
+        type: string
 
 concurrency:
   group: desktop-stable-release
   cancel-in-progress: false
 
 env:
-  CN_ACTION_REF: "crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c"
   CN_APPLICATION: "fastrepl/hyprnote2"
 
 jobs:
@@ -30,9 +33,11 @@ jobs:
       channel: ${{ steps.parse.outputs.channel }}
       candidate_sha: ${{ steps.parse.outputs.candidate_sha }}
       dry_run_id: ${{ steps.parse.outputs.dry_run_id }}
+      audio_qa_run_id: ${{ steps.parse.outputs.audio_qa_run_id }}
     steps:
       - id: parse
         env:
+          INPUT_AUDIO_QA_RUN_ID: ${{ inputs.audio_qa_run_id }}
           INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha }}
           INPUT_DRY_RUN_ID: ${{ inputs.dry_run_id }}
           INPUT_VERSION: ${{ inputs.version }}
@@ -50,6 +55,10 @@ jobs:
             echo "::error::Dry-run workflow ID must be a positive integer"
             exit 1
           fi
+          if [[ ! "$INPUT_AUDIO_QA_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Linux audio QA workflow ID must be a positive integer"
+            exit 1
+          fi
 
           VERSION="$INPUT_VERSION"
           CANDIDATE_SHA="${INPUT_CANDIDATE_SHA,,}"
@@ -57,6 +66,7 @@ jobs:
           echo "channel=stable" >> $GITHUB_OUTPUT
           echo "candidate_sha=$CANDIDATE_SHA" >> $GITHUB_OUTPUT
           echo "dry_run_id=$INPUT_DRY_RUN_ID" >> $GITHUB_OUTPUT
+          echo "audio_qa_run_id=$INPUT_AUDIO_QA_RUN_ID" >> $GITHUB_OUTPUT
 
   verify-candidate:
     needs: parse
@@ -174,15 +184,22 @@ jobs:
         run: |
           RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID")
           if ! echo "$RUN" | jq -e \
+            --arg repo "$GITHUB_REPOSITORY" \
             --arg sha "$EXPECTED_SHA" \
             --arg workflow ".github/workflows/desktop_cd.yaml" \
+            --argjson run_id "$RUN_ID" \
             '
-              (.head_sha | ascii_downcase) == $sha
-              and .event == "workflow_dispatch"
+              .id == $run_id
+              and .status == "completed"
               and .conclusion == "success"
+              and .run_attempt == 1
+              and .event == "workflow_dispatch"
+              and (.head_sha | ascii_downcase) == $sha
+              and .repository.full_name == $repo
+              and .head_repository.full_name == $repo
               and (.path | split("@")[0]) == $workflow
             ' > /dev/null; then
-            echo "::error::Run $RUN_ID is not a successful desktop CD run for candidate $EXPECTED_SHA"
+            echo "::error::Run $RUN_ID is not an unrerun, successful desktop CD run for candidate $EXPECTED_SHA"
             exit 1
           fi
 
@@ -190,6 +207,48 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --name "desktop-release-provenance-$VERSION-$EXPECTED_SHA" \
             --dir release-provenance
+      - name: Verify Linux virtual-audio QA evidence
+        env:
+          AUDIO_QA_RUN_ID: ${{ needs.parse.outputs.audio_qa_run_id }}
+          DRY_RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$AUDIO_QA_RUN_ID")
+          ARTIFACTS=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$AUDIO_QA_RUN_ID/artifacts?per_page=100")
+          printf '%s' "$RUN" > "$RUNNER_TEMP/linux-audio-qa-run.json"
+          printf '%s' "$ARTIFACTS" > "$RUNNER_TEMP/linux-audio-qa-artifacts.json"
+          node scripts/verify-linux-audio-qa-run.mjs \
+            --run "$RUNNER_TEMP/linux-audio-qa-run.json" \
+            --artifacts "$RUNNER_TEMP/linux-audio-qa-artifacts.json" \
+            --repository "$GITHUB_REPOSITORY" \
+            --version "$VERSION" \
+            --candidate-sha "$EXPECTED_SHA" \
+            --run-id "$AUDIO_QA_RUN_ID" \
+            --output "$RUNNER_TEMP/linux-audio-qa-downloads.json"
+
+          for arch in x64 arm64; do
+            NAME="linux-audio-qa-$VERSION-$arch"
+            ARTIFACT_ID=$(jq -er \
+              --arg arch "$arch" \
+              '.[] | select(.architecture == $arch) | .id' \
+              "$RUNNER_TEMP/linux-audio-qa-downloads.json")
+            mkdir -p "linux-audio-qa/$arch"
+            gh api \
+              "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
+              > "$RUNNER_TEMP/$NAME.zip"
+            unzip -q "$RUNNER_TEMP/$NAME.zip" -d "linux-audio-qa/$arch"
+          done
+
+          node scripts/verify-linux-audio-qa-evidence.mjs \
+            --evidence-dir linux-audio-qa \
+            --manifest release-provenance/manifest.json \
+            --version "$VERSION" \
+            --candidate-sha "$EXPECTED_SHA" \
+            --dry-run-id "$DRY_RUN_ID" \
+            --audio-qa-run-id "$AUDIO_QA_RUN_ID"
       - id: release
         uses: ./.github/actions/cn_release
         with:
@@ -269,14 +328,15 @@ jobs:
           esac
       - name: Verify candidate provenance
         env:
-          CN_ACTION_REF: ${{ env.CN_ACTION_REF }}
+          CN_ASSET_ID: ${{ steps.release.outputs.cli-asset-id }}
+          CN_SHA256: ${{ steps.release.outputs.cli-sha256 }}
+          CN_VERSION: ${{ steps.release.outputs.cli-version }}
           EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
           RELEASE: ${{ steps.release.outputs.raw }}
           RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
           VERSION: ${{ needs.parse.outputs.version }}
         run: |
           printf '%s' "$RELEASE" > "$RUNNER_TEMP/crabnebula-release.json"
-          CN_VERSION=$("$GITHUB_WORKSPACE/cn" --version)
           node scripts/desktop-release-provenance.mjs verify \
             --release "$RUNNER_TEMP/crabnebula-release.json" \
             --manifest release-provenance/manifest.json \
@@ -284,7 +344,8 @@ jobs:
             --candidate-sha "$EXPECTED_SHA" \
             --run-id "$RUN_ID" \
             --cn-version "$CN_VERSION" \
-            --cn-action-ref "$CN_ACTION_REF"
+            --cn-asset-id "$CN_ASSET_ID" \
+            --cn-sha256 "$CN_SHA256"
       - name: Create immutable release tag
         env:
           EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
@@ -344,6 +405,7 @@ jobs:
     needs: [parse, cn-publish]
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
       - uses: actions/checkout@v4
@@ -363,6 +425,17 @@ jobs:
             echo "::error::Tag $TAG points to $TAG_TARGET instead of candidate $EXPECTED_SHA"
             exit 1
           fi
+      - name: Download candidate provenance
+        env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "desktop-release-provenance-$VERSION-$EXPECTED_SHA" \
+            --dir release-provenance
       - id: download-macos-aarch64
         uses: ./.github/actions/cn_download
         with:
@@ -426,6 +499,56 @@ jobs:
           platform: nsis-x86_64
           output: anarlog-windows-x86_64-setup.exe
           key: ${{ secrets.CN_API_KEY }}
+      - name: Verify GitHub release assets against provenance
+        env:
+          CN_ASSET_ID: ${{ steps.download-macos-aarch64.outputs.cli-asset-id }}
+          CN_SHA256: ${{ steps.download-macos-aarch64.outputs.cli-sha256 }}
+          CN_VERSION: ${{ steps.download-macos-aarch64.outputs.cli-version }}
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          LINUX_ARM64_APPIMAGE_ID: ${{ steps.download-linux-aarch64-appimage.outputs.asset_id }}
+          LINUX_ARM64_DEB_ID: ${{ steps.download-linux-aarch64-deb.outputs.asset_id }}
+          LINUX_X64_APPIMAGE_ID: ${{ steps.download-linux-x86_64-appimage.outputs.asset_id }}
+          LINUX_X64_DEB_ID: ${{ steps.download-linux-x86_64-deb.outputs.asset_id }}
+          MACOS_ARM64_ID: ${{ steps.download-macos-aarch64.outputs.asset_id }}
+          MACOS_X64_ID: ${{ steps.download-macos-x86_64.outputs.asset_id }}
+          RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
+          VERSION: ${{ needs.parse.outputs.version }}
+          WINDOWS_X64_ID: ${{ steps.download-windows-x86_64.outputs.asset_id }}
+        run: |
+          ASSET_DIR="$RUNNER_TEMP/gh-release-assets"
+          mkdir -p "$ASSET_DIR"
+
+          copy_asset() {
+            local asset_id="$1"
+            local source="$2"
+            if [[ ! "$asset_id" =~ ^[A-Za-z0-9_-]+$ ]]; then
+              echo "::error::Invalid CrabNebula asset ID for $source"
+              exit 1
+            fi
+            if [[ -e "$ASSET_DIR/$asset_id" ]]; then
+              echo "::error::Duplicate CrabNebula asset ID $asset_id"
+              exit 1
+            fi
+            cp "$source" "$ASSET_DIR/$asset_id"
+          }
+
+          copy_asset "$MACOS_ARM64_ID" "hyprnote-macos-aarch64.dmg"
+          copy_asset "$MACOS_X64_ID" "hyprnote-macos-x86_64.dmg"
+          copy_asset "$LINUX_X64_APPIMAGE_ID" "anarlog-linux-x86_64.AppImage"
+          copy_asset "$LINUX_X64_DEB_ID" "anarlog-linux-x86_64.deb"
+          copy_asset "$LINUX_ARM64_APPIMAGE_ID" "anarlog-linux-aarch64.AppImage"
+          copy_asset "$LINUX_ARM64_DEB_ID" "anarlog-linux-aarch64.deb"
+          copy_asset "$WINDOWS_X64_ID" "anarlog-windows-x86_64-setup.exe"
+
+          node scripts/desktop-release-provenance.mjs verify-assets \
+            --manifest release-provenance/manifest.json \
+            --asset-dir "$ASSET_DIR" \
+            --version "$VERSION" \
+            --candidate-sha "$EXPECTED_SHA" \
+            --run-id "$RUN_ID" \
+            --cn-version "$CN_VERSION" \
+            --cn-asset-id "$CN_ASSET_ID" \
+            --cn-sha256 "$CN_SHA256"
       - id: checksums
         uses: ./.github/actions/generate_checksums
         with:

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -235,10 +235,19 @@ jobs:
               --arg arch "$arch" \
               '.[] | select(.architecture == $arch) | .id' \
               "$RUNNER_TEMP/linux-audio-qa-downloads.json")
+            ARTIFACT_DIGEST=$(jq -er \
+              --arg arch "$arch" \
+              '.[] | select(.architecture == $arch) | .digest' \
+              "$RUNNER_TEMP/linux-audio-qa-downloads.json")
             mkdir -p "linux-audio-qa/$arch"
             gh api \
               "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
               > "$RUNNER_TEMP/$NAME.zip"
+            ACTUAL_DIGEST="sha256:$(sha256sum "$RUNNER_TEMP/$NAME.zip" | cut -d ' ' -f 1)"
+            if [[ "$ACTUAL_DIGEST" != "$ARTIFACT_DIGEST" ]]; then
+              echo "::error::$NAME digest mismatch: expected $ARTIFACT_DIGEST, got $ACTUAL_DIGEST"
+              exit 1
+            fi
             unzip -q "$RUNNER_TEMP/$NAME.zip" -d "linux-audio-qa/$arch"
           done
 

--- a/.github/workflows/handle_release.yaml
+++ b/.github/workflows/handle_release.yaml
@@ -77,6 +77,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
       - id: result
+        if: ${{ always() }}
         run: |
           CHANNEL="${{ inputs.channel }}"
           RESOLVED="${{ steps.resolve.outputs.resolved }}"
@@ -105,12 +106,13 @@ jobs:
           fi
           echo "data=$DATA" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/comment-result
+        if: ${{ always() && steps.result.outputs.data != '' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
           issue_number: ${{ inputs.issue_number }}
           data: ${{ steps.result.outputs.data }}
-      - if: steps.resolve.outputs.resolved == 'true'
+      - if: ${{ always() && steps.resolve.outputs.resolved == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }}
         run: gh api repos/${{ github.repository }}/git/refs/heads/${{ steps.resolve.outputs.branch }} -X DELETE || true

--- a/.github/workflows/handle_release.yaml
+++ b/.github/workflows/handle_release.yaml
@@ -71,6 +71,7 @@ jobs:
         with:
           workflow: desktop_cd.yaml
           ref: ${{ steps.resolve.outputs.branch }}
+          sha: ${{ steps.resolve.outputs.target_sha }}
           channel: ${{ inputs.channel }}
           publish: ${{ inputs.publish }}
           version: ${{ inputs.version }}

--- a/.github/workflows/handle_release.yaml
+++ b/.github/workflows/handle_release.yaml
@@ -7,7 +7,7 @@ on:
       publish:
         required: false
         type: boolean
-        default: true
+        default: false
       version:
         required: true
         type: string
@@ -76,7 +76,6 @@ jobs:
           version: ${{ inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
-          max_attempts: "10"
       - id: result
         run: |
           CHANNEL="${{ inputs.channel }}"

--- a/.github/workflows/handle_staging.yaml
+++ b/.github/workflows/handle_staging.yaml
@@ -70,6 +70,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
       - id: result
+        if: ${{ always() }}
         run: |
           BRANCH="${{ steps.resolve.outputs.branch }}"
           SHA="${{ steps.resolve.outputs.sha }}"
@@ -95,12 +96,13 @@ jobs:
           fi
           echo "data=$DATA" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/comment-result
+        if: ${{ always() && steps.result.outputs.data != '' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
           issue_number: ${{ inputs.issue_number }}
           data: ${{ steps.result.outputs.data }}
-      - if: steps.resolve.outputs.needs_cleanup == 'true'
+      - if: ${{ always() && steps.resolve.outputs.needs_cleanup == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }}
         run: gh api repos/${{ github.repository }}/git/refs/heads/${{ steps.resolve.outputs.branch }} -X DELETE || true

--- a/.github/workflows/handle_staging.yaml
+++ b/.github/workflows/handle_staging.yaml
@@ -66,6 +66,7 @@ jobs:
         with:
           workflow: desktop_cd.yaml
           ref: ${{ steps.resolve.outputs.branch }}
+          sha: ${{ steps.resolve.outputs.sha }}
           channel: staging
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}

--- a/.github/workflows/handle_staging.yaml
+++ b/.github/workflows/handle_staging.yaml
@@ -69,7 +69,6 @@ jobs:
           channel: staging
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
-          max_attempts: "6"
       - id: result
         run: |
           BRANCH="${{ steps.resolve.outputs.branch }}"

--- a/scripts/desktop-release-provenance.mjs
+++ b/scripts/desktop-release-provenance.mjs
@@ -6,6 +6,24 @@ import { pathToFileURL } from "node:url";
 
 const DEFAULT_ASSET_BASE_URL = "https://cdn.crabnebula.app/asset";
 const SOURCE_WORKFLOW = ".github/workflows/desktop_cd.yaml";
+const EXPECTED_PUBLIC_PLATFORMS = [
+  "appimage-aarch64",
+  "appimage-x86_64",
+  "deb-aarch64",
+  "deb-x86_64",
+  "dmg-aarch64",
+  "dmg-x86_64",
+  "nsis-x86_64",
+];
+const EXPECTED_UPDATE_PLATFORMS = [
+  "darwin-aarch64",
+  "darwin-x86_64",
+  "linux-aarch64-appimage",
+  "linux-aarch64-deb",
+  "linux-x86_64-appimage",
+  "linux-x86_64-deb",
+  "windows-x86_64-nsis",
+];
 
 function invariant(condition, message) {
   if (!condition) {
@@ -122,6 +140,34 @@ function normalizeAssets(release) {
     "Release contains duplicate asset IDs",
   );
   return assets;
+}
+
+export function verifyDesktopPlatformSets(release) {
+  const assets = normalizeAssets(release);
+  invariant(
+    assets.length === EXPECTED_PUBLIC_PLATFORMS.length,
+    `Release must contain exactly ${EXPECTED_PUBLIC_PLATFORMS.length} desktop assets`,
+  );
+
+  const publicPlatforms = assets
+    .map((asset) => asset.publicPlatform)
+    .filter((platform) => platform !== null)
+    .sort();
+  invariant(
+    JSON.stringify(publicPlatforms) ===
+      JSON.stringify(EXPECTED_PUBLIC_PLATFORMS),
+    "Release public platforms do not match the desktop allowlist",
+  );
+
+  const updatePlatforms = assets
+    .map((asset) => asset.updatePlatform)
+    .filter((platform) => platform !== null)
+    .sort();
+  invariant(
+    JSON.stringify(updatePlatforms) ===
+      JSON.stringify(EXPECTED_UPDATE_PLATFORMS),
+    "Release update platforms do not match the desktop allowlist",
+  );
 }
 
 async function hashStream(stream) {
@@ -373,8 +419,11 @@ export async function verifyLocalAssets({
 async function main() {
   const { command, args } = parseArgs(process.argv.slice(2));
   invariant(
-    command === "create" || command === "verify" || command === "verify-assets",
-    "Expected create, verify, or verify-assets command",
+    command === "create" ||
+      command === "verify" ||
+      command === "verify-assets" ||
+      command === "verify-platforms",
+    "Expected create, verify, verify-assets, or verify-platforms command",
   );
 
   const common = {
@@ -395,6 +444,13 @@ async function main() {
       output: args.output,
     });
     console.log(`Wrote release provenance to ${args.output}`);
+    return;
+  }
+
+  if (command === "verify-platforms") {
+    invariant(args.release, "Missing --release");
+    verifyDesktopPlatformSets(await readJson(args.release));
+    console.log("Release desktop platforms match the allowlist");
     return;
   }
 

--- a/scripts/desktop-release-provenance.mjs
+++ b/scripts/desktop-release-provenance.mjs
@@ -298,6 +298,7 @@ export async function verifyLocalAssets({
   cnAssetId,
   cnSha256,
   assetDir,
+  platformAssetIds,
 }) {
   invariant(assetDir, "Missing local asset directory");
   invariant(
@@ -314,6 +315,34 @@ export async function verifyLocalAssets({
     (asset) => typeof asset?.publicPlatform === "string",
   );
   invariant(mirroredAssets.length > 0, "Provenance has no public assets");
+  invariant(
+    platformAssetIds &&
+      typeof platformAssetIds === "object" &&
+      !Array.isArray(platformAssetIds),
+    "Missing downloaded platform asset IDs",
+  );
+  const expectedPlatforms = mirroredAssets
+    .map((asset) => asset.publicPlatform)
+    .sort();
+  invariant(
+    new Set(expectedPlatforms).size === expectedPlatforms.length,
+    "Provenance contains duplicate public platforms",
+  );
+  const downloadedPlatforms = Object.keys(platformAssetIds).sort();
+  invariant(
+    JSON.stringify(downloadedPlatforms) === JSON.stringify(expectedPlatforms),
+    "Downloaded public platforms do not match the provenance manifest",
+  );
+  for (const asset of mirroredAssets) {
+    const downloadedAssetId = normalizeCnAssetId(
+      platformAssetIds[asset.publicPlatform],
+    );
+    invariant(
+      downloadedAssetId === normalizeCnAssetId(asset.id),
+      `Downloaded asset ID for ${asset.publicPlatform} does not match the provenance manifest`,
+    );
+  }
+
   const expectedAssetIds = mirroredAssets
     .map((asset) => normalizeCnAssetId(asset?.id))
     .sort();
@@ -372,7 +401,13 @@ async function main() {
   invariant(args.manifest, "Missing --manifest");
   const manifest = await readJson(args.manifest);
   if (command === "verify-assets") {
-    await verifyLocalAssets({ ...common, manifest });
+    let platformAssetIds;
+    try {
+      platformAssetIds = JSON.parse(args["platform-asset-ids"]);
+    } catch {
+      throw new Error("Downloaded platform asset IDs must be valid JSON");
+    }
+    await verifyLocalAssets({ ...common, manifest, platformAssetIds });
     console.log("Local release assets match provenance");
     return;
   }

--- a/scripts/desktop-release-provenance.mjs
+++ b/scripts/desktop-release-provenance.mjs
@@ -1,12 +1,11 @@
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 const DEFAULT_ASSET_BASE_URL = "https://cdn.crabnebula.app/asset";
 const SOURCE_WORKFLOW = ".github/workflows/desktop_cd.yaml";
-const CN_ACTION_REPOSITORY = "crabnebula-dev/cloud-release";
 
 function invariant(condition, message) {
   if (!condition) {
@@ -56,11 +55,18 @@ function normalizeCnVersion(value) {
   return value.trim();
 }
 
-function normalizeCnActionRef(value) {
+function normalizeCnAssetId(value) {
   invariant(
-    typeof value === "string" &&
-      new RegExp(`^${CN_ACTION_REPOSITORY}@[0-9a-f]{40}$`).test(value),
-    "CrabNebula action ref must be pinned to a full commit SHA",
+    typeof value === "string" && /^[A-Za-z0-9_-]+$/.test(value),
+    "CrabNebula CLI asset ID is invalid",
+  );
+  return value;
+}
+
+function normalizeSha256(value, label) {
+  invariant(
+    typeof value === "string" && /^[0-9a-f]{64}$/.test(value),
+    `${label} must be a lowercase SHA-256`,
   );
   return value;
 }
@@ -163,7 +169,8 @@ export async function createManifest({
   candidateSha,
   workflowRunId,
   cnVersion,
-  cnActionRef,
+  cnAssetId,
+  cnSha256,
   assetDir,
 }) {
   invariant(
@@ -195,7 +202,8 @@ export async function createManifest({
     tools: {
       crabNebula: {
         cliVersion: normalizeCnVersion(cnVersion),
-        actionRef: normalizeCnActionRef(cnActionRef),
+        cliAssetId: normalizeCnAssetId(cnAssetId),
+        cliSha256: normalizeSha256(cnSha256, "CrabNebula CLI SHA-256"),
       },
     },
     assets: hashedAssets,
@@ -212,7 +220,8 @@ export async function verifyManifest({
   candidateSha,
   workflowRunId,
   cnVersion,
-  cnActionRef,
+  cnAssetId,
+  cnSha256,
   assetDir,
 }) {
   invariant(
@@ -242,8 +251,13 @@ export async function verifyManifest({
     "CrabNebula CLI version mismatch",
   );
   invariant(
-    manifest.tools?.crabNebula?.actionRef === normalizeCnActionRef(cnActionRef),
-    "CrabNebula action ref mismatch",
+    manifest.tools?.crabNebula?.cliAssetId === normalizeCnAssetId(cnAssetId),
+    "CrabNebula CLI asset ID mismatch",
+  );
+  invariant(
+    manifest.tools?.crabNebula?.cliSha256 ===
+      normalizeSha256(cnSha256, "CrabNebula CLI SHA-256"),
+    "CrabNebula CLI SHA-256 mismatch",
   );
   invariant(
     release?.version === version,
@@ -275,33 +289,99 @@ export async function verifyManifest({
   }
 }
 
+export async function verifyLocalAssets({
+  manifest,
+  version,
+  candidateSha,
+  workflowRunId,
+  cnVersion,
+  cnAssetId,
+  cnSha256,
+  assetDir,
+}) {
+  invariant(assetDir, "Missing local asset directory");
+  invariant(
+    Array.isArray(manifest?.assets),
+    "Provenance manifest has no asset list",
+  );
+  const entries = await readdir(assetDir, { withFileTypes: true });
+  invariant(
+    entries.every((entry) => entry.isFile()),
+    "Local asset directory must contain only regular files",
+  );
+
+  const mirroredAssets = manifest.assets.filter(
+    (asset) => typeof asset?.publicPlatform === "string",
+  );
+  invariant(mirroredAssets.length > 0, "Provenance has no public assets");
+  const expectedAssetIds = mirroredAssets
+    .map((asset) => normalizeCnAssetId(asset?.id))
+    .sort();
+  const actualAssetIds = entries.map((entry) => entry.name).sort();
+  invariant(
+    JSON.stringify(actualAssetIds) === JSON.stringify(expectedAssetIds),
+    "Local asset IDs do not match the provenance manifest",
+  );
+
+  const release = {
+    version,
+    status: "draft",
+    assets: mirroredAssets.map(({ sha256: _sha256, ...asset }) => asset),
+  };
+  await verifyManifest({
+    release,
+    manifest: { ...manifest, assets: mirroredAssets },
+    version,
+    candidateSha,
+    workflowRunId,
+    cnVersion,
+    cnAssetId,
+    cnSha256,
+    assetDir,
+  });
+}
+
 async function main() {
   const { command, args } = parseArgs(process.argv.slice(2));
   invariant(
-    command === "create" || command === "verify",
-    "Expected create or verify command",
+    command === "create" || command === "verify" || command === "verify-assets",
+    "Expected create, verify, or verify-assets command",
   );
 
-  const release = await readJson(args.release);
   const common = {
-    release,
     version: args.version,
     candidateSha: args["candidate-sha"],
     workflowRunId: args["run-id"],
     cnVersion: args["cn-version"],
-    cnActionRef: args["cn-action-ref"],
+    cnAssetId: args["cn-asset-id"],
+    cnSha256: args["cn-sha256"],
     assetDir: args["asset-dir"],
   };
 
   if (command === "create") {
     invariant(args.output, "Missing --output");
-    await createManifest({ ...common, output: args.output });
+    await createManifest({
+      ...common,
+      release: await readJson(args.release),
+      output: args.output,
+    });
     console.log(`Wrote release provenance to ${args.output}`);
     return;
   }
 
   invariant(args.manifest, "Missing --manifest");
-  await verifyManifest({ ...common, manifest: await readJson(args.manifest) });
+  const manifest = await readJson(args.manifest);
+  if (command === "verify-assets") {
+    await verifyLocalAssets({ ...common, manifest });
+    console.log("Local release assets match provenance");
+    return;
+  }
+
+  await verifyManifest({
+    ...common,
+    release: await readJson(args.release),
+    manifest,
+  });
   console.log("Release provenance verified");
 }
 

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   createManifest,
+  verifyDesktopPlatformSets,
   verifyLocalAssets,
   verifyManifest,
 } from "./desktop-release-provenance.mjs";
@@ -15,6 +16,101 @@ const cnAssetId = "01KVDB8KPSKMQ5X3SJ0ANF6943";
 const cnSha256 =
   "760b11d1ab9326dc78068ac8ef450685ea116e329903b14d94a5133641a54128";
 const cnVersion = "cn 0.13.2";
+
+function createDesktopRelease() {
+  const publicPlatforms = [
+    "dmg-aarch64",
+    "dmg-x86_64",
+    "nsis-x86_64",
+    "appimage-x86_64",
+    "deb-x86_64",
+    "appimage-aarch64",
+    "deb-aarch64",
+  ];
+  const updatePlatforms = [
+    "darwin-aarch64",
+    "darwin-x86_64",
+    "windows-x86_64-nsis",
+    "linux-x86_64-appimage",
+    "linux-x86_64-deb",
+    "linux-aarch64-appimage",
+    "linux-aarch64-deb",
+  ];
+
+  return {
+    version: "1.4.0",
+    status: "draft",
+    assets: publicPlatforms.map((publicPlatform, index) => ({
+      id: `asset-${index}`,
+      publicPlatform,
+      updatePlatform: updatePlatforms[index],
+      size: index + 1,
+      signature: `signature-${index}`,
+    })),
+  };
+}
+
+test("accepts the exact desktop public and update platform sets", () => {
+  verifyDesktopPlatformSets(createDesktopRelease());
+});
+
+test("rejects an extra public desktop platform", () => {
+  const release = createDesktopRelease();
+  release.assets.push({
+    id: "asset-extra-public",
+    publicPlatform: "rpm-x86_64",
+    updatePlatform: null,
+    size: 1,
+    signature: null,
+  });
+
+  assert.throws(
+    () => verifyDesktopPlatformSets(release),
+    /exactly 7 desktop assets/,
+  );
+});
+
+test("rejects duplicate public desktop platforms", () => {
+  const release = createDesktopRelease();
+  release.assets[0].publicPlatform = release.assets[1].publicPlatform;
+
+  assert.throws(
+    () => verifyDesktopPlatformSets(release),
+    /public platforms do not match/,
+  );
+});
+
+test("rejects an updater-only desktop platform", () => {
+  const release = createDesktopRelease();
+  release.assets.push({
+    id: "asset-extra-updater",
+    publicPlatform: null,
+    updatePlatform: "linux-x86_64-rpm",
+    size: 1,
+    signature: "signature-extra",
+  });
+
+  assert.throws(
+    () => verifyDesktopPlatformSets(release),
+    /exactly 7 desktop assets/,
+  );
+});
+
+test("rejects an opaque desktop release asset", () => {
+  const release = createDesktopRelease();
+  release.assets.push({
+    id: "asset-opaque",
+    publicPlatform: null,
+    updatePlatform: null,
+    size: 1,
+    signature: null,
+  });
+
+  assert.throws(
+    () => verifyDesktopPlatformSets(release),
+    /exactly 7 desktop assets/,
+  );
+});
 
 test("binds every release asset to a candidate run and detects replacement", async () => {
   const directory = await mkdtemp(

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -6,13 +6,15 @@ import test from "node:test";
 
 import {
   createManifest,
+  verifyLocalAssets,
   verifyManifest,
 } from "./desktop-release-provenance.mjs";
 
 const candidateSha = "0123456789abcdef0123456789abcdef01234567";
-const cnActionRef =
-  "crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c";
-const cnVersion = "cn 0.21.0";
+const cnAssetId = "01KVDB8KPSKMQ5X3SJ0ANF6943";
+const cnSha256 =
+  "760b11d1ab9326dc78068ac8ef450685ea116e329903b14d94a5133641a54128";
+const cnVersion = "cn 0.13.2";
 
 test("binds every release asset to a candidate run and detects replacement", async () => {
   const directory = await mkdtemp(
@@ -64,13 +66,18 @@ test("binds every release asset to a candidate run and detects replacement", asy
     candidateSha,
     workflowRunId: "12345",
     cnVersion,
-    cnActionRef,
+    cnAssetId,
+    cnSha256,
     assetDir,
   });
   const manifest = JSON.parse(await readFile(output, "utf8"));
 
   assert.deepEqual(manifest.tools, {
-    crabNebula: { cliVersion: cnVersion, actionRef: cnActionRef },
+    crabNebula: {
+      cliVersion: cnVersion,
+      cliAssetId: cnAssetId,
+      cliSha256: cnSha256,
+    },
   });
   assert.deepEqual(
     manifest.assets.map((asset) => asset.id),
@@ -83,7 +90,8 @@ test("binds every release asset to a candidate run and detects replacement", asy
     candidateSha,
     workflowRunId: "12345",
     cnVersion,
-    cnActionRef,
+    cnAssetId,
+    cnSha256,
     assetDir,
   });
 
@@ -95,7 +103,8 @@ test("binds every release asset to a candidate run and detects replacement", asy
       candidateSha,
       workflowRunId: "12345",
       cnVersion: "cn 0.22.0",
-      cnActionRef,
+      cnAssetId,
+      cnSha256,
       assetDir,
     }),
     /CLI version mismatch/,
@@ -109,11 +118,26 @@ test("binds every release asset to a candidate run and detects replacement", asy
       candidateSha,
       workflowRunId: "12345",
       cnVersion,
-      cnActionRef:
-        "crabnebula-dev/cloud-release@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      cnAssetId: "different-asset",
+      cnSha256,
       assetDir,
     }),
-    /action ref mismatch/,
+    /CLI asset ID mismatch/,
+  );
+
+  await assert.rejects(
+    verifyManifest({
+      release,
+      manifest,
+      version: "1.4.0",
+      candidateSha,
+      workflowRunId: "12345",
+      cnVersion,
+      cnAssetId,
+      cnSha256: "a".repeat(64),
+      assetDir,
+    }),
+    /CLI SHA-256 mismatch/,
   );
 
   await writeFile(path.join(assetDir, "asset-b"), "replaced");
@@ -125,9 +149,75 @@ test("binds every release asset to a candidate run and detects replacement", asy
       candidateSha,
       workflowRunId: "12345",
       cnVersion,
-      cnActionRef,
+      cnAssetId,
+      cnSha256,
       assetDir,
     }),
     /size .* expected|SHA-256 changed/,
+  );
+});
+
+test("binds local GitHub release assets to exact manifest IDs and bytes", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "anarlog-release-mirror-"),
+  );
+  const assetDir = path.join(directory, "assets");
+  await mkdir(assetDir);
+  await writeFile(path.join(assetDir, "asset-a"), "macOS");
+  await writeFile(path.join(assetDir, "asset-b"), "Windows");
+
+  const release = {
+    version: "1.4.0",
+    status: "draft",
+    assets: [
+      {
+        id: "asset-a",
+        publicPlatform: "dmg-aarch64",
+        size: 5,
+        signature: null,
+      },
+      {
+        id: "asset-b",
+        publicPlatform: "nsis-x86_64",
+        updatePlatform: "windows-x86_64-nsis",
+        size: 7,
+        signature: "signature",
+      },
+    ],
+  };
+  const output = path.join(directory, "manifest.json");
+  await createManifest({
+    release,
+    output,
+    version: "1.4.0",
+    candidateSha,
+    workflowRunId: "12345",
+    cnVersion,
+    cnAssetId,
+    cnSha256,
+    assetDir,
+  });
+  const manifest = JSON.parse(await readFile(output, "utf8"));
+  const verify = () =>
+    verifyLocalAssets({
+      manifest,
+      version: "1.4.0",
+      candidateSha,
+      workflowRunId: "12345",
+      cnVersion,
+      cnAssetId,
+      cnSha256,
+      assetDir,
+    });
+
+  await verify();
+
+  await writeFile(path.join(assetDir, "asset-b"), "replace");
+  await assert.rejects(verify(), /SHA-256 changed/);
+
+  await writeFile(path.join(assetDir, "wrong-id"), "replace");
+  await assert.rejects(
+    verify(),
+    /Local asset IDs do not match the provenance manifest/,
   );
 });

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -198,7 +198,11 @@ test("binds local GitHub release assets to exact manifest IDs and bytes", async 
     assetDir,
   });
   const manifest = JSON.parse(await readFile(output, "utf8"));
-  const verify = () =>
+  const platformAssetIds = {
+    "dmg-aarch64": "asset-a",
+    "nsis-x86_64": "asset-b",
+  };
+  const verify = (assetIds = platformAssetIds) =>
     verifyLocalAssets({
       manifest,
       version: "1.4.0",
@@ -208,6 +212,7 @@ test("binds local GitHub release assets to exact manifest IDs and bytes", async 
       cnAssetId,
       cnSha256,
       assetDir,
+      platformAssetIds: assetIds,
     });
 
   await verify();
@@ -219,5 +224,67 @@ test("binds local GitHub release assets to exact manifest IDs and bytes", async 
   await assert.rejects(
     verify(),
     /Local asset IDs do not match the provenance manifest/,
+  );
+});
+
+test("rejects swapped public platform asset IDs with identical bytes", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "anarlog-release-platform-map-"),
+  );
+  const assetDir = path.join(directory, "assets");
+  await mkdir(assetDir);
+  const contents = "identical payload";
+  await writeFile(path.join(assetDir, "asset-a"), contents);
+  await writeFile(path.join(assetDir, "asset-b"), contents);
+
+  const release = {
+    version: "1.4.0",
+    status: "draft",
+    assets: [
+      {
+        id: "asset-a",
+        publicPlatform: "dmg-aarch64",
+        size: Buffer.byteLength(contents),
+        signature: null,
+      },
+      {
+        id: "asset-b",
+        publicPlatform: "nsis-x86_64",
+        updatePlatform: "windows-x86_64-nsis",
+        size: Buffer.byteLength(contents),
+        signature: "signature",
+      },
+    ],
+  };
+  const output = path.join(directory, "manifest.json");
+  await createManifest({
+    release,
+    output,
+    version: "1.4.0",
+    candidateSha,
+    workflowRunId: "12345",
+    cnVersion,
+    cnAssetId,
+    cnSha256,
+    assetDir,
+  });
+  const manifest = JSON.parse(await readFile(output, "utf8"));
+
+  await assert.rejects(
+    verifyLocalAssets({
+      manifest,
+      version: "1.4.0",
+      candidateSha,
+      workflowRunId: "12345",
+      cnVersion,
+      cnAssetId,
+      cnSha256,
+      assetDir,
+      platformAssetIds: {
+        "dmg-aarch64": "asset-b",
+        "nsis-x86_64": "asset-a",
+      },
+    }),
+    /Downloaded asset ID for dmg-aarch64 does not match the provenance manifest/,
   );
 });

--- a/scripts/verify-linux-audio-qa-evidence.mjs
+++ b/scripts/verify-linux-audio-qa-evidence.mjs
@@ -1,0 +1,441 @@
+import { lstat, readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const APPLICATION = "fastrepl/hyprnote2";
+const SOURCE_WORKFLOW = ".github/workflows/desktop_cd.yaml";
+const ARCHITECTURES = [
+  {
+    artifactArch: "x64",
+    publicPlatform: "deb-x86_64",
+    debianArch: "amd64",
+  },
+  {
+    artifactArch: "arm64",
+    publicPlatform: "deb-aarch64",
+    debianArch: "arm64",
+  },
+];
+const ANALYSIS_SCOPE =
+  "Virtual microphone/system routing, capture, separation, and persistence with NO_AEC=1. This result makes no AEC claim.";
+const ANALYSIS_THRESHOLDS = {
+  duration_delta_seconds_max: 0.15,
+  mic_active_rms_min: 0.0002,
+  speaker_active_rms_min: 0.001,
+  system_tone_amplitude_min: 0.0005,
+  mic_pilot_amplitude_min: 0.0002,
+  mic_isolation_db_min: 12,
+  speaker_isolation_db_min: 15,
+  system_tone_isolation_db_min: 18,
+  mic_pilot_isolation_db_min: 6,
+  cross_channel_isolation_db_min: 12,
+  clipped_fraction_max: 0.001,
+  recording_tail_tolerance_seconds: 0.5,
+};
+const ANALYSIS_METRICS = [
+  "mic_duration_seconds",
+  "speaker_duration_seconds",
+  "duration_delta_seconds",
+  "alignment_offset_seconds",
+  "recording_stop_seconds",
+  "aligned_recording_stop_seconds",
+  "mic_recording_tail_seconds",
+  "speaker_recording_tail_seconds",
+  "mic_clipped_fraction",
+  "speaker_clipped_fraction",
+  "mic_only_mic_rms",
+  "system_only_mic_rms",
+  "both_mic_rms",
+  "mic_only_speaker_rms",
+  "system_only_speaker_rms",
+  "both_speaker_rms",
+  "mic_only_523hz_amplitude",
+  "system_only_523hz_amplitude",
+  "both_523hz_amplitude",
+  "mic_only_997hz_amplitude",
+  "system_only_997hz_amplitude",
+  "both_997hz_amplitude",
+  "both_mic_997hz_amplitude",
+  "both_speaker_523hz_amplitude",
+  "mic_only_isolation_db",
+  "both_mic_isolation_db",
+  "system_only_speaker_isolation_db",
+  "both_speaker_isolation_db",
+  "system_tone_isolation_db",
+  "mic_pilot_isolation_db",
+  "both_system_to_mic_isolation_db",
+  "both_mic_to_speaker_isolation_db",
+];
+
+function invariant(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    invariant(key?.startsWith("--") && value, `Invalid argument: ${key ?? ""}`);
+    args[key.slice(2)] = value;
+  }
+  return args;
+}
+
+function normalizeVersion(value) {
+  invariant(
+    typeof value === "string" && /^[0-9]+\.[0-9]+\.[0-9]+$/.test(value),
+    "Version must be a stable semantic version",
+  );
+  return value;
+}
+
+function normalizeSha(value) {
+  invariant(
+    typeof value === "string" && /^[0-9a-fA-F]{40}$/.test(value),
+    "Candidate SHA must contain 40 hexadecimal characters",
+  );
+  return value.toLowerCase();
+}
+
+function normalizeRunId(value, label) {
+  const runId = String(value);
+  invariant(/^[1-9][0-9]*$/.test(runId), `${label} must be a positive integer`);
+  return runId;
+}
+
+function normalizeSha256(value, label) {
+  invariant(
+    typeof value === "string" && /^[0-9a-f]{64}$/.test(value),
+    `${label} must be a lowercase SHA-256`,
+  );
+  return value;
+}
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, "utf8"));
+}
+
+async function requireFile(root, basename, artifactArch) {
+  const file = path.join(root, basename);
+  let metadata;
+  try {
+    metadata = await lstat(file);
+  } catch {
+    throw new Error(
+      `Linux ${artifactArch} evidence is missing ${path.relative(process.cwd(), file)}`,
+    );
+  }
+  invariant(
+    metadata.isFile(),
+    `Linux ${artifactArch} evidence ${basename} is not a regular file`,
+  );
+  return file;
+}
+
+function parseChecksum(value, expectedFilename, label) {
+  const lines = value.trim().split(/\r?\n/);
+  invariant(lines.length === 1, `${label} must contain exactly one checksum`);
+  const match = lines[0].match(/^([0-9a-f]{64})[ \t]+\*?(.+)$/);
+  invariant(match, `${label} is not a valid SHA-256 checksum`);
+  invariant(
+    match[2] === expectedFilename,
+    `${label} names ${match[2]}, expected ${expectedFilename}`,
+  );
+  return match[1];
+}
+
+function parseKeyValues(value) {
+  const fields = {};
+  for (const line of value.trim().split(/\r?\n/)) {
+    const separator = line.indexOf("=");
+    invariant(separator > 0, `Invalid evidence field: ${line}`);
+    fields[line.slice(0, separator)] = line.slice(separator + 1);
+  }
+  return fields;
+}
+
+function verifyManifest(manifest, { version, candidateSha, dryRunId }) {
+  invariant(manifest?.schemaVersion === 1, "Unsupported release manifest");
+  invariant(
+    manifest.sourceWorkflow === SOURCE_WORKFLOW,
+    "Unexpected release source workflow",
+  );
+  invariant(manifest.workflowRunId === dryRunId, "Dry-run ID mismatch");
+  invariant(manifest.candidateSha === candidateSha, "Candidate SHA mismatch");
+  invariant(manifest.version === version, "Release manifest version mismatch");
+  invariant(manifest.channel === "stable", "Release channel is not stable");
+  invariant(
+    manifest.publish === false,
+    "Release manifest must come from a publish=false run",
+  );
+  invariant(
+    Array.isArray(manifest.assets) && manifest.assets.length > 0,
+    "Release manifest has no assets",
+  );
+}
+
+async function verifyArchitecture({
+  evidenceDir,
+  manifest,
+  version,
+  candidateSha,
+  dryRunId,
+  audioQaRunId,
+  architecture,
+}) {
+  const root = path.join(
+    evidenceDir,
+    architecture.artifactArch,
+    "qa-artifacts",
+    `linux-${architecture.artifactArch}`,
+  );
+  const required = (basename) =>
+    requireFile(root, basename, architecture.artifactArch);
+
+  const provenance = await readJson(await required("provenance.json"));
+  invariant(
+    provenance.application === APPLICATION,
+    `Linux ${architecture.artifactArch} application mismatch`,
+  );
+  invariant(
+    provenance.version === version,
+    `Linux ${architecture.artifactArch} version mismatch`,
+  );
+  invariant(
+    provenance.candidate_sha === candidateSha,
+    `Linux ${architecture.artifactArch} candidate SHA mismatch`,
+  );
+  invariant(
+    provenance.workflow_run_id === audioQaRunId,
+    `Linux ${architecture.artifactArch} audio QA run mismatch`,
+  );
+  invariant(
+    provenance.source_workflow_run_id === dryRunId,
+    `Linux ${architecture.artifactArch} dry-run mismatch`,
+  );
+  invariant(
+    provenance.public_platform === architecture.publicPlatform,
+    `Linux ${architecture.artifactArch} platform mismatch`,
+  );
+  invariant(
+    typeof provenance.crabnebula_asset_id === "string" &&
+      /^[A-Za-z0-9_-]+$/.test(provenance.crabnebula_asset_id),
+    `Linux ${architecture.artifactArch} asset ID is invalid`,
+  );
+  invariant(
+    Number.isSafeInteger(provenance.crabnebula_asset_size) &&
+      provenance.crabnebula_asset_size > 0,
+    `Linux ${architecture.artifactArch} asset size is invalid`,
+  );
+  const expectedSha256 = normalizeSha256(
+    provenance.expected_sha256,
+    `Linux ${architecture.artifactArch} expected hash`,
+  );
+
+  const matchingAssets = manifest.assets.filter(
+    (asset) => asset.id === provenance.crabnebula_asset_id,
+  );
+  invariant(
+    matchingAssets.length === 1,
+    `Linux ${architecture.artifactArch} asset is not unique in the release manifest`,
+  );
+  const manifestAsset = matchingAssets[0];
+  invariant(
+    manifestAsset.publicPlatform === architecture.publicPlatform &&
+      manifestAsset.size === provenance.crabnebula_asset_size &&
+      manifestAsset.sha256 === expectedSha256,
+    `Linux ${architecture.artifactArch} asset does not match release provenance`,
+  );
+
+  const embeddedManifest = await readJson(
+    await required(path.join("release-provenance", "manifest.json")),
+  );
+  invariant(
+    JSON.stringify(embeddedManifest) === JSON.stringify(manifest),
+    `Linux ${architecture.artifactArch} embedded release provenance mismatch`,
+  );
+
+  const crabNebulaAsset = await readJson(
+    await required("crabnebula-asset.json"),
+  );
+  invariant(
+    crabNebulaAsset.id === provenance.crabnebula_asset_id &&
+      typeof crabNebulaAsset.filename === "string" &&
+      crabNebulaAsset.filename.length > 0 &&
+      crabNebulaAsset.publicPlatform === architecture.publicPlatform &&
+      (crabNebulaAsset.updatePlatform ?? null) ===
+        (manifestAsset.updatePlatform ?? null) &&
+      Number(crabNebulaAsset.size) === provenance.crabnebula_asset_size,
+    `Linux ${architecture.artifactArch} CrabNebula metadata mismatch`,
+  );
+
+  const downloadSha256 = parseChecksum(
+    await readFile(await required("download.sha256"), "utf8"),
+    `candidate-linux-${architecture.artifactArch}.deb`,
+    `Linux ${architecture.artifactArch} download checksum`,
+  );
+  const testedSha256 = parseChecksum(
+    await readFile(await required("candidate.deb.sha256"), "utf8"),
+    "candidate.deb",
+    `Linux ${architecture.artifactArch} tested-package checksum`,
+  );
+  invariant(
+    downloadSha256 === expectedSha256 && testedSha256 === expectedSha256,
+    `Linux ${architecture.artifactArch} tested package hash mismatch`,
+  );
+
+  const packageFields = parseKeyValues(
+    await readFile(await required("debian-package.txt"), "utf8"),
+  );
+  invariant(
+    packageFields.package === "anarlog" &&
+      packageFields.version === version &&
+      packageFields.architecture === architecture.debianArch,
+    `Linux ${architecture.artifactArch} Debian package identity mismatch`,
+  );
+
+  const analysis = await readJson(await required("analysis.json"));
+  const thresholdNames = Object.keys(ANALYSIS_THRESHOLDS).sort();
+  const metricNames = Object.keys(analysis.metrics ?? {}).sort();
+  invariant(
+    analysis.status === "pass" &&
+      analysis.scope === ANALYSIS_SCOPE &&
+      Array.isArray(analysis.failures) &&
+      analysis.failures.length === 0 &&
+      JSON.stringify(Object.keys(analysis.thresholds ?? {}).sort()) ===
+        JSON.stringify(thresholdNames) &&
+      thresholdNames.every(
+        (threshold) =>
+          analysis.thresholds[threshold] === ANALYSIS_THRESHOLDS[threshold],
+      ) &&
+      JSON.stringify(metricNames) ===
+        JSON.stringify([...ANALYSIS_METRICS].sort()) &&
+      ANALYSIS_METRICS.every(
+        (metric) =>
+          typeof analysis.metrics?.[metric] === "number" &&
+          Number.isFinite(analysis.metrics[metric]),
+      ),
+    `Linux ${architecture.artifactArch} audio analysis did not pass`,
+  );
+
+  const phases = await readJson(await required("phases.json"));
+  const phaseList = Array.isArray(phases.phases) ? phases.phases : [];
+  const phaseNames = phaseList.map((phase) => phase?.name).sort();
+  const validIntervals = phaseList.every(
+    (phase) =>
+      typeof phase?.start_seconds === "number" &&
+      Number.isFinite(phase.start_seconds) &&
+      typeof phase?.end_seconds === "number" &&
+      Number.isFinite(phase.end_seconds) &&
+      phase.end_seconds - phase.start_seconds >= 5,
+  );
+  const latestPhaseEnd = Math.max(
+    ...phaseList.map((phase) => phase?.end_seconds ?? Number.POSITIVE_INFINITY),
+  );
+  invariant(
+    phases.schema_version === 1 &&
+      phases.no_aec === true &&
+      typeof phases.recording_stop_seconds === "number" &&
+      Number.isFinite(phases.recording_stop_seconds) &&
+      validIntervals &&
+      phases.recording_stop_seconds > latestPhaseEnd &&
+      JSON.stringify(phaseNames) ===
+        JSON.stringify(["both", "mic_only", "system_only"]),
+    `Linux ${architecture.artifactArch} phase evidence is invalid`,
+  );
+
+  const captureErrors = await readFile(
+    await required("capture-errors.txt"),
+    "utf8",
+  );
+  invariant(
+    captureErrors.length === 0,
+    `Linux ${architecture.artifactArch} evidence contains capture errors`,
+  );
+  const backendEvents = await readFile(
+    await required("capture-backend-events.txt"),
+    "utf8",
+  );
+  invariant(
+    backendEvents.includes("pipewire_capture_initialized") &&
+      !backendEvents.includes("pipewire_capture_unavailable") &&
+      !backendEvents.includes("pulseaudio_capture_initialized"),
+    `Linux ${architecture.artifactArch} did not prove direct PipeWire capture`,
+  );
+
+  for (const basename of ["audio_mic.wav", "audio_spk.wav"]) {
+    const file = await required(basename);
+    const header = await readFile(file);
+    invariant(
+      header.length > 44 &&
+        header.subarray(0, 4).toString("ascii") === "RIFF" &&
+        header.subarray(8, 12).toString("ascii") === "WAVE",
+      `Linux ${architecture.artifactArch} ${basename} is not a nonempty WAV`,
+    );
+  }
+
+  return {
+    artifactArch: architecture.artifactArch,
+    publicPlatform: architecture.publicPlatform,
+    sha256: expectedSha256,
+  };
+}
+
+export async function verifyLinuxAudioQaEvidence({
+  evidenceDir,
+  manifest,
+  version,
+  candidateSha,
+  dryRunId,
+  audioQaRunId,
+}) {
+  const normalized = {
+    version: normalizeVersion(version),
+    candidateSha: normalizeSha(candidateSha),
+    dryRunId: normalizeRunId(dryRunId, "Dry-run ID"),
+    audioQaRunId: normalizeRunId(audioQaRunId, "Audio QA run ID"),
+  };
+  verifyManifest(manifest, normalized);
+
+  const results = [];
+  for (const architecture of ARCHITECTURES) {
+    results.push(
+      await verifyArchitecture({
+        evidenceDir,
+        manifest,
+        ...normalized,
+        architecture,
+      }),
+    );
+  }
+  return results;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const results = await verifyLinuxAudioQaEvidence({
+    evidenceDir: args["evidence-dir"],
+    manifest: await readJson(args.manifest),
+    version: args.version,
+    candidateSha: args["candidate-sha"],
+    dryRunId: args["dry-run-id"],
+    audioQaRunId: args["audio-qa-run-id"],
+  });
+  console.log(
+    `Verified Linux audio QA evidence for ${results.map((result) => result.artifactArch).join(" and ")}`,
+  );
+}
+
+const isMain = process.argv[1]
+  ? import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+  : false;
+
+if (isMain) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-linux-audio-qa-evidence.test.mjs
+++ b/scripts/verify-linux-audio-qa-evidence.test.mjs
@@ -1,0 +1,428 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rename, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { verifyLinuxAudioQaEvidence } from "./verify-linux-audio-qa-evidence.mjs";
+
+const version = "1.4.0";
+const candidateSha = "0123456789abcdef0123456789abcdef01234567";
+const dryRunId = "12345";
+const audioQaRunId = "67890";
+const hashes = {
+  x64: "a".repeat(64),
+  arm64: "b".repeat(64),
+};
+const architectures = {
+  x64: {
+    publicPlatform: "deb-x86_64",
+    updatePlatform: "linux-x86_64-deb",
+    debianArch: "amd64",
+    assetId: "asset-x64",
+  },
+  arm64: {
+    publicPlatform: "deb-aarch64",
+    updatePlatform: "linux-aarch64-deb",
+    debianArch: "arm64",
+    assetId: "asset-arm64",
+  },
+};
+const thresholds = {
+  duration_delta_seconds_max: 0.15,
+  mic_active_rms_min: 0.0002,
+  speaker_active_rms_min: 0.001,
+  system_tone_amplitude_min: 0.0005,
+  mic_pilot_amplitude_min: 0.0002,
+  mic_isolation_db_min: 12,
+  speaker_isolation_db_min: 15,
+  system_tone_isolation_db_min: 18,
+  mic_pilot_isolation_db_min: 6,
+  cross_channel_isolation_db_min: 12,
+  clipped_fraction_max: 0.001,
+  recording_tail_tolerance_seconds: 0.5,
+};
+const metricNames = [
+  "mic_duration_seconds",
+  "speaker_duration_seconds",
+  "duration_delta_seconds",
+  "alignment_offset_seconds",
+  "recording_stop_seconds",
+  "aligned_recording_stop_seconds",
+  "mic_recording_tail_seconds",
+  "speaker_recording_tail_seconds",
+  "mic_clipped_fraction",
+  "speaker_clipped_fraction",
+  "mic_only_mic_rms",
+  "system_only_mic_rms",
+  "both_mic_rms",
+  "mic_only_speaker_rms",
+  "system_only_speaker_rms",
+  "both_speaker_rms",
+  "mic_only_523hz_amplitude",
+  "system_only_523hz_amplitude",
+  "both_523hz_amplitude",
+  "mic_only_997hz_amplitude",
+  "system_only_997hz_amplitude",
+  "both_997hz_amplitude",
+  "both_mic_997hz_amplitude",
+  "both_speaker_523hz_amplitude",
+  "mic_only_isolation_db",
+  "both_mic_isolation_db",
+  "system_only_speaker_isolation_db",
+  "both_speaker_isolation_db",
+  "system_tone_isolation_db",
+  "mic_pilot_isolation_db",
+  "both_system_to_mic_isolation_db",
+  "both_mic_to_speaker_isolation_db",
+];
+
+function wavFixture() {
+  const buffer = Buffer.alloc(45);
+  buffer.write("RIFF", 0, "ascii");
+  buffer.writeUInt32LE(37, 4);
+  buffer.write("WAVE", 8, "ascii");
+  return buffer;
+}
+
+async function createFixture() {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "anarlog-linux-audio-evidence-"),
+  );
+  const evidenceDir = path.join(directory, "evidence");
+  const manifest = {
+    schemaVersion: 1,
+    sourceWorkflow: ".github/workflows/desktop_cd.yaml",
+    workflowRunId: dryRunId,
+    candidateSha,
+    version,
+    channel: "stable",
+    publish: false,
+    assets: Object.entries(architectures).map(
+      ([artifactArch, architecture]) => ({
+        id: architecture.assetId,
+        publicPlatform: architecture.publicPlatform,
+        updatePlatform: architecture.updatePlatform,
+        size: 1024,
+        signature: "signature",
+        sha256: hashes[artifactArch],
+      }),
+    ),
+  };
+
+  for (const [artifactArch, architecture] of Object.entries(architectures)) {
+    const root = path.join(
+      evidenceDir,
+      artifactArch,
+      "qa-artifacts",
+      `linux-${artifactArch}`,
+    );
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      path.join(root, "provenance.json"),
+      JSON.stringify({
+        application: "fastrepl/hyprnote2",
+        version,
+        candidate_sha: candidateSha,
+        workflow_run_id: audioQaRunId,
+        source_workflow_run_id: dryRunId,
+        public_platform: architecture.publicPlatform,
+        crabnebula_asset_id: architecture.assetId,
+        crabnebula_asset_size: 1024,
+        expected_sha256: hashes[artifactArch],
+      }),
+    );
+    await writeFile(
+      path.join(root, "crabnebula-asset.json"),
+      JSON.stringify({
+        id: architecture.assetId,
+        filename: `anarlog-${artifactArch}.deb`,
+        publicPlatform: architecture.publicPlatform,
+        updatePlatform: architecture.updatePlatform,
+        size: 1024,
+      }),
+    );
+    await writeFile(
+      path.join(root, "download.sha256"),
+      `${hashes[artifactArch]}  candidate-linux-${artifactArch}.deb\n`,
+    );
+    await writeFile(
+      path.join(root, "candidate.deb.sha256"),
+      `${hashes[artifactArch]}  candidate.deb\n`,
+    );
+    await writeFile(
+      path.join(root, "debian-package.txt"),
+      `package=anarlog\nversion=${version}\narchitecture=${architecture.debianArch}\nsource=/candidate.deb\n`,
+    );
+    await writeFile(
+      path.join(root, "analysis.json"),
+      JSON.stringify({
+        status: "pass",
+        scope:
+          "Virtual microphone/system routing, capture, separation, and persistence with NO_AEC=1. This result makes no AEC claim.",
+        failures: [],
+        thresholds,
+        metrics: Object.fromEntries(metricNames.map((name) => [name, 1])),
+      }),
+    );
+    await writeFile(
+      path.join(root, "phases.json"),
+      JSON.stringify({
+        schema_version: 1,
+        no_aec: true,
+        recording_stop_seconds: 35,
+        phases: [
+          { name: "mic_only", start_seconds: 1, end_seconds: 7 },
+          { name: "system_only", start_seconds: 8, end_seconds: 14 },
+          { name: "both", start_seconds: 15, end_seconds: 21 },
+        ],
+      }),
+    );
+    await writeFile(path.join(root, "capture-errors.txt"), "");
+    await writeFile(
+      path.join(root, "capture-backend-events.txt"),
+      "pipewire_capture_initialized\n",
+    );
+    await writeFile(path.join(root, "audio_mic.wav"), wavFixture());
+    await writeFile(path.join(root, "audio_spk.wav"), wavFixture());
+    await mkdir(path.join(root, "release-provenance"));
+    await writeFile(
+      path.join(root, "release-provenance", "manifest.json"),
+      JSON.stringify(manifest),
+    );
+  }
+
+  return { evidenceDir, manifest };
+}
+
+test("accepts exact passing x64 and arm64 evidence", async () => {
+  const fixture = await createFixture();
+  const results = await verifyLinuxAudioQaEvidence({
+    ...fixture,
+    version,
+    candidateSha,
+    dryRunId,
+    audioQaRunId,
+  });
+
+  assert.deepEqual(
+    results.map((result) => result.artifactArch),
+    ["x64", "arm64"],
+  );
+});
+
+test("rejects failed or incomplete architecture evidence", async () => {
+  const fixture = await createFixture();
+  const analysisPath = path.join(
+    fixture.evidenceDir,
+    "arm64",
+    "qa-artifacts",
+    "linux-arm64",
+    "analysis.json",
+  );
+  await writeFile(
+    analysisPath,
+    JSON.stringify({ status: "fail", failures: ["leakage"], metrics: {} }),
+  );
+
+  await assert.rejects(
+    verifyLinuxAudioQaEvidence({
+      ...fixture,
+      version,
+      candidateSha,
+      dryRunId,
+      audioQaRunId,
+    }),
+    /arm64 audio analysis did not pass/,
+  );
+});
+
+test("rejects evidence from a different run or package hash", async () => {
+  const fixture = await createFixture();
+
+  await assert.rejects(
+    verifyLinuxAudioQaEvidence({
+      ...fixture,
+      version,
+      candidateSha,
+      dryRunId,
+      audioQaRunId: "99999",
+    }),
+    /x64 audio QA run mismatch/,
+  );
+
+  fixture.manifest.assets[0].sha256 = "c".repeat(64);
+  await assert.rejects(
+    verifyLinuxAudioQaEvidence({
+      ...fixture,
+      version,
+      candidateSha,
+      dryRunId,
+      audioQaRunId,
+    }),
+    /x64 asset does not match release provenance/,
+  );
+});
+
+test("rejects a basename decoy outside the exact evidence path", async () => {
+  const fixture = await createFixture();
+  const exact = path.join(
+    fixture.evidenceDir,
+    "x64",
+    "qa-artifacts",
+    "linux-x64",
+    "provenance.json",
+  );
+  const decoyDirectory = path.join(
+    fixture.evidenceDir,
+    "x64",
+    "e2e",
+    "blackbox",
+    "videos",
+  );
+  await mkdir(decoyDirectory, { recursive: true });
+  await rename(exact, path.join(decoyDirectory, "provenance.json"));
+
+  await assert.rejects(
+    verifyLinuxAudioQaEvidence({
+      ...fixture,
+      version,
+      candidateSha,
+      dryRunId,
+      audioQaRunId,
+    }),
+    /x64 evidence is missing .*provenance\.json/,
+  );
+});
+
+test("rejects incomplete analysis and invalid phase scope", async () => {
+  const fixture = await createFixture();
+  const root = path.join(
+    fixture.evidenceDir,
+    "x64",
+    "qa-artifacts",
+    "linux-x64",
+  );
+  await writeFile(
+    path.join(root, "analysis.json"),
+    JSON.stringify({
+      status: "pass",
+      scope:
+        "Virtual microphone/system routing, capture, separation, and persistence with NO_AEC=1. This result makes no AEC claim.",
+      failures: [],
+      thresholds,
+      metrics: { duration: 30 },
+    }),
+  );
+
+  await assert.rejects(
+    verifyLinuxAudioQaEvidence({
+      ...fixture,
+      version,
+      candidateSha,
+      dryRunId,
+      audioQaRunId,
+    }),
+    /x64 audio analysis did not pass/,
+  );
+
+  const refreshed = await createFixture();
+  const phasesPath = path.join(
+    refreshed.evidenceDir,
+    "arm64",
+    "qa-artifacts",
+    "linux-arm64",
+    "phases.json",
+  );
+  await writeFile(
+    phasesPath,
+    JSON.stringify({
+      schema_version: 1,
+      no_aec: false,
+      recording_stop_seconds: 35,
+      phases: [
+        { name: "mic_only", start_seconds: 1, end_seconds: 7 },
+        { name: "system_only", start_seconds: 8, end_seconds: 14 },
+        { name: "both", start_seconds: 15, end_seconds: 21 },
+      ],
+    }),
+  );
+  await assert.rejects(
+    verifyLinuxAudioQaEvidence({
+      ...refreshed,
+      version,
+      candidateSha,
+      dryRunId,
+      audioQaRunId,
+    }),
+    /arm64 phase evidence is invalid/,
+  );
+});
+
+test("rejects the wrong package, checksum, or capture backend", async () => {
+  const wrongPackage = await createFixture();
+  const x64Root = path.join(
+    wrongPackage.evidenceDir,
+    "x64",
+    "qa-artifacts",
+    "linux-x64",
+  );
+  await writeFile(
+    path.join(x64Root, "debian-package.txt"),
+    `package=other\nversion=${version}\narchitecture=amd64\nsource=/candidate.deb\n`,
+  );
+  await assert.rejects(
+    verifyLinuxAudioQaEvidence({
+      ...wrongPackage,
+      version,
+      candidateSha,
+      dryRunId,
+      audioQaRunId,
+    }),
+    /x64 Debian package identity mismatch/,
+  );
+
+  const wrongChecksum = await createFixture();
+  await writeFile(
+    path.join(
+      wrongChecksum.evidenceDir,
+      "arm64",
+      "qa-artifacts",
+      "linux-arm64",
+      "candidate.deb.sha256",
+    ),
+    `${"f".repeat(64)}  candidate.deb\n`,
+  );
+  await assert.rejects(
+    verifyLinuxAudioQaEvidence({
+      ...wrongChecksum,
+      version,
+      candidateSha,
+      dryRunId,
+      audioQaRunId,
+    }),
+    /arm64 tested package hash mismatch/,
+  );
+
+  const fallback = await createFixture();
+  await writeFile(
+    path.join(
+      fallback.evidenceDir,
+      "x64",
+      "qa-artifacts",
+      "linux-x64",
+      "capture-backend-events.txt",
+    ),
+    "pipewire_capture_initialized\npulseaudio_capture_initialized\n",
+  );
+  await assert.rejects(
+    verifyLinuxAudioQaEvidence({
+      ...fallback,
+      version,
+      candidateSha,
+      dryRunId,
+      audioQaRunId,
+    }),
+    /x64 did not prove direct PipeWire capture/,
+  );
+});

--- a/scripts/verify-linux-audio-qa-run.mjs
+++ b/scripts/verify-linux-audio-qa-run.mjs
@@ -1,0 +1,168 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const WORKFLOW = ".github/workflows/desktop_linux_audio_qa.yaml";
+const ARCHITECTURES = ["x64", "arm64"];
+
+function invariant(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    invariant(key?.startsWith("--") && value, `Invalid argument: ${key ?? ""}`);
+    args[key.slice(2)] = value;
+  }
+  return args;
+}
+
+function normalizeRunId(value) {
+  invariant(/^[1-9][0-9]*$/.test(String(value)), "Invalid audio QA run ID");
+  const runId = Number(value);
+  invariant(Number.isSafeInteger(runId), "Audio QA run ID is too large");
+  return runId;
+}
+
+function normalizeSha(value) {
+  invariant(
+    typeof value === "string" && /^[0-9a-fA-F]{40}$/.test(value),
+    "Candidate SHA must contain 40 hexadecimal characters",
+  );
+  return value.toLowerCase();
+}
+
+function normalizeVersion(value) {
+  invariant(
+    typeof value === "string" && /^[0-9]+\.[0-9]+\.[0-9]+$/.test(value),
+    "Version must be a stable semantic version",
+  );
+  return value;
+}
+
+export function verifyLinuxAudioQaRun({
+  run,
+  artifacts,
+  repository,
+  version,
+  candidateSha,
+  runId,
+}) {
+  const expected = {
+    repository,
+    version: normalizeVersion(version),
+    candidateSha: normalizeSha(candidateSha),
+    runId: normalizeRunId(runId),
+  };
+  invariant(
+    typeof expected.repository === "string" &&
+      /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(expected.repository),
+    "Invalid repository",
+  );
+
+  invariant(run?.id === expected.runId, "Audio QA run ID mismatch");
+  invariant(
+    run.status === "completed" && run.conclusion === "success",
+    "Audio QA run did not complete successfully",
+  );
+  invariant(run.run_attempt === 1, "Audio QA reruns are not accepted");
+  invariant(run.event === "workflow_dispatch", "Unexpected audio QA run event");
+  invariant(run.head_branch === "main", "Audio QA run did not use main");
+  invariant(
+    run.head_sha?.toLowerCase() === expected.candidateSha,
+    "Audio QA candidate SHA mismatch",
+  );
+  invariant(
+    run.repository?.full_name === expected.repository &&
+      run.head_repository?.full_name === expected.repository,
+    "Audio QA repository mismatch",
+  );
+  invariant(
+    run.path?.split("@")[0] === WORKFLOW,
+    "Unexpected audio QA workflow",
+  );
+  invariant(
+    Number.isSafeInteger(run.repository?.id) &&
+      run.repository.id > 0 &&
+      Number.isSafeInteger(run.head_repository?.id) &&
+      run.head_repository.id > 0,
+    "Audio QA repository identity is invalid",
+  );
+
+  invariant(
+    artifacts?.total_count === ARCHITECTURES.length &&
+      Array.isArray(artifacts.artifacts) &&
+      artifacts.artifacts.length === ARCHITECTURES.length,
+    "Audio QA run must contain exactly two artifacts",
+  );
+
+  return ARCHITECTURES.map((architecture) => {
+    const name = `linux-audio-qa-${expected.version}-${architecture}`;
+    const matches = artifacts.artifacts.filter(
+      (artifact) => artifact?.name === name,
+    );
+    invariant(matches.length === 1, `Expected one artifact named ${name}`);
+    const artifact = matches[0];
+    invariant(
+      Number.isSafeInteger(artifact.id) && artifact.id > 0,
+      `${name} has an invalid artifact ID`,
+    );
+    invariant(
+      artifact.expired === false &&
+        Number.isSafeInteger(artifact.size_in_bytes) &&
+        artifact.size_in_bytes > 0,
+      `${name} is expired or empty`,
+    );
+    invariant(
+      typeof artifact.digest === "string" &&
+        /^sha256:[0-9a-f]{64}$/.test(artifact.digest),
+      `${name} has no valid artifact digest`,
+    );
+    invariant(
+      artifact.workflow_run?.id === expected.runId &&
+        artifact.workflow_run?.repository_id === run.repository.id &&
+        artifact.workflow_run?.head_repository_id === run.head_repository.id &&
+        artifact.workflow_run?.head_branch === "main" &&
+        artifact.workflow_run?.head_sha?.toLowerCase() ===
+          expected.candidateSha,
+      `${name} is not bound to the expected run and candidate`,
+    );
+    return {
+      architecture,
+      id: artifact.id,
+      name,
+      digest: artifact.digest,
+    };
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  invariant(args.output, "Missing --output");
+  const result = verifyLinuxAudioQaRun({
+    run: JSON.parse(await readFile(args.run, "utf8")),
+    artifacts: JSON.parse(await readFile(args.artifacts, "utf8")),
+    repository: args.repository,
+    version: args.version,
+    candidateSha: args["candidate-sha"],
+    runId: args["run-id"],
+  });
+  await writeFile(args.output, `${JSON.stringify(result, null, 2)}\n`);
+  console.log("Verified exact x64 and arm64 Linux audio QA artifacts");
+}
+
+const isMain = process.argv[1]
+  ? import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+  : false;
+
+if (isMain) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-linux-audio-qa-run.test.mjs
+++ b/scripts/verify-linux-audio-qa-run.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { verifyLinuxAudioQaRun } from "./verify-linux-audio-qa-run.mjs";
+
+const repository = "fastrepl/anarlog";
+const version = "1.4.0";
+const candidateSha = "0123456789abcdef0123456789abcdef01234567";
+const runId = "67890";
+
+function fixture() {
+  const run = {
+    id: Number(runId),
+    status: "completed",
+    conclusion: "success",
+    run_attempt: 1,
+    event: "workflow_dispatch",
+    head_branch: "main",
+    head_sha: candidateSha,
+    path: ".github/workflows/desktop_linux_audio_qa.yaml@refs/heads/main",
+    repository: { id: 10, full_name: repository },
+    head_repository: { id: 10, full_name: repository },
+  };
+  const artifacts = {
+    total_count: 2,
+    artifacts: ["x64", "arm64"].map((architecture, index) => ({
+      id: 100 + index,
+      name: `linux-audio-qa-${version}-${architecture}`,
+      size_in_bytes: 1024,
+      expired: false,
+      digest: `sha256:${index === 0 ? "a" : "b"}`.padEnd(
+        71,
+        index === 0 ? "a" : "b",
+      ),
+      workflow_run: {
+        id: Number(runId),
+        repository_id: 10,
+        head_repository_id: 10,
+        head_branch: "main",
+        head_sha: candidateSha,
+      },
+    })),
+  };
+  return { run, artifacts };
+}
+
+function verify(values) {
+  return verifyLinuxAudioQaRun({
+    ...values,
+    repository,
+    version,
+    candidateSha,
+    runId,
+  });
+}
+
+test("accepts one exact x64 and arm64 artifact from the first run attempt", () => {
+  const result = verify(fixture());
+  assert.deepEqual(
+    result.map((artifact) => artifact.architecture),
+    ["x64", "arm64"],
+  );
+});
+
+test("rejects a successful rerun with the same run ID", () => {
+  const values = fixture();
+  values.run.run_attempt = 2;
+  assert.throws(() => verify(values), /reruns are not accepted/);
+});
+
+test("rejects missing, duplicate, expired, or unbound artifacts", () => {
+  const missing = fixture();
+  missing.artifacts.artifacts.pop();
+  missing.artifacts.total_count = 1;
+  assert.throws(() => verify(missing), /exactly two artifacts/);
+
+  const duplicate = fixture();
+  duplicate.artifacts.artifacts[1].name = duplicate.artifacts.artifacts[0].name;
+  assert.throws(() => verify(duplicate), /Expected one artifact named/);
+
+  const expired = fixture();
+  expired.artifacts.artifacts[1].expired = true;
+  assert.throws(() => verify(expired), /expired or empty/);
+
+  const unbound = fixture();
+  unbound.artifacts.artifacts[0].workflow_run.head_sha = "f".repeat(40);
+  assert.throws(() => verify(unbound), /not bound to the expected run/);
+});


### PR DESCRIPTION
## Summary
- require exact first-attempt x64 and ARM64 Linux virtual-audio evidence before CrabNebula publish
- make stable desktop builds dry-run-only and bind the GitHub mirror to release provenance
- execute a project-pinned, SHA-256-verified CrabNebula CLI and run release guard tests in CI

## Validation
- `node --test scripts/desktop-release-provenance.test.mjs scripts/verify-linux-audio-qa-run.test.mjs scripts/verify-linux-audio-qa-evidence.test.mjs`
- actionlint on modified workflows
- YAML parse and dprint check

No candidate release or QA workflow was triggered. Physical-device and AEC validation remain separate release gates.

<!-- GitButler Footer Boundary Top -->
---
This is **part 7 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #6311 👈 
- <kbd>&nbsp;6&nbsp;</kbd> #6309
- <kbd>&nbsp;5&nbsp;</kbd> #6306
- <kbd>&nbsp;4&nbsp;</kbd> #6296
- <kbd>&nbsp;3&nbsp;</kbd> #6301
- <kbd>&nbsp;2&nbsp;</kbd> #6294
- <kbd>&nbsp;1&nbsp;</kbd> #6280
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the entire stable release pipeline (auth-adjacent signing verification, artifact pinning, and publish gates); a bug could block releases or allow inconsistent artifacts if verification is wrong.
> 
> **Overview**
> Stable desktop release is split into **dry-run build** (`desktop_cd` with `publish=false` only) and **`desktop_publish`**, which now requires a successful first-attempt Linux virtual-audio QA run (`audio_qa_run_id`) plus the existing dry-run provenance before CrabNebula/GitHub publish.
> 
> **Linux audio QA** is enforced end-to-end: release docs describe dispatching `desktop_linux_audio_qa`, and publish downloads x64/arm64 evidence artifacts, validates run identity (no reruns, `run_attempt == 1`), and runs new `verify-linux-audio-qa-run.mjs` / `verify-linux-audio-qa-evidence.mjs` against the candidate manifest and DEB hashes.
> 
> **Supply-chain / provenance** tightens: CrabNebula work moves off `cloud-release` to a **pinned `cn` CLI** (`cn_install` with per-OS asset ID + SHA-256). Provenance manifests record CLI asset ID/hash (not action ref); publish verifies platform allowlists and that **GitHub release files match** the dry-run manifest via `verify-assets`. Workflow triggers return exact run IDs via the Actions API and pass `candidate_sha` through checkouts.
> 
> **/stable** comment handling no longer supports `--no-publish` and always triggers candidate builds only. CI runs the new Node tests for provenance and Linux QA verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 758973784c8700ad4600981bf4d783604b367b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->