### PR TITLE
Add current intelligence and transcription models

### DIFF
--- a/apps/desktop/src/settings/ai/shared/list-cloudflare-workers-ai.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-cloudflare-workers-ai.test.ts
@@ -10,9 +10,12 @@ describe("createStaticCloudflareWorkersAIModelResult", () => {
     const result = createStaticCloudflareWorkersAIModelResult();
 
     expect(result.models).toEqual([...CLOUDFLARE_WORKERS_AI_MODELS]);
-    expect(result.models[0]).toBe("@cf/moonshotai/kimi-k2.6");
-    expect(result.metadata["@cf/moonshotai/kimi-k2.6"]).toEqual({
+    expect(result.models[0]).toBe("@cf/moonshotai/kimi-k2.7-code");
+    expect(result.metadata["@cf/moonshotai/kimi-k2.7-code"]).toEqual({
       input_modalities: ["text", "image"],
+    });
+    expect(result.metadata["@cf/zai-org/glm-5.2"]).toEqual({
+      input_modalities: ["text"],
     });
     expect(result.metadata["@cf/openai/gpt-oss-120b"]).toEqual({
       input_modalities: ["text"],

--- a/apps/desktop/src/settings/ai/shared/list-cloudflare-workers-ai.ts
+++ b/apps/desktop/src/settings/ai/shared/list-cloudflare-workers-ai.ts
@@ -2,6 +2,8 @@ import type { ListModelsResult, ModelMetadata } from "./list-common";
 import { DEFAULT_RESULT } from "./list-common";
 
 export const CLOUDFLARE_WORKERS_AI_MODELS = [
+  "@cf/moonshotai/kimi-k2.7-code",
+  "@cf/zai-org/glm-5.2",
   "@cf/moonshotai/kimi-k2.6",
   "@cf/zai-org/glm-4.7-flash",
   "@cf/openai/gpt-oss-120b",
@@ -15,6 +17,7 @@ export const CLOUDFLARE_WORKERS_AI_MODELS = [
 ] as const;
 
 const VISION_MODELS = new Set<string>([
+  "@cf/moonshotai/kimi-k2.7-code",
   "@cf/moonshotai/kimi-k2.6",
   "@cf/meta/llama-4-scout-17b-16e-instruct",
   "@cf/google/gemma-4-26b-a4b-it",

--- a/apps/desktop/src/settings/ai/shared/list-common.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.test.ts
@@ -61,6 +61,7 @@ describe("isOldModel", () => {
     expect(isOldModel("claude-sonnet-4-6")).toBe(true);
 
     expect(isOldModel("claude-fable-5")).toBe(false);
+    expect(isOldModel("claude-opus-5")).toBe(false);
     expect(isOldModel("claude-opus-4-8")).toBe(false);
     expect(isOldModel("claude-sonnet-5")).toBe(false);
     expect(isOldModel("claude-sonnet-latest")).toBe(false);
@@ -72,7 +73,8 @@ describe("isOldModel", () => {
     expect(isOldModel("mistral-small-2506")).toBe(true);
     expect(isOldModel("mistral-medium-3.1")).toBe(true);
 
-    expect(isOldModel("gemini-3.5-flash")).toBe(false);
+    expect(isOldModel("gemini-3.6-flash")).toBe(false);
+    expect(isOldModel("gemini-3.5-flash-lite")).toBe(false);
     expect(isOldModel("gemini-3.1-pro-preview")).toBe(false);
     expect(isOldModel("mistral-medium-3-5")).toBe(false);
     expect(isOldModel("mistral-large-2512")).toBe(false);
@@ -85,18 +87,22 @@ describe("sortModelsByRecency", () => {
       sortModelsByRecency([
         "openai/gpt-5.4-mini",
         "anthropic/claude-sonnet-4.6",
+        "anthropic/claude-opus-5",
         "anthropic/claude-sonnet-5",
         "openai/gpt-5.5",
-        "google/gemini-3.5-flash",
+        "google/gemini-3.6-flash",
+        "google/gemini-3.5-flash-lite",
         "openai/chat-latest",
       ]),
     ).toEqual([
       "openai/gpt-5.5",
       "openai/chat-latest",
+      "anthropic/claude-opus-5",
       "anthropic/claude-sonnet-5",
       "openai/gpt-5.4-mini",
       "anthropic/claude-sonnet-4.6",
-      "google/gemini-3.5-flash",
+      "google/gemini-3.6-flash",
+      "google/gemini-3.5-flash-lite",
     ]);
   });
 });

--- a/apps/desktop/src/settings/ai/shared/list-common.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.ts
@@ -53,6 +53,7 @@ const commonIgnoreKeywords = [
 const modelPriorityPatterns = [
   /(?:^|\/)gpt-5\.5$/,
   /(?:^|\/)(?:chat-latest|gpt-chat-latest)$/,
+  /(?:^|\/)claude-opus-5$/,
   /(?:^|\/)claude-sonnet-(?:5|latest)$/,
   /(?:^|\/)gpt-5\.4$/,
   /(?:^|\/)gpt-5\.4-mini$/,
@@ -61,6 +62,8 @@ const modelPriorityPatterns = [
   /(?:^|\/)claude-opus-4[-.]8$/,
   /(?:^|\/)claude-sonnet-4[-.]6$/,
   /(?:^|\/)claude-haiku-4[-.]5(?:-\d{8})?$/,
+  /(?:^|\/)gemini-3\.6-flash$/,
+  /(?:^|\/)gemini-3\.5-flash-lite$/,
   /(?:^|\/)gemini-3\.1-pro-preview$/,
   /(?:^|\/)gemini-3\.5-flash$/,
   /(?:^|\/)gemini-3-flash-preview$/,

--- a/apps/desktop/src/settings/ai/shared/model-capabilities.test.ts
+++ b/apps/desktop/src/settings/ai/shared/model-capabilities.test.ts
@@ -35,7 +35,7 @@ describe("modelSupportsImageInput", () => {
     expect(
       modelSupportsImageInput(
         "cloudflare_workers_ai",
-        "@cf/moonshotai/kimi-k2.6",
+        "@cf/moonshotai/kimi-k2.7-code",
       ),
     ).toBe(true);
     expect(

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -47,6 +47,14 @@ export const displayModelId = (model: string) => {
     return "Nova 3 Medical";
   }
 
+  if (model === "flux-general-multi") {
+    return "Flux General Multilingual";
+  }
+
+  if (model === "flux-general-en") {
+    return "Flux General English";
+  }
+
   if (model === "u3-rt-pro") {
     return "Universal 3.5 Pro Realtime";
   }
@@ -73,6 +81,10 @@ export const displayModelId = (model: string) => {
 
   if (model === "solaria-1") {
     return "Solaria 1";
+  }
+
+  if (model === "solaria-3") {
+    return "Solaria 3";
   }
 
   if (model === "scribe_v2_realtime") {
@@ -199,7 +211,12 @@ const _PROVIDERS = [
       <Icon icon="simple-icons:deepgram" className="text-foreground size-4" />
     ),
     baseUrl: "https://api.deepgram.com/v1",
-    models: ["nova-3-general", "nova-3-medical"],
+    models: [
+      "flux-general-multi",
+      "flux-general-en",
+      "nova-3-general",
+      "nova-3-medical",
+    ],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
   },
   {
@@ -290,7 +307,7 @@ const _PROVIDERS = [
       />
     ),
     baseUrl: "https://api.gladia.io",
-    models: ["solaria-1"],
+    models: ["solaria-3", "solaria-1"],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
   },
   {

--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -87,6 +87,10 @@ describe("getSttModelTranscriptionMode", () => {
     expect(getSttModelTranscriptionMode("mistral", "voxtral-mini-2602")).toBe(
       "batch",
     );
+    expect(getSttModelTranscriptionMode("deepgram", "flux-general-multi")).toBe(
+      "live",
+    );
+    expect(getSttModelTranscriptionMode("gladia", "solaria-3")).toBe("batch");
   });
 
   test("leaves models without an explicit mode to provider inference", () => {

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -182,6 +182,14 @@ export function getSttModelTranscriptionMode(
     }
   }
 
+  if (provider === "deepgram" && model?.startsWith("flux-")) {
+    return "live";
+  }
+
+  if (provider === "gladia" && model === "solaria-3") {
+    return "batch";
+  }
+
   return undefined;
 }
 

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -6,8 +6,9 @@ use ractor::{ActorProcessingErr, ActorRef};
 
 use owhisper_client::{
     AdapterKind, AnarlogAdapter, ArgmaxAdapter, AssemblyAIAdapter, CartesiaAdapter,
-    DashScopeAdapter, DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter,
-    MistralAdapter, OpenAIAdapter, RealtimeSttAdapter, SonioxAdapter, anlg_ws_client,
+    DashScopeAdapter, DeepgramAdapter, DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter,
+    GladiaAdapter, MistralAdapter, OpenAIAdapter, RealtimeSttAdapter, SonioxAdapter,
+    anlg_ws_client,
 };
 use owhisper_interface::stream::Extra;
 use owhisper_interface::{ControlMessage, MixedMessage};
@@ -75,6 +76,15 @@ pub(super) async fn spawn_rx_task(
     let adapter_kind =
         AdapterKind::from_url_and_languages(&args.base_url, &args.languages, Some(&args.model));
     let is_dual = matches!(args.mode, crate::actors::ChannelMode::MicAndSpeaker);
+
+    if adapter_kind == AdapterKind::Deepgram && DeepgramFluxAdapter::is_model(&args.model) {
+        let result = if is_dual {
+            spawn_rx_task_dual_with_adapter::<DeepgramFluxAdapter>(args, myself).await?
+        } else {
+            spawn_rx_task_single_with_adapter::<DeepgramFluxAdapter>(args, myself).await?
+        };
+        return Ok((result.0, result.1, result.2, "deepgram".to_string()));
+    }
 
     macro_rules! dispatch_realtime {
         ($ak:expr, $is_dual:expr, $args:expr, $myself:expr,

--- a/crates/llm-proxy/src/model.rs
+++ b/crates/llm-proxy/src/model.rs
@@ -69,7 +69,7 @@ impl Default for StaticModelResolver {
             MODEL_KEY_AUDIO.to_owned(),
             vec![
                 "google/gemini-3.1-pro-preview".into(),
-                "google/gemini-3.5-flash".into(),
+                "google/gemini-3.6-flash".into(),
                 "mistralai/voxtral-small-24b-2507".into(),
             ],
         );
@@ -182,7 +182,7 @@ mod tests {
                 None,
                 &[
                     "google/gemini-3.1-pro-preview",
-                    "google/gemini-3.5-flash",
+                    "google/gemini-3.6-flash",
                     "mistralai/voxtral-small-24b-2507",
                 ],
             ),
@@ -194,7 +194,7 @@ mod tests {
                 None,
                 &[
                     "google/gemini-3.1-pro-preview",
-                    "google/gemini-3.5-flash",
+                    "google/gemini-3.6-flash",
                     "mistralai/voxtral-small-24b-2507",
                 ],
             ),

--- a/crates/owhisper-client/src/adapter/deepgram/flux.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/flux.rs
@@ -1,0 +1,369 @@
+use anlg_ws_client::client::Message;
+use owhisper_interface::ListenParams;
+use owhisper_interface::stream::{
+    Alternatives, Channel, Metadata, ModelInfo, StreamResponse, Word,
+};
+use serde::Deserialize;
+
+use crate::adapter::{
+    DeepgramModel, RealtimeSttAdapter, extract_query_params, set_scheme_from_host,
+};
+
+#[derive(Clone, Default)]
+pub struct DeepgramFluxAdapter;
+
+impl DeepgramFluxAdapter {
+    pub fn is_model(model: &str) -> bool {
+        model
+            .parse::<DeepgramModel>()
+            .is_ok_and(|model| model.is_flux())
+    }
+
+    fn endpoint_url(api_base: &str) -> (url::Url, Vec<(String, String)>) {
+        let mut url: url::Url = api_base.parse().unwrap_or_else(|error| {
+            tracing::error!(%error, "invalid api_base for Deepgram Flux; using default API base");
+            "https://api.deepgram.com/v1"
+                .parse()
+                .expect("invalid_default_deepgram_api_base")
+        });
+        let existing_params = extract_query_params(&url);
+        url.set_query(None);
+
+        let path = url.path().trim_end_matches('/');
+        if matches!(path, "/v1" | "/v1/listen" | "/v2" | "/v2/listen") {
+            url.set_path("/v2/listen");
+        } else {
+            crate::adapter::append_path_if_missing(&mut url, "/v2/listen");
+        }
+        set_scheme_from_host(&mut url);
+
+        (url, existing_params)
+    }
+
+    fn build_url(api_base: &str, params: &ListenParams) -> url::Url {
+        let (mut url, existing_params) = Self::endpoint_url(api_base);
+        let model = params
+            .model
+            .as_deref()
+            .filter(|model| Self::is_model(model))
+            .unwrap_or("flux-general-multi");
+
+        {
+            let mut query = url.query_pairs_mut();
+            for (key, value) in existing_params {
+                query.append_pair(&key, &value);
+            }
+            query
+                .append_pair("model", model)
+                .append_pair("encoding", "linear16")
+                .append_pair("sample_rate", &params.sample_rate.to_string());
+
+            if model == "flux-general-multi" {
+                for language in &params.languages {
+                    query.append_pair("language_hint", language.iso639().code());
+                }
+            }
+            for keyword in &params.keywords {
+                query.append_pair("keyterm", keyword);
+            }
+            if let Some(custom_query) = &params.custom_query {
+                for (key, value) in custom_query {
+                    query.append_pair(key, value);
+                }
+            }
+        }
+
+        url
+    }
+
+    fn parse_turn(turn: FluxTurnInfo) -> Option<StreamResponse> {
+        if turn.transcript.is_empty() && turn.words.is_empty() {
+            return None;
+        }
+
+        let is_final = turn.event == FluxTurnEvent::EndOfTurn;
+        let confidence = turn.end_of_turn_confidence.unwrap_or_else(|| {
+            if turn.words.is_empty() {
+                1.0
+            } else {
+                turn.words.iter().map(|word| word.confidence).sum::<f64>() / turn.words.len() as f64
+            }
+        });
+        let languages = turn.languages.unwrap_or_default();
+        let word_language = (languages.len() == 1).then(|| languages[0].clone());
+        let words = turn
+            .words
+            .into_iter()
+            .map(|word| Word {
+                punctuated_word: Some(word.word.clone()),
+                language: word_language.clone(),
+                word: word.word,
+                start: word.start,
+                end: word.end,
+                confidence: word.confidence,
+                speaker: None,
+            })
+            .collect();
+
+        Some(StreamResponse::TranscriptResponse {
+            start: turn.audio_window_start,
+            duration: (turn.audio_window_end - turn.audio_window_start).max(0.0),
+            is_final,
+            speech_final: is_final,
+            from_finalize: false,
+            channel: Channel {
+                alternatives: vec![Alternatives {
+                    transcript: turn.transcript,
+                    words,
+                    confidence,
+                    languages,
+                }],
+            },
+            metadata: Metadata {
+                request_id: turn.request_id,
+                model_info: ModelInfo {
+                    name: "flux".to_string(),
+                    version: String::new(),
+                    arch: String::new(),
+                },
+                model_uuid: String::new(),
+                extra: None,
+            },
+            channel_index: vec![0, 1],
+        })
+    }
+}
+
+impl RealtimeSttAdapter for DeepgramFluxAdapter {
+    fn provider_name(&self) -> &'static str {
+        "deepgram"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        model: Option<&str>,
+    ) -> bool {
+        if languages.is_empty() {
+            return false;
+        }
+
+        let model = model
+            .and_then(|model| model.parse::<DeepgramModel>().ok())
+            .filter(DeepgramModel::is_flux);
+        crate::adapter::DeepgramAdapter::language_support_live(languages, model).is_supported()
+    }
+
+    fn supports_native_multichannel(&self) -> bool {
+        false
+    }
+
+    fn build_ws_url(&self, api_base: &str, params: &ListenParams, _channels: u8) -> url::Url {
+        Self::build_url(api_base, params)
+    }
+
+    fn build_auth_header(&self, api_key: Option<&str>) -> Option<(&'static str, String)> {
+        api_key.and_then(|key| crate::providers::Provider::Deepgram.build_auth_header(key))
+    }
+
+    fn keep_alive_message(&self) -> Option<Message> {
+        None
+    }
+
+    fn finalize_message(&self) -> Message {
+        Message::Text(r#"{"type":"CloseStream"}"#.into())
+    }
+
+    fn parse_response(&self, raw: &str) -> Vec<StreamResponse> {
+        let message: FluxMessage = match serde_json::from_str(raw) {
+            Ok(message) => message,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    anarlog.payload.size_bytes = raw.len(),
+                    "deepgram_flux_response_parse_failed"
+                );
+                return vec![];
+            }
+        };
+
+        match message {
+            FluxMessage::TurnInfo(turn) => Self::parse_turn(turn).into_iter().collect(),
+            FluxMessage::Error(error) => vec![StreamResponse::ErrorResponse {
+                error_code: None,
+                error_message: error
+                    .description
+                    .or(error.message)
+                    .unwrap_or_else(|| "Deepgram Flux returned an unknown error".to_string()),
+                provider: "deepgram".to_string(),
+            }],
+            FluxMessage::Connected
+            | FluxMessage::ConfigureSuccess
+            | FluxMessage::ConfigureFailure
+            | FluxMessage::Unknown => vec![],
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum FluxMessage {
+    TurnInfo(FluxTurnInfo),
+    #[serde(alias = "FatalError")]
+    Error(FluxError),
+    Connected,
+    ConfigureSuccess,
+    ConfigureFailure,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+struct FluxTurnInfo {
+    #[serde(default)]
+    request_id: String,
+    event: FluxTurnEvent,
+    #[serde(default)]
+    audio_window_start: f64,
+    #[serde(default)]
+    audio_window_end: f64,
+    #[serde(default)]
+    transcript: String,
+    #[serde(default)]
+    words: Vec<FluxWord>,
+    #[serde(default)]
+    languages: Option<Vec<String>>,
+    #[serde(default)]
+    end_of_turn_confidence: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+enum FluxTurnEvent {
+    Update,
+    StartOfTurn,
+    EagerEndOfTurn,
+    TurnResumed,
+    EndOfTurn,
+}
+
+#[derive(Debug, Deserialize)]
+struct FluxWord {
+    word: String,
+    start: f64,
+    end: f64,
+    confidence: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct FluxError {
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use anlg_language::ISO639;
+
+    use super::*;
+
+    #[test]
+    fn builds_flux_v2_url_with_language_hints_and_keyterms() {
+        let params = ListenParams {
+            model: Some("flux-general-multi".to_string()),
+            languages: vec![ISO639::En.into(), ISO639::Ja.into()],
+            sample_rate: 16000,
+            keywords: vec!["Anarlog".to_string()],
+            ..Default::default()
+        };
+
+        let url = DeepgramFluxAdapter.build_ws_url("https://api.deepgram.com/v1", &params, 1);
+
+        assert_eq!(url.path(), "/v2/listen");
+        assert!(url.as_str().starts_with("wss://"));
+        assert!(url.as_str().contains("model=flux-general-multi"));
+        assert!(url.as_str().contains("language_hint=en"));
+        assert!(url.as_str().contains("language_hint=ja"));
+        assert!(url.as_str().contains("keyterm=Anarlog"));
+        assert!(!url.as_str().contains("channels="));
+    }
+
+    #[test]
+    fn parses_final_turn_info() {
+        let raw = r#"{
+            "type": "TurnInfo",
+            "request_id": "request-1",
+            "event": "EndOfTurn",
+            "audio_window_start": 1.0,
+            "audio_window_end": 2.5,
+            "transcript": "hello world",
+            "words": [
+                {"word": "hello", "start": 1.0, "end": 1.5, "confidence": 0.9},
+                {"word": "world", "start": 1.6, "end": 2.0, "confidence": 0.8}
+            ],
+            "languages": ["en"],
+            "end_of_turn_confidence": 0.95
+        }"#;
+
+        let responses = DeepgramFluxAdapter.parse_response(raw);
+        let StreamResponse::TranscriptResponse {
+            duration,
+            is_final,
+            channel,
+            ..
+        } = &responses[0]
+        else {
+            panic!("expected transcript response");
+        };
+
+        assert_eq!(*duration, 1.5);
+        assert!(*is_final);
+        assert_eq!(channel.alternatives[0].transcript, "hello world");
+        assert_eq!(
+            channel.alternatives[0].words[0].language.as_deref(),
+            Some("en")
+        );
+    }
+
+    #[test]
+    fn parses_flux_error_discriminators() {
+        for message_type in ["Error", "FatalError"] {
+            let raw = format!(
+                r#"{{
+                    "type": "{message_type}",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "description": "internal failure"
+                }}"#
+            );
+
+            let responses = DeepgramFluxAdapter.parse_response(&raw);
+            let StreamResponse::ErrorResponse {
+                error_message,
+                provider,
+                ..
+            } = &responses[0]
+            else {
+                panic!("expected error response");
+            };
+
+            assert_eq!(error_message, "internal failure");
+            assert_eq!(provider, "deepgram");
+        }
+    }
+
+    #[test]
+    fn flux_models_are_live_only() {
+        let languages = [anlg_language::Language::new(ISO639::En)];
+        let model = Some(DeepgramModel::FluxGeneralEn);
+
+        assert!(
+            crate::adapter::DeepgramAdapter::language_support_live(&languages, model)
+                .is_supported()
+        );
+        assert!(
+            !crate::adapter::DeepgramAdapter::language_support_batch(&languages, model)
+                .is_supported()
+        );
+    }
+}

--- a/crates/owhisper-client/src/adapter/deepgram/mod.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/mod.rs
@@ -1,11 +1,14 @@
 mod batch;
 mod callback;
 pub mod error;
+mod flux;
 mod keywords;
 mod language;
 mod live;
 
 use super::{LanguageQuality, LanguageSupport};
+
+pub use flux::DeepgramFluxAdapter;
 
 // https://developers.deepgram.com/docs/models-languages-overview
 const NOVA3_GENERAL_LANGUAGES: &[&str] = &[
@@ -30,6 +33,8 @@ const NOVA3_MEDICAL_LANGUAGES: &[&str] = &[
 ];
 
 const ENGLISH_ONLY: &[&str] = &["en", "en-US"];
+const FLUX_MULTILINGUAL_LANGUAGES: &[&str] =
+    &["de", "en", "es", "fr", "hi", "it", "ja", "nl", "pt", "ru"];
 
 const EXCELLENT_LANGS: &[&str] = &["ru", "en", "es", "pl", "fr", "it"];
 
@@ -61,6 +66,10 @@ pub enum DeepgramModel {
         serialize = "nova-2-atc"
     )]
     Nova2Specialized,
+    #[strum(serialize = "flux-general-en")]
+    FluxGeneralEn,
+    #[strum(serialize = "flux-general-multi")]
+    FluxGeneralMulti,
 }
 
 impl DeepgramModel {
@@ -70,6 +79,8 @@ impl DeepgramModel {
             Self::Nova3Medical => NOVA3_MEDICAL_LANGUAGES,
             Self::Nova2General => NOVA2_GENERAL_LANGUAGES,
             Self::Nova2Specialized => ENGLISH_ONLY,
+            Self::FluxGeneralEn => ENGLISH_ONLY,
+            Self::FluxGeneralMulti => FLUX_MULTILINGUAL_LANGUAGES,
         }
     }
 
@@ -78,7 +89,20 @@ impl DeepgramModel {
     }
 
     pub fn supports_multi(&self, languages: &[anlg_language::Language]) -> bool {
-        language::can_use_multi(self.as_ref(), languages)
+        match self {
+            Self::FluxGeneralMulti => {
+                languages.len() >= 2
+                    && languages
+                        .iter()
+                        .all(|language| self.supports_language(language))
+            }
+            Self::FluxGeneralEn => false,
+            _ => language::can_use_multi(self.as_ref(), languages),
+        }
+    }
+
+    pub fn is_flux(&self) -> bool {
+        matches!(self, Self::FluxGeneralEn | Self::FluxGeneralMulti)
     }
 }
 
@@ -115,6 +139,10 @@ impl DeepgramAdapter {
         languages: &[anlg_language::Language],
         model: Option<DeepgramModel>,
     ) -> LanguageSupport {
+        if model.is_some_and(|model| model.is_flux()) {
+            return LanguageSupport::NotSupported;
+        }
+
         Self::language_support_impl(languages, model)
     }
 
@@ -195,6 +223,7 @@ impl DeepgramAdapter {
             Some(DeepgramModel::Nova3Medical) => Some("nova-3-medical"),
             Some(DeepgramModel::Nova2General) => Some("nova-2"),
             Some(DeepgramModel::Nova2Specialized) => Some("nova-2"),
+            Some(DeepgramModel::FluxGeneralEn | DeepgramModel::FluxGeneralMulti) => None,
             None => None,
         }
     }
@@ -206,6 +235,7 @@ pub(super) fn documented_language_codes() -> Vec<&'static str> {
     codes.extend_from_slice(NOVA2_GENERAL_LANGUAGES);
     codes.extend_from_slice(NOVA3_MEDICAL_LANGUAGES);
     codes.extend_from_slice(ENGLISH_ONLY);
+    codes.extend_from_slice(FLUX_MULTILINGUAL_LANGUAGES);
     codes
 }
 
@@ -481,6 +511,8 @@ mod tests {
             ("nova-2-meeting", DeepgramModel::Nova2Specialized),
             ("nova-2-phonecall", DeepgramModel::Nova2Specialized),
             ("nova-2-medical", DeepgramModel::Nova2Specialized),
+            ("flux-general-en", DeepgramModel::FluxGeneralEn),
+            ("flux-general-multi", DeepgramModel::FluxGeneralMulti),
         ];
 
         for (input, expected) in valid_cases {

--- a/crates/owhisper-client/src/adapter/gladia/batch.rs
+++ b/crates/owhisper-client/src/adapter/gladia/batch.rs
@@ -23,9 +23,9 @@ impl BatchSttAdapter for GladiaAdapter {
     fn is_supported_languages(
         &self,
         languages: &[anlg_language::Language],
-        _model: Option<&str>,
+        model: Option<&str>,
     ) -> bool {
-        GladiaAdapter::is_supported_languages_batch(languages)
+        GladiaAdapter::is_supported_languages_batch(languages, model)
     }
 
     fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(

--- a/crates/owhisper-client/src/adapter/gladia/language.rs
+++ b/crates/owhisper-client/src/adapter/gladia/language.rs
@@ -11,9 +11,22 @@ pub(super) const SUPPORTED_LANGUAGES: &[&str] = &[
     "wo", "yi", "yo",
 ];
 
+pub(super) const SOLARIA_3_LANGUAGES: &[&str] = &["de", "en", "es", "fr", "it"];
+
 pub(super) fn single_language_support(language: &anlg_language::Language) -> LanguageSupport {
     let code = language.iso639().code();
     if SUPPORTED_LANGUAGES.contains(&code) {
+        LanguageSupport::Supported {
+            quality: LanguageQuality::NoData,
+        }
+    } else {
+        LanguageSupport::NotSupported
+    }
+}
+
+pub(super) fn solaria_3_language_support(language: &anlg_language::Language) -> LanguageSupport {
+    let code = language.iso639().code();
+    if SOLARIA_3_LANGUAGES.contains(&code) {
         LanguageSupport::Supported {
             quality: LanguageQuality::NoData,
         }

--- a/crates/owhisper-client/src/adapter/gladia/live.rs
+++ b/crates/owhisper-client/src/adapter/gladia/live.rs
@@ -53,9 +53,9 @@ impl RealtimeSttAdapter for GladiaAdapter {
     fn is_supported_languages(
         &self,
         languages: &[anlg_language::Language],
-        _model: Option<&str>,
+        model: Option<&str>,
     ) -> bool {
-        GladiaAdapter::is_supported_languages_live(languages)
+        GladiaAdapter::is_supported_languages_live(languages, model)
     }
 
     fn supports_native_multichannel(&self) -> bool {

--- a/crates/owhisper-client/src/adapter/gladia/mod.rs
+++ b/crates/owhisper-client/src/adapter/gladia/mod.rs
@@ -10,20 +10,46 @@ use super::LanguageSupport;
 pub struct GladiaAdapter;
 
 impl GladiaAdapter {
-    pub fn language_support_live(languages: &[anlg_language::Language]) -> LanguageSupport {
+    pub fn language_support_live(
+        languages: &[anlg_language::Language],
+        model: Option<&str>,
+    ) -> LanguageSupport {
+        if model == Some("solaria-3") {
+            return LanguageSupport::NotSupported;
+        }
+
         LanguageSupport::min(languages.iter().map(language::single_language_support))
     }
 
-    pub fn language_support_batch(languages: &[anlg_language::Language]) -> LanguageSupport {
-        Self::language_support_live(languages)
+    pub fn language_support_batch(
+        languages: &[anlg_language::Language],
+        model: Option<&str>,
+    ) -> LanguageSupport {
+        if model == Some("solaria-3") && languages.len() != 1 {
+            return LanguageSupport::NotSupported;
+        }
+
+        let support = if model == Some("solaria-3") {
+            language::solaria_3_language_support
+        } else {
+            language::single_language_support
+        };
+
+        LanguageSupport::min(languages.iter().map(support))
     }
 
-    pub fn is_supported_languages_live(languages: &[anlg_language::Language]) -> bool {
-        Self::language_support_live(languages).is_supported()
+    pub fn is_supported_languages_live(
+        languages: &[anlg_language::Language],
+        model: Option<&str>,
+    ) -> bool {
+        Self::language_support_live(languages, model).is_supported()
     }
 
-    pub fn is_supported_languages_batch(languages: &[anlg_language::Language]) -> bool {
-        Self::language_support_batch(languages).is_supported()
+    pub fn is_supported_languages_batch(
+        languages: &[anlg_language::Language],
+        model: Option<&str>,
+    ) -> bool {
+        Self::language_support_batch(languages, model).is_supported()
     }
 
     pub(crate) fn build_ws_url_from_base(api_base: &str) -> (url::Url, Vec<(String, String)>) {
@@ -79,6 +105,7 @@ pub(super) fn documented_language_codes() -> &'static [&'static str] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anlg_language::ISO639;
 
     #[test]
     fn test_build_ws_url_from_base() {
@@ -139,5 +166,36 @@ mod tests {
     fn test_batch_api_url_custom() {
         let url = GladiaAdapter::batch_api_url("https://custom.gladia.io/v2");
         assert_eq!(url.as_str(), "https://custom.gladia.io/v2");
+    }
+
+    #[test]
+    fn solaria_3_is_batch_only_and_requires_one_supported_language() {
+        let supported = [ISO639::En, ISO639::Fr, ISO639::De, ISO639::Es, ISO639::It]
+            .map(anlg_language::Language::new);
+
+        for language in &supported {
+            assert!(
+                GladiaAdapter::language_support_batch(
+                    std::slice::from_ref(language),
+                    Some("solaria-3"),
+                )
+                .is_supported()
+            );
+        }
+        assert!(!GladiaAdapter::language_support_batch(&[], Some("solaria-3")).is_supported());
+        assert!(
+            !GladiaAdapter::language_support_batch(&supported[..2], Some("solaria-3"))
+                .is_supported()
+        );
+        assert!(
+            !GladiaAdapter::language_support_batch(
+                &[anlg_language::Language::new(ISO639::Ja)],
+                Some("solaria-3"),
+            )
+            .is_supported()
+        );
+        assert!(
+            !GladiaAdapter::language_support_live(&supported, Some("solaria-3")).is_supported()
+        );
     }
 }

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -484,7 +484,7 @@ impl AdapterKind {
             }
             Self::Soniox => SonioxAdapter::language_support_live(languages),
             Self::AssemblyAI => AssemblyAIAdapter::language_support_live(languages),
-            Self::Gladia => GladiaAdapter::language_support_live(languages),
+            Self::Gladia => GladiaAdapter::language_support_live(languages, model),
             Self::OpenAI => OpenAIAdapter::language_support_live(languages),
             Self::Fireworks => FireworksAdapter::language_support_live(languages),
             Self::ElevenLabs => ElevenLabsAdapter::language_support_live(languages),
@@ -510,7 +510,7 @@ impl AdapterKind {
             }
             Self::Soniox => SonioxAdapter::language_support_batch(languages),
             Self::AssemblyAI => AssemblyAIAdapter::language_support_batch(languages),
-            Self::Gladia => GladiaAdapter::language_support_batch(languages),
+            Self::Gladia => GladiaAdapter::language_support_batch(languages, model),
             Self::OpenAI => OpenAIAdapter::language_support_batch(languages),
             Self::Fireworks => FireworksAdapter::language_support_batch(languages),
             Self::ElevenLabs => ElevenLabsAdapter::language_support_batch(languages),

--- a/crates/owhisper-client/src/adapter/url_builder.rs
+++ b/crates/owhisper-client/src/adapter/url_builder.rs
@@ -71,6 +71,8 @@ pub fn resolve_model_for_languages<'a>(
                 DeepgramModel::Nova2General => "nova-2",
                 DeepgramModel::Nova3Medical => "nova-3-medical",
                 DeepgramModel::Nova2Specialized => "nova-2-meeting",
+                DeepgramModel::FluxGeneralEn => "flux-general-en",
+                DeepgramModel::FluxGeneralMulti => "flux-general-multi",
             })
             .unwrap_or(default),
     }

--- a/crates/owhisper-client/src/lib.rs
+++ b/crates/owhisper-client/src/lib.rs
@@ -24,9 +24,9 @@ pub use adapter::deepgram::DeepgramModel;
 pub use adapter::{
     AdapterKind, AnarlogAdapter, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter,
     BatchSttAdapter, CallbackResult, CallbackSttAdapter, CartesiaAdapter, DashScopeAdapter,
-    DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, LanguageQuality,
-    LanguageSupport, MistralAdapter, OpenAIAdapter, PyannoteAdapter, RealtimeSttAdapter,
-    SmallestAIAdapter, SonioxAdapter, WhisperCppAdapter, append_provider_param,
+    DeepgramAdapter, DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter,
+    LanguageQuality, LanguageSupport, MistralAdapter, OpenAIAdapter, PyannoteAdapter,
+    RealtimeSttAdapter, SmallestAIAdapter, SonioxAdapter, WhisperCppAdapter, append_provider_param,
     documented_language_codes_batch, documented_language_codes_live, is_anarlog_proxy,
     is_local_host, normalize_languages,
 };

--- a/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
@@ -2,9 +2,9 @@ use base64::Engine;
 use std::sync::Arc;
 
 use owhisper_client::{
-    AssemblyAIAdapter, Auth, CartesiaAdapter, DashScopeAdapter, DeepgramAdapter, ElevenLabsAdapter,
-    FireworksAdapter, GladiaAdapter, MistralAdapter, OpenAIAdapter, Provider, RealtimeSttAdapter,
-    SonioxAdapter, normalize_listen_params,
+    AssemblyAIAdapter, Auth, CartesiaAdapter, DashScopeAdapter, DeepgramAdapter,
+    DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, MistralAdapter,
+    OpenAIAdapter, Provider, RealtimeSttAdapter, SonioxAdapter, normalize_listen_params,
 };
 use owhisper_interface::ListenParams;
 
@@ -42,6 +42,14 @@ fn build_upstream_url_with_adapter(
     channels: u8,
 ) -> url::Url {
     match provider {
+        Provider::Deepgram
+            if params
+                .model
+                .as_deref()
+                .is_some_and(DeepgramFluxAdapter::is_model) =>
+        {
+            DeepgramFluxAdapter.build_ws_url(api_base, params, channels)
+        }
         Provider::Deepgram => DeepgramAdapter.build_ws_url(api_base, params, channels),
         Provider::AssemblyAI => AssemblyAIAdapter.build_ws_url(api_base, params, channels),
         Provider::Cartesia => CartesiaAdapter.build_ws_url(api_base, params, channels),
@@ -64,6 +72,14 @@ fn build_initial_message_with_adapter(
     channels: u8,
 ) -> Option<String> {
     let msg = match provider {
+        Provider::Deepgram
+            if params
+                .model
+                .as_deref()
+                .is_some_and(DeepgramFluxAdapter::is_model) =>
+        {
+            DeepgramFluxAdapter.initial_message(api_key, params, channels)
+        }
         Provider::Deepgram => DeepgramAdapter.initial_message(api_key, params, channels),
         Provider::AssemblyAI => AssemblyAIAdapter.initial_message(api_key, params, channels),
         Provider::Cartesia => CartesiaAdapter.initial_message(api_key, params, channels),
@@ -86,11 +102,15 @@ fn build_initial_message_with_adapter(
 
 fn build_response_transformer(
     provider: Provider,
+    model: Option<&str>,
 ) -> impl Fn(&str) -> Option<String> + Send + Sync + 'static {
     let mistral_adapter = MistralAdapter::default();
     let openai_adapter = OpenAIAdapter::default();
+    let is_deepgram_flux =
+        provider == Provider::Deepgram && model.is_some_and(DeepgramFluxAdapter::is_model);
     move |raw: &str| {
         let responses: Vec<owhisper_interface::stream::StreamResponse> = match provider {
+            Provider::Deepgram if is_deepgram_flux => DeepgramFluxAdapter.parse_response(raw),
             Provider::Deepgram => DeepgramAdapter.parse_response(raw),
             Provider::AssemblyAI => AssemblyAIAdapter.parse_response(raw),
             Provider::Cartesia => CartesiaAdapter.parse_response(raw),
@@ -138,12 +158,23 @@ fn proxy_debug_enabled() -> bool {
         .unwrap_or(false)
 }
 
-fn build_client_message_filter(provider: Provider) -> ClientMessageFilter {
+fn build_client_message_filter(provider: Provider, model: Option<&str>) -> ClientMessageFilter {
+    let is_deepgram_flux =
+        provider == Provider::Deepgram && model.is_some_and(DeepgramFluxAdapter::is_model);
     Arc::new(move |text: String| {
         let msg = match serde_json::from_str::<owhisper_interface::ControlMessage>(&text) {
             Ok(msg) => msg,
             Err(_) => return Some(text),
         };
+        if is_deepgram_flux {
+            return match msg {
+                owhisper_interface::ControlMessage::Finalize
+                | owhisper_interface::ControlMessage::CloseStream => {
+                    Some(r#"{"type":"CloseStream"}"#.to_string())
+                }
+                owhisper_interface::ControlMessage::KeepAlive => None,
+            };
+        }
         provider.translate_control_message(&msg)
     })
 }
@@ -181,21 +212,24 @@ fn build_proxy_plan(
     selected: &SelectedProvider,
     channels: u8,
     sample_rate: u32,
+    model: Option<&str>,
     config: &SttProxyConfig,
     analytics_ctx: AnalyticsContext,
 ) -> Result<StreamingProxyPlan, crate::ProxyError> {
     let mut plan = StreamingProxyPlan::new(StreamingTransport::for_channels(
         channels,
-        provider.supports_native_multichannel(),
+        provider.supports_native_multichannel()
+            && !(provider == Provider::Deepgram
+                && model.is_some_and(DeepgramFluxAdapter::is_model)),
     )?)
     .connect_timeout(config.connect_timeout)
     .control_message_types(provider.control_message_types())
-    .response_transformer(build_response_transformer(provider))
-    .client_message_filter(build_client_message_filter(provider))
+    .response_transformer(build_response_transformer(provider, model))
+    .client_message_filter(build_client_message_filter(provider, model))
     .apply_auth(selected);
 
     if plan.upstream_count() == 2 {
-        plan = plan.split_response_transformer(build_response_transformer(provider));
+        plan = plan.split_response_transformer(build_response_transformer(provider, model));
     }
 
     if let Some(mapper) = build_client_binary_message_mapper(provider, sample_rate) {
@@ -210,29 +244,22 @@ fn build_proxy_plan(
 }
 
 fn build_proxy_with_adapter(
-    client_params: &QueryParams,
+    listen_params: &ListenParams,
+    channels: u8,
     api_base: &str,
     mut plan: StreamingProxyPlan,
     provider: Provider,
     api_key: &str,
 ) -> Result<StreamingProxy, crate::ProxyError> {
-    let mut listen_params = build_listen_params(client_params);
-    let channels: u8 = parse_param(client_params, "channels", 1);
-    if matches!(provider, Provider::AquaVoice | Provider::Pyannote) {
-        return Err(crate::ProxyError::InvalidRequest(format!(
-            "{provider} only supports batch transcription"
-        )));
-    }
-    resolve_model_live(provider, &mut listen_params);
     let upstream_channels = plan.upstream_request_channels(channels);
 
     let upstream_url =
-        build_upstream_url_with_adapter(provider, api_base, &listen_params, upstream_channels);
+        build_upstream_url_with_adapter(provider, api_base, listen_params, upstream_channels);
 
     let initial_message = build_initial_message_with_adapter(
         provider,
         Some(api_key),
-        &listen_params,
+        listen_params,
         upstream_channels,
     );
 
@@ -251,11 +278,21 @@ pub async fn build_proxy(
 ) -> Result<StreamingProxy, ProxyBuildError> {
     let provider = selected.provider();
     let channels: u8 = parse_param(params, "channels", 1);
+    if matches!(provider, Provider::AquaVoice | Provider::Pyannote) {
+        return Err(ProxyBuildError::ProxyError(
+            crate::ProxyError::InvalidRequest(format!(
+                "{provider} only supports batch transcription"
+            )),
+        ));
+    }
+    let mut listen_params = build_listen_params(params);
+    resolve_model_live(provider, &mut listen_params);
     let plan = build_proxy_plan(
         provider,
         selected,
         channels,
-        parse_param(params, "sample_rate", 16000),
+        listen_params.sample_rate,
+        listen_params.model.as_deref(),
         &state.config,
         analytics_ctx,
     )?;
@@ -267,7 +304,8 @@ pub async fn build_proxy(
         Auth::SessionInit { header_name } => {
             if selected.upstream_url().is_some() {
                 Ok(build_proxy_with_adapter(
-                    params,
+                    &listen_params,
+                    channels,
                     api_base,
                     plan,
                     provider,
@@ -307,7 +345,8 @@ pub async fn build_proxy(
             }
         }
         _ => Ok(build_proxy_with_adapter(
-            params,
+            &listen_params,
+            channels,
             api_base,
             plan,
             provider,
@@ -443,6 +482,29 @@ mod tests {
     }
 
     #[test]
+    fn test_build_upstream_url_deepgram_flux() {
+        let params = ListenParams {
+            model: Some("flux-general-multi".to_string()),
+            languages: vec![ISO639::En.into(), ISO639::Ja.into()],
+            sample_rate: 16000,
+            channels: 1,
+            ..Default::default()
+        };
+
+        let url = build_upstream_url_with_adapter(
+            Provider::Deepgram,
+            "https://api.deepgram.com/v1",
+            &params,
+            1,
+        );
+
+        assert_eq!(url.path(), "/v2/listen");
+        assert!(url.as_str().contains("model=flux-general-multi"));
+        assert!(url.as_str().contains("language_hint=en"));
+        assert!(url.as_str().contains("language_hint=ja"));
+    }
+
+    #[test]
     fn test_build_upstream_url_soniox() {
         let params = ListenParams {
             model: Some("stt-rt-v3".to_string()),
@@ -494,7 +556,7 @@ mod tests {
 
     #[test]
     fn test_response_transformer_deepgram() {
-        let transformer = build_response_transformer(Provider::Deepgram);
+        let transformer = build_response_transformer(Provider::Deepgram, Some("nova-3"));
 
         let deepgram_response = r#"{
             "type": "Results",
@@ -530,8 +592,32 @@ mod tests {
     }
 
     #[test]
+    fn test_response_transformer_deepgram_flux() {
+        let transformer =
+            build_response_transformer(Provider::Deepgram, Some("flux-general-multi"));
+        let result = transformer(
+            r#"{
+                "type": "TurnInfo",
+                "request_id": "test",
+                "event": "EndOfTurn",
+                "audio_window_start": 0.0,
+                "audio_window_end": 1.0,
+                "transcript": "hello",
+                "words": [
+                    {"word": "hello", "start": 0.0, "end": 0.5, "confidence": 0.9}
+                ],
+                "languages": ["en"]
+            }"#,
+        );
+
+        let parsed: serde_json::Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(parsed["type"], "Results");
+        assert_eq!(parsed["channel"]["alternatives"][0]["transcript"], "hello");
+    }
+
+    #[test]
     fn test_response_transformer_empty_response() {
-        let transformer = build_response_transformer(Provider::Soniox);
+        let transformer = build_response_transformer(Provider::Soniox, None);
 
         let result = transformer("{}");
         assert!(result.is_none());
@@ -539,7 +625,7 @@ mod tests {
 
     #[test]
     fn test_client_message_filter_deepgram_identity() {
-        let filter = build_client_message_filter(Provider::Deepgram);
+        let filter = build_client_message_filter(Provider::Deepgram, Some("nova-3"));
         assert_eq!(
             filter(r#"{"type":"KeepAlive"}"#.to_string()),
             Some(r#"{"type":"KeepAlive"}"#.to_string())
@@ -552,8 +638,22 @@ mod tests {
     }
 
     #[test]
+    fn test_client_message_filter_deepgram_flux_translates_finalize() {
+        let filter = build_client_message_filter(Provider::Deepgram, Some("flux-general-multi"));
+        assert_eq!(filter(r#"{"type":"KeepAlive"}"#.to_string()), None);
+        assert_eq!(
+            filter(r#"{"type":"Finalize"}"#.to_string()),
+            Some(r#"{"type":"CloseStream"}"#.to_string())
+        );
+        assert_eq!(
+            filter(r#"{"type":"CloseStream"}"#.to_string()),
+            Some(r#"{"type":"CloseStream"}"#.to_string())
+        );
+    }
+
+    #[test]
     fn test_client_message_filter_soniox_translates_control_messages() {
-        let filter = build_client_message_filter(Provider::Soniox);
+        let filter = build_client_message_filter(Provider::Soniox, None);
 
         assert_eq!(filter(r#"{"type":"CloseStream"}"#.to_string()), None);
         assert_eq!(
@@ -568,7 +668,7 @@ mod tests {
 
     #[test]
     fn test_client_message_filter_assemblyai_translates_finalize() {
-        let filter = build_client_message_filter(Provider::AssemblyAI);
+        let filter = build_client_message_filter(Provider::AssemblyAI, None);
         assert_eq!(filter(r#"{"type":"KeepAlive"}"#.to_string()), None);
         assert_eq!(
             filter(r#"{"type":"Finalize"}"#.to_string()),
@@ -578,7 +678,7 @@ mod tests {
 
     #[test]
     fn test_client_message_filter_non_json_passthrough() {
-        let filter = build_client_message_filter(Provider::Soniox);
+        let filter = build_client_message_filter(Provider::Soniox, None);
         assert_eq!(filter("not json".to_string()), Some("not json".to_string()));
     }
 


### PR DESCRIPTION
Prioritize new hosted LLMs and add protocol support for Deepgram Flux plus Gladia Solaria-3.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6354 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6352 
- <kbd>&nbsp;1&nbsp;</kbd> #6351 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New real-time STT paths (Flux WebSocket protocol and proxy routing) touch core transcription infrastructure, though behavior is covered by unit tests; catalog changes are comparatively low risk.
> 
> **Overview**
> Adds **live Deepgram Flux** (`flux-general-en` / `flux-general-multi`) end-to-end: a dedicated `DeepgramFluxAdapter` talks to `/v2/listen`, maps `TurnInfo` into the existing stream format, and is selected in the desktop listener and STT proxy (including Flux-specific finalize/keep-alive handling and disabling native multichannel for Flux).
> 
> Exposes **Gladia Solaria-3** as a **batch-only** STT option with a tighter language set (single language: de/en/es/fr/it) and model-aware Gladia language checks.
> 
> Refreshes **hosted model pickers and defaults**: Workers AI leads with `@cf/moonshotai/kimi-k2.7-code` plus `@cf/zai-org/glm-5.2`; chat sorting/`isOldModel` rules add **Claude Opus 5**, **Gemini 3.6 Flash**, and **Gemini 3.5 Flash Lite**; the LLM proxy audio fallback list uses **gemini-3.6-flash** instead of **gemini-3.5-flash**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49cb264e4f8e99ea87b558ddb58c502fb1d5a46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->