### PR TITLE
refactor(settings): align control widths with a shared row primitive

### DIFF
--- a/apps/desktop/src/settings/general/app-settings.tsx
+++ b/apps/desktop/src/settings/general/app-settings.tsx
@@ -1,6 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { platform } from "@tauri-apps/plugin-os";
-import { type ReactNode, useId } from "react";
 
 import {
   Select,
@@ -9,7 +8,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@hypr/ui/components/ui/select";
-import { Switch } from "@hypr/ui/components/ui/switch";
+
+import {
+  SETTING_CONTROL_CLASS,
+  SettingRow,
+  SettingSwitchRow,
+} from "~/settings/setting-row";
 
 interface SettingItem {
   value: boolean;
@@ -63,7 +67,7 @@ export function AppSettingsView({
     <div className="flex flex-col gap-8">
       <section>
         <div className="flex flex-col gap-4">
-          <SettingRow
+          <SettingSwitchRow
             title={<Trans>Start Anarlog at login</Trans>}
             description={
               <Trans>Always ready without manually launching.</Trans>
@@ -71,7 +75,7 @@ export function AppSettingsView({
             checked={autostart.value}
             onChange={autostart.onChange}
           />
-          <SettingRow
+          <SettingSwitchRow
             title={<Trans>Automatically install updates</Trans>}
             description={
               <Trans>
@@ -83,7 +87,7 @@ export function AppSettingsView({
             onChange={automaticUpdates.onChange}
           />
           {isMacos && (
-            <SettingRow
+            <SettingSwitchRow
               title={<Trans>Show app in Dock</Trans>}
               description={
                 <Trans>Show Anarlog in the Dock and app switcher.</Trans>
@@ -92,7 +96,7 @@ export function AppSettingsView({
               onChange={showAppInDock.onChange}
             />
           )}
-          <SettingRow
+          <SettingSwitchRow
             title={<Trans>Show tray icon</Trans>}
             description={
               isMacos ? (
@@ -110,7 +114,7 @@ export function AppSettingsView({
           <Trans>Meetings</Trans>
         </h2>
         <div className="flex flex-col gap-4">
-          <SettingRow
+          <SettingSwitchRow
             title={<Trans>Start when meeting begins</Trans>}
             description={
               <Trans>
@@ -121,7 +125,7 @@ export function AppSettingsView({
             checked={autoStartScheduledMeetings.value}
             onChange={autoStartScheduledMeetings.onChange}
           />
-          <SettingRow
+          <SettingSwitchRow
             title={<Trans>Join scheduled meetings</Trans>}
             description={
               <Trans>
@@ -134,7 +138,7 @@ export function AppSettingsView({
             disabled={!autoStartScheduledMeetings.value}
           />
           {supportsMicDetection && (
-            <SettingRow
+            <SettingSwitchRow
               title={<Trans>Stop when meeting ends</Trans>}
               description={
                 <Trans>
@@ -148,7 +152,7 @@ export function AppSettingsView({
           )}
           {isMacos && (
             <>
-              <SettingRow
+              <SettingSwitchRow
                 title={<Trans>Post recording disclosure in meeting chat</Trans>}
                 description={
                   <Trans>
@@ -161,7 +165,7 @@ export function AppSettingsView({
                 checked={meetingDisclosureAutoPost.value}
                 onChange={meetingDisclosureAutoPost.onChange}
               />
-              <SettingRow
+              <SettingSwitchRow
                 title={<Trans>Capture meeting chat in Memos</Trans>}
                 description={
                   <Trans>
@@ -176,7 +180,7 @@ export function AppSettingsView({
             </>
           )}
           {isMacos && (
-            <SettingRow
+            <SettingSwitchRow
               title={<Trans>Show floating bar</Trans>}
               description={
                 <Trans>
@@ -204,7 +208,7 @@ export function AppSettingsView({
           <Trans>Privacy</Trans>
         </h2>
         <div className="flex flex-col gap-4">
-          <SettingRow
+          <SettingSwitchRow
             title={<Trans>Share usage data</Trans>}
             description={
               <Trans>
@@ -231,8 +235,6 @@ function MicrophoneRow({
   devices: string[];
   onChange: (value: string) => void;
 }) {
-  const titleId = useId();
-  const descriptionId = useId();
   const availableDevices = [...new Set(devices)].sort((a, b) =>
     a.localeCompare(b),
   );
@@ -243,46 +245,39 @@ function MicrophoneRow({
   }
 
   return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="flex-1">
-        <h3 id={titleId} className="mb-1 text-sm font-medium">
-          <Trans>Microphone</Trans>
-        </h3>
-        <p id={descriptionId} className="text-muted-foreground text-xs">
-          <Trans>Use your microphone to capture your voice</Trans>
-        </p>
-      </div>
-      <Select
-        value={value || SYSTEM_DEFAULT_MICROPHONE}
-        onValueChange={(device) =>
-          onChange(device === SYSTEM_DEFAULT_MICROPHONE ? "" : device)
-        }
-      >
-        <SelectTrigger
-          aria-labelledby={titleId}
-          aria-describedby={descriptionId}
-          className="bg-card h-9 w-48 shadow-none focus:ring-0"
+    <SettingRow
+      title={<Trans>Microphone</Trans>}
+      description={<Trans>Use your microphone to capture your voice</Trans>}
+    >
+      {(labelProps) => (
+        <Select
+          value={value || SYSTEM_DEFAULT_MICROPHONE}
+          onValueChange={(device) =>
+            onChange(device === SYSTEM_DEFAULT_MICROPHONE ? "" : device)
+          }
         >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent className="max-h-64">
-          <SelectItem value={SYSTEM_DEFAULT_MICROPHONE}>
-            <Trans>Current default</Trans>
-          </SelectItem>
-          {availableDevices.map((device) => (
-            <SelectItem key={device} value={device}>
-              {device}
-              {selectedDeviceUnavailable && device === value ? (
-                <>
-                  {" "}
-                  <Trans>(Unavailable — using current default)</Trans>
-                </>
-              ) : null}
+          <SelectTrigger {...labelProps} className={SETTING_CONTROL_CLASS}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="max-h-64">
+            <SelectItem value={SYSTEM_DEFAULT_MICROPHONE}>
+              <Trans>Current default</Trans>
             </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+            {availableDevices.map((device) => (
+              <SelectItem key={device} value={device}>
+                {device}
+                {selectedDeviceUnavailable && device === value ? (
+                  <>
+                    {" "}
+                    <Trans>(Unavailable — using current default)</Trans>
+                  </>
+                ) : null}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </SettingRow>
   );
 }
 
@@ -303,8 +298,6 @@ function AudioRetentionRow({
   onChange: (value: string) => void;
 }) {
   const { t } = useLingui();
-  const titleId = useId();
-  const descriptionId = useId();
   const copyByValue = {
     none: t`Don't save`,
     oneDay: t`1 day`,
@@ -315,70 +308,26 @@ function AudioRetentionRow({
   } as const;
 
   return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="flex-1">
-        <h3 id={titleId} className="mb-1 text-sm font-medium">
-          <Trans>Audio file retention</Trans>
-        </h3>
-        <p id={descriptionId} className="text-muted-foreground text-xs">
-          <Trans>How long recorded meeting audio is kept on this device.</Trans>
-        </p>
-      </div>
-      <Select value={value} onValueChange={onChange}>
-        <SelectTrigger
-          aria-labelledby={titleId}
-          aria-describedby={descriptionId}
-          className="bg-card h-9 w-48 shadow-none focus:ring-0"
-        >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {AUDIO_RETENTION_OPTIONS.map((option) => (
-            <SelectItem key={option} value={option}>
-              {copyByValue[option]}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
-
-function SettingRow({
-  title,
-  description,
-  checked,
-  onChange,
-  disabled = false,
-}: {
-  title: ReactNode;
-  description?: ReactNode;
-  checked: boolean;
-  onChange: (checked: boolean) => void;
-  disabled?: boolean;
-}) {
-  const titleId = useId();
-  const descriptionId = useId();
-
-  return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="flex-1">
-        <h3 id={titleId} className="mb-1 text-sm font-medium">
-          {title}
-        </h3>
-        {description && (
-          <p id={descriptionId} className="text-muted-foreground text-xs">
-            {description}
-          </p>
-        )}
-      </div>
-      <Switch
-        checked={checked}
-        onCheckedChange={onChange}
-        disabled={disabled}
-        aria-labelledby={titleId}
-        aria-describedby={description ? descriptionId : undefined}
-      />
-    </div>
+    <SettingRow
+      title={<Trans>Audio file retention</Trans>}
+      description={
+        <Trans>How long recorded meeting audio is kept on this device.</Trans>
+      }
+    >
+      {(labelProps) => (
+        <Select value={value} onValueChange={onChange}>
+          <SelectTrigger {...labelProps} className={SETTING_CONTROL_CLASS}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {AUDIO_RETENTION_OPTIONS.map((option) => (
+              <SelectItem key={option} value={option}>
+                {copyByValue[option]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </SettingRow>
   );
 }

--- a/apps/desktop/src/settings/general/main-language.tsx
+++ b/apps/desktop/src/settings/general/main-language.tsx
@@ -7,6 +7,8 @@ import {
   type SearchableSelectOption,
 } from "./searchable-select";
 
+import { SettingRow } from "~/settings/setting-row";
+
 export function MainLanguageView({
   value,
   onChange,
@@ -44,26 +46,24 @@ export function MainLanguageView({
   );
 
   return (
-    <div className="flex flex-row items-center justify-between">
-      <div>
-        <h3 className="mb-1 text-sm font-medium">
-          <Trans>Main language</Trans>
-        </h3>
-        <p className="text-muted-foreground text-xs">
-          <Trans>
-            Language for summaries, chats, and AI-generated responses
-          </Trans>
-        </p>
-      </div>
-      <SearchableSelect
-        value={normalizedValue}
-        onChange={onChange}
-        options={options}
-        placeholder={t`Select language`}
-        searchPlaceholder={t`Search language...`}
-        emptyMessage={t`No matching languages found`}
-        className="w-48"
-      />
-    </div>
+    <SettingRow
+      title={<Trans>Main language</Trans>}
+      description={
+        <Trans>Language for summaries, chats, and AI-generated responses</Trans>
+      }
+    >
+      {(labelProps) => (
+        <SearchableSelect
+          {...labelProps}
+          value={normalizedValue}
+          onChange={onChange}
+          options={options}
+          placeholder={t`Select language`}
+          searchPlaceholder={t`Search language...`}
+          emptyMessage={t`No matching languages found`}
+          className="w-full"
+        />
+      )}
+    </SettingRow>
   );
 }

--- a/apps/desktop/src/settings/general/notification.tsx
+++ b/apps/desktop/src/settings/general/notification.tsx
@@ -34,7 +34,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@hypr/ui/components/ui/select";
-import { Switch } from "@hypr/ui/components/ui/switch";
 import { cn } from "@hypr/utils";
 
 import {
@@ -44,6 +43,7 @@ import {
 } from "./notification-app-options";
 
 import { useSetSettingValues } from "~/settings/queries";
+import { SettingSwitchRow } from "~/settings/setting-row";
 import { useConfigValues } from "~/shared/config";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
@@ -161,22 +161,14 @@ export function NotificationSettingsView() {
     <div className="flex flex-col gap-6">
       <form.Field name="notification_event">
         {(field) => (
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1">
-              <h3 className="mb-1 text-sm font-medium">
-                <Trans>Event notifications</Trans>
-              </h3>
-              <p className="text-muted-foreground text-xs">
-                <Trans>
-                  Get notified 5 minutes before calendar events start
-                </Trans>
-              </p>
-            </div>
-            <Switch
-              checked={field.state.value}
-              onCheckedChange={field.handleChange}
-            />
-          </div>
+          <SettingSwitchRow
+            title={<Trans>Event notifications</Trans>}
+            description={
+              <Trans>Get notified 5 minutes before calendar events start</Trans>
+            }
+            checked={field.state.value}
+            onChange={field.handleChange}
+          />
         )}
       </form.Field>
 
@@ -184,23 +176,17 @@ export function NotificationSettingsView() {
         <form.Field name="notification_detect">
           {(field) => (
             <div className="flex flex-col gap-4">
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1">
-                  <h3 className="mb-1 text-sm font-medium">
-                    <Trans>Microphone detection</Trans>
-                  </h3>
-                  <p className="text-muted-foreground text-xs">
-                    <Trans>
-                      Automatically detect when a meeting starts based on
-                      microphone activity.
-                    </Trans>
-                  </p>
-                </div>
-                <Switch
-                  checked={field.state.value}
-                  onCheckedChange={field.handleChange}
-                />
-              </div>
+              <SettingSwitchRow
+                title={<Trans>Microphone detection</Trans>}
+                description={
+                  <Trans>
+                    Automatically detect when a meeting starts based on
+                    microphone activity.
+                  </Trans>
+                }
+                checked={field.state.value}
+                onChange={field.handleChange}
+              />
 
               {field.state.value && (
                 <div className={cn(["border-muted ml-3 border-l-2 pt-2 pl-4"])}>
@@ -415,24 +401,18 @@ export function NotificationSettingsView() {
             {(anyNotificationEnabled) => (
               <form.Field name="respect_dnd">
                 {(field) => (
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="flex-1">
-                      <h3 className="mb-1 text-sm font-medium">
-                        <Trans>Respect Do-Not-Disturb mode</Trans>
-                      </h3>
-                      <p className="text-muted-foreground text-xs">
-                        <Trans>
-                          Don't show notifications when Do-Not-Disturb is
-                          enabled on your system
-                        </Trans>
-                      </p>
-                    </div>
-                    <Switch
-                      checked={field.state.value}
-                      onCheckedChange={field.handleChange}
-                      disabled={!anyNotificationEnabled}
-                    />
-                  </div>
+                  <SettingSwitchRow
+                    title={<Trans>Respect Do-Not-Disturb mode</Trans>}
+                    description={
+                      <Trans>
+                        Don't show notifications when Do-Not-Disturb is enabled
+                        on your system
+                      </Trans>
+                    }
+                    checked={field.state.value}
+                    onChange={field.handleChange}
+                    disabled={!anyNotificationEnabled}
+                  />
                 )}
               </form.Field>
             )}

--- a/apps/desktop/src/settings/general/searchable-select.tsx
+++ b/apps/desktop/src/settings/general/searchable-select.tsx
@@ -34,6 +34,8 @@ interface SearchableSelectProps {
   emptyMessage?: string;
   className?: string;
   dropdownClassName?: string;
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
 }
 
 const filterFunction = (value: string, search: string) => {
@@ -54,6 +56,8 @@ export function SearchableSelect({
   emptyMessage,
   className,
   dropdownClassName,
+  "aria-labelledby": ariaLabelledBy,
+  "aria-describedby": ariaDescribedBy,
 }: SearchableSelectProps) {
   const { t } = useLingui();
   const [open, setOpen] = useState(false);
@@ -81,6 +85,8 @@ export function SearchableSelect({
           variant="outline"
           role="combobox"
           aria-expanded={open}
+          aria-labelledby={ariaLabelledBy}
+          aria-describedby={ariaDescribedBy}
           className={cn([
             "bg-card justify-between font-normal shadow-none focus-visible:ring-0",
             "rounded-full px-3",

--- a/apps/desktop/src/settings/general/theme.tsx
+++ b/apps/desktop/src/settings/general/theme.tsx
@@ -10,6 +10,7 @@ import {
 } from "@hypr/ui/components/ui/select";
 
 import { useSetSettingValue } from "~/settings/queries";
+import { SETTING_CONTROL_CLASS, SettingRow } from "~/settings/setting-row";
 import { useConfigValue } from "~/shared/config";
 import { applyThemePreference } from "~/shared/theme/provider";
 import type { ThemePreference } from "~/shared/theme/resolve";
@@ -31,34 +32,33 @@ export function ThemeSelector() {
   );
 
   return (
-    <div className="flex flex-row items-center justify-between">
-      <div>
-        <h3 className="mb-1 text-sm font-medium">
-          <Trans>Appearance</Trans>
-        </h3>
-        <p className="text-muted-foreground text-xs">
-          <Trans>Choose light, dark, or match your system setting.</Trans>
-        </p>
-      </div>
-      <Select
-        value={THEME_OPTIONS.includes(value) ? value : "system"}
-        onValueChange={(next) => {
-          const preference = next as ThemePreference;
-          void applyThemePreference(preference);
-          setTheme(next);
-        }}
-      >
-        <SelectTrigger className="bg-card h-9 w-48 shadow-none focus:ring-0">
-          <SelectValue placeholder={t`Select appearance`} />
-        </SelectTrigger>
-        <SelectContent>
-          {options.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <SettingRow
+      title={<Trans>Appearance</Trans>}
+      description={
+        <Trans>Choose light, dark, or match your system setting.</Trans>
+      }
+    >
+      {(labelProps) => (
+        <Select
+          value={THEME_OPTIONS.includes(value) ? value : "system"}
+          onValueChange={(next) => {
+            const preference = next as ThemePreference;
+            void applyThemePreference(preference);
+            setTheme(next);
+          }}
+        >
+          <SelectTrigger {...labelProps} className={SETTING_CONTROL_CLASS}>
+            <SelectValue placeholder={t`Select appearance`} />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </SettingRow>
   );
 }

--- a/apps/desktop/src/settings/general/timezone.tsx
+++ b/apps/desktop/src/settings/general/timezone.tsx
@@ -7,6 +7,7 @@ import {
 } from "./searchable-select";
 
 import { useSetSettingValue } from "~/settings/queries";
+import { SettingRow } from "~/settings/setting-row";
 import { useConfigValue } from "~/shared/config";
 
 const COMMON_TIMEZONES = [
@@ -52,24 +53,24 @@ export function TimezoneSelector() {
   };
 
   return (
-    <div className="flex flex-row items-center justify-between">
-      <div>
-        <h3 className="mb-1 text-sm font-medium">
-          <Trans>Timezone</Trans>
-        </h3>
-        <p className="text-muted-foreground text-xs">
-          <Trans>Override the timezone used for the sidebar timeline</Trans>
-        </p>
-      </div>
-      <SearchableSelect
-        value={displayValue}
-        onChange={handleChange}
-        options={options}
-        placeholder={t`Select timezone`}
-        searchPlaceholder={t`Search timezone...`}
-        className="w-48"
-        dropdownClassName="w-72"
-      />
-    </div>
+    <SettingRow
+      title={<Trans>Timezone</Trans>}
+      description={
+        <Trans>Override the timezone used for the sidebar timeline</Trans>
+      }
+    >
+      {(labelProps) => (
+        <SearchableSelect
+          {...labelProps}
+          value={displayValue}
+          onChange={handleChange}
+          options={options}
+          placeholder={t`Select timezone`}
+          searchPlaceholder={t`Search timezone...`}
+          className="w-full"
+          dropdownClassName="w-72"
+        />
+      )}
+    </SettingRow>
   );
 }

--- a/apps/desktop/src/settings/general/week-start.tsx
+++ b/apps/desktop/src/settings/general/week-start.tsx
@@ -10,6 +10,7 @@ import {
 } from "@hypr/ui/components/ui/select";
 
 import { useSetSettingValue } from "~/settings/queries";
+import { SETTING_CONTROL_CLASS, SettingRow } from "~/settings/setting-row";
 import { useConfigValue } from "~/shared/config";
 
 function getSystemWeekStart(): "sunday" | "monday" {
@@ -44,27 +45,24 @@ export function WeekStartSelector() {
   };
 
   return (
-    <div className="flex flex-row items-center justify-between">
-      <div>
-        <h3 className="mb-1 text-sm font-medium">
-          <Trans>Week starts on</Trans>
-        </h3>
-        <p className="text-muted-foreground text-xs">
-          <Trans>First day of the week in the calendar view</Trans>
-        </p>
-      </div>
-      <Select value={displayValue} onValueChange={handleChange}>
-        <SelectTrigger className="bg-card h-9 w-48 shadow-none focus:ring-0">
-          <SelectValue placeholder={t`Select day`} />
-        </SelectTrigger>
-        <SelectContent>
-          {options.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <SettingRow
+      title={<Trans>Week starts on</Trans>}
+      description={<Trans>First day of the week in the calendar view</Trans>}
+    >
+      {(labelProps) => (
+        <Select value={displayValue} onValueChange={handleChange}>
+          <SelectTrigger {...labelProps} className={SETTING_CONTROL_CLASS}>
+            <SelectValue placeholder={t`Select day`} />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </SettingRow>
   );
 }

--- a/apps/desktop/src/settings/setting-row.tsx
+++ b/apps/desktop/src/settings/setting-row.tsx
@@ -1,0 +1,70 @@
+import { type ReactNode, useId } from "react";
+
+import { Switch } from "@hypr/ui/components/ui/switch";
+
+export const SETTING_CONTROL_CLASS =
+  "bg-card h-9 w-full shadow-none focus:ring-0";
+
+export function SettingRow({
+  title,
+  description,
+  children,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  children: (labelProps: {
+    "aria-labelledby": string;
+    "aria-describedby": string | undefined;
+  }) => ReactNode;
+}) {
+  const titleId = useId();
+  const descriptionId = useId();
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="min-w-0 flex-1">
+        <h3 id={titleId} className="mb-1 text-sm font-medium">
+          {title}
+        </h3>
+        {description && (
+          <p id={descriptionId} className="text-muted-foreground text-xs">
+            {description}
+          </p>
+        )}
+      </div>
+      <div className="flex w-48 shrink-0 justify-end">
+        {children({
+          "aria-labelledby": titleId,
+          "aria-describedby": description ? descriptionId : undefined,
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function SettingSwitchRow({
+  title,
+  description,
+  checked,
+  onChange,
+  disabled = false,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <SettingRow title={title} description={description}>
+      {(labelProps) => (
+        <Switch
+          {...labelProps}
+          checked={checked}
+          onCheckedChange={onChange}
+          disabled={disabled}
+        />
+      )}
+    </SettingRow>
+  );
+}


### PR DESCRIPTION
Settings rows were hand-rolled per file across two different layouts — some
gave the label column flex-1, some did not — so selects that all declared
w-48 rendered at different widths depending on their description length.

Add SettingRow/SettingSwitchRow with a fixed w-48 control slot, and move the
app, theme, main-language, timezone, week-start, and notification rows onto
it. The row hands controls their aria-labelledby/aria-describedby, so
SearchableSelect now accepts those props.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor across settings screens; behavior and persisted values are unchanged aside from consistent layout and improved labeling.
> 
> **Overview**
> Introduces shared **`SettingRow`** and **`SettingSwitchRow`** in `setting-row.tsx`, with a fixed **`w-48`** control column and **`SETTING_CONTROL_CLASS`** (`w-full` inside that slot) so selects and switches line up regardless of label/description length.
> 
> **App**, **theme**, **main language**, **timezone**, **week start**, and **notification** settings drop hand-rolled row markup and the duplicate switch row that lived in `app-settings.tsx`. Select-based rows use a render prop so controls receive **`aria-labelledby`** / **`aria-describedby`** from generated title/description IDs; **`SearchableSelect`** now accepts and forwards those ARIA props on its combobox trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb9816607b8af77e1173e3aed3157978ecffd48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->