### PR TITLE
Guard stable release provenance

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -47,14 +47,16 @@ macOS artifacts or Rust-only tests as cross-platform approval.
 sed -n '1,280p' .github/workflows/desktop_cd.yaml
 ```
 
-2. Check the version inputs that the workflow will use:
+2. Validate the explicit stable version requested by the user:
 
 ```bash
-doxxer --config doxxer.desktop.toml current
-doxxer --config doxxer.desktop.toml next patch
+VERSION=<version>
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+test -f "packages/changelog/content/$VERSION.md"
 ```
 
-Stable desktop releases use `next patch` unless the user explicitly asks for an override version.
+Stable desktop releases never infer a version. The workflow requires the exact
+stable semantic version and a matching changelog file.
 
 3. Identify the latest stable desktop tag and the commits that will ship:
 
@@ -71,7 +73,7 @@ Use read-only `git` commands for inspection. If the workspace is on `gitbutler/w
 The changelog is the release gate. Before releasing:
 
 1. Open `packages/changelog/content/AGENTS.md` and follow its instructions.
-2. Confirm `packages/changelog/content/<next-patch-version>.md` exists.
+2. Confirm `packages/changelog/content/<version>.md` exists.
 3. Compare the file against the desktop user-facing changes since the latest `desktop_v*` tag.
 4. If the changelog is missing or incomplete, update it before release.
 
@@ -120,17 +122,17 @@ Use actual IDs from `but diff` / `but status -fv`; do not invent IDs.
 ## Trigger Stable Release
 
 After the changelog merge and QA Gate pass on the same `main` SHA, verify
-`main` has not moved, then trigger the stable desktop workflow from `main`:
+`main` has not moved, then build the stable candidate without publishing:
 
 ```bash
 gh workflow run desktop_cd.yaml \
   --ref main \
   -f channel=stable \
-  -f publish=true \
-  -f version=
+  -f publish=false \
+  -f version=<version>
 ```
 
-Then watch the run:
+Watch the dry-run build:
 
 ```bash
 gh run list --workflow desktop_cd.yaml --branch main --limit 5
@@ -141,21 +143,38 @@ gh run watch <run-id>
 The run's `headSha` must equal the Dev/staging candidate SHA. A mismatch blocks
 acceptance even if the workflow succeeds.
 
-The stable workflow should:
+The dry-run workflow must:
 
-- compute the version from `doxxer --config doxxer.desktop.toml next patch` when no explicit version is supplied
+- use the exact explicit stable version
 - build both Apple Silicon and Intel macOS artifacts
-- draft, upload, and publish the CrabNebula release when `publish=true`
-- create or update `desktop_v<version>`
-- create the GitHub release pointing to `https://anarlog.so/changelog/<version>`
+- build the signed Windows and Linux artifacts for the same version and commit
+- upload a draft CrabNebula release without publishing it
+- upload `desktop-release-provenance-<version>-<sha>`, including the exact
+  artifact hashes and CrabNebula tool versions
+
+After the exact dry-run artifacts pass the required platform QA gates and
+`main` still points to the candidate SHA, publish only through the provenance
+workflow:
+
+```bash
+gh workflow run desktop_publish.yaml \
+  --ref main \
+  -f version=<version> \
+  -f candidate_sha=<40-character-main-sha> \
+  -f dry_run_id=<run-id>
+```
+
+Watch that workflow to completion. It must verify the dry-run run identity,
+artifact hashes, CrabNebula tool versions, current `main`, and the immutable
+tag before publishing.
 
 ## Final Checks
 
 Before reporting success, capture:
 
 - computed stable version
-- workflow run URL
-- workflow head SHA
+- dry-run workflow URL and head SHA
+- publish workflow URL and head SHA
 - `desktop_v<version>` tag
 - GitHub release URL
 - whether CrabNebula publish completed

--- a/.github/actions/cn_download/action.yaml
+++ b/.github/actions/cn_download/action.yaml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - id: get-assets
-      uses: crabnebula-dev/cloud-release@v0
+      uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       with:
         command: release show ${{ inputs.app }} ${{ inputs.version }} --channel ${{ inputs.channel }}
         api-key: ${{ inputs.key }}

--- a/.github/actions/cn_release/action.yaml
+++ b/.github/actions/cn_release/action.yaml
@@ -35,13 +35,13 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: crabnebula-dev/cloud-release@v0
+    - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       id: raw
       if: inputs.raw != ''
       with:
         command: ${{ inputs.raw }}
         api-key: ${{ inputs.key }}
-    - uses: crabnebula-dev/cloud-release@v0
+    - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       if: inputs.raw == '' && inputs.framework == 'tauri'
       with:
         command: >-
