### PR TITLE
Track the full customer lifecycle

### DIFF
--- a/apps/desktop/src/onboarding/meeting-note-analytics.test.ts
+++ b/apps/desktop/src/onboarding/meeting-note-analytics.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  eventFireAndForget: vi.fn().mockResolvedValue(undefined),
+  loadSessionContentSnapshot: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-analytics", () => ({
+  commands: {
+    eventFireAndForget: mocks.eventFireAndForget,
+  },
+}));
+
+vi.mock("~/session/content-queries", () => ({
+  loadSessionContentSnapshot: mocks.loadSessionContentSnapshot,
+}));
+
+import {
+  getMeetingNoteCompletionEvent,
+  trackMeetingNoteCompletion,
+} from "./meeting-note-analytics";
+
+describe("meeting note analytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("classifies the onboarding demo as the welcome note", () => {
+    expect(
+      getMeetingNoteCompletionEvent({
+        tracking_id: "anarlog-onboarding-demo-v1",
+      }),
+    ).toBe("welcome_meeting_note_completed");
+  });
+
+  it("classifies other sessions as real meeting notes", () => {
+    expect(getMeetingNoteCompletionEvent(null)).toBe("meeting_note_completed");
+    expect(
+      getMeetingNoteCompletionEvent({ tracking_id: "calendar-event" }),
+    ).toBe("meeting_note_completed");
+  });
+
+  it("tracks completion after loading the persisted session", async () => {
+    mocks.loadSessionContentSnapshot.mockResolvedValue({
+      event: { tracking_id: "anarlog-onboarding-demo-v1" },
+    });
+
+    await trackMeetingNoteCompletion("session-1");
+
+    expect(mocks.eventFireAndForget).toHaveBeenCalledWith({
+      event: "welcome_meeting_note_completed",
+    });
+  });
+
+  it("does not track a deleted session", async () => {
+    mocks.loadSessionContentSnapshot.mockResolvedValue(null);
+
+    await trackMeetingNoteCompletion("session-1");
+
+    expect(mocks.eventFireAndForget).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/onboarding/meeting-note-analytics.ts
+++ b/apps/desktop/src/onboarding/meeting-note-analytics.ts
@@ -1,0 +1,29 @@
+import { commands as analyticsCommands } from "@hypr/plugin-analytics";
+
+import { WELCOME_NOTE_TRACKING_ID } from "./welcome-note.constants";
+
+import { loadSessionContentSnapshot } from "~/session/content-queries";
+
+export function getMeetingNoteCompletionEvent(event: unknown) {
+  if (
+    event &&
+    typeof event === "object" &&
+    "tracking_id" in event &&
+    event.tracking_id === WELCOME_NOTE_TRACKING_ID
+  ) {
+    return "welcome_meeting_note_completed";
+  }
+
+  return "meeting_note_completed";
+}
+
+export async function trackMeetingNoteCompletion(sessionId: string) {
+  const snapshot = await loadSessionContentSnapshot(sessionId);
+  if (!snapshot) {
+    return;
+  }
+
+  await analyticsCommands.eventFireAndForget({
+    event: getMeetingNoteCompletionEvent(snapshot.event),
+  });
+}

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { json2md } from "@hypr/editor/markdown";
 
 import type { TaskConfig } from ".";
-import { enhanceSuccess } from "./enhance-success";
+import { enhanceSuccess, runEnhanceSuccess } from "./enhance-success";
 
 import { MIN_SUMMARY_CHARACTERS } from "~/services/enhancer/summary-length";
 import { useLiveTitle } from "~/store/zustand/live-title";
@@ -170,6 +170,33 @@ describe("enhanceSuccess.onSuccess", () => {
       "enhance",
       cloudsyncLeaseKey,
     );
+  });
+
+  it("reports persistence only after generated content is saved", async () => {
+    const onPersisted = vi.fn();
+
+    await runEnhanceSuccess({
+      ...createParams(),
+      onPersisted,
+    });
+
+    expect(mocks.persistGeneratedEnhancedNote).toHaveBeenCalledOnce();
+    expect(onPersisted).toHaveBeenCalledOnce();
+    expect(mocks.persistGeneratedEnhancedNote).toHaveBeenCalledBefore(
+      onPersisted,
+    );
+  });
+
+  it("does not report persistence for empty generated content", async () => {
+    const onPersisted = vi.fn();
+
+    await runEnhanceSuccess({
+      ...createParams({ text: "" }),
+      onPersisted,
+    });
+
+    expect(mocks.persistGeneratedEnhancedNote).not.toHaveBeenCalled();
+    expect(onPersisted).not.toHaveBeenCalled();
   });
 
   it("uses the durable auto-enhance baseline instead of a later user edit", async () => {
@@ -446,16 +473,19 @@ describe("enhanceSuccess.onSuccess", () => {
 
   it("does not save after cancellation during title generation", async () => {
     const abortController = new AbortController();
+    const onPersisted = vi.fn();
     const startTask = vi.fn().mockImplementation(async (_taskId, config) => {
       abortController.abort();
       config.onComplete?.("Generated title");
     });
 
-    await enhanceSuccess.onSuccess?.(
-      createParams({ signal: abortController.signal, startTask }),
-    );
+    await runEnhanceSuccess({
+      ...createParams({ signal: abortController.signal, startTask }),
+      onPersisted,
+    });
 
     expect(mocks.persistGeneratedEnhancedNote).not.toHaveBeenCalled();
+    expect(onPersisted).not.toHaveBeenCalled();
   });
 
   it("rejects persistence when the target summary disappeared", async () => {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
@@ -24,7 +24,13 @@ import { ensureMarkdownFirstLineTitle } from "~/session/title-content";
 import { id } from "~/shared/utils";
 import { hasLiveSessionTitleDraft } from "~/store/zustand/live-title";
 
-const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = async ({
+type EnhanceSuccessParams = Parameters<
+  NonNullable<TaskConfig<"enhance">["onSuccess"]>
+>[0] & {
+  onPersisted?: () => void;
+};
+
+export const runEnhanceSuccess = async ({
   text,
   taskId,
   args,
@@ -33,7 +39,8 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = async ({
   startTask,
   getTaskState,
   signal,
-}) => {
+  onPersisted,
+}: EnhanceSuccessParams) => {
   const lengthPolicy = getSummaryLengthPolicy(transformedArgs.transcripts);
   const constrainedText = constrainSummaryLength(text, lengthPolicy);
   if (!constrainedText) {
@@ -149,7 +156,7 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = async ({
         ...(args.pendingAutoEnhance
           ? { pendingAutoEnhance: args.pendingAutoEnhance }
           : {}),
-      });
+      }).then(onPersisted);
     });
 
     if (shouldPersistGeneratedTitle && !signal.aborted) {
@@ -164,5 +171,5 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = async ({
 };
 
 export const enhanceSuccess: Pick<TaskConfig<"enhance">, "onSuccess"> = {
-  onSuccess,
+  onSuccess: runEnhanceSuccess,
 };

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/index.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/index.test.ts
@@ -1,0 +1,80 @@
+import type { LanguageModel } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TASK_CONFIGS, type TaskConfig } from ".";
+
+const mocks = vi.hoisted(() => ({
+  runEnhanceSuccess: vi.fn(),
+  trackMeetingNoteCompletion: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./enhance-success", () => ({
+  enhanceSuccess: {},
+  runEnhanceSuccess: mocks.runEnhanceSuccess,
+}));
+
+vi.mock("./enhance-transform", () => ({
+  enhanceTransform: {},
+}));
+
+vi.mock("./enhance-workflow", () => ({
+  enhanceWorkflow: {},
+}));
+
+vi.mock("./title-success", () => ({
+  titleSuccess: {},
+}));
+
+vi.mock("./title-transform", () => ({
+  titleTransform: {},
+}));
+
+vi.mock("./title-workflow", () => ({
+  titleWorkflow: {},
+}));
+
+vi.mock("~/onboarding/meeting-note-analytics", () => ({
+  trackMeetingNoteCompletion: mocks.trackMeetingNoteCompletion,
+}));
+
+type EnhanceSuccessParams = Parameters<
+  NonNullable<TaskConfig<"enhance">["onSuccess"]>
+>[0];
+
+function createParams(): EnhanceSuccessParams {
+  return {
+    taskId: "note-1-enhance",
+    text: "# Summary",
+    model: {} as LanguageModel,
+    args: {
+      sessionId: "session-1",
+      enhancedNoteId: "note-1",
+      templateId: undefined,
+    },
+    transformedArgs: {} as EnhanceSuccessParams["transformedArgs"],
+    signal: new AbortController().signal,
+    startTask: vi.fn().mockResolvedValue(undefined),
+    getTaskState: vi.fn().mockReturnValue(undefined),
+  };
+}
+
+describe("enhance task config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.trackMeetingNoteCompletion.mockResolvedValue(undefined);
+  });
+
+  it("tracks persistence before later enhance-success work fails", async () => {
+    const error = new Error("title write failed");
+    mocks.runEnhanceSuccess.mockImplementationOnce(async ({ onPersisted }) => {
+      onPersisted();
+      throw error;
+    });
+
+    await expect(
+      TASK_CONFIGS.enhance.onSuccess?.(createParams()),
+    ).rejects.toThrow(error);
+
+    expect(mocks.trackMeetingNoteCompletion).toHaveBeenCalledWith("session-1");
+  });
+});

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/index.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/index.ts
@@ -8,13 +8,14 @@ import type {
 } from "@hypr/plugin-template";
 
 import type { EnhanceImageContext } from "./enhance-images";
-import { enhanceSuccess } from "./enhance-success";
+import { enhanceSuccess, runEnhanceSuccess } from "./enhance-success";
 import { enhanceTransform } from "./enhance-transform";
 import { enhanceWorkflow } from "./enhance-workflow";
 import { titleSuccess } from "./title-success";
 import { titleTransform } from "./title-transform";
 import { titleWorkflow } from "./title-workflow";
 
+import { trackMeetingNoteCompletion } from "~/onboarding/meeting-note-analytics";
 import type { SettingValues } from "~/settings/schema";
 import { StreamTransform } from "~/store/zustand/ai-task/shared/transform_infra";
 import type { TaskState, TaskStepInfo } from "~/store/zustand/ai-task/tasks";
@@ -94,11 +95,28 @@ type TaskConfigMap = {
   [K in TaskType]: TaskConfig<K>;
 };
 
+const onEnhanceSuccess: NonNullable<
+  TaskConfig<"enhance">["onSuccess"]
+> = async (params) => {
+  await runEnhanceSuccess({
+    ...params,
+    onPersisted: () => {
+      void trackMeetingNoteCompletion(params.args.sessionId).catch((error) => {
+        console.error(
+          "[analytics] failed to record meeting note completion",
+          error,
+        );
+      });
+    },
+  });
+};
+
 export const TASK_CONFIGS: TaskConfigMap = {
   enhance: {
     ...enhanceWorkflow,
     ...enhanceTransform,
     ...enhanceSuccess,
+    onSuccess: onEnhanceSuccess,
   },
   title: {
     ...titleWorkflow,

--- a/apps/stripe/src/analytics.ts
+++ b/apps/stripe/src/analytics.ts
@@ -58,3 +58,41 @@ export async function captureBillingEvent(event: Stripe.Event) {
   });
   await posthog.flush();
 }
+
+export async function captureTrialEndingEmailSent({
+  eventCreated,
+  eventId,
+  transactionalId,
+  trialEnd,
+  userId,
+}: {
+  eventCreated: number;
+  eventId: string;
+  transactionalId: string;
+  trialEnd: number;
+  userId: string | null;
+}) {
+  if (!posthog || !userId) {
+    return;
+  }
+
+  posthog.capture({
+    distinctId: userId,
+    event: "trial_ending_email_sent",
+    groups: {
+      account: userId,
+    },
+    timestamp: new Date(eventCreated * 1000),
+    properties: {
+      $insert_id: `stripe-event:${eventId}:trial-ending-email-sent`,
+      source: "loops",
+      transactional_id: transactionalId,
+      trial_end: trialEnd,
+      days_until_trial_end: Math.max(
+        0,
+        Math.ceil((trialEnd - eventCreated) / 86_400),
+      ),
+    },
+  });
+  await posthog.flush();
+}

--- a/apps/stripe/src/routes/webhook.ts
+++ b/apps/stripe/src/routes/webhook.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/bun";
 import { Hono } from "hono";
 
-import { captureBillingEvent } from "../analytics";
+import { captureBillingEvent, captureTrialEndingEmailSent } from "../analytics";
 import { syncBillingBridge } from "../billing-bridge";
 import { env } from "../env";
 import type { AppBindings } from "../hono-bindings";
@@ -75,7 +75,24 @@ webhook.post("/stripe", async (c) => {
   }
 
   try {
-    await sendTrialEndingEmail(stripeEvent);
+    const receipt = await sendTrialEndingEmail(stripeEvent);
+    if (receipt) {
+      try {
+        await captureTrialEndingEmailSent({
+          eventCreated: stripeEvent.created,
+          eventId: stripeEvent.id,
+          ...receipt,
+        });
+      } catch (error) {
+        Sentry.captureException(error, {
+          tags: {
+            webhook: "stripe",
+            step: "posthog_loops",
+            event_type: stripeEvent.type,
+          },
+        });
+      }
+    }
   } catch (error) {
     Sentry.captureException(error, {
       tags: {

--- a/apps/stripe/src/trial-emails.ts
+++ b/apps/stripe/src/trial-emails.ts
@@ -1,29 +1,39 @@
 import Stripe from "stripe";
 
-import { getCustomerId, getStripeCustomer } from "./billing-bridge";
+import {
+  getCustomerId,
+  getStripeCustomer,
+  getUserIdFromCustomer,
+} from "./billing-bridge";
 import { env } from "./env";
 import { buildTrialEndingEmail } from "./trial-email-payload";
 
 const LOOPS_TRANSACTIONAL_URL = "https://app.loops.so/api/v1/transactional";
 
+export type TrialEndingEmailReceipt = {
+  transactionalId: string;
+  trialEnd: number;
+  userId: string | null;
+};
+
 export async function sendTrialEndingEmail(event: Stripe.Event) {
   if (event.type !== "customer.subscription.trial_will_end") {
-    return;
+    return null;
   }
 
   if (!env.LOOPS_API_KEY || !env.LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID) {
-    return;
+    return null;
   }
 
   const subscription = event.data.object as Stripe.Subscription;
   const customerId = getCustomerId(subscription);
   if (!customerId) {
-    return;
+    return null;
   }
 
   const customer = await getStripeCustomer(customerId);
   if (!customer) {
-    return;
+    return null;
   }
 
   const payload = buildTrialEndingEmail({
@@ -32,7 +42,7 @@ export async function sendTrialEndingEmail(event: Stripe.Event) {
     now: Date.now(),
   });
   if (!payload) {
-    return;
+    return null;
   }
 
   const response = await fetch(LOOPS_TRANSACTIONAL_URL, {
@@ -56,4 +66,10 @@ export async function sendTrialEndingEmail(event: Stripe.Event) {
       `Loops transactional send failed (${response.status}): ${await response.text()}`,
     );
   }
+
+  return {
+    transactionalId: env.LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID,
+    trialEnd: subscription.trial_end!,
+    userId: getUserIdFromCustomer(customer),
+  } satisfies TrialEndingEmailReceipt;
 }

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { Download } from "lucide-react";
 
 import { SiteFooter } from "@/components/site-footer";
+import { useAnalytics } from "@/hooks/use-posthog";
 import { desktopDownloadSections } from "@/lib/download";
 import { ANARLOG_SITE_URL } from "@/lib/seo";
 
@@ -30,6 +31,8 @@ export const Route = createFileRoute("/_view/download/")({
 });
 
 function Component() {
+  const { track } = useAnalytics();
+
   return (
     <main className="surface text-color min-h-screen">
       <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
@@ -77,6 +80,13 @@ function Component() {
                     <li key={download.name}>
                       <a
                         href={download.url}
+                        onClick={() =>
+                          track("download_clicked", {
+                            platform: section.platform,
+                            spec: download.name,
+                            source: "download_page",
+                          })
+                        }
                         className="hover:bg-surface-subtle flex items-center justify-between gap-6 px-1 py-5 transition-colors"
                       >
                         <span className="min-w-0">

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -27,6 +27,7 @@ import {
   desktopSchemeSchema,
 } from "@/functions/desktop-flow";
 import { getGitHubStats } from "@/functions/github";
+import { useAnalytics } from "@/hooks/use-posthog";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import {
   type DesktopPlatform,
@@ -1288,6 +1289,7 @@ function HeroWorkflowDemo() {
 }
 
 function DownloadButton() {
+  const { track } = useAnalytics();
   const [open, setOpen] = useState(false);
   const [preferredPlatform, setPreferredPlatform] =
     useState<DesktopPlatform>("macos");
@@ -1332,6 +1334,13 @@ function DownloadButton() {
     >
       <a
         href={preferredDownload.url}
+        onClick={() =>
+          track("download_clicked", {
+            platform: preferredSection.platform,
+            spec: preferredDownload.name,
+            source: "homepage",
+          })
+        }
         className="inline-flex items-center gap-1.5 rounded-l-full bg-[#181613] py-3 pr-2 pl-4 text-[13px] text-white sm:pl-5 sm:text-sm"
       >
         <Icon
@@ -1367,7 +1376,14 @@ function DownloadButton() {
                   key={download.url}
                   href={download.url}
                   role="menuitem"
-                  onClick={() => setOpen(false)}
+                  onClick={() => {
+                    track("download_clicked", {
+                      platform: section.platform,
+                      spec: download.name,
+                      source: "homepage_menu",
+                    });
+                    setOpen(false);
+                  }}
                   className="text-color hover:surface-subtle flex items-center gap-3 rounded-xl px-3 py-2.5 transition-colors"
                 >
                   <Icon


### PR DESCRIPTION
Instrument web downloads, meeting-note milestones, and successful Loops trial reminders for PostHog journeys.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6336 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6335 
- <kbd>&nbsp;1&nbsp;</kbd> #6334 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth sign-out analytics ordering and broad analytics plumbing; behavior is mostly additive with tests, but mis-timed group clear could misattribute events briefly.
> 
> **Overview**
> Adds **PostHog `account` group analytics** end-to-end and wires several **lifecycle milestones** into journeys.
> 
> The analytics stack now supports **group membership on events**, **`$groupidentify` on identify**, and a **`clear_groups`** command so signed-out desktop clients stop attributing events to the previous account. Desktop auth **queues identify/sign-in/sign-out analytics** so `clearGroups` runs only after in-flight work finishes.
> 
> **Meeting-note completion** fires after enhance successfully persists (`meeting_note_completed` vs `welcome_meeting_note_completed` for the onboarding demo). **Web** download links emit `download_clicked` with platform/source; **account signup batches** attach `$groups` and prepend `$groupidentify` for `account_created`. **Stripe** billing events and successful **Loops trial-ending emails** capture with account groups (`trial_ending_email_sent` after send).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d3837f2f4c1d915da0229205172112edabb4ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->