### PR TITLE
Prevent local summary startup timeouts

### DIFF
--- a/apps/desktop/src/store/zustand/ai-task/shared/validate.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/shared/validate.test.ts
@@ -261,6 +261,59 @@ describe("withEarlyValidationRetry", () => {
     expect(results).toEqual(chunks);
   });
 
+  it("emits reasoning while visible text is still buffered", async () => {
+    let releaseText!: () => void;
+    const textReady = new Promise<void>((resolve) => {
+      releaseText = resolve;
+    });
+
+    async function* executeStream() {
+      yield { type: "reasoning-start", id: "reasoning-1" } as const;
+      yield {
+        type: "reasoning-delta",
+        id: "reasoning-1",
+        text: "Working",
+      } as const;
+      await textReady;
+      yield { type: "reasoning-end", id: "reasoning-1" } as const;
+      yield {
+        type: "text-delta",
+        id: "text-1",
+        text: "Valid summary",
+      } as const;
+    }
+
+    const iterator = withEarlyValidationRetry(
+      executeStream,
+      () => ({ valid: true }),
+      { minChar: 5 },
+    )[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "reasoning-start", id: "reasoning-1" },
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: {
+        type: "reasoning-delta",
+        id: "reasoning-1",
+        text: "Working",
+      },
+    });
+
+    releaseText();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "reasoning-end", id: "reasoning-1" },
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "text-delta", id: "text-1", text: "Valid summary" },
+    });
+  });
+
   it("should trim text when checking minChar threshold", async () => {
     const chunks: TextStreamPart<ToolSet>[] = [
       { type: "text-delta", text: "   ", id: "1" },

--- a/apps/desktop/src/store/zustand/ai-task/shared/validate.ts
+++ b/apps/desktop/src/store/zustand/ai-task/shared/validate.ts
@@ -55,6 +55,15 @@ export async function* withEarlyValidationRetry<
 
       for await (const chunk of stream) {
         if (!validationComplete) {
+          if (
+            chunk.type === "reasoning-start" ||
+            chunk.type === "reasoning-delta" ||
+            chunk.type === "reasoning-end"
+          ) {
+            yield chunk;
+            continue;
+          }
+
           buffer.push(chunk);
 
           if (chunk.type === "text-delta") {

--- a/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
@@ -5,7 +5,9 @@ import { TASK_CONFIGS } from "./task-configs";
 import {
   createTasksSlice,
   extractUnderlyingError,
+  getTaskStreamStartTimeoutMs,
   TASK_STREAM_IDLE_TIMEOUT_MS,
+  TASK_STREAM_LOCAL_START_TIMEOUT_MS,
   TASK_STREAM_START_TIMEOUT_MS,
 } from "./tasks";
 
@@ -397,6 +399,23 @@ describe("createTasksSlice", () => {
         message: "AI generation did not return any text.",
       }),
     });
+  });
+});
+
+describe("getTaskStreamStartTimeoutMs", () => {
+  it.each(["ollama.chat", "lmstudio.chat", "apple_foundation"])(
+    "allows local provider %s more time to start",
+    (provider) => {
+      expect(getTaskStreamStartTimeoutMs({ provider } as any)).toBe(
+        TASK_STREAM_LOCAL_START_TIMEOUT_MS,
+      );
+    },
+  );
+
+  it("keeps the standard start timeout for remote providers", () => {
+    expect(
+      getTaskStreamStartTimeoutMs({ provider: "openai.chat" } as any),
+    ).toBe(TASK_STREAM_START_TIMEOUT_MS);
   });
 });
 

--- a/apps/desktop/src/store/zustand/ai-task/tasks.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.ts
@@ -81,11 +81,29 @@ const initialState: TasksState = {
 
 export const TASK_STREAM_IDLE_TIMEOUT_MS = 15_000;
 export const TASK_STREAM_START_TIMEOUT_MS = 60_000;
+export const TASK_STREAM_LOCAL_START_TIMEOUT_MS = 5 * 60_000;
 
 const DATABASE_LOCK_RETRY_DELAYS_MS = [
   250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 30_000,
 ];
 const STREAM_TIMEOUT = Symbol("stream-timeout");
+const LOCAL_MODEL_PROVIDERS = new Set([
+  "apple_foundation",
+  "lmstudio",
+  "ollama",
+]);
+
+export function getTaskStreamStartTimeoutMs(model: LanguageModel) {
+  const provider =
+    typeof model !== "string" && typeof model.provider === "string"
+      ? model.provider
+      : "";
+  const providerId = provider.split(".", 1)[0];
+
+  return LOCAL_MODEL_PROVIDERS.has(providerId)
+    ? TASK_STREAM_LOCAL_START_TIMEOUT_MS
+    : TASK_STREAM_START_TIMEOUT_MS;
+}
 
 function createAbortError() {
   const error = new Error("Aborted");
@@ -346,7 +364,7 @@ export const createTasksSlice = <T extends TasksState & TasksActions>(
             iterator,
             fullText.trim()
               ? TASK_STREAM_IDLE_TIMEOUT_MS
-              : TASK_STREAM_START_TIMEOUT_MS,
+              : getTaskStreamStartTimeoutMs(config.model),
           );
           checkAbort();
 


### PR DESCRIPTION
Count reasoning output as stream activity and allow local models more time to cold-start.