@@ -49,7 +49,7 @@ runs:
           --framework tauri${{ inputs.channel != '' && format(' --channel {0}', inputs.channel) || '' }}
         api-key: ${{ inputs.key }}
         working-directory: ${{ inputs.working-directory }}
-    - uses: crabnebula-dev/cloud-release@v0
+    - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       if: inputs.raw == '' && inputs.framework != 'tauri'
       with:
         command: >-

--- a/.github/actions/cn_release/action.yaml
+++ b/.github/actions/cn_release/action.yaml
@@ -41,6 +41,7 @@ runs:
       with:
         command: ${{ inputs.raw }}
         api-key: ${{ inputs.key }}
+        path: ${{ github.workspace }}
     - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       if: inputs.raw == '' && inputs.framework == 'tauri'
       with:
@@ -48,6 +49,7 @@ runs:
           release ${{ inputs.cmd }} ${{ inputs.app }}
           --framework tauri${{ inputs.channel != '' && format(' --channel {0}', inputs.channel) || '' }}
         api-key: ${{ inputs.key }}
+        path: ${{ github.workspace }}
         working-directory: ${{ inputs.working-directory }}
     - uses: crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c # v0.2.6
       if: inputs.raw == '' && inputs.framework != 'tauri'
@@ -55,4 +57,5 @@ runs:
         command: >-
           release ${{ inputs.cmd }} ${{ inputs.app }} ${{ inputs.version }}${{ inputs.channel != '' && format(' --channel {0}', inputs.channel) || '' }}
         api-key: ${{ inputs.key }}
+        path: ${{ github.workspace }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/trigger-workflow/action.yml
+++ b/.github/actions/trigger-workflow/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Publish to Crabnebula and create GitHub release
     required: false
     default: "true"
+  version:
+    description: "Explicit stable version"
+    required: false
+    default: ""
   token:
     description: GitHub token
     required: true
@@ -37,12 +41,22 @@ runs:
     - id: trigger
       shell: bash
       env:
+        CHANNEL: ${{ inputs.channel }}
         GH_TOKEN: ${{ inputs.token }}
+        PUBLISH: ${{ inputs.publish }}
+        REF: ${{ inputs.ref }}
+        REPO: ${{ inputs.repo }}
+        VERSION: ${{ inputs.version }}
+        WORKFLOW: ${{ inputs.workflow }}
       run: |
-        gh workflow run ${{ inputs.workflow }} --repo ${{ inputs.repo }} --ref "${{ inputs.ref }}" -f channel=${{ inputs.channel }} -f publish=${{ inputs.publish }}
+        ARGS=(workflow run "$WORKFLOW" --repo "$REPO" --ref "$REF" -f "channel=$CHANNEL" -f "publish=$PUBLISH")
+        if [[ -n "$VERSION" ]]; then
+          ARGS+=(-f "version=$VERSION")
+        fi
+        gh "${ARGS[@]}"
         for i in $(seq 1 ${{ inputs.max_attempts }}); do
           sleep 5
-          RUN_ID=$(gh run list --workflow=${{ inputs.workflow }} --repo ${{ inputs.repo }} --branch="${{ inputs.ref }}" --json databaseId,createdAt --jq 'sort_by(.createdAt) | reverse | .[0].databaseId // empty')
+          RUN_ID=$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --branch="$REF" --json databaseId,createdAt --jq 'sort_by(.createdAt) | reverse | .[0].databaseId // empty')
           [ -n "$RUN_ID" ] && break
         done
         echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT

--- a/.github/workflows/command_dispatcher.yaml
+++ b/.github/workflows/command_dispatcher.yaml
@@ -27,16 +27,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       publish: ${{ steps.parse.outputs.publish }}
+      version: ${{ steps.parse.outputs.version }}
     steps:
       - id: parse
         env:
           COMMENT: ${{ github.event.comment.body }}
         run: |
+          if [[ ! "$COMMENT" =~ /stable[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+)($|[[:space:]]) ]]; then
+            echo "::error::Use /stable <version> [--no-publish], for example /stable 1.4.0"
+            exit 1
+          fi
+
+          VERSION="${BASH_REMATCH[1]}"
           PUBLISH="true"
           if [[ "$COMMENT" =~ --no-publish ]]; then
             PUBLISH="false"
           fi
           echo "publish=$PUBLISH" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   handle-stable:
     needs: [check-permission, parse-stable-options]
@@ -45,6 +53,7 @@ jobs:
     with:
       channel: stable
       publish: ${{ needs.parse-stable-options.outputs.publish == 'true' }}
