### PR TITLE
Suppress Apple Speech echo duplication

### DIFF
--- a/crates/listener-core/src/live_transcript.rs
+++ b/crates/listener-core/src/live_transcript.rs
@@ -252,6 +252,7 @@ impl RenderedSegmentState {
 #[derive(Default)]
 enum TranscriptNormalizer {
     Soniqo(SoniqoTranscriptNormalizer),
+    AppleSpeech,
     #[default]
     Passthrough,
 }
@@ -260,6 +261,7 @@ impl TranscriptNormalizer {
     fn for_provider(provider_name: &str) -> Self {
         match provider_name {
             "soniqo" => Self::Soniqo(SoniqoTranscriptNormalizer::default()),
+            "apple-speech" => Self::AppleSpeech,
             _ => Self::Passthrough,
         }
     }
@@ -267,16 +269,16 @@ impl TranscriptNormalizer {
     fn normalize(&mut self, response: &mut StreamResponse) {
         match self {
             Self::Soniqo(normalizer) => normalizer.normalize(response),
-            Self::Passthrough => {}
+            Self::AppleSpeech | Self::Passthrough => {}
         }
     }
 
     fn finalize_partials(&self) -> bool {
-        !matches!(self, Self::Soniqo(_))
+        matches!(self, Self::Passthrough)
     }
 
     fn flush_partials(&self) -> bool {
-        true
+        !matches!(self, Self::AppleSpeech)
     }
 }
 
@@ -1267,6 +1269,60 @@ mod tests {
             .collect::<String>();
 
         assert_eq!(final_text.trim(), "hello world");
+        assert!(flush_update.transcript_delta.partials.is_empty());
+    }
+
+    #[test]
+    fn apple_speech_engine_does_not_commit_volatile_hypotheses() {
+        let mut engine = LiveTranscriptEngine::new("apple-speech", &[], None);
+        let partial = transcript_response_at(
+            "what do you think",
+            words_from_text("what do you think", 0.0, 4.0),
+            false,
+            1,
+            0.0,
+            4.0,
+        );
+        engine.process(&partial).expect("partial update");
+
+        let final_response = transcript_response_at(
+            "what do you think about open source",
+            words_from_text("what do you think about open source", 4.0, 4.0),
+            true,
+            1,
+            4.0,
+            4.0,
+        );
+        let final_update = engine.process(&final_response).expect("final update");
+        let flush_update = engine.flush().expect("flush update");
+        let final_text = final_update
+            .transcript_delta
+            .new_words
+            .iter()
+            .chain(flush_update.transcript_delta.new_words.iter())
+            .map(|word| word.text.as_str())
+            .collect::<String>();
+
+        assert_eq!(final_text.trim(), "what do you think about open source");
+        assert!(flush_update.transcript_delta.partials.is_empty());
+    }
+
+    #[test]
+    fn apple_speech_engine_drops_unfinalized_hypothesis_on_flush() {
+        let mut engine = LiveTranscriptEngine::new("apple-speech", &[], None);
+        let response = transcript_response_at(
+            "volatile tail",
+            words_from_text("volatile tail", 10.0, 1.0),
+            false,
+            1,
+            10.0,
+            1.0,
+        );
+
+        engine.process(&response).expect("partial update");
+        let flush_update = engine.flush().expect("flush update");
+
+        assert!(flush_update.transcript_delta.new_words.is_empty());
         assert!(flush_update.transcript_delta.partials.is_empty());
     }
 

--- a/crates/owhisper-client/src/local_apple_speech_live.rs
+++ b/crates/owhisper-client/src/local_apple_speech_live.rs
@@ -6,7 +6,10 @@ use owhisper_interface::stream::StreamResponse;
 use owhisper_interface::{ControlMessage, MixedMessage};
 use tokio_stream::wrappers::ReceiverStream;
 
-use crate::{FinalizeHandle, ListenClientDualInput, ListenClientInput};
+use crate::{
+    FinalizeHandle, ListenClientDualInput, ListenClientInput,
+    local_soniqo_live::suppress_echo_dominant_mic,
+};
 
 const FLUSH_INTERVAL: Duration = Duration::from_millis(250);
 
@@ -184,8 +187,13 @@ async fn run_dual(
 
                 match msg {
                     MixedMessage::Audio((mic, spk)) => {
-                        mic_buffer.extend(i16_bytes_to_f32(&mic));
-                        spk_buffer.extend(i16_bytes_to_f32(&spk));
+                        let mut mic_samples = i16_bytes_to_f32(&mic);
+                        let spk_samples = i16_bytes_to_f32(&spk);
+                        if suppress_echo_dominant_mic(&mut mic_samples, &spk_samples) {
+                            tracing::debug!("apple_speech_echo_dominant_mic_chunk_suppressed");
+                        }
+                        mic_buffer.extend(mic_samples);
+                        spk_buffer.extend(spk_samples);
                     }
                     MixedMessage::Control(ControlMessage::CloseStream | ControlMessage::Finalize) => {
                         let result = finalize_dual(session, &mut mic_buffer, &mut spk_buffer, &response_tx).await;
@@ -321,4 +329,53 @@ fn i16_bytes_to_f32(bytes: &Bytes) -> Vec<f32> {
         .chunks_exact(2)
         .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_signal(len: usize, seed: u32) -> Vec<f32> {
+        let mut state = seed;
+        (0..len)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                state as f32 / u32::MAX as f32 * 2.0 - 1.0
+            })
+            .collect()
+    }
+
+    #[test]
+    fn suppresses_aec_residual_when_speaker_dominates() {
+        let speaker = test_signal(1920, 0x1234_5678);
+        let mut mic: Vec<f32> = speaker.iter().map(|sample| sample * 0.2).collect();
+
+        assert!(suppress_echo_dominant_mic(&mut mic, &speaker));
+        assert!(mic.iter().all(|sample| *sample == 0.0));
+    }
+
+    #[test]
+    fn keeps_quiet_uncorrelated_near_end_speech() {
+        let speaker = test_signal(1920, 0x1234_5678);
+        let mut mic: Vec<f32> = test_signal(1920, 0x8765_4321)
+            .into_iter()
+            .map(|sample| sample * 0.2)
+            .collect();
+        let original = mic.clone();
+
+        assert!(!suppress_echo_dominant_mic(&mut mic, &speaker));
+        assert_eq!(mic, original);
+    }
+
+    #[test]
+    fn keeps_mic_when_speaker_is_quiet() {
+        let speaker = vec![0.001; 1920];
+        let mut mic = test_signal(1920, 0x1234_5678);
+        let original = mic.clone();
+
+        assert!(!suppress_echo_dominant_mic(&mut mic, &speaker));
+        assert_eq!(mic, original);
+    }
 }

--- a/crates/owhisper-client/src/local_soniqo_live.rs
+++ b/crates/owhisper-client/src/local_soniqo_live.rs
@@ -424,7 +424,7 @@ fn i16_bytes_to_f32(bytes: &Bytes) -> Vec<f32> {
         .collect()
 }
 
-fn suppress_echo_dominant_mic(mic: &mut [f32], speaker: &[f32]) -> bool {
+pub(crate) fn suppress_echo_dominant_mic(mic: &mut [f32], speaker: &[f32]) -> bool {
     let Some(score) = best_echo_score(mic, speaker) else {
         return false;
     };


### PR DESCRIPTION
Gate speaker-dominant microphone residuals before local transcription while preserving near-end speech.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6339 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6337
- <kbd>&nbsp;1&nbsp;</kbd> #6332
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time transcript persistence for apple-speech and mutates mic audio before transcription; incorrect gating could drop near-end speech, though correlation/RMS guards and tests mitigate that.
> 
> **Overview**
> Reduces **echo duplication** in local Apple Speech dual-stream capture and tightens how **live transcript** treats Apple’s volatile partial hypotheses.
> 
> **Audio (dual mic + speaker):** Before mic samples are buffered for Apple Speech, the same **echo-dominant mic gate** used for Soniqo runs on each chunk—when the mic track looks like a correlated, speaker-dominant residual, the chunk is zeroed so remote playback is less likely transcribed again on the mic channel. `suppress_echo_dominant_mic` is exposed as `pub(crate)` in `local_soniqo_live` for reuse.
> 
> **Live transcript engine:** Provider `"apple-speech"` gets an explicit normalizer profile: partials are **not** auto-finalized during streaming (like Soniqo), and **flush no longer commits** leftover partials—only finalized text is kept, so shifting hypotheses and unfinalized tails are dropped at session end. Soniqo vs passthrough partial/flush behavior is adjusted so only passthrough still finalizes partials on flush in the old broad way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d99d36f470bab6f1ecbd2c56740eefabd0dd1c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->