### PR TITLE
Rename macOS release artifacts for Anarlog

### DIFF
--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -467,7 +467,7 @@ jobs:
           version: ${{ needs.parse.outputs.version }}
           channel: ${{ needs.parse.outputs.channel }}
           platform: dmg-aarch64
-          output: hyprnote-macos-aarch64.dmg
+          output: anarlog-macos-aarch64.dmg
           key: ${{ secrets.CN_API_KEY }}
       - id: download-macos-x86_64
         uses: ./.github/actions/cn_download
@@ -476,7 +476,7 @@ jobs:
           version: ${{ needs.parse.outputs.version }}
           channel: ${{ needs.parse.outputs.channel }}
           platform: dmg-x86_64
-          output: hyprnote-macos-x86_64.dmg
+          output: anarlog-macos-x86_64.dmg
           key: ${{ secrets.CN_API_KEY }}
       - id: download-linux-x86_64-appimage
         uses: ./.github/actions/cn_download
@@ -556,8 +556,8 @@ jobs:
             cp "$source" "$ASSET_DIR/$asset_id"
           }
 
-          copy_asset "$MACOS_ARM64_ID" "hyprnote-macos-aarch64.dmg"
-          copy_asset "$MACOS_X64_ID" "hyprnote-macos-x86_64.dmg"
+          copy_asset "$MACOS_ARM64_ID" "anarlog-macos-aarch64.dmg"
+          copy_asset "$MACOS_X64_ID" "anarlog-macos-x86_64.dmg"
           copy_asset "$LINUX_X64_APPIMAGE_ID" "anarlog-linux-x86_64.AppImage"
           copy_asset "$LINUX_X64_DEB_ID" "anarlog-linux-x86_64.deb"
           copy_asset "$LINUX_ARM64_APPIMAGE_ID" "anarlog-linux-aarch64.AppImage"
@@ -596,8 +596,8 @@ jobs:
         uses: ./.github/actions/generate_checksums
         with:
           files: |
-            hyprnote-macos-aarch64.dmg
-            hyprnote-macos-x86_64.dmg
+            anarlog-macos-aarch64.dmg
+            anarlog-macos-x86_64.dmg
             anarlog-linux-x86_64.AppImage
             anarlog-linux-x86_64.deb
             anarlog-linux-aarch64.AppImage
@@ -612,7 +612,7 @@ jobs:
           name: desktop_v${{ needs.parse.outputs.version }}
           body: ${{ steps.release-body.outputs.value }}
           prerelease: false
-          artifacts: hyprnote-macos-aarch64.dmg,hyprnote-macos-x86_64.dmg,anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb,anarlog-windows-x86_64-setup.exe,${{ steps.checksums.outputs.checksum_files }}
+          artifacts: anarlog-macos-aarch64.dmg,anarlog-macos-x86_64.dmg,anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb,anarlog-windows-x86_64-setup.exe,${{ steps.checksums.outputs.checksum_files }}
           allowUpdates: true
           makeLatest: true
           replacesArtifacts: true


### PR DESCRIPTION
Publish branded macOS DMG filenames and checksums in GitHub releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only filename renames with no change to build, signing, or CrabNebula publish logic; anyone scripting downloads by the old hyprnote macOS names would need to update.
> 
> **Overview**
> Aligns **macOS desktop GitHub release assets** with the existing Anarlog naming used for Linux and Windows.
> 
> In `desktop_publish.yaml`, CrabNebula download outputs for `dmg-aarch64` and `dmg-x86_64` change from `hyprnote-macos-*.dmg` to **`anarlog-macos-aarch64.dmg`** and **`anarlog-macos-x86_64.dmg`**. The same filenames are used when copying assets for provenance verification, in the checksum generation step, and in the `ncipollo/release-action` **artifacts** list so published release files match the new names end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b51a62a1f4b01f67836b360a4d0128decab7b21a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->