### PR TITLE
Make Windows notification lifecycle reliable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18836,6 +18836,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -212,6 +212,52 @@ describe("EventListeners notification events", () => {
     expect(openNewMock).not.toHaveBeenCalled();
   });
 
+  test("notification_timeout with auto-stop prompt stops the active session", async () => {
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_timeout",
+        key: createAutoStopEndedNotificationKey("session-1"),
+        source: null,
+      },
+    });
+
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(createSessionMock).not.toHaveBeenCalled();
+    expect(openNewMock).not.toHaveBeenCalled();
+  });
+
+  test("notification_timeout ignores a stale auto-stop session", async () => {
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_timeout",
+        key: createAutoStopEndedNotificationKey("session-old"),
+        source: null,
+      },
+    });
+
+    expect(stopMock).not.toHaveBeenCalled();
+    expect(createSessionMock).not.toHaveBeenCalled();
+    expect(openNewMock).not.toHaveBeenCalled();
+  });
+
   test("live capture config sync mounts without auth providers", async () => {
     vi.useFakeTimers();
     useConfigValuesMock.mockReturnValue({

--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -19,8 +19,9 @@ are still pending.
 
 ## Windows Preview
 
-- Show native event reminders while hiding microphone-detection controls that
-  are not yet supported on Windows
+- Show native event reminders; notification click actions remain unavailable
+  in this preview
+- Hide microphone-detection controls that are not yet supported on Windows
 - Protect signed-in sessions with Windows user encryption and migrate older
   plaintext session data
 - Stop stalled Cloud Sync requests cleanly so the app can recover without

--- a/plugins/notification/Cargo.toml
+++ b/plugins/notification/Cargo.toml
@@ -40,3 +40,4 @@ chrono = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 notify-rust = { workspace = true }
+windows = { workspace = true, features = ["UI_Notifications"] }

--- a/plugins/notification/src/error.rs
+++ b/plugins/notification/src/error.rs
@@ -5,6 +5,9 @@ pub enum Error {
     #[cfg(target_os = "windows")]
     #[error("failed to show Windows notification: {0}")]
     WindowsNotification(#[from] notify_rust::error::Error),
+    #[cfg(target_os = "windows")]
+    #[error("failed to clear Windows notifications: {0}")]
+    WindowsNotificationHistory(#[from] windows::core::Error),
 }
 
 impl Serialize for Error {

--- a/plugins/notification/src/ext.rs
+++ b/plugins/notification/src/ext.rs
@@ -1,7 +1,12 @@
 use crate::error::Error;
 
+#[cfg(target_os = "windows")]
+use crate::events::NotificationEvent;
+
 #[cfg(any(target_os = "windows", test))]
 use std::collections::HashMap;
+#[cfg(any(target_os = "windows", test))]
+use std::path::Path;
 #[cfg(any(target_os = "windows", test))]
 use std::sync::{Mutex, OnceLock};
 #[cfg(any(target_os = "windows", test))]
@@ -10,8 +15,54 @@ use std::time::{Duration, Instant};
 #[cfg(any(target_os = "windows", test))]
 static RECENT_WINDOWS_NOTIFICATIONS: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
 
+#[cfg(target_os = "windows")]
+static WINDOWS_NOTIFICATION_TIMEOUTS: OnceLock<Mutex<WindowsNotificationTimeouts>> =
+    OnceLock::new();
+
 #[cfg(any(target_os = "windows", test))]
 const WINDOWS_DEDUPE_WINDOW: Duration = Duration::from_mins(1);
+
+#[cfg(any(target_os = "windows", test))]
+#[derive(Default)]
+struct WindowsNotificationTimeouts {
+    active: HashMap<String, u64>,
+    next_generation: u64,
+}
+
+#[cfg(any(target_os = "windows", test))]
+impl WindowsNotificationTimeouts {
+    fn schedule(&mut self, key: &str, timeout: Option<Duration>) -> Option<(u64, Duration)> {
+        let Some(timeout) = timeout.filter(|timeout| !timeout.is_zero()) else {
+            self.cancel(key);
+            return None;
+        };
+
+        Some((self.register(key), timeout))
+    }
+
+    fn register(&mut self, key: &str) -> u64 {
+        self.next_generation = self.next_generation.wrapping_add(1);
+        self.active.insert(key.to_string(), self.next_generation);
+        self.next_generation
+    }
+
+    fn take_if_current(&mut self, key: &str, generation: u64) -> bool {
+        if self.active.get(key) != Some(&generation) {
+            return false;
+        }
+
+        self.active.remove(key);
+        true
+    }
+
+    fn cancel(&mut self, key: &str) {
+        self.active.remove(key);
+    }
+
+    fn clear(&mut self) {
+        self.active.clear();
+    }
+}
 
 pub struct Notification<'a, R: tauri::Runtime, M: tauri::Manager<R>> {
     manager: &'a M,
@@ -24,6 +75,7 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Notification<'a, R, M> {
         #[cfg(target_os = "windows")]
         if should_show_windows_notification(v.key.as_deref()) {
             show_windows_notification(self.manager, &v)?;
+            schedule_windows_notification_timeout(self.manager, &v);
         }
 
         #[cfg(not(target_os = "windows"))]
@@ -35,7 +87,16 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Notification<'a, R, M> {
     #[tracing::instrument(skip(self))]
     pub fn clear(&self) -> Result<(), Error> {
         let _ = self.manager;
+
+        #[cfg(target_os = "windows")]
+        {
+            cancel_windows_notification_timeouts();
+            clear_windows_notifications(self.manager)?;
+        }
+
+        #[cfg(not(target_os = "windows"))]
         hypr_notification::clear();
+
         Ok(())
     }
 }
@@ -61,6 +122,95 @@ fn should_show_windows_notification(key: Option<&str>) -> bool {
 }
 
 #[cfg(target_os = "windows")]
+fn windows_notification_timeouts() -> &'static Mutex<WindowsNotificationTimeouts> {
+    WINDOWS_NOTIFICATION_TIMEOUTS.get_or_init(|| Mutex::new(WindowsNotificationTimeouts::default()))
+}
+
+#[cfg(target_os = "windows")]
+fn schedule_windows_notification_timeout<R: tauri::Runtime, M: tauri::Manager<R>>(
+    manager: &M,
+    notification: &hypr_notification::Notification,
+) {
+    use tauri_specta::Event;
+
+    let Some(key) = notification.key.clone() else {
+        return;
+    };
+
+    let (generation, timeout) = {
+        let mut timeouts = windows_notification_timeouts()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let Some(timeout) = timeouts.schedule(&key, notification.timeout) else {
+            return;
+        };
+        timeout
+    };
+    let app = manager.app_handle().clone();
+    let source = notification.source.clone();
+
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(timeout).await;
+
+        let should_emit = windows_notification_timeouts()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take_if_current(&key, generation);
+        if !should_emit {
+            return;
+        }
+
+        if let Err(error) = (NotificationEvent::Timeout { key, source }).emit(&app) {
+            tracing::warn!(%error, "failed_to_emit_windows_notification_timeout");
+        }
+    });
+}
+
+#[cfg(target_os = "windows")]
+fn cancel_windows_notification_timeouts() {
+    windows_notification_timeouts()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .clear();
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn is_cargo_target_profile_dir(path: &Path) -> bool {
+    let Some(profile) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+
+    if !matches!(profile, "debug" | "release") {
+        return false;
+    }
+
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+
+    parent.file_name().is_some_and(|name| name == "target")
+        || parent
+            .parent()
+            .and_then(Path::file_name)
+            .is_some_and(|name| name == "target")
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn windows_app_id<'a>(
+    identifier: &'a str,
+    is_dev: bool,
+    executable: Option<&Path>,
+) -> Option<&'a str> {
+    if is_dev {
+        return None;
+    }
+
+    let executable_dir = executable?.parent()?;
+
+    (!is_cargo_target_profile_dir(executable_dir)).then_some(identifier)
+}
+
+#[cfg(target_os = "windows")]
 fn show_windows_notification<R: tauri::Runtime, M: tauri::Manager<R>>(
     manager: &M,
     notification: &hypr_notification::Notification,
@@ -76,27 +226,34 @@ fn show_windows_notification<R: tauri::Runtime, M: tauri::Manager<R>>(
                 .unwrap_or(notify_rust::Timeout::Never),
         );
 
-    if let Ok(exe) = tauri::utils::platform::current_exe()
-        && let Some(exe_dir) = exe.parent()
-    {
-        let current_dir = exe_dir.display().to_string();
-        let target_debug = format!(
-            "{}target{}debug",
-            std::path::MAIN_SEPARATOR,
-            std::path::MAIN_SEPARATOR
-        );
-        let target_release = format!(
-            "{}target{}release",
-            std::path::MAIN_SEPARATOR,
-            std::path::MAIN_SEPARATOR
-        );
-
-        if !current_dir.ends_with(&target_debug) && !current_dir.ends_with(&target_release) {
-            toast.app_id(&manager.config().identifier);
-        }
+    let executable = tauri::utils::platform::current_exe().ok();
+    if let Some(app_id) = windows_app_id(
+        &manager.config().identifier,
+        tauri::is_dev(),
+        executable.as_deref(),
+    ) {
+        toast.app_id(app_id);
     }
 
     toast.show()?;
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn clear_windows_notifications<R: tauri::Runtime, M: tauri::Manager<R>>(
+    manager: &M,
+) -> Result<(), Error> {
+    let executable = tauri::utils::platform::current_exe().ok();
+    let Some(app_id) = windows_app_id(
+        &manager.config().identifier,
+        tauri::is_dev(),
+        executable.as_deref(),
+    ) else {
+        return Ok(());
+    };
+
+    windows::UI::Notifications::ToastNotificationManager::History()?
+        .ClearWithId(&windows::core::HSTRING::from(app_id))?;
     Ok(())
 }
 
@@ -134,5 +291,107 @@ mod tests {
 
         assert!(should_show_windows_notification(Some(key)));
         assert!(!should_show_windows_notification(Some(key)));
+    }
+
+    #[test]
+    fn development_windows_notifications_use_the_fallback_app_id() {
+        let executable = Path::new("C:/Users/anarlog/Anarlog.exe");
+
+        assert_eq!(
+            windows_app_id("com.hyprnote.dev", true, Some(executable)),
+            None
+        );
+    }
+
+    #[test]
+    fn direct_cargo_builds_use_the_fallback_app_id() {
+        for profile in ["debug", "release"] {
+            let executable = Path::new("C:/repo/target")
+                .join(profile)
+                .join("Anarlog.exe");
+
+            assert_eq!(
+                windows_app_id("com.hyprnote.dev", false, Some(&executable)),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn target_triple_cargo_builds_use_the_fallback_app_id() {
+        for profile in ["debug", "release"] {
+            let executable = Path::new("C:/repo/target")
+                .join("x86_64-pc-windows-msvc")
+                .join(profile)
+                .join("Anarlog.exe");
+
+            assert_eq!(
+                windows_app_id("com.hyprnote.dev", false, Some(&executable)),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn installed_windows_notifications_use_the_configured_app_id() {
+        let executable = Path::new("C:/Users/anarlog/AppData/Local/Anarlog/Anarlog.exe");
+
+        assert_eq!(
+            windows_app_id("com.hyprnote.stable", false, Some(executable)),
+            Some("com.hyprnote.stable")
+        );
+    }
+
+    #[test]
+    fn windows_notification_timeout_only_fires_for_the_current_generation() {
+        let mut timeouts = WindowsNotificationTimeouts::default();
+        let first = timeouts.register("meeting");
+        let second = timeouts.register("meeting");
+
+        assert!(!timeouts.take_if_current("meeting", first));
+        assert!(timeouts.take_if_current("meeting", second));
+        assert!(!timeouts.take_if_current("meeting", second));
+    }
+
+    #[test]
+    fn clearing_windows_notification_timeouts_invalidates_pending_generations() {
+        let mut timeouts = WindowsNotificationTimeouts::default();
+        let meeting_generation = timeouts.register("meeting");
+        let mic_generation = timeouts.register("mic");
+
+        timeouts.clear();
+
+        assert!(!timeouts.take_if_current("meeting", meeting_generation));
+        assert!(!timeouts.take_if_current("mic", mic_generation));
+    }
+
+    #[test]
+    fn cancelling_a_windows_notification_timeout_invalidates_its_generation() {
+        let mut timeouts = WindowsNotificationTimeouts::default();
+        let generation = timeouts.register("meeting");
+
+        timeouts.cancel("meeting");
+
+        assert!(!timeouts.take_if_current("meeting", generation));
+    }
+
+    #[test]
+    fn zero_windows_notification_timeout_cancels_without_scheduling() {
+        let mut timeouts = WindowsNotificationTimeouts::default();
+        let generation = timeouts.register("meeting");
+
+        assert_eq!(timeouts.schedule("meeting", Some(Duration::ZERO)), None);
+        assert!(!timeouts.take_if_current("meeting", generation));
+    }
+
+    #[test]
+    fn persistent_windows_notification_cancels_an_older_timeout() {
+        let mut timeouts = WindowsNotificationTimeouts::default();
+        let (generation, _) = timeouts
+            .schedule("meeting", Some(Duration::from_secs(30)))
+            .unwrap();
+
+        assert_eq!(timeouts.schedule("meeting", None), None);
+        assert!(!timeouts.take_if_current("meeting", generation));
     }
 }

--- a/plugins/notification/src/lib.rs
+++ b/plugins/notification/src/lib.rs
@@ -41,7 +41,9 @@ pub fn init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
                     tauri_plugin_windows::AppWindow::from_str(label.as_ref())
                     && let tauri::WindowEvent::Focused(true) = event
                 {
-                    app.notification().clear().unwrap();
+                    if let Err(error) = app.notification().clear() {
+                        tracing::warn!(%error, "failed_to_clear_notifications");
+                    }
                 }
             }
             _ => {}


### PR DESCRIPTION
Summary:
- use the configured Windows app identity for installed builds and a safe fallback for direct development runs
- clear only Anarlog notification history and avoid panics when history cleanup fails
- make timeout delivery generation-safe so stale timers cannot affect newer notifications
- document that Windows notification click actions remain unavailable in Preview

Verification:
- cargo test --locked -p tauri-plugin-notification --lib (12 passed)
- desktop event-listener tests (13 passed)
- full desktop suite (2385 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop notification infrastructure and session auto-stop via timeout events; scope is Windows-specific with added error paths rather than broad behavioral rewrites.
> 
> **Overview**
> Improves **Windows** notification behavior so toasts use the right app identity, time out safely, and clear without crashing the app.
> 
> **App identity:** Installed builds set the toast **app ID** from Tauri config; dev and direct `target/...` cargo runs omit it so notifications still work locally.
> 
> **Timeouts:** After showing a toast with a non-zero timeout, the plugin schedules an async timer and emits **`notification_timeout`** only for the latest generation of that notification key—reschedules, zero timeout, and **`clear()`** cancel stale timers.
> 
> **Cleanup:** **`clear()`** cancels pending Windows timeout tasks and clears **Anarlog-only** toast history via the Windows notifications API; main-window focus logs a warning instead of panicking if history cleanup fails.
> 
> Desktop **event-listener** tests cover auto-stop on timeout and ignoring stale session keys. **1.4.0** changelog notes that Windows Preview still lacks notification click actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb832c8d4522d2ee623bb138e2213453fb20db3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->