### PR TITLE
Complete the 1.4.0 transcription changelog

### DIFF
--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -63,6 +63,10 @@ are still pending.
 
 ## Transcription
 
+- Use Apple Speech for private, on-device live and batch transcription on
+  supported Apple Silicon Macs running macOS 26
+- Detect the meeting language from your configured language choices instead of
+  forcing multilingual recordings into code-switching mode
 - Label diarized speakers with known participant names when the transcript
   provides a high-confidence identity match
 


### PR DESCRIPTION
Document Apple Speech and automatic meeting-language detection in the desktop release notes.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6339
- <kbd>&nbsp;2&nbsp;</kbd> #6337 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6332
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update with no runtime or build impact.
> 
> **Overview**
> **Completes the 1.4.0 release notes** under **Transcription** with two new user-facing bullets.
> 
> Documents **Apple Speech** for private, on-device live and batch transcription on supported Apple Silicon Macs running **macOS 26**. Documents **automatic meeting language detection** from configured language choices so multilingual recordings are not forced into code-switching mode.
> 
> No application code changes—only `packages/changelog/content/1.4.0.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a59af451687d74ea0db87a4de38393c6a75f1c4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->