### PR TITLE
Install libclang in API build image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -15,7 +15,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM rust:${RUST_VERSION}-bookworm AS build
 ARG APP_VERSION
-RUN apt-get update && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends pkg-config libssl-dev libclang-dev ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN cargo install cargo-chef --locked
 ENV APP_VERSION=${APP_VERSION}
 WORKDIR /app


### PR DESCRIPTION
Install libclang-dev in the API builder stage so the CloudSync SQLite dependency can generate bindings during Fly container builds.

Verified with a full local API build target for version 0.0.60.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Dockerfile dependency addition for the build image only; no runtime or application logic changes.
> 
> **Overview**
> Adds **`libclang-dev`** to the **`build`** stage `apt-get install` line in `apps/api/Dockerfile` so containerized API builds (e.g. on Fly) can compile dependencies that use **bindgen** against SQLite/CloudSync.
> 
> The **planner** stage is unchanged; only the stage that runs **`cargo chef cook`** and the final **`cargo build`** gets the extra package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91e3da7c744bfe2b6af4594dc364498580260205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->