### PR TITLE
Load Common Controls v6 in Windows auth tests

### DIFF
--- a/plugins/auth/src/lib.rs
+++ b/plugins/auth/src/lib.rs
@@ -5,6 +5,13 @@ mod migrate;
 #[cfg(any(target_os = "windows", test))]
 mod windows;
 
+// Tauri unit tests bypass the application manifest while still importing
+// TaskDialogIndirect, so the test object must activate Common Controls v6.
+#[cfg(all(test, target_os = "windows", target_env = "msvc"))]
+#[used]
+#[unsafe(link_section = ".drectve")]
+static WINDOWS_TEST_MANIFEST_DIRECTIVES: [u8; 184] = *b" /MANIFEST:EMBED /MANIFESTDEPENDENCY:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"\0";
+
 pub use error::{Error, Result};
 pub use ext::*;
 use tauri::Manager;


### PR DESCRIPTION
## Summary
- activate Common Controls v6 only in Windows MSVC unit-test objects
- keep normal auth library and DPAPI production paths unchanged

## Verification
- native Windows fresh-target normal build: no auth manifest directives
- native Windows direct test EXE list: exit 0 with v6 sidecar
- native Windows cargo test: 20 passed
- macOS cargo test: 19 passed
- macOS cross-check for x86_64-pc-windows-msvc tests: passed

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6315 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6298
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Windows MSVC test builds via cfg gates; no change to production auth or manifest handling.
> 
> **Overview**
> Adds a **test-only** linker directive in `plugins/auth/src/lib.rs` so Windows **MSVC** unit-test binaries embed a manifest dependency on **Microsoft.Windows.Common Controls v6**.
> 
> Tauri’s test harness does not use the full application manifest, but the auth plugin’s Windows code still pulls in **TaskDialogIndirect**, which expects Common Controls v6 to be activated. The new `WINDOWS_TEST_MANIFEST_DIRECTIVES` static is gated with `#[cfg(all(test, target_os = "windows", target_env = "msvc"))]` so normal library and production DPAPI paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4192c01d9e5aacee709d68f3f0b6a0dbc583f567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->