### PR TITLE
fix(notification): load Windows notification tests against Common Controls 6

### DIFF
--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -177,6 +177,7 @@ jobs:
           retention-days: 7
       - run: cargo check --locked -p desktop
       - run: cargo test --locked -p desktop --no-run
+      - run: cargo test --locked -p tauri-plugin-notification --lib
       - run: cargo test --locked -p cloudsync
       - run: "cargo test --locked -p db-core 'cloudsync::'"
       - if: github.event_name == 'workflow_dispatch'

--- a/plugins/notification/build.rs
+++ b/plugins/notification/build.rs
@@ -1,5 +1,15 @@
 const COMMANDS: &[&str] = &["show_notification", "clear_notifications"];
 
 fn main() {
+    let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+
+    if is_windows_msvc {
+        println!("cargo::rustc-link-arg=/MANIFEST:EMBED");
+        println!(
+            "cargo::rustc-link-arg=/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'"
+        );
+    }
+
     tauri_plugin::Builder::new(COMMANDS).build();
 }


### PR DESCRIPTION

The notification plugin's Windows test binary imported `TaskDialogIndirect`
from `comctl32.dll` but shipped no resource section or embedded manifest, so
the process loader failed with `0xC0000139` before it could enumerate a single
test. Compile-only CI (`cargo test --no-run`) never linked and ran the binary,
so the failure stayed invisible.

## Changes

- `plugins/notification/build.rs`: on `windows-msvc`, embed a manifest that
  declares a dependency on `Microsoft.Windows.Common-Controls` 6.0.0.0. The
  build script emits `rustc-link-arg`, which applies only to this package's own
  linked artifacts, so the desktop application manifest is untouched.
- `.github/workflows/desktop_ci.yaml`: run `cargo test -p tauri-plugin-notification --lib`
  so a missing manifest or process-loader failure can no longer pass a
  compile-only check.

## Verification

Validated on the Windows Cloud PC against the actual rebuilt binary:

- 12/12 notification plugin tests pass
- the rebuilt EXE contains Common Controls 6.0
- that exact EXE returns a clean 12-test listing instead of `0xC0000139`

macOS plugin suite also green (12/12).

Follow-up to #6317, required for the 1.4.0 cross-platform release.
