### PR TITLE
Track account groups in PostHog

### DIFF
--- a/apps/desktop/src/auth/context.test.tsx
+++ b/apps/desktop/src/auth/context.test.tsx
@@ -16,6 +16,9 @@ import * as authProviderModule from "./context";
 const { AuthProvider } = authProviderModule;
 
 const mocks = vi.hoisted(() => ({
+  analyticsClearGroups: vi.fn(),
+  analyticsEvent: vi.fn(),
+  analyticsIdentify: vi.fn(),
   authCallback: null as
     | ((event: AuthChangeEvent, session: Session | null) => void)
     | null,
@@ -79,8 +82,9 @@ vi.mock("./errors", () => ({
 
 vi.mock("@hypr/plugin-analytics", () => ({
   commands: {
-    event: vi.fn(),
-    identify: vi.fn(),
+    clearGroups: mocks.analyticsClearGroups,
+    event: mocks.analyticsEvent,
+    identify: mocks.analyticsIdentify,
   },
 }));
 
@@ -222,6 +226,9 @@ describe("AuthProvider", () => {
   });
 
   beforeEach(() => {
+    mocks.analyticsClearGroups.mockReset();
+    mocks.analyticsEvent.mockReset();
+    mocks.analyticsIdentify.mockReset();
     mocks.authCallback = null;
     mocks.bindCloudsyncAccountForAuth.mockReset();
     mocks.clearAuthStorage.mockReset();
@@ -259,6 +266,120 @@ describe("AuthProvider", () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  it("associates signed-in analytics with the account group", async () => {
+    const currentSession = makeSession("account-id");
+    currentSession.user.email = "person@example.com";
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", currentSession);
+    });
+
+    await waitFor(() => {
+      expect(mocks.analyticsIdentify).toHaveBeenCalledWith(
+        "account-id",
+        expect.objectContaining({
+          group: {
+            type: "account",
+            key: "account-id",
+            properties: {
+              name: "person@example.com",
+              email: "person@example.com",
+              created_at: "2026-01-01T00:00:00.000Z",
+              plan: "free",
+              trial_end_date: null,
+            },
+          },
+        }),
+      );
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_OUT", null);
+    });
+
+    await waitFor(() => {
+      expect(mocks.analyticsClearGroups).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("clears account groups after an in-flight identify settles", async () => {
+    const identify = deferred();
+    mocks.analyticsIdentify.mockReturnValueOnce(identify.promise);
+    const currentSession = makeSession("account-id");
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", currentSession);
+    });
+
+    await waitFor(() => {
+      expect(mocks.analyticsIdentify).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_OUT", null);
+    });
+
+    await waitFor(() => {
+      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.analyticsClearGroups).not.toHaveBeenCalled();
+
+    identify.resolve();
+
+    await waitFor(() => {
+      expect(mocks.analyticsClearGroups).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("clears account groups after the sign-in event settles", async () => {
+    const signInEvent = deferred();
+    mocks.analyticsEvent.mockReturnValueOnce(signInEvent.promise);
+    const currentSession = makeSession("event-account-id");
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", currentSession);
+    });
+
+    await waitFor(() => {
+      expect(mocks.analyticsEvent).toHaveBeenCalledWith({
+        event: "user_signed_in",
+      });
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_OUT", null);
+    });
+
+    await waitFor(() => {
+      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.analyticsClearGroups).not.toHaveBeenCalled();
+
+    signInEvent.resolve();
+
+    await waitFor(() => {
+      expect(mocks.analyticsClearGroups).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("refreshes cloudsync when the main window regains focus", async () => {
@@ -640,6 +761,7 @@ describe("AuthProvider", () => {
     await waitFor(() => {
       expect(mocks.eventCallbacks.has("hypr:auth-sign-out-result")).toBe(false);
     });
+    expect(mocks.analyticsClearGroups).not.toHaveBeenCalled();
     expect(mocks.clearAuthStorage).not.toHaveBeenCalled();
     expect(screen.getByTestId("session").textContent).toBe("none");
 

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -128,7 +128,7 @@ async function trackAuthEvent(
     if (identifySignature !== trackedIdentifySignature) {
       trackedIdentifySignature = identifySignature;
 
-      void analyticsCommands.identify(session.user.id, {
+      await analyticsCommands.identify(session.user.id, {
         email: session.user.email,
         set: {
           account_created_date: session.user.created_at,
@@ -139,18 +139,24 @@ async function trackAuthEvent(
           plan: billing.plan,
           trial_end_date: billing.trialEndDate,
         },
+        group: {
+          type: "account",
+          key: session.user.id,
+          properties: {
+            name: session.user.email ?? session.user.id,
+            email: session.user.email ?? null,
+            created_at: session.user.created_at,
+            plan: billing.plan,
+            trial_end_date: billing.trialEndDate,
+          },
+        },
       });
     }
 
     if (event === "SIGNED_IN" && trackedSignedInUserId !== session.user.id) {
       trackedSignedInUserId = session.user.id;
-      void analyticsCommands.event({ event: "user_signed_in" });
+      await analyticsCommands.event({ event: "user_signed_in" });
     }
-  }
-
-  if (event === "SIGNED_OUT") {
-    trackedIdentifySignature = null;
-    trackedSignedInUserId = null;
   }
 }
 
@@ -248,8 +254,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const authTransitionEventRef = useRef<AuthChangeEvent | null>(null);
   const nonInitialAuthTransitionRef = useRef(0);
   const authTransitionQueueRef = useRef(Promise.resolve());
+  const authAnalyticsQueueRef = useRef(Promise.resolve());
   const authStorageRevisionRef = useRef(0);
   const coordinatedMainSignOutRef = useRef<Promise<boolean> | null>(null);
+
+  const enqueueAuthAnalytics = useCallback((task: () => Promise<void>) => {
+    const queued = authAnalyticsQueueRef.current.then(task, task);
+    authAnalyticsQueueRef.current = queued.catch(() => {});
+    return queued;
+  }, []);
 
   const coordinateMainSignOut = useCallback(() => {
     const existing = coordinatedMainSignOutRef.current;
@@ -379,12 +392,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       trackedIdentifySignature = null;
       trackedSignedInUserId = null;
+      await enqueueAuthAnalytics(() => analyticsCommands.clearGroups());
       setSession(null);
       if (managesCloudsync) {
         await handleCloudsyncAuthChange("SIGNED_OUT", null);
       }
     },
-    [coordinateMainSignOut, managesCloudsync],
+    [coordinateMainSignOut, enqueueAuthAnalytics, managesCloudsync],
   );
 
   const applyAuthChange = useCallback(
@@ -481,7 +495,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       setSession(nextSession);
-      void trackAuthEvent(event, nextSession);
+      void enqueueAuthAnalytics(() => trackAuthEvent(event, nextSession));
 
       if (!managesCloudsync) {
         return;
@@ -502,7 +516,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       await rejectAccountMismatch();
     },
-    [coordinateMainSignOut, managesCloudsync, rejectAuthChange],
+    [
+      coordinateMainSignOut,
+      enqueueAuthAnalytics,
+      managesCloudsync,
+      rejectAuthChange,
+    ],
   );
 
   const enqueueAuthChange = useCallback(

--- a/apps/stripe/src/analytics.ts
+++ b/apps/stripe/src/analytics.ts
@@ -45,6 +45,9 @@ export async function captureBillingEvent(event: Stripe.Event) {
   posthog.capture({
     distinctId: userId,
     event: payload.event,
+    groups: {
+      account: userId,
+    },
     timestamp: new Date(event.created * 1000),
     properties: {
       ...payload.properties,

--- a/apps/web/src/lib/account-analytics.test.ts
+++ b/apps/web/src/lib/account-analytics.test.ts
@@ -54,11 +54,49 @@ test("sends stable distinct and insert IDs with original timestamps", async () =
   assert.equal(body.historical_migration, true);
   assert.equal(body.batch[0].event, "account_confirmed");
   assert.equal(body.batch[0].properties.distinct_id, "user-historical");
+  assert.deepEqual(body.batch[0].properties.$groups, {
+    account: "user-historical",
+  });
   assert.equal(
     body.batch[0].properties.$insert_id,
     "account_confirmed:user-historical",
   );
   assert.equal(body.batch[0].timestamp, "2025-07-25T03:00:00.000Z");
+});
+
+test("identifies new account groups before capturing signup events", async () => {
+  let request: { init?: RequestInit } | undefined;
+
+  await sendPostHogBatch({
+    events: [events[0]],
+    projectToken: "project-token",
+    host: "https://us.i.posthog.com",
+    fetcher: async (_url, init) => {
+      request = { init };
+      return Response.json({ status: "Ok" });
+    },
+  });
+
+  const body = JSON.parse(String(request?.init?.body));
+  assert.equal(body.batch.length, 2);
+  assert.deepEqual(body.batch[0], {
+    event: "$groupidentify",
+    properties: {
+      distinct_id: "user-live",
+      $group_type: "account",
+      $group_key: "user-live",
+      $group_set: {
+        name: "user-live",
+        email: null,
+        created_at: "2026-07-25T03:00:00.000Z",
+      },
+      $insert_id: "account-group:user-live",
+    },
+    timestamp: "2026-07-25T03:00:00.000Z",
+  });
+  assert.deepEqual(body.batch[1].properties.$groups, {
+    account: "user-live",
+  });
 });
 
 test("surfaces PostHog ingestion errors", async () => {

--- a/apps/web/src/lib/account-analytics.ts
+++ b/apps/web/src/lib/account-analytics.ts
@@ -7,6 +7,8 @@ export type AccountAnalyticsEvent = {
   historical: boolean;
 };
 
+const ACCOUNT_GROUP_TYPE = "account";
+
 export function groupAccountAnalyticsEvents(events: AccountAnalyticsEvent[]) {
   return [
     events.filter((event) => !event.historical),
@@ -37,15 +39,55 @@ export async function sendPostHogBatch({
     body: JSON.stringify({
       api_key: projectToken,
       historical_migration: events.every((event) => event.historical),
-      batch: events.map((event) => ({
-        event: event.event_name,
-        properties: {
-          ...event.properties,
-          distinct_id: event.user_id,
-          $insert_id: `${event.event_name}:${event.user_id}`,
-        },
-        timestamp: event.occurred_at,
-      })),
+      batch: events.flatMap((event) => {
+        const capturedEvent = {
+          event: event.event_name,
+          properties: {
+            ...event.properties,
+            distinct_id: event.user_id,
+            $groups: {
+              [ACCOUNT_GROUP_TYPE]: event.user_id,
+            },
+            $insert_id: `${event.event_name}:${event.user_id}`,
+          },
+          timestamp: event.occurred_at,
+        };
+
+        if (event.event_name !== "account_created") {
+          return [capturedEvent];
+        }
+
+        const setProperties =
+          event.properties["$set"] &&
+          typeof event.properties["$set"] === "object" &&
+          !Array.isArray(event.properties["$set"])
+            ? (event.properties["$set"] as Record<string, unknown>)
+            : {};
+        const email =
+          typeof setProperties["email"] === "string"
+            ? setProperties["email"]
+            : null;
+
+        return [
+          {
+            event: "$groupidentify",
+            properties: {
+              distinct_id: event.user_id,
+              $group_type: ACCOUNT_GROUP_TYPE,
+              $group_key: event.user_id,
+              $group_set: {
+                name: email ?? event.user_id,
+                email,
+                created_at:
+                  setProperties["account_created_at"] ?? event.occurred_at,
+              },
+              $insert_id: `account-group:${event.user_id}`,
+            },
+            timestamp: event.occurred_at,
+          },
+          capturedEvent,
+        ];
+      }),
     }),
   });
 

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -121,6 +121,11 @@ impl AnalyticsClient {
             for (key, value) in &payload.props {
                 let _ = event.insert_prop(key, value);
             }
+            if let Some(groups) = &payload.groups {
+                for (group_type, group_key) in groups {
+                    event.add_group(group_type, group_key);
+                }
+            }
             state.client.capture(event).await?;
         } else {
             tracing::info!("event: {:?}", payload);
@@ -252,6 +257,9 @@ impl AnalyticsClient {
             let state = lazy.get().await;
             let mut event = Event::new("$identify", &user_id);
             let _ = event.insert_prop("$anon_distinct_id", &anon_distinct_id);
+            if let Some(group) = &payload.group {
+                event.add_group(&group.r#type, &group.key);
+            }
 
             let mut set_props = payload.set.clone();
             if let Some(ref email) = payload.email {
@@ -264,6 +272,14 @@ impl AnalyticsClient {
                 let _ = event.insert_prop("$set_once", &payload.set_once);
             }
             state.client.capture(event).await?;
+
+            if let Some(group) = payload.group {
+                let mut event = Event::new("$groupidentify", &user_id);
+                let _ = event.insert_prop("$group_type", &group.r#type);
+                let _ = event.insert_prop("$group_key", &group.key);
+                let _ = event.insert_prop("$group_set", &group.properties);
+                state.client.capture(event).await?;
+            }
         } else {
             tracing::info!(
                 "identify: user_id={}, anon_distinct_id={}, payload={:?}",
@@ -288,11 +304,21 @@ pub trait ToAnalyticsPayload {
 #[derive(Debug, serde::Serialize, serde::Deserialize, specta::Type)]
 pub struct AnalyticsPayload {
     pub event: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub groups: Option<HashMap<String, String>>,
     #[serde(flatten)]
     pub props: HashMap<String, serde_json::Value>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, specta::Type)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct AnalyticsGroup {
+    pub r#type: String,
+    pub key: String,
+    #[serde(default)]
+    pub properties: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
 pub struct PropertiesPayload {
     #[serde(default)]
     pub set: HashMap<String, serde_json::Value>,
@@ -302,6 +328,8 @@ pub struct PropertiesPayload {
     pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<AnalyticsGroup>,
 }
 
 #[derive(Default)]
@@ -333,6 +361,7 @@ impl PropertiesPayloadBuilder {
             set_once: self.set_once,
             email: None,
             user_id: None,
+            group: None,
         }
     }
 }
@@ -340,6 +369,7 @@ impl PropertiesPayloadBuilder {
 #[derive(Clone)]
 pub struct AnalyticsPayloadBuilder {
     event: Option<String>,
+    groups: HashMap<String, String>,
     props: HashMap<String, serde_json::Value>,
 }
 
@@ -347,12 +377,18 @@ impl AnalyticsPayload {
     pub fn builder(event: impl Into<String>) -> AnalyticsPayloadBuilder {
         AnalyticsPayloadBuilder {
             event: Some(event.into()),
+            groups: HashMap::new(),
             props: HashMap::new(),
         }
     }
 }
 
 impl AnalyticsPayloadBuilder {
+    pub fn group(mut self, group_type: impl Into<String>, group_key: impl Into<String>) -> Self {
+        self.groups.insert(group_type.into(), group_key.into());
+        self
+    }
+
     pub fn with(mut self, key: impl Into<String>, value: impl Into<serde_json::Value>) -> Self {
         self.props.insert(key.into(), value.into());
         self
@@ -365,6 +401,7 @@ impl AnalyticsPayloadBuilder {
 
         AnalyticsPayload {
             event: self.event.unwrap(),
+            groups: (!self.groups.is_empty()).then_some(self.groups),
             props: self.props,
         }
     }
@@ -373,6 +410,18 @@ impl AnalyticsPayloadBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn analytics_payload_builder_attaches_groups() {
+        let payload = AnalyticsPayload::builder("test_event")
+            .group("account", "account_123")
+            .build();
+
+        assert_eq!(
+            payload.groups.unwrap().get("account"),
+            Some(&"account_123".to_string())
+        );
+    }
 
     #[ignore]
     #[tokio::test]

--- a/crates/api-subscription/src/routes/billing.rs
+++ b/crates/api-subscription/src/routes/billing.rs
@@ -211,6 +211,10 @@ where
     if let Some(analytics) = analytics {
         let mut payload = outcome.to_analytics_payload();
         payload.props.insert("source".to_string(), source.into());
+        payload
+            .groups
+            .get_or_insert_default()
+            .insert("account".to_string(), user_id.to_string());
         if distinct_id != user_id {
             payload.props.insert("user_id".to_string(), user_id.into());
         }

--- a/crates/llm-proxy/src/analytics.rs
+++ b/crates/llm-proxy/src/analytics.rs
@@ -45,7 +45,9 @@ impl AnalyticsReporter for AnalyticsClient {
             };
 
             let payload = if let Some(user_id) = &event.user_id {
-                payload.with("user_id", user_id.clone())
+                payload
+                    .group("account", user_id.clone())
+                    .with("user_id", user_id.clone())
             } else {
                 payload
             };

--- a/crates/transcribe-proxy/src/analytics.rs
+++ b/crates/transcribe-proxy/src/analytics.rs
@@ -28,7 +28,9 @@ impl SttAnalyticsReporter for AnalyticsClient {
                 .with("$stt_duration", event.duration.as_secs_f64());
 
             let payload = if let Some(user_id) = &event.user_id {
-                payload.with("user_id", user_id.clone())
+                payload
+                    .group("account", user_id.clone())
+                    .with("user_id", user_id.clone())
             } else {
                 payload
             };

--- a/plugins/analytics/build.rs
+++ b/plugins/analytics/build.rs
@@ -5,6 +5,7 @@ const COMMANDS: &[&str] = &[
     "set_disabled",
     "is_disabled",
     "identify",
+    "clear_groups",
 ];
 
 fn main() {

--- a/plugins/analytics/js/bindings.gen.ts
+++ b/plugins/analytics/js/bindings.gen.ts
@@ -73,6 +73,9 @@ export const commands = {
       else return { status: "error", error: e as any };
     }
   },
+  async clearGroups(): Promise<void> {
+    await TAURI_INVOKE("plugin:analytics|clear_groups");
+  },
 };
 
 /** user-defined events **/
@@ -81,6 +84,11 @@ export const commands = {
 
 /** user-defined types **/
 
+export type AnalyticsGroup = {
+  type: string;
+  key: string;
+  properties?: Partial<{ [key in string]: JsonValue }>;
+};
 export type AnalyticsPayload = Partial<{
   [key in string]:
     | null
@@ -89,7 +97,7 @@ export type AnalyticsPayload = Partial<{
     | string
     | JsonValue[]
     | Partial<{ [key in string]: JsonValue }>;
-}> & { event: string };
+}> & { event: string; groups?: Partial<{ [key in string]: string }> | null };
 export type JsonValue =
   | null
   | boolean
@@ -102,6 +110,7 @@ export type PropertiesPayload = {
   set_once?: Partial<{ [key in string]: JsonValue }>;
   email?: string | null;
   user_id?: string | null;
+  group?: AnalyticsGroup | null;
 };
 
 /** tauri-specta globals **/

--- a/plugins/analytics/permissions/autogenerated/commands/clear_groups.toml
+++ b/plugins/analytics/permissions/autogenerated/commands/clear_groups.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-clear-groups"
+description = "Enables the clear_groups command without any pre-configured scope."
+commands.allow = ["clear_groups"]
+
+[[permission]]
+identifier = "deny-clear-groups"
+description = "Denies the clear_groups command without any pre-configured scope."
+commands.deny = ["clear_groups"]

--- a/plugins/analytics/permissions/autogenerated/reference.md
+++ b/plugins/analytics/permissions/autogenerated/reference.md
@@ -10,6 +10,7 @@ Default permissions for the plugin
 - `allow-set-disabled`
 - `allow-is-disabled`
 - `allow-identify`
+- `allow-clear-groups`
 
 ## Permission Table
 
@@ -19,6 +20,32 @@ Default permissions for the plugin
 <th>Description</th>
 </tr>
 
+
+<tr>
+<td>
+
+`analytics:allow-clear-groups`
+
+</td>
+<td>
+
+Enables the clear_groups command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`analytics:deny-clear-groups`
+
+</td>
+<td>
+
+Denies the clear_groups command without any pre-configured scope.
+
+</td>
+</tr>
 
 <tr>
 <td>

--- a/plugins/analytics/permissions/default.toml
+++ b/plugins/analytics/permissions/default.toml
@@ -1,3 +1,3 @@
 [default]
 description = "Default permissions for the plugin"
-permissions = ["allow-event-fire-and-forget", "allow-event", "allow-set-properties", "allow-set-disabled", "allow-is-disabled", "allow-identify"]
+permissions = ["allow-event-fire-and-forget", "allow-event", "allow-set-properties", "allow-set-disabled", "allow-is-disabled", "allow-identify", "allow-clear-groups"]

--- a/plugins/analytics/permissions/schemas/schema.json
+++ b/plugins/analytics/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the clear_groups command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-clear-groups",
+          "markdownDescription": "Enables the clear_groups command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the clear_groups command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-clear-groups",
+          "markdownDescription": "Denies the clear_groups command without any pre-configured scope."
+        },
+        {
           "description": "Enables the event command without any pre-configured scope.",
           "type": "string",
           "const": "allow-event",
@@ -367,10 +379,10 @@
           "markdownDescription": "Denies the set_properties command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-event-fire-and-forget`\n- `allow-event`\n- `allow-set-properties`\n- `allow-set-disabled`\n- `allow-is-disabled`\n- `allow-identify`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-event-fire-and-forget`\n- `allow-event`\n- `allow-set-properties`\n- `allow-set-disabled`\n- `allow-is-disabled`\n- `allow-identify`\n- `allow-clear-groups`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-event-fire-and-forget`\n- `allow-event`\n- `allow-set-properties`\n- `allow-set-disabled`\n- `allow-is-disabled`\n- `allow-identify`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-event-fire-and-forget`\n- `allow-event`\n- `allow-set-properties`\n- `allow-set-disabled`\n- `allow-is-disabled`\n- `allow-identify`\n- `allow-clear-groups`"
         }
       ]
     }

--- a/plugins/analytics/src/commands.rs
+++ b/plugins/analytics/src/commands.rs
@@ -64,3 +64,9 @@ pub(crate) async fn identify<R: tauri::Runtime>(
         .await
         .map_err(|e| e.to_string())
 }
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) fn clear_groups<R: tauri::Runtime>(app: tauri::AppHandle<R>) {
+    app.analytics().clear_groups();
+}

--- a/plugins/analytics/src/ext.rs
+++ b/plugins/analytics/src/ext.rs
@@ -60,10 +60,26 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
         let git_hash = manager.misc().get_git_hash();
         let bundle_id = manager.config().identifier.clone();
         let session_id = Self::session_id(manager);
+        let groups = {
+            let state = manager.state::<crate::ManagedState>();
+            state
+                .groups
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        };
 
         payload
             .props
             .insert("$session_id".into(), session_id.into());
+
+        for (group_type, group_key) in groups {
+            payload
+                .groups
+                .get_or_insert_default()
+                .entry(group_type)
+                .or_insert(group_key);
+        }
 
         payload
             .props
@@ -134,6 +150,13 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
             let user_id = user_id.into();
 
             let state = self.manager.state::<crate::ManagedState>();
+            if let Some(group) = &payload.group {
+                state
+                    .groups
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .insert(group.r#type.clone(), group.key.clone());
+            }
             state
                 .client
                 .identify(user_id, machine_id, payload)
@@ -142,6 +165,15 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
         }
 
         Ok(())
+    }
+
+    pub fn clear_groups(&self) {
+        self.manager
+            .state::<crate::ManagedState>()
+            .groups
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
     }
 }
 

--- a/plugins/analytics/src/lib.rs
+++ b/plugins/analytics/src/lib.rs
@@ -15,6 +15,7 @@ pub use hypr_analytics::*;
 
 pub struct ManagedState {
     client: hypr_analytics::AnalyticsClient,
+    groups: std::sync::Mutex<std::collections::HashMap<String, String>>,
     session: std::sync::Mutex<SessionTracker>,
 }
 
@@ -22,6 +23,7 @@ impl ManagedState {
     fn new(client: hypr_analytics::AnalyticsClient) -> Self {
         Self {
             client,
+            groups: std::sync::Mutex::new(std::collections::HashMap::new()),
             session: std::sync::Mutex::new(SessionTracker::new(std::time::SystemTime::now())),
         }
     }
@@ -39,6 +41,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::set_disabled::<tauri::Wry>,
             commands::is_disabled::<tauri::Wry>,
             commands::identify::<tauri::Wry>,
+            commands::clear_groups::<tauri::Wry>,
         ])
         .error_handling(tauri_specta::ErrorHandlingMode::Result)
 }


### PR DESCRIPTION
Associate canonical customer events with stable account groups across desktop, signup, billing, AI, and transcription analytics.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6336 
- <kbd>&nbsp;2&nbsp;</kbd> #6335 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6334 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth sign-out analytics ordering and broad analytics ingestion paths; mistakes could mis-attribute events to accounts or leak group context after logout, but changes are mostly additive with new tests.
> 
> **Overview**
> Adds **PostHog `account` group** association end-to-end so customer-facing events roll up to a stable account key, not just person/device distinct IDs.
> 
> **Shared analytics (`hypr-analytics` + Tauri plugin):** Events can carry `groups`; `identify` accepts an optional group and emits `$groupidentify`. The desktop plugin keeps active groups in memory, merges them into outgoing events, adds **`$session_id`** via a UUID v7 session tracker (idle/max duration rotation), and exposes **`clearGroups`**. Auth analytics run through a **serialized queue** so sign-out waits for in-flight identify/`user_signed_in` before clearing groups.
> 
> **Desktop auth:** On sign-in, identify includes account group properties (email, plan, trial). Sign-out/reject paths call `clearGroups` after queued analytics finish.
> 
> **Other surfaces:** Web signup batches attach `$groups` and prepend `$groupidentify` for `account_created`; Stripe billing captures use `groups.account`; subscription trial, LLM, and STT proxy events attach the account group when a user id is present. Desktop also fires **`app_started`** and **`app_exit_requested`** lifecycle events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff61b18ebbbe1ad67c36c208237c0ca21868ed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->