### PR TITLE
Update OpenAI transcription models

### DIFF
--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -7,7 +7,7 @@ use ractor::{ActorProcessingErr, ActorRef};
 use owhisper_client::{
     AdapterKind, AnarlogAdapter, ArgmaxAdapter, AssemblyAIAdapter, CartesiaAdapter,
     DashScopeAdapter, DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter,
-    MistralAdapter, RealtimeSttAdapter, SonioxAdapter, anlg_ws_client,
+    MistralAdapter, OpenAIAdapter, RealtimeSttAdapter, SonioxAdapter, anlg_ws_client,
 };
 use owhisper_interface::stream::Extra;
 use owhisper_interface::{ControlMessage, MixedMessage};
@@ -106,6 +106,7 @@ pub(super) async fn spawn_rx_task(
         Cartesia => CartesiaAdapter,
         Soniox => SonioxAdapter,
         Fireworks => FireworksAdapter,
+        OpenAI => OpenAIAdapter,
         Deepgram => DeepgramAdapter,
         AssemblyAI => AssemblyAIAdapter,
         Gladia => GladiaAdapter,
@@ -113,7 +114,7 @@ pub(super) async fn spawn_rx_task(
         DashScope => DashScopeAdapter,
         Mistral => MistralAdapter,
         Anarlog => AnarlogAdapter,
-    }, batch_only: [OpenAI, AquaVoice, Pyannote])?;
+    }, batch_only: [AquaVoice, Pyannote])?;
 
     Ok((result.0, result.1, result.2, adapter_kind.to_string()))
 }

--- a/crates/openai-transcription/src/batch/model.rs
+++ b/crates/openai-transcription/src/batch/model.rs
@@ -4,6 +4,7 @@ use strum::{AsRefStr, Display, EnumString};
 use super::request::AudioResponseFormat;
 
 pub const MODEL_WHISPER_1: AudioModel = AudioModel::Whisper1;
+pub const MODEL_GPT_TRANSCRIBE: AudioModel = AudioModel::GptTranscribe;
 pub const MODEL_GPT_4O_TRANSCRIBE: AudioModel = AudioModel::Gpt4oTranscribe;
 pub const MODEL_GPT_4O_MINI_TRANSCRIBE: AudioModel = AudioModel::Gpt4oMiniTranscribe;
 pub const MODEL_GPT_4O_MINI_TRANSCRIBE_2025_12_15: AudioModel =
