### PR TITLE
Install Metal tools on macOS runners

### DIFF
--- a/.github/actions/install_desktop_deps/action.yaml
+++ b/.github/actions/install_desktop_deps/action.yaml
@@ -6,6 +6,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - if: ${{ runner.os == 'macOS' }}
+      shell: bash
+      run: xcodebuild -downloadComponent MetalToolchain
     - if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |

--- a/.github/actions/install_desktop_deps/action.yaml
+++ b/.github/actions/install_desktop_deps/action.yaml
@@ -8,7 +8,11 @@ runs:
   steps:
     - if: ${{ runner.os == 'macOS' }}
       shell: bash
-      run: xcodebuild -downloadComponent MetalToolchain
+      run: |
+        xcode_major=$(xcodebuild -version | awk 'NR == 1 { split($2, version, "."); print version[1] }')
+        if [[ "$xcode_major" -ge 26 ]]; then
+          xcodebuild -downloadComponent MetalToolchain
+        fi
     - if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - .github/actions/install_desktop_deps/**
       - .github/workflows/desktop_ci.yaml
       - apps/cli/**
       - apps/desktop/**
@@ -14,6 +15,7 @@ on:
       - Cargo.lock
   pull_request:
     paths:
+      - .github/actions/install_desktop_deps/**
       - .github/workflows/desktop_ci.yaml
       - apps/cli/**
       - apps/desktop/**


### PR DESCRIPTION
Download Xcode 26's optional Metal toolchain through the shared desktop dependency action so CI and release builds can compile MLX Metal shaders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only composite action and workflow path-filter changes; no application runtime or security-sensitive code.
> 
> **Overview**
> **macOS desktop dependency setup** now installs Xcode’s optional **Metal toolchain** when the runner’s Xcode major version is **26 or newer**, via `xcodebuild -downloadComponent MetalToolchain`. That unblocks MLX Metal shader compilation on newer GitHub/Depot macOS images without changing Linux steps.
> 
> **Desktop CI path filters** now include `.github/actions/install_desktop_deps/**` on push and pull_request so edits to this composite action re-run desktop CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 937a73c95cfa12c88dacd00ae76f69c91ce00136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->