### PR TITLE
Migrate legacy Linux packages

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.stable.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable.json
@@ -3,6 +3,15 @@
   "productName": "Anarlog",
   "mainBinaryName": "anarlog",
   "identifier": "com.hyprnote.stable",
+  "bundle": {
+    "linux": {
+      "deb": {
+        "provides": ["char"],
+        "conflicts": ["char"],
+        "replaces": ["char"]
+      }
+    }
+  },
   "plugins": {
     "deep-link": {
       "desktop": { "schemes": ["anarlog", "hyprnote"] }
@@ -10,8 +19,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable",
-        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}/{{current_version}}?channel=stable"
+        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable"
       ]
     }
   }


### PR DESCRIPTION
- Migrated legacy Linux packages to the updated packaging setup for compatibility and maintenance improvements.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6322 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6296 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and updater URL configuration only; no application runtime or security logic changes.
> 
> **Overview**
> **Stable Linux `.deb` builds** now declare Debian relationships against the legacy **`char`** package so installs/upgrades can replace the old Hyprnote-era package instead of conflicting with it (`provides`, `conflicts`, and `replaces`).
> 
> The **stable updater** drops the fallback endpoint without `{{bundle_type}}` and keeps only the bundle-type-specific stable update URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7561e70905c60e05fd8d597bac77d7498529e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->