### PR TITLE
Polish download actions

### DIFF
--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -46,10 +46,6 @@ function Component() {
           <h1 className="font-hand text-color text-6xl leading-[0.98] font-semibold tracking-normal text-balance md:text-8xl">
             Download Anarlog
           </h1>
-          <p className="text-color-secondary mt-6 max-w-2xl text-xl leading-9">
-            macOS, Windows Preview, and Linux Beta ship together with the same
-            desktop version.
-          </p>
         </section>
 
         <div className="grid gap-14 pb-12">
@@ -58,22 +54,17 @@ function Component() {
 
             return (
               <section key={section.name} aria-labelledby={headingId}>
-                <div className="mb-5">
-                  <h2
-                    id={headingId}
-                    className="font-hand flex items-center gap-2.5 text-3xl leading-none font-semibold tracking-normal"
-                  >
-                    <Icon
-                      icon={platformIcons[section.name]}
-                      className="text-2xl"
-                      aria-hidden="true"
-                    />
-                    {section.name}
-                  </h2>
-                  <p className="text-color-secondary mt-2 leading-7">
-                    {section.description}
-                  </p>
-                </div>
+                <h2
+                  id={headingId}
+                  className="font-hand mb-5 flex items-center gap-2.5 text-3xl leading-none font-semibold tracking-normal"
+                >
+                  <Icon
+                    icon={platformIcons[section.name]}
+                    className="text-2xl"
+                    aria-hidden="true"
+                  />
+                  {section.name}
+                </h2>
 
                 <ul className="border-color-subtle divide-y divide-[var(--color-border-subtle)] border-y">
                   {section.downloads.map((download) => (
@@ -89,15 +80,8 @@ function Component() {
                         }
                         className="hover:bg-surface-subtle flex items-center justify-between gap-6 px-1 py-5 transition-colors"
                       >
-                        <span className="min-w-0">
-                          <span className="block font-medium">
-                            {download.name}
-                          </span>
-                          <span className="text-color-secondary mt-1 block text-sm">
-                            {download.detail}
-                          </span>
-                        </span>
-                        <span className="inline-flex shrink-0 items-center gap-2 font-mono text-sm font-medium">
+                        <span className="font-medium">{download.name}</span>
+                        <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[#181613] px-4 py-3 text-[13px] font-medium text-white sm:px-5 sm:text-sm">
                           Download
                           <Download
                             size={16}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1393,13 +1393,8 @@ function DownloadButton() {
                     className="shrink-0"
                     aria-hidden="true"
                   />
-                  <span className="min-w-0">
-                    <span className="block">
-                      {getDownloadOptionLabel(section.platform, download.name)}
-                    </span>
-                    <span className="text-color-muted block truncate text-xs font-normal">
-                      {download.detail}
-                    </span>
+                  <span>
+                    {getDownloadOptionLabel(section.platform, download.name)}
                   </span>
                 </a>
               );
@@ -1431,6 +1426,7 @@ function getDownloadOptionLabel(
   downloadName: string,
 ) {
   if (platform === "macos" && downloadName === "Intel") return "Apple Intel";
-  if (platform === "linux") return `Linux ${downloadName}`;
-  return downloadName;
+  const label = downloadName.replace(/ x64$/, "");
+  if (platform === "linux") return `Linux ${label}`;
+  return label;
 }


### PR DESCRIPTION
Simplify homepage and download-page actions by removing redundant metadata and using consistent labels and button styling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only marketing UI changes; download URLs and analytics events are unchanged.
> 
> **Overview**
> **Download page** and the **homepage download menu** are streamlined so users see fewer secondary lines and more consistent actions.
> 
> On `/download/`, the hero blurb and per-platform **description** copy are removed. Each row is now the build **name** plus a **dark pill “Download”** control (replacing the prior text link with `download.detail` under the name). Platform headings stay icon + title only.
> 
> In the homepage split button menu, the muted **detail** subtitle under each option is dropped so labels match the simplified naming. **`getDownloadOptionLabel`** now strips a trailing **` x64`** from names before applying the existing macOS/Linux label rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ebb4af41ab23ba14892260705a22d67eb1f7d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->