### PR TITLE
Center recording playback audio

### DIFF
--- a/apps/desktop/src/audio-player/playback.test.ts
+++ b/apps/desktop/src/audio-player/playback.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { configureCenteredPlayback } from "./playback";
+
+describe("configureCenteredPlayback", () => {
+  it("folds stereo playback into a centered mono output", () => {
+    const context = {
+      close: vi.fn(),
+      resume: vi.fn(),
+    };
+    const gainNode = {
+      channelCount: 2,
+      channelCountMode: "max",
+      channelInterpretation: "discrete",
+      context,
+    };
+    const media = {
+      getGainNode: () => gainNode,
+    } as unknown as HTMLMediaElement;
+
+    expect(configureCenteredPlayback(media)).toBe(context);
+    expect(gainNode).toMatchObject({
+      channelCount: 1,
+      channelCountMode: "explicit",
+      channelInterpretation: "speakers",
+    });
+  });
+
+  it("keeps media-element playback as a fallback", () => {
+    expect(configureCenteredPlayback({} as HTMLMediaElement)).toBeNull();
+  });
+});

--- a/apps/desktop/src/audio-player/playback.ts
+++ b/apps/desktop/src/audio-player/playback.ts
@@ -1,0 +1,20 @@
+export function configureCenteredPlayback(
+  media: HTMLMediaElement,
+): AudioContext | null {
+  const gainNode = (
+    media as HTMLMediaElement & { getGainNode?: () => GainNode }
+  ).getGainNode?.();
+
+  if (!gainNode) {
+    return null;
+  }
+
+  gainNode.channelCount = 1;
+  gainNode.channelCountMode = "explicit";
+  gainNode.channelInterpretation = "speakers";
+
+  const context = gainNode.context;
+  return "resume" in context && "close" in context
+    ? (context as AudioContext)
+    : null;
+}

--- a/apps/desktop/src/audio-player/provider.tsx
+++ b/apps/desktop/src/audio-player/provider.tsx
@@ -14,6 +14,8 @@ import WaveSurfer from "wavesurfer.js";
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 
+import { configureCenteredPlayback } from "./playback";
+
 import { useBillingAccess } from "~/auth/billing-context";
 import { isSessionAudioIdle } from "~/services/audio-retention";
 import { deleteSessionAudio } from "~/session/attachments";
@@ -138,6 +140,7 @@ export function AudioPlayerProvider({
   const [playbackRate, setPlaybackRateState] = useState(1);
   const timeStoreRef = useRef(new TimeStore());
   const stopRequestedRef = useRef(false);
+  const audioContextRef = useRef<AudioContext | null>(null);
   const { audioExists: audioExistsValue, audioExistsResolved } =
     useAudioExistence(sessionId);
 
@@ -154,11 +157,12 @@ export function AudioPlayerProvider({
     store.reset();
     stopRequestedRef.current = false;
 
-    const audio = new Audio(url);
     let lastReportedTime = 0;
 
     const ws = WaveSurfer.create({
       container,
+      url,
+      backend: "WebAudio",
       height: 24,
       waveColor: "#e5e5e5",
       progressColor: "#a8a8a8",
@@ -168,7 +172,6 @@ export function AudioPlayerProvider({
       barGap: 2,
       barRadius: 2,
       barHeight: 1,
-      media: audio,
       dragToSeek: true,
       normalize: true,
       splitChannels: [
@@ -176,6 +179,8 @@ export function AudioPlayerProvider({
         { waveColor: "#d5dde8", progressColor: "#a3b3c9", overlay: true },
       ],
     });
+    const audioContext = configureCenteredPlayback(ws.getMediaElement());
+    audioContextRef.current = audioContext;
 
     const syncCurrentTime = (currentTime: number, force = false) => {
       if (
@@ -252,29 +257,32 @@ export function AudioPlayerProvider({
 
     return () => {
       stopRequestedRef.current = false;
+      if (audioContextRef.current === audioContext) {
+        audioContextRef.current = null;
+      }
       ws.destroy();
       setWavesurfer(null);
-      audio.pause();
-      audio.src = "";
-      audio.load();
+      void audioContext?.close();
     };
   }, [container, url]);
 
-  const start = useCallback(() => {
-    if (wavesurfer) {
-      void wavesurfer.play();
+  const play = useCallback(() => {
+    if (!wavesurfer) {
+      return;
     }
+
+    const audioContext = audioContextRef.current;
+    if (audioContext?.state === "suspended") {
+      void audioContext.resume().then(() => wavesurfer.play());
+      return;
+    }
+
+    void wavesurfer.play();
   }, [wavesurfer]);
 
   const pause = useCallback(() => {
     if (wavesurfer) {
       wavesurfer.pause();
-    }
-  }, [wavesurfer]);
-
-  const resume = useCallback(() => {
-    if (wavesurfer) {
-      void wavesurfer.play();
     }
   }, [wavesurfer]);
 
@@ -352,9 +360,9 @@ export function AudioPlayerProvider({
       wavesurfer,
       state,
       timeStore: timeStoreRef.current,
-      start,
+      start: play,
       pause,
-      resume,
+      resume: play,
       stop,
       seek,
       audioExists: audioExistsValue,
@@ -368,9 +376,8 @@ export function AudioPlayerProvider({
       registerContainer,
       wavesurfer,
       state,
-      start,
+      play,
       pause,
-      resume,
       stop,
       seek,
       audioExistsValue,

--- a/apps/desktop/src/audio-player/provider.tsx
+++ b/apps/desktop/src/audio-player/provider.tsx
@@ -273,7 +273,14 @@ export function AudioPlayerProvider({
 
     const audioContext = audioContextRef.current;
     if (audioContext?.state === "suspended") {
-      void audioContext.resume().then(() => wavesurfer.play());
+      void audioContext
+        .resume()
+        .then(() => {
+          if (audioContextRef.current === audioContext) {
+            return wavesurfer.play();
+          }
+        })
+        .catch(() => {});
       return;
     }
 


### PR DESCRIPTION
Fold stereo mic and system tracks to centered mono during playback while retaining the original recording channels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Playback moves to WebAudio and changes channel routing, which can affect behavior across browsers/OS even though scope is limited to the desktop session player.
> 
> **Overview**
> Session recording playback is switched from a separate `HTMLAudioElement` to WaveSurfer’s **WebAudio** backend (`url` + `backend: "WebAudio"`), so output can be routed through the graph’s gain node.
> 
> A new **`configureCenteredPlayback`** helper sets that gain node to **mono** (`channelCount: 1`, `channelInterpretation: "speakers"`) so mic/system stereo is heard as centered mono; if no gain node exists, playback behavior is unchanged. The provider tracks the **`AudioContext`**, closes it on teardown, and **resumes** it when suspended before calling play; **`start`** and **`resume`** both use the same play path. Vitest covers the mono fold and the null fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cfbcf033818fa9d13a52962a3e2115cf8f07325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->