### PR TITLE
Open Linux notification options from the body

### DIFF
--- a/crates/notification-linux/src/impl.rs
+++ b/crates/notification-linux/src/impl.rs
@@ -250,16 +250,9 @@ impl NotificationManager {
         let content_event_box = EventBox::new();
         content_event_box.set_visible_window(false);
         content_event_box.add(&content_box);
-        let content_key = key.to_string();
-        let content_window = window.clone();
-        content_event_box.connect_button_press_event(move |_, _| {
-            callbacks::confirm(content_key.clone());
-            NotificationInstance::dismiss_window(&content_window, &content_key, false);
-            glib::Propagation::Stop
-        });
         main_box.pack_start(&content_event_box, true, true, 0);
 
-        match callbacks::primary_action(notification) {
+        let options_button = match callbacks::primary_action(notification) {
             callbacks::PrimaryAction::Options(options) => {
                 let menu = Menu::new();
                 for (index, option) in options.iter().enumerate() {
@@ -289,6 +282,7 @@ impl NotificationManager {
                 menu_button.style_context().add_class("action-button");
                 menu_button.set_popup(Some(&menu));
                 main_box.pack_start(&menu_button, false, false, 0);
+                Some(menu_button)
             }
             callbacks::PrimaryAction::Accept { label, destructive } => {
                 let action_button = Button::with_label(label);
@@ -306,8 +300,22 @@ impl NotificationManager {
                     NotificationInstance::dismiss_window(&action_window, &action_key, false);
                 });
                 main_box.pack_start(&action_button, false, false, 0);
+                None
             }
-        }
+        };
+
+        let content_key = key.to_string();
+        let content_window = window.clone();
+        content_event_box.connect_button_press_event(move |_, _| {
+            if let Some(options_button) = &options_button {
+                options_button.clicked();
+            } else {
+                callbacks::confirm(content_key.clone());
+                NotificationInstance::dismiss_window(&content_window, &content_key, false);
+            }
+
+            glib::Propagation::Stop
+        });
 
         let close_button = Button::new();
         close_button.set_label("×");


### PR DESCRIPTION
Summary:
- open the notification options menu when the notification body is clicked
- preserve confirm-and-dismiss behavior for ordinary notifications
- keep option notifications active until an option is selected

Verification:
- cargo test -p notification-linux (2 passed plus doctests)
- independent GTK lifetime and callback-routing review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized GTK click-routing in `notification-linux` with no auth, data, or shared API contract changes.
> 
> **Overview**
> **Linux GTK notifications** change how a click on the title/message area behaves.
> 
> For notifications whose primary action is an **Options** menu, a body click now **programmatically opens that menu** (`MenuButton::clicked()`) instead of treating the tap like a confirm action. The notification stays visible until the user picks a menu item, matching the existing option-selection flow.
> 
> For **Accept**-style notifications, body clicks are unchanged: they still call `confirm` and dismiss the window.
> 
> Implementation-wise, the `primary_action` match now yields an optional `MenuButton` handle so the `content_event_box` press handler can branch after the action UI is built.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87201e4e853797bb6aaf3371c482935abb4fec31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->