### PR TITLE
Add structured Sentry error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "dirs 6.0.0",
  "insta",
  "rmcp",
+ "sentry",
  "serde",
  "serde_json",
  "sqlx",

--- a/apps/api/src/auth.rs
+++ b/apps/api/src/auth.rs
@@ -19,8 +19,6 @@ pub async fn sentry_and_analytics(mut request: Request, next: Next) -> Response 
         sentry::configure_scope(|scope| {
             scope.set_user(Some(sentry::User {
                 id: Some(auth.claims.sub.clone()),
-                email: auth.claims.email.clone(),
-                username: Some(auth.claims.sub.clone()),
                 ..Default::default()
             }));
             scope.set_tag("enduser.id", &auth.claims.sub);

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -573,7 +573,7 @@ fn main() -> std::io::Result<()> {
         ),
         traces_sample_rate: 1.0,
         sample_rate: 1.0,
-        send_default_pii: true,
+        send_default_pii: false,
         auto_session_tracking: true,
         session_mode: sentry::SessionMode::Request,
         attach_stacktrace: true,

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -15,6 +15,7 @@ hypr-db-core = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 dirs = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
+sentry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/apps/cli/src/analytics.rs
+++ b/apps/cli/src/analytics.rs
@@ -6,7 +6,7 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 pub fn capture_command_completed(command: &str, outcome: &str, duration: Duration) {
-    if !analytics_enabled() {
+    if !telemetry_enabled() {
         return;
     }
 
@@ -65,7 +65,7 @@ pub fn capture_command_completed(command: &str, outcome: &str, duration: Duratio
     let _ = child.wait();
 }
 
-fn analytics_enabled() -> bool {
+pub fn telemetry_enabled() -> bool {
     std::env::var("ANARLOG_ANALYTICS")
         .map(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
         .unwrap_or(false)

--- a/apps/cli/src/error_reporting.rs
+++ b/apps/cli/src/error_reporting.rs
@@ -1,0 +1,49 @@
+use std::time::Duration;
+
+pub fn init() -> Option<sentry::ClientInitGuard> {
+    if !crate::analytics::telemetry_enabled() {
+        return None;
+    }
+
+    let dsn = std::env::var("SENTRY_DSN")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| option_env!("SENTRY_DSN").map(ToOwned::to_owned))?;
+    let guard = sentry::init(sentry::ClientOptions {
+        dsn: dsn.parse().ok(),
+        release: Some(format!("anarlog-cli@{}", env!("CARGO_PKG_VERSION")).into()),
+        environment: Some(if cfg!(debug_assertions) {
+            "development".into()
+        } else {
+            "production".into()
+        }),
+        send_default_pii: false,
+        attach_stacktrace: true,
+        ..Default::default()
+    });
+    sentry::configure_scope(|scope| {
+        scope.set_tag("service.name", "cli");
+        scope.set_tag("service.namespace", "hyprnote");
+        scope.set_tag("hyprnote.surface", "cli");
+    });
+    Some(guard)
+}
+
+pub fn capture_command_error(command: &str, error_code: &str) {
+    sentry::with_scope(
+        |scope| {
+            scope.set_tag("hyprnote.operation", "cli_command");
+            scope.set_tag("hyprnote.command", command);
+            scope.set_tag("error.code", error_code);
+        },
+        || {
+            sentry::capture_message("CLI command failed", sentry::Level::Error);
+        },
+    );
+}
+
+pub fn flush() {
+    if let Some(client) = sentry::Hub::current().client() {
+        client.close(Some(Duration::from_millis(750)));
+    }
+}

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use clap::error::ErrorKind;
 
 mod analytics;
+mod error_reporting;
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -40,12 +41,17 @@ async fn main() -> ExitCode {
 
     let command = args.analytics_command_name();
     let started_at = Instant::now();
+    let _sentry_guard = error_reporting::init();
     let result = anarlog_cli::run(args).await;
     let outcome = match &result {
         Ok(0) => "succeeded",
         Ok(_) | Err(_) => "failed",
     };
     analytics::capture_command_completed(command, outcome, started_at.elapsed());
+    if let Err(error) = &result {
+        error_reporting::capture_command_error(command, error.code());
+        error_reporting::flush();
+    }
 
     match result {
         Ok(code) => ExitCode::from(code),

--- a/apps/desktop/src/analytics.ts
+++ b/apps/desktop/src/analytics.ts
@@ -16,9 +16,9 @@ export function trackAnalyticsEvent(
       ...properties,
     });
     void pending.catch((error: unknown) => {
-      console.error(`[analytics] failed to record ${event}`, error);
+      console.warn(`[analytics] failed to record ${event}`, error);
     });
   } catch (error) {
-    console.error(`[analytics] failed to record ${event}`, error);
+    console.warn(`[analytics] failed to record ${event}`, error);
   }
 }

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -31,6 +31,7 @@ import {
 import { clearAuthStorage, isFatalSessionError } from "./errors";
 
 import { trackAnalyticsEvent } from "~/analytics";
+import { setErrorReportingUser } from "~/error-reporting";
 import { useLatestRef } from "~/shared/hooks/useLatestRef";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import {
@@ -116,6 +117,7 @@ async function trackAuthEvent(
       event === "TOKEN_REFRESHED") &&
     session
   ) {
+    setErrorReportingUser(session.user.id);
     const appVersion = await getVersion();
     const billing = await getBillingAnalytics(session.access_token);
     const identifySignature = JSON.stringify({
@@ -393,6 +395,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       trackedIdentifySignature = null;
       trackedSignedInUserId = null;
+      setErrorReportingUser(null);
       await enqueueAuthAnalytics(() => analyticsCommands.clearGroups());
       setSession(null);
       if (managesCloudsync) {
@@ -419,6 +422,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (event === "SIGNED_OUT" && !managesCloudsync) {
           trackedIdentifySignature = null;
           trackedSignedInUserId = null;
+          setErrorReportingUser(null);
           setSession(null);
 
           try {

--- a/apps/desktop/src/error-reporting.test.ts
+++ b/apps/desktop/src/error-reporting.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeOperationalError,
+  operationalErrorMetadata,
+  sanitizeErrorEvent,
+} from "./error-reporting";
+
+describe("normalizeOperationalError", () => {
+  it("preserves useful fields from structured API failures", () => {
+    expect(
+      normalizeOperationalError(
+        {
+          status: 403,
+          code: "subscription_required",
+          message: "A Pro subscription is required",
+          responseBody: "private response body",
+        },
+        "integration_connect",
+      ).message,
+    ).toBe(
+      "integration_connect failed (status=403, code=subscription_required, message=A Pro subscription is required)",
+    );
+  });
+
+  it("keeps primitive failures and ignores arbitrary object data", () => {
+    expect(
+      normalizeOperationalError("connection refused", "sync").message,
+    ).toBe("sync failed: connection refused");
+    expect(
+      normalizeOperationalError({ transcript: "private transcript" }, "sync")
+        .message,
+    ).toBe("sync failed");
+  });
+
+  it("extracts only privacy-safe operational diagnostics", () => {
+    expect(
+      operationalErrorMetadata({
+        name: "ApiError",
+        code: "subscription_required",
+        stage: "billing_check",
+        statusCode: 403,
+        message: "private@example.com",
+      }),
+    ).toEqual({
+      type: "ApiError",
+      code: "subscription_required",
+      stage: "billing_check",
+      status: 403,
+    });
+    expect(
+      operationalErrorMetadata({
+        code: "private email@example.com",
+        stage: "billing check",
+        status: 999,
+      }),
+    ).toEqual({
+      type: "Error",
+      code: undefined,
+      stage: undefined,
+      status: undefined,
+    });
+  });
+});
+
+describe("sanitizeErrorEvent", () => {
+  it("keeps diagnostics while removing user and request data", () => {
+    const event = sanitizeErrorEvent({
+      type: undefined,
+      user: {
+        id: "user-1",
+        email: "private@example.com",
+        ip_address: "127.0.0.1",
+      },
+      request: {
+        method: "POST",
+        url: "https://anarlog.so/note/123?token=secret#selection",
+        headers: { authorization: "Bearer secret" },
+        data: { note: "private note" },
+      },
+      message: "private@example.com opened a private note",
+      logentry: {
+        message: "token=secret",
+      },
+      exception: {
+        values: [
+          {
+            type: "RouteError",
+            value: "private note content",
+            mechanism: {
+              type: "generic",
+              handled: false,
+              data: { token: "secret" },
+            },
+          },
+        ],
+      },
+      extra: { transcript: "private transcript" },
+      breadcrumbs: [
+        {
+          category: "console",
+          message: "private note",
+          data: { arguments: ["private note"] },
+        },
+        {
+          category: "navigation",
+          data: {
+            from: "https://anarlog.so/?token=secret",
+            to: "https://anarlog.so/app/?share=secret",
+          },
+        },
+      ],
+    });
+
+    expect(event.user).toEqual({ id: "user-1" });
+    expect(event.request).toEqual({
+      method: "POST",
+      url: "https://anarlog.so/note/123",
+    });
+    expect(event.extra).toBeUndefined();
+    expect(event.message).toBeUndefined();
+    expect(event.logentry).toBeUndefined();
+    expect(event.exception?.values).toEqual([
+      {
+        type: "RouteError",
+        value: "RouteError captured",
+        mechanism: {
+          type: "generic",
+          handled: false,
+        },
+      },
+    ]);
+    expect(event.breadcrumbs).toEqual([
+      {
+        category: "console",
+        level: undefined,
+        timestamp: undefined,
+        type: undefined,
+      },
+      {
+        category: "navigation",
+        level: undefined,
+        timestamp: undefined,
+        type: undefined,
+        data: {
+          from: "https://anarlog.so/",
+          to: "https://anarlog.so/app/",
+        },
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/error-reporting.ts
+++ b/apps/desktop/src/error-reporting.ts
@@ -1,0 +1,203 @@
+import * as Sentry from "@sentry/react";
+import type { ErrorEvent, SeverityLevel } from "@sentry/react";
+
+import { env } from "./env";
+
+type ErrorContextValue = null | boolean | number | string;
+const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9_.:/-]{1,128}$/;
+
+function safeIdentifier(value: unknown): string | undefined {
+  return typeof value === "string" && SAFE_IDENTIFIER_RE.test(value)
+    ? value
+    : undefined;
+}
+
+export function operationalErrorMetadata(error: unknown) {
+  if (!error || typeof error !== "object") {
+    return { type: "Error" };
+  }
+
+  const record = error as Record<string, unknown>;
+  const statusValue = record.status ?? record.statusCode;
+  const status =
+    typeof statusValue === "number" &&
+    Number.isInteger(statusValue) &&
+    statusValue >= 100 &&
+    statusValue <= 599
+      ? statusValue
+      : undefined;
+
+  return {
+    type: safeIdentifier(record.name) ?? "Error",
+    code: safeIdentifier(record.code),
+    stage: safeIdentifier(record.stage),
+    status,
+  };
+}
+
+export function normalizeOperationalError(
+  error: unknown,
+  operation: string,
+): Error {
+  if (error instanceof Error) return error;
+
+  if (
+    typeof error === "string" ||
+    typeof error === "number" ||
+    typeof error === "boolean"
+  ) {
+    return new Error(`${operation} failed: ${String(error).slice(0, 256)}`);
+  }
+
+  if (error && typeof error === "object") {
+    const record = error as Record<string, unknown>;
+    const details = ["status", "statusCode", "code", "message"]
+      .flatMap((key) => {
+        const value = record[key];
+        return typeof value === "string" ||
+          typeof value === "number" ||
+          typeof value === "boolean"
+          ? [`${key}=${String(value).slice(0, 256)}`]
+          : [];
+      })
+      .join(", ");
+
+    if (details) {
+      return new Error(`${operation} failed (${details})`);
+    }
+  }
+
+  return new Error(`${operation} failed`);
+}
+
+function sanitizeUrl(value: string | undefined) {
+  if (!value) return value;
+
+  try {
+    const url = new URL(value);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value.split(/[?#]/, 1)[0];
+  }
+}
+
+export function sanitizeErrorEvent(event: ErrorEvent): ErrorEvent {
+  if (event.user) {
+    event.user = event.user.id ? { id: event.user.id } : undefined;
+  }
+
+  if (event.request) {
+    event.request = {
+      method: event.request.method,
+      url: sanitizeUrl(event.request.url),
+    };
+  }
+
+  delete event.extra;
+  delete event.message;
+  delete event.logentry;
+  if (event.exception?.values) {
+    event.exception.values = event.exception.values.map((exception) => {
+      const sanitized = {
+        ...exception,
+        value: exception.type ? `${exception.type} captured` : "Error captured",
+      };
+      if (sanitized.mechanism) {
+        delete sanitized.mechanism.data;
+      }
+      return sanitized;
+    });
+  }
+  event.breadcrumbs = event.breadcrumbs?.map((breadcrumb) => ({
+    category: breadcrumb.category,
+    level: breadcrumb.level,
+    timestamp: breadcrumb.timestamp,
+    type: breadcrumb.type,
+    ...(breadcrumb.category === "navigation"
+      ? {
+          data: {
+            from: sanitizeUrl(String(breadcrumb.data?.from ?? "")),
+            to: sanitizeUrl(String(breadcrumb.data?.to ?? "")),
+          },
+        }
+      : {}),
+  }));
+
+  return event;
+}
+
+export function initializeErrorReporting() {
+  if (!env.VITE_SENTRY_DSN) return;
+
+  Sentry.init({
+    dsn: env.VITE_SENTRY_DSN,
+    release: env.VITE_APP_VERSION
+      ? `hyprnote-desktop@${env.VITE_APP_VERSION}`
+      : undefined,
+    environment: import.meta.env.MODE,
+    sendDefaultPii: false,
+    tracePropagationTargets: [],
+    beforeSend: sanitizeErrorEvent,
+    integrations: [
+      Sentry.replayIntegration({
+        blockAllMedia: true,
+        maskAllText: true,
+      }),
+    ],
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+    initialScope: {
+      tags: {
+        "service.name": "desktop",
+        "service.namespace": "hyprnote",
+        "hyprnote.surface": "desktop",
+      },
+    },
+  });
+}
+
+export function captureOperationalError(
+  error: unknown,
+  {
+    operation,
+    level = "error",
+    tags,
+    context,
+  }: {
+    operation: string;
+    level?: SeverityLevel;
+    tags?: Record<string, ErrorContextValue>;
+    context?: Record<string, ErrorContextValue>;
+  },
+) {
+  const metadata = operationalErrorMetadata(error);
+  const exception = normalizeOperationalError(error, operation);
+
+  return Sentry.withScope((scope) => {
+    scope.setLevel(level);
+    scope.setTag("hyprnote.operation", operation);
+    scope.setTag("error.type", metadata.type);
+    if (metadata.code) scope.setTag("error.code", metadata.code);
+    if (metadata.stage) {
+      scope.setTag("hyprnote.error.stage", metadata.stage);
+    }
+    if (metadata.status) {
+      scope.setTag("http.response.status_code", metadata.status);
+    }
+    for (const [key, value] of Object.entries(tags ?? {})) {
+      if (value !== null) {
+        scope.setTag(`hyprnote.${key}`, value);
+      }
+    }
+    if (context) {
+      scope.setContext("hyprnote.operation", context);
+    }
+    return Sentry.captureException(exception);
+  });
+}
+
+export function setErrorReportingUser(userId: string | null) {
+  Sentry.setUser(userId ? { id: userId } : null);
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,7 +1,6 @@
 import "./styles/globals.css";
 import "./styles/cursor.css";
 
-import * as Sentry from "@sentry/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { StrictMode, useMemo } from "react";
@@ -23,7 +22,10 @@ import { Toaster } from "@hypr/ui/components/ui/toast";
 import { AITaskWindowSyncBridge } from "./ai/task-window-sync";
 import { trackAnalyticsEvent } from "./analytics";
 import { createToolRegistry } from "./contexts/tool-registry/core";
-import { env } from "./env";
+import {
+  captureOperationalError,
+  initializeErrorReporting,
+} from "./error-reporting";
 import { AppI18nProvider } from "./i18n/provider";
 import { FloatingMeetingWindowHost } from "./meeting-float/host";
 import { routeTree } from "./routeTree.gen";
@@ -80,19 +82,7 @@ function App() {
   );
 }
 
-if (env.VITE_SENTRY_DSN) {
-  Sentry.init({
-    dsn: env.VITE_SENTRY_DSN,
-    release: env.VITE_APP_VERSION
-      ? `hyprnote-desktop@${env.VITE_APP_VERSION}`
-      : undefined,
-    environment: import.meta.env.MODE,
-    tracePropagationTargets: [],
-    integrations: [Sentry.replayIntegration()],
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
-  });
-}
+initializeErrorReporting();
 
 function AppRoot() {
   const manager = useCreateManager(() => {
@@ -131,7 +121,9 @@ if (isMainWindow) {
     }
   } catch {}
   void initializeAppExitFlush().catch((error) => {
-    console.error("Failed to initialize the exit flush listener", error);
+    captureOperationalError(error, {
+      operation: "app_exit_flush_initialize",
+    });
   });
 }
 
@@ -155,13 +147,19 @@ async function enableReactScanInDev() {
 async function renderApp() {
   if (isMainWindow) {
     await refreshLegacySettingsSnapshots().catch((error) => {
-      console.error("Failed to refresh legacy settings snapshots", error);
+      captureOperationalError(error, {
+        operation: "legacy_settings_refresh",
+      });
     });
     await initializeApplicationSettings().catch((error) => {
-      console.error("Failed to initialize application settings", error);
+      captureOperationalError(error, {
+        operation: "application_settings_initialize",
+      });
     });
     await migratePlaintextAiProviderApiKeys().catch((error) => {
-      console.error("Failed to migrate AI provider credentials", error);
+      captureOperationalError(error, {
+        operation: "ai_credentials_migrate",
+      });
     });
   }
   await Promise.all([bootstrapThemeFromSettings(), enableReactScanInDev()]);

--- a/apps/desktop/src/settings/sync/index.tsx
+++ b/apps/desktop/src/settings/sync/index.tsx
@@ -33,6 +33,7 @@ import {
   getCloudsyncCredentialBlock,
   subscribeCloudsyncCredentialBlock,
 } from "~/auth/cloudsync";
+import { captureOperationalError } from "~/error-reporting";
 import { SettingsPageTitle } from "~/settings/page-title";
 import {
   setSettingValue,
@@ -116,7 +117,11 @@ export function SettingsSync() {
         },
       );
     },
-    onError: (_, enabled) => {
+    onError: (error, enabled) => {
+      captureOperationalError(error, {
+        operation: "cloud_sync_preference_update",
+        context: { enabled },
+      });
       trackAnalyticsEvent("cloud_sync_failed", {
         trigger: enabled ? "enable" : "disable",
         failure_stage: "preference",
@@ -164,7 +169,10 @@ export function SettingsSync() {
         trigger: "manual",
       });
     },
-    onError: () => {
+    onError: (error) => {
+      captureOperationalError(error, {
+        operation: "cloud_sync_manual",
+      });
       trackAnalyticsEvent("cloud_sync_failed", {
         trigger: "manual",
         failure_stage: "sync",

--- a/apps/desktop/src/shared/control.tsx
+++ b/apps/desktop/src/shared/control.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/react";
 import {
   type ErrorRouteComponent,
   NotFoundRouteComponent,
@@ -7,20 +6,44 @@ import {
 import { relaunch } from "@tauri-apps/plugin-process";
 import { AlertTriangle, Home, RotateCw, Search } from "lucide-react";
 import { motion } from "motion/react";
-import { useEffect } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
 
-export const ErrorComponent: ErrorRouteComponent = ({ error }) => {
-  useEffect(() => {
-    Sentry.captureException(error);
-  }, [error]);
+import { captureOperationalError } from "~/error-reporting";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+
+const routeErrorKeys = new WeakMap<object, number>();
+let nextRouteErrorKey = 0;
+
+function getRouteErrorKey(error: unknown) {
+  if (typeof error !== "object" || error === null) {
+    return String(error);
+  }
+
+  const existing = routeErrorKeys.get(error);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  nextRouteErrorKey += 1;
+  routeErrorKeys.set(error, nextRouteErrorKey);
+  return nextRouteErrorKey;
+}
+
+const ReportedErrorComponent = ({ error }: { error: Error }) => {
+  useMountEffect(() => {
+    captureOperationalError(error, {
+      operation: "route_render",
+    });
+  });
 
   const handleRestart = async () => {
     try {
       await relaunch();
     } catch (err) {
-      console.error("Failed to restart app:", err);
+      captureOperationalError(err, {
+        operation: "app_restart",
+      });
     }
   };
 
@@ -75,6 +98,10 @@ export const ErrorComponent: ErrorRouteComponent = ({ error }) => {
     </div>
   );
 };
+
+export const ErrorComponent: ErrorRouteComponent = ({ error }) => (
+  <ReportedErrorComponent key={getRouteErrorKey(error)} error={error} />
+);
 
 export const NotFoundComponent: NotFoundRouteComponent = () => {
   const navigate = useNavigate();

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -20,5 +20,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       "",
     posthogHost:
       process.env.EXPO_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
+    sentryDsn:
+      process.env.EXPO_PUBLIC_SENTRY_DSN ?? process.env.SENTRY_DSN ?? "",
   },
 });

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -42,7 +42,8 @@
           "enableBackgroundRecording": true
         }
       ],
-      "expo-sqlite"
+      "expo-sqlite",
+      "@sentry/react-native/expo"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,6 +1,6 @@
-const { getDefaultConfig } = require("expo/metro-config");
+const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 
-const config = getDefaultConfig(__dirname);
+const config = getSentryExpoConfig(__dirname);
 
 // expo-sqlite web support: bundle the wa-sqlite wasm binary and serve with the
 // cross-origin isolation headers SharedArrayBuffer requires.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,6 +7,7 @@
     "start": "dotenvx run --ignore MISSING_ENV_FILE -f ../../.env.supabase -f .env -- expo start",
     "android": "dotenvx run --ignore MISSING_ENV_FILE -f ../../.env.supabase -f .env -- expo start --android",
     "ios": "dotenvx run --ignore MISSING_ENV_FILE -f ../../.env.supabase -f .env -- expo start --ios",
+    "test:error-reporting": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test --experimental-strip-types src/lib/error-sanitization.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,6 +15,7 @@
     "@hypr/db-react": "workspace:*",
     "@hypr/db-runtime": "workspace:*",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@sentry/react-native": "^8.20.0",
     "@supabase/supabase-js": "^2.103.0",
     "expo": "~57.0.8",
     "expo-audio": "~57.0.3",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,26 +1,55 @@
 import * as Sentry from "@sentry/react-native";
-import { Stack, usePathname } from "expo-router";
+import { type ErrorBoundaryProps, Stack, usePathname } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useEffect, useState } from "react";
-import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 
 import { AuthProvider, useAuth } from "@/auth/context";
 import { PaywallScreen, SignInScreen } from "@/auth/screens";
 import { Colors } from "@/constants/theme";
 import { initializeAnalytics, screenAnalytics } from "@/lib/analytics";
-import { initializeErrorReporting } from "@/lib/error-reporting";
+import {
+  addNavigationBreadcrumb,
+  captureOperationalError,
+  initializeErrorReporting,
+} from "@/lib/error-reporting";
+import { useMountEffect } from "@/lib/use-mount-effect";
 
 initializeErrorReporting();
 
+const routeErrorKeys = new WeakMap<Error, number>();
+let nextRouteErrorKey = 0;
+
+function getRouteErrorKey(error: Error) {
+  const existing = routeErrorKeys.get(error);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  nextRouteErrorKey += 1;
+  routeErrorKeys.set(error, nextRouteErrorKey);
+  return nextRouteErrorKey;
+}
+
 function AnalyticsLifecycle() {
   const pathname = usePathname();
+  const previousPathRef = useRef<string | null>(null);
 
   useEffect(() => {
     void initializeAnalytics();
   }, []);
 
   useEffect(() => {
-    screenAnalytics(pathname.replace(/^\/note\/[^/]+/, "/note/:id"));
+    const normalizedPathname = pathname.replace(/^\/note\/[^/]+/, "/note/:id");
+    screenAnalytics(normalizedPathname);
+    addNavigationBreadcrumb(previousPathRef.current, normalizedPathname);
+    previousPathRef.current = normalizedPathname;
   }, [pathname]);
 
   return null;
@@ -41,6 +70,17 @@ function Gate() {
   const auth = useAuth();
   const [signingIn, setSigningIn] = useState(false);
 
+  const handleSignIn = async () => {
+    setSigningIn(true);
+    try {
+      await auth.signIn();
+    } catch {
+      // AuthProvider reports the actionable failure before rejecting.
+    } finally {
+      setSigningIn(false);
+    }
+  };
+
   if (auth.bypass) return <Screens />;
 
   if (
@@ -56,13 +96,7 @@ function Gate() {
 
   if (auth.status === "signed_out") {
     return (
-      <SignInScreen
-        busy={signingIn}
-        onSignIn={() => {
-          setSigningIn(true);
-          auth.signIn().finally(() => setSigningIn(false));
-        }}
-      />
+      <SignInScreen busy={signingIn} onSignIn={() => void handleSignIn()} />
     );
   }
 
@@ -77,6 +111,54 @@ function Gate() {
   }
 
   return <Screens />;
+}
+
+function RouteError({
+  error,
+  retry,
+}: {
+  error: Error;
+  retry: () => Promise<void>;
+}) {
+  useMountEffect(() => {
+    captureOperationalError(error, {
+      operation: "route_render",
+    });
+  });
+
+  const handleRetry = async () => {
+    try {
+      await retry();
+    } catch (retryError) {
+      captureOperationalError(retryError, {
+        operation: "route_retry",
+      });
+    }
+  };
+
+  return (
+    <View style={styles.routeError}>
+      <Text style={styles.routeErrorTitle}>Something went wrong</Text>
+      <Text style={styles.routeErrorBody}>
+        Your notes are still stored on this device.
+      </Text>
+      <Pressable
+        onPress={() => void handleRetry()}
+        style={({ pressed }) => [
+          styles.routeErrorButton,
+          pressed && styles.routeErrorButtonPressed,
+        ]}
+      >
+        <Text style={styles.routeErrorButtonLabel}>Try again</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
+  return (
+    <RouteError key={getRouteErrorKey(error)} error={error} retry={retry} />
+  );
 }
 
 function RootLayout() {
@@ -97,5 +179,39 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: Colors.paper,
+  },
+  routeError: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 12,
+    paddingHorizontal: 32,
+    backgroundColor: Colors.paper,
+  },
+  routeErrorTitle: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: Colors.ink,
+  },
+  routeErrorBody: {
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: "center",
+    color: Colors.muted,
+  },
+  routeErrorButton: {
+    marginTop: 8,
+    paddingHorizontal: 22,
+    paddingVertical: 12,
+    borderRadius: 999,
+    backgroundColor: Colors.ink,
+  },
+  routeErrorButtonPressed: {
+    opacity: 0.7,
+  },
+  routeErrorButtonLabel: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: Colors.inkInverse,
   },
 });

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react-native";
 import { Stack, usePathname } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useEffect, useState } from "react";
@@ -7,6 +8,9 @@ import { AuthProvider, useAuth } from "@/auth/context";
 import { PaywallScreen, SignInScreen } from "@/auth/screens";
 import { Colors } from "@/constants/theme";
 import { initializeAnalytics, screenAnalytics } from "@/lib/analytics";
+import { initializeErrorReporting } from "@/lib/error-reporting";
+
+initializeErrorReporting();
 
 function AnalyticsLifecycle() {
   const pathname = usePathname();
@@ -75,7 +79,7 @@ function Gate() {
   return <Screens />;
 }
 
-export default function RootLayout() {
+function RootLayout() {
   return (
     <AuthProvider>
       <AnalyticsLifecycle />
@@ -84,6 +88,8 @@ export default function RootLayout() {
     </AuthProvider>
   );
 }
+
+export default Sentry.wrap(RootLayout);
 
 const styles = StyleSheet.create({
   loading: {

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -20,6 +20,7 @@ import { createSession, deleteSession } from "@/data/session";
 import { useTimelineSessions, type TimelineSession } from "@/data/timeline";
 import { captureAnalytics } from "@/lib/analytics";
 import { confirmDestructive } from "@/lib/confirm";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 export default function HomeScreen() {
   const router = useRouter();
@@ -49,7 +50,15 @@ export default function HomeScreen() {
       `Delete "${session.title || "Untitled"}"?`,
       "Delete",
     );
-    if (confirmed) void deleteSession(session.id);
+    if (!confirmed) return;
+    try {
+      await deleteSession(session.id);
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "session_delete",
+        tags: { entry_point: "mobile_home" },
+      });
+    }
   };
 
   const createAndOpen = async (query = "") => {
@@ -60,6 +69,15 @@ export default function HomeScreen() {
         entryPoint: query.includes("listen=1") ? "start_listening" : "new_note",
       });
       router.push(`/note/${sessionId}${query}`);
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "session_create",
+        tags: {
+          entry_point: query.includes("listen=1")
+            ? "start_listening"
+            : "new_note",
+        },
+      });
     } finally {
       busyRef.current = false;
     }
@@ -74,6 +92,10 @@ export default function HomeScreen() {
       if (sessionIds.length === 1) {
         router.push(`/note/${sessionIds[0]}`);
       }
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "voice_memo_picker",
+      });
     } finally {
       busyRef.current = false;
       setImporting(false);

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -26,6 +26,7 @@ import {
 import { transcribeSession, useTranscriptionState } from "@/data/transcribe";
 import { useSessionTranscripts } from "@/data/transcripts";
 import { confirmDestructive } from "@/lib/confirm";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 export default function NoteScreen() {
   const router = useRouter();
@@ -68,10 +69,23 @@ export default function NoteScreen() {
         title,
         bodyText: draft.body,
         bodyFormat: current.bodyFormat,
+      }).catch((error) => {
+        captureOperationalError(error, {
+          operation: "session_note_save",
+          tags: {
+            body_format: current.bodyFormat,
+            edit_type: "body",
+          },
+        });
       });
     } else if (draft.title !== undefined) {
       savedTitleRef.current = draft.title;
-      void saveSessionTitle(id, draft.title);
+      void saveSessionTitle(id, draft.title).catch((error) => {
+        captureOperationalError(error, {
+          operation: "session_note_save",
+          tags: { edit_type: "title" },
+        });
+      });
     }
   };
 
@@ -114,9 +128,16 @@ export default function NoteScreen() {
       await recorder.stop();
     }
     draftRef.current = {};
-    await deleteSession(id);
-    if (router.canGoBack()) router.back();
-    else router.replace("/");
+    try {
+      await deleteSession(id);
+      if (router.canGoBack()) router.back();
+      else router.replace("/");
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "session_delete",
+        tags: { entry_point: "mobile_note" },
+      });
+    }
   };
 
   return (
@@ -141,7 +162,7 @@ export default function NoteScreen() {
           />
           {audio.data && (
             <AudioChip
-              key={audio.data.filename}
+              key={`${audio.data.filename}:${audio.data.createdAt}`}
               uri={
                 new File(Paths.document, "sessions", id, audio.data.filename)
                   .uri

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -13,6 +13,7 @@ import { WAVEFORM_BAR_COUNT } from "@/components/waveform";
 import { catalogSessionAudio } from "@/data/audio-catalog";
 import { transcribeSession } from "@/data/transcribe";
 import { captureAnalytics } from "@/lib/analytics";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 const METERING_FLOOR_DB = -50;
 
@@ -98,6 +99,9 @@ export function useSessionRecorder(
         });
         setPhase("recording");
       } catch (error) {
+        captureOperationalError(error, {
+          operation: "recording_start",
+        });
         console.warn("[recorder] failed to start", error);
         captureAnalytics("session_start_failed", {
           failure_stage: "capture_start",
@@ -161,6 +165,9 @@ export function useSessionRecorder(
       setPhase("saved");
       return "saved";
     } catch (error) {
+      captureOperationalError(error, {
+        operation: "recording_save",
+      });
       console.warn("[recorder] failed to save recording", error);
       setPhase("error");
       return "failed";

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -1,13 +1,14 @@
 import {
   getRecordingPermissionsAsync,
   RecordingPresets,
+  type RecordingStatus,
   requestRecordingPermissionsAsync,
   setAudioModeAsync,
   useAudioRecorder,
   useAudioRecorderState,
 } from "expo-audio";
 import { Directory, File, Paths } from "expo-file-system";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { WAVEFORM_BAR_COUNT } from "@/components/waveform";
 import { catalogSessionAudio } from "@/data/audio-catalog";
@@ -45,10 +46,41 @@ export function useSessionRecorder(
   durationMs: number;
   stop: () => Promise<StopResult>;
 } {
-  const recorder = useAudioRecorder({
-    ...RecordingPresets.HIGH_QUALITY,
-    isMeteringEnabled: true,
-  });
+  const reportedStatusErrorRef = useRef<string | null>(null);
+  const handleRecorderStatus = useCallback((status: RecordingStatus) => {
+    const errorKey = status.hasError
+      ? (status.error ?? "unknown")
+      : status.mediaServicesDidReset
+        ? "media_services_reset"
+        : null;
+    if (!errorKey || reportedStatusErrorRef.current === errorKey) return;
+
+    reportedStatusErrorRef.current = errorKey;
+    captureOperationalError(
+      new Error(
+        status.mediaServicesDidReset
+          ? "Audio media services reset"
+          : (status.error ?? "Native recording failed"),
+      ),
+      {
+        operation: status.mediaServicesDidReset
+          ? "recording_media_services_reset"
+          : "recording_native_status",
+        level: status.mediaServicesDidReset ? "warning" : "error",
+        tags: {
+          media_services_reset: status.mediaServicesDidReset === true,
+        },
+      },
+    );
+  }, []);
+  const recorder = useAudioRecorder(
+    {
+      ...RecordingPresets.HIGH_QUALITY,
+      directory: "document",
+      isMeteringEnabled: true,
+    },
+    handleRecorderStatus,
+  );
   const recorderState = useAudioRecorderState(recorder, 50);
   const [phase, setPhase] = useState<RecorderPhase>("idle");
   const [levels, setLevels] = useState<number[] | null>(null);
@@ -101,8 +133,8 @@ export function useSessionRecorder(
       } catch (error) {
         captureOperationalError(error, {
           operation: "recording_start",
+          tags: { stage: "capture_start" },
         });
-        console.warn("[recorder] failed to start", error);
         captureAnalytics("session_start_failed", {
           failure_stage: "capture_start",
         });
@@ -167,8 +199,8 @@ export function useSessionRecorder(
     } catch (error) {
       captureOperationalError(error, {
         operation: "recording_save",
+        tags: { stage: "persist_audio" },
       });
-      console.warn("[recorder] failed to save recording", error);
       setPhase("error");
       return "failed";
     }

--- a/apps/mobile/src/auth/context.tsx
+++ b/apps/mobile/src/auth/context.tsx
@@ -29,6 +29,10 @@ import {
   resetAnalytics,
 } from "@/lib/analytics";
 import { env, hasSupabaseEnv } from "@/lib/env";
+import {
+  captureOperationalError,
+  setErrorReportingUser,
+} from "@/lib/error-reporting";
 
 export type AuthState = {
   status: "loading" | "signed_out" | "signed_in";
@@ -119,7 +123,10 @@ function acceptAuthTokens(accessToken: string, refreshToken: string): void {
       ({ error }) => {
         inFlightTokens.delete(key);
         if (error) {
-          console.error("[auth] setSession failed", error);
+          captureOperationalError(error, {
+            operation: "auth_session_set",
+            tags: { method: "browser_handoff" },
+          });
           captureAnalytics("auth_failed", {
             method: "browser_handoff",
             failure_stage: "set_session",
@@ -130,7 +137,10 @@ function acceptAuthTokens(accessToken: string, refreshToken: string): void {
       },
       (error) => {
         inFlightTokens.delete(key);
-        console.error("[auth] setSession failed", error);
+        captureOperationalError(error, {
+          operation: "auth_session_set",
+          tags: { method: "browser_handoff" },
+        });
         captureAnalytics("auth_failed", {
           method: "browser_handoff",
           failure_stage: "set_session",
@@ -165,12 +175,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     bypass ? null : undefined,
   );
   const sessionRef = useRef<Session | null | undefined>(session);
+  const identifiedUserIdRef = useRef<string | null>(null);
   // Prevents double init in React StrictMode (refresh token races)
   const initStartedRef = useRef(false);
 
   const setSession = useCallback((next: Session | null) => {
     sessionRef.current = next;
     setSessionState(next);
+    const userId = next?.user.id ?? null;
+    setErrorReportingUser(userId);
+    if (userId && userId !== identifiedUserIdRef.current) {
+      identifiedUserIdRef.current = userId;
+      identifyAnalytics(userId);
+    } else if (!userId) {
+      identifiedUserIdRef.current = null;
+    }
   }, []);
 
   useEffect(() => {
@@ -215,7 +234,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       setSession(nextSession);
       if (event === "SIGNED_IN" && nextSession) {
-        identifyAnalytics(nextSession.user.id);
         captureAnalytics("user_signed_in", {
           method: "browser_handoff",
         });
@@ -228,12 +246,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       subscription.unsubscribe();
     };
   }, [setSession]);
-
-  useEffect(() => {
-    if (session?.user.id) {
-      identifyAnalytics(session.user.id);
-    }
-  }, [session?.user.id]);
 
   useEffect(() => {
     if (!supabase) {
@@ -277,6 +289,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         });
       }
     } catch (error) {
+      captureOperationalError(error, {
+        operation: "auth_browser_open",
+        tags: { method: "browser_handoff" },
+      });
       captureAnalytics("auth_failed", {
         method: "browser_handoff",
         failure_stage: "open_browser",
@@ -295,12 +311,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .signOut({ scope: "local" })
       .catch((error: unknown) => ({ error }));
     if (error) {
+      captureOperationalError(error, {
+        operation: "auth_sign_out",
+        level: "warning",
+      });
       // auth-js can early-return without clearing storage; force local cleanup
       // so the session cannot silently resurrect on next launch.
       supabase.auth.stopAutoRefresh();
       await AsyncStorage.removeItem(authStorageKey).catch(() => {});
     }
     setSession(null);
+    setErrorReportingUser(null);
     resetAnalytics();
   }, [setSession]);
 

--- a/apps/mobile/src/auth/context.tsx
+++ b/apps/mobile/src/auth/context.tsx
@@ -3,6 +3,7 @@ import {
   AuthApiError,
   AuthSessionMissingError,
   type Session,
+  type SupabaseClient,
 } from "@supabase/supabase-js";
 import * as Linking from "expo-linking";
 import * as WebBrowser from "expo-web-browser";
@@ -30,6 +31,7 @@ import {
 } from "@/lib/analytics";
 import { env, hasSupabaseEnv } from "@/lib/env";
 import {
+  addOperationalBreadcrumb,
   captureOperationalError,
   setErrorReportingUser,
 } from "@/lib/error-reporting";
@@ -164,8 +166,28 @@ async function readPersistedSession(): Promise<Session | null> {
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Session;
     return parsed?.access_token && parsed?.refresh_token ? parsed : null;
-  } catch {
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "auth_persisted_session_read",
+      level: "warning",
+    });
     return null;
+  }
+}
+
+async function clearInvalidSession(
+  client: SupabaseClient,
+  reason: "fatal_error" | "rejected",
+) {
+  const { error } = await client.auth
+    .signOut({ scope: "local" })
+    .catch((error: unknown) => ({ error }));
+  if (error) {
+    captureOperationalError(error, {
+      operation: "auth_invalid_session_clear",
+      level: "warning",
+      tags: { reason },
+    });
   }
 }
 
@@ -176,6 +198,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
   const sessionRef = useRef<Session | null | undefined>(session);
   const identifiedUserIdRef = useRef<string | null>(null);
+  const reportedUndecodableUserIdRef = useRef<string | null>(null);
   // Prevents double init in React StrictMode (refresh token races)
   const initStartedRef = useRef(false);
 
@@ -184,6 +207,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setSessionState(next);
     const userId = next?.user.id ?? null;
     setErrorReportingUser(userId);
+    if (
+      next &&
+      !decodeJwtPayload(next.access_token) &&
+      reportedUndecodableUserIdRef.current !== userId
+    ) {
+      reportedUndecodableUserIdRef.current = userId;
+      captureOperationalError(new Error("Mobile auth token decode failed"), {
+        operation: "auth_token_decode",
+        level: "warning",
+      });
+    } else if (!next) {
+      reportedUndecodableUserIdRef.current = null;
+    }
     if (userId && userId !== identifiedUserIdRef.current) {
       identifiedUserIdRef.current = userId;
       identifyAnalytics(userId);
@@ -204,10 +240,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         async ({ data, error }) => {
           if (error) {
             if (isFatalSessionError(error)) {
-              await client.auth.signOut({ scope: "local" }).catch(() => {});
+              await clearInvalidSession(client, "fatal_error");
               setSession(null);
               return;
             }
+            addOperationalBreadcrumb("auth_session_restore", {
+              outcome: "persisted_fallback",
+              reason: "get_session_error",
+            });
             setSession(await readPersistedSession());
             return;
           }
@@ -215,10 +255,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         },
         async (error) => {
           if (isFatalSessionError(error)) {
-            await client.auth.signOut({ scope: "local" }).catch(() => {});
+            await clearInvalidSession(client, "rejected");
             setSession(null);
             return;
           }
+          addOperationalBreadcrumb("auth_session_restore", {
+            outcome: "persisted_fallback",
+            reason: "get_session_rejected",
+          });
           setSession(await readPersistedSession());
         },
       );
@@ -255,11 +299,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const subscription = Linking.addEventListener("url", (event) => {
       handleAuthCallbackUrl(event.url);
     });
-    void Linking.getInitialURL().then((url) => {
-      if (url) {
-        handleAuthCallbackUrl(url);
-      }
-    });
+    void Linking.getInitialURL().then(
+      (url) => {
+        if (url) {
+          handleAuthCallbackUrl(url);
+        }
+      },
+      (error) => {
+        captureOperationalError(error, {
+          operation: "auth_initial_url_read",
+          level: "warning",
+        });
+      },
+    );
 
     return () => {
       subscription.remove();
@@ -318,7 +370,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // auth-js can early-return without clearing storage; force local cleanup
       // so the session cannot silently resurrect on next launch.
       supabase.auth.stopAutoRefresh();
-      await AsyncStorage.removeItem(authStorageKey).catch(() => {});
+      await AsyncStorage.removeItem(authStorageKey).catch((storageError) => {
+        captureOperationalError(storageError, {
+          operation: "auth_storage_clear",
+          level: "warning",
+        });
+      });
     }
     setSession(null);
     setErrorReportingUser(null);

--- a/apps/mobile/src/auth/screens.tsx
+++ b/apps/mobile/src/auth/screens.tsx
@@ -1,5 +1,4 @@
 import * as WebBrowser from "expo-web-browser";
-import { useEffect } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -13,6 +12,8 @@ import type { BillingInfo } from "@/auth/billing";
 import { Colors, Radius, Spacing } from "@/constants/theme";
 import { captureAnalytics } from "@/lib/analytics";
 import { env } from "@/lib/env";
+import { captureOperationalError } from "@/lib/error-reporting";
+import { useMountEffect } from "@/lib/use-mount-effect";
 
 export function SignInScreen({
   onSignIn,
@@ -62,12 +63,25 @@ export function PaywallScreen({
   email: string;
   onSignOut: () => void;
 }) {
-  useEffect(() => {
+  useMountEffect(() => {
     captureAnalytics("paywall_viewed", {
       entry_point: "mobile_gate",
       feature: "mobile_access",
     });
-  }, []);
+  });
+
+  const handleOpenPlans = async () => {
+    try {
+      await WebBrowser.openBrowserAsync(
+        `${env.appUrl}/app/checkout?source=mobile`,
+      );
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "billing_checkout_open",
+        tags: { entry_point: "mobile_gate" },
+      });
+    }
+  };
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -88,11 +102,7 @@ export function PaywallScreen({
       </View>
 
       <Pressable
-        onPress={() => {
-          void WebBrowser.openBrowserAsync(
-            `${env.appUrl}/app/checkout?source=mobile`,
-          );
-        }}
+        onPress={() => void handleOpenPlans()}
         style={({ pressed }) => [styles.cta, pressed && styles.ctaPressed]}
       >
         <Text style={styles.ctaLabel}>View plans</Text>

--- a/apps/mobile/src/components/audio-chip.tsx
+++ b/apps/mobile/src/components/audio-chip.tsx
@@ -3,6 +3,8 @@ import { useAudioPlayer, useAudioPlayerStatus } from "expo-audio";
 import { Pressable, StyleSheet, Text } from "react-native";
 
 import { Colors, Radius, Spacing } from "@/constants/theme";
+import { captureOperationalError } from "@/lib/error-reporting";
+import { useMountEffect } from "@/lib/use-mount-effect";
 
 function formatBytes(bytes: number): string {
   if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -27,15 +29,48 @@ export function AudioChip({
   const player = useAudioPlayer(uri);
   const status = useAudioPlayerStatus(player);
 
-  const toggle = () => {
-    if (status.playing) {
-      player.pause();
-      return;
+  useMountEffect(() => {
+    let lastError: string | null = null;
+    const subscription = player.addListener(
+      "playbackStatusUpdate",
+      (nextStatus) => {
+        const errorKey = nextStatus.error
+          ? nextStatus.error
+          : nextStatus.mediaServicesDidReset
+            ? "media_services_reset"
+            : null;
+        if (!errorKey || errorKey === lastError) return;
+
+        lastError = errorKey;
+        captureOperationalError(
+          new Error(nextStatus.error ?? "Audio media services reset"),
+          {
+            operation: nextStatus.mediaServicesDidReset
+              ? "audio_playback_media_services_reset"
+              : "audio_playback",
+            level: nextStatus.mediaServicesDidReset ? "warning" : "error",
+          },
+        );
+      },
+    );
+    return () => subscription.remove();
+  });
+
+  const toggle = async () => {
+    try {
+      if (status.playing) {
+        player.pause();
+        return;
+      }
+      if (status.duration > 0 && status.currentTime >= status.duration - 0.05) {
+        await player.seekTo(0);
+      }
+      player.play();
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "audio_playback_control",
+      });
     }
-    if (status.duration > 0 && status.currentTime >= status.duration - 0.05) {
-      void player.seekTo(0);
-    }
-    player.play();
   };
 
   const detail =
@@ -45,7 +80,7 @@ export function AudioChip({
 
   return (
     <Pressable
-      onPress={toggle}
+      onPress={() => void toggle()}
       style={({ pressed }) => [styles.chip, pressed && styles.pressed]}
     >
       <Ionicons

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -87,7 +87,12 @@ async function importAsset(asset: DocumentPickerAsset): Promise<string> {
   } catch (error) {
     // The session exists before the audio does, so a failed copy or catalog
     // would otherwise strand an empty session on the timeline.
-    await deleteSession(sessionId).catch(() => {});
+    await deleteSession(sessionId).catch((cleanupError) => {
+      captureOperationalError(cleanupError, {
+        operation: "voice_memo_import_cleanup",
+        level: "warning",
+      });
+    });
     throw error;
   }
 
@@ -115,7 +120,6 @@ export async function importVoiceMemos(): Promise<string[]> {
           content_type: asset.mimeType ?? "unknown",
         },
       });
-      console.warn("voice memo import failed", error);
     }
   }
   return created;

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -8,6 +8,7 @@ import { catalogSessionAudio } from "@/data/audio-catalog";
 import { createSession, deleteSession } from "@/data/session";
 import { transcribeSession } from "@/data/transcribe";
 import { captureAnalytics } from "@/lib/analytics";
+import { captureOperationalError } from "@/lib/error-reporting";
 import { nowIso } from "@/lib/ids";
 
 const CONTENT_TYPES: Record<string, string> = {
@@ -108,7 +109,13 @@ export async function importVoiceMemos(): Promise<string[]> {
     try {
       created.push(await importAsset(asset));
     } catch (error) {
-      console.warn(`voice memo import failed for ${asset.name}`, error);
+      captureOperationalError(error, {
+        operation: "voice_memo_import",
+        context: {
+          content_type: asset.mimeType ?? "unknown",
+        },
+      });
+      console.warn("voice memo import failed", error);
     }
   }
   return created;

--- a/apps/mobile/src/data/transcribe.ts
+++ b/apps/mobile/src/data/transcribe.ts
@@ -7,6 +7,7 @@ import { supabase } from "@/auth/client";
 import { execute, executeTransaction } from "@/db";
 import { captureAnalytics } from "@/lib/analytics";
 import { env } from "@/lib/env";
+import { captureOperationalError } from "@/lib/error-reporting";
 import { id, nowIso } from "@/lib/ids";
 
 // Client-driven batch STT, mirroring desktop's useRunBatch: POST the audio to
@@ -326,6 +327,10 @@ export function transcribeSession(sessionId: string): Promise<void> {
       clearStateSilently(sessionId);
     })
     .catch((error: unknown) => {
+      captureOperationalError(error, {
+        operation: "transcription_batch",
+        tags: { mode: "batch" },
+      });
       console.warn("[transcribe] failed", error);
       captureAnalytics("transcription_failed", {
         mode: "batch",

--- a/apps/mobile/src/data/transcribe.ts
+++ b/apps/mobile/src/data/transcribe.ts
@@ -196,6 +196,46 @@ const REQUEST_TIMEOUT_MAX_MS = 900_000;
 // the synchronous response comes back.
 const UPLOAD_MS_PER_KIB = 8;
 const PROCESSING_MS_PER_KIB = 8;
+type TranscriptionStage =
+  | "auth"
+  | "load_audio"
+  | "persist"
+  | "request"
+  | "response";
+
+function transcriptionFailure(
+  message: string,
+  stage: TranscriptionStage,
+  details?: { code?: string; status?: number },
+) {
+  return Object.assign(new Error(message), { stage, ...details });
+}
+
+function withTranscriptionStage(
+  error: unknown,
+  stage: TranscriptionStage,
+): unknown {
+  if (error && typeof error === "object") {
+    try {
+      Object.defineProperty(error, "stage", {
+        configurable: true,
+        value: stage,
+      });
+      return error;
+    } catch {}
+  }
+  return transcriptionFailure("Transcription failed", stage);
+}
+
+function transcriptionStage(error: unknown): TranscriptionStage | "unknown" {
+  if (!error || typeof error !== "object") return "unknown";
+  const stage = (error as { stage?: unknown }).stage;
+  return ["auth", "load_audio", "persist", "request", "response"].includes(
+    String(stage),
+  )
+    ? (stage as TranscriptionStage)
+    : "unknown";
+}
 
 function requestTimeoutMs(sizeBytes: number): number {
   // The abort covers the whole /stt/listen round trip, not just the upload, so
@@ -261,10 +301,15 @@ async function runTranscription(sessionId: string): Promise<void> {
 
   const file = new File(Paths.document, "sessions", sessionId, audio.filename);
   if (!file.exists) {
-    throw new Error(`audio file missing: ${audio.filename}`);
+    throw transcriptionFailure("Audio file missing", "load_audio", {
+      code: "audio_missing",
+    });
   }
 
   const auth = await supabase?.auth.getSession();
+  if (auth?.error) {
+    throw withTranscriptionStage(auth.error, "auth");
+  }
   const token = auth?.data.session?.access_token;
   const startedAtMs = Date.now();
 
@@ -273,18 +318,29 @@ async function runTranscription(sessionId: string): Promise<void> {
     audio.content_type || "application/octet-stream",
     token,
     requestTimeoutMs(audio.size_bytes),
-  );
+  ).catch((error) => {
+    throw withTranscriptionStage(error, "request");
+  });
   if (response.status < 200 || response.status >= 300) {
-    throw new Error(
-      `stt request failed: ${response.status} ${response.body.slice(0, 256)}`,
-    );
+    throw transcriptionFailure("STT request failed", "response", {
+      code: "stt_http_error",
+      status: response.status,
+    });
   }
 
-  const { words, hints } = mapBatchResponse(JSON.parse(response.body));
+  let payload: unknown;
+  try {
+    payload = JSON.parse(response.body);
+  } catch (error) {
+    throw withTranscriptionStage(error, "response");
+  }
+  const { words, hints } = mapBatchResponse(payload);
   if (words.length === 0) {
     // Never mark complete on an empty result — transcript_status stays
     // 'processing' so the tap-to-retry affordance remains reachable.
-    throw new Error("stt returned no words");
+    throw transcriptionFailure("STT returned no words", "response", {
+      code: "stt_empty_result",
+    });
   }
   const now = nowIso();
   const attachmentId = `session-audio:${sessionId}`;
@@ -310,7 +366,9 @@ async function runTranscription(sessionId: string): Promise<void> {
       sql: MARK_COMPLETE_SQL,
       params: [now, attachmentId, sessionId] as unknown[],
     },
-  ]);
+  ]).catch((error) => {
+    throw withTranscriptionStage(error, "persist");
+  });
 }
 
 export function transcribeSession(sessionId: string): Promise<void> {
@@ -329,9 +387,11 @@ export function transcribeSession(sessionId: string): Promise<void> {
     .catch((error: unknown) => {
       captureOperationalError(error, {
         operation: "transcription_batch",
-        tags: { mode: "batch" },
+        tags: {
+          mode: "batch",
+          stage: transcriptionStage(error),
+        },
       });
-      console.warn("[transcribe] failed", error);
       captureAnalytics("transcription_failed", {
         mode: "batch",
         entry_point: "mobile_audio",

--- a/apps/mobile/src/data/transcripts.ts
+++ b/apps/mobile/src/data/transcripts.ts
@@ -1,4 +1,5 @@
 import { useLiveQuery } from "@/db";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 type TranscriptRow = {
   id: string;
@@ -9,6 +10,8 @@ export type TranscriptSegment = {
   id: string;
   text: string;
 };
+
+const reportedInvalidRows = new Set<string>();
 
 function mapTranscriptRows(rows: TranscriptRow[]): TranscriptSegment[] {
   return rows
@@ -21,7 +24,15 @@ function mapTranscriptRows(rows: TranscriptRow[]): TranscriptSegment[] {
           .join(" ")
           .replace(/\s+/g, " ")
           .trim();
-      } catch {}
+      } catch (error) {
+        if (!reportedInvalidRows.has(row.id)) {
+          reportedInvalidRows.add(row.id);
+          captureOperationalError(error, {
+            operation: "transcript_words_parse",
+            level: "warning",
+          });
+        }
+      }
       return { id: row.id, text };
     })
     .filter((segment) => segment.text !== "");

--- a/apps/mobile/src/db/client.ts
+++ b/apps/mobile/src/db/client.ts
@@ -14,6 +14,7 @@ import type {
 } from "@hypr/db-runtime";
 
 import { migrate } from "@/db/migrations";
+import { captureOperationalError } from "@/lib/error-reporting";
 import { id } from "@/lib/ids";
 
 const READ_TABLE_RE = /\b(?:from|join)\s+([^\s(,;]+)/gi;
@@ -69,6 +70,7 @@ type Subscription = {
   params: SQLiteBindValue[];
   tables: Set<string>;
   active: boolean;
+  reportedError?: string;
   onData: (rows: Row[]) => void;
   onError?: (error: string) => void;
 };
@@ -169,11 +171,19 @@ async function refresh(subscription: Subscription): Promise<void> {
       db.getAllAsync<Row>(subscription.sql, subscription.params),
     );
     if (subscription.active) {
+      subscription.reportedError = undefined;
       subscription.onData(rows);
     }
   } catch (error) {
+    const message = errorMessage(error);
+    if (subscription.reportedError !== message) {
+      subscription.reportedError = message;
+      captureOperationalError(error, {
+        operation: "database_live_query_refresh",
+      });
+    }
     if (subscription.active) {
-      subscription.onError?.(errorMessage(error));
+      subscription.onError?.(message);
     }
   }
 }
@@ -241,17 +251,23 @@ async function subscribe<T = Row>(
       `[mobile-db] live query subscription is non-reactive for SQL "${sql}": query has no reactive dependencies`,
     );
   }
+  let reportedError: string | undefined;
   try {
     const rows = await enqueue(() => db.getAllAsync<T>(sql, boundParams));
     options.onData(rows);
   } catch (error) {
-    options.onError?.(errorMessage(error));
+    reportedError = errorMessage(error);
+    captureOperationalError(error, {
+      operation: "database_live_query_subscribe",
+    });
+    options.onError?.(reportedError);
   }
   const subscription: Subscription = {
     sql,
     params: boundParams,
     tables,
     active: true,
+    reportedError,
     onData: options.onData as (rows: Row[]) => void,
     onError: options.onError,
   };

--- a/apps/mobile/src/db/client.ts
+++ b/apps/mobile/src/db/client.ts
@@ -102,12 +102,38 @@ async function openDb(): Promise<SQLiteDatabase> {
   });
   try {
     await db.execAsync("PRAGMA journal_mode = WAL");
-  } catch {}
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "database_pragma",
+      level: "warning",
+      tags: { pragma: "journal_mode_wal" },
+    });
+  }
   try {
     await db.execAsync("PRAGMA foreign_keys = ON");
-  } catch {}
-  await migrate(db);
-  await ensureWorkspaceBinding(db);
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "database_pragma",
+      level: "warning",
+      tags: { pragma: "foreign_keys_on" },
+    });
+  }
+  try {
+    await migrate(db);
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "database_migrate",
+    });
+    throw error;
+  }
+  try {
+    await ensureWorkspaceBinding(db);
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "database_workspace_binding",
+    });
+    throw error;
+  }
   try {
     addDatabaseChangeListener((event) => {
       if (event.tableName) {
@@ -220,7 +246,12 @@ async function runTransaction(
   } catch (error) {
     try {
       await db.execAsync("ROLLBACK");
-    } catch {}
+    } catch (rollbackError) {
+      captureOperationalError(rollbackError, {
+        operation: "database_transaction_rollback",
+        level: "warning",
+      });
+    }
     throw error;
   } finally {
     // Also after ROLLBACK: hook events consumed mid-transaction must not

--- a/apps/mobile/src/db/migrations.ts
+++ b/apps/mobile/src/db/migrations.ts
@@ -3,6 +3,8 @@
 // disposable — cloud sync repopulates it.
 import type { SQLiteDatabase } from "expo-sqlite";
 
+import { captureOperationalError } from "@/lib/error-reporting";
+
 const CANONICAL_TABLES = [
   `CREATE TABLE IF NOT EXISTS sessions (
   id                   TEXT PRIMARY KEY NOT NULL,
@@ -383,7 +385,12 @@ export async function migrate(db: SQLiteDatabase): Promise<void> {
     } catch (error) {
       try {
         await db.execAsync("ROLLBACK");
-      } catch {}
+      } catch (rollbackError) {
+        captureOperationalError(rollbackError, {
+          operation: "database_migration_rollback",
+          level: "warning",
+        });
+      }
       throw error;
     }
     current = migration.version;

--- a/apps/mobile/src/lib/env.ts
+++ b/apps/mobile/src/lib/env.ts
@@ -14,6 +14,7 @@ export const env = {
   appUrl: read("appUrl", "http://localhost:3000"),
   posthogApiKey: read("posthogApiKey"),
   posthogHost: read("posthogHost", "https://us.i.posthog.com"),
+  sentryDsn: read("sentryDsn"),
 };
 
 export const hasSupabaseEnv = Boolean(env.supabaseUrl && env.supabaseAnonKey);

--- a/apps/mobile/src/lib/error-reporting.ts
+++ b/apps/mobile/src/lib/error-reporting.ts
@@ -1,85 +1,38 @@
 import * as Sentry from "@sentry/react-native";
-import type { ErrorEvent, SeverityLevel } from "@sentry/react-native";
+import type {
+  Breadcrumb,
+  ErrorEvent,
+  SeverityLevel,
+} from "@sentry/react-native";
 import Constants from "expo-constants";
+import { Platform } from "react-native";
 
 import { env } from "@/lib/env";
+import {
+  normalizeOperationalError,
+  operationalErrorMetadata,
+  sanitizeBreadcrumb,
+  sanitizeMobileErrorEvent,
+  type MobileErrorEvent,
+} from "@/lib/error-sanitization";
 
 type ErrorContextValue = null | boolean | number | string;
-
-function normalizeOperationalError(error: unknown, operation: string): Error {
-  if (error instanceof Error) return error;
-
-  if (
-    typeof error === "string" ||
-    typeof error === "number" ||
-    typeof error === "boolean"
-  ) {
-    return new Error(`${operation} failed: ${String(error).slice(0, 256)}`);
-  }
-
-  if (error && typeof error === "object") {
-    const record = error as Record<string, unknown>;
-    const details = ["status", "statusCode", "code", "message"]
-      .flatMap((key) => {
-        const value = record[key];
-        return typeof value === "string" ||
-          typeof value === "number" ||
-          typeof value === "boolean"
-          ? [`${key}=${String(value).slice(0, 256)}`]
-          : [];
-      })
-      .join(", ");
-
-    if (details) {
-      return new Error(`${operation} failed (${details})`);
-    }
-  }
-
-  return new Error(`${operation} failed`);
-}
-
-function sanitizeUrl(value: string | undefined) {
-  if (!value) return value;
-
-  try {
-    const url = new URL(value);
-    url.search = "";
-    url.hash = "";
-    return url.toString();
-  } catch {
-    return value.split(/[?#]/, 1)[0];
-  }
-}
+const capturedErrors = new WeakSet<object>();
 
 export function sanitizeErrorEvent(event: ErrorEvent): ErrorEvent {
-  if (event.user) {
-    event.user = event.user.id ? { id: event.user.id } : undefined;
-  }
+  return sanitizeMobileErrorEvent(
+    event as unknown as MobileErrorEvent,
+  ) as unknown as ErrorEvent;
+}
 
-  if (event.request) {
-    event.request = {
-      method: event.request.method,
-      url: sanitizeUrl(event.request.url),
-    };
-  }
-
-  delete event.extra;
-  event.breadcrumbs = event.breadcrumbs?.map((breadcrumb) => ({
-    category: breadcrumb.category,
-    level: breadcrumb.level,
-    timestamp: breadcrumb.timestamp,
-    type: breadcrumb.type,
-    ...(breadcrumb.category === "navigation"
-      ? {
-          data: {
-            from: sanitizeUrl(String(breadcrumb.data?.from ?? "")),
-            to: sanitizeUrl(String(breadcrumb.data?.to ?? "")),
-          },
-        }
-      : {}),
-  }));
-
-  return event;
+function appDist(): string | undefined {
+  const build =
+    Platform.OS === "ios"
+      ? (Constants.platform?.ios?.buildNumber ??
+        Constants.expoConfig?.ios?.buildNumber)
+      : (Constants.platform?.android?.versionCode ??
+        Constants.expoConfig?.android?.versionCode);
+  return build === undefined ? undefined : String(build);
 }
 
 export function initializeErrorReporting() {
@@ -88,14 +41,27 @@ export function initializeErrorReporting() {
     enabled: Boolean(env.sentryDsn) && !__DEV__,
     environment: __DEV__ ? "development" : "production",
     release: `anarlog-mobile@${Constants.expoConfig?.version ?? "unknown"}`,
+    dist: appDist(),
     sendDefaultPii: false,
     attachStacktrace: true,
     beforeSend: sanitizeErrorEvent,
+    beforeBreadcrumb: (breadcrumb) =>
+      sanitizeBreadcrumb(breadcrumb as Breadcrumb),
+    enableAutoSessionTracking: true,
+    sessionTrackingIntervalMillis: 30_000,
+    enableTombstone: true,
+    enableAppHangTracking: true,
+    appHangTimeoutInterval: 5,
+    enableWatchdogTerminationTracking: true,
+    attachScreenshot: false,
+    attachViewHierarchy: false,
     initialScope: {
       tags: {
         "service.name": "mobile",
         "service.namespace": "hyprnote",
-        surface: "mobile",
+        "hyprnote.mobile.execution_environment": Constants.executionEnvironment,
+        "hyprnote.mobile.os": Platform.OS,
+        "hyprnote.surface": "mobile",
       },
     },
   });
@@ -115,20 +81,54 @@ export function captureOperationalError(
     context?: Record<string, ErrorContextValue>;
   },
 ) {
+  if (error && typeof error === "object") {
+    if (capturedErrors.has(error)) return;
+    capturedErrors.add(error);
+  }
+
+  const metadata = operationalErrorMetadata(error);
   const exception = normalizeOperationalError(error, operation);
 
   return Sentry.withScope((scope) => {
     scope.setLevel(level);
-    scope.setTag("operation", operation);
+    scope.setTag("hyprnote.operation", operation);
+    scope.setTag("error.type", metadata.type);
+    if (metadata.code) scope.setTag("error.code", metadata.code);
+    if (metadata.stage) {
+      scope.setTag("hyprnote.error.stage", metadata.stage);
+    }
+    if (metadata.status) {
+      scope.setTag("http.response.status_code", metadata.status);
+    }
     for (const [key, value] of Object.entries(tags ?? {})) {
       if (value !== null) {
-        scope.setTag(key, value);
+        scope.setTag(`hyprnote.${key}`, value);
       }
     }
     if (context) {
-      scope.setContext("operation", context);
+      scope.setContext("hyprnote.operation", context);
     }
     return Sentry.captureException(exception);
+  });
+}
+
+export function addOperationalBreadcrumb(
+  operation: string,
+  data?: Record<string, ErrorContextValue>,
+) {
+  Sentry.addBreadcrumb({
+    category: "hyprnote.operation",
+    level: "info",
+    message: operation,
+    data,
+  });
+}
+
+export function addNavigationBreadcrumb(from: string | null, to: string) {
+  Sentry.addBreadcrumb({
+    category: "navigation",
+    level: "info",
+    data: { from: from ?? "", to },
   });
 }
 

--- a/apps/mobile/src/lib/error-reporting.ts
+++ b/apps/mobile/src/lib/error-reporting.ts
@@ -1,0 +1,137 @@
+import * as Sentry from "@sentry/react-native";
+import type { ErrorEvent, SeverityLevel } from "@sentry/react-native";
+import Constants from "expo-constants";
+
+import { env } from "@/lib/env";
+
+type ErrorContextValue = null | boolean | number | string;
+
+function normalizeOperationalError(error: unknown, operation: string): Error {
+  if (error instanceof Error) return error;
+
+  if (
+    typeof error === "string" ||
+    typeof error === "number" ||
+    typeof error === "boolean"
+  ) {
+    return new Error(`${operation} failed: ${String(error).slice(0, 256)}`);
+  }
+
+  if (error && typeof error === "object") {
+    const record = error as Record<string, unknown>;
+    const details = ["status", "statusCode", "code", "message"]
+      .flatMap((key) => {
+        const value = record[key];
+        return typeof value === "string" ||
+          typeof value === "number" ||
+          typeof value === "boolean"
+          ? [`${key}=${String(value).slice(0, 256)}`]
+          : [];
+      })
+      .join(", ");
+
+    if (details) {
+      return new Error(`${operation} failed (${details})`);
+    }
+  }
+
+  return new Error(`${operation} failed`);
+}
+
+function sanitizeUrl(value: string | undefined) {
+  if (!value) return value;
+
+  try {
+    const url = new URL(value);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value.split(/[?#]/, 1)[0];
+  }
+}
+
+export function sanitizeErrorEvent(event: ErrorEvent): ErrorEvent {
+  if (event.user) {
+    event.user = event.user.id ? { id: event.user.id } : undefined;
+  }
+
+  if (event.request) {
+    event.request = {
+      method: event.request.method,
+      url: sanitizeUrl(event.request.url),
+    };
+  }
+
+  delete event.extra;
+  event.breadcrumbs = event.breadcrumbs?.map((breadcrumb) => ({
+    category: breadcrumb.category,
+    level: breadcrumb.level,
+    timestamp: breadcrumb.timestamp,
+    type: breadcrumb.type,
+    ...(breadcrumb.category === "navigation"
+      ? {
+          data: {
+            from: sanitizeUrl(String(breadcrumb.data?.from ?? "")),
+            to: sanitizeUrl(String(breadcrumb.data?.to ?? "")),
+          },
+        }
+      : {}),
+  }));
+
+  return event;
+}
+
+export function initializeErrorReporting() {
+  Sentry.init({
+    dsn: env.sentryDsn,
+    enabled: Boolean(env.sentryDsn) && !__DEV__,
+    environment: __DEV__ ? "development" : "production",
+    release: `anarlog-mobile@${Constants.expoConfig?.version ?? "unknown"}`,
+    sendDefaultPii: false,
+    attachStacktrace: true,
+    beforeSend: sanitizeErrorEvent,
+    initialScope: {
+      tags: {
+        "service.name": "mobile",
+        "service.namespace": "hyprnote",
+        surface: "mobile",
+      },
+    },
+  });
+}
+
+export function captureOperationalError(
+  error: unknown,
+  {
+    operation,
+    level = "error",
+    tags,
+    context,
+  }: {
+    operation: string;
+    level?: SeverityLevel;
+    tags?: Record<string, ErrorContextValue>;
+    context?: Record<string, ErrorContextValue>;
+  },
+) {
+  const exception = normalizeOperationalError(error, operation);
+
+  return Sentry.withScope((scope) => {
+    scope.setLevel(level);
+    scope.setTag("operation", operation);
+    for (const [key, value] of Object.entries(tags ?? {})) {
+      if (value !== null) {
+        scope.setTag(key, value);
+      }
+    }
+    if (context) {
+      scope.setContext("operation", context);
+    }
+    return Sentry.captureException(exception);
+  });
+}
+
+export function setErrorReportingUser(userId: string | null) {
+  Sentry.setUser(userId ? { id: userId } : null);
+}

--- a/apps/mobile/src/lib/error-sanitization.test.mjs
+++ b/apps/mobile/src/lib/error-sanitization.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeOperationalError,
+  operationalErrorMetadata,
+  sanitizeMobileErrorEvent,
+} from "./error-sanitization.ts";
+
+test("removes user content while preserving safe diagnostics", () => {
+  const event = sanitizeMobileErrorEvent({
+    platform: "javascript",
+    tags: { "hyprnote.operation": "session_save" },
+    user: {
+      id: "user-1",
+      email: "private@example.com",
+      ip_address: "127.0.0.1",
+    },
+    request: {
+      method: "POST",
+      url: "https://api.anarlog.so/stt/listen?token=secret#selection",
+      headers: { authorization: "Bearer secret" },
+      data: { transcript: "private transcript" },
+    },
+    extra: { note: "private note" },
+    message: "private note",
+    logentry: { message: "private note" },
+    exception: {
+      values: [
+        {
+          type: "Error",
+          value: "private note",
+          mechanism: { data: { token: "secret" } },
+        },
+      ],
+    },
+    breadcrumbs: [
+      {
+        category: "hyprnote.operation",
+        message: "auth_session_restore",
+        data: {
+          outcome: "persisted_fallback",
+          email: "private@example.com",
+        },
+      },
+      {
+        category: "console",
+        message: "private note",
+        data: { arguments: ["private note"] },
+      },
+      {
+        category: "navigation",
+        data: {
+          from: "anarlog://note/123?token=secret",
+          to: "https://anarlog.so/app/?share=secret",
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(event.user, { id: "user-1" });
+  assert.deepEqual(event.request, {
+    method: "POST",
+    url: "https://api.anarlog.so/stt/listen",
+  });
+  assert.equal(event.extra, undefined);
+  assert.equal(event.message, "session_save failed");
+  assert.equal(event.logentry, undefined);
+  assert.equal(event.exception?.values?.[0]?.value, "session_save failed");
+  assert.equal(event.exception?.values?.[0]?.mechanism?.data, undefined);
+  assert.deepEqual(event.breadcrumbs, [
+    {
+      category: "hyprnote.operation",
+      level: undefined,
+      message: "auth_session_restore",
+      timestamp: undefined,
+      type: undefined,
+      data: {
+        outcome: "persisted_fallback",
+      },
+    },
+    {
+      category: "console",
+      level: undefined,
+      timestamp: undefined,
+      type: undefined,
+    },
+    {
+      category: "navigation",
+      level: undefined,
+      timestamp: undefined,
+      type: undefined,
+      data: {
+        from: "anarlog://note/123",
+        to: "https://anarlog.so/app/",
+      },
+    },
+  ]);
+});
+
+test("normalizes messages but retains stack frames and safe error fields", () => {
+  const source = Object.assign(new Error("private@example.com token=secret"), {
+    code: "refresh_token_not_found",
+    stage: "auth_bootstrap",
+    status: 401,
+  });
+  source.stack = [
+    "Error: private@example.com token=secret",
+    "    at restoreSession (auth.ts:42:3)",
+  ].join("\n");
+
+  const normalized = normalizeOperationalError(source, "auth_session_restore");
+
+  assert.equal(normalized.message, "auth_session_restore failed");
+  assert.equal(normalized.stack?.includes("private@example.com"), false);
+  assert.equal(normalized.stack?.includes("auth.ts:42:3"), true);
+  assert.deepEqual(operationalErrorMetadata(source), {
+    type: "Error",
+    code: "refresh_token_not_found",
+    stage: "auth_bootstrap",
+    status: 401,
+  });
+});

--- a/apps/mobile/src/lib/error-sanitization.ts
+++ b/apps/mobile/src/lib/error-sanitization.ts
@@ -1,0 +1,196 @@
+type BreadcrumbLike = {
+  category?: string;
+  data?: Record<string, unknown>;
+  level?: string;
+  message?: string;
+  timestamp?: number;
+  type?: string;
+};
+
+type ExceptionLike = {
+  mechanism?: {
+    data?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  type?: string;
+  value?: string;
+};
+
+export type MobileErrorEvent = {
+  breadcrumbs?: BreadcrumbLike[];
+  exception?: { values?: ExceptionLike[] };
+  extra?: Record<string, unknown>;
+  logentry?: unknown;
+  message?: string;
+  platform?: string;
+  request?: {
+    method?: string;
+    url?: string;
+    [key: string]: unknown;
+  };
+  tags?: Record<string, unknown>;
+  user?: {
+    id?: string;
+    [key: string]: unknown;
+  };
+};
+
+type SafeErrorMetadata = {
+  code?: string;
+  stage?: string;
+  status?: number;
+  type: string;
+};
+
+const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9_.:/-]{1,128}$/;
+const STACK_FRAME_RE = /^(?:\s*at\s|.*@.*:\d+:\d+$)/;
+
+function safeIdentifier(value: unknown): string | undefined {
+  if (typeof value !== "string" || !SAFE_IDENTIFIER_RE.test(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+function safeBreadcrumbData(
+  data: Record<string, unknown> | undefined,
+): Record<string, boolean | number | string> | undefined {
+  const safe: Record<string, boolean | number | string> = {};
+  for (const [key, value] of Object.entries(data ?? {})) {
+    if (!safeIdentifier(key)) continue;
+    if (typeof value === "boolean" || typeof value === "number") {
+      safe[key] = value;
+      continue;
+    }
+    const identifier = safeIdentifier(value);
+    if (identifier !== undefined) {
+      safe[key] = identifier;
+    }
+  }
+  return Object.keys(safe).length > 0 ? safe : undefined;
+}
+
+export function sanitizeUrl(value: string | undefined) {
+  if (!value) return value;
+
+  try {
+    const url = new URL(value);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value.split(/[?#]/, 1)[0];
+  }
+}
+
+export function sanitizeBreadcrumb<T extends BreadcrumbLike>(breadcrumb: T): T {
+  if (breadcrumb.category === "hyprnote.operation") {
+    return {
+      category: breadcrumb.category,
+      level: breadcrumb.level,
+      message: safeIdentifier(breadcrumb.message),
+      timestamp: breadcrumb.timestamp,
+      type: breadcrumb.type,
+      data: safeBreadcrumbData(breadcrumb.data),
+    } as T;
+  }
+
+  return {
+    category: breadcrumb.category,
+    level: breadcrumb.level,
+    timestamp: breadcrumb.timestamp,
+    type: breadcrumb.type,
+    ...(breadcrumb.category === "navigation"
+      ? {
+          data: {
+            from: sanitizeUrl(String(breadcrumb.data?.from ?? "")),
+            to: sanitizeUrl(String(breadcrumb.data?.to ?? "")),
+          },
+        }
+      : {}),
+  } as T;
+}
+
+export function sanitizeMobileErrorEvent<T extends MobileErrorEvent>(event: T) {
+  if (event.user) {
+    event.user = event.user.id ? { id: event.user.id } : undefined;
+  }
+
+  if (event.request) {
+    event.request = {
+      method: event.request.method,
+      url: sanitizeUrl(event.request.url),
+    };
+  }
+
+  delete event.extra;
+  event.breadcrumbs = event.breadcrumbs?.map(sanitizeBreadcrumb);
+
+  const operation =
+    typeof event.tags?.["hyprnote.operation"] === "string"
+      ? event.tags["hyprnote.operation"]
+      : undefined;
+  if (event.platform === "javascript" || operation) {
+    const value = operation
+      ? `${operation} failed`
+      : "Mobile application error";
+    for (const exception of event.exception?.values ?? []) {
+      exception.value = value;
+      if (exception.mechanism) {
+        delete exception.mechanism.data;
+      }
+    }
+    if (event.message) {
+      event.message = value;
+    }
+    delete event.logentry;
+  }
+
+  return event;
+}
+
+export function operationalErrorMetadata(error: unknown): SafeErrorMetadata {
+  if (!error || typeof error !== "object") {
+    return { type: "Error" };
+  }
+
+  const record = error as Record<string, unknown>;
+  const statusValue = record.status ?? record.statusCode;
+  const status =
+    typeof statusValue === "number" &&
+    Number.isInteger(statusValue) &&
+    statusValue >= 100 &&
+    statusValue <= 599
+      ? statusValue
+      : undefined;
+
+  return {
+    type: safeIdentifier(record.name) ?? "Error",
+    code: safeIdentifier(record.code),
+    stage: safeIdentifier(record.stage),
+    status,
+  };
+}
+
+export function normalizeOperationalError(
+  error: unknown,
+  operation: string,
+): Error {
+  const normalized = new Error(`${operation} failed`);
+  const metadata = operationalErrorMetadata(error);
+  normalized.name = metadata.type;
+
+  if (error instanceof Error && error.stack) {
+    const frames = error.stack
+      .split("\n")
+      .filter((line) => STACK_FRAME_RE.test(line));
+    if (frames.length > 0) {
+      normalized.stack = [
+        `${normalized.name}: ${normalized.message}`,
+        ...frames,
+      ].join("\n");
+    }
+  }
+
+  return normalized;
+}

--- a/apps/mobile/src/lib/use-mount-effect.ts
+++ b/apps/mobile/src/lib/use-mount-effect.ts
@@ -1,0 +1,5 @@
+import { useEffect } from "react";
+
+export function useMountEffect(effect: () => void | (() => void)) {
+  useEffect(effect, []);
+}

--- a/apps/stripe/src/error-reporting.test.ts
+++ b/apps/stripe/src/error-reporting.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+
+import { sanitizeErrorEvent } from "./error-reporting";
+
+describe("sanitizeErrorEvent", () => {
+  it("removes customer error content while preserving exception diagnostics", () => {
+    const event = sanitizeErrorEvent({
+      type: undefined,
+      message: "customer@example.com",
+      logentry: { message: "payment token" },
+      exception: {
+        values: [
+          {
+            type: "StripeError",
+            value: "private request details",
+            mechanism: {
+              type: "generic",
+              handled: false,
+              data: { customer: "cus_private" },
+            },
+          },
+        ],
+      },
+      extra: { customer: "cus_private" },
+      breadcrumbs: [
+        {
+          category: "console",
+          message: "private card details",
+          data: { arguments: ["private card details"] },
+        },
+        {
+          category: "navigation",
+          data: {
+            from: "https://anarlog.so/?token=secret",
+            to: "https://anarlog.so/billing?customer=private",
+          },
+        },
+      ],
+    });
+
+    expect(event.message).toBeUndefined();
+    expect(event.logentry).toBeUndefined();
+    expect(event.extra).toBeUndefined();
+    expect(event.exception?.values).toEqual([
+      {
+        type: "StripeError",
+        value: "StripeError captured",
+        mechanism: { type: "generic", handled: false },
+      },
+    ]);
+    expect(event.breadcrumbs).toEqual([
+      {
+        category: "console",
+        level: undefined,
+        timestamp: undefined,
+        type: undefined,
+      },
+      {
+        category: "navigation",
+        level: undefined,
+        timestamp: undefined,
+        type: undefined,
+        data: {
+          from: "https://anarlog.so/",
+          to: "https://anarlog.so/billing",
+        },
+      },
+    ]);
+  });
+});

--- a/apps/stripe/src/error-reporting.ts
+++ b/apps/stripe/src/error-reporting.ts
@@ -1,0 +1,87 @@
+import * as Sentry from "@sentry/bun";
+import type { SeverityLevel } from "@sentry/bun";
+
+type ErrorContextValue = null | boolean | number | string;
+
+function sanitizeUrl(value: string | undefined) {
+  return value?.split(/[?#]/, 1)[0];
+}
+
+export function sanitizeErrorEvent(
+  event: Sentry.ErrorEvent,
+): Sentry.ErrorEvent {
+  if (event.user) {
+    event.user = event.user.id ? { id: event.user.id } : undefined;
+  }
+
+  if (event.request) {
+    event.request = {
+      method: event.request.method,
+      url: sanitizeUrl(event.request.url),
+    };
+  }
+
+  delete event.extra;
+  delete event.message;
+  delete event.logentry;
+  if (event.exception?.values) {
+    event.exception.values = event.exception.values.map((exception) => {
+      const sanitized = {
+        ...exception,
+        value: exception.type ? `${exception.type} captured` : "Error captured",
+      };
+      if (sanitized.mechanism) {
+        delete sanitized.mechanism.data;
+      }
+      return sanitized;
+    });
+  }
+  event.breadcrumbs = event.breadcrumbs?.map((breadcrumb) => ({
+    category: breadcrumb.category,
+    level: breadcrumb.level,
+    timestamp: breadcrumb.timestamp,
+    type: breadcrumb.type,
+    ...(breadcrumb.category === "navigation"
+      ? {
+          data: {
+            from: sanitizeUrl(String(breadcrumb.data?.from ?? "")),
+            to: sanitizeUrl(String(breadcrumb.data?.to ?? "")),
+          },
+        }
+      : {}),
+  }));
+  return event;
+}
+
+export function captureOperationalError(
+  error: unknown,
+  {
+    operation,
+    level = "error",
+    tags,
+    context,
+  }: {
+    operation: string;
+    level?: SeverityLevel;
+    tags?: Record<string, ErrorContextValue>;
+    context?: Record<string, ErrorContextValue>;
+  },
+) {
+  const exception =
+    error instanceof Error ? error : new Error(`${operation} failed`);
+
+  return Sentry.withScope((scope) => {
+    scope.setLevel(level);
+    scope.setTag("hyprnote.operation", operation);
+    scope.setTag("hyprnote.surface", "billing");
+    for (const [key, value] of Object.entries(tags ?? {})) {
+      if (value !== null) {
+        scope.setTag(`hyprnote.${key}`, value);
+      }
+    }
+    if (context) {
+      scope.setContext("hyprnote.operation", context);
+    }
+    return Sentry.captureException(exception);
+  });
+}

--- a/apps/stripe/src/index.ts
+++ b/apps/stripe/src/index.ts
@@ -5,6 +5,7 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 
 import { env } from "./env";
+import { captureOperationalError, sanitizeErrorEvent } from "./error-reporting";
 import type { AppBindings } from "./hono-bindings";
 import { verifyStripeWebhook } from "./middleware";
 import { routes } from "./routes";
@@ -13,6 +14,18 @@ Sentry.init({
   dsn: Bun.env.SENTRY_DSN,
   environment: env.NODE_ENV,
   enabled: env.NODE_ENV === "production",
+  release: Bun.env.APP_VERSION
+    ? `anarlog-billing@${Bun.env.APP_VERSION}`
+    : undefined,
+  sendDefaultPii: false,
+  beforeSend: sanitizeErrorEvent,
+  initialScope: {
+    tags: {
+      "service.name": "billing",
+      "service.namespace": "hyprnote",
+      "hyprnote.surface": "billing",
+    },
+  },
 });
 
 const app = new Hono<AppBindings>();
@@ -33,8 +46,9 @@ app.use("/webhook/stripe", verifyStripeWebhook);
 app.route("/", routes);
 
 app.onError((err, c) => {
-  Sentry.captureException(err, {
-    extra: { path: c.req.path, method: c.req.method },
+  captureOperationalError(err, {
+    operation: "http_request",
+    context: { method: c.req.method },
   });
   return c.json({ error: "internal_server_error" }, 500);
 });

--- a/apps/stripe/src/middleware/stripe.ts
+++ b/apps/stripe/src/middleware/stripe.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/bun";
 import { createMiddleware } from "hono/factory";
 import Stripe from "stripe";
 
@@ -35,9 +34,6 @@ export const verifyStripeWebhook = createMiddleware<{
     c.set("stripeSignature", signature);
     await next();
   } catch (err) {
-    Sentry.captureException(err, {
-      tags: { webhook: "stripe", step: "signature_verification" },
-    });
     const message = err instanceof Error ? err.message : "unknown_error";
     return c.text(message, 400);
   }

--- a/apps/stripe/src/routes/webhook.ts
+++ b/apps/stripe/src/routes/webhook.ts
@@ -1,9 +1,9 @@
-import * as Sentry from "@sentry/bun";
 import { Hono } from "hono";
 
 import { captureBillingEvent, captureTrialEndingEmailSent } from "../analytics";
 import { syncBillingBridge } from "../billing-bridge";
 import { env } from "../env";
+import { captureOperationalError } from "../error-reporting";
 import type { AppBindings } from "../hono-bindings";
 import { stripeSync } from "../integration/stripe-sync";
 import { sendTrialEndingEmail } from "../trial-emails";
@@ -25,26 +25,22 @@ webhook.post("/stripe", async (c) => {
         error instanceof Error &&
         error.message === "Unhandled webhook event"
       ) {
-        Sentry.captureMessage(
-          `Unhandled Stripe webhook event: ${stripeEvent.type}`,
-          {
-            level: "warning",
-            tags: {
-              webhook: "stripe",
-              event_type: stripeEvent.type,
-            },
-            extra: {
-              api_version: stripeEvent.api_version,
-            },
-          },
-        );
-      } else {
-        Sentry.captureException(error, {
+        captureOperationalError(error, {
+          operation: "stripe_webhook_unhandled_event",
+          level: "warning",
           tags: {
             webhook: "stripe",
             event_type: stripeEvent.type,
+            api_version: stripeEvent.api_version ?? "unknown",
           },
-          extra: {
+        });
+      } else {
+        captureOperationalError(error, {
+          operation: "stripe_webhook_process",
+          tags: {
+            event_type: stripeEvent.type,
+          },
+          context: {
             api_version: stripeEvent.api_version,
           },
         });
@@ -56,8 +52,9 @@ webhook.post("/stripe", async (c) => {
   try {
     await syncBillingBridge(stripeEvent);
   } catch (error) {
-    Sentry.captureException(error, {
-      tags: { webhook: "stripe", event_type: stripeEvent.type },
+    captureOperationalError(error, {
+      operation: "billing_bridge_sync",
+      tags: { event_type: stripeEvent.type },
     });
     return c.json({ error: "billing_bridge_sync_failed" }, 500);
   }
@@ -65,10 +62,10 @@ webhook.post("/stripe", async (c) => {
   try {
     await captureBillingEvent(stripeEvent);
   } catch (error) {
-    Sentry.captureException(error, {
+    captureOperationalError(error, {
+      operation: "billing_analytics_capture",
+      level: "warning",
       tags: {
-        webhook: "stripe",
-        step: "posthog",
         event_type: stripeEvent.type,
       },
     });
@@ -84,20 +81,19 @@ webhook.post("/stripe", async (c) => {
           ...receipt,
         });
       } catch (error) {
-        Sentry.captureException(error, {
+        captureOperationalError(error, {
+          operation: "trial_email_analytics_capture",
+          level: "warning",
           tags: {
-            webhook: "stripe",
-            step: "posthog_loops",
             event_type: stripeEvent.type,
           },
         });
       }
     }
   } catch (error) {
-    Sentry.captureException(error, {
+    captureOperationalError(error, {
+      operation: "trial_email_send",
       tags: {
-        webhook: "stripe",
-        step: "loops",
         event_type: stripeEvent.type,
       },
     });

--- a/apps/web/instrument.server.mjs
+++ b/apps/web/instrument.server.mjs
@@ -1,6 +1,64 @@
 import * as Sentry from "@sentry/tanstackstart-react";
 
+function sanitizeUrl(value) {
+  return value?.split(/[?#]/, 1)[0];
+}
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  sendDefaultPii: true,
+  environment: process.env.NODE_ENV ?? "production",
+  release: process.env.APP_VERSION
+    ? `anarlog-web@${process.env.APP_VERSION}`
+    : undefined,
+  sendDefaultPii: false,
+  beforeSend(event) {
+    if (event.user) {
+      event.user = event.user.id ? { id: event.user.id } : undefined;
+    }
+    if (event.request) {
+      event.request = {
+        method: event.request.method,
+        url: sanitizeUrl(event.request.url),
+      };
+    }
+    delete event.extra;
+    delete event.message;
+    delete event.logentry;
+    if (event.exception?.values) {
+      event.exception.values = event.exception.values.map((exception) => {
+        const sanitized = {
+          ...exception,
+          value: exception.type
+            ? `${exception.type} captured`
+            : "Error captured",
+        };
+        if (sanitized.mechanism) {
+          delete sanitized.mechanism.data;
+        }
+        return sanitized;
+      });
+    }
+    event.breadcrumbs = event.breadcrumbs?.map((breadcrumb) => ({
+      category: breadcrumb.category,
+      level: breadcrumb.level,
+      timestamp: breadcrumb.timestamp,
+      type: breadcrumb.type,
+      ...(breadcrumb.category === "navigation"
+        ? {
+            data: {
+              from: sanitizeUrl(String(breadcrumb.data?.from ?? "")),
+              to: sanitizeUrl(String(breadcrumb.data?.to ?? "")),
+            },
+          }
+        : {}),
+    }));
+    return event;
+  },
+  initialScope: {
+    tags: {
+      "service.name": "web",
+      "service.namespace": "hyprnote",
+      "hyprnote.surface": "web_server",
+    },
+  },
 });

--- a/apps/web/src/components/error-page.tsx
+++ b/apps/web/src/components/error-page.tsx
@@ -1,0 +1,58 @@
+import type { ErrorRouteComponent } from "@tanstack/react-router";
+
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { captureOperationalError } from "@/lib/error-reporting";
+
+const errorKeys = new WeakMap<object, number>();
+let nextErrorKey = 0;
+
+function getErrorKey(error: unknown): number | string {
+  if (
+    (typeof error === "object" && error !== null) ||
+    typeof error === "function"
+  ) {
+    const object = error as object;
+    let key = errorKeys.get(object);
+    if (key === undefined) {
+      key = nextErrorKey;
+      nextErrorKey += 1;
+      errorKeys.set(object, key);
+    }
+    return key;
+  }
+
+  return `${typeof error}:${String(error)}`;
+}
+
+function ErrorReporter({ error }: { error: unknown }) {
+  useMountEffect(() => {
+    captureOperationalError(error, {
+      operation: "route_render",
+    });
+  });
+
+  return null;
+}
+
+export const ErrorPage: ErrorRouteComponent = ({ error }) => {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[#f7f2e8] px-5 text-center text-[#181613]">
+      <ErrorReporter key={getErrorKey(error)} error={error} />
+      <div>
+        <p className="text-sm font-medium tracking-[0.18em] text-[#756b5d] uppercase">
+          Something went wrong
+        </p>
+        <h1 className="mt-3 text-4xl font-semibold tracking-normal">
+          We could not load this page.
+        </h1>
+        <button
+          type="button"
+          className="mt-6 inline-flex rounded-full bg-[#181613] px-5 py-3 text-sm font-medium text-white"
+          onClick={() => window.location.reload()}
+        >
+          Try again
+        </button>
+      </div>
+    </main>
+  );
+};

--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -16,6 +16,7 @@ import {
   getSupabaseServerClient,
 } from "@/functions/supabase";
 import { sanitizeInternalReturnPath } from "@/lib/auth-redirect";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 const shared = z.object({
   flow: z.enum(["desktop", "web"]).default("desktop"),
@@ -151,9 +152,11 @@ async function mintDesktopSessionFromEmail(email: string) {
       });
 
     if (linkError || !linkData.properties?.hashed_token) {
-      console.error(
-        "[mintDesktopSessionFromEmail] generateLink failed:",
-        linkError?.message ?? "no hashed_token",
+      captureOperationalError(
+        new Error("Desktop auth link generation failed"),
+        {
+          operation: "desktop_auth_link_generate",
+        },
       );
       return null;
     }
@@ -165,10 +168,9 @@ async function mintDesktopSessionFromEmail(email: string) {
     });
 
     if (error || !authData.session) {
-      console.error(
-        "[mintDesktopSessionFromEmail] verifyOtp failed:",
-        error?.message ?? "no session",
-      );
+      captureOperationalError(new Error("Desktop auth verification failed"), {
+        operation: "desktop_auth_otp_verify",
+      });
       return null;
     }
 
@@ -176,8 +178,10 @@ async function mintDesktopSessionFromEmail(email: string) {
       access_token: authData.session.access_token,
       refresh_token: authData.session.refresh_token,
     };
-  } catch (e) {
-    console.error("[mintDesktopSessionFromEmail] unexpected error:", e);
+  } catch {
+    captureOperationalError(new Error("Desktop auth session mint failed"), {
+      operation: "desktop_auth_session_mint",
+    });
     return null;
   }
 }

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -21,6 +21,7 @@ import {
   sanitizeInternalReturnPath,
   toAbsoluteInternalReturnUrl,
 } from "@/lib/auth-redirect";
+import { captureOperationalError } from "@/lib/error-reporting";
 import { captureServerAnalytics } from "@/lib/server-analytics";
 import {
   getStripeCustomerIdentityMetadata,
@@ -348,7 +349,10 @@ async function createCheckoutUrl({
       entry_point: source,
     },
   }).catch((error) => {
-    console.error("[analytics] failed to record checkout start", error);
+    captureOperationalError(error, {
+      operation: "checkout_analytics_capture",
+      level: "warning",
+    });
   });
 
   return { url: checkout.url, stripeCustomerId };
@@ -442,7 +446,9 @@ export const createCheckoutSession = createServerFn({ method: "POST" })
       if (reservationId && !(error instanceof TrialCheckoutCreationError)) {
         await releaseTrialReservation(user.id, reservationId).catch(
           (releaseError) => {
-            console.error("release_pro_trial_reservation error:", releaseError);
+            captureOperationalError(releaseError, {
+              operation: "trial_reservation_release",
+            });
           },
         );
       }
@@ -654,7 +660,9 @@ export const canStartTrial = createServerFn({ method: "POST" }).handler(
     const { data, error } = await canStartTrialApi({ client });
 
     if (error) {
-      console.error("can_start_trial error:", error);
+      captureOperationalError(error, {
+        operation: "trial_eligibility_check",
+      });
       return false;
     }
 

--- a/apps/web/src/lib/error-reporting.test.ts
+++ b/apps/web/src/lib/error-reporting.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  operationalErrorMetadata,
+  sanitizeErrorEvent,
+} from "./error-reporting.ts";
+
+test("extracts only privacy-safe operational diagnostics", () => {
+  assert.deepEqual(
+    operationalErrorMetadata({
+      name: "ApiError",
+      code: "subscription_required",
+      stage: "billing_check",
+      statusCode: 403,
+      message: "private@example.com",
+    }),
+    {
+      type: "ApiError",
+      code: "subscription_required",
+      stage: "billing_check",
+      status: 403,
+    },
+  );
+  assert.deepEqual(
+    operationalErrorMetadata({
+      code: "private email@example.com",
+      stage: "billing check",
+      status: 999,
+    }),
+    {
+      type: "Error",
+      code: undefined,
+      stage: undefined,
+      status: undefined,
+    },
+  );
+});
+
+test("removes private error content while preserving exception diagnostics", () => {
+  const event = sanitizeErrorEvent({
+    type: undefined,
+    message: "private note",
+    logentry: { message: "token=secret" },
+    exception: {
+      values: [
+        {
+          type: "RouteError",
+          value: "private note content",
+          mechanism: {
+            type: "generic",
+            handled: false,
+            data: { token: "secret" },
+          },
+        },
+      ],
+    },
+    extra: { transcript: "private transcript" },
+  });
+
+  assert.equal(event.message, undefined);
+  assert.equal(event.logentry, undefined);
+  assert.equal(event.extra, undefined);
+  assert.deepEqual(event.exception?.values, [
+    {
+      type: "RouteError",
+      value: "RouteError captured",
+      mechanism: { type: "generic", handled: false },
+    },
+  ]);
+});

--- a/apps/web/src/lib/error-reporting.ts
+++ b/apps/web/src/lib/error-reporting.ts
@@ -1,0 +1,172 @@
+import * as Sentry from "@sentry/tanstackstart-react";
+import type { ErrorEvent, SeverityLevel } from "@sentry/tanstackstart-react";
+
+type ErrorContextValue = null | boolean | number | string;
+const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9_.:/-]{1,128}$/;
+
+function safeIdentifier(value: unknown): string | undefined {
+  return typeof value === "string" && SAFE_IDENTIFIER_RE.test(value)
+    ? value
+    : undefined;
+}
+
+export function operationalErrorMetadata(error: unknown) {
+  if (!error || typeof error !== "object") {
+    return { type: "Error" };
+  }
+
+  const record = error as Record<string, unknown>;
+  const statusValue = record.status ?? record.statusCode;
+  const status =
+    typeof statusValue === "number" &&
+    Number.isInteger(statusValue) &&
+    statusValue >= 100 &&
+    statusValue <= 599
+      ? statusValue
+      : undefined;
+
+  return {
+    type: safeIdentifier(record.name) ?? "Error",
+    code: safeIdentifier(record.code),
+    stage: safeIdentifier(record.stage),
+    status,
+  };
+}
+
+function normalizeOperationalError(error: unknown, operation: string): Error {
+  if (error instanceof Error) return error;
+
+  if (
+    typeof error === "string" ||
+    typeof error === "number" ||
+    typeof error === "boolean"
+  ) {
+    return new Error(`${operation} failed: ${String(error).slice(0, 256)}`);
+  }
+
+  if (error && typeof error === "object") {
+    const record = error as Record<string, unknown>;
+    const details = ["status", "statusCode", "code", "message"]
+      .flatMap((key) => {
+        const value = record[key];
+        return typeof value === "string" ||
+          typeof value === "number" ||
+          typeof value === "boolean"
+          ? [`${key}=${String(value).slice(0, 256)}`]
+          : [];
+      })
+      .join(", ");
+
+    if (details) {
+      return new Error(`${operation} failed (${details})`);
+    }
+  }
+
+  return new Error(`${operation} failed`);
+}
+
+function sanitizeUrl(value: string | undefined) {
+  if (!value) return value;
+
+  try {
+    const url = new URL(value);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value.split(/[?#]/, 1)[0];
+  }
+}
+
+export function sanitizeErrorEvent(event: ErrorEvent): ErrorEvent {
+  if (event.user) {
+    event.user = event.user.id ? { id: event.user.id } : undefined;
+  }
+
+  if (event.request) {
+    event.request = {
+      method: event.request.method,
+      url: sanitizeUrl(event.request.url),
+    };
+  }
+
+  delete event.extra;
+  delete event.message;
+  delete event.logentry;
+  if (event.exception?.values) {
+    event.exception.values = event.exception.values.map((exception) => {
+      const sanitized = {
+        ...exception,
+        value: exception.type ? `${exception.type} captured` : "Error captured",
+      };
+      if (sanitized.mechanism) {
+        delete sanitized.mechanism.data;
+      }
+      return sanitized;
+    });
+  }
+  event.breadcrumbs = event.breadcrumbs?.map((breadcrumb) => ({
+    category: breadcrumb.category,
+    level: breadcrumb.level,
+    timestamp: breadcrumb.timestamp,
+    type: breadcrumb.type,
+    ...(breadcrumb.category === "navigation"
+      ? {
+          data: {
+            from: sanitizeUrl(String(breadcrumb.data?.from ?? "")),
+            to: sanitizeUrl(String(breadcrumb.data?.to ?? "")),
+          },
+        }
+      : {}),
+  }));
+
+  return event;
+}
+
+export function captureOperationalError(
+  error: unknown,
+  {
+    operation,
+    level = "error",
+    tags,
+    context,
+  }: {
+    operation: string;
+    level?: SeverityLevel;
+    tags?: Record<string, ErrorContextValue>;
+    context?: Record<string, ErrorContextValue>;
+  },
+) {
+  const metadata = operationalErrorMetadata(error);
+  const exception = normalizeOperationalError(error, operation);
+
+  return Sentry.withScope((scope) => {
+    scope.setLevel(level);
+    scope.setTag("hyprnote.operation", operation);
+    scope.setTag("error.type", metadata.type);
+    if (metadata.code) scope.setTag("error.code", metadata.code);
+    if (metadata.stage) {
+      scope.setTag("hyprnote.error.stage", metadata.stage);
+    }
+    if (metadata.status) {
+      scope.setTag("http.response.status_code", metadata.status);
+    }
+    scope.setTag(
+      "hyprnote.surface",
+      typeof window === "undefined" ? "web_server" : "web",
+    );
+    for (const [key, value] of Object.entries(tags ?? {})) {
+      if (value !== null) {
+        scope.setTag(`hyprnote.${key}`, value);
+      }
+    }
+    if (context) {
+      scope.setContext("hyprnote.operation", context);
+    }
+    return Sentry.captureException(exception);
+  });
+}
+
+export function setErrorReportingUser(userId: string | null) {
+  Sentry.setUser(userId ? { id: userId } : null);
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -3,8 +3,10 @@ import { QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 
+import { ErrorPage } from "./components/error-page";
 import { env } from "./env";
 import { isTelemetryPrivateLocation } from "./lib/auth-route-privacy";
+import { sanitizeErrorEvent } from "./lib/error-reporting";
 import { prepareShareRoutePrivacy } from "./lib/share-route-privacy";
 import { routeTree } from "./routeTree.gen";
 
@@ -15,6 +17,7 @@ export function getRouter() {
     routeTree,
     context: { queryClient },
     defaultPreload: "intent",
+    defaultErrorComponent: ErrorPage,
     scrollRestoration: true,
     trailingSlash: "always",
   });
@@ -27,7 +30,7 @@ export function getRouter() {
       release: env.VITE_APP_VERSION
         ? `anarlog-web@${env.VITE_APP_VERSION}`
         : undefined,
-      sendDefaultPii: true,
+      sendDefaultPii: false,
       tracePropagationTargets: [],
       beforeSend: (event) =>
         isTelemetryPrivateLocation(
@@ -35,7 +38,7 @@ export function getRouter() {
           window.location.search,
         )
           ? null
-          : event,
+          : sanitizeErrorEvent(event),
       beforeSendTransaction: (event) =>
         isTelemetryPrivateLocation(
           window.location.pathname,
@@ -43,6 +46,13 @@ export function getRouter() {
         )
           ? null
           : event,
+      initialScope: {
+        tags: {
+          "service.name": "web",
+          "service.namespace": "hyprnote",
+          "hyprnote.surface": "web",
+        },
+      },
     });
   }
 

--- a/apps/web/src/routes/_view/app/-account-access.tsx
+++ b/apps/web/src/routes/_view/app/-account-access.tsx
@@ -11,6 +11,7 @@ import {
 
 import { signOutFn } from "@/functions/auth";
 import { deleteAccount } from "@/functions/billing";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 export function AccountAccessSection() {
   const navigate = useNavigate();
@@ -29,7 +30,9 @@ export function AccountAccessSection() {
       navigate({ to: "/" });
     },
     onError: (error) => {
-      console.error(error);
+      captureOperationalError(error, {
+        operation: "account_sign_out",
+      });
       navigate({ to: "/" });
     },
   });
@@ -38,6 +41,11 @@ export function AccountAccessSection() {
     mutationFn: () => deleteAccount(),
     onSuccess: () => {
       navigate({ to: "/" });
+    },
+    onError: (error) => {
+      captureOperationalError(error, {
+        operation: "account_delete",
+      });
     },
   });
 

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -8,6 +8,7 @@ import { createClient } from "@hypr/api-client/client";
 import { env } from "@/env";
 import { getAccessToken } from "@/functions/access-token";
 import { useAnalytics } from "@/hooks/use-posthog";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
 import { getIntegrationDisplay, Route } from "./integration";
@@ -65,6 +66,16 @@ export function ConnectFlow() {
         },
       });
       if (error || !data) {
+        captureOperationalError(
+          error ?? new Error("Integration session was not created"),
+          {
+            operation: "integration_connection_session",
+            tags: {
+              integration: search.integration_id,
+              mode: search.action,
+            },
+          },
+        );
         inFlightRef.current = false;
         updateStatus("error");
         track("integration_connection_failed", {
@@ -76,7 +87,14 @@ export function ConnectFlow() {
         return;
       }
       sessionToken = data.token;
-    } catch {
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "integration_connection_session",
+        tags: {
+          integration: search.integration_id,
+          mode: search.action,
+        },
+      });
       inFlightRef.current = false;
       updateStatus("error");
       track("integration_connection_failed", {

--- a/apps/web/src/routes/_view/app/-integrations-disconnect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-disconnect-flow.tsx
@@ -8,6 +8,7 @@ import { env } from "@/env";
 import { getAccessToken } from "@/functions/access-token";
 import { useAnalytics } from "@/hooks/use-posthog";
 import { useMountEffect } from "@/hooks/useMountEffect";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
 import { getIntegrationDisplay, Route } from "./integration";
@@ -51,6 +52,13 @@ export function DisconnectFlow() {
       });
 
       if (error || !data) {
+        captureOperationalError(
+          error ?? new Error("Integration was not disconnected"),
+          {
+            operation: "integration_disconnect",
+            tags: { integration: search.integration_id },
+          },
+        );
         setStatus("error");
         track("integration_connection_failed", {
           integration: search.integration_id,
@@ -60,7 +68,11 @@ export function DisconnectFlow() {
         });
         return;
       }
-    } catch {
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "integration_disconnect",
+        tags: { integration: search.integration_id },
+      });
       setStatus("error");
       track("integration_connection_failed", {
         integration: search.integration_id,

--- a/apps/web/src/routes/_view/app/checkout.tsx
+++ b/apps/web/src/routes/_view/app/checkout.tsx
@@ -7,6 +7,7 @@ import {
   addInternalReturnPathSearch,
   sanitizeInternalReturnPath,
 } from "@/lib/auth-redirect";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 const validateSearch = z.object({
   period: z.enum(["monthly", "yearly"]).catch("monthly"),
@@ -39,7 +40,14 @@ export const Route = createFileRoute("/_view/app/checkout")({
         },
       }));
     } catch (e) {
-      console.error("Checkout error:", e);
+      captureOperationalError(e, {
+        operation: "checkout_session_create",
+        context: {
+          checkout_type: search.trial ? "trial" : "paid",
+          period: search.period,
+          source: search.source,
+        },
+      });
     }
 
     if (url) {

--- a/apps/web/src/routes/_view/app/portal.tsx
+++ b/apps/web/src/routes/_view/app/portal.tsx
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { createPortalSession } from "@/functions/billing";
 import { desktopSchemeSchema } from "@/functions/desktop-flow";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 const validateSearch = z.object({
   scheme: desktopSchemeSchema.optional(),
@@ -17,7 +18,9 @@ export const Route = createFileRoute("/_view/app/portal")({
         data: { scheme: search.scheme },
       }));
     } catch (e) {
-      console.error("Portal error:", e);
+      captureOperationalError(e, {
+        operation: "billing_portal_session_create",
+      });
     }
 
     if (url) {

--- a/apps/web/src/routes/_view/app/route.tsx
+++ b/apps/web/src/routes/_view/app/route.tsx
@@ -1,6 +1,8 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 
 import { fetchUser } from "@/functions/auth";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { setErrorReportingUser } from "@/lib/error-reporting";
 
 export const Route = createFileRoute("/_view/app")({
   head: () => ({
@@ -23,4 +25,30 @@ export const Route = createFileRoute("/_view/app")({
     }
     return { user };
   },
+  component: AppRoute,
 });
+
+function AppRoute() {
+  const { user } = Route.useRouteContext();
+
+  return (
+    <ErrorReportingIdentity key={user.id} userId={user.id}>
+      <Outlet />
+    </ErrorReportingIdentity>
+  );
+}
+
+function ErrorReportingIdentity({
+  children,
+  userId,
+}: {
+  children: React.ReactNode;
+  userId: string;
+}) {
+  useMountEffect(() => {
+    setErrorReportingUser(userId);
+    return () => setErrorReportingUser(null);
+  });
+
+  return children;
+}

--- a/apps/web/src/routes/_view/app/switch-plan.tsx
+++ b/apps/web/src/routes/_view/app/switch-plan.tsx
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { createPlanSwitchSession } from "@/functions/billing";
 import { desktopSchemeSchema } from "@/functions/desktop-flow";
+import { captureOperationalError } from "@/lib/error-reporting";
 
 const validateSearch = z.object({
   targetPlan: z.enum(["pro"]).catch("pro").optional(),
@@ -23,7 +24,10 @@ export const Route = createFileRoute("/_view/app/switch-plan")({
         },
       }));
     } catch (e) {
-      console.error("Plan switch error:", e);
+      captureOperationalError(e, {
+        operation: "subscription_plan_switch",
+        context: { target_period: search.targetPeriod },
+      });
     }
 
     if (url) {

--- a/crates/api-error/src/lib.rs
+++ b/crates/api-error/src/lib.rs
@@ -19,8 +19,7 @@ pub struct ErrorResponse {
 
 pub fn error_response(status: StatusCode, code: &str, message: &str) -> Response {
     let (code, message) = if status.is_server_error() {
-        tracing::error!(error.type = %code, error = %message);
-        sentry::capture_message(message, sentry::Level::Error);
+        tracing::error!(error.type = %code, "api_error_response");
         (code.to_string(), "Internal server error".to_string())
     } else {
         (code.to_string(), message.to_string())

--- a/plugins/tracing/src/ext.rs
+++ b/plugins/tracing/src/ext.rs
@@ -20,19 +20,19 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Tracing<'a, R, M> {
     pub fn do_log(&self, level: Level, data: Vec<serde_json::Value>) -> Result<(), crate::Error> {
         match level {
             Level::Trace => {
-                tracing::trace!("{:?}", data);
+                tracing::trace!(target: super::WEBVIEW_CONSOLE_TARGET, "{:?}", data);
             }
             Level::Debug => {
-                tracing::debug!("{:?}", data);
+                tracing::debug!(target: super::WEBVIEW_CONSOLE_TARGET, "{:?}", data);
             }
             Level::Info => {
-                tracing::info!("{:?}", data);
+                tracing::info!(target: super::WEBVIEW_CONSOLE_TARGET, "{:?}", data);
             }
             Level::Warn => {
-                tracing::warn!("{:?}", data);
+                tracing::warn!(target: super::WEBVIEW_CONSOLE_TARGET, "{:?}", data);
             }
             Level::Error => {
-                tracing::error!("{:?}", data);
+                tracing::error!(target: super::WEBVIEW_CONSOLE_TARGET, "{:?}", data);
             }
         }
         Ok(())

--- a/plugins/tracing/src/lib.rs
+++ b/plugins/tracing/src/lib.rs
@@ -17,11 +17,20 @@ use tracing_subscriber::{
 use utils::{cleanup_legacy_logs, make_file_writer_if_enabled};
 
 const PLUGIN_NAME: &str = "tracing";
+const WEBVIEW_CONSOLE_TARGET: &str = "hyprnote.webview.console";
 
 fn sentry_event_filter(metadata: &tracing::Metadata<'_>) -> EventFilter {
-    match *metadata.level() {
-        tracing::Level::ERROR | tracing::Level::WARN => EventFilter::Event,
-        tracing::Level::INFO => EventFilter::Breadcrumb,
+    sentry_event_filter_for(metadata.level(), metadata.target())
+}
+
+fn sentry_event_filter_for(level: &tracing::Level, target: &str) -> EventFilter {
+    if target == WEBVIEW_CONSOLE_TARGET {
+        return EventFilter::Ignore;
+    }
+
+    match *level {
+        tracing::Level::ERROR => EventFilter::Event,
+        tracing::Level::WARN | tracing::Level::INFO => EventFilter::Breadcrumb,
         tracing::Level::DEBUG | tracing::Level::TRACE => EventFilter::Ignore,
     }
 }
@@ -144,5 +153,21 @@ mod test {
         let app = create_mock_app();
         let result = app.tracing().log_content();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sentry_filter_keeps_only_native_errors_as_events() {
+        assert_eq!(
+            sentry_event_filter_for(&tracing::Level::ERROR, "native").bits(),
+            EventFilter::Event.bits()
+        );
+        assert_eq!(
+            sentry_event_filter_for(&tracing::Level::WARN, "native").bits(),
+            EventFilter::Breadcrumb.bits()
+        );
+        assert_eq!(
+            sentry_event_filter_for(&tracing::Level::ERROR, WEBVIEW_CONSOLE_TARGET).bits(),
+            EventFilter::Ignore.bits()
+        );
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
         version: 2.2.0(react-native@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
+      '@sentry/react-native':
+        specifier: ^8.20.0
+        version: 8.20.0(@expo/env@2.4.2)(dotenv@17.4.2)(expo@57.0.8)(react-native@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       '@supabase/supabase-js':
         specifier: ^2.103.0
         version: 2.103.0
@@ -7565,8 +7568,20 @@ packages:
     resolution: {integrity: sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg==}
     engines: {node: '>= 18'}
 
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser-utils@10.67.0':
+    resolution: {integrity: sha512-HUzaf0xAnPAB+OHBkD7N1Py+CTbD5InHulQ/pdhX4JctWtxuwD8odMD1LzdPnW8J6gVHlDVvcVBR8mXMZYSLSw==}
+    engines: {node: '>=18'}
+
   '@sentry/browser@10.48.0':
     resolution: {integrity: sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.67.0':
+    resolution: {integrity: sha512-/ZhsAvte4rYhg0A0RtSFFgAgXhyMOfQIeOAfMfptN+X6IVSYOfkA9jtrP+Ej4+6vlaUFWRir1HweF56y63dEEA==}
     engines: {node: '>=18'}
 
   '@sentry/browser@8.55.1':
@@ -7586,9 +7601,20 @@ packages:
     engines: {node: '>=10'}
     os: [darwin]
 
+  '@sentry/cli-darwin@3.6.1':
+    resolution: {integrity: sha512-hit8SHXYTSZnKvT87/n/5RLwJnl0Nm24dewqEXwMzw7YkDFg7Ptq0bIhvGWINgyuBsmEfXGMnrbBZw5sueBtnQ==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
   '@sentry/cli-linux-arm64@2.58.5':
     resolution: {integrity: sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==}
     engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm64@3.6.1':
+    resolution: {integrity: sha512-+6UpbQo56wW5pf1TTBfNoYzf+WuG7c1fj9DAKchQwUzDN7886OwSYC326rDyh/PaafszYj5gAOElFhymNVA1WA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux, freebsd, android]
 
@@ -7598,9 +7624,21 @@ packages:
     cpu: [arm]
     os: [linux, freebsd, android]
 
+  '@sentry/cli-linux-arm@3.6.1':
+    resolution: {integrity: sha512-FgfKPa4sXianCQxpujNE1JrJYbF6Ug+UPjwdEGAnCZtDeRRQdXbSIih7ikaocg4BcpHxwoRm0BHG1wYeizkCbQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
   '@sentry/cli-linux-i686@2.58.5':
     resolution: {integrity: sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==}
     engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@3.6.1':
+    resolution: {integrity: sha512-xDzb2knLayJKv6FGggjrfvQiIpA4wvYvxeNV6B3plTlu1Qunkz5889A+Ayrp4wv19bgMVI6wLdKF9U2TpHPTbQ==}
+    engines: {node: '>=18'}
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
 
@@ -7610,9 +7648,21 @@ packages:
     cpu: [x64]
     os: [linux, freebsd, android]
 
+  '@sentry/cli-linux-x64@3.6.1':
+    resolution: {integrity: sha512-OJChq61ZoKFLAVC+LPqensvBcoToxnAfAZF19emTLNQNjBbGZBL6G/4P0uK4tlwlhB5wAeobu58xX2kfJEgkjA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
   '@sentry/cli-win32-arm64@2.58.5':
     resolution: {integrity: sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==}
     engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-arm64@3.6.1':
+    resolution: {integrity: sha512-SR4JESQdr1+XmK3kAVa9BAUdOA9QYkreJkWzUlj1oXbTlD5OdRmzc1yMHlkrkbbKSu6vrlqYiEaox3Pgsc08sg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -7622,9 +7672,21 @@ packages:
     cpu: [x86, ia32]
     os: [win32]
 
+  '@sentry/cli-win32-i686@3.6.1':
+    resolution: {integrity: sha512-EBOR2Yx5nYUcwbGXp5AHuQPjNZ9QLcoKlTKAt9ygQX4SF7S0pwnrAfXktkA4QOZqSXtzlKhrpwwnWNq0zPksNw==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [win32]
+
   '@sentry/cli-win32-x64@2.58.5':
     resolution: {integrity: sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==}
     engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@3.6.1':
+    resolution: {integrity: sha512-qQkVQOMoE5U6NtigezFNYSJncP1DOuauvp7JS+1DRpE5pXTKjHkOT6niWceGQc7wH4UGk6iwzOkNzx6klNd4Yw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -7633,8 +7695,17 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@sentry/cli@3.6.1':
+    resolution: {integrity: sha512-9KGZEe/o+vdHS69JhkNztPysqknnI3W5cceovi2G3yb5z29At6SAbGGOdFe3qxYDfC/c2Uw5MKYfev8K9xFI9Q==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   '@sentry/conventions@0.12.0':
     resolution: {integrity: sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g==}
+    engines: {node: '>=14'}
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
     engines: {node: '>=14'}
 
   '@sentry/core@10.48.0':
@@ -7645,9 +7716,30 @@ packages:
     resolution: {integrity: sha512-OtUbsrnbEHffOF2S2+M5zXa3HIM0U2b4CDVLKMY1dgS0J3ivRF8XvkjvyIcEG/y8JXnwXbnprLyjhG+AqMdUZQ==}
     engines: {node: '>=18'}
 
+  '@sentry/core@10.67.0':
+    resolution: {integrity: sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==}
+    engines: {node: '>=18'}
+
   '@sentry/core@8.55.1':
     resolution: {integrity: sha512-0ea+yDOgaijR3ba2al1QZxY0bZ9MBZq2a0G+2A0uCBpBkiXnpLFGVAo9UAlEikN1C4M8ROZYiuFU7yZCqacgLQ==}
     engines: {node: '>=14.18'}
+
+  '@sentry/expo-upload-sourcemaps@8.20.0':
+    resolution: {integrity: sha512-FWIJmNTWWY+E/tHQdFIxKMzEB0n47mF8W+1otcXr1hqEsePgBjMqeY2X3NhGRrt4b8rvTCXCjPlc3APyR+nCAg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@expo/env': '*'
+      dotenv: '*'
+    peerDependenciesMeta:
+      '@expo/env':
+        optional: true
+      dotenv:
+        optional: true
+
+  '@sentry/feedback@10.67.0':
+    resolution: {integrity: sha512-I4ML2/SF3enwikb6ZSoRiqolQrx0zSzTSnUgwCmugICF/jpHW0th1pCray9R+t1Zzibw/Dpj4t/DNXaSDRa2MA==}
+    engines: {node: '>=18'}
 
   '@sentry/node-core@10.48.0':
     resolution: {integrity: sha512-D1TnPhN6vhrRqJ+bN+rdXDM+INibI6lNBm0eGx45zz7DBx9ouq2e9gm/DPx+y/hAkYYq0qTd6x84cGxtVZbKLw==}
@@ -7726,8 +7818,25 @@ packages:
       '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
 
+  '@sentry/react-native@8.20.0':
+    resolution: {integrity: sha512-Visy8xWo4wJm3OW1QWiHB4avj0mp+En4fiY9uiaPmWhgX0RIx2fwAm73x3o5+etZdRDnC6oVhV5skofy9rEC6A==}
+    hasBin: true
+    peerDependencies:
+      expo: '>=49.0.0'
+      react: '>=17.0.0'
+      react-native: '>=0.65.0'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
   '@sentry/react@10.48.0':
     resolution: {integrity: sha512-uc93vKjmu6gNns+JAX4qquuxWpAMit0uGPA1TYlMjct9NG1uX3TkDPJAr9Pgd1lOXx8mKqCmj5fK33QeExMpPw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/react@10.67.0':
+    resolution: {integrity: sha512-fS0DplcP9eMxBIRurPC/uxa4NrFK+l9ZsnvQo7wZvNutc7DpTAH0hgFt6laVNCe57s1pFo+OZuKsYBA6JDvH4Q==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
@@ -7737,6 +7846,14 @@ packages:
     engines: {node: '>=14.18'}
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.67.0':
+    resolution: {integrity: sha512-neNA4T6MFtZzMdKYetiR+LZd9BNSd0q2szMn0wk+A15PqHE/IN7a34V6JZc9rCtmzB0wldh0eWGOBb49MSNKjA==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.67.0':
+    resolution: {integrity: sha512-nkEUgPCR82EcyJkCf3XCE9H0R5KisCqyCAaSGxe7NpAoQbvASHx4MUNgXVAn+D0M494gvPZh6lFH7JgzqTcSqQ==}
+    engines: {node: '>=18'}
 
   '@sentry/rollup-plugin@5.2.0':
     resolution: {integrity: sha512-a8LfpvcYMFtFSroro5MpCcOoS528LeLfUHzxWURnpofOnY+Aso9Si4y4dFlna+RKqxCXjmFbn6CLnfI+YrHysQ==}
@@ -24886,6 +25003,13 @@ snapshots:
 
   '@sentry/babel-plugin-component-annotate@5.2.0': {}
 
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
+  '@sentry/browser-utils@10.67.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+
   '@sentry/browser@10.48.0':
     dependencies:
       '@sentry-internal/browser-utils': 10.48.0
@@ -24893,6 +25017,15 @@ snapshots:
       '@sentry-internal/replay': 10.48.0
       '@sentry-internal/replay-canvas': 10.48.0
       '@sentry/core': 10.48.0
+
+  '@sentry/browser@10.67.0':
+    dependencies:
+      '@sentry/browser-utils': 10.67.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/feedback': 10.67.0
+      '@sentry/replay': 10.67.0
+      '@sentry/replay-canvas': 10.67.0
 
   '@sentry/browser@8.55.1':
     dependencies:
@@ -24926,25 +25059,49 @@ snapshots:
   '@sentry/cli-darwin@2.58.5':
     optional: true
 
+  '@sentry/cli-darwin@3.6.1':
+    optional: true
+
   '@sentry/cli-linux-arm64@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-arm64@3.6.1':
     optional: true
 
   '@sentry/cli-linux-arm@2.58.5':
     optional: true
 
+  '@sentry/cli-linux-arm@3.6.1':
+    optional: true
+
   '@sentry/cli-linux-i686@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-i686@3.6.1':
     optional: true
 
   '@sentry/cli-linux-x64@2.58.5':
     optional: true
 
+  '@sentry/cli-linux-x64@3.6.1':
+    optional: true
+
   '@sentry/cli-win32-arm64@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-arm64@3.6.1':
     optional: true
 
   '@sentry/cli-win32-i686@2.58.5':
     optional: true
 
+  '@sentry/cli-win32-i686@3.6.1':
+    optional: true
+
   '@sentry/cli-win32-x64@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-x64@3.6.1':
     optional: true
 
   '@sentry/cli@2.58.5':
@@ -24967,13 +25124,46 @@ snapshots:
       - encoding
       - supports-color
 
+  '@sentry/cli@3.6.1':
+    dependencies:
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      undici: 6.24.1
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 3.6.1
+      '@sentry/cli-linux-arm': 3.6.1
+      '@sentry/cli-linux-arm64': 3.6.1
+      '@sentry/cli-linux-i686': 3.6.1
+      '@sentry/cli-linux-x64': 3.6.1
+      '@sentry/cli-win32-arm64': 3.6.1
+      '@sentry/cli-win32-i686': 3.6.1
+      '@sentry/cli-win32-x64': 3.6.1
+
   '@sentry/conventions@0.12.0': {}
+
+  '@sentry/conventions@0.16.0': {}
 
   '@sentry/core@10.48.0': {}
 
   '@sentry/core@10.63.0': {}
 
+  '@sentry/core@10.67.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
   '@sentry/core@8.55.1': {}
+
+  '@sentry/expo-upload-sourcemaps@8.20.0(@expo/env@2.4.2)(dotenv@17.4.2)':
+    dependencies:
+      '@sentry/cli': 3.6.1
+    optionalDependencies:
+      '@expo/env': 2.4.2
+      dotenv: 17.4.2
+
+  '@sentry/feedback@10.67.0':
+    dependencies:
+      '@sentry/core': 10.67.0
 
   '@sentry/node-core@10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
@@ -25077,11 +25267,34 @@ snapshots:
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
 
+  '@sentry/react-native@8.20.0(@expo/env@2.4.2)(dotenv@17.4.2)(expo@57.0.8)(react-native@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/browser': 10.67.0
+      '@sentry/cli': 3.6.1
+      '@sentry/core': 10.67.0
+      '@sentry/expo-upload-sourcemaps': 8.20.0(@expo/env@2.4.2)(dotenv@17.4.2)
+      '@sentry/react': 10.67.0(react@19.2.3)
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
+    optionalDependencies:
+      expo: 57.0.8(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.7)(expo-router@57.0.8)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@expo/env'
+      - dotenv
+
   '@sentry/react@10.48.0(react@19.2.5)':
     dependencies:
       '@sentry/browser': 10.48.0
       '@sentry/core': 10.48.0
       react: 19.2.5
+
+  '@sentry/react@10.67.0(react@19.2.3)':
+    dependencies:
+      '@sentry/browser': 10.67.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      react: 19.2.3
 
   '@sentry/react@8.55.1(react@19.2.5)':
     dependencies:
@@ -25089,6 +25302,16 @@ snapshots:
       '@sentry/core': 8.55.1
       hoist-non-react-statics: 3.3.2
       react: 19.2.5
+
+  '@sentry/replay-canvas@10.67.0':
+    dependencies:
+      '@sentry/core': 10.67.0
+      '@sentry/replay': 10.67.0
+
+  '@sentry/replay@10.67.0':
+    dependencies:
+      '@sentry/browser-utils': 10.67.0
+      '@sentry/core': 10.67.0
 
   '@sentry/rollup-plugin@5.2.0':
     dependencies:


### PR DESCRIPTION
Capture privacy-safe failures across desktop, web, mobile, API, billing, and the opt-in CLI while reducing duplicate and noisy events.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6342 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6341 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad observability changes across auth-adjacent and billing flows could miss real failures if sanitization is too aggressive, but the intent is privacy hardening rather than new business logic.
> 
> **Overview**
> Introduces a shared **privacy-first Sentry** pattern: `sendDefaultPii` is disabled, `beforeSend` sanitizers strip messages/URLs/extras/breadcrumb payloads, and Sentry users are limited to **user id** (set/cleared on auth lifecycle).
> 
> **Desktop, web, and mobile** gain `error-reporting` helpers (`captureOperationalError`, `sanitizeErrorEvent`, normalized errors with safe tags) wired into route error UIs, startup failures, cloud sync, sessions, auth, audio/recording, transcription, and DB paths. **Mobile** also adds Expo/Sentry RN setup, a root error boundary, and navigation/operational breadcrumbs.
> 
> **Web** adds a default route error page and replaces `console.error` reporting on billing/auth/integration/checkout flows with structured captures. **Stripe/billing** and **web server instrumentation** use the same sanitization and `captureOperationalError` for HTTP/webhook failures.
> 
> **CLI** reports command failures to Sentry only when telemetry is enabled (`ANARLOG_ANALYTICS`), sharing the analytics gate renamed to `telemetry_enabled()`.
> 
> **API** stops attaching email/username to Sentry scope and disables default PII; **`api-error`** no longer auto-captures 5xx messages to Sentry. **Desktop tracing** routes webview console logs to a dedicated target so they are **not** promoted to Sentry events (native errors still are).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4501964ad8581125f7b5d0f30f390f4aac6d55d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->