### PR TITLE
Track missing product analytics events

### DIFF
--- a/apps/cli/src/analytics.rs
+++ b/apps/cli/src/analytics.rs
@@ -1,0 +1,116 @@
+use std::fs;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub fn capture_command_completed(command: &str, outcome: &str, duration: Duration) {
+    if !analytics_enabled() {
+        return;
+    }
+
+    let Some(posthog_key) = posthog_key() else {
+        return;
+    };
+    let Some(distinct_id) = distinct_id() else {
+        return;
+    };
+
+    let host = std::env::var("POSTHOG_HOST")
+        .unwrap_or_else(|_| "https://us.i.posthog.com".to_string())
+        .trim_end_matches('/')
+        .to_string();
+    let payload = serde_json::json!({
+        "api_key": posthog_key,
+        "event": "cli_command_completed",
+        "properties": {
+            "distinct_id": distinct_id,
+            "$session_id": new_id(),
+            "surface": "cli",
+            "analytics_schema_version": 1,
+            "app_version": env!("CARGO_PKG_VERSION"),
+            "command": command,
+            "outcome": outcome,
+            "duration_ms": duration.as_millis(),
+        },
+    });
+
+    let Ok(mut child) = Command::new("curl")
+        .args([
+            "--silent",
+            "--fail",
+            "--max-time",
+            "0.75",
+            "--request",
+            "POST",
+            "--header",
+            "Content-Type: application/json",
+            "--data-binary",
+            "@-",
+            &format!("{host}/capture/"),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return;
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = serde_json::to_writer(&mut stdin, &payload);
+        let _ = stdin.flush();
+    }
+    let _ = child.wait();
+}
+
+fn analytics_enabled() -> bool {
+    std::env::var("ANARLOG_ANALYTICS")
+        .map(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+fn posthog_key() -> Option<String> {
+    std::env::var("POSTHOG_API_KEY")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            option_env!("POSTHOG_API_KEY")
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        })
+}
+
+fn distinct_id() -> Option<String> {
+    let path = analytics_id_path()?;
+
+    if let Ok(value) = fs::read_to_string(&path) {
+        let value = value.trim();
+        if !value.is_empty() {
+            return Some(value.to_owned());
+        }
+    }
+
+    let value = new_id();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(path, &value);
+    Some(value)
+}
+
+fn analytics_id_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|path| path.join("anarlog").join("analytics-id"))
+}
+
+fn new_id() -> String {
+    let mut hasher = DefaultHasher::new();
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .hash(&mut hasher);
+    std::process::id().hash(&mut hasher);
+    format!("cli-{:016x}", hasher.finish())
+}

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -32,6 +32,23 @@ pub struct Args {
     pub command: Command,
 }
 
