### PR TITLE
Require local CI checks before commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,14 +13,20 @@ SQLite is the primary data store (schema and migrations in `crates/db-app/`, des
 - Web dev: `pnpm -F @hypr/web dev`
 - Dev docs: https://docs.anarlog.so
 
+## Pre-commit verification
+
+- Before every commit, run the locally available checks from the CI workflows affected by the changed paths. Do not defer routine validation to CI.
+- Always run `pnpm exec dprint fmt`, then `pnpm fmt:check`.
+- For TypeScript changes, run the affected package's typecheck and tests. For desktop changes, run `pnpm -F desktop typecheck` and `pnpm -F desktop test`; use `pnpm -r typecheck` when changes span packages.
+- For desktop TypeScript changes, run the CI lint command: `pnpm exec oxlint --quiet --format=github apps/desktop/src/`.
+- When desktop translated copy, message extraction, or catalogs may change, run `pnpm -F desktop exec lingui extract --clean --workers 1` and `pnpm -F desktop exec lingui compile --strict --workers 1`, include all generated `apps/desktop/src/i18n/locales` changes, and rerun until generation is stable. When there is no intentional uncommitted catalog diff, run the exact CI check: `pnpm -F desktop i18n:check`.
+- For Rust changes, run `cargo check` and the affected package tests. Match stricter workflow commands such as `cargo clippy --locked ... -D warnings` when the changed paths trigger them.
+- Check the relevant `.github/workflows/*_ci.*`, `fmt.yaml`, and `lint.yaml` files for package-specific tests, generated-file checks, or build validation, and run the locally reproducible commands before committing.
+- If a required check fails, fix it before committing. If a check cannot run locally because of platform, secrets, or unavailable infrastructure, report the exact skipped command and reason; do not claim full validation.
+
 ## Guidelines
 
-- Format via dprint after making changes.
 - JavaScript/TypeScript formatting runs through `oxfmt` via dprint's exec plugin.
-- Run `pnpm -r typecheck` after TypeScript changes, `cargo check` after Rust changes.
-- After editing files, run the relevant verification commands before finishing.
-- For `apps/desktop/` TypeScript changes, prefer `pnpm -F desktop typecheck` to match CI.
-- After edits, run `pnpm exec dprint fmt`.
 - Use `useForm` (tanstack-form) and `useQuery`/`useMutation` (tanstack-query) for form/mutation state. Avoid manual state management (e.g. `setError`).
 - For `plugins/db` live queries, keep schema creation, migrations, and DB initialization on the Rust side; TypeScript should only consume `execute`/`subscribe` APIs.
 - Branch naming: `fix/`, `chore/`, `refactor/` prefixes.


### PR DESCRIPTION
Document formatting, typecheck, test, lint, i18n, Rust, and generated-file validation gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor/agent workflow; no runtime, auth, or application code affected.
> 
> **Overview**
> **Adds a dedicated "Pre-commit verification" section to `AGENTS.md`** so agents and contributors run path-appropriate CI checks locally before committing, instead of relying on CI alone.
> 
> The new rules spell out **format** (`dprint fmt` + `pnpm fmt:check`), **TypeScript** typecheck/tests (desktop vs workspace-wide), **desktop oxlint**, **Lingui extract/compile** and `i18n:check` when copy changes, **Rust** `cargo check`/tests/clippy when workflows demand it, and consulting **`.github/workflows`** for anything else reproducible locally. Failures must be fixed before commit; skips need an explicit command and reason.
> 
> **Guidelines** are trimmed: redundant "run typecheck/cargo/dprint after edits" bullets are removed in favor of the pre-commit section, while formatting stack and other coding rules stay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d285f2bc948a18a7b4286d0b0fccaa17db2a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->