### PR TITLE
Prevent truncated Apple Intelligence summaries

### DIFF
--- a/apps/desktop/src/ai/apple-foundation-model.test.ts
+++ b/apps/desktop/src/ai/apple-foundation-model.test.ts
@@ -75,7 +75,7 @@ describe("prepareFoundationModelRequest", () => {
     );
   });
 
-  it("adds JSON schema guidance and leaves oversized limits to the model", () => {
+  it("adds JSON schema guidance and caps oversized output limits", () => {
     const result = prepareFoundationModelRequest({
       prompt: [
         {
@@ -93,7 +93,7 @@ describe("prepareFoundationModelRequest", () => {
       },
     });
 
-    expect(result.maximumResponseTokens).toBeNull();
+    expect(result.maximumResponseTokens).toBe(4096);
     expect(result.prompt).toContain("Return only valid JSON");
     expect(result.prompt).toContain('"facts"');
   });

--- a/apps/desktop/src/ai/apple-foundation-model.ts
+++ b/apps/desktop/src/ai/apple-foundation-model.ts
@@ -186,9 +186,9 @@ export function prepareFoundationModelRequest(options: CallOptions) {
     instructions: systemMessages.join("\n\n"),
     prompt: `${prompt}${jsonGuidance}`,
     maximumResponseTokens:
-      requestedTokens && requestedTokens <= MAX_SUPPORTED_RESPONSE_TOKENS
-        ? requestedTokens
-        : null,
+      requestedTokens == null
+        ? null
+        : Math.min(requestedTokens, MAX_SUPPORTED_RESPONSE_TOKENS),
     temperature: options.temperature ?? null,
     useGreedySampling: options.temperature === 0,
   };
@@ -215,7 +215,7 @@ function getWarnings(options: CallOptions): Warning[] {
     warnings.push({
       type: "unsupported",
       feature: "maxOutputTokens",
-      details: "Values above 4096 are left to the system model default.",
+      details: "Values above 4096 are capped at 4096.",
     });
   }
   if (options.responseFormat?.type === "json") {

--- a/apps/desktop/src/services/enhancer/summary-length.test.ts
+++ b/apps/desktop/src/services/enhancer/summary-length.test.ts
@@ -101,11 +101,11 @@ describe("summary length policy", () => {
   it("keeps no more than two sections or the transcript character count", () => {
     const markdown = `# First
 
-- ${"a".repeat(100)}
+- ${"a".repeat(40)}
 
 # Second
 
-- ${"b".repeat(100)}
+- ${"b".repeat(40)}
 
 # Third
 
@@ -120,5 +120,39 @@ describe("summary length policy", () => {
     expect(result).toContain("# Second");
     expect(result).not.toContain("# Third");
     expect(countNormalizedCharacters(result)).toBeLessThanOrEqual(160);
+  });
+
+  it("never truncates a summary in the middle of a sentence", () => {
+    const result = constrainSummaryLength(
+      `# Decision
+
+- The team approved the launch. This additional explanation does not fit within the summary limit.
+
+# Follow-up`,
+      {
+        transcriptCharacters: 60,
+        maxCharacters: 60,
+        maxSections: null,
+      },
+    );
+
+    expect(result).toBe("# Decision\n\n- The team approved the launch.");
+    expect(countNormalizedCharacters(result)).toBeLessThanOrEqual(60);
+  });
+
+  it("keeps period-less bullets at a word boundary", () => {
+    const result = constrainSummaryLength(
+      `# Decision
+
+- alpha beta gamma delta epsilon zeta`,
+      {
+        transcriptCharacters: 30,
+        maxCharacters: 30,
+        maxSections: null,
+      },
+    );
+
+    expect(result).toBe("# Decision\n\n- alpha beta");
+    expect(countNormalizedCharacters(result)).toBeLessThanOrEqual(30);
   });
 });

--- a/apps/desktop/src/services/enhancer/summary-length.ts
+++ b/apps/desktop/src/services/enhancer/summary-length.ts
@@ -121,7 +121,7 @@ export function constrainSummaryLength(
       continue;
     }
 
-    const truncatedLine = truncateLineToFit(
+    const truncatedLine = truncateLineToSafeBoundary(
       keptLines,
       line,
       policy.maxCharacters,
@@ -132,7 +132,7 @@ export function constrainSummaryLength(
     break;
   }
 
-  return keptLines.join("\n").trim();
+  return removeTrailingEmptyHeading(keptLines).join("\n").trim();
 }
 
 function limitSections(markdown: string, maxSections: number | null): string {
@@ -155,7 +155,7 @@ function limitSections(markdown: string, maxSections: number | null): string {
   return keptLines.join("\n").trim();
 }
 
-function truncateLineToFit(
+function truncateLineToSafeBoundary(
   keptLines: string[],
   line: string,
   maxCharacters: number,
@@ -176,11 +176,28 @@ function truncateLineToFit(
     }
   }
 
-  let truncated = characters.slice(0, low).join("").trimEnd();
-  const lastSpace = truncated.lastIndexOf(" ");
-  if (lastSpace >= Math.floor(truncated.length * 0.6)) {
-    truncated = truncated.slice(0, lastSpace);
+  const truncated = characters.slice(0, low).join("").trimEnd();
+  const sentenceEndings = [...truncated.matchAll(/[.!?](?=\s|$)/gu)];
+  const lastSentenceEnding = sentenceEndings[sentenceEndings.length - 1];
+  if (!lastSentenceEnding?.index) {
+    return truncated.match(/^(.+\S)\s+\S*$/u)?.[1] ?? truncated;
   }
 
-  return truncated.replace(/[,:;\-–—]+$/u, "").trimEnd();
+  return truncated.slice(
+    0,
+    lastSentenceEnding.index + lastSentenceEnding[0].length,
+  );
+}
+
+function removeTrailingEmptyHeading(lines: string[]): string[] {
+  let lastContentIndex = lines.length - 1;
+  while (lastContentIndex >= 0 && !lines[lastContentIndex].trim()) {
+    lastContentIndex -= 1;
+  }
+
+  if (/^#{1,6}\s+\S/u.test(lines[lastContentIndex] ?? "")) {
+    return lines.slice(0, lastContentIndex);
+  }
+
+  return lines;
 }


### PR DESCRIPTION
Clamp Apple Foundation Models response limits to its supported maximum and add regression coverage for oversized summary requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AI request shaping and post-processing for summaries; behavior changes are covered by unit tests with no auth or data-path impact.
> 
> **Overview**
> **Apple Foundation Models** now **caps** `maxOutputTokens` at **4096** instead of dropping the limit when callers ask for more; the unsupported-token warning text says values are capped rather than left to the system default. Tests expect **4096** for an **8192** request.
> 
> **Summary length enforcement** replaces mid-line character chopping with **sentence- or word-boundary** truncation via `truncateLineToSafeBoundary`, and strips a **trailing empty heading** after cutoffs. New tests cover sentence-complete bullets and word-boundary bullets without periods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1668b4e7ba54c8a1c20ffe81913fe41c61f331ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->