### PR TITLE
fix(stt): detect meeting language instead of forcing code-switching

### DIFF
--- a/.github/actions/install_desktop_deps/action.yaml
+++ b/.github/actions/install_desktop_deps/action.yaml
@@ -16,5 +16,10 @@ runs:
     - if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |
+        if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
+          sudo sed -i \
+            's|http://us-east-1.ec2.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list.d/ubuntu.sources
+        fi
         bash ${{ github.workspace }}/scripts/setup-linux-tauri.sh
         bash ${{ github.workspace }}/scripts/setup-linux-others.sh

--- a/.github/actions/rust_install/action.yaml
+++ b/.github/actions/rust_install/action.yaml
@@ -50,8 +50,13 @@ runs:
         components: ${{ steps.toolchain.outputs.components }}
     - if: inputs.platform == 'linux'
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libasound2-dev
+        if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
+          sudo sed -i \
+            's|http://us-east-1.ec2.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list.d/ubuntu.sources
+        fi
+        sudo apt-get -o Acquire::Retries=5 update
+        sudo apt-get -o Acquire::Retries=5 install -y libasound2-dev
       shell: bash
     - if: inputs.platform == 'linux-x86_64'
       uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/stt_e2e.yaml
+++ b/.github/workflows/stt_e2e.yaml
@@ -105,7 +105,7 @@ jobs:
           platform: linux
       - uses: ./.github/actions/infisical_install
       - run: |
-          infisical run --token="$INFISICAL_TOKEN" --env=dev --projectId="$INFISICAL_PROJECT_ID" --path="/stt" -- bash -lc '
+          infisical run --token="$INFISICAL_TOKEN" --env=dev --projectId="$INFISICAL_PROJECT_ID" --path="/anarlog/stt" -- bash -lc '
             set -euo pipefail
 
             provider="${PROVIDER}"
@@ -161,7 +161,7 @@ jobs:
           platform: linux
       - uses: ./.github/actions/infisical_install
       - run: |
-          infisical run --token="$INFISICAL_TOKEN" --env=dev --projectId="$INFISICAL_PROJECT_ID" --path="/stt" -- bash -lc '
+          infisical run --token="$INFISICAL_TOKEN" --env=dev --projectId="$INFISICAL_PROJECT_ID" --path="/anarlog/stt" -- bash -lc '
             set -euo pipefail
 
             provider="${PROVIDER}"

--- a/.github/workflows/stt_e2e.yaml
+++ b/.github/workflows/stt_e2e.yaml
@@ -105,7 +105,7 @@ jobs:
           platform: linux
       - uses: ./.github/actions/infisical_install
       - run: |
-          infisical run --token="$INFISICAL_TOKEN" --env=dev --projectId="$INFISICAL_PROJECT_ID" --path="/anarlog/stt" -- bash -lc '
+          infisical run --token="$INFISICAL_TOKEN" --env=dev --projectId="$INFISICAL_PROJECT_ID" --path="/stt" -- bash -lc '
             set -euo pipefail
 
             provider="${PROVIDER}"
@@ -161,7 +161,7 @@ jobs:
           platform: linux
       - uses: ./.github/actions/infisical_install
       - run: |
-          infisical run --token="$INFISICAL_TOKEN" --env=dev --projectId="$INFISICAL_PROJECT_ID" --path="/anarlog/stt" -- bash -lc '
+          infisical run --token="$INFISICAL_TOKEN" --env=dev --projectId="$INFISICAL_PROJECT_ID" --path="/stt" -- bash -lc '
             set -euo pipefail
 
             provider="${PROVIDER}"

--- a/crates/owhisper-client/src/adapter/deepgram/batch.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/batch.rs
@@ -280,6 +280,30 @@ mod tests {
         assert!(!query.contains("language=multi"));
     }
 
