### PR TITLE
ci(cloudsync): rebuild the Linux CloudSync library in CI

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -31,13 +31,21 @@ critical checklist results. Any failure, missing evidence, SHA mismatch,
 rebuild, or later source change blocks stable unless the user explicitly
 waives that specific gate.
 
-This release path currently approves macOS only. The patched CloudSync vendor
-bundle was rebuilt and cancellation-tested for Apple Silicon and Intel, but
-not for Windows, Linux, or mobile. Before opening any of those release lanes,
-rebuild the bundled native library for every target architecture and pass the
-QA skill's equivalent stalled-network, logout, configuration cleanup/init,
-worker-drain, and immediate-local-write cancellation gates. Do not treat the
-macOS artifacts or Rust-only tests as cross-platform approval.
+This release path approves macOS, Windows, and Linux. Mobile remains closed.
+The patched CloudSync vendor bundle is rebuilt from source and
+cancellation-tested on every desktop lane: `rebuild-macos.sh` for Apple
+Silicon and Intel, `rebuild-windows.sh` under UCRT64 in `windows_ci`, and
+`rebuild-linux.sh` in `linux_ci` for x86_64 and aarch64. Each lane then runs
+`cargo test -p cloudsync` and `cargo test -p db-core cloudsync::` against that
+freshly built library, covering the stalled-network, logout, configuration
+cleanup/init, worker-drain, and immediate-local-write cancellation gates.
+
+The rebuild steps run only on `workflow_dispatch`, so a routine pull-request
+run does not prove them. Dispatch `desktop_ci.yaml` against the candidate SHA
+and confirm the `cloudsync-windows-*` and `cloudsync-linux-*` artifacts before
+treating a desktop lane as approved. Do not treat macOS artifacts or
+Rust-only tests as cross-platform approval, and do not open the mobile lane
+until its bundle gets the same treatment.
 
 ## Preflight
 

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -374,6 +374,7 @@ jobs:
             debian_arch: amd64
             file_arch: x86-64
             docker_arch: amd64
+            cloudsync_arch: x86_64
           - runner: depot-ubuntu-24.04-arm-8
             target: aarch64-unknown-linux-gnu
             rust_platform: linux-aarch64
@@ -381,6 +382,7 @@ jobs:
             debian_arch: arm64
             file_arch: ARM aarch64
             docker_arch: arm64
+            cloudsync_arch: aarch64
     runs-on: ${{ matrix.runner }}
     defaults:
       run:
@@ -396,6 +398,15 @@ jobs:
       - uses: ./.github/actions/rust_install
         with:
           platform: ${{ matrix.rust_platform }}
+      - if: github.event_name == 'workflow_dispatch'
+        run: crates/cloudsync/scripts/rebuild-linux.sh
+      - if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudsync-linux-gnu-${{ matrix.cloudsync_arch }}-${{ github.sha }}
+          path: crates/cloudsync/vendor/cloudsync/linux/gnu/${{ matrix.cloudsync_arch }}/cloudsync.so
+          if-no-files-found: error
+          retention-days: 7
       - run: cargo check --locked --target ${{ matrix.target }} -p desktop
       - run: cargo test --locked --target ${{ matrix.target }} -p desktop embedded_cli --lib
       - run: cargo test --locked --target ${{ matrix.target }} -p cloudsync


### PR DESCRIPTION
The release runbook (`.agents/skills/release-new-version/SKILL.md`) blocked the
Windows and Linux release lanes until the patched CloudSync vendor bundle was
*rebuilt from source and cancellation-tested for every target architecture*.

`windows_ci` already satisfied this — it installs UCRT64 and runs
`rebuild-windows.sh` before the cloudsync suites. `linux_ci` had no rebuild
path at all: it ran `cargo test -p cloudsync` and `cargo test -p db-core
cloudsync::` against the `.so` files committed under
`crates/cloudsync/vendor/`. A stale, mismatched, or unreproducible vendored
library would have passed CI unnoticed, and 1.4.0 is the first release to open
the Linux lane.

## Changes

- **`.github/workflows/desktop_ci.yaml`** — add a `workflow_dispatch`-gated
  `rebuild-linux.sh` step to `linux_ci` for both matrix entries, plus an
  artifact upload, mirroring `windows_ci`. A `cloudsync_arch` matrix key
  (`x86_64` / `aarch64`) resolves the vendored path. The rebuild runs *before*
  the `cargo test` steps so the suites exercise the freshly built library.

- **`.agents/skills/release-new-version/SKILL.md`** — the runbook said "This
  release path currently approves macOS only." That is now stale: it approves
  macOS, Windows, and Linux, naming the per-lane rebuild script and the
  cancellation gates each satisfies. It also records that the rebuild steps
  only run on `workflow_dispatch`, so a routine pull-request run does not
  prove them — dispatch `desktop_ci.yaml` against the candidate SHA and
  confirm the `cloudsync-windows-*` / `cloudsync-linux-*` artifacts before
  treating a lane as approved. Mobile stays closed.

## Verification

- `pnpm exec dprint fmt` clean.
- Workflow job graph unchanged; no dangling `needs`.
- The rebuild is dispatch-gated, so routine PR CI cost is unchanged.

Required for the 1.4.0 cross-platform release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation only; rebuild is optional on PR runs and aligns Linux with an existing Windows workflow pattern.
> 
> **Overview**
> **Linux CI now rebuilds CloudSync from source on manual runs**, matching the existing Windows pattern so `cargo test -p cloudsync` and `db-core cloudsync::` run against a freshly built `cloudsync.so` instead of only the vendored binary.
> 
> On `workflow_dispatch`, `linux_ci` runs `rebuild-linux.sh` for both **x86_64** and **aarch64** (new `cloudsync_arch` matrix key), uploads `cloudsync-linux-gnu-*` artifacts, and keeps those steps **before** the CloudSync test steps. Routine PR/push CI is unchanged because the rebuild stays dispatch-gated.
> 
> The **release-new-version** skill is updated to treat **macOS, Windows, and Linux** as approved desktop lanes (mobile still closed), documents per-lane rebuild scripts and cancellation tests, and requires dispatching `desktop_ci.yaml` on the release SHA and verifying `cloudsync-windows-*` / `cloudsync-linux-*` artifacts—PR CI alone does not prove rebuild approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e7b8960ceedc21b5d7f2b5b8a1d6e6d339b23a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->