### PR TITLE
feat(analytics): attach a rotating session id to every event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18147,6 +18147,7 @@ dependencies = [
  "tauri-specta",
  "thiserror 2.0.18",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -13,6 +13,7 @@ import {
 } from "tinytick/ui-react";
 
 import "@hypr/ui/globals.css";
+import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import {
   getCurrentWebviewWindowLabel,
   init as initWindowsPlugin,
@@ -118,6 +119,7 @@ initWindowsPlugin();
 const isMainWindow = getCurrentWebviewWindowLabel() === "main";
 
 if (isMainWindow) {
+  void analyticsCommands.eventFireAndForget({ event: "app_started" });
   void initializeAppExitFlush().catch((error) => {
     console.error("Failed to initialize the exit flush listener", error);
   });

--- a/apps/desktop/src/shared/app-exit.test.ts
+++ b/apps/desktop/src/shared/app-exit.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  analyticsEvent: vi.fn().mockResolvedValue({ status: "ok", data: null }),
   completeAppExit: vi.fn().mockResolvedValue(undefined),
   flushDatabaseWritesWithin: vi.fn().mockResolvedValue(undefined),
   listener: null as (() => void) | null,
@@ -12,6 +13,10 @@ vi.mock("@tauri-apps/api/event", () => ({
     mocks.listener = listener;
     return vi.fn();
   }),
+}));
+
+vi.mock("@hypr/plugin-analytics", () => ({
+  commands: { event: mocks.analyticsEvent },
 }));
 
 vi.mock("@hypr/plugin-store2", () => ({
@@ -31,6 +36,7 @@ describe("initializeAppExitFlush", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.listener = null;
+    mocks.analyticsEvent.mockResolvedValue({ status: "ok", data: null });
     mocks.completeAppExit.mockResolvedValue(undefined);
     mocks.flushDatabaseWritesWithin.mockResolvedValue(undefined);
     mocks.save.mockResolvedValue(undefined);
@@ -45,6 +51,9 @@ describe("initializeAppExitFlush", () => {
     await vi.waitFor(() =>
       expect(mocks.completeAppExit).toHaveBeenCalledOnce(),
     );
+    expect(mocks.analyticsEvent).toHaveBeenCalledWith({
+      event: "app_exit_requested",
+    });
     expect(mocks.flushDatabaseWritesWithin).toHaveBeenCalledWith(5000);
     expect(mocks.save).toHaveBeenCalledOnce();
     expect(

--- a/apps/desktop/src/shared/app-exit.ts
+++ b/apps/desktop/src/shared/app-exit.ts
@@ -1,5 +1,6 @@
 import { listen } from "@tauri-apps/api/event";
 
+import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import { commands as store2Commands } from "@hypr/plugin-store2";
 
 import { flushDatabaseWritesWithin } from "~/db/write-queue";
@@ -29,6 +30,7 @@ async function flushApplicationStateWithin(timeoutMs: number): Promise<void> {
   try {
     const results = await Promise.race([
       Promise.allSettled([
+        analyticsCommands.event({ event: "app_exit_requested" }),
         flushDatabaseWritesWithin(timeoutMs),
         store2Commands.save(),
       ]),

--- a/plugins/analytics/Cargo.toml
+++ b/plugins/analytics/Cargo.toml
@@ -31,3 +31,4 @@ specta = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 
 thiserror = { workspace = true }
+uuid = { workspace = true, features = ["v7"] }

--- a/plugins/analytics/src/ext.rs
+++ b/plugins/analytics/src/ext.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use tauri_plugin_misc::MiscPluginExt;
 use tauri_plugin_store2::Store2PluginExt;
 
@@ -11,15 +13,16 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
         &self,
         mut payload: hypr_analytics::AnalyticsPayload,
     ) -> Result<(), crate::Error> {
-        Self::enrich_payload(self.manager, &mut payload);
-
         if self.is_disabled().unwrap_or(true) {
             return Ok(());
         }
 
+        Self::enrich_payload(self.manager, &mut payload);
+
         let machine_id = hypr_host::fingerprint();
-        let client = self.manager.state::<crate::ManagedState>();
-        client
+        let state = self.manager.state::<crate::ManagedState>();
+        state
+            .client
             .event(machine_id, payload)
             .await
             .map_err(crate::Error::HyprAnalytics)?;
@@ -28,18 +31,27 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
     }
 
     pub fn event_fire_and_forget(&self, mut payload: hypr_analytics::AnalyticsPayload) {
-        Self::enrich_payload(self.manager, &mut payload);
-
         if self.is_disabled().unwrap_or(true) {
             return;
         }
 
+        Self::enrich_payload(self.manager, &mut payload);
+
         let machine_id = hypr_host::fingerprint();
-        let client = self.manager.state::<crate::ManagedState>().inner().clone();
+        let client = self.manager.state::<crate::ManagedState>().client.clone();
 
         tauri::async_runtime::spawn(async move {
             let _ = client.event(machine_id, payload).await;
         });
+    }
+
+    fn session_id(manager: &M) -> String {
+        let state = manager.state::<crate::ManagedState>();
+        let mut session = state
+            .session
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        session.session_id(SystemTime::now())
     }
 
     fn enrich_payload(manager: &M, payload: &mut hypr_analytics::AnalyticsPayload) {
@@ -47,6 +59,11 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
         let app_identifier = manager.config().identifier.clone();
         let git_hash = manager.misc().get_git_hash();
         let bundle_id = manager.config().identifier.clone();
+        let session_id = Self::session_id(manager);
+
+        payload
+            .props
+            .insert("$session_id".into(), session_id.into());
 
         payload
             .props
@@ -96,8 +113,9 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
         if !self.is_disabled()? {
             let machine_id = hypr_host::fingerprint();
 
-            let client = self.manager.state::<crate::ManagedState>();
-            client
+            let state = self.manager.state::<crate::ManagedState>();
+            state
+                .client
                 .set_properties(machine_id, payload)
                 .await
                 .map_err(crate::Error::HyprAnalytics)?;
@@ -115,8 +133,9 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
             let machine_id = hypr_host::fingerprint();
             let user_id = user_id.into();
 
-            let client = self.manager.state::<crate::ManagedState>();
-            client
+            let state = self.manager.state::<crate::ManagedState>();
+            state
+                .client
                 .identify(user_id, machine_id, payload)
                 .await
                 .map_err(crate::Error::HyprAnalytics)?;

--- a/plugins/analytics/src/lib.rs
+++ b/plugins/analytics/src/lib.rs
@@ -3,15 +3,29 @@ use tauri::Manager;
 mod commands;
 mod error;
 mod ext;
+mod session;
 mod store;
 
 pub use error::{Error, Result};
 pub use ext::*;
+use session::*;
 use store::*;
 
 pub use hypr_analytics::*;
 
-pub type ManagedState = hypr_analytics::AnalyticsClient;
+pub struct ManagedState {
+    client: hypr_analytics::AnalyticsClient,
+    session: std::sync::Mutex<SessionTracker>,
+}
+
+impl ManagedState {
+    fn new(client: hypr_analytics::AnalyticsClient) -> Self {
+        Self {
+            client,
+            session: std::sync::Mutex::new(SessionTracker::new(std::time::SystemTime::now())),
+        }
+    }
+}
 
 const PLUGIN_NAME: &str = "analytics";
 
@@ -58,7 +72,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
                 builder.build()
             };
 
-            assert!(app.manage(client));
+            assert!(app.manage(ManagedState::new(client)));
             Ok(())
         })
         .build()

--- a/plugins/analytics/src/session.rs
+++ b/plugins/analytics/src/session.rs
@@ -1,0 +1,96 @@
+use std::time::{Duration, SystemTime};
+
+const IDLE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const MAX_DURATION: Duration = Duration::from_secs(24 * 60 * 60);
+
+pub(crate) struct SessionTracker {
+    id: uuid::Uuid,
+    started_at: SystemTime,
+    last_activity_at: SystemTime,
+}
+
+impl SessionTracker {
+    pub(crate) fn new(now: SystemTime) -> Self {
+        Self {
+            id: uuid::Uuid::now_v7(),
+            started_at: now,
+            last_activity_at: now,
+        }
+    }
+
+    pub(crate) fn session_id(&mut self, now: SystemTime) -> String {
+        let idle_timed_out = now
+            .duration_since(self.last_activity_at)
+            .is_ok_and(|elapsed| elapsed >= IDLE_TIMEOUT);
+        let max_duration_reached = now
+            .duration_since(self.started_at)
+            .is_ok_and(|elapsed| elapsed >= MAX_DURATION);
+
+        if now < self.started_at
+            || now < self.last_activity_at
+            || idle_timed_out
+            || max_duration_reached
+        {
+            *self = Self::new(now);
+        } else {
+            self.last_activity_at = now;
+        }
+
+        self.id.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_a_uuid_v7_session() {
+        let now = SystemTime::UNIX_EPOCH;
+        let mut tracker = SessionTracker::new(now);
+        let id = uuid::Uuid::parse_str(&tracker.session_id(now)).unwrap();
+
+        assert_eq!(id.get_version_num(), 7);
+    }
+
+    #[test]
+    fn keeps_the_session_while_activity_is_recent() {
+        let now = SystemTime::UNIX_EPOCH;
+        let mut tracker = SessionTracker::new(now);
+        let first = tracker.session_id(now);
+        let next = tracker.session_id(now + IDLE_TIMEOUT - Duration::from_millis(1));
+
+        assert_eq!(next, first);
+    }
+
+    #[test]
+    fn rotates_after_the_idle_timeout() {
+        let now = SystemTime::UNIX_EPOCH;
+        let mut tracker = SessionTracker::new(now);
+        let first = tracker.session_id(now);
+        let next = tracker.session_id(now + IDLE_TIMEOUT);
+
+        assert_ne!(next, first);
+    }
+
+    #[test]
+    fn rotates_at_the_maximum_session_duration() {
+        let now = SystemTime::UNIX_EPOCH;
+        let mut tracker = SessionTracker::new(now);
+        let first = tracker.session_id(now);
+        tracker.last_activity_at = now + MAX_DURATION - Duration::from_millis(1);
+        let next = tracker.session_id(now + MAX_DURATION);
+
+        assert_ne!(next, first);
+    }
+
+    #[test]
+    fn rotates_when_the_wall_clock_moves_backwards() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        let mut tracker = SessionTracker::new(now);
+        let first = tracker.session_id(now);
+        let next = tracker.session_id(SystemTime::UNIX_EPOCH);
+
+        assert_ne!(next, first);
+    }
+}


### PR DESCRIPTION
Events carried no notion of a session, so funnels and retention could not group activity into visits. Add a SessionTracker holding a UUIDv7 that enrich_payload stamps onto every payload as $session_id, matching PostHog session semantics.

The id rotates after 30 minutes of inactivity, at a 24-hour ceiling, and whenever the monotonic clock reads backwards. ManagedState becomes a struct holding the client alongside the tracker behind a Mutex, so call sites now reach the client through state.client.

enrich_payload moved after the is_disabled check in both event paths: a disabled client no longer advances session activity, so rotation reflects only events actually sent. Fires app_started on main-window boot and app_exit_requested from the existing exit-flush race.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6336 
- <kbd>&nbsp;2&nbsp;</kbd> #6335 
- <kbd>&nbsp;1&nbsp;</kbd> #6334 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with bounded session logic and tests; no auth, data, or payment paths touched.
> 
> **Overview**
> Adds **PostHog-style session grouping** by stamping **`$session_id`** on every analytics payload via a new **`SessionTracker`** (UUID v7). Sessions **rotate** after **30 minutes** of inactivity, at a **24-hour** cap, or when the wall clock moves backward; plugin state now holds the client and tracker behind a **`Mutex`**.
> 
> **`enrich_payload`** runs only when analytics is **enabled**, so disabled clients no longer advance session activity. The desktop **main** window fires **`app_started`** at boot; the exit flush path sends **`app_exit_requested`** alongside DB and settings flush.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2083af42fe3d381922e05ed9d0398b77b62b256f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->