### PR TITLE
Migrate legacy Linux packages

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.stable.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable.json
@@ -3,6 +3,15 @@
   "productName": "Anarlog",
   "mainBinaryName": "anarlog",
   "identifier": "com.hyprnote.stable",
+  "bundle": {
+    "linux": {
+      "deb": {
+        "provides": ["char"],
+        "conflicts": ["char"],
+        "replaces": ["char"]
+      }
+    }
+  },
   "plugins": {
     "deep-link": {
       "desktop": { "schemes": ["anarlog", "hyprnote"] }
@@ -10,8 +19,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable",
-        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}/{{current_version}}?channel=stable"
+        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable"
       ]
     }
   }


### PR DESCRIPTION
- Migrated legacy Linux packages to the updated packaging setup for compatibility and maintenance improvements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and updater URL config only; no application runtime or auth logic changes.
> 
> **Overview**
> **Stable Linux `.deb` packaging** now declares **`provides` / `conflicts` / `replaces`** for the legacy **`char`** package so installs and upgrades from the old name resolve cleanly under **Anarlog**.
> 
> The **stable updater** drops the fallback URL without **`{{bundle_type}}`** and keeps a single endpoint that includes **`{{target}}-{{arch}}-{{bundle_type}}`**, so update checks match bundle-specific artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 640aff97b343028fc218cc06613ba9e776185be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


---
Supersedes #6322, which GitHub auto-closed when its base branch `chore/cross-platform-release` was deleted on merge of #6296. Rebased onto `main`.