+impl Args {
+    pub fn analytics_command_name(&self) -> &'static str {
+        match &self.command {
+            Command::Doctor => "doctor",
+            Command::Meetings { command } => match command {
+                MeetingCommand::List { .. } => "meetings_list",
+                MeetingCommand::Get { .. } => "meetings_get",
+                MeetingCommand::Note { .. } => "meetings_note",
+                MeetingCommand::Transcript { .. } => "meetings_transcript",
+                MeetingCommand::History { .. } => "meetings_history",
+                MeetingCommand::Export { .. } => "meetings_export",
+            },
+            Command::Mcp => "mcp",
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Check the local CLI and database connection without changing data

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,8 +1,11 @@
 use std::process::ExitCode;
+use std::time::Instant;
 
 use anarlog_cli::Args;
 use clap::Parser;
 use clap::error::ErrorKind;
+
+mod analytics;
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -35,7 +38,16 @@ async fn main() -> ExitCode {
         }
     };
 
-    match anarlog_cli::run(args).await {
+    let command = args.analytics_command_name();
+    let started_at = Instant::now();
+    let result = anarlog_cli::run(args).await;
+    let outcome = match &result {
+        Ok(0) => "succeeded",
+        Ok(_) | Err(_) => "failed",
+    };
+    analytics::capture_command_completed(command, outcome, started_at.elapsed());
+
+    match result {
         Ok(code) => ExitCode::from(code),
         Err(error) => {
             if json {

--- a/apps/desktop/src/analytics.ts
+++ b/apps/desktop/src/analytics.ts
@@ -1,0 +1,24 @@
+import {
+  commands as analyticsCommands,
+  type JsonValue,
+} from "@hypr/plugin-analytics";
+
+export function trackAnalyticsEvent(
+  event: string,
+  properties: Record<string, JsonValue> = {},
+) {
+  try {
+    const capture = analyticsCommands.eventFireAndForget;
+    if (typeof capture !== "function") return;
+
+    const pending = capture({
+      event,
+      ...properties,
+    });
+    void pending.catch((error: unknown) => {
+      console.error(`[analytics] failed to record ${event}`, error);
+    });
+  } catch (error) {
+    console.error(`[analytics] failed to record ${event}`, error);
+  }
+}

--- a/apps/desktop/src/attachment-sync/runner.ts
+++ b/apps/desktop/src/attachment-sync/runner.ts
@@ -16,6 +16,8 @@ import {
 } from "./native";
 import { type AttachmentTransferJob, attachmentTransferStore } from "./store";
 
+import { trackAnalyticsEvent } from "~/analytics";
+
 const MAX_JOBS_PER_PASS = 4;
 const PASS_INTERVAL_MS = 20_000;
 const MAX_RETRY_DELAY_MS = 15 * 60 * 1000;
@@ -58,6 +60,15 @@ export async function runAttachmentTransferPass(
     try {
       await runAttachmentTransferJob(dependencies, job, signal);
     } catch (error) {
+      if (
+        error instanceof AttachmentBackupGatewayError &&
+        error.status === 409
+      ) {
+        trackAnalyticsEvent("cloud_sync_conflict", {
+          resource_type: "attachment",
+          operation: job.direction,
+        });
+      }
       await persistTransferFailure(store, job, error, signal?.aborted ?? false);
     } finally {
       releaseProcessLocalAttempt();

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -30,6 +30,7 @@ import {
 } from "./cloudsync";
 import { clearAuthStorage, isFatalSessionError } from "./errors";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { useLatestRef } from "~/shared/hooks/useLatestRef";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import {
@@ -702,10 +703,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [managesCloudsync, rejectAuthChange]);
 
   const signIn = useCallback(async () => {
-    const url = await buildWebAppUrl("/auth");
-    await openUrlWithInstruction(url, "sign-in", (u) =>
-      openerCommands.openUrl(u, null),
-    );
+    trackAnalyticsEvent("auth_started", {
+      entry_point: "desktop_sign_in",
+      method: "browser_handoff",
+    });
+    try {
+      const url = await buildWebAppUrl("/auth");
+      await openUrlWithInstruction(url, "sign-in", (u) =>
+        openerCommands.openUrl(u, null),
+      );
+    } catch (error) {
+      trackAnalyticsEvent("auth_failed", {
+        entry_point: "desktop_sign_in",
+        method: "browser_handoff",
+        failure_stage: "open_browser",
+      });
+      throw error;
+    }
   }, []);
 
   const signOutFromMain = useCallback(async (): Promise<boolean> => {

--- a/apps/desktop/src/billing/trial-ended-dialog.tsx
+++ b/apps/desktop/src/billing/trial-ended-dialog.tsx
@@ -1,4 +1,5 @@
 import { arch, platform } from "@tauri-apps/plugin-os";
+import { useEffect } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
 import {
@@ -12,6 +13,7 @@ import {
 
 import { TrialDialogIcon } from "./trial-dialog-icon";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { isDesktopLocalSttAvailable } from "~/stt/capabilities";
 
 interface TrialEndedDialogProps {
@@ -29,6 +31,13 @@ export function TrialEndedDialog({
     platform(),
     arch(),
   );
+  useEffect(() => {
+    if (!open) return;
+    trackAnalyticsEvent("paywall_viewed", {
+      entry_point: "trial_ended_dialog",
+      feature: "pro_plan",
+    });
+  }, [open]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/desktop/src/chat/components/message/tool/search-meetings.tsx
+++ b/apps/desktop/src/chat/components/message/tool/search-meetings.tsx
@@ -12,6 +12,7 @@ import {
 
 import { useToolState } from "./shared";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { Disclosure } from "~/chat/components/message/shared";
 import { ToolRenderer } from "~/chat/components/message/types";
 import { useTabs } from "~/store/zustand/tabs";
@@ -235,6 +236,10 @@ function RenderMeeting({ result }: { result: MeetingSearchResult }) {
   const openNew = useTabs((state) => state.openNew);
 
   const handleClick = useCallback(() => {
+    trackAnalyticsEvent("search_result_opened", {
+      entry_point: "chat_search",
+      result_type: "session",
+    });
     openNew({ type: "sessions", id: sessionId });
   }, [openNew, sessionId]);
 

--- a/apps/desktop/src/chat/transport/index.ts
+++ b/apps/desktop/src/chat/transport/index.ts
@@ -28,6 +28,8 @@ import {
   type ToolOutputPart,
 } from "./helpers";
 
+import { trackAnalyticsEvent } from "~/analytics";
+
 export type ResolvedChatContext =
   | { kind: "session"; context: SessionContext }
   | { kind: "text"; text: string };
@@ -264,6 +266,9 @@ export class CustomChatTransport implements ChatTransport<HyprUIMessage> {
       },
       onError: (error: unknown) => {
         console.error(error);
+        trackAnalyticsEvent("chat_response_failed", {
+          failure_stage: "response_stream",
+        });
         if (error instanceof Error) {
           return `${error.name}: ${error.message}`;
         }

--- a/apps/desktop/src/contacts/queries.test.tsx
+++ b/apps/desktop/src/contacts/queries.test.tsx
@@ -7,7 +7,12 @@ const mocks = vi.hoisted(() => ({
     (_statements: Array<{ sql: string; params: unknown[] }>) =>
       Promise.resolve([1]),
   ),
+  trackAnalyticsEvent: vi.fn(),
   rows: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("~/analytics", () => ({
+  trackAnalyticsEvent: mocks.trackAnalyticsEvent,
 }));
 
 vi.mock("~/db", () => ({
@@ -36,6 +41,7 @@ import {
   searchContacts,
   toggleContactPin,
   updateHuman,
+  updateOrganization,
   useHumans,
   useOrganizations,
 } from "./queries";
@@ -320,6 +326,16 @@ describe("contact SQLite queries", () => {
     expect(statements[3].params[statements[3].params.length - 1]).toBe(
       "human-duplicate",
     );
+    expect(mocks.trackAnalyticsEvent).toHaveBeenCalledWith("contact_merged", {
+      entry_point: "contact_details",
+    });
+  });
+
+  it("does not report an organization edit as a contact merge", async () => {
+    await updateOrganization("organization-1", { name: "Renamed" });
+
+    expect(mocks.executeTransaction).toHaveBeenCalledOnce();
+    expect(mocks.trackAnalyticsEvent).not.toHaveBeenCalled();
   });
 
   it("keeps the bound self human when it is selected as the duplicate", async () => {

--- a/apps/desktop/src/contacts/queries.ts
+++ b/apps/desktop/src/contacts/queries.ts
@@ -1,3 +1,4 @@
+import { trackAnalyticsEvent } from "~/analytics";
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
 import { DEFAULT_USER_ID, id } from "~/shared/utils";
@@ -258,10 +259,12 @@ export function createHuman({
   ownerUserId = DEFAULT_USER_ID,
   name,
   email = "",
+  entryPoint = "contacts",
 }: {
   ownerUserId?: string;
   name: string;
   email?: string;
+  entryPoint?: "contacts" | "session_participants" | "speaker_assignment";
 }): Promise<string> {
   const humanId = id();
   const now = new Date().toISOString();
@@ -293,6 +296,10 @@ export function createHuman({
         params: [humanId, ownerUserId, name, email, now, now],
       },
     ]);
+    trackAnalyticsEvent("contact_created", {
+      entry_point: entryPoint,
+      has_email: Boolean(email),
+    });
     return humanId;
   });
 }
@@ -561,6 +568,9 @@ export function mergeHumans(
         params: [now, now, duplicateId],
       },
     ]);
+    trackAnalyticsEvent("contact_merged", {
+      entry_point: "contact_details",
+    });
   });
 }
 

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -21,6 +21,7 @@ import {
 import { Toaster } from "@hypr/ui/components/ui/toast";
 
 import { AITaskWindowSyncBridge } from "./ai/task-window-sync";
+import { trackAnalyticsEvent } from "./analytics";
 import { createToolRegistry } from "./contexts/tool-registry/core";
 import { env } from "./env";
 import { AppI18nProvider } from "./i18n/provider";
@@ -120,6 +121,15 @@ const isMainWindow = getCurrentWebviewWindowLabel() === "main";
 
 if (isMainWindow) {
   void analyticsCommands.eventFireAndForget({ event: "app_started" });
+  try {
+    const firstOpenKey = "anarlog:analytics:first-opened";
+    if (localStorage.getItem(firstOpenKey) === null) {
+      localStorage.setItem(firstOpenKey, "1");
+      trackAnalyticsEvent("app_first_opened", {
+        first_open_marker: "local_install",
+      });
+    }
+  } catch {}
   void initializeAppExitFlush().catch((error) => {
     console.error("Failed to initialize the exit flush listener", error);
   });

--- a/apps/desktop/src/onboarding/index.tsx
+++ b/apps/desktop/src/onboarding/index.tsx
@@ -5,7 +5,6 @@ import { Volume2Icon, VolumeXIcon } from "lucide-react";
 import { motion } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import { commands as sfxCommands } from "@hypr/plugin-sfx";
 import { cn } from "@hypr/utils";
 
@@ -22,6 +21,7 @@ import { FolderLocationSection } from "./folder-location";
 import { PermissionsSection } from "./permissions";
 import { OnboardingSection } from "./shared";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { useAuth } from "~/auth";
 import { StandaloneWindowShell } from "~/shared/window-shell";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
@@ -91,9 +91,22 @@ function OnboardingScreenContent({
   const currentPlatform = platform();
 
   const goNext = useCallback(() => {
+    trackAnalyticsEvent("onboarding_step_completed", {
+      step: currentStep,
+      platform: currentPlatform,
+    });
     const next = getNextStep(currentStep);
     if (next) setCurrentStep(next);
-  }, [currentStep]);
+  }, [currentPlatform, currentStep]);
+
+  const skipCurrentStep = useCallback(() => {
+    trackAnalyticsEvent("onboarding_step_skipped", {
+      step: currentStep,
+      platform: currentPlatform,
+    });
+    const next = getNextStep(currentStep);
+    if (next) setCurrentStep(next);
+  }, [currentPlatform, currentStep]);
 
   const goBack = useCallback(() => {
     const prev = getPrevStep(currentStep);
@@ -106,8 +119,7 @@ function OnboardingScreenContent({
   }, [auth]);
 
   useEffect(() => {
-    void analyticsCommands.event({
-      event: "onboarding_step_viewed",
+    trackAnalyticsEvent("onboarding_step_viewed", {
       step: currentStep,
       platform: currentPlatform,
     });
@@ -135,10 +147,14 @@ function OnboardingScreenContent({
 
   const handleFinish = useCallback(
     (sessionId: string) => {
+      trackAnalyticsEvent("onboarding_step_completed", {
+        step: "final",
+        platform: currentPlatform,
+      });
       void queryClient.invalidateQueries({ queryKey: ["onboarding-needed"] });
       onFinish(sessionId);
     },
-    [onFinish, queryClient],
+    [currentPlatform, onFinish, queryClient],
   );
 
   return (
@@ -254,9 +270,13 @@ function OnboardingScreenContent({
             onNext={goNext}
             onSkip={() => {
               setDidSkipLogin(true);
-              void analyticsCommands.event({
-                event: "onboarding_login_skipped",
+              trackAnalyticsEvent("onboarding_login_skipped");
+              trackAnalyticsEvent("onboarding_step_skipped", {
+                step: "login",
+                platform: currentPlatform,
               });
+              const next = getNextStep("login");
+              if (next) setCurrentStep(next);
             }}
           >
             <LoginSection
@@ -276,6 +296,7 @@ function OnboardingScreenContent({
             status={getStepStatus("calendar", currentStep)}
             onBack={goBack}
             onNext={goNext}
+            onSkip={skipCurrentStep}
           >
             <CalendarSection
               onContinue={goNext}
@@ -292,6 +313,7 @@ function OnboardingScreenContent({
             status={getStepStatus("folder-location", currentStep)}
             onBack={goBack}
             onNext={goNext}
+            onSkip={skipCurrentStep}
           >
             <FolderLocationSection onContinue={goNext} />
           </OnboardingSection>

--- a/apps/desktop/src/onboarding/permissions.test.tsx
+++ b/apps/desktop/src/onboarding/permissions.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => {
   const createPermission = () => ({
     status: "denied" as "authorized" | "denied" | "neverRequested",
+    confirmedStatus: "denied" as "authorized" | "denied" | "neverRequested",
     isPending: false,
     open: vi.fn(),
     request: vi.fn(),

--- a/apps/desktop/src/onboarding/permissions.tsx
+++ b/apps/desktop/src/onboarding/permissions.tsx
@@ -14,6 +14,10 @@ import { type PermissionStatus } from "@hypr/plugin-permissions";
 import { cn } from "@hypr/utils";
 
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
+import {
+  trackPermissionRequested,
+  usePermissionAnalytics,
+} from "~/shared/hooks/usePermissionAnalytics";
 import { usePermission } from "~/shared/hooks/usePermissions";
 
 function PermissionBlock({
@@ -126,6 +130,17 @@ function PermissionsSectionContent({
   const mic = usePermission("microphone");
   const systemAudio = usePermission("systemAudio");
   const hasContinuedRef = useRef(false);
+  usePermissionAnalytics("microphone", mic.confirmedStatus, "onboarding");
+  usePermissionAnalytics(
+    "system_audio",
+    systemAudio.confirmedStatus,
+    "onboarding",
+  );
+  usePermissionAnalytics(
+    "accessibility",
+    accessibility?.confirmedStatus,
+    "onboarding",
+  );
 
   const isComplete =
     mic.status === "authorized" &&
@@ -133,12 +148,25 @@ function PermissionsSectionContent({
     (!accessibility || accessibility.status === "authorized");
 
   const handleAction = (
+    permission: string,
     perm: ReturnType<typeof usePermission>,
     opensSettingsWhenDenied: boolean,
   ) => {
     if (opensSettingsWhenDenied && perm.status === "denied") {
+      trackPermissionRequested(
+        permission,
+        perm.status,
+        "onboarding",
+        "open_settings",
+      );
       perm.open();
     } else {
+      trackPermissionRequested(
+        permission,
+        perm.status,
+        "onboarding",
+        "request",
+      );
       perm.request();
     }
   };
@@ -162,7 +190,7 @@ function PermissionsSectionContent({
           permissionName={t`Microphone`}
           status={mic.status}
           isPending={mic.isPending}
-          onAction={() => handleAction(mic, !runtimeCapabilities)}
+          onAction={() => handleAction("microphone", mic, !runtimeCapabilities)}
           actionLabel={
             runtimeCapabilities && mic.status === "denied"
               ? `${t`Try again`}: ${t`Microphone`}`
@@ -182,7 +210,9 @@ function PermissionsSectionContent({
           permissionName={t`System audio`}
           status={systemAudio.status}
           isPending={systemAudio.isPending}
-          onAction={() => handleAction(systemAudio, !runtimeCapabilities)}
+          onAction={() =>
+            handleAction("system_audio", systemAudio, !runtimeCapabilities)
+          }
           actionLabel={
             runtimeCapabilities && systemAudio.status === "denied"
               ? `${t`Try again`}: ${t`System audio`}`
@@ -201,7 +231,7 @@ function PermissionsSectionContent({
             permissionName={t`Accessibility`}
             status={accessibility.status}
             isPending={accessibility.isPending}
-            onAction={accessibility.request}
+            onAction={() => handleAction("accessibility", accessibility, false)}
             opensSettingsWhenDenied={false}
           />
         )}

--- a/apps/desktop/src/onboarding/shared.tsx
+++ b/apps/desktop/src/onboarding/shared.tsx
@@ -97,8 +97,11 @@ export function OnboardingSection({
                   (skippable ? (
                     <button
                       onClick={() => {
-                        onSkip?.();
-                        onNext?.();
+                        if (onSkip) {
+                          onSkip();
+                        } else {
+                          onNext?.();
+                        }
                       }}
                       className="text-muted-foreground hover:text-muted-foreground flex items-center gap-1 text-sm transition-colors"
                     >

--- a/apps/desktop/src/search/contexts/engine/index.tsx
+++ b/apps/desktop/src/search/contexts/engine/index.tsx
@@ -6,6 +6,8 @@ import { buildTantivyFilters } from "./filters";
 import type { SearchEntityType, SearchFilters, SearchHit } from "./types";
 import { normalizeQuery } from "./utils";
 
+import { trackAnalyticsEvent } from "~/analytics";
+
 export type {
   SearchDocument,
   SearchEntityType,
@@ -32,6 +34,8 @@ export function SearchEngineProvider({
     ): Promise<SearchHit[]> => {
       const normalizedQuery = normalizeQuery(query);
       const tantivyFilters = buildTantivyFilters(filters);
+      const filterCount = filters?.created_at ? 1 : 0;
+      const startedAt = performance.now();
 
       try {
         const result = await tantivy.search({
@@ -41,10 +45,15 @@ export function SearchEngineProvider({
 
         if (result.status === "error") {
           console.error("Search failed:", result.error);
+          trackAnalyticsEvent("search_performed", {
+            outcome: "failed",
+            latency_ms: Math.round(performance.now() - startedAt),
+            filter_count: filterCount,
+          });
           return [];
         }
 
-        return result.data.hits.map((hit) => ({
+        const hits = result.data.hits.map((hit) => ({
           score: hit.score,
           document: {
             id: hit.document.id,
@@ -54,8 +63,23 @@ export function SearchEngineProvider({
             created_at: hit.document.created_at,
           },
         }));
+        trackAnalyticsEvent("search_performed", {
+          outcome: "succeeded",
+          result_count: hits.length,
+          latency_ms: Math.round(performance.now() - startedAt),
+          filter_count: filterCount,
+          entity_types: [
+            ...new Set(hits.map((hit) => hit.document.type)),
+          ].sort(),
+        });
+        return hits;
       } catch (error) {
         console.error("Search failed:", error);
+        trackAnalyticsEvent("search_performed", {
+          outcome: "failed",
+          latency_ms: Math.round(performance.now() - startedAt),
+          filter_count: filterCount,
+        });
         return [];
       }
     },

--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -222,15 +222,19 @@ describe("EnhancerService", () => {
       undefined,
     );
     expect(mocks.ensureSummaryDocument).toHaveBeenCalledBefore(ai.generate);
-    expect(ai.generate).toHaveBeenCalledWith("note-1-enhance", {
-      model: expect.any(Object),
-      taskType: "enhance",
-      args: {
-        sessionId: "session-1",
-        enhancedNoteId: "note-1",
-        templateId: undefined,
-      },
-    });
+    expect(ai.generate).toHaveBeenCalledWith(
+      "note-1-enhance",
+      expect.objectContaining({
+        model: expect.any(Object),
+        taskType: "enhance",
+        args: {
+          sessionId: "session-1",
+          enhancedNoteId: "note-1",
+          templateId: undefined,
+        },
+        onComplete: expect.any(Function),
+      }),
+    );
   });
 
   it("reuses a matching summary and its stored auto-enhance template", async () => {

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -1,7 +1,5 @@
 import type { LanguageModel } from "ai";
 
-import { commands as analyticsCommands } from "@hypr/plugin-analytics";
-
 import { type EnhanceEligibilitySkipCode, getEligibility } from "./eligibility";
 import {
   type EnhancerNote,
@@ -13,6 +11,7 @@ import {
   updateSummaryDocumentTitleIfCurrent,
 } from "./storage";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { retryDatabaseLock } from "~/db/retry";
 import {
   loadSessionContentSnapshot,
@@ -501,37 +500,51 @@ export class EnhancerService {
     }
 
     const llmConn = getLLMConn();
-    void analyticsCommands
-      .event({
-        event: "note_enhanced",
-        is_auto: opts?.isAuto ?? false,
-        llm_provider: llmConn?.providerId,
-        llm_model: llmConn?.modelId,
-        template_id: templateId,
+    void aiTaskStore
+      .getState()
+      .generate(enhanceTaskId, {
+        model,
+        taskType: "enhance",
+        args: {
+          sessionId,
+          enhancedNoteId: note.id,
+          templateId,
+          ...(opts?.pendingAutoEnhance
+            ? {
+                pendingAutoEnhance: {
+                  generation: opts.pendingAutoEnhance.generation,
+                  expectedBody: opts.pendingAutoEnhance.expectedBody,
+                  expectedContentFormat:
+                    opts.pendingAutoEnhance.expectedContentFormat,
+                },
+              }
+            : {}),
+        },
+        onComplete: () => {
+          trackAnalyticsEvent("note_enhanced", {
+            is_auto: opts?.isAuto ?? false,
+            llm_provider: llmConn?.providerId ?? "unknown",
+            llm_model: llmConn?.modelId ?? "unknown",
+            used_template: Boolean(templateId),
+          });
+          if (templateId) {
+            trackAnalyticsEvent("template_applied", {
+              entry_point: opts?.isAuto ? "auto_enhance" : "enhance",
+            });
+          }
+        },
       })
-      .catch((error: unknown) => {
-        console.error("[enhancer] failed to record analytics", error);
+      .then(() => {
+        if (
+          aiTaskStore.getState().getState(enhanceTaskId)?.status === "error"
+        ) {
+          trackAnalyticsEvent("enhancement_failed", {
+            is_auto: opts?.isAuto ?? false,
+            llm_provider: llmConn?.providerId ?? "unknown",
+            failure_stage: "generation",
+          });
+        }
       });
-
-    void aiTaskStore.getState().generate(enhanceTaskId, {
-      model,
-      taskType: "enhance",
-      args: {
-        sessionId,
-        enhancedNoteId: note.id,
-        templateId,
-        ...(opts?.pendingAutoEnhance
-          ? {
-              pendingAutoEnhance: {
-                generation: opts.pendingAutoEnhance.generation,
-                expectedBody: opts.pendingAutoEnhance.expectedBody,
-                expectedContentFormat:
-                  opts.pendingAutoEnhance.expectedContentFormat,
-              },
-            }
-          : {}),
-      },
-    });
 
     return { type: "started", noteId: note.id };
   }

--- a/apps/desktop/src/session-sharing/comments.tsx
+++ b/apps/desktop/src/session-sharing/comments.tsx
@@ -41,6 +41,7 @@ import {
   sessionShareCommentsQueryKey,
 } from "./comment-anchors";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { useAuth } from "~/auth";
 import { loadManagedSharedNoteForSession } from "~/shared-notes/cache";
 
@@ -196,6 +197,11 @@ function useSessionComments({
     },
     onSuccess: (comment) => {
       if (!shareId) return;
+      trackAnalyticsEvent("share_collaboration_performed", {
+        action: "comment_created",
+        actor_role: manageAccess ? "owner" : "recipient",
+        anchor_type: comment.anchor ? "selection" : "note",
+      });
       queryClient.setQueryData<SessionShareCommentPage>(
         sessionShareCommentsQueryKey(shareId),
         (current) => ({

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -81,6 +81,7 @@ import {
   type ShareDesktopScheme,
 } from "./urls";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
 import { useHumans } from "~/contacts/queries";
@@ -100,6 +101,7 @@ import { getScheme } from "~/shared/utils";
 type SharePanelData = {
   management: SessionShareManagement;
   access: SessionShareAccessEntry[];
+  wasCreated?: boolean;
 };
 
 type SharePreparationIdentity = {
@@ -353,6 +355,11 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
           workspaceId: source.workspaceId,
           sessionId: source.sessionId,
         });
+        if (share.wasCreated) {
+          trackAnalyticsEvent("share_created", {
+            entry_point: "session_header",
+          });
+        }
         context = requireActivePrepareContext(identity, signal);
         const management = await getSessionShareManagement(
           context,
@@ -430,7 +437,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
         requireActivePrepareContext(identity, signal);
         return {
           identity: { ...identity, shareId: share.shareId },
-          data: { management, access },
+          data: { management, access, wasCreated: share.wasCreated },
         };
       }),
     onSuccess: ({ identity, data }) => {
@@ -758,6 +765,13 @@ function SessionSharePreparationContent({
 }
 
 function SessionShareUpgradeContent({ onUpgrade }: { onUpgrade: () => void }) {
+  useMountEffect(() => {
+    trackAnalyticsEvent("paywall_viewed", {
+      entry_point: "session_sharing",
+      feature: "sharing",
+    });
+  });
+
   return (
     <PopoverContent
       variant="app"
@@ -1125,7 +1139,11 @@ function SessionSharePopoverContent({
         requireActiveContext(signal);
         return { deliveredBy: "email" as const };
       }),
-    onSuccess: ({ deliveredBy }) => {
+    onSuccess: ({ deliveredBy }, input) => {
+      trackAnalyticsEvent("share_invitation_sent", {
+        delivery_method: deliveredBy,
+        capability: input.capability,
+      });
       inviteForm.reset();
       sonnerToast.success(
         deliveredBy === "email"
@@ -1429,6 +1447,9 @@ function SessionSharePopoverContent({
         requireActiveContext(signal);
       }),
     onSuccess: () => {
+      trackAnalyticsEvent("share_link_copied", {
+        entry_point: "share_panel",
+      });
       sonnerToast.success("Share link copied.");
     },
     onError: (error) => {

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -856,7 +856,7 @@ function TemplatePickerPopover({
   const searchInputRef = useRef<HTMLInputElement>(null);
   const resultRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const userTemplates = useUserTemplates();
-  const createTemplate = useCreateTemplate();
+  const createTemplate = useCreateTemplate("session_note");
   const { data: rawWebTemplates = [] } =
     useWebResources<Record<string, unknown>>("templates");
   const webTemplates = useMemo(

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -12,6 +12,7 @@ import {
 } from "@hypr/ui/components/ui/popover";
 import { cn } from "@hypr/utils";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { useSessionEventParticipants } from "~/calendar/queries";
 import { createHuman, useHumans } from "~/contacts/queries";
 import {
@@ -61,6 +62,10 @@ export function SpeakerAssignPopover({
         wordIds: getAssignmentWordIds(segment),
       })
         .then(() => {
+          trackAnalyticsEvent("participant_assigned", {
+            assignment_scope: assignmentMode,
+            word_count: segment.words.length,
+          });
           onAssigned?.(humanId);
           handleOpenChange(false);
         })
@@ -408,6 +413,7 @@ function ParticipantList({
         ownerUserId: session.user_id,
         name: option.name,
         email: option.email,
+        entryPoint: "speaker_assignment",
       });
     },
     [contacts, session?.user_id],

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
@@ -296,6 +296,7 @@ function useParticipantMutations(
           humanId = await createHuman({
             ownerUserId: session.user_id,
             name: option.name,
+            entryPoint: "session_participants",
           });
           // Backfill the id so the pending chip disappears as soon as the
           // real participant row shows up, instead of lingering until the

--- a/apps/desktop/src/settings/dictionary/index.tsx
+++ b/apps/desktop/src/settings/dictionary/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "@hypr/ui/components/ui/input-group";
 import { cn } from "@hypr/utils";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { SettingsPageTitle } from "~/settings/page-title";
 import { useSetSettingValue } from "~/settings/queries";
 import { useConfigValue } from "~/shared/config";
@@ -49,12 +50,23 @@ export function DictionarySettings({
       }
 
       onSave(JSON.stringify(nextTerms));
+      trackAnalyticsEvent("dictionary_updated", {
+        operation: "added",
+        term_count: nextTerms.length,
+        added_count: nextTerms.length - normalizedTerms.length,
+      });
       form.setFieldValue("term", "");
     },
   });
 
   const removeTerm = (term: string) => {
-    onSave(JSON.stringify(normalizedTerms.filter((value) => value !== term)));
+    const nextTerms = normalizedTerms.filter((value) => value !== term);
+    onSave(JSON.stringify(nextTerms));
+    trackAnalyticsEvent("dictionary_updated", {
+      operation: "removed",
+      term_count: nextTerms.length,
+      removed_count: normalizedTerms.length - nextTerms.length,
+    });
   };
 
   return (

--- a/apps/desktop/src/settings/general/permissions.test.tsx
+++ b/apps/desktop/src/settings/general/permissions.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
     Permission,
     {
       status: PermissionStatus;
+      confirmedStatus: PermissionStatus;
       isPending: boolean;
       open: ReturnType<typeof vi.fn>;
       request: ReturnType<typeof vi.fn>;
@@ -35,6 +36,7 @@ import { Permissions } from "./permissions";
 function permission(status: PermissionStatus) {
   return {
     status,
+    confirmedStatus: status,
     isPending: false,
     open: vi.fn(),
     request: vi.fn(),

--- a/apps/desktop/src/settings/general/permissions.tsx
+++ b/apps/desktop/src/settings/general/permissions.tsx
@@ -6,6 +6,10 @@ import type { PermissionStatus } from "@hypr/plugin-permissions";
 import { Button } from "@hypr/ui/components/ui/button";
 import { cn } from "@hypr/utils";
 
+import {
+  trackPermissionRequested,
+  usePermissionAnalytics,
+} from "~/shared/hooks/usePermissionAnalytics";
 import { usePermission } from "~/shared/hooks/usePermissions";
 
 function PermissionRow({
@@ -14,6 +18,7 @@ function PermissionRow({
   status,
   isPending,
   error,
+  permission,
   onRequest,
   onOpen,
   runtimeCapability = false,
@@ -23,6 +28,7 @@ function PermissionRow({
   status: PermissionStatus | undefined;
   isPending: boolean;
   error?: string | null;
+  permission: string;
   onRequest: () => void;
   onOpen: () => void;
   runtimeCapability?: boolean;
@@ -33,13 +39,18 @@ function PermissionRow({
 
   const handleButtonClick = () => {
     if (runtimeCapability) {
-      if (!isAuthorized) onRequest();
+      if (!isAuthorized) {
+        trackPermissionRequested(permission, status, "settings", "request");
+        onRequest();
+      }
       return;
     }
 
     if (isAuthorized || isDenied) {
+      trackPermissionRequested(permission, status, "settings", "open_settings");
       onOpen();
     } else {
+      trackPermissionRequested(permission, status, "settings", "request");
       onRequest();
     }
   };
@@ -130,10 +141,17 @@ function AudioPermissions({
   const { t } = useLingui();
   const mic = usePermission("microphone");
   const systemAudio = usePermission("systemAudio");
+  usePermissionAnalytics("microphone", mic.confirmedStatus, "settings");
+  usePermissionAnalytics(
+    "system_audio",
+    systemAudio.confirmedStatus,
+    "settings",
+  );
 
   return (
     <PermissionGroup title={<Trans>Audio</Trans>}>
       <PermissionRow
+        permission="microphone"
         title={t`Microphone`}
         description={t`Required to record your voice during meetings and calls`}
         status={mic.status}
@@ -144,6 +162,7 @@ function AudioPermissions({
         runtimeCapability={runtimeCapabilities}
       />
       <PermissionRow
+        permission="system_audio"
         title={t`System audio`}
         description={t`Required to capture other participants' voices in meetings`}
         status={systemAudio.status}
@@ -161,12 +180,19 @@ function MacOSPermissions() {
   const { t } = useLingui();
   const calendar = usePermission("calendar");
   const accessibility = usePermission("accessibility");
+  usePermissionAnalytics("calendar", calendar.confirmedStatus, "settings");
+  usePermissionAnalytics(
+    "accessibility",
+    accessibility.confirmedStatus,
+    "settings",
+  );
 
   return (
     <div className="flex flex-col gap-8">
       <AudioPermissions />
 
       <PermissionRow
+        permission="accessibility"
         title={t`Accessibility`}
         description={t`Required to read meeting controls, visible chat, and participant status`}
         status={accessibility.status}
@@ -177,6 +203,7 @@ function MacOSPermissions() {
 
       <PermissionGroup title={<Trans>Others</Trans>}>
         <PermissionRow
+          permission="calendar"
           title={t`Calendar`}
           description={t`Required to sync Apple Calendar events into Anarlog`}
           status={calendar.status}

--- a/apps/desktop/src/settings/sync/index.test.tsx
+++ b/apps/desktop/src/settings/sync/index.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   openUrl: vi.fn(),
   openNew: vi.fn(),
   signOut: vi.fn(),
+  trackAnalyticsEvent: vi.fn(),
   billing: { isPro: true, isReady: true },
   syncEnabled: true,
   session: {
@@ -47,6 +48,10 @@ vi.mock("~/auth/cloudsync", () => ({
   applyCloudsyncPreference: mocks.applyCloudsyncPreference,
   getCloudsyncCredentialBlock: () => null,
   subscribeCloudsyncCredentialBlock: () => () => {},
+}));
+
+vi.mock("~/analytics", () => ({
+  trackAnalyticsEvent: mocks.trackAnalyticsEvent,
 }));
 
 vi.mock("~/settings/queries", () => ({
@@ -107,11 +112,14 @@ function renderSettings() {
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
 
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <SettingsSync />
-    </QueryClientProvider>,
-  );
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <SettingsSync />
+      </QueryClientProvider>,
+    ),
+    queryClient,
+  };
 }
 
 describe("SettingsSync", () => {
@@ -184,7 +192,37 @@ describe("SettingsSync", () => {
     expect(mocks.applyCloudsyncPreference).toHaveBeenCalledWith(mocks.session);
   });
 
+  it("records an account mismatch as a failed preference change", async () => {
+    mocks.applyCloudsyncPreference.mockResolvedValue("account_mismatch");
+    renderSettings();
+
+    const syncSwitch = await screen.findByRole("switch", {
+      name: "Cloud sync",
+    });
+    await vi.waitFor(() =>
+      expect(syncSwitch.hasAttribute("disabled")).toBe(false),
+    );
+    fireEvent.click(syncSwitch);
+
+    await vi.waitFor(() => expect(mocks.signOut).toHaveBeenCalledOnce());
+    expect(mocks.trackAnalyticsEvent).not.toHaveBeenCalledWith(
+      "cloud_sync_disabled",
+      expect.anything(),
+    );
+    expect(mocks.trackAnalyticsEvent).toHaveBeenCalledWith(
+      "cloud_sync_failed",
+      {
+        trigger: "disable",
+        failure_stage: "preference",
+      },
+    );
+    expect(screen.queryByText("Cloud sync account mismatch.")).toBeNull();
+  });
+
   it("runs an on-demand sync", async () => {
+    mocks.getCloudsyncStatus
+      .mockResolvedValueOnce({ ...syncedStatus(), last_sync_at_ms: 1 })
+      .mockResolvedValue({ ...syncedStatus(), last_sync_at_ms: 2 });
     renderSettings();
 
     const syncNow = await screen.findByRole("button", { name: "Sync now" });
@@ -196,6 +234,88 @@ describe("SettingsSync", () => {
     await vi.waitFor(() => {
       expect(mocks.syncCloudsyncNow).toHaveBeenCalledTimes(1);
     });
+    await vi.waitFor(() => {
+      expect(mocks.getCloudsyncStatus).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      mocks.trackAnalyticsEvent.mock.calls.filter(
+        ([event]) => event === "cloud_sync_completed",
+      ),
+    ).toEqual([["cloud_sync_completed", { trigger: "manual" }]]);
+  });
+
+  it("does not count a status poll during manual sync as background", async () => {
+    let finishSync: (() => void) | undefined;
+    mocks.getCloudsyncStatus
+      .mockResolvedValueOnce({ ...syncedStatus(), last_sync_at_ms: 1 })
+      .mockResolvedValue({ ...syncedStatus(), last_sync_at_ms: 2 });
+    mocks.syncCloudsyncNow.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishSync = resolve;
+      }),
+    );
+    const { queryClient } = renderSettings();
+
+    const syncNow = await screen.findByRole("button", { name: "Sync now" });
+    await vi.waitFor(() =>
+      expect(syncNow.hasAttribute("disabled")).toBe(false),
+    );
+    fireEvent.click(syncNow);
+    await vi.waitFor(() =>
+      expect(mocks.syncCloudsyncNow).toHaveBeenCalledOnce(),
+    );
+
+    await queryClient.refetchQueries({
+      queryKey: ["cloudsync-status-settings", "user-1"],
+    });
+    expect(
+      mocks.trackAnalyticsEvent.mock.calls.filter(
+        ([event]) => event === "cloud_sync_completed",
+      ),
+    ).toEqual([]);
+
+    finishSync?.();
+    await vi.waitFor(() =>
+      expect(
+        mocks.trackAnalyticsEvent.mock.calls.filter(
+          ([event]) => event === "cloud_sync_completed",
+        ),
+      ).toEqual([["cloud_sync_completed", { trigger: "manual" }]]),
+    );
+  });
+
+  it("does not count a failed on-demand sync again as background", async () => {
+    mocks.getCloudsyncStatus
+      .mockResolvedValueOnce({
+        ...syncedStatus(),
+        last_sync_at_ms: 1,
+        consecutive_failures: 0,
+      })
+      .mockResolvedValue({
+        ...syncedStatus(),
+        last_sync_at_ms: 1,
+        consecutive_failures: 1,
+        last_error_kind: "network",
+      });
+    mocks.syncCloudsyncNow.mockRejectedValueOnce(new Error("offline"));
+    renderSettings();
+
+    const syncNow = await screen.findByRole("button", { name: "Sync now" });
+    await vi.waitFor(() =>
+      expect(syncNow.hasAttribute("disabled")).toBe(false),
+    );
+    fireEvent.click(syncNow);
+
+    await vi.waitFor(() => {
+      expect(mocks.getCloudsyncStatus).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      mocks.trackAnalyticsEvent.mock.calls.filter(
+        ([event]) => event === "cloud_sync_failed",
+      ),
+    ).toEqual([
+      ["cloud_sync_failed", { trigger: "manual", failure_stage: "sync" }],
+    ]);
   });
 
   it("routes free users to account plans", () => {

--- a/apps/desktop/src/settings/sync/index.tsx
+++ b/apps/desktop/src/settings/sync/index.tsx
@@ -9,7 +9,7 @@ import {
   ShieldCheckIcon,
   ShieldIcon,
 } from "lucide-react";
-import { useState, useSyncExternalStore } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 
 import {
   getCloudsyncStatus,
@@ -25,6 +25,7 @@ import { cn, formatDistanceToNow } from "@hypr/utils";
 import { E2eeSetupDialog } from "../general/e2ee-setup";
 import { detectCloudStorageService } from "../general/storage/path-utils";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
 import {
@@ -50,6 +51,13 @@ export function SettingsSync() {
   const openNew = useTabs((state) => state.openNew);
   const queryClient = useQueryClient();
   const [e2eeSetupOpen, setE2eeSetupOpen] = useState(false);
+  const lastTrackedSyncAtRef = useRef<number | null>(null);
+  const lastTrackedFailureCountRef = useRef<number | null>(null);
+  const manualSyncBaselineRef = useRef<number | null>(null);
+  const manualFailureBaselineRef = useRef<number | null>(null);
+  const manualSyncInFlightRef = useRef(false);
+  const manualSyncResultAtRef = useRef<number | null>(null);
+  const manualFailureResultRef = useRef<number | null>(null);
   const settingsQuery = useStoredSettingValuesQuery();
   const session = auth.session;
   const credentialBlock = useSyncExternalStore(
@@ -91,6 +99,28 @@ export function SettingsSync() {
       if (result === "account_mismatch") {
         await auth.signOut();
       }
+      return result;
+    },
+    onSuccess: (result, enabled) => {
+      if (result === "account_mismatch") {
+        trackAnalyticsEvent("cloud_sync_failed", {
+          trigger: enabled ? "enable" : "disable",
+          failure_stage: "preference",
+        });
+        return;
+      }
+      trackAnalyticsEvent(
+        enabled ? "cloud_sync_enabled" : "cloud_sync_disabled",
+        {
+          entry_point: "settings",
+        },
+      );
+    },
+    onError: (_, enabled) => {
+      trackAnalyticsEvent("cloud_sync_failed", {
+        trigger: enabled ? "enable" : "disable",
+        failure_stage: "preference",
+      });
     },
     onSettled: async () => {
       await queryClient.invalidateQueries({ queryKey: statusQueryKey });
@@ -124,10 +154,87 @@ export function SettingsSync() {
   });
   const syncNowMutation = useMutation({
     mutationFn: syncCloudsyncNow,
-    onSettled: async () => {
+    onMutate: () => {
+      manualSyncInFlightRef.current = true;
+      manualSyncBaselineRef.current = lastTrackedSyncAtRef.current;
+      manualFailureBaselineRef.current = lastTrackedFailureCountRef.current;
+    },
+    onSuccess: () => {
+      trackAnalyticsEvent("cloud_sync_completed", {
+        trigger: "manual",
+      });
+    },
+    onError: () => {
+      trackAnalyticsEvent("cloud_sync_failed", {
+        trigger: "manual",
+        failure_stage: "sync",
+      });
+    },
+    onSettled: async (_data, error) => {
       await queryClient.invalidateQueries({ queryKey: statusQueryKey });
+      const refreshedStatus =
+        queryClient.getQueryData<
+          Awaited<ReturnType<typeof getCloudsyncStatus>>
+        >(statusQueryKey);
+      if (error) {
+        manualFailureResultRef.current =
+          refreshedStatus?.consecutive_failures ?? null;
+      } else {
+        manualSyncResultAtRef.current =
+          refreshedStatus?.last_sync_at_ms ?? null;
+      }
+      manualSyncInFlightRef.current = false;
+      manualSyncBaselineRef.current = null;
+      manualFailureBaselineRef.current = null;
     },
   });
+  const status = statusQuery.data;
+
+  useEffect(() => {
+    if (!status) return;
+
+    if (
+      status.last_sync_at_ms !== null &&
+      status.last_sync_at_ms !== lastTrackedSyncAtRef.current
+    ) {
+      if (lastTrackedSyncAtRef.current !== null) {
+        if (
+          (manualSyncInFlightRef.current &&
+            manualSyncBaselineRef.current === lastTrackedSyncAtRef.current) ||
+          manualSyncResultAtRef.current === status.last_sync_at_ms
+        ) {
+          manualSyncBaselineRef.current = null;
+          manualSyncResultAtRef.current = null;
+        } else {
+          trackAnalyticsEvent("cloud_sync_completed", {
+            trigger: "background",
+          });
+        }
+      }
+      lastTrackedSyncAtRef.current = status.last_sync_at_ms;
+    }
+
+    if (
+      lastTrackedFailureCountRef.current !== null &&
+      status.consecutive_failures > lastTrackedFailureCountRef.current
+    ) {
+      if (
+        (manualSyncInFlightRef.current &&
+          manualFailureBaselineRef.current ===
+            lastTrackedFailureCountRef.current) ||
+        manualFailureResultRef.current === status.consecutive_failures
+      ) {
+        manualFailureBaselineRef.current = null;
+        manualFailureResultRef.current = null;
+      } else {
+        trackAnalyticsEvent("cloud_sync_failed", {
+          trigger: "background",
+          failure_kind: status.last_error_kind ?? "unknown",
+        });
+      }
+    }
+    lastTrackedFailureCountRef.current = status.consecutive_failures;
+  }, [status]);
 
   if (settingsQuery.error) {
     throw settingsQuery.error;
@@ -180,7 +287,6 @@ export function SettingsSync() {
     );
   }
 
-  const status = statusQuery.data;
   const statusView = (() => {
     if (!syncEnabled) {
       return {

--- a/apps/desktop/src/shared-notes/index.tsx
+++ b/apps/desktop/src/shared-notes/index.tsx
@@ -12,6 +12,7 @@ import { NoteEditor } from "@hypr/editor/note";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { Button } from "@hypr/ui/components/ui/button";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { useAuth } from "~/auth";
 import { openEditorLink } from "~/editor-bridge/open-editor-link";
 import {
@@ -26,6 +27,7 @@ import {
 } from "~/shared-notes/cache";
 import { useSharedNotePreview } from "~/shared-notes/preview";
 import { useSharedAttachmentResolver } from "~/shared-notes/use-shared-attachment-resolver";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import type { Tab } from "~/store/zustand/tabs";
 
 export function TabContentSharedNote({
@@ -235,6 +237,17 @@ function SharedNoteDocument({
     currentRevision: comments?.currentRevision ?? -1,
     manageAccess: comments?.manageAccess ?? false,
     shareId: comments?.shareId ?? null,
+  });
+  useMountEffect(() => {
+    trackAnalyticsEvent("shared_note_opened", {
+      access_mode: comments
+        ? comments.manageAccess
+          ? "owner"
+          : comments.canCompose
+            ? "collaborator"
+            : "viewer"
+        : "public_preview",
+    });
   });
 
   const content = ensureFirstLineTitle(

--- a/apps/desktop/src/shared/hooks/usePermissionAnalytics.ts
+++ b/apps/desktop/src/shared/hooks/usePermissionAnalytics.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from "react";
+
+import type { PermissionStatus } from "@hypr/plugin-permissions";
+
+import { trackAnalyticsEvent } from "~/analytics";
+
+export function usePermissionAnalytics(
+  permission: string,
+  status: PermissionStatus | undefined,
+  entryPoint: "onboarding" | "settings",
+) {
+  const previousStatus = useRef(status);
+
+  useEffect(() => {
+    const previous = previousStatus.current;
+    previousStatus.current = status;
+
+    if (
+      previous === undefined ||
+      previous === status ||
+      (status !== "authorized" && status !== "denied")
+    ) {
+      return;
+    }
+
+    trackAnalyticsEvent("permission_resolved", {
+      permission,
+      status,
+      entry_point: entryPoint,
+    });
+  }, [entryPoint, permission, status]);
+}
+
+export function trackPermissionRequested(
+  permission: string,
+  status: PermissionStatus | undefined,
+  entryPoint: "onboarding" | "settings",
+  action: "request" | "open_settings",
+) {
+  trackAnalyticsEvent("permission_requested", {
+    permission,
+    previous_status: status ?? "unknown",
+    entry_point: entryPoint,
+    action,
+  });
+}

--- a/apps/desktop/src/shared/hooks/usePermissions.test.tsx
+++ b/apps/desktop/src/shared/hooks/usePermissions.test.tsx
@@ -74,6 +74,7 @@ describe("usePermission", () => {
     act(() => result.current.request());
 
     await waitFor(() => expect(result.current.status).toBe("authorized"));
+    expect(result.current.confirmedStatus).toBe("denied");
 
     await waitFor(() => expect(result.current.status).toBe("denied"), {
       timeout: 5000,

--- a/apps/desktop/src/shared/hooks/usePermissions.ts
+++ b/apps/desktop/src/shared/hooks/usePermissions.ts
@@ -87,6 +87,7 @@ export function usePermission(type: Permission) {
 
   return {
     status: effectiveStatus,
+    confirmedStatus: status,
     isPending,
     // A recovered capability must not keep rendering the diagnostics of an older
     // failed request.

--- a/apps/desktop/src/shared/open-note-dialog.tsx
+++ b/apps/desktop/src/shared/open-note-dialog.tsx
@@ -5,6 +5,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -13,6 +14,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 import { cn } from "@hypr/utils";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { useAuth } from "~/auth";
 import { useSessionSummaries } from "~/session/queries";
 import { useDurableSharedNotes } from "~/shared-notes/cache";
@@ -173,6 +175,24 @@ export function OpenNoteDialog({
   const hasAnyResults =
     filteredRecentSessions.length > 0 || filteredOtherNotes.length > 0;
 
+  useEffect(() => {
+    if (!open || !query.trim()) return;
+    const timeout = setTimeout(() => {
+      trackAnalyticsEvent("search_performed", {
+        entry_point: "open_note_dialog",
+        result_count: filteredRecentSessions.length + filteredOtherNotes.length,
+        entity_types: [
+          ...new Set(
+            [...filteredRecentSessions, ...filteredOtherNotes].map(
+              (note) => note.resourceType,
+            ),
+          ),
+        ].sort(),
+      });
+    }, 300);
+    return () => clearTimeout(timeout);
+  }, [filteredOtherNotes.length, filteredRecentSessions.length, open, query]);
+
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
       if (!nextOpen) {
@@ -189,6 +209,11 @@ export function OpenNoteDialog({
 
   const handleSelect = useCallback(
     (note: NoteResult) => {
+      trackAnalyticsEvent("search_result_opened", {
+        entry_point: "open_note_dialog",
+        result_type: note.resourceType,
+        had_query: Boolean(query.trim()),
+      });
       handleOpenChange(false);
       openCurrent(
         note.resourceType === "shared_session"
@@ -196,7 +221,7 @@ export function OpenNoteDialog({
           : { type: "sessions", id: note.id },
       );
     },
-    [handleOpenChange, openCurrent],
+    [handleOpenChange, openCurrent, query],
   );
 
   if (!open) return null;

--- a/apps/desktop/src/store/zustand/listener/general-batch.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.ts
@@ -15,6 +15,7 @@ import {
   type BatchState,
 } from "./batch";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { createBatchCompletedNotificationKey } from "~/stt/batch-completed-notification";
 
 type BatchStore = BatchActions & BatchState;
@@ -142,12 +143,20 @@ export const runBatchSession = async <T extends BatchStore>(
       if (handled === false) {
         throw new Error(EMPTY_BATCH_TRANSCRIPT_ERROR);
       }
+      trackAnalyticsEvent("transcription_completed", {
+        mode: "batch",
+        provider: params.provider,
+      });
       cleanup();
     } catch (error) {
       console.error("[runBatch] error handling batch response", error);
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       get().handleBatchFailed(sessionId, errorMessage);
+      trackAnalyticsEvent("transcription_failed", {
+        mode: "batch",
+        failure_stage: "persist",
+      });
       cleanup(false);
       reject(error);
       return;
@@ -178,6 +187,12 @@ export const runBatchSession = async <T extends BatchStore>(
       options?.terminalReason,
       options?.errorCode,
     );
+    trackAnalyticsEvent("transcription_failed", {
+      mode: "batch",
+      failure_stage: options?.terminalReason ?? "provider",
+      error_code: options?.errorCode ?? "unknown",
+      provider: params.provider,
+    });
     cleanup(options?.clearSession ?? false);
     reject(error);
   };

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -18,6 +18,7 @@ import {
 import { useSTTConnection } from "./useSTTConnection";
 
 import { requestMainAutoEnhance } from "~/ai/task-window-sync";
+import { trackAnalyticsEvent } from "~/analytics";
 import { useShell } from "~/contexts/shell";
 import { releaseCloudsyncActivityEventually } from "~/db/cloudsync-activity";
 import {
@@ -383,6 +384,7 @@ function useCaptureLifecycle(sessionId: string) {
       const model = recoveredMarker?.model ?? conn?.model;
       const cloudsyncLeaseKey = `${sessionId}:${transcriptId}`;
       let pendingSummaryMode = recoveredMarker?.summaryMode;
+      let completionTracked = false;
       let capturePhase =
         recoveredMarker?.phase ??
         (recoveredMarker?.summaryMode ? "finalizing" : "capturing");
@@ -576,6 +578,10 @@ function useCaptureLifecycle(sessionId: string) {
               reasons: repairReasons,
               error,
             });
+            trackAnalyticsEvent("transcription_failed", {
+              mode: "post_capture",
+              failure_stage: "batch_repair",
+            });
             if (transcriptWriteError || !details.liveTranscriptionActive) {
               sonnerToast.error(
                 "Anarlog could not finish saving the transcript. The recording was kept so you can try again.",
@@ -619,6 +625,10 @@ function useCaptureLifecycle(sessionId: string) {
           postCaptureAction === "enhance_only" ||
           emptyFreshCapture;
         if (!transcriptIsComplete) {
+          trackAnalyticsEvent("transcription_failed", {
+            mode: "live",
+            failure_stage: "persist",
+          });
           await requestRecovery();
           return;
         }
@@ -710,6 +720,11 @@ function useCaptureLifecycle(sessionId: string) {
           await clearCaptureLifecycleMarker(sessionId, transcriptId);
           recoveryPending = false;
           recoveryStateCleared = true;
+          if (hasTranscriptEvidence && !batchCompleted) {
+            trackAnalyticsEvent("transcription_completed", {
+              mode: "live",
+            });
+          }
         } catch (error) {
           await requestRecovery();
           throw error;
@@ -749,12 +764,35 @@ function useCaptureLifecycle(sessionId: string) {
           }
         }
       };
+      const trackSessionCompletion = (
+        details: Parameters<OnStoppedCallback>[1],
+        completionReason: "capture_stopped" | "recovered_capture_stopped",
+      ) => {
+        if (!completionTracked) {
+          completionTracked = true;
+          trackAnalyticsEvent("session_completed", {
+            duration_seconds: Math.max(
+              0,
+              Math.round((Date.now() - startedAt) / 1_000),
+            ),
+            transcription_requested:
+              details.liveTranscriptionActive || canRunBatchRef.current,
+            completion_reason: completionReason,
+          });
+        }
+      };
       const onStopped: OnStoppedCallback = (_sessionId, details) => {
+        trackSessionCompletion(
+          details,
+          recoveredMarker ? "recovered_capture_stopped" : "capture_stopped",
+        );
         recoveryPending = false;
         return finalizeStopped(details, true);
       };
-      const recoverStopped: OnStoppedCallback = (_sessionId, details) =>
-        finalizeStopped(details, false);
+      const recoverStopped: OnStoppedCallback = (_sessionId, details) => {
+        trackSessionCompletion(details, "recovered_capture_stopped");
+        return finalizeStopped(details, false);
+      };
 
       const handlePersist: LiveTranscriptPersistCallback = (delta) => {
         if (delta.new_words.length === 0 && delta.replaced_ids.length === 0) {
@@ -1090,6 +1128,9 @@ export function useStartListening(sessionId: string) {
       await lifecycle.acquireCloudsyncLease();
     } catch (error) {
       console.error("[listener] failed to defer CloudSync for capture", error);
+      trackAnalyticsEvent("session_start_failed", {
+        failure_stage: "cloud_sync_deferral",
+      });
       try {
         await lifecycle.releaseCloudsyncLease();
       } catch (cleanupError) {
@@ -1112,6 +1153,9 @@ export function useStartListening(sessionId: string) {
         "[listener] failed to prepare durable capture state",
         error,
       );
+      trackAnalyticsEvent("session_start_failed", {
+        failure_stage: "recovery_marker",
+      });
       try {
         await lifecycle.cleanupFailedStart();
       } catch (cleanupError) {
@@ -1158,6 +1202,9 @@ export function useStartListening(sessionId: string) {
       );
     } catch (error) {
       console.error("[listener] failed to start recording", error);
+      trackAnalyticsEvent("session_start_failed", {
+        failure_stage: "capture_start",
+      });
       try {
         await lifecycle.cleanupFailedStart();
       } catch (cleanupError) {
@@ -1176,6 +1223,9 @@ export function useStartListening(sessionId: string) {
     }
 
     if (!started) {
+      trackAnalyticsEvent("session_start_failed", {
+        failure_stage: "capture_rejected",
+      });
       await stopMeetingChatTasks();
       try {
         await lifecycle.cleanupFailedStart();

--- a/apps/desktop/src/templates/queries.ts
+++ b/apps/desktop/src/templates/queries.ts
@@ -16,6 +16,7 @@ import {
   type TemplateIcon,
 } from "./template-icon";
 
+import { trackAnalyticsEvent } from "~/analytics";
 import { db, useDrizzleLiveQuery } from "~/db";
 
 type TemplateRow = (typeof templates)["$inferSelect"];
@@ -167,7 +168,9 @@ export async function getTemplateById(
   return mapTemplateRows([row])[0] ?? null;
 }
 
-export function useCreateTemplate() {
+export function useCreateTemplate(
+  entryPoint: "templates" | "session_note" = "templates",
+) {
   const { mutateAsync } = useMutation({
     mutationFn: async (template: UserTemplateDraft) => {
       const id = crypto.randomUUID();
@@ -197,6 +200,11 @@ export function useCreateTemplate() {
         updatedAt: sql`strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`,
       });
 
+      trackAnalyticsEvent("template_created", {
+        entry_point: entryPoint,
+        section_count: sections.length,
+        target_count: targets?.length ?? 0,
+      });
       return id;
     },
     onError: (error) => {
@@ -248,6 +256,9 @@ export function useDeleteTemplate() {
   const { mutateAsync } = useMutation({
     mutationFn: async (id: string) => {
       await db.delete(templates).where(eq(templates.id, id));
+      trackAnalyticsEvent("template_deleted", {
+        entry_point: "templates",
+      });
     },
     onError: (error) => {
       console.error("[useDeleteTemplate]", error);

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -14,5 +14,11 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       "",
     apiUrl: process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3001",
     appUrl: process.env.EXPO_PUBLIC_APP_URL ?? "http://localhost:3000",
+    posthogApiKey:
+      process.env.EXPO_PUBLIC_POSTHOG_API_KEY ??
+      process.env.POSTHOG_API_KEY ??
+      "",
+    posthogHost:
+      process.env.EXPO_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
   },
 });

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,11 +1,26 @@
-import { Stack } from "expo-router";
+import { Stack, usePathname } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
 
 import { AuthProvider, useAuth } from "@/auth/context";
 import { PaywallScreen, SignInScreen } from "@/auth/screens";
 import { Colors } from "@/constants/theme";
+import { initializeAnalytics, screenAnalytics } from "@/lib/analytics";
+
+function AnalyticsLifecycle() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    void initializeAnalytics();
+  }, []);
+
+  useEffect(() => {
+    screenAnalytics(pathname.replace(/^\/note\/[^/]+/, "/note/:id"));
+  }, [pathname]);
+
+  return null;
+}
 
 function Screens() {
   return (
@@ -63,6 +78,7 @@ function Gate() {
 export default function RootLayout() {
   return (
     <AuthProvider>
+      <AnalyticsLifecycle />
       <Gate />
       <StatusBar style="dark" />
     </AuthProvider>

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Pressable,
   ScrollView,
@@ -18,6 +18,7 @@ import { importVoiceMemos } from "@/data/import-voice-memo";
 import { useSessionSearch } from "@/data/search";
 import { createSession, deleteSession } from "@/data/session";
 import { useTimelineSessions, type TimelineSession } from "@/data/timeline";
+import { captureAnalytics } from "@/lib/analytics";
 import { confirmDestructive } from "@/lib/confirm";
 
 export default function HomeScreen() {
@@ -31,6 +32,18 @@ export default function HomeScreen() {
   // Ref, not state: two taps in the same frame both pass a state check.
   const busyRef = useRef(false);
 
+  useEffect(() => {
+    if (!searching || !query?.trim() || search.isLoading) return;
+    const timeout = setTimeout(() => {
+      captureAnalytics("search_performed", {
+        entry_point: "mobile_home",
+        result_count: search.results.length,
+        entity_types: ["note"],
+      });
+    }, 300);
+    return () => clearTimeout(timeout);
+  }, [query, search.isLoading, search.results.length, searching]);
+
   const handleDelete = async (session: TimelineSession) => {
     const confirmed = await confirmDestructive(
       `Delete "${session.title || "Untitled"}"?`,
@@ -43,7 +56,9 @@ export default function HomeScreen() {
     if (busyRef.current) return;
     busyRef.current = true;
     try {
-      const sessionId = await createSession();
+      const sessionId = await createSession({
+        entryPoint: query.includes("listen=1") ? "start_listening" : "new_note",
+      });
       router.push(`/note/${sessionId}${query}`);
     } finally {
       busyRef.current = false;
@@ -112,7 +127,13 @@ export default function HomeScreen() {
               <SessionCard
                 key={session.id}
                 session={session}
-                onPress={() => router.push(`/note/${session.id}`)}
+                onPress={() => {
+                  captureAnalytics("search_result_opened", {
+                    entry_point: "mobile_home",
+                    result_type: "session",
+                  });
+                  router.push(`/note/${session.id}`);
+                }}
                 onDelete={() => void handleDelete(session)}
               />
             ))}

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -1,4 +1,5 @@
 import {
+  getRecordingPermissionsAsync,
   RecordingPresets,
   requestRecordingPermissionsAsync,
   setAudioModeAsync,
@@ -11,6 +12,7 @@ import { useEffect, useRef, useState } from "react";
 import { WAVEFORM_BAR_COUNT } from "@/components/waveform";
 import { catalogSessionAudio } from "@/data/audio-catalog";
 import { transcribeSession } from "@/data/transcribe";
+import { captureAnalytics } from "@/lib/analytics";
 
 const METERING_FLOOR_DB = -50;
 
@@ -59,9 +61,25 @@ export function useSessionRecorder(
     setPhase("starting");
     startRef.current = (async () => {
       try {
-        const permission = await requestRecordingPermissionsAsync();
+        let permission = await getRecordingPermissionsAsync();
+        if (!permission.granted) {
+          captureAnalytics("permission_requested", {
+            permission: "microphone",
+            entry_point: "start_listening",
+            action: "request",
+          });
+          permission = await requestRecordingPermissionsAsync();
+          captureAnalytics("permission_resolved", {
+            permission: "microphone",
+            entry_point: "start_listening",
+            status: permission.granted ? "authorized" : "denied",
+          });
+        }
         if (!active) return;
         if (!permission.granted) {
+          captureAnalytics("session_start_failed", {
+            failure_stage: "microphone_permission",
+          });
           setPhase("unavailable");
           return;
         }
@@ -74,9 +92,16 @@ export function useSessionRecorder(
         await recorder.prepareToRecordAsync();
         if (!active) return;
         recorder.record();
+        captureAnalytics("session_started", {
+          entry_point: "mobile_recorder",
+          transcription_mode: "post_capture",
+        });
         setPhase("recording");
       } catch (error) {
         console.warn("[recorder] failed to start", error);
+        captureAnalytics("session_start_failed", {
+          failure_stage: "capture_start",
+        });
         if (active) setPhase("unavailable");
       }
     })();
@@ -124,6 +149,13 @@ export function useSessionRecorder(
         filename: `audio.${extension}`,
         contentType: CONTENT_TYPES[extension] ?? "application/octet-stream",
         sizeBytes: destination.size ?? 0,
+      });
+      captureAnalytics("session_completed", {
+        duration_seconds: Math.round(
+          (recorderState.durationMillis ?? 0) / 1000,
+        ),
+        completion_reason: "user_stopped",
+        transcription_requested: true,
       });
       void transcribeSession(sessionId);
       setPhase("saved");

--- a/apps/mobile/src/auth/context.tsx
+++ b/apps/mobile/src/auth/context.tsx
@@ -23,6 +23,11 @@ import {
   type BillingInfo,
 } from "@/auth/billing";
 import { authStorageKey, supabase } from "@/auth/client";
+import {
+  captureAnalytics,
+  identifyAnalytics,
+  resetAnalytics,
+} from "@/lib/analytics";
 import { env, hasSupabaseEnv } from "@/lib/env";
 
 export type AuthState = {
@@ -115,6 +120,10 @@ function acceptAuthTokens(accessToken: string, refreshToken: string): void {
         inFlightTokens.delete(key);
         if (error) {
           console.error("[auth] setSession failed", error);
+          captureAnalytics("auth_failed", {
+            method: "browser_handoff",
+            failure_stage: "set_session",
+          });
         } else {
           recentTokens.set(key, Date.now());
         }
@@ -122,6 +131,10 @@ function acceptAuthTokens(accessToken: string, refreshToken: string): void {
       (error) => {
         inFlightTokens.delete(key);
         console.error("[auth] setSession failed", error);
+        captureAnalytics("auth_failed", {
+          method: "browser_handoff",
+          failure_stage: "set_session",
+        });
       },
     );
 }
@@ -201,12 +214,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return;
       }
       setSession(nextSession);
+      if (event === "SIGNED_IN" && nextSession) {
+        identifyAnalytics(nextSession.user.id);
+        captureAnalytics("user_signed_in", {
+          method: "browser_handoff",
+        });
+      } else if (event === "SIGNED_OUT") {
+        resetAnalytics();
+      }
     });
 
     return () => {
       subscription.unsubscribe();
     };
   }, [setSession]);
+
+  useEffect(() => {
+    if (session?.user.id) {
+      identifyAnalytics(session.user.id);
+    }
+  }, [session?.user.id]);
 
   useEffect(() => {
     if (!supabase) {
@@ -232,12 +259,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    const result = await WebBrowser.openAuthSessionAsync(
-      `${env.appUrl}/auth?flow=desktop&scheme=anarlog`,
-      "anarlog://auth/callback",
-    );
-    if (result.type === "success") {
-      handleAuthCallbackUrl(result.url);
+    captureAnalytics("auth_started", {
+      method: "browser_handoff",
+      entry_point: "mobile_sign_in",
+    });
+    try {
+      const result = await WebBrowser.openAuthSessionAsync(
+        `${env.appUrl}/auth?flow=desktop&scheme=anarlog`,
+        "anarlog://auth/callback",
+      );
+      if (result.type === "success") {
+        handleAuthCallbackUrl(result.url);
+      } else {
+        captureAnalytics("auth_failed", {
+          method: "browser_handoff",
+          failure_stage: "cancelled",
+        });
+      }
+    } catch (error) {
+      captureAnalytics("auth_failed", {
+        method: "browser_handoff",
+        failure_stage: "open_browser",
+      });
+      throw error;
     }
   }, []);
 
@@ -246,6 +290,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    captureAnalytics("user_signed_out");
     const { error } = await supabase.auth
       .signOut({ scope: "local" })
       .catch((error: unknown) => ({ error }));
@@ -256,6 +301,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       await AsyncStorage.removeItem(authStorageKey).catch(() => {});
     }
     setSession(null);
+    resetAnalytics();
   }, [setSession]);
 
   const accessToken = session?.access_token ?? null;

--- a/apps/mobile/src/auth/screens.tsx
+++ b/apps/mobile/src/auth/screens.tsx
@@ -1,4 +1,5 @@
 import * as WebBrowser from "expo-web-browser";
+import { useEffect } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -10,6 +11,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import type { BillingInfo } from "@/auth/billing";
 import { Colors, Radius, Spacing } from "@/constants/theme";
+import { captureAnalytics } from "@/lib/analytics";
 import { env } from "@/lib/env";
 
 export function SignInScreen({
@@ -60,6 +62,13 @@ export function PaywallScreen({
   email: string;
   onSignOut: () => void;
 }) {
+  useEffect(() => {
+    captureAnalytics("paywall_viewed", {
+      entry_point: "mobile_gate",
+      feature: "mobile_access",
+    });
+  }, []);
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.body}>

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -7,6 +7,7 @@ import { Directory, File, Paths } from "expo-file-system";
 import { catalogSessionAudio } from "@/data/audio-catalog";
 import { createSession, deleteSession } from "@/data/session";
 import { transcribeSession } from "@/data/transcribe";
+import { captureAnalytics } from "@/lib/analytics";
 import { nowIso } from "@/lib/ids";
 
 const CONTENT_TYPES: Record<string, string> = {
@@ -46,7 +47,12 @@ async function importAsset(asset: DocumentPickerAsset): Promise<string> {
       ? new Date(asset.lastModified).toISOString()
       : nowIso();
 
-  const sessionId = await createSession({ title, createdAt });
+  const sessionId = await createSession({
+    title,
+    createdAt,
+    entryPoint: "voice_memo_import",
+    trackCreated: false,
+  });
 
   try {
     const directory = new Directory(Paths.document, "sessions", sessionId);
@@ -63,6 +69,19 @@ async function importAsset(asset: DocumentPickerAsset): Promise<string> {
         CONTENT_TYPES[extension] ??
         "application/octet-stream",
       sizeBytes: asset.size ?? destination.size ?? 0,
+    });
+    captureAnalytics("file_uploaded", {
+      entry_point: "voice_memo_import",
+      file_type: "audio",
+      content_type:
+        asset.mimeType ??
+        CONTENT_TYPES[extension] ??
+        "application/octet-stream",
+      size_bytes: asset.size ?? destination.size ?? 0,
+    });
+    captureAnalytics("note_created", {
+      entry_point: "voice_memo_import",
+      has_initial_title: Boolean(title),
     });
   } catch (error) {
     // The session exists before the audio does, so a failed copy or catalog

--- a/apps/mobile/src/data/session.ts
+++ b/apps/mobile/src/data/session.ts
@@ -7,6 +7,7 @@ import {
   stripMarkdownTitle,
 } from "@/data/note-doc";
 import { execute, executeTransaction, useLiveQuery } from "@/db";
+import { captureAnalytics } from "@/lib/analytics";
 import { DEFAULT_USER_ID, id, nowIso } from "@/lib/ids";
 
 const SESSION_INSERT_SQL = `
@@ -58,6 +59,8 @@ FROM sessions AS session WHERE session.id = ? AND session.deleted_at IS NULL
 export async function createSession(options?: {
   title?: string;
   createdAt?: string;
+  entryPoint?: "new_note" | "start_listening" | "voice_memo_import";
+  trackCreated?: boolean;
 }): Promise<string> {
   const sessionId = id();
   const participantId = id();
@@ -78,6 +81,12 @@ export async function createSession(options?: {
     },
   ]);
 
+  if (options?.trackCreated !== false) {
+    captureAnalytics("note_created", {
+      entry_point: options?.entryPoint ?? "new_note",
+      has_initial_title: Boolean(options?.title),
+    });
+  }
   return sessionId;
 }
 
@@ -162,6 +171,30 @@ ON CONFLICT(id) DO UPDATE SET
 
 const SESSION_TITLE_UPDATE_SQL =
   "UPDATE sessions SET title = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL";
+const NOTE_EDIT_ANALYTICS_SESSION_MS = 30 * 60 * 1_000;
+const lastTrackedNoteEditAt = new Map<string, number>();
+
+function captureNoteEditOnce(
+  sessionId: string,
+  editType: "body" | "title",
+  bodyFormat?: "prosemirror_json" | "markdown",
+) {
+  const key = `${sessionId}:${editType}`;
+  const now = Date.now();
+  const lastTrackedAt = lastTrackedNoteEditAt.get(key);
+  if (
+    lastTrackedAt !== undefined &&
+    now - lastTrackedAt < NOTE_EDIT_ANALYTICS_SESSION_MS
+  ) {
+    return;
+  }
+
+  lastTrackedNoteEditAt.set(key, now);
+  captureAnalytics("note_edited", {
+    edit_type: editType,
+    ...(bodyFormat ? { body_format: bodyFormat } : {}),
+  });
+}
 
 export async function saveSessionNote(
   sessionId: string,
@@ -187,6 +220,7 @@ export async function saveSessionNote(
       params: [sessionId, input.bodyFormat, body, now, now, sessionId],
     },
   ]);
+  captureNoteEditOnce(sessionId, "body", input.bodyFormat);
 }
 
 // Mirrors desktop buildSessionTombstoneStatements: one transaction, the same
@@ -244,4 +278,5 @@ export async function saveSessionTitle(
     }
   }
   await executeTransaction(statements);
+  captureNoteEditOnce(sessionId, "title");
 }

--- a/apps/mobile/src/data/transcribe.ts
+++ b/apps/mobile/src/data/transcribe.ts
@@ -5,6 +5,7 @@ import { Platform } from "react-native";
 
 import { supabase } from "@/auth/client";
 import { execute, executeTransaction } from "@/db";
+import { captureAnalytics } from "@/lib/analytics";
 import { env } from "@/lib/env";
 import { id, nowIso } from "@/lib/ids";
 
@@ -317,9 +318,20 @@ export function transcribeSession(sessionId: string): Promise<void> {
 
   setState(sessionId, "running");
   const task = runTranscription(sessionId)
-    .then(() => clearStateSilently(sessionId))
+    .then(() => {
+      captureAnalytics("transcription_completed", {
+        mode: "batch",
+        entry_point: "mobile_audio",
+      });
+      clearStateSilently(sessionId);
+    })
     .catch((error: unknown) => {
       console.warn("[transcribe] failed", error);
+      captureAnalytics("transcription_failed", {
+        mode: "batch",
+        entry_point: "mobile_audio",
+        failure_stage: "transcription",
+      });
       setState(sessionId, "failed");
     })
     .finally(() => {

--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -1,0 +1,173 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import Constants from "expo-constants";
+import { randomUUID } from "expo-crypto";
+import { AppState } from "react-native";
+
+import { env } from "@/lib/env";
+
+type AnalyticsValue = null | boolean | number | string | string[] | number[];
+
+const FIRST_OPEN_KEY = "anarlog:analytics:first-opened";
+const DISTINCT_ID_KEY = "anarlog:analytics:distinct-id";
+const SESSION_TIMEOUT_MS = 30 * 60 * 1_000;
+const appVersion = Constants.expoConfig?.version ?? "unknown";
+const enabled = Boolean(env.posthogApiKey) && !__DEV__;
+
+let anonymousIdPromise: Promise<string> | null = null;
+let identifiedUserId: string | null = null;
+let accountId: string | null = null;
+let identityGeneration = 0;
+let sessionId = randomUUID();
+let lastEventAt = Date.now();
+let lifecycleStarted = false;
+
+function getAnonymousId() {
+  anonymousIdPromise ??= (async () => {
+    const stored = await AsyncStorage.getItem(DISTINCT_ID_KEY).catch(
+      () => null,
+    );
+    if (stored) return stored;
+
+    const created = randomUUID();
+    await AsyncStorage.setItem(DISTINCT_ID_KEY, created).catch(() => {});
+    return created;
+  })();
+  return anonymousIdPromise;
+}
+
+function currentSessionId() {
+  const now = Date.now();
+  if (now - lastEventAt >= SESSION_TIMEOUT_MS) {
+    sessionId = randomUUID();
+  }
+  lastEventAt = now;
+  return sessionId;
+}
+
+async function sendAnalytics(
+  event: string,
+  properties: Record<string, unknown> = {},
+  distinctId?: string,
+) {
+  if (!enabled) return;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 1_000);
+  try {
+    const resolvedDistinctId =
+      distinctId ?? identifiedUserId ?? (await getAnonymousId());
+    await fetch(`${env.posthogHost.replace(/\/+$/, "")}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: controller.signal,
+      body: JSON.stringify({
+        api_key: env.posthogApiKey,
+        event,
+        properties: {
+          ...properties,
+          distinct_id: resolvedDistinctId,
+          $session_id: currentSessionId(),
+          ...(accountId ? { $groups: { account: accountId } } : {}),
+          surface: "mobile",
+          analytics_schema_version: 1,
+          app_version: appVersion,
+        },
+      }),
+    });
+  } catch {
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function captureAnalytics(
+  event: string,
+  properties: Record<string, AnalyticsValue> = {},
+) {
+  void sendAnalytics(event, properties);
+}
+
+export function screenAnalytics(pathname: string) {
+  captureAnalytics("$screen", {
+    $screen_name: pathname,
+  });
+}
+
+export function identifyAnalytics(userId: string) {
+  if (identifiedUserId === userId) return;
+
+  const generation = ++identityGeneration;
+  identifiedUserId = userId;
+  accountId = userId;
+  void getAnonymousId().then((resolvedAnonymousId) => {
+    if (generation !== identityGeneration || identifiedUserId !== userId) {
+      return;
+    }
+
+    void sendAnalytics(
+      "$identify",
+      { $anon_distinct_id: resolvedAnonymousId },
+      userId,
+    );
+    void sendAnalytics(
+      "$groupidentify",
+      {
+        $group_type: "account",
+        $group_key: userId,
+        $group_set: {},
+      },
+      userId,
+    );
+  });
+}
+
+export function resetAnalytics() {
+  if (!identifiedUserId && !accountId) {
+    return;
+  }
+
+  identityGeneration += 1;
+  identifiedUserId = null;
+  accountId = null;
+  sessionId = randomUUID();
+  lastEventAt = Date.now();
+  const nextAnonymousId = randomUUID();
+  anonymousIdPromise = Promise.resolve(nextAnonymousId);
+  void AsyncStorage.setItem(DISTINCT_ID_KEY, nextAnonymousId).catch(() => {});
+}
+
+let initialization: Promise<void> | null = null;
+
+export function initializeAnalytics() {
+  initialization ??= (async () => {
+    if (!enabled) return;
+
+    await getAnonymousId();
+    await sendAnalytics("app_started");
+    await sendAnalytics("$app_opened");
+
+    const firstOpen = await AsyncStorage.getItem(FIRST_OPEN_KEY).catch(
+      () => null,
+    );
+    if (firstOpen === null) {
+      await AsyncStorage.setItem(FIRST_OPEN_KEY, "1").catch(() => {});
+      await sendAnalytics("app_first_opened", {
+        first_open_marker: "local_install",
+      });
+    }
+
+    if (lifecycleStarted) return;
+    lifecycleStarted = true;
+    let previousState = AppState.currentState;
+    AppState.addEventListener("change", (nextState) => {
+      if (nextState === previousState) return;
+      if (nextState === "active") {
+        captureAnalytics("$app_opened");
+      } else if (previousState === "active") {
+        captureAnalytics("$app_backgrounded");
+      }
+      previousState = nextState;
+    });
+  })();
+  return initialization;
+}

--- a/apps/mobile/src/lib/env.ts
+++ b/apps/mobile/src/lib/env.ts
@@ -12,6 +12,8 @@ export const env = {
   supabaseAnonKey: read("supabaseAnonKey"),
   apiUrl: read("apiUrl", "http://localhost:3001"),
   appUrl: read("appUrl", "http://localhost:3000"),
+  posthogApiKey: read("posthogApiKey"),
+  posthogHost: read("posthogHost", "https://us.i.posthog.com"),
 };
 
 export const hasSupabaseEnv = Boolean(env.supabaseUrl && env.supabaseAnonKey);

--- a/apps/stripe/src/analytics-payload.ts
+++ b/apps/stripe/src/analytics-payload.ts
@@ -42,12 +42,34 @@ export function getBillingAnalyticsPayload(
     }
     case "customer.subscription.updated": {
       const subscription = event.data.object as Stripe.Subscription;
-      const previousStatus = (
-        event.data.previous_attributes as { status?: string } | undefined
-      )?.status;
+      const previous = event.data.previous_attributes as
+        | {
+            status?: string;
+            cancel_at_period_end?: boolean;
+            items?: unknown;
+          }
+        | undefined;
 
-      if (subscription.status === "active" && previousStatus === "trialing") {
+      if (subscription.status === "active" && previous?.status === "trialing") {
         return subscriptionPayload("subscription_activated", subscription);
+      }
+      if (
+        previous?.cancel_at_period_end === false &&
+        subscription.cancel_at_period_end
+      ) {
+        return subscriptionPayload(
+          "subscription_cancel_scheduled",
+          subscription,
+        );
+      }
+      if (
+        previous?.cancel_at_period_end === true &&
+        !subscription.cancel_at_period_end
+      ) {
+        return subscriptionPayload("subscription_resumed", subscription);
+      }
+      if (previous?.items !== undefined) {
+        return subscriptionPayload("subscription_plan_changed", subscription);
       }
 
       return null;

--- a/apps/stripe/src/analytics.test.ts
+++ b/apps/stripe/src/analytics.test.ts
@@ -68,6 +68,60 @@ describe("getBillingAnalyticsPayload", () => {
     expect(payload?.event).toBe("subscription_activated");
   });
 
+  it("tracks cancellation scheduling", () => {
+    const payload = getBillingAnalyticsPayload(
+      event(
+        "customer.subscription.updated",
+        {
+          status: "active",
+          metadata: {},
+          cancel_at_period_end: true,
+          trial_end: null,
+          items: { data: [] },
+        },
+        { cancel_at_period_end: false },
+      ),
+    );
+
+    expect(payload?.event).toBe("subscription_cancel_scheduled");
+  });
+
+  it("tracks subscription resumes", () => {
+    const payload = getBillingAnalyticsPayload(
+      event(
+        "customer.subscription.updated",
+        {
+          status: "active",
+          metadata: {},
+          cancel_at_period_end: false,
+          trial_end: null,
+          items: { data: [] },
+        },
+        { cancel_at_period_end: true },
+      ),
+    );
+
+    expect(payload?.event).toBe("subscription_resumed");
+  });
+
+  it("tracks plan changes", () => {
+    const payload = getBillingAnalyticsPayload(
+      event(
+        "customer.subscription.updated",
+        {
+          status: "active",
+          metadata: {},
+          cancel_at_period_end: false,
+          trial_end: null,
+          items: { data: [] },
+        },
+        { items: { data: [] } },
+      ),
+    );
+
+    expect(payload?.event).toBe("subscription_plan_changed");
+  });
+
   it("ignores zero-dollar trial invoices", () => {
     expect(
       getBillingAnalyticsPayload(

--- a/apps/stripe/src/analytics.ts
+++ b/apps/stripe/src/analytics.ts
@@ -53,6 +53,8 @@ export async function captureBillingEvent(event: Stripe.Event) {
       ...payload.properties,
       $insert_id: `stripe-event:${event.id}`,
       source: "stripe",
+      surface: "stripe",
+      analytics_schema_version: 1,
       stripe_event_id: event.id,
     },
   });
@@ -86,6 +88,8 @@ export async function captureTrialEndingEmailSent({
     properties: {
       $insert_id: `stripe-event:${eventId}:trial-ending-email-sent`,
       source: "loops",
+      surface: "stripe",
+      analytics_schema_version: 1,
       transactional_id: transactionalId,
       trial_end: trialEnd,
       days_until_trial_end: Math.max(

--- a/apps/web/src/components/shared-note-comments-data.ts
+++ b/apps/web/src/components/shared-note-comments-data.ts
@@ -10,6 +10,7 @@ import {
   deleteSharedNoteComment,
   listSharedNoteComments,
 } from "@/functions/shared-notes";
+import { capturePrivateRouteEvent } from "@/lib/private-route-analytics";
 import type {
   SharedNoteComment,
   SharedNoteCommentAnchor,
@@ -108,6 +109,12 @@ export function useCreateSharedNoteComment({
           context.previous,
         );
       }
+    },
+    onSuccess: (_comment, variables) => {
+      capturePrivateRouteEvent("share_collaboration_performed", {
+        action: "comment_created",
+        anchor_type: variables.anchor ? "selection" : "note",
+      });
     },
     onSettled: async () => {
       await queryClient.invalidateQueries({

--- a/apps/web/src/components/shared-note-viewer.tsx
+++ b/apps/web/src/components/shared-note-viewer.tsx
@@ -14,6 +14,8 @@ import {
   type SharedAttachmentResolver,
   SharedNoteDocument,
 } from "@/components/shared-note-document";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { capturePrivateRouteEvent } from "@/lib/private-route-analytics";
 import {
   findFeaturedSharedNoteAudio,
   formatSharedNotePublishedAt,
@@ -57,6 +59,12 @@ export function SharedNoteViewer({
 }) {
   const body = withoutDuplicateLeadingTitle(snapshot.body, snapshot.title);
   const featuredAudio = findFeaturedSharedNoteAudio(snapshot.attachments);
+  useMountEffect(() => {
+    capturePrivateRouteEvent("shared_note_opened", {
+      has_audio: Boolean(featuredAudio),
+      has_collaboration_actions: Boolean(actions),
+    });
+  });
 
   return (
     <SharedNoteShell

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -21,6 +21,7 @@ import {
   sanitizeInternalReturnPath,
   toAbsoluteInternalReturnUrl,
 } from "@/lib/auth-redirect";
+import { captureServerAnalytics } from "@/lib/server-analytics";
 import {
   getStripeCustomerIdentityMetadata,
   getStripeCustomerOwnership,
@@ -335,6 +336,20 @@ async function createCheckoutUrl({
     }
     throw error;
   }
+
+  void captureServerAnalytics({
+    event: "checkout_started",
+    userId: user.id,
+    insertId: `checkout-started:${checkout.id}`,
+    properties: {
+      plan: "pro",
+      period,
+      checkout_type: checkoutType,
+      entry_point: source,
+    },
+  }).catch((error) => {
+    console.error("[analytics] failed to record checkout start", error);
+  });
 
   return { url: checkout.url, stripeCustomerId };
 }

--- a/apps/web/src/hooks/use-posthog.ts
+++ b/apps/web/src/hooks/use-posthog.ts
@@ -1,45 +1,44 @@
 import { usePostHog } from "@posthog/react";
 import { useCallback } from "react";
 
-import { usePostHogReady } from "@/providers/posthog";
+import { env } from "@/env";
+import { usePostHogOperation, usePostHogReady } from "@/providers/posthog";
 
 export { usePostHog };
 
 /**
  * Hook for type-safe PostHog event tracking.
- * All callbacks are stable references that update when PostHog initializes,
- * so mount-time useEffects depending on them will re-run after init.
+ * All callbacks are stable references that use the latest readiness state.
  */
 export function useAnalytics() {
   const posthog = usePostHog();
   const analyticsReady = usePostHogReady();
+  const runOrQueue = usePostHogOperation();
 
   const track = useCallback(
     (eventName: string, properties?: Record<string, any>) => {
-      if (!analyticsReady || !posthog) {
-        return;
-      }
-      posthog.capture(eventName, properties);
+      runOrQueue((client) => {
+        client.capture(eventName, {
+          ...properties,
+          surface: "web",
+          analytics_schema_version: 1,
+          app_version: env.VITE_APP_VERSION ?? "unknown",
+        });
+      });
     },
-    [posthog, analyticsReady],
+    [runOrQueue],
   );
 
   const identify = useCallback(
     (userId: string, properties?: Record<string, any>) => {
-      if (!analyticsReady || !posthog) {
-        return;
-      }
-      posthog.identify(userId, properties);
+      runOrQueue((client) => client.identify(userId, properties));
     },
-    [posthog, analyticsReady],
+    [runOrQueue],
   );
 
   const reset = useCallback(() => {
-    if (!analyticsReady || !posthog) {
-      return;
-    }
-    posthog.reset();
-  }, [posthog, analyticsReady]);
+    runOrQueue((client) => client.reset());
+  }, [runOrQueue]);
 
   return {
     track,

--- a/apps/web/src/lib/private-route-analytics.ts
+++ b/apps/web/src/lib/private-route-analytics.ts
@@ -1,0 +1,55 @@
+import { env } from "@/env";
+
+const PRIVATE_ANALYTICS_ID_KEY = "anarlog.private-analytics-id";
+let fallbackDistinctId: string | null = null;
+
+function getDistinctId() {
+  try {
+    const existing = window.sessionStorage.getItem(PRIVATE_ANALYTICS_ID_KEY);
+    if (existing) return existing;
+
+    const created = crypto.randomUUID();
+    window.sessionStorage.setItem(PRIVATE_ANALYTICS_ID_KEY, created);
+    return created;
+  } catch {
+    fallbackDistinctId ??= crypto.randomUUID();
+    return fallbackDistinctId;
+  }
+}
+
+export function capturePrivateRouteEvent(
+  event: string,
+  properties: Record<string, unknown> = {},
+) {
+  if (
+    typeof window === "undefined" ||
+    import.meta.env.DEV ||
+    !env.VITE_POSTHOG_API_KEY ||
+    (navigator as Navigator & { globalPrivacyControl?: boolean })
+      .globalPrivacyControl === true
+  ) {
+    return;
+  }
+
+  try {
+    const host = env.VITE_POSTHOG_HOST.replace(/\/+$/, "");
+    const distinctId = getDistinctId();
+    void fetch(`${host}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      keepalive: true,
+      body: JSON.stringify({
+        api_key: env.VITE_POSTHOG_API_KEY,
+        event,
+        properties: {
+          ...properties,
+          distinct_id: distinctId,
+          $session_id: distinctId,
+          surface: "web",
+          analytics_schema_version: 1,
+          app_version: env.VITE_APP_VERSION ?? "unknown",
+        },
+      }),
+    }).catch(() => undefined);
+  } catch {}
+}

--- a/apps/web/src/lib/server-analytics.ts
+++ b/apps/web/src/lib/server-analytics.ts
@@ -1,0 +1,43 @@
+import { env } from "@/env";
+
+export async function captureServerAnalytics({
+  event,
+  userId,
+  properties = {},
+  insertId,
+}: {
+  event: string;
+  userId: string;
+  properties?: Record<string, unknown>;
+  insertId?: string;
+}) {
+  if (!env.VITE_POSTHOG_API_KEY || process.env.NODE_ENV !== "production") {
+    return;
+  }
+
+  const response = await fetch(
+    `${env.VITE_POSTHOG_HOST.replace(/\/+$/, "")}/capture/`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: AbortSignal.timeout(1_000),
+      body: JSON.stringify({
+        api_key: env.VITE_POSTHOG_API_KEY,
+        event,
+        properties: {
+          ...properties,
+          distinct_id: userId,
+          $groups: { account: userId },
+          ...(insertId ? { $insert_id: insertId } : {}),
+          surface: "api",
+          analytics_schema_version: 1,
+          app_version: env.VITE_APP_VERSION ?? "unknown",
+        },
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`PostHog capture failed with ${response.status}`);
+  }
+}

--- a/apps/web/src/providers/posthog.tsx
+++ b/apps/web/src/providers/posthog.tsx
@@ -1,16 +1,32 @@
 import { PostHogProvider as PostHogReactProvider } from "@posthog/react";
 import posthog from "posthog-js";
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { env } from "../env";
 import { isTelemetryPrivateLocation } from "../lib/auth-route-privacy";
 
 const isDev = import.meta.env.DEV;
 
-const PostHogReadyContext = createContext(false);
+type PendingAnalyticsOperation = (client: typeof posthog) => void;
+
+const PostHogContext = createContext({
+  analyticsReady: false,
+  runOrQueue: (_operation: PendingAnalyticsOperation) => {},
+});
 
 export function usePostHogReady() {
-  return useContext(PostHogReadyContext);
+  return useContext(PostHogContext).analyticsReady;
+}
+
+export function usePostHogOperation() {
+  return useContext(PostHogContext).runOrQueue;
 }
 
 export function PostHogProvider({
@@ -22,22 +38,46 @@ export function PostHogProvider({
 }) {
   const didInitRef = useRef(false);
   const routeDisabledRef = useRef(false);
+  const pendingOperationsRef = useRef<PendingAnalyticsOperation[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
+  const globalPrivacyControl =
+    typeof navigator !== "undefined" &&
+    (navigator as Navigator & { globalPrivacyControl?: boolean })
+      .globalPrivacyControl === true;
+  const analyticsAvailable =
+    typeof window !== "undefined" &&
+    Boolean(env.VITE_POSTHOG_API_KEY) &&
+    !isDev &&
+    !globalPrivacyControl &&
+    enabled &&
+    !isTelemetryPrivateLocation(
+      window.location.pathname,
+      window.location.search,
+    );
+  const analyticsReady = analyticsAvailable && isInitialized;
+  const analyticsStatusRef = useRef<"disabled" | "pending" | "ready">(
+    analyticsAvailable ? "pending" : "disabled",
+  );
+  analyticsStatusRef.current = analyticsAvailable
+    ? analyticsReady
+      ? "ready"
+      : "pending"
+    : "disabled";
+
+  const runOrQueue = useCallback((operation: PendingAnalyticsOperation) => {
+    if (analyticsStatusRef.current === "ready") {
+      operation(posthog);
+    } else if (analyticsStatusRef.current === "pending") {
+      pendingOperationsRef.current.push(operation);
+    }
+  }, []);
 
   useEffect(() => {
-    if (typeof window === "undefined" || !env.VITE_POSTHOG_API_KEY || isDev) {
-      setIsInitialized(false);
-      return;
-    }
-
-    if (
-      !enabled ||
-      isTelemetryPrivateLocation(
-        window.location.pathname,
-        window.location.search,
-      )
-    ) {
-      if (didInitRef.current) {
+    if (!analyticsAvailable || !env.VITE_POSTHOG_API_KEY) {
+      pendingOperationsRef.current = [];
+      if (globalPrivacyControl && didInitRef.current) {
+        posthog.opt_out_capturing();
+      } else if (didInitRef.current) {
         posthog.set_config({
           autocapture: false,
           capture_pageview: false,
@@ -74,20 +114,25 @@ export function PostHogProvider({
       routeDisabledRef.current = false;
     }
 
+    analyticsStatusRef.current = "ready";
+    const pendingOperations = pendingOperationsRef.current.splice(0);
+    for (const operation of pendingOperations) {
+      operation(posthog);
+    }
     setIsInitialized(true);
-  }, [enabled]);
+  }, [analyticsAvailable, globalPrivacyControl]);
 
   if (!enabled || !env.VITE_POSTHOG_API_KEY || isDev) {
     return (
-      <PostHogReadyContext.Provider value={isInitialized}>
+      <PostHogContext.Provider value={{ analyticsReady, runOrQueue }}>
         {children}
-      </PostHogReadyContext.Provider>
+      </PostHogContext.Provider>
     );
   }
 
   return (
-    <PostHogReadyContext.Provider value={isInitialized}>
+    <PostHogContext.Provider value={{ analyticsReady, runOrQueue }}>
       <PostHogReactProvider client={posthog}>{children}</PostHogReactProvider>
-    </PostHogReadyContext.Provider>
+    </PostHogContext.Provider>
   );
 }

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -7,6 +7,7 @@ import { createClient } from "@hypr/api-client/client";
 
 import { env } from "@/env";
 import { getAccessToken } from "@/functions/access-token";
+import { useAnalytics } from "@/hooks/use-posthog";
 
 import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
 import { getIntegrationDisplay, Route } from "./integration";
@@ -14,6 +15,7 @@ import { getIntegrationDisplay, Route } from "./integration";
 export function ConnectFlow() {
   const search = Route.useSearch();
   const navigate = useNavigate();
+  const { track } = useAnalytics();
   const isGoogleCalendar = search.integration_id === "google-calendar";
   const isOutlookCalendar = search.integration_id === "outlook";
   const isConnectedCalendar = isGoogleCalendar || isOutlookCalendar;
@@ -39,6 +41,11 @@ export function ConnectFlow() {
     if (inFlightRef.current) return;
     inFlightRef.current = true;
     updateStatus("loading");
+    track("integration_connection_started", {
+      integration: search.integration_id,
+      mode: search.action,
+      flow: search.flow,
+    });
 
     let sessionToken: string;
 
@@ -60,12 +67,24 @@ export function ConnectFlow() {
       if (error || !data) {
         inFlightRef.current = false;
         updateStatus("error");
+        track("integration_connection_failed", {
+          integration: search.integration_id,
+          mode: search.action,
+          flow: search.flow,
+          failure_stage: "session",
+        });
         return;
       }
       sessionToken = data.token;
     } catch {
       inFlightRef.current = false;
       updateStatus("error");
+      track("integration_connection_failed", {
+        integration: search.integration_id,
+        mode: search.action,
+        flow: search.flow,
+        failure_stage: "session",
+      });
       return;
     }
 
@@ -80,10 +99,21 @@ export function ConnectFlow() {
           ) {
             inFlightRef.current = false;
             updateStatus("idle");
+            track("integration_connection_failed", {
+              integration: search.integration_id,
+              mode: search.action,
+              flow: search.flow,
+              failure_stage: "cancelled",
+            });
           }
         } else if (event.type === "connect") {
           inFlightRef.current = false;
           updateStatus("success");
+          track("integration_connection_succeeded", {
+            integration: search.integration_id,
+            mode: search.action,
+            flow: search.flow,
+          });
           const callbackSearch =
             search.flow === "desktop"
               ? {

--- a/apps/web/src/routes/_view/app/-integrations-disconnect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-disconnect-flow.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@hypr/api-client/client";
 
 import { env } from "@/env";
 import { getAccessToken } from "@/functions/access-token";
+import { useAnalytics } from "@/hooks/use-posthog";
 import { useMountEffect } from "@/hooks/useMountEffect";
 
 import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
@@ -14,6 +15,7 @@ import { getIntegrationDisplay, Route } from "./integration";
 export function DisconnectFlow() {
   const search = Route.useSearch();
   const navigate = useNavigate();
+  const { track } = useAnalytics();
   const [status, setStatus] = useState<
     "idle" | "loading" | "success" | "error"
   >("loading");
@@ -23,6 +25,12 @@ export function DisconnectFlow() {
   const handleDisconnect = async () => {
     if (!search.connection_id) {
       setStatus("error");
+      track("integration_connection_failed", {
+        integration: search.integration_id,
+        mode: "disconnect",
+        flow: search.flow,
+        failure_stage: "validation",
+      });
       return;
     }
 
@@ -44,14 +52,30 @@ export function DisconnectFlow() {
 
       if (error || !data) {
         setStatus("error");
+        track("integration_connection_failed", {
+          integration: search.integration_id,
+          mode: "disconnect",
+          flow: search.flow,
+          failure_stage: "disconnect",
+        });
         return;
       }
     } catch {
       setStatus("error");
+      track("integration_connection_failed", {
+        integration: search.integration_id,
+        mode: "disconnect",
+        flow: search.flow,
+        failure_stage: "disconnect",
+      });
       return;
     }
 
     setStatus("success");
+    track("integration_disconnected", {
+      integration: search.integration_id,
+      flow: search.flow,
+    });
     const callbackSearch =
       search.flow === "desktop"
         ? {

--- a/apps/web/src/routes/_view/app/-integrations-upgrade-prompt.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-upgrade-prompt.tsx
@@ -1,10 +1,34 @@
 import { Link } from "@tanstack/react-router";
 
+import { useAnalytics } from "@/hooks/use-posthog";
+import { useMountEffect } from "@/hooks/useMountEffect";
+
 import {
   IntegrationPageLayout,
   integrationButtonClassName,
 } from "./-integration-ui";
 import { getIntegrationDisplay } from "./integration";
+
+function PaywallViewedAnalytics({
+  integrationId,
+  flow,
+}: {
+  integrationId: string;
+  flow: string;
+}) {
+  const { track } = useAnalytics();
+
+  useMountEffect(() => {
+    track("paywall_viewed", {
+      entry_point: "integration_connect",
+      feature: "integrations",
+      integration: integrationId,
+      flow,
+    });
+  });
+
+  return null;
+}
 
 export function UpgradePrompt({
   integrationId,
@@ -16,9 +40,17 @@ export function UpgradePrompt({
   scheme: string;
 }) {
   const display = getIntegrationDisplay(integrationId);
+  const { analyticsReady } = useAnalytics();
 
   return (
     <IntegrationPageLayout>
+      {analyticsReady && (
+        <PaywallViewedAnalytics
+          key={`${integrationId}:${flow}`}
+          integrationId={integrationId}
+          flow={flow}
+        />
+      )}
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-center gap-2">
           <h1 className="font-sans text-3xl tracking-tight text-stone-700">

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -32,6 +32,7 @@ import {
   buildPostAuthDestination,
   sanitizeInternalReturnPath,
 } from "@/lib/auth-redirect";
+import { capturePrivateRouteEvent } from "@/lib/private-route-analytics";
 
 const commonSearch = {
   redirect: z.string().optional(),
@@ -181,7 +182,13 @@ function DesktopReauthView({
   scheme: DesktopScheme;
 }) {
   const retryMutation = useMutation({
-    mutationFn: () => createDesktopSession(),
+    mutationFn: () => {
+      capturePrivateRouteEvent("auth_started", {
+        method: "desktop_reauth",
+        flow: "desktop",
+      });
+      return createDesktopSession();
+    },
     onSuccess: (result) => {
       if (result) {
         const params = new URLSearchParams();
@@ -191,6 +198,13 @@ function DesktopReauthView({
         params.set("refresh_token", result.refresh_token);
         window.location.href = `/callback/auth?${params.toString()}`;
       }
+    },
+    onError: () => {
+      capturePrivateRouteEvent("auth_failed", {
+        method: "desktop_reauth",
+        flow: "desktop",
+        failure_stage: "session_handoff",
+      });
     },
   });
 
@@ -332,12 +346,24 @@ function PasswordForm({
   const [submitted, setSubmitted] = useState(false);
 
   const signInMutation = useMutation({
-    mutationFn: () =>
-      doPasswordSignIn({
+    mutationFn: () => {
+      capturePrivateRouteEvent("auth_started", {
+        method: "password",
+        action: "sign_in",
+        flow,
+      });
+      return doPasswordSignIn({
         data: { email, password, flow, scheme, redirect },
-      }),
+      });
+    },
     onSuccess: (result) => {
       if (result && "error" in result && result.error) {
+        capturePrivateRouteEvent("auth_failed", {
+          method: "password",
+          action: "sign_in",
+          flow,
+          failure_stage: "provider",
+        });
         setErrorMessage(
           (result as { error: boolean; message: string }).message,
         );
@@ -359,15 +385,35 @@ function PasswordForm({
         );
       }
     },
+    onError: () => {
+      capturePrivateRouteEvent("auth_failed", {
+        method: "password",
+        action: "sign_in",
+        flow,
+        failure_stage: "request",
+      });
+    },
   });
 
   const signUpMutation = useMutation({
-    mutationFn: () =>
-      doPasswordSignUp({
+    mutationFn: () => {
+      capturePrivateRouteEvent("auth_started", {
+        method: "password",
+        action: "sign_up",
+        flow,
+      });
+      return doPasswordSignUp({
         data: { name, email, password, flow, scheme, redirect },
-      }),
+      });
+    },
     onSuccess: (result) => {
       if (result && "error" in result && result.error) {
+        capturePrivateRouteEvent("auth_failed", {
+          method: "password",
+          action: "sign_up",
+          flow,
+          failure_stage: "provider",
+        });
         setErrorMessage(
           (result as { error: boolean; message: string }).message,
         );
@@ -390,6 +436,14 @@ function PasswordForm({
         }
       }
     },
+    onError: () => {
+      capturePrivateRouteEvent("auth_failed", {
+        method: "password",
+        action: "sign_up",
+        flow,
+        failure_stage: "request",
+      });
+    },
   });
 
   const isPending = signInMutation.isPending || signUpMutation.isPending;
@@ -400,10 +454,22 @@ function PasswordForm({
 
     if (isSignUp) {
       if (password !== confirmPassword) {
+        capturePrivateRouteEvent("auth_failed", {
+          method: "password",
+          action: "sign_up",
+          flow,
+          failure_stage: "validation",
+        });
         setErrorMessage("Passwords do not match");
         return;
       }
       if (password.length < 6) {
+        capturePrivateRouteEvent("auth_failed", {
+          method: "password",
+          action: "sign_up",
+          flow,
+          failure_stage: "validation",
+        });
         setErrorMessage("Password must be at least 6 characters");
         return;
       }
@@ -543,19 +609,37 @@ function MagicLinkForm({
   const [submitted, setSubmitted] = useState(false);
 
   const magicLinkMutation = useMutation({
-    mutationFn: (email: string) =>
-      doMagicLinkAuth({
+    mutationFn: (email: string) => {
+      capturePrivateRouteEvent("auth_started", {
+        method: "magic_link",
+        flow,
+      });
+      return doMagicLinkAuth({
         data: {
           email,
           flow,
           scheme,
           redirect,
         },
-      }),
+      });
+    },
     onSuccess: (result) => {
       if (result && !("error" in result)) {
         setSubmitted(true);
+      } else {
+        capturePrivateRouteEvent("auth_failed", {
+          method: "magic_link",
+          flow,
+          failure_stage: "provider",
+        });
       }
+    },
+    onError: () => {
+      capturePrivateRouteEvent("auth_failed", {
+        method: "magic_link",
+        flow,
+        failure_stage: "request",
+      });
     },
   });
 
@@ -620,8 +704,13 @@ function OAuthButton({
   autoStart?: boolean;
 }) {
   const oauthMutation = useMutation({
-    mutationFn: (provider: "google" | "github") =>
-      doAuth({
+    mutationFn: (provider: "google" | "github") => {
+      capturePrivateRouteEvent("auth_started", {
+        method: "oauth",
+        provider,
+        flow,
+      });
+      return doAuth({
         data: {
           provider,
           flow,
@@ -629,11 +718,27 @@ function OAuthButton({
           redirect,
           rra,
         },
-      }),
+      });
+    },
     onSuccess: (result) => {
       if (result?.url) {
         window.location.href = result.url;
+      } else {
+        capturePrivateRouteEvent("auth_failed", {
+          method: "oauth",
+          provider,
+          flow,
+          failure_stage: "provider",
+        });
       }
+    },
+    onError: () => {
+      capturePrivateRouteEvent("auth_failed", {
+        method: "oauth",
+        provider,
+        flow,
+        failure_stage: "request",
+      });
     },
   });
   const { mutate, isPending } = oauthMutation;

--- a/plugins/analytics/src/ext.rs
+++ b/plugins/analytics/src/ext.rs
@@ -88,6 +88,16 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
 
         payload
             .props
+            .entry("surface".into())
+            .or_insert("desktop".into());
+
+        payload
+            .props
+            .entry("analytics_schema_version".into())
+            .or_insert(1.into());
+
+        payload
+            .props
             .entry("app_identifier".into())
             .or_insert(app_identifier.into());
 

--- a/plugins/notification/src/commands.rs
+++ b/plugins/notification/src/commands.rs
@@ -1,4 +1,5 @@
 use crate::NotificationPluginExt;
+use tauri_plugin_analytics::{AnalyticsPayload, AnalyticsPluginExt};
 
 #[tauri::command]
 #[specta::specta]
@@ -6,7 +7,26 @@ pub(crate) async fn show_notification<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     v: hypr_notification::Notification,
 ) -> Result<(), String> {
-    app.notification().show(v).map_err(|e| e.to_string())
+    let source = match &v.source {
+        Some(hypr_notification::NotificationSource::CalendarEvent { .. }) => "calendar_event",
+        Some(hypr_notification::NotificationSource::Session { .. }) => "session",
+        Some(hypr_notification::NotificationSource::MicDetected { .. }) => "mic_detected",
+        None => "unknown",
+    };
+    let is_persistent = v.is_persistent();
+    let has_options = v
+        .options
+        .as_ref()
+        .is_some_and(|options| !options.is_empty());
+    app.notification().show(v).map_err(|e| e.to_string())?;
+    app.analytics().event_fire_and_forget(
+        AnalyticsPayload::builder("notification_shown")
+            .with("source_type", source)
+            .with("is_persistent", is_persistent)
+            .with("has_options", has_options)
+            .build(),
+    );
+    Ok(())
 }
 
 #[tauri::command]

--- a/plugins/notification/src/handler.rs
+++ b/plugins/notification/src/handler.rs
@@ -4,10 +4,33 @@ use tauri_specta::Event;
 
 use crate::events::NotificationEvent;
 
+fn source_kind(source: &Option<hypr_notification::NotificationSource>) -> &'static str {
+    match source {
+        Some(hypr_notification::NotificationSource::CalendarEvent { .. }) => "calendar_event",
+        Some(hypr_notification::NotificationSource::Session { .. }) => "session",
+        Some(hypr_notification::NotificationSource::MicDetected { .. }) => "mic_detected",
+        None => "unknown",
+    }
+}
+
+fn track_notification_event(
+    app: &tauri::AppHandle<tauri::Wry>,
+    event: &'static str,
+    source: &'static str,
+    action: Option<&'static str>,
+) {
+    let mut payload = AnalyticsPayload::builder(event).with("source_type", source);
+    if let Some(action) = action {
+        payload = payload.with("action", action);
+    }
+    app.analytics().event_fire_and_forget(payload.build());
+}
+
 pub fn init(app: tauri::AppHandle<tauri::Wry>) {
     {
         let app = app.clone();
         hypr_notification::setup_collapsed_confirm_handler(move |ctx| {
+            let source = source_kind(&ctx.source);
             if let Err(_e) = app.windows().show(tauri_plugin_windows::AppWindow::Main) {}
 
             let _ = NotificationEvent::Confirm {
@@ -18,12 +41,14 @@ pub fn init(app: tauri::AppHandle<tauri::Wry>) {
 
             app.analytics()
                 .event_fire_and_forget(AnalyticsPayload::builder("collapsed_confirm").build());
+            track_notification_event(&app, "notification_actioned", source, Some("confirm"));
         });
     }
 
     {
         let app = app.clone();
         hypr_notification::setup_expanded_accept_handler(move |ctx| {
+            let source = source_kind(&ctx.source);
             if let Err(_e) = app.windows().show(tauri_plugin_windows::AppWindow::Main) {}
 
             let _ = NotificationEvent::Accept {
@@ -34,12 +59,14 @@ pub fn init(app: tauri::AppHandle<tauri::Wry>) {
 
             app.analytics()
                 .event_fire_and_forget(AnalyticsPayload::builder("expanded_accept").build());
+            track_notification_event(&app, "notification_actioned", source, Some("accept"));
         });
     }
 
     {
         let app = app.clone();
         hypr_notification::setup_dismiss_handler(move |ctx| {
+            let source = source_kind(&ctx.source);
             let _ = NotificationEvent::Dismiss {
                 key: ctx.key,
                 source: ctx.source,
@@ -48,12 +75,14 @@ pub fn init(app: tauri::AppHandle<tauri::Wry>) {
 
             app.analytics()
                 .event_fire_and_forget(AnalyticsPayload::builder("dismiss").build());
+            track_notification_event(&app, "notification_dismissed", source, None);
         });
     }
 
     {
         let app = app.clone();
         hypr_notification::setup_collapsed_timeout_handler(move |ctx| {
+            let source = source_kind(&ctx.source);
             let _ = NotificationEvent::Timeout {
                 key: ctx.key,
                 source: ctx.source,
@@ -62,12 +91,14 @@ pub fn init(app: tauri::AppHandle<tauri::Wry>) {
 
             app.analytics()
                 .event_fire_and_forget(AnalyticsPayload::builder("collapsed_timeout").build());
+            track_notification_event(&app, "notification_timed_out", source, None);
         });
     }
 
     {
         let app = app.clone();
         hypr_notification::setup_option_selected_handler(move |ctx, selected_index| {
+            let source = source_kind(&ctx.source);
             if let Err(_e) = app.windows().show(tauri_plugin_windows::AppWindow::Main) {}
 
             let _ = NotificationEvent::OptionSelected {
@@ -79,12 +110,20 @@ pub fn init(app: tauri::AppHandle<tauri::Wry>) {
 
             app.analytics()
                 .event_fire_and_forget(AnalyticsPayload::builder("option_selected").build());
+            app.analytics().event_fire_and_forget(
+                AnalyticsPayload::builder("notification_actioned")
+                    .with("source_type", source)
+                    .with("action", "option_selected")
+                    .with("option_index", selected_index)
+                    .build(),
+            );
         });
     }
 
     {
         let app = app.clone();
         hypr_notification::setup_footer_action_handler(move |ctx| {
+            let source = source_kind(&ctx.source);
             let _ = NotificationEvent::FooterAction {
                 key: ctx.key,
                 source: ctx.source,
@@ -93,6 +132,7 @@ pub fn init(app: tauri::AppHandle<tauri::Wry>) {
 
             app.analytics()
                 .event_fire_and_forget(AnalyticsPayload::builder("footer_action").build());
+            track_notification_event(&app, "notification_actioned", source, Some("footer_action"));
         });
     }
 }


### PR DESCRIPTION
Add privacy-safe event coverage across desktop, web, mobile, billing, notifications, and the opt-in CLI.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6342 
- <kbd>&nbsp;1&nbsp;</kbd> #6341 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, cross-cutting telemetry touchpoints (auth, billing, sync, recording) increase the chance of duplicate or sensitive-property leaks if misconfigured, though web auth uses a separate capture path and CLI remains opt-in.
> 
> **Overview**
> Introduces **cross-surface product analytics** aimed at missing funnel and reliability signals, standardized with `surface` and `analytics_schema_version` on captures.
> 
> The **CLI** gains opt-in `cli_command_completed` events (`ANARLOG_ANALYTICS`) sent to PostHog via a short `curl` POST, with a persisted anonymous distinct id and per-subcommand naming from `Args::analytics_command_name()`.
> 
> **Desktop** routes most new instrumentation through `trackAnalyticsEvent` (Tauri `eventFireAndForget`), covering auth, onboarding (step viewed/completed/skipped), permissions, sessions/transcription lifecycle, search, sharing/collaboration, contacts/templates, cloud sync (with deduping so manual sync isn’t double-counted as background), paywalls, chat failures, attachment sync conflicts, and enhancer success/failure (including moving `note_enhanced` to run on task completion).
> 
> **Mobile** adds a dedicated PostHog client (disabled in `__DEV__`), app/screen lifecycle, identify/reset on auth, and events for notes, recording, transcription, search, imports, and paywall.
> 
> **Web** enriches `useAnalytics` captures, **queues** operations until PostHog is ready, respects **Global Privacy Control**, and uses **`capturePrivateRouteEvent`** on auth routes for coarse auth funnel events without the full SDK. Server-side **`captureServerAnalytics`** records checkout starts; integration connect/disconnect flows and shared-note views/comments are instrumented.
> 
> **Stripe** webhook mapping expands for cancel-schedule, resume, and plan-change updates; notification plugin code records show/action/dismiss/timeout analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a720fd72ad6dc61b2c3a0af8a0e5bbfefbc99d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->