### PR TITLE
Complete the Anarlog 1.4.0 changelog

### DIFF
--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -1,6 +1,6 @@
 ---
-date: "2026-07-27"
-summary: "Anarlog 1.4.0 brings one desktop version to macOS, Windows Preview, and Linux Beta with dedicated downloads for each platform."
+date: "2026-07-28"
+summary: "Anarlog 1.4.0 expands to Windows Preview and Linux Beta, adds automatic updates, and refreshes note editing and desktop reliability."
 ---
 
 <banner title="Windows Preview and Linux Beta" variant="info">
@@ -16,6 +16,33 @@ are still pending.
   or Linux AppImage and Debian packages for x64 and ARM64
 - Receive matching `1.4.0` application and updater versions on every supported
   desktop platform
+- Install the Anarlog CLI and MCP server with Windows and Linux packages
+
+## Notes and editor
+
+- Type more smoothly in long notes while Anarlog keeps continuous edits safely
+  persisted
+- Use refreshed typography, task checkboxes, mention and hashtag styles, and
+  more compact formatting and slash-command menus
+- Add underline formatting and type common arrows, fractions, smart quotes,
+  ellipses, and highlighted text with familiar shortcuts
+
+## Updates and settings
+
+- Let Anarlog download updates in the background and install them the next time
+  the app opens, with a new setting to turn automatic updates off
+- Get a warning before combining Cloud Sync with an Anarlog storage folder
+  managed by iCloud Drive, Dropbox, Google Drive, OneDrive, or another file
+  syncing service
+- Make a newly configured transcription or language-model provider current
+  directly from the confirmation after saving its first API key
+- Restore excluded meeting apps reliably after startup and present cleaner,
+  platform-aware settings and window controls
+
+## Local AI on macOS
+
+- Try Apple Intelligence as an experimental on-device text generation provider
+  on supported macOS 26 devices
 
 ## Windows Preview
 


### PR DESCRIPTION
Add the user-facing desktop improvements omitted from the initial release notes before SHA-locked release QA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no application or runtime behavior changes.
> 
> **Overview**
> Fills out the **1.4.0** changelog with user-facing desktop improvements that were missing from the first draft, ahead of SHA-locked release QA.
> 
> The release **date** moves to `2026-07-28` and the top-level **summary** now highlights automatic updates and note-editing refresh alongside Windows/Linux expansion. New sections cover **CLI/MCP on Windows and Linux**, **notes and editor** (long-note persistence, UI refresh, underline and typography shortcuts), **updates and settings** (background updates, cloud-folder warning, provider selection after API key save, excluded apps and settings UI), and **experimental Apple Intelligence** on supported macOS 26 hardware.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f6b59ee3892648935c5527abd73ce69b574b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->