+    #[test]
+    fn batch_url_prefers_detect_language_over_multi_capable_pair() {
+        let params = ListenParams {
+            model: Some("nova-3".to_string()),
+            languages: vec![
+                hypr_language::ISO639::En.into(),
+                hypr_language::ISO639::De.into(),
+            ],
+            ..Default::default()
+        };
+
+        let url = build_batch_url(
+            "https://api.deepgram.com/v1",
+            &params,
+            &DeepgramLanguageStrategy,
+            &DeepgramKeywordStrategy,
+        );
+
+        let query = url.query().unwrap_or_default();
+        assert!(query.contains("detect_language=en"));
+        assert!(query.contains("detect_language=de"));
+        assert!(!query.contains("language=multi"));
+    }
+
     #[tokio::test]
     #[ignore]
     async fn test_deepgram_batch_transcription() {

--- a/crates/owhisper-client/src/adapter/deepgram/language.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/language.rs
@@ -57,10 +57,14 @@ impl LanguageQueryStrategy for DeepgramLanguageStrategy {
                 }
             }
             _ => {
-                if can_use_multi(model, &params.languages) {
-                    query_pairs.append_pair("language", "multi");
-                } else if mode == TranscriptionMode::Batch {
+                // Configured languages are the ones the user speaks, not the ones spoken in
+                // any single meeting. Most meetings are monolingual, so prefer detection over
+                // code-switching: `multi` decodes the whole file with a code-switching model
+                // and loses accuracy against the language-locked one.
+                if mode == TranscriptionMode::Batch {
                     append_detect_language_query(query_pairs, &params.languages);
+                } else if can_use_multi(model, &params.languages) {
+                    query_pairs.append_pair("language", "multi");
                 } else if let Some(language) = params.languages.first() {
                     let code = single_language_query_code(params, language);
                     query_pairs.append_pair("language", &code);

--- a/crates/owhisper-client/src/adapter/gladia/batch.rs
+++ b/crates/owhisper-client/src/adapter/gladia/batch.rs
@@ -221,7 +221,7 @@ impl GladiaAdapter {
 
         let language_config = (!languages.is_empty()).then(|| LanguageConfig {
             languages,
-            code_switching: (params.languages.len() > 1).then_some(true),
+            code_switching: Some(false),
         });
 
         let custom_vocabulary = (!params.keywords.is_empty()).then(|| params.keywords.clone());

--- a/crates/owhisper-client/src/adapter/gladia/live.rs
+++ b/crates/owhisper-client/src/adapter/gladia/live.rs
@@ -111,7 +111,7 @@ impl RealtimeSttAdapter for GladiaAdapter {
                 None
             } else {
                 Some(LanguageConfig {
-                    code_switching: languages.len() > 1,
+                    code_switching: false,
                     languages,
                 })
             };
@@ -300,6 +300,10 @@ struct GladiaConfig<'a> {
     realtime_processing: Option<RealtimeProcessing>,
 }
 
+// `languages` is a candidate set Gladia detects within; `code_switching` additionally lets it
+// switch language mid-audio. Configured languages describe the user, not one meeting, so leave
+// switching off — otherwise a monolingual German meeting is decoded by the code-switching path
+// and loses accuracy against detecting German once and locking to it.
 #[derive(Serialize, Debug, PartialEq)]
 struct LanguageConfig {
     languages: Vec<String>,
@@ -319,7 +323,7 @@ impl GladiaAdapter {
             None
         } else {
             Some(LanguageConfig {
-                code_switching: languages.len() > 1,
+                code_switching: false,
                 languages,
             })
         }
@@ -578,8 +582,8 @@ mod tests {
 
         assert_eq!(config.languages, vec!["en", "es"]);
         assert!(
-            config.code_switching,
-            "Multi language should have code_switching=true"
+            !config.code_switching,
+            "Multi language should detect within the candidates, not code-switch"
         );
     }
 
@@ -598,8 +602,8 @@ mod tests {
 
         assert_eq!(config.languages, vec!["en", "ko", "ja"]);
         assert!(
-            config.code_switching,
-            "Three languages should have code_switching=true"
+            !config.code_switching,
+            "Three languages should detect within the candidates, not code-switch"
         );
     }
 
@@ -619,11 +623,11 @@ mod tests {
     fn test_build_language_config_serialization() {
         let config = LanguageConfig {
             languages: vec!["en".to_string(), "fr".to_string()],
-            code_switching: true,
+            code_switching: false,
         };
 
         let json = serde_json::to_string(&config).unwrap();
-        assert!(json.contains("\"code_switching\":true"));
+        assert!(json.contains("\"code_switching\":false"));
         assert!(json.contains("\"languages\":[\"en\",\"fr\"]"));
     }
 

--- a/scripts/setup-linux-tauri.sh
+++ b/scripts/setup-linux-tauri.sh
@@ -4,8 +4,8 @@
 
 set -euo pipefail
 
-sudo apt update
-sudo apt-get install -y \
+sudo apt-get -o Acquire::Retries=5 update
+sudo apt-get -o Acquire::Retries=5 install -y \
   libwebkit2gtk-4.1-dev \
   build-essential \
   curl \


### PR DESCRIPTION
Reported on Discord: with the main language set to English and German added as
an additional language, German meetings transcribe badly. Switching the main
language to German and re-transcribing fixes it. Seen on both Deepgram and
Gladia, with the user's own API keys.

## Cause

Configured languages describe what the user *speaks*, not what is spoken in a
given meeting, but every request built from a multi-language list was put into
code-switching mode:

- Gladia derived `code_switching` from list length, so two configured languages
  always enabled mid-audio switching.
- Deepgram preferred `language=multi` whenever the pair was multi-capable, so
  `[en, de]` on nova-3 decoded German with the code-switching model rather than
  the German one.

The workaround works because `getAdditionalSpokenLanguages` strips the main
language from the additional list — setting main to German collapses the list to
a single entry, which is the only way to get a language-locked request today.

## Changes

- Gladia (live + batch): stop deriving `code_switching` from list length and
  leave it off. `languages` is a candidate set Gladia detects within;
  `code_switching` is a separate opt-in to switching mid-audio. Multiple
  candidates now mean detection.
- Deepgram batch: prefer `detect_language` over `language=multi` for
  multi-capable pairs, so a monolingual file is decoded by the language-locked
  model.
- Deepgram live is unchanged. Its streaming API has no language detection, so
  `multi` stays the only option for more than one candidate.

Net effect: the reporter can leave main=English/additional=German and
Re-transcribe produces a correct German transcript with no settings change. A
live Deepgram meeting is still degraded until re-transcribed.

## Verification

283 unit tests pass, `cargo check -p owhisper-client` clean.
`batch_url_prefers_detect_language_over_multi_capable_pair` pins the reported
case (en+de on nova-3 → `detect_language`, not `multi`). Three Gladia tests that
asserted the old `code_switching=true` were updated.

## Before merging

The Gladia change rests on their candidate-set semantics — that
`code_switching: false` with multiple languages means "detect among these"
rather than rejecting the request or silently using the first. The code path is
verified; the API response is not. `test_single_multi_lang_2` in
`gladia/live.rs` is `#[ignore]`d behind `GLADIA_API_KEY` and would confirm it
against the real service.

## Follow-up (not in this PR)

Deepgram live still falls back to `languages.first()` when a pair is not
multi-capable, so e.g. en+ko force-decodes Korean audio as English with no
warning. Fixing that needs a per-meeting language signal — which is what the
reporter actually asked for ("Is there any way I can set the transcription
language on a meeting?"). `sessions.language` already exists and is unused
client-side, and `useRunBatch` already accepts `options.languages`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default STT request shaping for multi-language users on Gladia and Deepgram batch, which can alter transcript quality and provider behavior without a per-meeting language override.
> 
> **Overview**
> Fixes poor batch/live transcription when users configure **multiple spoken languages** (e.g. English + German) by stopping automatic **code-switching** and preferring **language detection** within the candidate set.
> 
> **Gladia** (batch and live) now always sends `code_switching: false` instead of turning it on whenever more than one language is configured. Multiple `languages` are treated as candidates to detect/lock onto, not as a signal to decode the whole audio with a code-switching model.
> 
> **Deepgram batch** reorders multi-language handling: for two or more configured languages it uses `detect_language` (per candidate) before falling back to `language=multi`. Live Deepgram behavior is unchanged (`multi` when the pair is multi-capable).
> 
> Also includes **CI reliability** tweaks: Linux desktop deps rewrite EC2 Ubuntu mirrors to `archive.ubuntu.com` when using `ubuntu.sources`, and `setup-linux-tauri.sh` uses `apt-get` with `Acquire::Retries=5`.
> 
> A new unit test locks the reported **en+de on nova-3** batch URL to `detect_language` and not `multi`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98950792148f0602a8a969c30850c198884d4027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->