+      version: ${{ needs.parse-stable-options.outputs.version }}
       issue_number: ${{ github.event.issue.number }}
       comment_id: ${{ github.event.comment.id }}
     secrets: inherit

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -14,15 +14,16 @@ on:
         type: boolean
         default: true
       version:
-        description: "Optional explicit version for stable releases"
+        description: "Explicit semantic version required for stable releases"
         required: false
         type: string
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.channel }}
-  cancel-in-progress: true
+  group: ${{ inputs.channel == 'stable' && 'desktop-stable-release' || format('{0}-{1}-{2}', github.workflow, github.ref, inputs.channel) }}
+  cancel-in-progress: ${{ inputs.channel != 'stable' }}
 env:
+  CN_ACTION_REF: "crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c"
   CN_APPLICATION: "fastrepl/hyprnote2"
   RELEASE_CHANNEL: ${{ inputs.channel }}
   TAURI_CONF_PATH: ./src-tauri/tauri.conf.${{ inputs.channel }}.json
@@ -55,13 +56,24 @@ jobs:
           fi
       - uses: ./.github/actions/doxxer_install
       - id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          RELEASE_CHANNEL: ${{ inputs.channel }}
         run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
-          elif [[ "${{ inputs.channel }}" == "staging" ]]; then
+          if [[ "$RELEASE_CHANNEL" == "stable" ]]; then
+            if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Stable releases require an explicit semantic version such as 1.4.0"
+              exit 1
+            fi
+            VERSION="$INPUT_VERSION"
+            if [[ ! -f "packages/changelog/content/$VERSION.md" ]]; then
+              echo "::error::Missing changelog for stable version $VERSION"
+              exit 1
+            fi
+          elif [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="$INPUT_VERSION"
+          elif [[ "$RELEASE_CHANNEL" == "staging" ]]; then
             VERSION=$(doxxer --config doxxer.desktop.toml next dev)
-          elif [[ "${{ inputs.channel }}" == "stable" ]]; then
-            VERSION=$(doxxer --config doxxer.desktop.toml next patch)
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Computed version: $VERSION"
@@ -708,6 +720,31 @@ jobs:
             echo "::error::CrabNebula release $EXPECTED_VERSION has missing, duplicate, unsigned, or empty updater assets: ${INVALID_UPDATE_PLATFORMS[*]}"
             exit 1
           fi
+      - if: ${{ !inputs.publish }}
+        name: Record release provenance
+        env:
+          CN_ACTION_REF: ${{ env.CN_ACTION_REF }}
+          RELEASE: ${{ steps.release.outputs.raw }}
+          VERSION: ${{ needs.compute-version.outputs.version }}
+        run: |
+          mkdir -p release-provenance
+          printf '%s' "$RELEASE" > "$RUNNER_TEMP/crabnebula-release.json"
+          CN_VERSION=$("$GITHUB_WORKSPACE/cn" --version)
+          node scripts/desktop-release-provenance.mjs create \
+            --release "$RUNNER_TEMP/crabnebula-release.json" \
+            --output release-provenance/manifest.json \
+            --version "$VERSION" \
+            --candidate-sha "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --cn-version "$CN_VERSION" \
+            --cn-action-ref "$CN_ACTION_REF"
+      - if: ${{ !inputs.publish }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-release-provenance-${{ needs.compute-version.outputs.version }}-${{ github.sha }}
+          path: release-provenance/manifest.json
+          if-no-files-found: error
+          retention-days: 30
 
   create-tag:
     if: ${{ inputs.channel != 'staging' && inputs.publish && !cancelled() && needs.verify-cn-release.result == 'success' }}
@@ -721,11 +758,18 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - run: |
+          git fetch origin main --no-tags
           git fetch --tags --force
 
           TAG="desktop_v${{ needs.compute-version.outputs.version }}"
           TARGET=$(git rev-parse HEAD)
+          MAIN=$(git rev-parse origin/main)
           EXISTING=$(git rev-parse -q --verify "refs/tags/$TAG" || true)
+
+          if [[ "$TARGET" != "$MAIN" ]]; then
+            echo "::error::Candidate moved before tagging (candidate=$TARGET, main=$MAIN)"
+            exit 1
+          fi
 
           if [[ -n "$EXISTING" ]]; then
             if [[ "$EXISTING" != "$TARGET" ]]; then
@@ -745,7 +789,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.compute-version.outputs.version }}"
+      - name: Verify candidate before publication
+        run: |
+          git fetch origin main --no-tags
+          git fetch --tags --force
+
+          TARGET=$(git rev-parse HEAD)
+          MAIN=$(git rev-parse origin/main)
+          TAG="desktop_v${{ needs.compute-version.outputs.version }}"
+          TAG_TARGET=$(git rev-parse "$TAG^{commit}")
+
+          if [[ "$TARGET" != "$MAIN" || "$TAG_TARGET" != "$TARGET" ]]; then
+            echo "::error::Candidate moved before publication (candidate=$TARGET, main=$MAIN, tag=$TAG_TARGET)"
+            exit 1
+          fi
       - uses: ./.github/actions/cn_release
         with:
           cmd: publish

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -9,8 +9,17 @@ on:
         description: "Exact 40-character main commit used to build the candidate"
         required: true
         type: string