@@ -32,6 +33,9 @@ pub enum AudioModel {
     #[serde(rename = "whisper-1")]
     #[strum(serialize = "whisper-1")]
     Whisper1,
+    #[serde(rename = "gpt-transcribe")]
+    #[strum(serialize = "gpt-transcribe")]
+    GptTranscribe,
     #[serde(rename = "gpt-4o-transcribe")]
     #[strum(serialize = "gpt-4o-transcribe")]
     Gpt4oTranscribe,
@@ -69,7 +73,8 @@ impl AudioModel {
     pub fn default_response_format(self) -> AudioResponseFormat {
         match self {
             Self::Whisper1 => AudioResponseFormat::VerboseJson,
-            Self::Gpt4oTranscribe
+            Self::GptTranscribe
+            | Self::Gpt4oTranscribe
             | Self::Gpt4oMiniTranscribe
             | Self::Gpt4oMiniTranscribe20251215
             | Self::Gpt4oTranscribeDiarize => AudioResponseFormat::Json,
@@ -79,6 +84,7 @@ impl AudioModel {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GptTranscriptionModel {
+    GptTranscribe,
     Gpt4oTranscribe,
     Gpt4oMiniTranscribe,
     Gpt4oMiniTranscribe20251215,
@@ -87,6 +93,7 @@ pub enum GptTranscriptionModel {
 impl From<GptTranscriptionModel> for AudioModel {
     fn from(value: GptTranscriptionModel) -> Self {
         match value {
+            GptTranscriptionModel::GptTranscribe => Self::GptTranscribe,
             GptTranscriptionModel::Gpt4oTranscribe => Self::Gpt4oTranscribe,
             GptTranscriptionModel::Gpt4oMiniTranscribe => Self::Gpt4oMiniTranscribe,
             GptTranscriptionModel::Gpt4oMiniTranscribe20251215 => Self::Gpt4oMiniTranscribe20251215,
@@ -99,6 +106,7 @@ impl TryFrom<AudioModel> for GptTranscriptionModel {
 
     fn try_from(value: AudioModel) -> Result<Self, Self::Error> {
         match value {
+            AudioModel::GptTranscribe => Ok(Self::GptTranscribe),
             AudioModel::Gpt4oTranscribe => Ok(Self::Gpt4oTranscribe),
             AudioModel::Gpt4oMiniTranscribe => Ok(Self::Gpt4oMiniTranscribe),
             AudioModel::Gpt4oMiniTranscribe20251215 => Ok(Self::Gpt4oMiniTranscribe20251215),
@@ -132,6 +140,10 @@ mod tests {
         assert!(AudioModel::Gpt4oTranscribe.supports_streaming());
         assert!(AudioModel::Gpt4oTranscribe.supports_logprobs());
         assert!(AudioModel::Gpt4oTranscribe.supports_prompt());
+
+        assert!(AudioModel::GptTranscribe.supports_streaming());
+        assert!(!AudioModel::GptTranscribe.supports_logprobs());
+        assert!(AudioModel::GptTranscribe.supports_prompt());
 
         assert!(!AudioModel::Gpt4oTranscribeDiarize.supports_timestamp_granularities());
         assert!(AudioModel::Gpt4oTranscribeDiarize.supports_streaming());

--- a/crates/openai-transcription/src/batch/request.rs
+++ b/crates/openai-transcription/src/batch/request.rs
@@ -12,9 +12,11 @@ pub struct MultipartTextField {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CommonTranscriptionOptions {
     pub chunking_strategy: Option<ChunkingStrategy>,
+    pub keywords: Vec<String>,
     pub known_speaker_names: Vec<String>,
     pub known_speaker_references: Vec<String>,
     pub language: Option<String>,
+    pub languages: Vec<String>,
     pub temperature: Option<f32>,
 }
 
@@ -83,7 +85,9 @@ impl CreateTranscriptionOptions {
                 response_format: use_response_format.then_some(WhisperResponseFormat::VerboseJson),
                 ..Default::default()
             }),
-            AudioModel::Gpt4oTranscribe | AudioModel::Gpt4oMiniTranscribe => {
+            AudioModel::GptTranscribe
+            | AudioModel::Gpt4oTranscribe
+            | AudioModel::Gpt4oMiniTranscribe => {
                 let model = GptTranscriptionModel::try_from(model)
                     .expect("resolved OpenAI GPT transcription model should be typed");
                 Self::Gpt(CreateGptTranscriptionOptions {
@@ -150,7 +154,15 @@ impl CreateTranscriptionOptions {
     }
 
     pub fn push_language(&mut self, language: impl Into<String>) {
-        self.common_mut().language = Some(language.into());
+        if self.model() == AudioModel::GptTranscribe {
+            self.common_mut().languages.push(language.into());
+        } else {
+            self.common_mut().language = Some(language.into());
+        }
+    }
+
+    pub fn push_keyword(&mut self, keyword: impl Into<String>) {
+        self.common_mut().keywords.push(keyword.into());
     }
 
     pub fn multipart_text_fields(&self) -> Result<Vec<MultipartTextField>, serde_json::Error> {
@@ -255,6 +267,13 @@ fn append_common_fields(
         });
     }
 
+    for keyword in &common.keywords {
+        fields.push(MultipartTextField {
+            name: "keywords[]",
+            value: keyword.clone(),
+        });
+    }
+
     for speaker_name in &common.known_speaker_names {
         fields.push(MultipartTextField {
             name: "known_speaker_names[]",
@@ -272,6 +291,13 @@ fn append_common_fields(
     if let Some(language) = &common.language {
         fields.push(MultipartTextField {
             name: "language",
+            value: language.clone(),
+        });
+    }
+
+    for language in &common.languages {
+        fields.push(MultipartTextField {
+            name: "languages[]",
             value: language.clone(),
         });
     }
@@ -533,6 +559,33 @@ mod tests {
             fields
                 .iter()
                 .any(|field| field.name == "stream" && field.value == "true")
+        );
+    }
+
+    #[test]
+    fn gpt_transcribe_uses_plural_languages() {
+        let mut options =
+            CreateTranscriptionOptions::for_model(AudioModel::GptTranscribe, true, true);
+        options.push_language("en");
+        options.push_language("ko");
+        options.push_keyword("technical term");
+
+        let fields = options
+            .multipart_text_fields()
+            .expect("serialize multipart");
+
+        let languages = fields
+            .iter()
+            .filter(|field| field.name == "languages[]")
+            .map(|field| field.value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(languages, vec!["en", "ko"]);
+        assert!(!fields.iter().any(|field| field.name == "language"));
+        assert!(
+            fields
+                .iter()
+                .any(|field| field.name == "keywords[]" && field.value == "technical term")
         );
     }
 

--- a/crates/openai-transcription/src/realtime.rs
+++ b/crates/openai-transcription/src/realtime.rs
@@ -58,6 +58,10 @@ pub struct TranscriptionConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub languages: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keywords: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
 }
 
@@ -286,6 +290,8 @@ mod tests {
                         transcription: Some(TranscriptionConfig {
                             model: "gpt-4o-transcribe".to_string(),
                             language: Some("en".to_string()),
+                            languages: None,
+                            keywords: None,
                             prompt: Some("expect technical terms".to_string()),
                         }),
                         turn_detection: Some(TurnDetectionConfig {

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -124,6 +124,10 @@ pub fn documented_language_codes_batch() -> Vec<String> {
 }
 
 pub trait RealtimeSttAdapter: Clone + Default + Send + Sync + 'static {
+    fn fork_session(&self) -> Self {
+        self.clone()
+    }
+
     fn provider_name(&self) -> &'static str;
 
     fn is_supported_languages(
@@ -451,12 +455,13 @@ impl AdapterKind {
 
     pub fn has_live_mode(&self) -> bool {
         match self {
-            Self::AquaVoice | Self::Argmax | Self::OpenAI | Self::Pyannote => false,
+            Self::AquaVoice | Self::Argmax | Self::Pyannote => false,
             Self::Soniox
             | Self::Cartesia
             | Self::Fireworks
             | Self::Deepgram
             | Self::AssemblyAI
+            | Self::OpenAI
             | Self::Gladia
             | Self::ElevenLabs
             | Self::DashScope
@@ -480,7 +485,7 @@ impl AdapterKind {
             Self::Soniox => SonioxAdapter::language_support_live(languages),
             Self::AssemblyAI => AssemblyAIAdapter::language_support_live(languages),
             Self::Gladia => GladiaAdapter::language_support_live(languages),
-            Self::OpenAI => LanguageSupport::NotSupported,
+            Self::OpenAI => OpenAIAdapter::language_support_live(languages),
             Self::Fireworks => FireworksAdapter::language_support_live(languages),
             Self::ElevenLabs => ElevenLabsAdapter::language_support_live(languages),
             Self::DashScope => DashScopeAdapter::language_support_live(languages),
@@ -797,6 +802,7 @@ mod tests {
             AdapterKind::AssemblyAI,
             AdapterKind::Gladia,
             AdapterKind::Fireworks,
+            AdapterKind::OpenAI,
             AdapterKind::ElevenLabs,
             AdapterKind::DashScope,
             AdapterKind::Mistral,
@@ -809,7 +815,6 @@ mod tests {
         let batch_only = [
             AdapterKind::AquaVoice,
             AdapterKind::Argmax,
-            AdapterKind::OpenAI,
             AdapterKind::Pyannote,
         ];
         for kind in batch_only {

--- a/crates/owhisper-client/src/adapter/openai/batch.rs
+++ b/crates/owhisper-client/src/adapter/openai/batch.rs
@@ -168,8 +168,15 @@ fn build_transcription_options(
         }
     }
 
-    if let Some(lang) = params.languages.first() {
-        options.push_language(lang.iso639().code().to_string());
+    if model == openai_transcription::batch::AudioModel::GptTranscribe {
+        for language in &params.languages {
+            options.push_language(language.iso639().code().to_string());
+        }
+        for keyword in &params.keywords {
+            options.push_keyword(keyword);
+        }
+    } else if let Some(language) = params.languages.first() {
+        options.push_language(language.iso639().code().to_string());
     }
 
     options
@@ -504,7 +511,7 @@ mod tests {
     use crate::http_client::create_client;
 
     #[test]
-    fn build_transcription_options_defaults_to_diarized_json_for_diarize_model() {
+    fn build_transcription_options_defaults_to_gpt_transcribe_json() {
         let options = build_transcription_options(&ListenParams::default(), true, false);
 
         let fields = options
@@ -513,9 +520,36 @@ mod tests {
         assert!(
             fields
                 .iter()
-                .any(|field| { field.name == "response_format" && field.value == "diarized_json" })
+                .any(|field| { field.name == "response_format" && field.value == "json" })
         );
         assert!(!fields.iter().any(|field| field.name == "stream"));
+    }
+
+    #[test]
+    fn gpt_transcribe_preserves_all_language_hints() {
+        let options = build_transcription_options(
+            &ListenParams {
+                languages: vec![
+                    anlg_language::ISO639::En.into(),
+                    anlg_language::ISO639::Ko.into(),
+                ],
+                ..Default::default()
+            },
+            true,
+            false,
+        );
+
+        let fields = options
+            .multipart_text_fields()
+            .expect("serialize multipart");
+        let languages = fields
+            .iter()
+            .filter(|field| field.name == "languages[]")
+            .map(|field| field.value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(languages, vec!["en", "ko"]);
+        assert!(!fields.iter().any(|field| field.name == "language"));
     }
 
     #[test]

--- a/crates/owhisper-client/src/adapter/openai/live.rs
+++ b/crates/owhisper-client/src/adapter/openai/live.rs
@@ -1,0 +1,713 @@
+use anlg_ws_client::client::Message;
+use openai_transcription::realtime::{
+    AudioConfig, AudioFormat, AudioFormatType, AudioInputConfig, ClientEventType,
+    InputAudioBufferAppendEvent, InputAudioBufferCommitEvent, ServerEvent, SessionConfig,
+    SessionInclude, SessionType, SessionUpdateEvent, TranscriptionConfig, TurnDetectionConfig,
+    TurnDetectionType,
+};
+use owhisper_interface::ListenParams;
+use owhisper_interface::stream::{Alternatives, Channel, Metadata, StreamResponse};
+
+use super::{OpenAIAdapter, OpenAILiveItem, OpenAILiveState};
+use crate::adapter::RealtimeSttAdapter;
+use crate::adapter::parsing::{WordBuilder, ms_to_secs};
+
+const VAD_THRESHOLD: f32 = 0.4;
+const VAD_PREFIX_PADDING_MS: u32 = 300;
+const VAD_SILENCE_DURATION_MS: u32 = 350;
+
+impl RealtimeSttAdapter for OpenAIAdapter {
+    fn fork_session(&self) -> Self {
+        let input_sample_rate = self
+            .live_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .input_sample_rate;
+        Self::for_live_sample_rate(input_sample_rate)
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "openai"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        OpenAIAdapter::is_supported_languages_live(languages)
+    }
+
+    fn supports_native_multichannel(&self) -> bool {
+        false
+    }
+
+    fn build_ws_url(&self, api_base: &str, _params: &ListenParams, _channels: u8) -> url::Url {
+        let (mut url, existing_params) = Self::build_ws_url_from_base(api_base);
+
+        if !existing_params.is_empty() {
+            url.query_pairs_mut().extend_pairs(&existing_params);
+        }
+
+        url
+    }
+
+    fn build_auth_header(&self, api_key: Option<&str>) -> Option<(&'static str, String)> {
+        api_key.and_then(|key| crate::providers::Provider::OpenAI.build_auth_header(key))
+    }
+
+    fn keep_alive_message(&self) -> Option<Message> {
+        None
+    }
+
+    fn audio_to_message(&self, audio: bytes::Bytes) -> Message {
+        use base64::Engine;
+
+        let input_sample_rate = self
+            .live_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .input_sample_rate;
+        let audio = resample_pcm16(
+            &audio,
+            input_sample_rate,
+            crate::providers::Provider::OpenAI.default_live_sample_rate(),
+        );
+        let event = InputAudioBufferAppendEvent {
+            event_id: None,
+            event_type: ClientEventType::InputAudioBufferAppend,
+            audio: base64::engine::general_purpose::STANDARD.encode(audio),
+        };
+        Message::Text(serde_json::to_string(&event).unwrap().into())
+    }
+
+    fn initial_message(
+        &self,
+        _api_key: Option<&str>,
+        params: &ListenParams,
+        _channels: u8,
+    ) -> Option<Message> {
+        let default = crate::providers::Provider::OpenAI.default_live_model();
+        let model = match params.model.as_deref() {
+            Some(model) if crate::providers::is_meta_model(model) => default,
+            Some(model) => model,
+            None => default,
+        };
+        let uses_plural_hints = matches!(model, "gpt-live-transcribe" | "gpt-transcribe");
+        let language_codes = params
+            .languages
+            .iter()
+            .map(|language| language.iso639().code().to_string())
+            .collect::<Vec<_>>();
+        let sample_rate = crate::providers::Provider::OpenAI.default_live_sample_rate();
+
+        self.live_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .input_sample_rate = params.sample_rate;
+
+        let event = SessionUpdateEvent {
+            event_id: None,
+            event_type: ClientEventType::SessionUpdate,
+            session: SessionConfig {
+                session_type: SessionType::Transcription,
+                audio: Some(AudioConfig {
+                    input: Some(AudioInputConfig {
+                        format: Some(AudioFormat {
+                            format_type: AudioFormatType::AudioPcm,
+                            rate: Some(sample_rate),
+                        }),
+                        transcription: Some(TranscriptionConfig {
+                            model: model.to_string(),
+                            language: (!uses_plural_hints)
+                                .then(|| language_codes.first().cloned())
+                                .flatten(),
+                            languages: (uses_plural_hints && !language_codes.is_empty())
+                                .then_some(language_codes),
+                            keywords: (uses_plural_hints && !params.keywords.is_empty())
+                                .then(|| params.keywords.clone()),
+                            prompt: None,
+                        }),
+                        turn_detection: Some(TurnDetectionConfig {
+                            detection_type: TurnDetectionType::ServerVad,
+                            create_response: None,
+                            interrupt_response: None,
+                            idle_timeout_ms: None,
+                            eagerness: None,
+                            threshold: Some(VAD_THRESHOLD),
+                            prefix_padding_ms: Some(VAD_PREFIX_PADDING_MS),
+                            silence_duration_ms: Some(VAD_SILENCE_DURATION_MS),
+                        }),
+                        noise_reduction: None,
+                    }),
+                }),
+                include: (!uses_plural_hints)
+                    .then_some(vec![SessionInclude::InputAudioTranscriptionLogprobs]),
+            },
+        };
+
+        let json = serde_json::to_string(&event).ok()?;
+        tracing::debug!(
+            anarlog.payload.size_bytes = json.len() as u64,
+            "openai_session_update_payload"
+        );
+        Some(Message::Text(json.into()))
+    }
+
+    fn finalize_message(&self) -> Message {
+        let event = InputAudioBufferCommitEvent {
+            event_id: None,
+            event_type: ClientEventType::InputAudioBufferCommit,
+        };
+        Message::Text(serde_json::to_string(&event).unwrap().into())
+    }
+
+    fn parse_response(&self, raw: &str) -> Vec<StreamResponse> {
+        let event: ServerEvent = match serde_json::from_str(raw) {
+            Ok(event) => event,
+            Err(error) => {
+                tracing::warn!(
+                    error = ?error,
+                    anarlog.payload.size_bytes = raw.len() as u64,
+                    "openai_json_parse_failed"
+                );
+                return vec![];
+            }
+        };
+
+        match event {
+            ServerEvent::SessionCreated { session, .. } => {
+                tracing::debug!(
+                    anarlog.stt.provider_session.id = %session.id,
+                    "openai_session_created"
+                );
+                vec![]
+            }
+            ServerEvent::SessionUpdated { session, .. } => {
+                tracing::debug!(
+                    anarlog.stt.provider_session.id = %session.id,
+                    "openai_session_updated"
+                );
+                vec![]
+            }
+            ServerEvent::InputAudioBufferCommitted { item_id, .. } => {
+                self.ensure_item(&item_id);
+                tracing::debug!(anarlog.stt.item.id = %item_id, "openai_audio_buffer_committed");
+                vec![]
+            }
+            ServerEvent::InputAudioBufferCleared { .. } => {
+                tracing::debug!("openai_audio_buffer_cleared");
+                vec![]
+            }
+            ServerEvent::InputAudioBufferSpeechStarted {
+                item_id,
+                audio_start_ms,
+                ..
+            } => {
+                self.record_item_start(&item_id, audio_start_ms);
+                tracing::debug!(
+                    anarlog.stt.item.id = %item_id,
+                    anarlog.stt.audio_start_ms = audio_start_ms,
+                    "openai_speech_started"
+                );
+                vec![]
+            }
+            ServerEvent::InputAudioBufferSpeechStopped {
+                item_id,
+                audio_end_ms,
+                ..
+            } => {
+                self.record_item_end(&item_id, audio_end_ms);
+                tracing::debug!(
+                    anarlog.stt.item.id = %item_id,
+                    anarlog.stt.audio_end_ms = audio_end_ms,
+                    "openai_speech_stopped"
+                );
+                vec![]
+            }
+            ServerEvent::InputAudioBufferTimeoutTriggered {
+                item_id,
+                audio_start_ms,
+                audio_end_ms,
+                ..
+            } => {
+                self.record_item_span(&item_id, audio_start_ms, audio_end_ms);
+                tracing::debug!(
+                    anarlog.stt.item.id = %item_id,
+                    anarlog.stt.audio_start_ms = audio_start_ms,
+                    anarlog.stt.audio_end_ms = audio_end_ms,
+                    "openai_audio_buffer_timeout_triggered"
+                );
+                vec![]
+            }
+            ServerEvent::ConversationItemInputAudioTranscriptionCompleted {
+                item_id,
+                content_index,
+                transcript,
+                ..
+            } => {
+                tracing::debug!(
+                    anarlog.stt.item.id = %item_id,
+                    anarlog.stt.content_index = content_index,
+                    anarlog.transcript.char_count = transcript.chars().count() as u64,
+                    "openai_transcription_completed"
+                );
+                self.complete_items(&item_id, &transcript)
+                    .into_iter()
+                    .flat_map(|(transcript, start_ms, end_ms)| {
+                        Self::build_transcript_response(&transcript, true, true, start_ms, end_ms)
+                    })
+                    .collect()
+            }
+            ServerEvent::ConversationItemInputAudioTranscriptionDelta {
+                item_id,
+                content_index,
+                delta,
+                obfuscation,
+                ..
+            } => {
+                let (transcript, start_ms, end_ms) = self.append_item_delta(&item_id, &delta);
+                tracing::debug!(
+                    anarlog.stt.item.id = %item_id,
+                    anarlog.stt.content_index = content_index.unwrap_or_default(),
+                    anarlog.transcript.char_count = delta.chars().count() as u64,
+                    "openai_transcription_delta"
+                );
+                if let Some(obfuscation) = obfuscation {
+                    tracing::trace!(anarlog.stt.obfuscation = %obfuscation);
+                }
+                Self::build_transcript_response(&transcript, false, false, start_ms, end_ms)
+            }
+            ServerEvent::ConversationItemInputAudioTranscriptionFailed {
+                item_id, error, ..
+            } => {
+                let completed = self.discard_item(&item_id);
+                let error_type = error.error_type.as_deref().unwrap_or("unknown_error");
+                let message = error.message.as_deref().unwrap_or("unknown error");
+                tracing::error!(
+                    anarlog.stt.item.id = %item_id,
+                    error.type = %error_type,
+                    error = %message,
+                    "openai_transcription_failed"
+                );
+                completed
+                    .into_iter()
+                    .flat_map(|(transcript, start_ms, end_ms)| {
+                        Self::build_transcript_response(&transcript, true, true, start_ms, end_ms)
+                    })
+                    .collect()
+            }
+            ServerEvent::ConversationItemInputAudioTranscriptionSegment { .. } => vec![],
+            ServerEvent::Error { error, .. } => {
+                let error_type = error.error_type.as_deref().unwrap_or("unknown_error");
+                let message = error.message.as_deref().unwrap_or("unknown error");
+                tracing::error!(
+                    error.type = %error_type,
+                    error = %message,
+                    "openai_error"
+                );
+                vec![StreamResponse::ErrorResponse {
+                    error_code: None,
+                    error_message: format!("{error_type}: {message}"),
+                    provider: "openai".to_string(),
+                }]
+            }
+            ServerEvent::Unknown => {
+                tracing::debug!(
+                    anarlog.payload.size_bytes = raw.len() as u64,
+                    "openai_unknown_event"
+                );
+                vec![]
+            }
+        }
+    }
+}
+
+impl OpenAIAdapter {
+    fn item_mut<'a>(state: &'a mut OpenAILiveState, item_id: &str) -> &'a mut OpenAILiveItem {
+        if !state.items.contains_key(item_id) {
+            state.item_order.push_back(item_id.to_string());
+        }
+        state.items.entry(item_id.to_string()).or_default()
+    }
+
+    fn ensure_item(&self, item_id: &str) {
+        let mut state = self
+            .live_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Self::item_mut(&mut state, item_id);
+    }
+
+    fn record_item_start(&self, item_id: &str, start_ms: u64) {
+        let mut state = self
+            .live_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Self::item_mut(&mut state, item_id).start_ms = Some(start_ms);
+    }
+
+    fn record_item_end(&self, item_id: &str, end_ms: u64) {
+        let mut state = self
+            .live_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Self::item_mut(&mut state, item_id).end_ms = Some(end_ms);
+    }
+
+    fn record_item_span(&self, item_id: &str, start_ms: u64, end_ms: u64) {
+        let mut state = self
+            .live_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let item = Self::item_mut(&mut state, item_id);
+        item.start_ms = Some(start_ms);
+        item.end_ms = Some(end_ms);
+    }
+
+    fn append_item_delta(&self, item_id: &str, delta: &str) -> (String, u64, u64) {
+        let mut state = self
+            .live_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let fallback_start_ms = state.fallback_end_ms;
+        let item = Self::item_mut(&mut state, item_id);
+        item.transcript.push_str(delta);
+
+        let transcript = item.transcript.clone();
+        let start_ms = item.start_ms.unwrap_or(fallback_start_ms);
+        let end_ms = item
+            .end_ms
+            .unwrap_or_else(|| synthetic_end_ms(start_ms, &transcript));
+        (transcript, start_ms, end_ms)
+    }
+
+    fn complete_items(&self, item_id: &str, transcript: &str) -> Vec<(String, u64, u64)> {
+        let mut state = self
+            .live_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Self::item_mut(&mut state, item_id).completed_transcript = Some(transcript.to_string());
+        Self::drain_completed(&mut state)
+    }
+
+    fn drain_completed(state: &mut OpenAILiveState) -> Vec<(String, u64, u64)> {
+        let mut completed = Vec::new();
+        loop {
+            let Some(next_item_id) = state.item_order.front() else {
+                break;
+            };
+            if state
+                .items
+                .get(next_item_id)
+                .and_then(|item| item.completed_transcript.as_ref())
+                .is_none()
+            {
+                break;
+            }
+
+            let next_item_id = state.item_order.pop_front().unwrap();
+            let item = state.items.remove(&next_item_id).unwrap();
+            let transcript = item.completed_transcript.unwrap();
+            let observed_start_ms = item.start_ms.unwrap_or(state.fallback_end_ms);
+            let start_ms = observed_start_ms.max(state.fallback_end_ms);
+            let observed_duration_ms = item
+                .end_ms
+                .unwrap_or_else(|| synthetic_end_ms(observed_start_ms, &transcript))
+                .saturating_sub(observed_start_ms);
+            let end_ms =
+                (start_ms + observed_duration_ms).max(synthetic_end_ms(start_ms, &transcript));
+            state.fallback_end_ms = end_ms;
+            completed.push((transcript, start_ms, end_ms));
+        }
+
+        completed
+    }
+
+    fn discard_item(&self, item_id: &str) -> Vec<(String, u64, u64)> {
+        let mut state = self
+            .live_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.items.remove(item_id);
+        state.item_order.retain(|queued| queued != item_id);
+        Self::drain_completed(&mut state)
+    }
+
+    fn build_transcript_response(
+        transcript: &str,
+        is_final: bool,
+        speech_final: bool,
+        start_ms: u64,
+        end_ms: u64,
+    ) -> Vec<StreamResponse> {
+        if transcript.trim().is_empty() {
+            return vec![];
+        }
+
+        let raw_words = transcript.split_whitespace().collect::<Vec<_>>();
+        let word_count = raw_words.len() as u64;
+        let span_ms = end_ms.saturating_sub(start_ms).max(word_count);
+        let words = raw_words
+            .into_iter()
+            .enumerate()
+            .map(|(index, word)| {
+                let index = index as u64;
+                WordBuilder::new(word)
+                    .start(ms_to_secs(start_ms + span_ms * index / word_count))
+                    .end(ms_to_secs(start_ms + span_ms * (index + 1) / word_count))
+                    .confidence(1.0)
+                    .build()
+            })
+            .collect::<Vec<_>>();
+        let start = ms_to_secs(start_ms);
+        let duration = ms_to_secs(span_ms);
+
+        vec![StreamResponse::TranscriptResponse {
+            is_final,
+            speech_final,
+            from_finalize: false,
+            start,
+            duration,
+            channel: Channel {
+                alternatives: vec![Alternatives {
+                    transcript: transcript.to_string(),
+                    words,
+                    confidence: 1.0,
+                    languages: vec![],
+                }],
+            },
+            metadata: Metadata::default(),
+            channel_index: vec![0, 1],
+        }]
+    }
+}
+
+fn synthetic_end_ms(start_ms: u64, transcript: &str) -> u64 {
+    start_ms + transcript.split_whitespace().count().max(1) as u64
+}
+
+fn resample_pcm16(audio: &[u8], input_rate: u32, output_rate: u32) -> Vec<u8> {
+    if input_rate == 0 || input_rate == output_rate {
+        return audio.to_vec();
+    }
+
+    let samples = audio
+        .chunks_exact(2)
+        .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]))
+        .collect::<Vec<_>>();
+    if samples.is_empty() {
+        return vec![];
+    }
+
+    let output_len = ((samples.len() as u64 * output_rate as u64 + input_rate as u64 / 2)
+        / input_rate as u64) as usize;
+    let mut output = Vec::with_capacity(output_len * 2);
+
+    for output_index in 0..output_len {
+        let position = output_index as u64 * input_rate as u64;
+        let left_index = ((position / output_rate as u64) as usize).min(samples.len() - 1);
+        let right_index = (left_index + 1).min(samples.len() - 1);
+        let remainder = (position % output_rate as u64) as i64;
+        let denominator = output_rate as i64;
+        let left = samples[left_index] as i64;
+        let right = samples[right_index] as i64;
+        let sample = (left * (denominator - remainder) + right * remainder) / denominator;
+        output.extend_from_slice(&(sample as i16).to_le_bytes());
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use anlg_ws_client::client::Message;
+    use base64::Engine;
+
+    use super::*;
+
+    fn initial_message_json(params: &ListenParams) -> serde_json::Value {
+        match OpenAIAdapter::default()
+            .initial_message(None, params, 1)
+            .expect("initial message")
+        {
+            Message::Text(text) => serde_json::from_str(&text).expect("valid JSON"),
+            _ => panic!("expected text message"),
+        }
+    }
+
+    #[test]
+    fn live_model_uses_plural_language_and_keyword_hints() {
+        let json = initial_message_json(&ListenParams {
+            languages: vec![
+                anlg_language::ISO639::En.into(),
+                anlg_language::ISO639::Ko.into(),
+            ],
+            keywords: vec!["technical term".to_string()],
+            ..Default::default()
+        });
+        let transcription = &json["session"]["audio"]["input"]["transcription"];
+
+        assert_eq!(transcription["model"], "gpt-live-transcribe");
+        assert_eq!(transcription["languages"], serde_json::json!(["en", "ko"]));
+        assert_eq!(
+            transcription["keywords"],
+            serde_json::json!(["technical term"])
+        );
+        assert!(transcription.get("language").is_none());
+        assert!(json["session"].get("include").is_none());
+    }
+
+    #[test]
+    fn legacy_model_uses_singular_language_hint() {
+        let json = initial_message_json(&ListenParams {
+            model: Some("gpt-4o-transcribe".to_string()),
+            languages: vec![
+                anlg_language::ISO639::En.into(),
+                anlg_language::ISO639::Ko.into(),
+            ],
+            ..Default::default()
+        });
+        let transcription = &json["session"]["audio"]["input"]["transcription"];
+
+        assert_eq!(transcription["language"], "en");
+        assert!(transcription.get("languages").is_none());
+        assert_eq!(
+            json["session"]["include"],
+            serde_json::json!(["item.input_audio_transcription.logprobs"])
+        );
+    }
+
+    #[test]
+    fn realtime_audio_is_declared_and_resampled_at_24khz() {
+        let adapter = OpenAIAdapter::default();
+        let params = ListenParams {
+            sample_rate: 16_000,
+            ..Default::default()
+        };
+        let message = adapter.initial_message(None, &params, 1).unwrap();
+        let Message::Text(message) = message else {
+            panic!("expected text message");
+        };
+        let json: serde_json::Value = serde_json::from_str(&message).unwrap();
+        assert_eq!(json["session"]["audio"]["input"]["format"]["rate"], 24_000);
+
+        let input = (0..160_i16).flat_map(i16::to_le_bytes).collect::<Vec<_>>();
+        let Message::Text(message) = adapter.audio_to_message(input.into()) else {
+            panic!("expected text message");
+        };
+        let json: serde_json::Value = serde_json::from_str(&message).unwrap();
+        let output = base64::engine::general_purpose::STANDARD
+            .decode(json["audio"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(output.len(), 240 * std::mem::size_of::<i16>());
+    }
+
+    #[test]
+    fn transcript_deltas_are_cumulative_and_final_turns_keep_monotonic_times() {
+        let adapter = OpenAIAdapter::default();
+        adapter.parse_response(
+            r#"{"type":"input_audio_buffer.speech_started","event_id":"e1","item_id":"item-1","audio_start_ms":0}"#,
+        );
+        let first_delta = adapter.parse_response(
+            r#"{"type":"conversation.item.input_audio_transcription.delta","event_id":"e2","item_id":"item-1","content_index":0,"delta":"Hello","logprobs":[]}"#,
+        );
+        let second_delta = adapter.parse_response(
+            r#"{"type":"conversation.item.input_audio_transcription.delta","event_id":"e3","item_id":"item-1","content_index":0,"delta":" world","logprobs":[]}"#,
+        );
+
+        assert_eq!(transcript(&first_delta), "Hello");
+        assert_eq!(transcript(&second_delta), "Hello world");
+
+        adapter.parse_response(
+            r#"{"type":"input_audio_buffer.speech_stopped","event_id":"e4","item_id":"item-1","audio_end_ms":1000}"#,
+        );
+        adapter.parse_response(
+            r#"{"type":"input_audio_buffer.speech_started","event_id":"e5","item_id":"item-2","audio_start_ms":1200}"#,
+        );
+        adapter.parse_response(
+            r#"{"type":"input_audio_buffer.speech_stopped","event_id":"e6","item_id":"item-2","audio_end_ms":1800}"#,
+        );
+        let out_of_order_final = adapter.parse_response(
+            r#"{"type":"conversation.item.input_audio_transcription.completed","event_id":"e7","item_id":"item-2","content_index":0,"transcript":"Next turn","logprobs":[]}"#,
+        );
+        assert!(out_of_order_final.is_empty());
+        let ordered_finals = adapter.parse_response(
+            r#"{"type":"conversation.item.input_audio_transcription.completed","event_id":"e8","item_id":"item-1","content_index":0,"transcript":"Hello world","logprobs":[]}"#,
+        );
+
+        assert_eq!(transcript_at(&ordered_finals, 0), "Hello world");
+        assert_eq!(transcript_at(&ordered_finals, 1), "Next turn");
+        assert!(last_word_end_at(&ordered_finals, 0) <= first_word_start_at(&ordered_finals, 1));
+    }
+
+    #[test]
+    fn forked_sessions_keep_transcript_state_isolated() {
+        let adapter = OpenAIAdapter::for_live_sample_rate(16_000);
+        let mic = adapter.fork_session();
+        let speaker = adapter.fork_session();
+
+        mic.parse_response(
+            r#"{"type":"input_audio_buffer.speech_started","event_id":"e1","item_id":"item-1","audio_start_ms":0}"#,
+        );
+        speaker.parse_response(
+            r#"{"type":"input_audio_buffer.speech_started","event_id":"e2","item_id":"item-1","audio_start_ms":0}"#,
+        );
+        let mic_delta = mic.parse_response(
+            r#"{"type":"conversation.item.input_audio_transcription.delta","event_id":"e3","item_id":"item-1","content_index":0,"delta":"Mic","logprobs":[]}"#,
+        );
+        let speaker_delta = speaker.parse_response(
+            r#"{"type":"conversation.item.input_audio_transcription.delta","event_id":"e4","item_id":"item-1","content_index":0,"delta":"Speaker","logprobs":[]}"#,
+        );
+
+        assert_eq!(transcript(&mic_delta), "Mic");
+        assert_eq!(transcript(&speaker_delta), "Speaker");
+    }
+
+    #[test]
+    fn failed_item_is_nonfatal_and_releases_completed_later_items() {
+        let adapter = OpenAIAdapter::default();
+        adapter.parse_response(
+            r#"{"type":"input_audio_buffer.speech_started","event_id":"e1","item_id":"item-1","audio_start_ms":0}"#,
+        );
+        adapter.parse_response(
+            r#"{"type":"input_audio_buffer.speech_started","event_id":"e2","item_id":"item-2","audio_start_ms":1000}"#,
+        );
+        let held_final = adapter.parse_response(
+            r#"{"type":"conversation.item.input_audio_transcription.completed","event_id":"e3","item_id":"item-2","content_index":0,"transcript":"Later turn","logprobs":[]}"#,
+        );
+        assert!(held_final.is_empty());
+
+        let responses = adapter.parse_response(
+            r#"{"type":"conversation.item.input_audio_transcription.failed","event_id":"e4","item_id":"item-1","content_index":0,"error":{"type":"server_error","code":"server_error","message":"failed"}}"#,
+        );
+
+        assert_eq!(responses.len(), 1);
+        assert_eq!(transcript(&responses), "Later turn");
+    }
+
+    fn transcript(responses: &[StreamResponse]) -> &str {
+        transcript_at(responses, 0)
+    }
+
+    fn transcript_at(responses: &[StreamResponse], index: usize) -> &str {
+        let StreamResponse::TranscriptResponse { channel, .. } = &responses[index] else {
+            panic!("expected transcript response");
+        };
+        &channel.alternatives[0].transcript
+    }
+
+    fn first_word_start_at(responses: &[StreamResponse], index: usize) -> f64 {
+        let StreamResponse::TranscriptResponse { channel, .. } = &responses[index] else {
+            panic!("expected transcript response");
+        };
+        channel.alternatives[0].words[0].start
+    }
+
+    fn last_word_end_at(responses: &[StreamResponse], index: usize) -> f64 {
+        let StreamResponse::TranscriptResponse { channel, .. } = &responses[index] else {
+            panic!("expected transcript response");
+        };
+        channel.alternatives[0].words.last().unwrap().end
+    }
+}

--- a/crates/owhisper-client/src/adapter/openai/mod.rs
+++ b/crates/owhisper-client/src/adapter/openai/mod.rs
@@ -1,4 +1,8 @@
 mod batch;
+mod live;
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
 
 use openai_transcription::batch::AudioModel;
 
@@ -7,13 +11,48 @@ use crate::providers::Provider;
 use super::{LanguageQuality, LanguageSupport};
 
 #[derive(Clone, Default)]
-pub struct OpenAIAdapter;
+pub struct OpenAIAdapter {
+    live_state: Arc<Mutex<OpenAILiveState>>,
+}
+
+#[derive(Default)]
+struct OpenAILiveState {
+    input_sample_rate: u32,
+    fallback_end_ms: u64,
+    item_order: VecDeque<String>,
+    items: HashMap<String, OpenAILiveItem>,
+}
+
+#[derive(Default)]
+struct OpenAILiveItem {
+    start_ms: Option<u64>,
+    end_ms: Option<u64>,
+    transcript: String,
+    completed_transcript: Option<String>,
+}
 
 impl OpenAIAdapter {
-    pub fn language_support_batch(_languages: &[anlg_language::Language]) -> LanguageSupport {
+    pub fn for_live_sample_rate(input_sample_rate: u32) -> Self {
+        Self {
+            live_state: Arc::new(Mutex::new(OpenAILiveState {
+                input_sample_rate,
+                ..Default::default()
+            })),
+        }
+    }
+
+    pub fn language_support_live(_languages: &[anlg_language::Language]) -> LanguageSupport {
         LanguageSupport::Supported {
             quality: LanguageQuality::NoData,
         }
+    }
+
+    pub fn language_support_batch(_languages: &[anlg_language::Language]) -> LanguageSupport {
+        Self::language_support_live(_languages)
+    }
+
+    pub fn is_supported_languages_live(languages: &[anlg_language::Language]) -> bool {
+        Self::language_support_live(languages).is_supported()
     }
 
     pub fn is_supported_languages_batch(languages: &[anlg_language::Language]) -> bool {
@@ -37,10 +76,43 @@ impl OpenAIAdapter {
     pub fn supports_progressive_batch_model(model: Option<&str>) -> bool {
         matches!(
             Self::resolve_batch_model(model),
-            AudioModel::Gpt4oTranscribe
+            AudioModel::GptTranscribe
+                | AudioModel::Gpt4oTranscribe
                 | AudioModel::Gpt4oMiniTranscribe
                 | AudioModel::Gpt4oMiniTranscribe20251215
         )
+    }
+
+    pub(crate) fn build_ws_url_from_base(api_base: &str) -> (url::Url, Vec<(String, String)>) {
+        if api_base.is_empty() {
+            return (
+                Provider::OpenAI
+                    .default_ws_url()
+                    .parse()
+                    .expect("invalid_default_ws_url"),
+                vec![("intent".to_string(), "transcription".to_string())],
+            );
+        }
+
+        if let Some(proxy_result) = super::build_proxy_ws_url(api_base) {
+            return proxy_result;
+        }
+
+        let parsed: url::Url = api_base.parse().expect("invalid_api_base");
+        let mut existing_params = super::extract_query_params(&parsed);
+
+        if !existing_params.iter().any(|(key, _)| key == "intent") {
+            existing_params.push(("intent".to_string(), "transcription".to_string()));
+        }
+
+        let url = super::build_url_with_scheme(
+            &parsed,
+            Provider::OpenAI.default_ws_host(),
+            Provider::OpenAI.ws_path(),
+            true,
+        );
+
+        (url, existing_params)
     }
 }
 
@@ -56,15 +128,18 @@ mod tests {
     }
 
     #[test]
-    fn resolve_batch_model_defaults_to_diarize() {
+    fn resolve_batch_model_defaults_to_gpt_transcribe() {
         assert_eq!(
             OpenAIAdapter::resolve_batch_model(None),
-            AudioModel::Gpt4oTranscribeDiarize
+            AudioModel::GptTranscribe
         );
     }
 
     #[test]
     fn progressive_batch_only_supports_non_diarized_gpt_models() {
+        assert!(OpenAIAdapter::supports_progressive_batch_model(Some(
+            "gpt-transcribe"
+        )));
         assert!(OpenAIAdapter::supports_progressive_batch_model(Some(
             "gpt-4o-transcribe"
         )));
@@ -77,6 +152,38 @@ mod tests {
         assert!(!OpenAIAdapter::supports_progressive_batch_model(Some(
             "whisper-1"
         )));
-        assert!(!OpenAIAdapter::supports_progressive_batch_model(None));
+        assert!(OpenAIAdapter::supports_progressive_batch_model(None));
+    }
+
+    #[test]
+    fn build_ws_url_adds_transcription_intent() {
+        let (url, params) = OpenAIAdapter::build_ws_url_from_base("");
+
+        assert_eq!(url.as_str(), "wss://api.openai.com/v1/realtime");
+        assert_eq!(
+            params,
+            vec![("intent".to_string(), "transcription".to_string())]
+        );
+    }
+
+    #[test]
+    fn build_ws_url_preserves_proxy_provider() {
+        let (url, params) =
+            OpenAIAdapter::build_ws_url_from_base("https://api.anarlog.so?provider=openai");
+
+        assert_eq!(url.as_str(), "wss://api.anarlog.so/listen");
+        assert_eq!(params, vec![("provider".to_string(), "openai".to_string())]);
+    }
+
+    #[test]
+    fn build_ws_url_preserves_custom_port() {
+        let (url, params) =
+            OpenAIAdapter::build_ws_url_from_base("https://stt.example.com:8443/v1");
+
+        assert_eq!(url.as_str(), "wss://stt.example.com:8443/v1/realtime");
+        assert_eq!(
+            params,
+            vec![("intent".to_string(), "transcription".to_string())]
+        );
     }
 }

--- a/crates/owhisper-client/src/live.rs
+++ b/crates/owhisper-client/src/live.rs
@@ -441,16 +441,18 @@ impl<A: RealtimeSttAdapter> ListenClientDual<A> {
         stream: impl Stream<Item = ListenClientDualInput> + Send + Unpin + 'static,
     ) -> Result<(DualOutputStream, DualHandle), anlg_ws_client::Error> {
         let finalize_text = extract_finalize_text(&self.adapter);
+        let mic_adapter = self.adapter.fork_session();
+        let spk_adapter = self.adapter.fork_session();
         let (mic_tx, mic_rx) = tokio::sync::mpsc::channel::<TransformedInput>(32);
         let (spk_tx, spk_rx) = tokio::sync::mpsc::channel::<TransformedInput>(32);
 
         let mic_ws = websocket_client_with_keep_alive(
             &self.request,
-            &self.adapter,
+            &mic_adapter,
             self.connect_policy.clone(),
         );
         let spk_ws =
-            websocket_client_with_keep_alive(&self.request, &self.adapter, self.connect_policy);
+            websocket_client_with_keep_alive(&self.request, &spk_adapter, self.connect_policy);
 
         let mic_outbound = tokio_stream::wrappers::ReceiverStream::new(mic_rx);
         let spk_outbound = tokio_stream::wrappers::ReceiverStream::new(spk_rx);
@@ -467,12 +469,12 @@ impl<A: RealtimeSttAdapter> ListenClientDual<A> {
             stream,
             mic_tx,
             spk_tx,
-            self.adapter.clone(),
+            mic_adapter.clone(),
+            spk_adapter.clone(),
         ));
 
-        let adapter = self.adapter.clone();
         let mic_stream = mic_raw.flat_map({
-            let adapter = adapter.clone();
+            let adapter = mic_adapter;
             move |result| {
                 let adapter = adapter.clone();
                 let responses: Vec<Result<StreamResponse, anlg_ws_client::Error>> = match result {
@@ -484,7 +486,7 @@ impl<A: RealtimeSttAdapter> ListenClientDual<A> {
         });
 
         let spk_stream = spk_raw.flat_map({
-            let adapter = adapter.clone();
+            let adapter = spk_adapter;
             move |result| {
                 let adapter = adapter.clone();
                 let responses: Vec<Result<StreamResponse, anlg_ws_client::Error>> = match result {
@@ -512,13 +514,14 @@ async fn forward_dual_to_single<A: RealtimeSttAdapter>(
     mut stream: impl Stream<Item = ListenClientDualInput> + Send + Unpin + 'static,
     mic_tx: tokio::sync::mpsc::Sender<TransformedInput>,
     spk_tx: tokio::sync::mpsc::Sender<TransformedInput>,
-    adapter: A,
+    mic_adapter: A,
+    spk_adapter: A,
 ) {
     while let Some(msg) = stream.next().await {
         match msg {
             MixedMessage::Audio((mic, spk)) => {
-                let mic_msg = adapter.audio_to_message(mic);
-                let spk_msg = adapter.audio_to_message(spk);
+                let mic_msg = mic_adapter.audio_to_message(mic);
+                let spk_msg = spk_adapter.audio_to_message(spk);
                 if mic_tx.send(MixedMessage::Audio(mic_msg)).await.is_err() {
                     break;
                 }
@@ -670,7 +673,13 @@ mod tests {
         let (mic_tx, mut mic_rx) = tokio::sync::mpsc::channel(1);
         let (spk_tx, mut spk_rx) = tokio::sync::mpsc::channel(1);
 
-        let task = tokio::spawn(forward_dual_to_single(stream, mic_tx, spk_tx, TestAdapter));
+        let task = tokio::spawn(forward_dual_to_single(
+            stream,
+            mic_tx,
+            spk_tx,
+            TestAdapter,
+            TestAdapter,
+        ));
 
         let Some(TransformedInput::Audio(Message::Binary(first_mic))) = mic_rx.recv().await else {
             panic!("missing first mic frame");

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -317,7 +317,7 @@ impl Provider {
             Self::Soniox => "stt-rt-v5",
             Self::AssemblyAI => "u3-rt-pro",
             Self::Fireworks => "whisper-v3-turbo",
-            Self::OpenAI => "gpt-4o-transcribe",
+            Self::OpenAI => "gpt-live-transcribe",
             Self::Gladia => "solaria-1",
             Self::ElevenLabs => "scribe_v2_realtime",
             Self::DashScope => "qwen3-asr-flash-realtime",
@@ -343,7 +343,7 @@ impl Provider {
             Self::Soniox => "stt-async-v5",
             Self::AssemblyAI => "universal-3-pro",
             Self::Fireworks => "whisper-v3-turbo",
-            Self::OpenAI => "gpt-4o-transcribe-diarize",
+            Self::OpenAI => "gpt-transcribe",
             Self::Gladia => "solaria-1",
             Self::ElevenLabs => "scribe_v2",
             Self::DashScope => "qwen3-asr-flash-filetrans",
@@ -446,7 +446,7 @@ impl Provider {
             Self::Mistral => from_adapter(&crate::adapter::MistralAdapter::default(), msg),
             Self::AquaVoice => None,
             Self::Cartesia => from_adapter(&crate::adapter::CartesiaAdapter, msg),
-            Self::OpenAI => None,
+            Self::OpenAI => from_adapter(&crate::adapter::OpenAIAdapter::default(), msg),
             Self::Pyannote => None,
         }
     }

--- a/crates/owhisper-client/tests/provider_live_e2e.rs
+++ b/crates/owhisper-client/tests/provider_live_e2e.rs
@@ -181,6 +181,7 @@ direct_live_test!(assemblyai, AssemblyAIAdapter, Provider::AssemblyAI);
 direct_live_test!(soniox, SonioxAdapter, Provider::Soniox);
 direct_live_test!(gladia, GladiaAdapter, Provider::Gladia);
 direct_live_test!(fireworks, FireworksAdapter, Provider::Fireworks);
+direct_live_test!(openai, OpenAIAdapter, Provider::OpenAI);
 direct_live_test!(elevenlabs, ElevenLabsAdapter, Provider::ElevenLabs);
 direct_live_test!(dashscope, DashScopeAdapter, Provider::DashScope);
 direct_live_test!(mistral, MistralAdapter, Provider::Mistral);

--- a/crates/transcribe-proxy/src/anarlog_routing.rs
+++ b/crates/transcribe-proxy/src/anarlog_routing.rs
@@ -594,7 +594,7 @@ mod tests {
 
         assert_eq!(
             router.select_provider_chain_with_mode(RoutingMode::Live, &languages, &available),
-            Vec::<Provider>::new()
+            vec![Provider::OpenAI]
         );
         assert_eq!(
             router.select_provider_chain_with_mode(RoutingMode::Batch, &languages, &available),

--- a/crates/transcribe-proxy/src/relay/channel_split/mod.rs
+++ b/crates/transcribe-proxy/src/relay/channel_split/mod.rs
@@ -36,7 +36,7 @@ pub struct ChannelSplitProxy {
     mic_request: ClientRequestBuilder,
     spk_request: ClientRequestBuilder,
     initial_message: Option<InitialMessage>,
-    response_transformer: Option<ResponseTransformer>,
+    response_transformers: [Option<ResponseTransformer>; 2],
     connect_timeout: Duration,
     on_close: Option<OnCloseCallback>,
     client_message_filter: Option<ClientMessageFilter>,
@@ -47,7 +47,7 @@ impl ChannelSplitProxy {
     pub fn new(
         upstream_request: ClientRequestBuilder,
         initial_message: Option<InitialMessage>,
-        response_transformer: Option<ResponseTransformer>,
+        response_transformers: [Option<ResponseTransformer>; 2],
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
     ) -> Self {
@@ -55,7 +55,7 @@ impl ChannelSplitProxy {
             upstream_request.clone(),
             upstream_request,
             initial_message,
-            response_transformer,
+            response_transformers,
             connect_timeout,
             on_close,
         )
@@ -65,7 +65,7 @@ impl ChannelSplitProxy {
         mic_request: ClientRequestBuilder,
         spk_request: ClientRequestBuilder,
         initial_message: Option<InitialMessage>,
-        response_transformer: Option<ResponseTransformer>,
+        response_transformers: [Option<ResponseTransformer>; 2],
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
     ) -> Self {
@@ -73,7 +73,7 @@ impl ChannelSplitProxy {
             mic_request,
             spk_request,
             initial_message,
-            response_transformer,
+            response_transformers,
             connect_timeout,
             on_close,
             client_message_filter: None,
@@ -190,7 +190,7 @@ impl ChannelSplitProxy {
 
         let event_coordinator = {
             let shutdown_tx = shutdown_tx.clone();
-            let response_transformer = self.response_transformer.clone();
+            let response_transformers = self.response_transformers.clone();
             async move {
                 let mut coordinator = SplitCoordinator::default();
 
@@ -204,7 +204,7 @@ impl ChannelSplitProxy {
                             let raw_log = proxy_debug_enabled().then(|| raw.clone());
                             let upstream_error = Provider::detect_any_error(raw.as_bytes())
                                 .map(|error| (error.to_ws_close_code(), error.message));
-                            let transformed = match &response_transformer {
+                            let transformed = match &response_transformers[channel as usize] {
                                 Some(transformer) => transformer(&raw),
                                 None => Some(raw),
                             };

--- a/crates/transcribe-proxy/src/relay/mod.rs
+++ b/crates/transcribe-proxy/src/relay/mod.rs
@@ -70,6 +70,7 @@ pub struct StreamingProxyPlan {
     transform_first_message: Option<FirstMessageTransformer>,
     initial_message: Option<InitialMessage>,
     response_transformer: Option<ResponseTransformer>,
+    split_response_transformer: Option<ResponseTransformer>,
     connect_timeout: Duration,
     on_close: Option<OnCloseCallback>,
     client_message_filter: Option<ClientMessageFilter>,
@@ -90,6 +91,7 @@ impl StreamingProxyPlan {
             transform_first_message: None,
             initial_message: None,
             response_transformer: None,
+            split_response_transformer: None,
             connect_timeout: Duration::default(),
             on_close: None,
             client_message_filter: None,
@@ -125,6 +127,14 @@ impl StreamingProxyPlan {
         F: Fn(&str) -> Option<String> + Send + Sync + 'static,
     {
         self.response_transformer = Some(std::sync::Arc::new(transformer));
+        self
+    }
+
+    pub fn split_response_transformer<F>(mut self, transformer: F) -> Self
+    where
+        F: Fn(&str) -> Option<String> + Send + Sync + 'static,
+    {
+        self.split_response_transformer = Some(std::sync::Arc::new(transformer));
         self
     }
 
@@ -212,7 +222,10 @@ impl StreamingProxyPlan {
             StreamingTransport::SplitStereo => StreamingProxy::split(
                 apply_headers(request, self.headers),
                 self.initial_message,
-                self.response_transformer,
+                response_transformers_for_split(
+                    self.response_transformer,
+                    self.split_response_transformer,
+                ),
                 self.connect_timeout,
                 self.on_close,
                 self.client_message_filter,
@@ -232,7 +245,10 @@ impl StreamingProxyPlan {
                 apply_headers(mic_request, self.headers.clone()),
                 apply_headers(spk_request, self.headers),
                 self.initial_message,
-                self.response_transformer,
+                response_transformers_for_split(
+                    self.response_transformer,
+                    self.split_response_transformer,
+                ),
                 self.connect_timeout,
                 self.on_close,
                 self.client_message_filter,
@@ -250,7 +266,7 @@ impl StreamingProxy {
     pub fn split(
         upstream_request: ClientRequestBuilder,
         initial_message: Option<InitialMessage>,
-        response_transformer: Option<ResponseTransformer>,
+        response_transformers: [Option<ResponseTransformer>; 2],
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
@@ -259,7 +275,7 @@ impl StreamingProxy {
         let proxy = ChannelSplitProxy::new(
             upstream_request,
             initial_message,
-            response_transformer,
+            response_transformers,
             connect_timeout,
             on_close,
         );
@@ -275,7 +291,7 @@ impl StreamingProxy {
         mic_request: ClientRequestBuilder,
         spk_request: ClientRequestBuilder,
         initial_message: Option<InitialMessage>,
-        response_transformer: Option<ResponseTransformer>,
+        response_transformers: [Option<ResponseTransformer>; 2],
         connect_timeout: Duration,
         on_close: Option<OnCloseCallback>,
         client_message_filter: Option<ClientMessageFilter>,
@@ -285,7 +301,7 @@ impl StreamingProxy {
             mic_request,
             spk_request,
             initial_message,
-            response_transformer,
+            response_transformers,
             connect_timeout,
             on_close,
         );
@@ -315,6 +331,14 @@ impl StreamingProxy {
             Self::ChannelSplit(proxy) => proxy.handle_upgrade(ws).await,
         }
     }
+}
+
+fn response_transformers_for_split(
+    primary: Option<ResponseTransformer>,
+    secondary: Option<ResponseTransformer>,
+) -> [Option<ResponseTransformer>; 2] {
+    let secondary = secondary.or_else(|| primary.clone());
+    [primary, secondary]
 }
 
 fn control_message_types(

--- a/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
@@ -8,8 +8,6 @@ use owhisper_client::{
 };
 use owhisper_interface::ListenParams;
 
-const _: Option<OpenAIAdapter> = None;
-
 use crate::config::SttProxyConfig;
 use crate::provider_selector::SelectedProvider;
 use crate::query_params::{QueryParams, QueryValue};
@@ -49,7 +47,7 @@ fn build_upstream_url_with_adapter(
         Provider::Cartesia => CartesiaAdapter.build_ws_url(api_base, params, channels),
         Provider::Soniox => SonioxAdapter.build_ws_url(api_base, params, channels),
         Provider::Fireworks => FireworksAdapter.build_ws_url(api_base, params, channels),
-        Provider::OpenAI => unreachable!("openai only supports batch transcription"),
+        Provider::OpenAI => OpenAIAdapter::default().build_ws_url(api_base, params, channels),
         Provider::Gladia => GladiaAdapter.build_ws_url(api_base, params, channels),
         Provider::ElevenLabs => ElevenLabsAdapter.build_ws_url(api_base, params, channels),
         Provider::DashScope => DashScopeAdapter.build_ws_url(api_base, params, channels),
@@ -71,7 +69,7 @@ fn build_initial_message_with_adapter(
         Provider::Cartesia => CartesiaAdapter.initial_message(api_key, params, channels),
         Provider::Soniox => SonioxAdapter.initial_message(api_key, params, channels),
         Provider::Fireworks => FireworksAdapter.initial_message(api_key, params, channels),
-        Provider::OpenAI => unreachable!("openai only supports batch transcription"),
+        Provider::OpenAI => OpenAIAdapter::default().initial_message(api_key, params, channels),
         Provider::Gladia => GladiaAdapter.initial_message(api_key, params, channels),
         Provider::ElevenLabs => ElevenLabsAdapter.initial_message(api_key, params, channels),
         Provider::DashScope => DashScopeAdapter.initial_message(api_key, params, channels),
@@ -90,6 +88,7 @@ fn build_response_transformer(
     provider: Provider,
 ) -> impl Fn(&str) -> Option<String> + Send + Sync + 'static {
     let mistral_adapter = MistralAdapter::default();
+    let openai_adapter = OpenAIAdapter::default();
     move |raw: &str| {
         let responses: Vec<owhisper_interface::stream::StreamResponse> = match provider {
             Provider::Deepgram => DeepgramAdapter.parse_response(raw),
@@ -97,7 +96,7 @@ fn build_response_transformer(
             Provider::Cartesia => CartesiaAdapter.parse_response(raw),
             Provider::Soniox => SonioxAdapter.parse_response(raw),
             Provider::Fireworks => FireworksAdapter.parse_response(raw),
-            Provider::OpenAI => unreachable!("openai only supports batch transcription"),
+            Provider::OpenAI => openai_adapter.parse_response(raw),
             Provider::Gladia => GladiaAdapter.parse_response(raw),
             Provider::ElevenLabs => ElevenLabsAdapter.parse_response(raw),
             Provider::DashScope => DashScopeAdapter.parse_response(raw),
@@ -149,25 +148,39 @@ fn build_client_message_filter(provider: Provider) -> ClientMessageFilter {
     })
 }
 
-fn build_client_binary_message_mapper(provider: Provider) -> Option<ClientBinaryMessageMapper> {
-    if provider != Provider::ElevenLabs {
-        return None;
+fn build_client_binary_message_mapper(
+    provider: Provider,
+    sample_rate: u32,
+) -> Option<ClientBinaryMessageMapper> {
+    match provider {
+        Provider::ElevenLabs => Some(Arc::new(|audio: Vec<u8>| {
+            let chunk = serde_json::json!({
+                "message_type": "input_audio_chunk",
+                "audio_base_64": base64::engine::general_purpose::STANDARD.encode(audio),
+            });
+
+            Some(ClientBinaryMessage::Text(chunk.to_string()))
+        })),
+        Provider::OpenAI => {
+            let adapter = OpenAIAdapter::for_live_sample_rate(sample_rate);
+            Some(Arc::new(move |audio: Vec<u8>| {
+                let owhisper_client::anlg_ws_client::client::Message::Text(message) =
+                    adapter.audio_to_message(audio.into())
+                else {
+                    return None;
+                };
+                Some(ClientBinaryMessage::Text(message.to_string()))
+            }))
+        }
+        _ => None,
     }
-
-    Some(Arc::new(|audio: Vec<u8>| {
-        let chunk = serde_json::json!({
-            "message_type": "input_audio_chunk",
-            "audio_base_64": base64::engine::general_purpose::STANDARD.encode(audio),
-        });
-
-        Some(ClientBinaryMessage::Text(chunk.to_string()))
-    }))
 }
 
 fn build_proxy_plan(
     provider: Provider,
     selected: &SelectedProvider,
     channels: u8,
+    sample_rate: u32,
     config: &SttProxyConfig,
     analytics_ctx: AnalyticsContext,
 ) -> Result<StreamingProxyPlan, crate::ProxyError> {
@@ -181,7 +194,11 @@ fn build_proxy_plan(
     .client_message_filter(build_client_message_filter(provider))
     .apply_auth(selected);
 
-    if let Some(mapper) = build_client_binary_message_mapper(provider) {
+    if plan.upstream_count() == 2 {
+        plan = plan.split_response_transformer(build_response_transformer(provider));
+    }
+
+    if let Some(mapper) = build_client_binary_message_mapper(provider, sample_rate) {
         plan = plan.client_binary_message_mapper(mapper);
     }
 
@@ -234,7 +251,14 @@ pub async fn build_proxy(
 ) -> Result<StreamingProxy, ProxyBuildError> {
     let provider = selected.provider();
     let channels: u8 = parse_param(params, "channels", 1);
-    let plan = build_proxy_plan(provider, selected, channels, &state.config, analytics_ctx)?;
+    let plan = build_proxy_plan(
+        provider,
+        selected,
+        channels,
+        parse_param(params, "sample_rate", 16000),
+        &state.config,
+        analytics_ctx,
+    )?;
     let api_base = selected
         .upstream_url()
         .unwrap_or(provider.default_api_base());
@@ -560,9 +584,9 @@ mod tests {
 
     #[test]
     fn test_client_binary_message_mapper_elevenlabs_wraps_audio_chunks() {
-        assert!(build_client_binary_message_mapper(Provider::Deepgram).is_none());
+        assert!(build_client_binary_message_mapper(Provider::Deepgram, 16_000).is_none());
 
-        let mapper = build_client_binary_message_mapper(Provider::ElevenLabs).unwrap();
+        let mapper = build_client_binary_message_mapper(Provider::ElevenLabs, 16_000).unwrap();
         let Some(ClientBinaryMessage::Text(text)) = mapper(vec![1, 2, 3]) else {
             panic!("expected ElevenLabs binary audio to map to text JSON");
         };
@@ -570,6 +594,22 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(parsed["message_type"], "input_audio_chunk");
         assert_eq!(parsed["audio_base_64"], "AQID");
+    }
+
+    #[test]
+    fn test_client_binary_message_mapper_openai_encodes_resampled_audio() {
+        let mapper = build_client_binary_message_mapper(Provider::OpenAI, 16_000).unwrap();
+        let input = (0..160_i16).flat_map(i16::to_le_bytes).collect::<Vec<_>>();
+        let Some(ClientBinaryMessage::Text(text)) = mapper(input) else {
+            panic!("expected OpenAI binary audio to map to text JSON");
+        };
+
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["type"], "input_audio_buffer.append");
+        let output = base64::engine::general_purpose::STANDARD
+            .decode(parsed["audio"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(output.len(), 240 * std::mem::size_of::<i16>());
     }
 
     #[test]

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -1,5 +1,5 @@
 use anlg_transcription_core::{listener, listener2};
-use owhisper_client::AdapterKind;
+use owhisper_client::{AdapterKind, Provider};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
@@ -88,6 +88,12 @@ impl CaptureParams {
 
         let adapter_kind =
             AdapterKind::from_url_and_languages(&self.base_url, &self.languages, Some(&self.model));
+
+        if adapter_kind == AdapterKind::OpenAI
+            && self.model != Provider::OpenAI.default_live_model()
+        {
+            return listener::TranscriptionMode::Batch;
+        }
 
         if !adapter_kind.has_live_mode() {
             return listener::TranscriptionMode::Batch;
@@ -482,6 +488,13 @@ mod tests {
             params.default_transcription_mode(),
             TranscriptionMode::Batch
         );
+    }
+
+    #[test]
+    fn defaults_openai_live_capture_to_live_mode() {
+        let params = capture_params("https://api.openai.com/v1", "gpt-live-transcribe");
+
+        assert_eq!(params.default_transcription_mode(), TranscriptionMode::Live);
     }
 
     #[test]


### PR DESCRIPTION
Add GPT Transcribe request support and restore OpenAI Realtime transcription with GPT Live Transcribe.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6354 
- <kbd>&nbsp;2&nbsp;</kbd> #6352 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6351 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live transcription, WebSocket relay, and default OpenAI models across client, proxy, and desktop capture—regressions could affect streaming quality or routing, though coverage includes unit and live e2e tests.
> 
> **Overview**
> **OpenAI is no longer batch-only**: the listener dispatches `OpenAIAdapter` for live WebSockets, defaults shift to **`gpt-transcribe`** (batch) and **`gpt-live-transcribe`** (live), and Anarlog live routing can select OpenAI again.
> 
> **Batch API** gains the **`gpt-transcribe`** model with **`languages[]`** and **`keywords[]`** multipart fields (singular `language` for other models). The OpenAI batch client forwards all language hints and keywords when that model is selected.
> 
> **New realtime adapter** (`openai/live.rs`) speaks OpenAI’s transcription session protocol: `session.update` with server VAD, base64 PCM append at 24 kHz (with resampling), delta/completed event handling with ordered item draining, and plural hints for `gpt-live-transcribe` / `gpt-transcribe`. **`fork_session`** on `RealtimeSttAdapter` isolates live state so mic/speaker split streams use separate upstream sessions.
> 
> **Proxy and client plumbing**: transcribe-proxy builds OpenAI WS URLs (`intent=transcription`), maps binary audio to JSON append events, parses provider events through the adapter, and applies per-channel response transformers on stereo split. Capture mode selection treats **`gpt-live-transcribe`** as live; other OpenAI models stay batch unless configured otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb42cfc499b5db0704899054c6bcf06ab87f732d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->