### PR TITLE
Complete the 1.4.0 API changelog

### DIFF
--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -43,6 +43,18 @@ are still pending.
 
 - Try Apple Intelligence as an experimental on-device text generation provider
   on supported macOS 26 devices
+- Keep Apple Intelligence summaries readable by ending generated content at a
+  complete sentence instead of cutting it off mid-thought
+
+## Developer tools
+
+- Enable a device-local REST API from Settings → Developers to read meetings,
+  notes, summaries, transcripts, history, and exports on every plan
+- Create local API keys and signed webhooks for completed meetings and
+  generated summaries while keeping the underlying data on your device
+- Opt in to Cloud API & Connectors with Anarlog Pro for hosted REST and remote
+  MCP access while the desktop app is closed; turning it off deletes the
+  separate server-readable copies
 
 ## Windows Preview
 
@@ -65,6 +77,7 @@ are still pending.
 
 - Use Apple Speech for private, on-device live and batch transcription on
   supported Apple Silicon Macs running macOS 26
+- Avoid duplicate Apple Speech phrases when live hypotheses are revised
 - Detect the meeting language from your configured language choices instead of
   forcing multilingual recordings into code-switching mode
 - Label diarized speakers with known participant names when the transcript

--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -36,6 +36,8 @@ are still pending.
   syncing service
 - Make a newly configured transcription or language-model provider current
   directly from the confirmation after saving its first API key
+- Choose newer hosted AI models, including Claude Opus 5, Gemini 3.6 Flash,
+  Kimi K2.7 Code, and GLM 5.2
 - Restore excluded meeting apps reliably after startup and present cleaner,
   platform-aware settings and window controls
 
@@ -75,6 +77,12 @@ are still pending.
 
 ## Transcription
 
+- Hear microphone and system audio centered during recording playback while
+  Anarlog preserves the original recording channels
+- Use OpenAI's latest GPT Transcribe models for live and batch transcription,
+  including language and keyword hints
+- Choose Deepgram Flux for live transcription or Gladia Solaria 3 for batch
+  transcription
 - Use Apple Speech for private, on-device live and batch transcription on
   supported Apple Silicon Macs running macOS 26
 - Avoid duplicate Apple Speech phrases when live hypotheses are revised


### PR DESCRIPTION
Document the local and hosted programmatic interfaces added after the earlier changelog merge, plus Apple provider reliability fixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `packages/changelog/content/1.4.0.md` with no runtime or build impact.
> 
> **Overview**
> Completes the **1.4.0** changelog with release notes that were missing after an earlier merge.
> 
> Adds a **Developer tools** section covering the device-local REST API (Settings → Developers), local API keys and signed webhooks, and optional **Cloud API & Connectors** on Pro for hosted REST, remote MCP, and cleanup when disabled.
> 
> Expands **Updates and settings** with newer hosted models (Claude Opus 5, Gemini 3.6 Flash, Kimi K2.7 Code, GLM 5.2). Under **Local AI on macOS**, documents that Apple Intelligence summaries now stop at a complete sentence. Under **Transcription**, adds centered playback mix, GPT Transcribe, Deepgram Flux / Gladia Solaria 3, and a fix for duplicate Apple Speech phrases on revised live hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b897f096ce74181f2846f7aa5faa123f4cd3088c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->