+      dry_run_id:
+        description: "Successful publish=false desktop CD run that built the candidate"
+        required: true
+        type: string
+
+concurrency:
+  group: desktop-stable-release
+  cancel-in-progress: false
 
 env:
+  CN_ACTION_REF: "crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c"
   CN_APPLICATION: "fastrepl/hyprnote2"
 
 jobs:
@@ -20,10 +29,12 @@ jobs:
       version: ${{ steps.parse.outputs.version }}
       channel: ${{ steps.parse.outputs.channel }}
       candidate_sha: ${{ steps.parse.outputs.candidate_sha }}
+      dry_run_id: ${{ steps.parse.outputs.dry_run_id }}
     steps:
       - id: parse
         env:
           INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          INPUT_DRY_RUN_ID: ${{ inputs.dry_run_id }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -35,12 +46,17 @@ jobs:
             echo "::error::Candidate SHA must be a full 40-character commit SHA"
             exit 1
           fi
+          if [[ ! "$INPUT_DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Dry-run workflow ID must be a positive integer"
+            exit 1
+          fi
 
           VERSION="$INPUT_VERSION"
           CANDIDATE_SHA="${INPUT_CANDIDATE_SHA,,}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "channel=stable" >> $GITHUB_OUTPUT
           echo "candidate_sha=$CANDIDATE_SHA" >> $GITHUB_OUTPUT
+          echo "dry_run_id=$INPUT_DRY_RUN_ID" >> $GITHUB_OUTPUT
 
   verify-candidate:
     needs: parse
@@ -140,6 +156,7 @@ jobs:
     needs: [parse, verify-candidate, verify-windows-signature]
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
       - uses: actions/checkout@v4
@@ -148,6 +165,31 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.parse.outputs.version }}"
+      - name: Download candidate provenance
+        env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID")
+          if ! echo "$RUN" | jq -e \
+            --arg sha "$EXPECTED_SHA" \
+            --arg workflow ".github/workflows/desktop_cd.yaml" \
+            '
+              (.head_sha | ascii_downcase) == $sha
+              and .event == "workflow_dispatch"
+              and .conclusion == "success"
+              and (.path | split("@")[0]) == $workflow
+            ' > /dev/null; then
+            echo "::error::Run $RUN_ID is not a successful desktop CD run for candidate $EXPECTED_SHA"
+            exit 1
+          fi
+
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "desktop-release-provenance-$VERSION-$EXPECTED_SHA" \
+            --dir release-provenance
       - id: release
         uses: ./.github/actions/cn_release
         with:
@@ -225,6 +267,24 @@ jobs:
               exit 1
               ;;
           esac
+      - name: Verify candidate provenance
+        env:
+          CN_ACTION_REF: ${{ env.CN_ACTION_REF }}
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          RELEASE: ${{ steps.release.outputs.raw }}
+          RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          printf '%s' "$RELEASE" > "$RUNNER_TEMP/crabnebula-release.json"
+          CN_VERSION=$("$GITHUB_WORKSPACE/cn" --version)
+          node scripts/desktop-release-provenance.mjs verify \
+            --release "$RUNNER_TEMP/crabnebula-release.json" \
+            --manifest release-provenance/manifest.json \
+            --version "$VERSION" \
+            --candidate-sha "$EXPECTED_SHA" \
+            --run-id "$RUN_ID" \
+            --cn-version "$CN_VERSION" \
+            --cn-action-ref "$CN_ACTION_REF"
       - name: Create immutable release tag
         env:
           EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
@@ -253,6 +313,22 @@ jobs:
           else
             git tag "$TAG" "$EXPECTED_SHA"
             git push origin "refs/tags/$TAG"
+          fi
+      - name: Verify candidate before publication
+        if: ${{ steps.publish-decision.outputs.publish_needed == 'true' }}
+        env:
+          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          git fetch origin main --no-tags
+          git fetch --tags --force
+
+          TARGET=$(git rev-parse HEAD)
+          MAIN=$(git rev-parse origin/main)
+          TAG_TARGET=$(git rev-parse "desktop_v$VERSION^{commit}")
+          if [[ "$TARGET" != "$EXPECTED_SHA" || "$MAIN" != "$EXPECTED_SHA" || "$TAG_TARGET" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Candidate moved before publication (candidate=$EXPECTED_SHA, checkout=$TARGET, main=$MAIN, tag=$TAG_TARGET)"
+            exit 1
           fi
       - uses: ./.github/actions/cn_release
         if: ${{ steps.publish-decision.outputs.publish_needed == 'true' }}
@@ -294,7 +370,7 @@ jobs:
           version: ${{ needs.parse.outputs.version }}
           channel: ${{ needs.parse.outputs.channel }}
           platform: dmg-aarch64
-          output: char-macos-aarch64.dmg
+          output: hyprnote-macos-aarch64.dmg
           key: ${{ secrets.CN_API_KEY }}
       - id: download-macos-x86_64
         uses: ./.github/actions/cn_download
@@ -303,7 +379,7 @@ jobs:
           version: ${{ needs.parse.outputs.version }}
           channel: ${{ needs.parse.outputs.channel }}
           platform: dmg-x86_64
-          output: char-macos-x86_64.dmg
+          output: hyprnote-macos-x86_64.dmg
           key: ${{ secrets.CN_API_KEY }}
       - id: download-linux-x86_64-appimage
         uses: ./.github/actions/cn_download
@@ -354,8 +430,8 @@ jobs:
         uses: ./.github/actions/generate_checksums
         with:
           files: |
-            char-macos-aarch64.dmg
-            char-macos-x86_64.dmg
+            hyprnote-macos-aarch64.dmg
+            hyprnote-macos-x86_64.dmg
             anarlog-linux-x86_64.AppImage
             anarlog-linux-x86_64.deb
             anarlog-linux-aarch64.AppImage
@@ -370,7 +446,7 @@ jobs:
           name: desktop_v${{ needs.parse.outputs.version }}
           body: ${{ steps.release-body.outputs.value }}
           prerelease: false
-          artifacts: char-macos-aarch64.dmg,char-macos-x86_64.dmg,anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb,anarlog-windows-x86_64-setup.exe,${{ steps.checksums.outputs.checksum_files }}
+          artifacts: hyprnote-macos-aarch64.dmg,hyprnote-macos-x86_64.dmg,anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb,anarlog-windows-x86_64-setup.exe,${{ steps.checksums.outputs.checksum_files }}
           allowUpdates: true
           makeLatest: true
           replacesArtifacts: true

--- a/.github/workflows/handle_release.yaml
+++ b/.github/workflows/handle_release.yaml
@@ -8,6 +8,9 @@ on:
         required: false
         type: boolean
         default: true
+      version:
+        required: true
+        type: string
       issue_number:
         required: true
         type: number
@@ -70,6 +73,7 @@ jobs:
           ref: ${{ steps.resolve.outputs.branch }}
           channel: ${{ inputs.channel }}
           publish: ${{ inputs.publish }}
+          version: ${{ inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
           max_attempts: "10"

--- a/apps/desktop/src-tauri/tauri.conf.stable.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable.json
@@ -3,6 +3,15 @@
   "productName": "Anarlog",
   "mainBinaryName": "anarlog",
   "identifier": "com.hyprnote.stable",
+  "bundle": {
+    "linux": {
+      "deb": {
+        "provides": ["char"],
+        "conflicts": ["char"],
+        "replaces": ["char"]
+      }
+    }
+  },
   "plugins": {
     "deep-link": {
       "desktop": { "schemes": ["anarlog", "hyprnote"] }
@@ -10,8 +19,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable",
-        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}/{{current_version}}?channel=stable"
+        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable"
       ]
     }
   }

--- a/scripts/desktop-release-provenance.mjs
+++ b/scripts/desktop-release-provenance.mjs
@@ -1,0 +1,317 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_ASSET_BASE_URL = "https://cdn.crabnebula.app/asset";
+const SOURCE_WORKFLOW = ".github/workflows/desktop_cd.yaml";
+const CN_ACTION_REPOSITORY = "crabnebula-dev/cloud-release";
+
+function invariant(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const args = {};
+
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index];
+    const value = rest[index + 1];
+    invariant(key?.startsWith("--") && value, `Invalid argument: ${key ?? ""}`);
+    args[key.slice(2)] = value;
+  }
+
+  return { command, args };
+}
+
+function normalizeSha(value) {
+  invariant(
+    typeof value === "string" && /^[0-9a-fA-F]{40}$/.test(value),
+    "Candidate SHA must contain 40 hexadecimal characters",
+  );
+  return value.toLowerCase();
+}
+
+function normalizeRunId(value) {
+  const runId = String(value);
+  invariant(
+    /^[1-9][0-9]*$/.test(runId),
+    "Workflow run ID must be a positive integer",
+  );
+  return runId;
+}
+
+function normalizeCnVersion(value) {
+  invariant(
+    typeof value === "string" &&
+      value.trim().length > 0 &&
+      value.trim().length <= 200 &&
+      !/[\r\n]/.test(value.trim()),
+    "CrabNebula CLI version must be one non-empty line",
+  );
+  return value.trim();
+}
+
+function normalizeCnActionRef(value) {
+  invariant(
+    typeof value === "string" &&
+      new RegExp(`^${CN_ACTION_REPOSITORY}@[0-9a-f]{40}$`).test(value),
+    "CrabNebula action ref must be pinned to a full commit SHA",
+  );
+  return value;
+}
+
+function normalizeAsset(asset) {
+  invariant(
+    typeof asset?.id === "string" && /^[A-Za-z0-9_-]+$/.test(asset.id),
+    "Every CrabNebula asset must have a safe ID",
+  );
+
+  const size = Number(asset.size);
+  invariant(
+    Number.isSafeInteger(size) && size > 0,
+    `Asset ${asset.id} has an invalid size`,
+  );
+
+  const publicPlatform = asset.publicPlatform ?? null;
+  const updatePlatform = asset.updatePlatform ?? null;
+  const signature = asset.signature ?? null;
+  invariant(
+    publicPlatform === null || typeof publicPlatform === "string",
+    `Asset ${asset.id} has an invalid public platform`,
+  );
+  invariant(
+    updatePlatform === null || typeof updatePlatform === "string",
+    `Asset ${asset.id} has an invalid update platform`,
+  );
+  invariant(
+    signature === null || typeof signature === "string",
+    `Asset ${asset.id} has an invalid signature`,
+  );
+
+  return {
+    id: asset.id,
+    publicPlatform,
+    updatePlatform,
+    size,
+    signature,
+  };
+}
+
+function normalizeAssets(release) {
+  invariant(
+    Array.isArray(release?.assets) && release.assets.length > 0,
+    "Release has no assets",
+  );
+
+  const assets = release.assets
+    .map(normalizeAsset)
+    .sort((left, right) => left.id.localeCompare(right.id));
+  invariant(
+    new Set(assets.map((asset) => asset.id)).size === assets.length,
+    "Release contains duplicate asset IDs",
+  );
+  return assets;
+}
+
+async function hashStream(stream) {
+  const hash = createHash("sha256");
+  let size = 0;
+
+  for await (const chunk of stream) {
+    hash.update(chunk);
+    size += chunk.length;
+  }
+
+  return { sha256: hash.digest("hex"), size };
+}
+
+async function hashAsset(asset, assetDir) {
+  const result = assetDir
+    ? await hashStream(createReadStream(path.join(assetDir, asset.id)))
+    : await hashRemoteAsset(asset.id);
+
+  invariant(
+    result.size === asset.size,
+    `Asset ${asset.id} has size ${result.size}, expected ${asset.size}`,
+  );
+  return result.sha256;
+}
+
+async function hashRemoteAsset(assetId) {
+  const baseUrl = process.env.CN_ASSET_BASE_URL ?? DEFAULT_ASSET_BASE_URL;
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}/${assetId}`);
+  invariant(
+    response.ok && response.body,
+    `Could not download asset ${assetId}: ${response.status}`,
+  );
+  return hashStream(response.body);
+}
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, "utf8"));
+}
+
+export async function createManifest({
+  release,
+  output,
+  version,
+  candidateSha,
+  workflowRunId,
+  cnVersion,
+  cnActionRef,
+  assetDir,
+}) {
+  invariant(
+    release?.version === version,
+    `Release version is ${release?.version}, expected ${version}`,
+  );
+  invariant(
+    String(release?.status ?? "").toLowerCase() === "draft",
+    "A provenance manifest can only be created from a draft release",
+  );
+
+  const assets = normalizeAssets(release);
+  const hashedAssets = [];
+  for (const asset of assets) {
+    hashedAssets.push({
+      ...asset,
+      sha256: await hashAsset(asset, assetDir),
+    });
+  }
+
+  const manifest = {
+    schemaVersion: 1,
+    sourceWorkflow: SOURCE_WORKFLOW,
+    workflowRunId: normalizeRunId(workflowRunId),
+    candidateSha: normalizeSha(candidateSha),
+    version,
+    channel: "stable",
+    publish: false,
+    tools: {
+      crabNebula: {
+        cliVersion: normalizeCnVersion(cnVersion),
+        actionRef: normalizeCnActionRef(cnActionRef),
+      },
+    },
+    assets: hashedAssets,
+  };
+
+  await writeFile(output, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+export async function verifyManifest({
+  release,
+  manifest,
+  version,
+  candidateSha,
+  workflowRunId,
+  cnVersion,
+  cnActionRef,
+  assetDir,
+}) {
+  invariant(
+    manifest?.schemaVersion === 1,
+    "Unsupported provenance manifest schema",
+  );
+  invariant(
+    manifest.sourceWorkflow === SOURCE_WORKFLOW,
+    "Unexpected source workflow",
+  );
+  invariant(
+    manifest.workflowRunId === normalizeRunId(workflowRunId),
+    "Workflow run ID mismatch",
+  );
+  invariant(
+    manifest.candidateSha === normalizeSha(candidateSha),
+    "Candidate SHA mismatch",
+  );
+  invariant(manifest.version === version, "Manifest version mismatch");
+  invariant(manifest.channel === "stable", "Manifest channel is not stable");
+  invariant(
+    manifest.publish === false,
+    "Provenance must come from a publish=false run",
+  );
+  invariant(
+    manifest.tools?.crabNebula?.cliVersion === normalizeCnVersion(cnVersion),
+    "CrabNebula CLI version mismatch",
+  );
+  invariant(
+    manifest.tools?.crabNebula?.actionRef === normalizeCnActionRef(cnActionRef),
+    "CrabNebula action ref mismatch",
+  );
+  invariant(
+    release?.version === version,
+    `Release version is ${release?.version}, expected ${version}`,
+  );
+
+  const currentAssets = normalizeAssets(release);
+  invariant(
+    Array.isArray(manifest.assets) &&
+      manifest.assets.length === currentAssets.length,
+    "Release asset count does not match the provenance manifest",
+  );
+
+  for (let index = 0; index < currentAssets.length; index += 1) {
+    const current = currentAssets[index];
+    const recorded = manifest.assets[index];
+    const { sha256, ...recordedMetadata } = recorded ?? {};
+    invariant(
+      JSON.stringify(recordedMetadata) === JSON.stringify(current),
+      `Asset metadata changed at index ${index}`,
+    );
+    invariant(
+      typeof sha256 === "string" && /^[0-9a-f]{64}$/.test(sha256),
+      `Asset ${current.id} has an invalid recorded SHA-256`,
+    );
+
+    const currentSha256 = await hashAsset(current, assetDir);
+    invariant(currentSha256 === sha256, `Asset ${current.id} SHA-256 changed`);
+  }
+}
+
+async function main() {
+  const { command, args } = parseArgs(process.argv.slice(2));
+  invariant(
+    command === "create" || command === "verify",
+    "Expected create or verify command",
+  );
+
+  const release = await readJson(args.release);
+  const common = {
+    release,
+    version: args.version,
+    candidateSha: args["candidate-sha"],
+    workflowRunId: args["run-id"],
+    cnVersion: args["cn-version"],
+    cnActionRef: args["cn-action-ref"],
+    assetDir: args["asset-dir"],
+  };
+
+  if (command === "create") {
+    invariant(args.output, "Missing --output");
+    await createManifest({ ...common, output: args.output });
+    console.log(`Wrote release provenance to ${args.output}`);
+    return;
+  }
+
+  invariant(args.manifest, "Missing --manifest");
+  await verifyManifest({ ...common, manifest: await readJson(args.manifest) });
+  console.log("Release provenance verified");
+}
+
+const isMain = process.argv[1]
+  ? import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+  : false;
+
+if (isMain) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createManifest,
+  verifyManifest,
+} from "./desktop-release-provenance.mjs";
+
+const candidateSha = "0123456789abcdef0123456789abcdef01234567";
+const cnActionRef =
+  "crabnebula-dev/cloud-release@1a8803698ba41de6b23e42abc5dcc3721308233c";
+const cnVersion = "cn 0.21.0";
+
+test("binds every release asset to a candidate run and detects replacement", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "anarlog-release-provenance-"),
+  );
+  const assetDir = path.join(directory, "assets");
+  await mkdir(assetDir);
+
+  const contents = new Map([
+    ["asset-a", "macOS"],
+    ["asset-b", "Windows"],
+    ["asset-c", "Linux"],
+  ]);
+  for (const [id, content] of contents) {
+    await writeFile(path.join(assetDir, id), content);
+  }
+
+  const release = {
+    version: "1.4.0",
+    status: "draft",
+    assets: [
+      {
+        id: "asset-c",
+        publicPlatform: "appimage-x86_64",
+        updatePlatform: "linux-x86_64-appimage",
+        size: Buffer.byteLength(contents.get("asset-c")),
+        signature: "linux-signature",
+      },
+      {
+        id: "asset-a",
+        publicPlatform: "dmg-aarch64",
+        size: Buffer.byteLength(contents.get("asset-a")),
+      },
+      {
+        id: "asset-b",
+        publicPlatform: "nsis-x86_64",
+        updatePlatform: "windows-x86_64-nsis",
+        size: Buffer.byteLength(contents.get("asset-b")),
+        signature: "windows-signature",
+      },
+    ],
+  };
+  const output = path.join(directory, "manifest.json");
+
+  await createManifest({
+    release,
+    output,
+    version: "1.4.0",
+    candidateSha,
+    workflowRunId: "12345",
+    cnVersion,
+    cnActionRef,
+    assetDir,
+  });
+  const manifest = JSON.parse(await readFile(output, "utf8"));
+
+  assert.deepEqual(manifest.tools, {
+    crabNebula: { cliVersion: cnVersion, actionRef: cnActionRef },
+  });
+  assert.deepEqual(
+    manifest.assets.map((asset) => asset.id),
+    ["asset-a", "asset-b", "asset-c"],
+  );
+  await verifyManifest({
+    release,
+    manifest,
+    version: "1.4.0",
+    candidateSha,
+    workflowRunId: "12345",
+    cnVersion,
+    cnActionRef,
+    assetDir,
+  });
+
+  await assert.rejects(
+    verifyManifest({
+      release,
+      manifest,
+      version: "1.4.0",
+      candidateSha,
+      workflowRunId: "12345",
+      cnVersion: "cn 0.22.0",
+      cnActionRef,
+      assetDir,
+    }),
+    /CLI version mismatch/,
+  );
+
+  await assert.rejects(
+    verifyManifest({
+      release,
+      manifest,
+      version: "1.4.0",
+      candidateSha,
+      workflowRunId: "12345",
+      cnVersion,
+      cnActionRef:
+        "crabnebula-dev/cloud-release@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      assetDir,
+    }),
+    /action ref mismatch/,
+  );
+
+  await writeFile(path.join(assetDir, "asset-b"), "replaced");
+  await assert.rejects(
+    verifyManifest({
+      release,
+      manifest,
+      version: "1.4.0",
+      candidateSha,
+      workflowRunId: "12345",
+      cnVersion,
+      cnActionRef,
+      assetDir,
+    }),
+    /size .* expected|SHA-256 changed/,
+  );
+});


### PR DESCRIPTION
Require explicit stable versions, verify immutable dry-run asset provenance, pin CrabNebula tooling, and recheck main before publishing.

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #6311
- <kbd>&nbsp;6&nbsp;</kbd> #6309
- <kbd>&nbsp;5&nbsp;</kbd> #6306 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #6296
- <kbd>&nbsp;3&nbsp;</kbd> #6301
- <kbd>&nbsp;2&nbsp;</kbd> #6294
- <kbd>&nbsp;1&nbsp;</kbd> #6280
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core release and publish pipelines for signed desktop artifacts; mistakes could block releases or, without the new checks, ship wrong builds—mitigated by provenance verification and main/tag gates.
> 
> **Overview**
> **Stable desktop releases are split into a dry-run build and a separate publish step**, and stable versions must be supplied explicitly (with a matching changelog) instead of being inferred from `doxxer next patch`.
> 
> `desktop_cd` with `publish=false` now uploads a **provenance manifest** (artifact SHA-256s, candidate commit, workflow run, pinned CrabNebula CLI/action). **`desktop_publish`** requires that dry-run run ID plus `candidate_sha` and `version`, re-checks that `main` and the immutable tag still match the candidate, and **verifies CrabNebula assets against the manifest** before publishing. CrabNebula actions are **pinned to a full commit SHA**; stable runs share a **`desktop-stable-release` concurrency** group. **`/stable`** and the release skill are updated to **`/stable <version>`** and the two-step flow.
> 
> Adds `scripts/desktop-release-provenance.mjs` with tests for create/verify and tamper detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55aca184e4b1ff6da1efde2512da6064716ac370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


---
Supersedes #6306, which GitHub auto-closed when its base branch `chore/cross-platform-release` was deleted on merge of #6296. Restacked onto `fix/linux-deb-migration`.
