### PR TITLE
feat: add Apple Watch recording foundation

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -1,0 +1,87 @@
+name: mobile_ci
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/actions/pnpm_install/**
+      - .github/workflows/mobile_ci.yaml
+      - apps/mobile/**
+      - apps/watch/apple/**
+      - packages/db-react/**
+      - packages/db-runtime/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+  pull_request:
+    paths:
+      - .github/actions/pnpm_install/**
+      - .github/workflows/mobile_ci.yaml
+      - apps/mobile/**
+      - apps/watch/apple/**
+      - packages/db-react/**
+      - packages/db-runtime/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+
+permissions:
+  contents: read
+
+env:
+  CI: "1"
+  EXPO_NO_GIT_STATUS: "1"
+  SENTRY_DISABLE_AUTO_UPLOAD: "true"
+
+jobs:
+  watchos_build:
+    runs-on: depot-macos-26
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          xcodebuild \
+            -project apps/watch/apple/AnarlogWatch.xcodeproj \
+            -scheme AnarlogWatch \
+            -configuration Release \
+            -destination "generic/platform=watchOS Simulator" \
+            -derivedDataPath "$RUNNER_TEMP/AnarlogWatchDerivedData" \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+  ios_build:
+    runs-on: depot-macos-26
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pnpm_install
+      - run: |
+          pnpm -F @anlg/mobile exec expo run:ios \
+            --configuration Release \
+            --device generic \
+            --output "$RUNNER_TEMP/anarlog-mobile-ios" \
+            --no-bundler
+
+  android_build:
+    runs-on: depot-ubuntu-24.04-8
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pnpm_install
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - run: pnpm -F @anlg/mobile exec expo prebuild --platform android --no-install
+      - run: ./gradlew :app:assembleRelease --no-daemon
+        working-directory: apps/mobile/android
+
+  mobile_ci:
+    if: always()
+    needs: [watchos_build, ios_build, android_build]
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/apps/mobile/modules/watch-connectivity/expo-module.config.json
+++ b/apps/mobile/modules/watch-connectivity/expo-module.config.json
@@ -1,0 +1,9 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["AnarlogWatchConnectivityModule"],
+    "appDelegateSubscribers": [
+      "AnarlogWatchConnectivityAppDelegateSubscriber"
+    ]
+  }
+}

--- a/apps/mobile/modules/watch-connectivity/index.ts
+++ b/apps/mobile/modules/watch-connectivity/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./src/AnarlogWatchConnectivityModule";
+export * from "./src/AnarlogWatchConnectivity.types";

--- a/apps/mobile/modules/watch-connectivity/ios/AnarlogWatchConnectivity.podspec
+++ b/apps/mobile/modules/watch-connectivity/ios/AnarlogWatchConnectivity.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name           = 'AnarlogWatchConnectivity'
+  s.version        = '1.0.0'
+  s.summary        = 'Connects the Anarlog iPhone and watchOS apps.'
+  s.description    = 'Transfers account state and watch recordings through Watch Connectivity.'
+  s.author         = 'Anarlog'
+  s.homepage       = 'https://anarlog.so'
+  s.platform       = :ios, '16.4'
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+  s.frameworks = 'WatchConnectivity'
+
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/apps/mobile/modules/watch-connectivity/ios/AnarlogWatchConnectivityModule.swift
+++ b/apps/mobile/modules/watch-connectivity/ios/AnarlogWatchConnectivityModule.swift
@@ -1,0 +1,353 @@
+import ExpoModulesCore
+import Foundation
+import UIKit
+import WatchConnectivity
+
+public class AnarlogWatchConnectivityModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("AnarlogWatchConnectivity")
+
+    Events("onRecordingReceived", "onStateChanged")
+
+    OnCreate {
+      WatchConnectivityService.shared.attach(module: self)
+    }
+
+    OnDestroy {
+      WatchConnectivityService.shared.detach(module: self)
+    }
+
+    Function("updateAccount") { (userId: String?, email: String?) in
+      WatchConnectivityService.shared.updateAccount(
+        userId: userId,
+        email: email
+      )
+    }
+
+    Function("getState") {
+      WatchConnectivityService.shared.statePayload()
+    }
+
+    Function("getPendingRecordings") {
+      WatchConnectivityService.shared.pendingRecordingPayloads()
+    }
+
+    Function("markRecordingImported") { (id: String) in
+      WatchConnectivityService.shared.markRecordingImported(id: id)
+    }
+  }
+
+  fileprivate func emitRecording(_ recording: PendingWatchRecording) {
+    sendEvent("onRecordingReceived", recording.payload)
+  }
+
+  fileprivate func emitState(_ state: [String: Any]) {
+    sendEvent("onStateChanged", state)
+  }
+}
+
+public class AnarlogWatchConnectivityAppDelegateSubscriber:
+  ExpoAppDelegateSubscriber
+{
+  public func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    WatchConnectivityService.shared.activate()
+    return true
+  }
+}
+
+private struct PendingWatchRecording: Codable {
+  let id: String
+  let uri: String
+  let filename: String
+  let recordedAt: String
+  let accountUserId: String
+
+  var payload: [String: Any] {
+    [
+      "id": id,
+      "uri": uri,
+      "filename": filename,
+      "recordedAt": recordedAt,
+      "accountUserId": accountUserId,
+    ]
+  }
+}
+
+private final class WatchConnectivityService: NSObject, WCSessionDelegate {
+  static let shared = WatchConnectivityService()
+
+  private let accountUserIdKey = "watch-connectivity-account-user-id"
+  private let accountEmailKey = "watch-connectivity-account-email"
+  private let pendingRecordingsKey = "watch-connectivity-pending-recordings"
+  private let defaults = UserDefaults.standard
+  private weak var module: AnarlogWatchConnectivityModule?
+
+  private override init() {
+    super.init()
+  }
+
+  func attach(module: AnarlogWatchConnectivityModule) {
+    self.module = module
+    activate()
+    emitState()
+  }
+
+  func detach(module: AnarlogWatchConnectivityModule) {
+    if self.module === module {
+      self.module = nil
+    }
+  }
+
+  func activate() {
+    guard WCSession.isSupported() else {
+      return
+    }
+
+    let session = WCSession.default
+    session.delegate = self
+    session.activate()
+  }
+
+  func updateAccount(userId: String?, email: String?) {
+    if let userId, !userId.isEmpty {
+      defaults.set(userId, forKey: accountUserIdKey)
+      defaults.set(email, forKey: accountEmailKey)
+    } else {
+      defaults.removeObject(forKey: accountUserIdKey)
+      defaults.removeObject(forKey: accountEmailKey)
+    }
+
+    pushAccountContext()
+  }
+
+  func statePayload() -> [String: Any] {
+    guard WCSession.isSupported() else {
+      return [
+        "supported": false,
+        "activationState": "unsupported",
+        "paired": false,
+        "watchAppInstalled": false,
+        "reachable": false,
+      ]
+    }
+
+    let session = WCSession.default
+    return [
+      "supported": true,
+      "activationState": activationStateName(session.activationState),
+      "paired": session.activationState == .activated && session.isPaired,
+      "watchAppInstalled": session.activationState == .activated
+        && session.isWatchAppInstalled,
+      "reachable": session.activationState == .activated
+        && session.isReachable,
+    ]
+  }
+
+  func pendingRecordingPayloads() -> [[String: Any]] {
+    guard let userId = defaults.string(forKey: accountUserIdKey) else {
+      return []
+    }
+    return pendingRecordings()
+      .filter { $0.accountUserId == userId }
+      .map(\.payload)
+  }
+
+  func markRecordingImported(id: String) {
+    var recordings = pendingRecordings()
+    guard let index = recordings.firstIndex(where: { $0.id == id }) else {
+      return
+    }
+
+    let recording = recordings.remove(at: index)
+    if let url = URL(string: recording.uri) {
+      try? FileManager.default.removeItem(at: url)
+    }
+    persist(recordings)
+  }
+
+  private func accountContext() -> [String: Any] {
+    guard let userId = defaults.string(forKey: accountUserIdKey) else {
+      return [
+        "schema_version": 1,
+        "kind": "account",
+        "signed_in": false,
+      ]
+    }
+
+    var context: [String: Any] = [
+      "schema_version": 1,
+      "kind": "account",
+      "signed_in": true,
+      "user_id": userId,
+    ]
+    if let email = defaults.string(forKey: accountEmailKey), !email.isEmpty {
+      context["email"] = email
+    }
+    return context
+  }
+
+  private func pushAccountContext() {
+    guard WCSession.isSupported() else {
+      return
+    }
+
+    let session = WCSession.default
+    guard session.activationState == .activated else {
+      return
+    }
+
+    try? session.updateApplicationContext(accountContext())
+    if session.isReachable {
+      session.sendMessage(
+        accountContext(),
+        replyHandler: nil,
+        errorHandler: nil
+      )
+    }
+    emitState()
+  }
+
+  private func receive(_ file: WCSessionFile) {
+    let metadata = file.metadata ?? [:]
+    guard let accountUserId = metadata["account_user_id"] as? String else {
+      return
+    }
+    let id = metadata["id"] as? String ?? UUID().uuidString
+    let recordedAt =
+      metadata["recorded_at"] as? String
+      ?? ISO8601DateFormatter().string(from: Date())
+    let fileExtension =
+      file.fileURL.pathExtension.isEmpty
+      ? "m4a"
+      : file.fileURL.pathExtension
+    let filename = "\(id).\(fileExtension)"
+
+    do {
+      let directory = try watchInboxDirectory()
+      let destination = directory.appendingPathComponent(filename)
+      if FileManager.default.fileExists(atPath: destination.path) {
+        try FileManager.default.removeItem(at: destination)
+      }
+      try FileManager.default.moveItem(at: file.fileURL, to: destination)
+
+      var recordings = pendingRecordings()
+      let recording = PendingWatchRecording(
+        id: id,
+        uri: destination.absoluteString,
+        filename: filename,
+        recordedAt: recordedAt,
+        accountUserId: accountUserId
+      )
+      recordings.removeAll(where: { $0.id == id })
+      recordings.append(recording)
+      persist(recordings)
+
+      DispatchQueue.main.async { [weak self] in
+        guard let self else {
+          return
+        }
+        guard
+          self.defaults.string(forKey: self.accountUserIdKey)
+            == recording.accountUserId
+        else {
+          return
+        }
+        self.module?.emitRecording(recording)
+      }
+    } catch {
+      return
+    }
+  }
+
+  private func watchInboxDirectory() throws -> URL {
+    let directory = FileManager.default
+      .urls(for: .documentDirectory, in: .userDomainMask)[0]
+      .appendingPathComponent("watch-inbox", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: directory,
+      withIntermediateDirectories: true
+    )
+    return directory
+  }
+
+  private func pendingRecordings() -> [PendingWatchRecording] {
+    guard let data = defaults.data(forKey: pendingRecordingsKey) else {
+      return []
+    }
+    return (try? JSONDecoder().decode([PendingWatchRecording].self, from: data))
+      ?? []
+  }
+
+  private func persist(_ recordings: [PendingWatchRecording]) {
+    guard let data = try? JSONEncoder().encode(recordings) else {
+      return
+    }
+    defaults.set(data, forKey: pendingRecordingsKey)
+  }
+
+  private func activationStateName(
+    _ state: WCSessionActivationState
+  ) -> String {
+    switch state {
+    case .notActivated:
+      return "not_activated"
+    case .inactive:
+      return "inactive"
+    case .activated:
+      return "activated"
+    @unknown default:
+      return "unknown"
+    }
+  }
+
+  private func emitState() {
+    let state = statePayload()
+    DispatchQueue.main.async { [weak self] in
+      self?.module?.emitState(state)
+    }
+  }
+
+  func session(
+    _ session: WCSession,
+    activationDidCompleteWith activationState: WCSessionActivationState,
+    error: Error?
+  ) {
+    if error == nil && activationState == .activated {
+      pushAccountContext()
+    }
+    emitState()
+  }
+
+  func sessionDidBecomeInactive(_ session: WCSession) {
+    emitState()
+  }
+
+  func sessionDidDeactivate(_ session: WCSession) {
+    session.activate()
+    emitState()
+  }
+
+  func sessionWatchStateDidChange(_ session: WCSession) {
+    pushAccountContext()
+    emitState()
+  }
+
+  func session(
+    _ session: WCSession,
+    didReceiveMessage message: [String: Any],
+    replyHandler: @escaping ([String: Any]) -> Void
+  ) {
+    if message["kind"] as? String == "account_request" {
+      replyHandler(accountContext())
+    } else {
+      replyHandler([:])
+    }
+  }
+
+  func session(_ session: WCSession, didReceive file: WCSessionFile) {
+    receive(file)
+  }
+}

--- a/apps/mobile/modules/watch-connectivity/ios/AnarlogWatchConnectivityModule.swift
+++ b/apps/mobile/modules/watch-connectivity/ios/AnarlogWatchConnectivityModule.swift
@@ -82,6 +82,8 @@ private final class WatchConnectivityService: NSObject, WCSessionDelegate {
   private let accountUserIdKey = "watch-connectivity-account-user-id"
   private let accountEmailKey = "watch-connectivity-account-email"
   private let pendingRecordingsKey = "watch-connectivity-pending-recordings"
+  private let pendingAcknowledgementsKey =
+    "watch-connectivity-pending-acknowledgements"
   private let defaults = UserDefaults.standard
   private let recordingsQueue = DispatchQueue(
     label: "so.anarlog.watch-connectivity.recordings"
@@ -161,17 +163,25 @@ private final class WatchConnectivityService: NSObject, WCSessionDelegate {
   }
 
   func markRecordingImported(id: String) {
-    recordingsQueue.sync {
+    let imported = recordingsQueue.sync {
       var recordings = pendingRecordings()
       guard let index = recordings.firstIndex(where: { $0.id == id }) else {
-        return
+        return false
       }
 
       let recording = recordings.remove(at: index)
+      var acknowledgements = pendingAcknowledgements()
+      acknowledgements[id] = "recording_imported"
+      persistAcknowledgements(acknowledgements)
       if let url = URL(string: recording.uri) {
         try? FileManager.default.removeItem(at: url)
       }
       persist(recordings)
+      return true
+    }
+
+    if imported {
+      flushAcknowledgements()
     }
   }
 
@@ -207,6 +217,7 @@ private final class WatchConnectivityService: NSObject, WCSessionDelegate {
     }
 
     try? session.updateApplicationContext(accountContext())
+    flushAcknowledgements()
     if session.isReachable {
       session.sendMessage(
         accountContext(),
@@ -255,15 +266,8 @@ private final class WatchConnectivityService: NSObject, WCSessionDelegate {
         return recording
       }
     } catch {
+      queueAcknowledgement(kind: "recording_receive_failed", id: id)
       return
-    }
-
-    if session.activationState == .activated {
-      session.transferUserInfo([
-        "schema_version": 1,
-        "kind": "recording_received",
-        "id": id,
-      ])
     }
 
     DispatchQueue.main.async { [weak self] in
@@ -304,6 +308,61 @@ private final class WatchConnectivityService: NSObject, WCSessionDelegate {
       return
     }
     defaults.set(data, forKey: pendingRecordingsKey)
+  }
+
+  private func queueAcknowledgement(kind: String, id: String) {
+    recordingsQueue.sync {
+      var acknowledgements = pendingAcknowledgements()
+      acknowledgements[id] = kind
+      persistAcknowledgements(acknowledgements)
+    }
+    flushAcknowledgements()
+  }
+
+  private func flushAcknowledgements() {
+    guard WCSession.isSupported() else {
+      return
+    }
+
+    let session = WCSession.default
+    guard session.activationState == .activated else {
+      return
+    }
+
+    let acknowledgements = recordingsQueue.sync {
+      pendingAcknowledgements()
+    }
+    for (id, kind) in acknowledgements {
+      session.transferUserInfo([
+        "schema_version": 1,
+        "kind": kind,
+        "id": id,
+      ])
+    }
+
+    recordingsQueue.sync {
+      var pending = pendingAcknowledgements()
+      for (id, kind) in acknowledgements where pending[id] == kind {
+        pending.removeValue(forKey: id)
+      }
+      persistAcknowledgements(pending)
+    }
+  }
+
+  private func pendingAcknowledgements() -> [String: String] {
+    guard let data = defaults.data(forKey: pendingAcknowledgementsKey) else {
+      return [:]
+    }
+    return (try? JSONDecoder().decode([String: String].self, from: data)) ?? [:]
+  }
+
+  private func persistAcknowledgements(
+    _ acknowledgements: [String: String]
+  ) {
+    guard let data = try? JSONEncoder().encode(acknowledgements) else {
+      return
+    }
+    defaults.set(data, forKey: pendingAcknowledgementsKey)
   }
 
   private func activationStateName(

--- a/apps/mobile/modules/watch-connectivity/ios/AnarlogWatchConnectivityModule.swift
+++ b/apps/mobile/modules/watch-connectivity/ios/AnarlogWatchConnectivityModule.swift
@@ -83,6 +83,9 @@ private final class WatchConnectivityService: NSObject, WCSessionDelegate {
   private let accountEmailKey = "watch-connectivity-account-email"
   private let pendingRecordingsKey = "watch-connectivity-pending-recordings"
   private let defaults = UserDefaults.standard
+  private let recordingsQueue = DispatchQueue(
+    label: "so.anarlog.watch-connectivity.recordings"
+  )
   private weak var module: AnarlogWatchConnectivityModule?
 
   private override init() {
@@ -150,22 +153,26 @@ private final class WatchConnectivityService: NSObject, WCSessionDelegate {
     guard let userId = defaults.string(forKey: accountUserIdKey) else {
       return []
     }
-    return pendingRecordings()
-      .filter { $0.accountUserId == userId }
-      .map(\.payload)
+    return recordingsQueue.sync {
+      pendingRecordings()
+        .filter { $0.accountUserId == userId }
+        .map(\.payload)
+    }
   }
 
   func markRecordingImported(id: String) {
-    var recordings = pendingRecordings()
-    guard let index = recordings.firstIndex(where: { $0.id == id }) else {
-      return
-    }
+    recordingsQueue.sync {
+      var recordings = pendingRecordings()
+      guard let index = recordings.firstIndex(where: { $0.id == id }) else {
+        return
+      }
 
-    let recording = recordings.remove(at: index)
-    if let url = URL(string: recording.uri) {
-      try? FileManager.default.removeItem(at: url)
+      let recording = recordings.remove(at: index)
+      if let url = URL(string: recording.uri) {
+        try? FileManager.default.removeItem(at: url)
+      }
+      persist(recordings)
     }
-    persist(recordings)
   }
 
   private func accountContext() -> [String: Any] {
@@ -210,7 +217,7 @@ private final class WatchConnectivityService: NSObject, WCSessionDelegate {
     emitState()
   }
 
-  private func receive(_ file: WCSessionFile) {
+  private func receive(_ file: WCSessionFile, from session: WCSession) {
     let metadata = file.metadata ?? [:]
     guard let accountUserId = metadata["account_user_id"] as? String else {
       return
@@ -225,40 +232,51 @@ private final class WatchConnectivityService: NSObject, WCSessionDelegate {
       : file.fileURL.pathExtension
     let filename = "\(id).\(fileExtension)"
 
+    let recording: PendingWatchRecording
     do {
-      let directory = try watchInboxDirectory()
-      let destination = directory.appendingPathComponent(filename)
-      if FileManager.default.fileExists(atPath: destination.path) {
-        try FileManager.default.removeItem(at: destination)
-      }
-      try FileManager.default.moveItem(at: file.fileURL, to: destination)
-
-      var recordings = pendingRecordings()
-      let recording = PendingWatchRecording(
-        id: id,
-        uri: destination.absoluteString,
-        filename: filename,
-        recordedAt: recordedAt,
-        accountUserId: accountUserId
-      )
-      recordings.removeAll(where: { $0.id == id })
-      recordings.append(recording)
-      persist(recordings)
-
-      DispatchQueue.main.async { [weak self] in
-        guard let self else {
-          return
+      recording = try recordingsQueue.sync {
+        let directory = try watchInboxDirectory()
+        let destination = directory.appendingPathComponent(filename)
+        if !FileManager.default.fileExists(atPath: destination.path) {
+          try FileManager.default.moveItem(at: file.fileURL, to: destination)
         }
-        guard
-          self.defaults.string(forKey: self.accountUserIdKey)
-            == recording.accountUserId
-        else {
-          return
-        }
-        self.module?.emitRecording(recording)
+
+        var recordings = pendingRecordings()
+        let recording = PendingWatchRecording(
+          id: id,
+          uri: destination.absoluteString,
+          filename: filename,
+          recordedAt: recordedAt,
+          accountUserId: accountUserId
+        )
+        recordings.removeAll(where: { $0.id == id })
+        recordings.append(recording)
+        persist(recordings)
+        return recording
       }
     } catch {
       return
+    }
+
+    if session.activationState == .activated {
+      session.transferUserInfo([
+        "schema_version": 1,
+        "kind": "recording_received",
+        "id": id,
+      ])
+    }
+
+    DispatchQueue.main.async { [weak self] in
+      guard let self else {
+        return
+      }
+      guard
+        self.defaults.string(forKey: self.accountUserIdKey)
+          == recording.accountUserId
+      else {
+        return
+      }
+      self.module?.emitRecording(recording)
     }
   }
 
@@ -348,6 +366,6 @@ private final class WatchConnectivityService: NSObject, WCSessionDelegate {
   }
 
   func session(_ session: WCSession, didReceive file: WCSessionFile) {
-    receive(file)
+    receive(file, from: session)
   }
 }

--- a/apps/mobile/modules/watch-connectivity/src/AnarlogWatchConnectivity.types.ts
+++ b/apps/mobile/modules/watch-connectivity/src/AnarlogWatchConnectivity.types.ts
@@ -1,0 +1,20 @@
+export type AnarlogWatchConnectivityModuleEvents = {
+  onRecordingReceived: (recording: PendingWatchRecording) => void;
+  onStateChanged: (state: WatchConnectivityState) => void;
+};
+
+export type PendingWatchRecording = {
+  id: string;
+  uri: string;
+  filename: string;
+  recordedAt: string;
+  accountUserId: string;
+};
+
+export type WatchConnectivityState = {
+  supported: boolean;
+  activationState: string;
+  paired: boolean;
+  watchAppInstalled: boolean;
+  reachable: boolean;
+};

--- a/apps/mobile/modules/watch-connectivity/src/AnarlogWatchConnectivityModule.ts
+++ b/apps/mobile/modules/watch-connectivity/src/AnarlogWatchConnectivityModule.ts
@@ -1,0 +1,18 @@
+import { NativeModule, requireOptionalNativeModule } from "expo";
+
+import type {
+  AnarlogWatchConnectivityModuleEvents,
+  PendingWatchRecording,
+  WatchConnectivityState,
+} from "./AnarlogWatchConnectivity.types";
+
+declare class AnarlogWatchConnectivityModule extends NativeModule<AnarlogWatchConnectivityModuleEvents> {
+  updateAccount(userId: string | null, email: string | null): void;
+  getState(): WatchConnectivityState;
+  getPendingRecordings(): PendingWatchRecording[];
+  markRecordingImported(id: string): void;
+}
+
+export default requireOptionalNativeModule<AnarlogWatchConnectivityModule>(
+  "AnarlogWatchConnectivity",
+);

--- a/apps/mobile/modules/watch-connectivity/src/AnarlogWatchConnectivityModule.web.ts
+++ b/apps/mobile/modules/watch-connectivity/src/AnarlogWatchConnectivityModule.web.ts
@@ -1,0 +1,32 @@
+import { NativeModule, registerWebModule } from "expo";
+
+import type {
+  AnarlogWatchConnectivityModuleEvents,
+  PendingWatchRecording,
+  WatchConnectivityState,
+} from "./AnarlogWatchConnectivity.types";
+
+class AnarlogWatchConnectivityModule extends NativeModule<AnarlogWatchConnectivityModuleEvents> {
+  updateAccount(_userId: string | null, _email: string | null): void {}
+
+  getState(): WatchConnectivityState {
+    return {
+      supported: false,
+      activationState: "unsupported",
+      paired: false,
+      watchAppInstalled: false,
+      reachable: false,
+    };
+  }
+
+  getPendingRecordings(): PendingWatchRecording[] {
+    return [];
+  }
+
+  markRecordingImported(_id: string): void {}
+}
+
+export default registerWebModule(
+  AnarlogWatchConnectivityModule,
+  "AnarlogWatchConnectivityModule",
+);

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -20,8 +20,10 @@ import {
   initializeErrorReporting,
 } from "@/lib/error-reporting";
 import { useMountEffect } from "@/lib/use-mount-effect";
+import { initializeWatchConnectivity } from "@/watch-connectivity";
 
 initializeErrorReporting();
+initializeWatchConnectivity();
 
 const routeErrorKeys = new WeakMap<Error, number>();
 let nextRouteErrorKey = 0;

--- a/apps/mobile/src/auth/context.tsx
+++ b/apps/mobile/src/auth/context.tsx
@@ -35,6 +35,7 @@ import {
   captureOperationalError,
   setErrorReportingUser,
 } from "@/lib/error-reporting";
+import { updateWatchAccount } from "@/watch-connectivity";
 
 export type AuthState = {
   status: "loading" | "signed_out" | "signed_in";
@@ -207,6 +208,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setSessionState(next);
     const userId = next?.user.id ?? null;
     setErrorReportingUser(userId);
+    updateWatchAccount(
+      next
+        ? {
+            userId: next.user.id,
+            email: next.user.email ?? null,
+          }
+        : null,
+    );
     if (
       next &&
       !decodeJwtPayload(next.access_token) &&

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -185,16 +185,19 @@ export async function importWatchRecording(
           SELECT 1 FROM session_attachments
           WHERE session_id = sessions.id
             AND source_type = 'session_audio'
+            AND deleted_at IS NULL
         ) AS has_audio,
         COALESCE((
           SELECT json_extract(metadata_json, '$.transcript_status')
           FROM session_attachments
           WHERE session_id = sessions.id
             AND source_type = 'session_audio'
+            AND deleted_at IS NULL
           LIMIT 1
         ), '') AS transcript_status
       FROM sessions
       WHERE id = ?
+        AND deleted_at IS NULL
       LIMIT 1`,
       [recording.id],
     )

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -1,7 +1,4 @@
-import {
-  type DocumentPickerAsset,
-  getDocumentAsync,
-} from "expo-document-picker";
+import { getDocumentAsync } from "expo-document-picker";
 import { Directory, File, Paths } from "expo-file-system";
 
 import { catalogSessionAudio } from "@/data/audio-catalog";
@@ -16,6 +13,14 @@ const CONTENT_TYPES: Record<string, string> = {
   mp3: "audio/mpeg",
   wav: "audio/wav",
   ogg: "audio/ogg",
+};
+
+type AudioImportAsset = {
+  uri: string;
+  name: string;
+  mimeType?: string | null;
+  size?: number;
+  lastModified?: number;
 };
 
 export function sessionAudioDirectory(sessionId: string): string {
@@ -41,7 +46,10 @@ function splitName(name: string): { title: string; extension: string } {
   };
 }
 
-async function importAsset(asset: DocumentPickerAsset): Promise<string> {
+async function importAsset(
+  asset: AudioImportAsset,
+  entryPoint: "voice_memo_import" | "watch_recording",
+): Promise<string> {
   const { title, extension } = splitName(asset.name);
   const createdAt =
     typeof asset.lastModified === "number" && asset.lastModified > 0
@@ -51,7 +59,7 @@ async function importAsset(asset: DocumentPickerAsset): Promise<string> {
   const sessionId = await createSession({
     title,
     createdAt,
-    entryPoint: "voice_memo_import",
+    entryPoint,
     trackCreated: false,
   });
 
@@ -72,7 +80,7 @@ async function importAsset(asset: DocumentPickerAsset): Promise<string> {
       sizeBytes: asset.size ?? destination.size ?? 0,
     });
     captureAnalytics("file_uploaded", {
-      entry_point: "voice_memo_import",
+      entry_point: entryPoint,
       file_type: "audio",
       content_type:
         asset.mimeType ??
@@ -81,7 +89,7 @@ async function importAsset(asset: DocumentPickerAsset): Promise<string> {
       size_bytes: asset.size ?? destination.size ?? 0,
     });
     captureAnalytics("note_created", {
-      entry_point: "voice_memo_import",
+      entry_point: entryPoint,
       has_initial_title: Boolean(title),
     });
   } catch (error) {
@@ -112,7 +120,7 @@ export async function importVoiceMemos(): Promise<string[]> {
   const created: string[] = [];
   for (const asset of result.assets) {
     try {
-      created.push(await importAsset(asset));
+      created.push(await importAsset(asset, "voice_memo_import"));
     } catch (error) {
       captureOperationalError(error, {
         operation: "voice_memo_import",
@@ -123,4 +131,19 @@ export async function importVoiceMemos(): Promise<string[]> {
     }
   }
   return created;
+}
+
+export async function importWatchRecording(recording: {
+  uri: string;
+  recordedAt: string;
+}): Promise<string> {
+  return importAsset(
+    {
+      uri: recording.uri,
+      name: "Watch recording.m4a",
+      mimeType: "audio/mp4",
+      lastModified: Date.parse(recording.recordedAt),
+    },
+    "watch_recording",
+  );
 }

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -4,6 +4,7 @@ import { Directory, File, Paths } from "expo-file-system";
 import { catalogSessionAudio } from "@/data/audio-catalog";
 import { createSession, deleteSession } from "@/data/session";
 import { transcribeSession } from "@/data/transcribe";
+import { execute } from "@/db";
 import { captureAnalytics } from "@/lib/analytics";
 import { captureOperationalError } from "@/lib/error-reporting";
 import { nowIso } from "@/lib/ids";
@@ -22,6 +23,20 @@ type AudioImportAsset = {
   size?: number;
   lastModified?: number;
 };
+
+type AudioImportOptions = {
+  sessionId?: string;
+  ownerUserId?: string;
+  signal?: AbortSignal;
+};
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new Error("Audio import was cancelled");
+  }
+}
 
 export function sessionAudioDirectory(sessionId: string): string {
   return new Directory(Paths.document, "sessions", sessionId).uri;
@@ -49,7 +64,9 @@ function splitName(name: string): { title: string; extension: string } {
 async function importAsset(
   asset: AudioImportAsset,
   entryPoint: "voice_memo_import" | "watch_recording",
+  options?: AudioImportOptions,
 ): Promise<string> {
+  throwIfAborted(options?.signal);
   const { title, extension } = splitName(asset.name);
   const createdAt =
     typeof asset.lastModified === "number" && asset.lastModified > 0
@@ -57,19 +74,27 @@ async function importAsset(
       : nowIso();
 
   const sessionId = await createSession({
+    sessionId: options?.sessionId,
+    ownerUserId: options?.ownerUserId,
     title,
     createdAt,
     entryPoint,
     trackCreated: false,
   });
+  throwIfAborted(options?.signal);
 
+  let cataloged = false;
   try {
     const directory = new Directory(Paths.document, "sessions", sessionId);
     directory.create({ intermediates: true, idempotent: true });
 
     const filename = `audio.${extension}`;
     const destination = new File(directory, filename);
+    if (options?.sessionId && destination.exists) {
+      destination.delete();
+    }
     await new File(asset.uri).copy(destination);
+    throwIfAborted(options?.signal);
 
     await catalogSessionAudio(sessionId, {
       filename,
@@ -79,28 +104,33 @@ async function importAsset(
         "application/octet-stream",
       sizeBytes: asset.size ?? destination.size ?? 0,
     });
-    captureAnalytics("file_uploaded", {
-      entry_point: entryPoint,
-      file_type: "audio",
-      content_type:
-        asset.mimeType ??
-        CONTENT_TYPES[extension] ??
-        "application/octet-stream",
-      size_bytes: asset.size ?? destination.size ?? 0,
-    });
-    captureAnalytics("note_created", {
-      entry_point: entryPoint,
-      has_initial_title: Boolean(title),
-    });
-  } catch (error) {
-    // The session exists before the audio does, so a failed copy or catalog
-    // would otherwise strand an empty session on the timeline.
-    await deleteSession(sessionId).catch((cleanupError) => {
-      captureOperationalError(cleanupError, {
-        operation: "voice_memo_import_cleanup",
-        level: "warning",
+    cataloged = true;
+    if (!options?.signal?.aborted) {
+      captureAnalytics("file_uploaded", {
+        entry_point: entryPoint,
+        file_type: "audio",
+        content_type:
+          asset.mimeType ??
+          CONTENT_TYPES[extension] ??
+          "application/octet-stream",
+        size_bytes: asset.size ?? destination.size ?? 0,
       });
-    });
+      captureAnalytics("note_created", {
+        entry_point: entryPoint,
+        has_initial_title: Boolean(title),
+      });
+    }
+  } catch (error) {
+    if (!cataloged) {
+      // The session exists before the audio does, so a failed copy or catalog
+      // would otherwise strand an empty session on the timeline.
+      await deleteSession(sessionId).catch((cleanupError) => {
+        captureOperationalError(cleanupError, {
+          operation: "voice_memo_import_cleanup",
+          level: "warning",
+        });
+      });
+    }
     throw error;
   }
 
@@ -133,10 +163,55 @@ export async function importVoiceMemos(): Promise<string[]> {
   return created;
 }
 
-export async function importWatchRecording(recording: {
-  uri: string;
-  recordedAt: string;
-}): Promise<string> {
+export async function importWatchRecording(
+  recording: {
+    id: string;
+    uri: string;
+    recordedAt: string;
+    accountUserId: string;
+  },
+  signal?: AbortSignal,
+): Promise<string> {
+  throwIfAborted(signal);
+  const existing = (
+    await execute<{
+      owner_user_id: string;
+      has_audio: number;
+      transcript_status: string;
+    }>(
+      `SELECT
+        owner_user_id,
+        EXISTS (
+          SELECT 1 FROM session_attachments
+          WHERE session_id = sessions.id
+            AND source_type = 'session_audio'
+        ) AS has_audio,
+        COALESCE((
+          SELECT json_extract(metadata_json, '$.transcript_status')
+          FROM session_attachments
+          WHERE session_id = sessions.id
+            AND source_type = 'session_audio'
+          LIMIT 1
+        ), '') AS transcript_status
+      FROM sessions
+      WHERE id = ?
+      LIMIT 1`,
+      [recording.id],
+    )
+  )[0];
+  throwIfAborted(signal);
+  if (existing) {
+    if (existing.owner_user_id !== recording.accountUserId) {
+      throw new Error("Watch recording belongs to a different session owner");
+    }
+    if (existing.has_audio === 1) {
+      if (existing.transcript_status !== "complete") {
+        void transcribeSession(recording.id);
+      }
+      return recording.id;
+    }
+  }
+
   return importAsset(
     {
       uri: recording.uri,
@@ -145,5 +220,10 @@ export async function importWatchRecording(recording: {
       lastModified: Date.parse(recording.recordedAt),
     },
     "watch_recording",
+    {
+      sessionId: recording.id,
+      ownerUserId: recording.accountUserId,
+      signal,
+    },
   );
 }

--- a/apps/mobile/src/data/session.ts
+++ b/apps/mobile/src/data/session.ts
@@ -59,7 +59,11 @@ FROM sessions AS session WHERE session.id = ? AND session.deleted_at IS NULL
 export async function createSession(options?: {
   title?: string;
   createdAt?: string;
-  entryPoint?: "new_note" | "start_listening" | "voice_memo_import";
+  entryPoint?:
+    | "new_note"
+    | "start_listening"
+    | "voice_memo_import"
+    | "watch_recording";
   trackCreated?: boolean;
 }): Promise<string> {
   const sessionId = id();

--- a/apps/mobile/src/data/session.ts
+++ b/apps/mobile/src/data/session.ts
@@ -57,6 +57,8 @@ FROM sessions AS session WHERE session.id = ? AND session.deleted_at IS NULL
 `;
 
 export async function createSession(options?: {
+  sessionId?: string;
+  ownerUserId?: string;
   title?: string;
   createdAt?: string;
   entryPoint?:
@@ -66,7 +68,42 @@ export async function createSession(options?: {
     | "watch_recording";
   trackCreated?: boolean;
 }): Promise<string> {
-  const sessionId = id();
+  const sessionId = options?.sessionId ?? id();
+  if (options?.sessionId) {
+    const existing = (
+      await execute<{ owner_user_id: string; deleted_at: string | null }>(
+        "SELECT owner_user_id, deleted_at FROM sessions WHERE id = ? LIMIT 1",
+        [sessionId],
+      )
+    )[0];
+    if (existing) {
+      if (
+        options.ownerUserId &&
+        existing.owner_user_id !== options.ownerUserId
+      ) {
+        throw new Error("Session owner does not match the requested owner");
+      }
+      if (existing.deleted_at) {
+        const restoredAt = nowIso();
+        await executeTransaction([
+          {
+            sql: "UPDATE sessions SET deleted_at = NULL, updated_at = ? WHERE id = ?",
+            params: [restoredAt, sessionId],
+          },
+          {
+            sql: "UPDATE session_documents SET deleted_at = NULL, updated_at = ? WHERE session_id = ?",
+            params: [restoredAt, sessionId],
+          },
+          {
+            sql: "UPDATE session_participants SET deleted_at = NULL, updated_at = ? WHERE session_id = ?",
+            params: [restoredAt, sessionId],
+          },
+        ]);
+      }
+      return sessionId;
+    }
+  }
+
   const participantId = id();
   const now = nowIso();
   const createdAt = options?.createdAt ?? now;
@@ -75,7 +112,14 @@ export async function createSession(options?: {
   await executeTransaction([
     {
       sql: SESSION_INSERT_SQL,
-      params: [sessionId, DEFAULT_USER_ID, title, "", createdAt, createdAt],
+      params: [
+        sessionId,
+        options?.ownerUserId ?? DEFAULT_USER_ID,
+        title,
+        "",
+        createdAt,
+        createdAt,
+      ],
     },
     { sql: NOTE_INSERT_SQL, params: [sessionId, "", now, now, sessionId] },
     { sql: SELF_HUMAN_UPSERT_SQL, params: [now, sessionId] },

--- a/apps/mobile/src/watch-connectivity/index.ts
+++ b/apps/mobile/src/watch-connectivity/index.ts
@@ -10,6 +10,49 @@ import WatchConnectivityModule, {
 let initialized = false;
 let activeAccountUserId: string | null | undefined;
 const importsInFlight = new Set<string>();
+const importRetryAttempts = new Map<string, number>();
+const importRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const MAX_IMPORT_RETRIES = 5;
+
+function clearImportRetry(id: string): void {
+  const timer = importRetryTimers.get(id);
+  if (timer) {
+    clearTimeout(timer);
+  }
+  importRetryTimers.delete(id);
+  importRetryAttempts.delete(id);
+}
+
+function clearImportRetries(): void {
+  for (const id of importRetryTimers.keys()) {
+    clearImportRetry(id);
+  }
+  importRetryAttempts.clear();
+}
+
+function scheduleImportRetry(recording: PendingWatchRecording): void {
+  if (
+    activeAccountUserId !== recording.accountUserId ||
+    importRetryTimers.has(recording.id)
+  ) {
+    return;
+  }
+
+  const attempt = (importRetryAttempts.get(recording.id) ?? 0) + 1;
+  if (attempt > MAX_IMPORT_RETRIES) {
+    return;
+  }
+  importRetryAttempts.set(recording.id, attempt);
+
+  const timer = setTimeout(
+    () => {
+      importRetryTimers.delete(recording.id);
+      void importRecording(recording);
+    },
+    Math.min(1_000 * 2 ** (attempt - 1), 30_000),
+  );
+  importRetryTimers.set(recording.id, timer);
+}
 
 async function importRecording(
   recording: PendingWatchRecording,
@@ -17,7 +60,8 @@ async function importRecording(
   if (
     !WatchConnectivityModule ||
     activeAccountUserId !== recording.accountUserId ||
-    importsInFlight.has(recording.id)
+    importsInFlight.has(recording.id) ||
+    importRetryTimers.has(recording.id)
   ) {
     return;
   }
@@ -26,11 +70,13 @@ async function importRecording(
   try {
     await importWatchRecording(recording);
     WatchConnectivityModule.markRecordingImported(recording.id);
+    clearImportRetry(recording.id);
   } catch (error) {
     captureOperationalError(error, {
       operation: "watch_recording_import",
       context: { recording_id: recording.id },
     });
+    scheduleImportRetry(recording);
   } finally {
     importsInFlight.delete(recording.id);
   }
@@ -50,7 +96,11 @@ export function initializeWatchConnectivity(): void {
 export function updateWatchAccount(
   account: { userId: string; email: string | null } | null,
 ): void {
-  activeAccountUserId = account?.userId ?? null;
+  const nextAccountUserId = account?.userId ?? null;
+  if (activeAccountUserId !== nextAccountUserId) {
+    clearImportRetries();
+  }
+  activeAccountUserId = nextAccountUserId;
   if (Platform.OS !== "ios" || !WatchConnectivityModule) {
     return;
   }

--- a/apps/mobile/src/watch-connectivity/index.ts
+++ b/apps/mobile/src/watch-connectivity/index.ts
@@ -1,0 +1,67 @@
+import { Platform } from "react-native";
+
+import { importWatchRecording } from "@/data/import-voice-memo";
+import { captureOperationalError } from "@/lib/error-reporting";
+
+import WatchConnectivityModule, {
+  type PendingWatchRecording,
+} from "../../modules/watch-connectivity";
+
+let initialized = false;
+let activeAccountUserId: string | null | undefined;
+const importsInFlight = new Set<string>();
+
+async function importRecording(
+  recording: PendingWatchRecording,
+): Promise<void> {
+  if (
+    !WatchConnectivityModule ||
+    activeAccountUserId !== recording.accountUserId ||
+    importsInFlight.has(recording.id)
+  ) {
+    return;
+  }
+
+  importsInFlight.add(recording.id);
+  try {
+    await importWatchRecording(recording);
+    WatchConnectivityModule.markRecordingImported(recording.id);
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "watch_recording_import",
+      context: { recording_id: recording.id },
+    });
+  } finally {
+    importsInFlight.delete(recording.id);
+  }
+}
+
+export function initializeWatchConnectivity(): void {
+  if (initialized || Platform.OS !== "ios" || !WatchConnectivityModule) {
+    return;
+  }
+
+  initialized = true;
+  WatchConnectivityModule.addListener("onRecordingReceived", (recording) => {
+    void importRecording(recording);
+  });
+}
+
+export function updateWatchAccount(
+  account: { userId: string; email: string | null } | null,
+): void {
+  activeAccountUserId = account?.userId ?? null;
+  if (Platform.OS !== "ios" || !WatchConnectivityModule) {
+    return;
+  }
+
+  WatchConnectivityModule.updateAccount(
+    account?.userId ?? null,
+    account?.email ?? null,
+  );
+  if (account) {
+    for (const recording of WatchConnectivityModule.getPendingRecordings()) {
+      void importRecording(recording);
+    }
+  }
+}

--- a/apps/mobile/src/watch-connectivity/index.ts
+++ b/apps/mobile/src/watch-connectivity/index.ts
@@ -9,6 +9,7 @@ import WatchConnectivityModule, {
 
 let initialized = false;
 let activeAccountUserId: string | null | undefined;
+let activeImportController = new AbortController();
 const importsInFlight = new Set<string>();
 const importRetryAttempts = new Map<string, number>();
 const importRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -67,11 +68,21 @@ async function importRecording(
   }
 
   importsInFlight.add(recording.id);
+  const importController = activeImportController;
   try {
-    await importWatchRecording(recording);
+    await importWatchRecording(recording, importController.signal);
+    if (
+      importController.signal.aborted ||
+      activeAccountUserId !== recording.accountUserId
+    ) {
+      return;
+    }
     WatchConnectivityModule.markRecordingImported(recording.id);
     clearImportRetry(recording.id);
   } catch (error) {
+    if (importController.signal.aborted) {
+      return;
+    }
     captureOperationalError(error, {
       operation: "watch_recording_import",
       context: { recording_id: recording.id },
@@ -98,6 +109,8 @@ export function updateWatchAccount(
 ): void {
   const nextAccountUserId = account?.userId ?? null;
   if (activeAccountUserId !== nextAccountUserId) {
+    activeImportController.abort();
+    activeImportController = new AbortController();
     clearImportRetries();
   }
   activeAccountUserId = nextAccountUserId;

--- a/apps/watch/apple/AnarlogWatch.xcodeproj/project.pbxproj
+++ b/apps/watch/apple/AnarlogWatch.xcodeproj/project.pbxproj
@@ -1,0 +1,256 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A1000001 /* AnarlogWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001 /* AnarlogWatchApp.swift */; };
+		A1000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000002 /* ContentView.swift */; };
+		A1000003 /* RecordingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000003 /* RecordingController.swift */; };
+		A1000004 /* WatchSyncController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000005 /* WatchSyncController.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A2000001 /* AnarlogWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnarlogWatchApp.swift; sourceTree = "<group>"; };
+		A2000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A2000003 /* RecordingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingController.swift; sourceTree = "<group>"; };
+		A2000004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A2000005 /* WatchSyncController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSyncController.swift; sourceTree = "<group>"; };
+		A2000010 /* AnarlogWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AnarlogWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A3000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A4000001 /* Root */ = {
+			isa = PBXGroup;
+			children = (
+				A4000002 /* AnarlogWatch */,
+				A4000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A4000002 /* AnarlogWatch */ = {
+			isa = PBXGroup;
+			children = (
+				A2000001 /* AnarlogWatchApp.swift */,
+				A2000002 /* ContentView.swift */,
+				A2000003 /* RecordingController.swift */,
+				A2000005 /* WatchSyncController.swift */,
+				A2000004 /* Info.plist */,
+			);
+			path = AnarlogWatch;
+			sourceTree = "<group>";
+		};
+		A4000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A2000010 /* AnarlogWatch.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A5000001 /* AnarlogWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A7000001 /* Build configuration list for PBXNativeTarget "AnarlogWatch" */;
+			buildPhases = (
+				A6000001 /* Sources */,
+				A3000001 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AnarlogWatch;
+			productName = AnarlogWatch;
+			productReference = A2000010 /* AnarlogWatch.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A8000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2640;
+				LastUpgradeCheck = 2640;
+				TargetAttributes = {
+					A5000001 = {
+						CreatedOnToolsVersion = 26.4;
+					};
+				};
+			};
+			buildConfigurationList = A7000002 /* Build configuration list for PBXProject "AnarlogWatch" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A4000001 /* Root */;
+			productRefGroup = A4000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A5000001 /* AnarlogWatch */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A6000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000001 /* AnarlogWatchApp.swift in Sources */,
+				A1000002 /* ContentView.swift in Sources */,
+				A1000003 /* RecordingController.swift in Sources */,
+				A1000004 /* WatchSyncController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A9000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = AnarlogWatch/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = so.anarlog.mobile.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = NO;
+				SUPPORTED_PLATFORMS = "watchos watchsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 11.0;
+			};
+			name = Debug;
+		};
+		A9000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = AnarlogWatch/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = so.anarlog.mobile.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = NO;
+				SUPPORTED_PLATFORMS = "watchos watchsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 11.0;
+			};
+			name = Release;
+		};
+		A9000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A9000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A7000001 /* Build configuration list for PBXNativeTarget "AnarlogWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A9000001 /* Debug */,
+				A9000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A7000002 /* Build configuration list for PBXProject "AnarlogWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A9000003 /* Debug */,
+				A9000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+	};
+	rootObject = A8000001 /* Project object */;
+}

--- a/apps/watch/apple/AnarlogWatch.xcodeproj/xcshareddata/xcschemes/AnarlogWatch.xcscheme
+++ b/apps/watch/apple/AnarlogWatch.xcodeproj/xcshareddata/xcschemes/AnarlogWatch.xcscheme
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5000001"
+               BuildableName = "AnarlogWatch.app"
+               BlueprintName = "AnarlogWatch"
+               ReferencedContainer = "container:AnarlogWatch.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5000001"
+            BuildableName = "AnarlogWatch.app"
+            BlueprintName = "AnarlogWatch"
+            ReferencedContainer = "container:AnarlogWatch.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+</Scheme>

--- a/apps/watch/apple/AnarlogWatch/AnarlogWatchApp.swift
+++ b/apps/watch/apple/AnarlogWatch/AnarlogWatchApp.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+@main
+struct AnarlogWatchApp: App {
+  @StateObject private var recorder = RecordingController()
+  @StateObject private var syncController = WatchSyncController()
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView(
+        recorder: recorder,
+        syncController: syncController
+      )
+    }
+  }
+}

--- a/apps/watch/apple/AnarlogWatch/ContentView.swift
+++ b/apps/watch/apple/AnarlogWatch/ContentView.swift
@@ -1,0 +1,252 @@
+import SwiftUI
+
+private enum WatchPage: Hashable {
+  case listening
+  case account
+}
+
+struct ContentView: View {
+  @ObservedObject var recorder: RecordingController
+  @ObservedObject var syncController: WatchSyncController
+  @State private var recordingAccountUserId: String?
+  @State private var selectedPage = WatchPage.listening
+
+  var body: some View {
+    Group {
+      if syncController.account == nil {
+        PairingView(syncController: syncController)
+      } else {
+        TabView(selection: $selectedPage) {
+          ListeningView(recorder: recorder)
+            .tag(WatchPage.listening)
+          AccountSettingsView(syncController: syncController)
+            .tag(WatchPage.account)
+        }
+        .tabViewStyle(.page(indexDisplayMode: .always))
+        .onAppear {
+          #if DEBUG
+            if ProcessInfo.processInfo.arguments.contains("-demo-settings") {
+              selectedPage = .account
+            }
+          #endif
+        }
+      }
+    }
+    .onChange(of: recorder.isRecording) { _, isRecording in
+      if isRecording {
+        recordingAccountUserId = syncController.account?.userId
+      }
+    }
+    .onChange(of: recorder.lastCompletedRecording) { _, recording in
+      guard let recording, let recordingAccountUserId else {
+        return
+      }
+      syncController.enqueueRecording(
+        url: recording.url,
+        recordedAt: recording.recordedAt,
+        accountUserId: recordingAccountUserId
+      )
+      self.recordingAccountUserId = nil
+    }
+    .onChange(of: syncController.account) { _, account in
+      if account == nil {
+        recorder.stopIfNeeded()
+      }
+    }
+    .alert(
+      "Unable to listen",
+      isPresented: Binding(
+        get: { recorder.errorMessage != nil },
+        set: { isPresented in
+          if !isPresented {
+            recorder.dismissError()
+          }
+        }
+      )
+    ) {
+      Button("OK") {
+        recorder.dismissError()
+      }
+    } message: {
+      Text(recorder.errorMessage ?? "")
+    }
+    .sensoryFeedback(trigger: recorder.isRecording) { _, isRecording in
+      isRecording ? .start : .stop
+    }
+  }
+}
+
+private struct PairingView: View {
+  @ObservedObject var syncController: WatchSyncController
+
+  var body: some View {
+    ContentUnavailableView {
+      Label(
+        "Connect iPhone",
+        systemImage: "iphone.and.arrow.forward.inward"
+      )
+    } description: {
+      Text("Open Anarlog on iPhone to sync.")
+    } actions: {
+      if syncController.activationState == .notActivated {
+        ProgressView()
+          .accessibilityLabel("Connecting…")
+      } else {
+        Button("Check again") {
+          syncController.refreshAccount()
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(.white)
+        .foregroundStyle(.black)
+      }
+    }
+    .onAppear {
+      syncController.refreshAccount()
+    }
+  }
+}
+
+private struct ListeningView: View {
+  @ObservedObject var recorder: RecordingController
+
+  var body: some View {
+    ZStack {
+      (recorder.isRecording ? Color.red : Color(white: 0.08))
+
+      if recorder.isRecording {
+        Waveform(levels: recorder.levels)
+          .padding(.horizontal, 14)
+          .padding(.vertical, 24)
+      } else {
+        HStack(spacing: 14) {
+          PulsingRecordDot()
+
+          Text("Start listening")
+            .font(.system(size: 21, weight: .medium, design: .rounded))
+            .foregroundStyle(.white)
+            .minimumScaleFactor(0.75)
+            .lineLimit(1)
+        }
+        .padding(.horizontal, 12)
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .contentShape(Rectangle())
+    .onTapGesture {
+      recorder.toggle()
+    }
+    .ignoresSafeArea()
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(
+      recorder.isRecording ? "Stop listening" : "Start listening"
+    )
+    .accessibilityValue(recorder.isRecording ? "Recording" : "Not recording")
+    .accessibilityAddTraits(.isButton)
+    .accessibilityAction {
+      recorder.toggle()
+    }
+  }
+}
+
+private struct AccountSettingsView: View {
+  @ObservedObject var syncController: WatchSyncController
+
+  var body: some View {
+    Form {
+      Section {
+        if let email = syncController.account?.email {
+          LabeledContent("Email") {
+            Text(email)
+              .multilineTextAlignment(.trailing)
+          }
+        } else {
+          Text("Connected to Anarlog")
+        }
+
+        connectionStatus
+
+        if syncController.pendingTransferCount > 0 {
+          LabeledContent("Waiting to sync") {
+            Text("\(syncController.pendingTransferCount)")
+          }
+        }
+
+        Button("Sync now") {
+          syncController.syncNow()
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(.white)
+        .foregroundStyle(.black)
+      } header: {
+        Label("Account", systemImage: "person.crop.circle.fill")
+      }
+    }
+    .padding(.bottom, 18)
+    .accessibilityElement(children: .contain)
+  }
+
+  @ViewBuilder
+  private var connectionStatus: some View {
+    switch syncController.activationState {
+    case .notActivated:
+      HStack(spacing: 8) {
+        ProgressView()
+          .progressViewStyle(.circular)
+          .controlSize(.small)
+          .fixedSize()
+        Text("Connecting…")
+          .font(.footnote)
+          .lineLimit(1)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    case .activated where syncController.isPhoneReachable:
+      Label(
+        syncController.statusText,
+        systemImage: "iphone.radiowaves.left.and.right"
+      )
+      .foregroundStyle(.secondary)
+    case .activated, .inactive:
+      Label(
+        syncController.statusText,
+        systemImage: "arrow.trianglehead.2.clockwise.rotate.90"
+      )
+      .foregroundStyle(.secondary)
+    @unknown default:
+      Label(
+        syncController.statusText,
+        systemImage: "arrow.trianglehead.2.clockwise.rotate.90"
+      )
+      .foregroundStyle(.secondary)
+    }
+  }
+}
+
+private struct PulsingRecordDot: View {
+  var body: some View {
+    Image(systemName: "circle.fill")
+      .font(.system(size: 18))
+      .foregroundStyle(.red)
+      .symbolEffect(.pulse)
+      .frame(width: 24, height: 24)
+      .accessibilityHidden(true)
+  }
+}
+
+private struct Waveform: View {
+  let levels: [CGFloat]
+
+  var body: some View {
+    GeometryReader { geometry in
+      HStack(spacing: 3) {
+        ForEach(levels.indices, id: \.self) { index in
+          Capsule()
+            .fill(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: max(4, geometry.size.height * levels[index]))
+        }
+      }
+      .frame(maxHeight: .infinity)
+      .animation(.linear(duration: 0.08), value: levels)
+    }
+  }
+}

--- a/apps/watch/apple/AnarlogWatch/ContentView.swift
+++ b/apps/watch/apple/AnarlogWatch/ContentView.swift
@@ -17,8 +17,10 @@ struct ContentView: View {
         PairingView(syncController: syncController)
       } else {
         TabView(selection: $selectedPage) {
-          ListeningView(recorder: recorder)
-            .tag(WatchPage.listening)
+          ListeningView(recorder: recorder) {
+            toggleRecording()
+          }
+          .tag(WatchPage.listening)
           AccountSettingsView(syncController: syncController)
             .tag(WatchPage.account)
         }
@@ -32,11 +34,6 @@ struct ContentView: View {
         }
       }
     }
-    .onChange(of: recorder.isRecording) { _, isRecording in
-      if isRecording {
-        recordingAccountUserId = syncController.account?.userId
-      }
-    }
     .onChange(of: recorder.lastCompletedRecording) { _, recording in
       guard let recording, let recordingAccountUserId else {
         return
@@ -48,8 +45,8 @@ struct ContentView: View {
       )
       self.recordingAccountUserId = nil
     }
-    .onChange(of: syncController.account) { _, account in
-      if account == nil {
+    .onChange(of: syncController.account) { previousAccount, account in
+      if previousAccount?.userId != account?.userId {
         recorder.stopIfNeeded()
       }
     }
@@ -73,6 +70,19 @@ struct ContentView: View {
     .sensoryFeedback(trigger: recorder.isRecording) { _, isRecording in
       isRecording ? .start : .stop
     }
+  }
+
+  private func toggleRecording() {
+    if recorder.isRecording {
+      recorder.toggle()
+      return
+    }
+
+    guard let accountUserId = syncController.account?.userId else {
+      return
+    }
+    recordingAccountUserId = accountUserId
+    recorder.toggle()
   }
 }
 
@@ -108,6 +118,7 @@ private struct PairingView: View {
 
 private struct ListeningView: View {
   @ObservedObject var recorder: RecordingController
+  let onToggle: () -> Void
 
   var body: some View {
     ZStack {
@@ -133,7 +144,7 @@ private struct ListeningView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .contentShape(Rectangle())
     .onTapGesture {
-      recorder.toggle()
+      onToggle()
     }
     .ignoresSafeArea()
     .accessibilityElement(children: .ignore)
@@ -143,7 +154,7 @@ private struct ListeningView: View {
     .accessibilityValue(recorder.isRecording ? "Recording" : "Not recording")
     .accessibilityAddTraits(.isButton)
     .accessibilityAction {
-      recorder.toggle()
+      onToggle()
     }
   }
 }

--- a/apps/watch/apple/AnarlogWatch/Info.plist
+++ b/apps/watch/apple/AnarlogWatch/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Anarlog</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Anarlog uses the microphone to record conversations.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKApplication</key>
+	<true/>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>so.anarlog.mobile</string>
+	<key>WKRunsIndependentlyOfCompanionApp</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/watch/apple/AnarlogWatch/RecordingController.swift
+++ b/apps/watch/apple/AnarlogWatch/RecordingController.swift
@@ -1,0 +1,208 @@
+import AVFAudio
+import Combine
+import Foundation
+
+struct CompletedRecording: Equatable {
+  let url: URL
+  let recordedAt: Date
+}
+
+@MainActor
+final class RecordingController: ObservableObject {
+  @Published private(set) var isRecording = false
+  @Published private(set) var levels = Array(repeating: CGFloat(0.12), count: 28)
+  @Published private(set) var errorMessage: String?
+  @Published private(set) var lastCompletedRecording: CompletedRecording?
+
+  private let audioSession = AVAudioSession.sharedInstance()
+  private var isStarting = false
+  private var meterTimer: Timer?
+  private var audioRecorder: AVAudioRecorder?
+  private var currentRecordingURL: URL?
+  private var recordingStartedAt: Date?
+
+  func toggle() {
+    if isRecording {
+      stop()
+    } else if !isStarting {
+      isStarting = true
+      Task {
+        await start()
+      }
+    }
+  }
+
+  func dismissError() {
+    errorMessage = nil
+  }
+
+  func stopIfNeeded() {
+    if isRecording {
+      stop()
+    }
+  }
+
+  private func start() async {
+    defer {
+      isStarting = false
+    }
+
+    guard await requestMicrophonePermission() else {
+      errorMessage = "Allow microphone access in Settings to record from your watch."
+      return
+    }
+
+    var recordingURL: URL?
+
+    do {
+      try audioSession.setCategory(.record, mode: .default)
+      try await activateAudioSession()
+
+      let url = try nextRecordingURL()
+      recordingURL = url
+      let recorder = try AVAudioRecorder(
+        url: url,
+        settings: [
+          AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+          AVSampleRateKey: 16_000,
+          AVNumberOfChannelsKey: 1,
+          AVEncoderBitRateKey: 64_000,
+          AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
+        ]
+      )
+      recorder.isMeteringEnabled = true
+      audioRecorder = recorder
+
+      guard recorder.record() else {
+        throw RecordingError.couldNotStart
+      }
+
+      currentRecordingURL = url
+      recordingStartedAt = Date()
+      isRecording = true
+      startMetering()
+    } catch {
+      audioRecorder = nil
+      currentRecordingURL = nil
+      recordingStartedAt = nil
+      if let recordingURL {
+        try? FileManager.default.removeItem(at: recordingURL)
+      }
+      try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+      errorMessage = "Recording could not start. Try again in a moment."
+    }
+  }
+
+  private func stop() {
+    let completedRecording: CompletedRecording? =
+      if isRecording,
+        let currentRecordingURL,
+        let recordingStartedAt
+      {
+        CompletedRecording(
+          url: currentRecordingURL,
+          recordedAt: recordingStartedAt
+        )
+      } else {
+        nil
+      }
+
+    meterTimer?.invalidate()
+    meterTimer = nil
+    audioRecorder?.stop()
+    audioRecorder = nil
+    currentRecordingURL = nil
+    recordingStartedAt = nil
+    isRecording = false
+    levels = Array(repeating: 0.12, count: levels.count)
+    try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+
+    if let completedRecording,
+      FileManager.default.fileExists(atPath: completedRecording.url.path)
+    {
+      lastCompletedRecording = completedRecording
+    }
+  }
+
+  private func requestMicrophonePermission() async -> Bool {
+    switch AVAudioApplication.shared.recordPermission {
+    case .granted:
+      return true
+    case .denied:
+      return false
+    case .undetermined:
+      return await withCheckedContinuation { continuation in
+        AVAudioApplication.requestRecordPermission { granted in
+          continuation.resume(returning: granted)
+        }
+      }
+    @unknown default:
+      return false
+    }
+  }
+
+  private func activateAudioSession() async throws {
+    try await withCheckedThrowingContinuation { continuation in
+      audioSession.activate(options: []) { activated, error in
+        if activated {
+          continuation.resume()
+        } else {
+          continuation.resume(throwing: error ?? RecordingError.couldNotActivateAudio)
+        }
+      }
+    }
+  }
+
+  private func nextRecordingURL() throws -> URL {
+    let recordingsDirectory = FileManager.default
+      .urls(for: .documentDirectory, in: .userDomainMask)[0]
+      .appendingPathComponent("Recordings", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: recordingsDirectory,
+      withIntermediateDirectories: true
+    )
+
+    return
+      recordingsDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathExtension("m4a")
+  }
+
+  private func startMetering() {
+    levels = Array(repeating: 0.12, count: levels.count)
+    meterTimer?.invalidate()
+    meterTimer = Timer.scheduledTimer(withTimeInterval: 0.08, repeats: true) {
+      [weak self] _ in
+      Task { @MainActor [weak self] in
+        self?.updateMeter()
+      }
+    }
+  }
+
+  private func updateMeter() {
+    guard let audioRecorder, audioRecorder.isRecording else {
+      stop()
+      return
+    }
+
+    audioRecorder.updateMeters()
+    let average = normalizedPower(audioRecorder.averagePower(forChannel: 0))
+    let peak = normalizedPower(audioRecorder.peakPower(forChannel: 0))
+    let level = max(average, peak * 0.75)
+
+    levels.removeFirst()
+    levels.append(level)
+  }
+
+  private func normalizedPower(_ decibels: Float) -> CGFloat {
+    let floor: Float = -55
+    let clamped = max(floor, min(0, decibels))
+    let linearAmplitude = pow(10, Double(clamped / 20))
+    return max(0.08, min(1, CGFloat(linearAmplitude * 3.5)))
+  }
+}
+
+private enum RecordingError: Error {
+  case couldNotActivateAudio
+  case couldNotStart
+}

--- a/apps/watch/apple/AnarlogWatch/RecordingController.swift
+++ b/apps/watch/apple/AnarlogWatch/RecordingController.swift
@@ -15,7 +15,7 @@ final class RecordingController: ObservableObject {
   @Published private(set) var lastCompletedRecording: CompletedRecording?
 
   private let audioSession = AVAudioSession.sharedInstance()
-  private var isStarting = false
+  private var startTask: Task<Void, Never>?
   private var meterTimer: Timer?
   private var audioRecorder: AVAudioRecorder?
   private var currentRecordingURL: URL?
@@ -24,11 +24,18 @@ final class RecordingController: ObservableObject {
   func toggle() {
     if isRecording {
       stop()
-    } else if !isStarting {
-      isStarting = true
-      Task {
-        await start()
+      return
+    }
+
+    guard startTask == nil else {
+      return
+    }
+    startTask = Task { [weak self] in
+      guard let self else {
+        return
       }
+      await start()
+      startTask = nil
     }
   }
 
@@ -37,17 +44,18 @@ final class RecordingController: ObservableObject {
   }
 
   func stopIfNeeded() {
+    startTask?.cancel()
     if isRecording {
       stop()
     }
   }
 
   private func start() async {
-    defer {
-      isStarting = false
+    let hasMicrophonePermission = await requestMicrophonePermission()
+    guard !Task.isCancelled else {
+      return
     }
-
-    guard await requestMicrophonePermission() else {
+    guard hasMicrophonePermission else {
       errorMessage = "Allow microphone access in Settings to record from your watch."
       return
     }
@@ -57,6 +65,7 @@ final class RecordingController: ObservableObject {
     do {
       try audioSession.setCategory(.record, mode: .default)
       try await activateAudioSession()
+      try Task.checkCancellation()
 
       let url = try nextRecordingURL()
       recordingURL = url
@@ -76,12 +85,14 @@ final class RecordingController: ObservableObject {
       guard recorder.record() else {
         throw RecordingError.couldNotStart
       }
+      try Task.checkCancellation()
 
       currentRecordingURL = url
       recordingStartedAt = Date()
       isRecording = true
       startMetering()
     } catch {
+      audioRecorder?.stop()
       audioRecorder = nil
       currentRecordingURL = nil
       recordingStartedAt = nil
@@ -89,7 +100,9 @@ final class RecordingController: ObservableObject {
         try? FileManager.default.removeItem(at: recordingURL)
       }
       try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
-      errorMessage = "Recording could not start. Try again in a moment."
+      if !(error is CancellationError) {
+        errorMessage = "Recording could not start. Try again in a moment."
+      }
     }
   }
 

--- a/apps/watch/apple/AnarlogWatch/WatchSyncController.swift
+++ b/apps/watch/apple/AnarlogWatch/WatchSyncController.swift
@@ -30,6 +30,8 @@ final class WatchSyncController: NSObject, ObservableObject {
   private let iso8601Formatter = ISO8601DateFormatter()
   private var pendingRecordings: [PendingRecording] = []
   private var queuedRecordingIds: Set<String> = []
+  private var retryDelay: TimeInterval = 2
+  private var retryWorkItem: DispatchWorkItem?
 
   override init() {
     if let data = UserDefaults.standard.data(forKey: Self.accountDefaultsKey) {
@@ -240,6 +242,7 @@ final class WatchSyncController: NSObject, ObservableObject {
     persistPendingRecordings()
     persistQueuedRecordingIds()
     try? FileManager.default.removeItem(at: recording.url)
+    retryDelay = 2
     flushPendingRecordings()
   }
 
@@ -248,6 +251,25 @@ final class WatchSyncController: NSObject, ObservableObject {
       return
     }
     persistQueuedRecordingIds()
+    scheduleRetry()
+  }
+
+  private func scheduleRetry() {
+    guard retryWorkItem == nil else {
+      return
+    }
+
+    let delay = retryDelay
+    retryDelay = min(retryDelay * 2, 60)
+    let workItem = DispatchWorkItem { [weak self] in
+      guard let self else {
+        return
+      }
+      retryWorkItem = nil
+      flushPendingRecordings()
+    }
+    retryWorkItem = workItem
+    DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
   }
 }
 
@@ -311,6 +333,7 @@ extension WatchSyncController: WCSessionDelegate {
           .lastPathComponent
         self.queuedRecordingIds.remove(id)
         self.persistQueuedRecordingIds()
+        self.scheduleRetry()
       }
       self.updateState(from: session)
     }

--- a/apps/watch/apple/AnarlogWatch/WatchSyncController.swift
+++ b/apps/watch/apple/AnarlogWatch/WatchSyncController.swift
@@ -206,6 +206,17 @@ final class WatchSyncController: NSObject, ObservableObject {
       defaults.set(data, forKey: Self.pendingRecordingsDefaultsKey)
     }
   }
+
+  private func acknowledgeRecording(id: String) {
+    guard let index = pendingRecordings.firstIndex(where: { $0.id == id }) else {
+      return
+    }
+
+    let recording = pendingRecordings.remove(at: index)
+    persistPendingRecordings()
+    try? FileManager.default.removeItem(at: recording.url)
+    flushPendingRecordings()
+  }
 }
 
 extension WatchSyncController: WCSessionDelegate {
@@ -261,18 +272,20 @@ extension WatchSyncController: WCSessionDelegate {
         return
       }
 
-      if error == nil {
-        let id =
-          fileTransfer.file.metadata?["id"] as? String
-          ?? fileTransfer.file.fileURL.deletingPathExtension()
-          .lastPathComponent
-        self.pendingRecordings.removeAll(where: { $0.id == id })
-        self.persistPendingRecordings()
-        try? FileManager.default.removeItem(at: fileTransfer.file.fileURL)
-        self.flushPendingRecordings()
-      } else {
-        self.updateState(from: session)
-      }
+      self.updateState(from: session)
+    }
+  }
+
+  func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any]) {
+    guard
+      userInfo["kind"] as? String == "recording_received",
+      let id = userInfo["id"] as? String
+    else {
+      return
+    }
+
+    DispatchQueue.main.async { [weak self] in
+      self?.acknowledgeRecording(id: id)
     }
   }
 }

--- a/apps/watch/apple/AnarlogWatch/WatchSyncController.swift
+++ b/apps/watch/apple/AnarlogWatch/WatchSyncController.swift
@@ -23,10 +23,13 @@ final class WatchSyncController: NSObject, ObservableObject {
   private static let accountDefaultsKey = "watch-connectivity-account"
   private static let pendingRecordingsDefaultsKey =
     "watch-connectivity-pending-recordings"
+  private static let queuedRecordingIdsDefaultsKey =
+    "watch-connectivity-queued-recording-ids"
 
   private let defaults = UserDefaults.standard
   private let iso8601Formatter = ISO8601DateFormatter()
   private var pendingRecordings: [PendingRecording] = []
+  private var queuedRecordingIds: Set<String> = []
 
   override init() {
     if let data = UserDefaults.standard.data(forKey: Self.accountDefaultsKey) {
@@ -38,6 +41,12 @@ final class WatchSyncController: NSObject, ObservableObject {
       pendingRecordings =
         (try? JSONDecoder().decode([PendingRecording].self, from: data)) ?? []
     }
+    queuedRecordingIds = Set(
+      UserDefaults.standard.stringArray(
+        forKey: Self.queuedRecordingIdsDefaultsKey
+      ) ?? []
+    )
+    queuedRecordingIds.formIntersection(pendingRecordings.map(\.id))
     pendingTransferCount = pendingRecordings.count
 
     #if DEBUG
@@ -135,7 +144,9 @@ final class WatchSyncController: NSObject, ObservableObject {
     pendingRecordings.removeAll {
       !FileManager.default.fileExists(atPath: $0.url.path)
     }
+    queuedRecordingIds.formIntersection(pendingRecordings.map(\.id))
     persistPendingRecordings()
+    persistQueuedRecordingIds()
 
     guard WCSession.isSupported() else {
       return
@@ -153,7 +164,12 @@ final class WatchSyncController: NSObject, ObservableObject {
       }
     )
     for recording in pendingRecordings
-    where !outstandingIds.contains(recording.id) {
+    where
+      !outstandingIds.contains(recording.id)
+      && !queuedRecordingIds.contains(recording.id)
+    {
+      queuedRecordingIds.insert(recording.id)
+      persistQueuedRecordingIds()
       session.transferFile(
         recording.url,
         metadata: [
@@ -207,15 +223,31 @@ final class WatchSyncController: NSObject, ObservableObject {
     }
   }
 
-  private func acknowledgeRecording(id: String) {
+  private func persistQueuedRecordingIds() {
+    defaults.set(
+      queuedRecordingIds.sorted(),
+      forKey: Self.queuedRecordingIdsDefaultsKey
+    )
+  }
+
+  private func acknowledgeImportedRecording(id: String) {
     guard let index = pendingRecordings.firstIndex(where: { $0.id == id }) else {
       return
     }
 
     let recording = pendingRecordings.remove(at: index)
+    queuedRecordingIds.remove(id)
     persistPendingRecordings()
+    persistQueuedRecordingIds()
     try? FileManager.default.removeItem(at: recording.url)
     flushPendingRecordings()
+  }
+
+  private func retryRecording(id: String) {
+    guard queuedRecordingIds.remove(id) != nil else {
+      return
+    }
+    persistQueuedRecordingIds()
   }
 }
 
@@ -272,20 +304,35 @@ extension WatchSyncController: WCSessionDelegate {
         return
       }
 
+      if error != nil {
+        let id =
+          fileTransfer.file.metadata?["id"] as? String
+          ?? fileTransfer.file.fileURL.deletingPathExtension()
+          .lastPathComponent
+        self.queuedRecordingIds.remove(id)
+        self.persistQueuedRecordingIds()
+      }
       self.updateState(from: session)
     }
   }
 
   func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any]) {
     guard
-      userInfo["kind"] as? String == "recording_received",
+      let kind = userInfo["kind"] as? String,
       let id = userInfo["id"] as? String
     else {
       return
     }
 
     DispatchQueue.main.async { [weak self] in
-      self?.acknowledgeRecording(id: id)
+      switch kind {
+      case "recording_imported":
+        self?.acknowledgeImportedRecording(id: id)
+      case "recording_receive_failed":
+        self?.retryRecording(id: id)
+      default:
+        break
+      }
     }
   }
 }

--- a/apps/watch/apple/AnarlogWatch/WatchSyncController.swift
+++ b/apps/watch/apple/AnarlogWatch/WatchSyncController.swift
@@ -1,0 +1,278 @@
+import Combine
+import Foundation
+import WatchConnectivity
+
+struct AccountIdentity: Codable, Equatable {
+  let userId: String
+  let email: String?
+}
+
+private struct PendingRecording: Codable, Equatable {
+  let id: String
+  let url: URL
+  let recordedAt: Date
+  let accountUserId: String
+}
+
+final class WatchSyncController: NSObject, ObservableObject {
+  @Published private(set) var account: AccountIdentity?
+  @Published private(set) var isPhoneReachable = false
+  @Published private(set) var activationState = WCSessionActivationState.notActivated
+  @Published private(set) var pendingTransferCount = 0
+
+  private static let accountDefaultsKey = "watch-connectivity-account"
+  private static let pendingRecordingsDefaultsKey =
+    "watch-connectivity-pending-recordings"
+
+  private let defaults = UserDefaults.standard
+  private let iso8601Formatter = ISO8601DateFormatter()
+  private var pendingRecordings: [PendingRecording] = []
+
+  override init() {
+    if let data = UserDefaults.standard.data(forKey: Self.accountDefaultsKey) {
+      account = try? JSONDecoder().decode(AccountIdentity.self, from: data)
+    }
+    if let data = UserDefaults.standard.data(
+      forKey: Self.pendingRecordingsDefaultsKey
+    ) {
+      pendingRecordings =
+        (try? JSONDecoder().decode([PendingRecording].self, from: data)) ?? []
+    }
+    pendingTransferCount = pendingRecordings.count
+
+    #if DEBUG
+      if ProcessInfo.processInfo.arguments.contains("-demo-account") {
+        account = AccountIdentity(
+          userId: "preview-account",
+          email: "jane@anarlog.so"
+        )
+      }
+    #endif
+
+    super.init()
+    activate()
+  }
+
+  var statusText: String {
+    switch activationState {
+    case .activated where isPhoneReachable:
+      return "iPhone connected"
+    case .activated:
+      return "Syncs when your iPhone is nearby"
+    case .inactive:
+      return "Waiting for iPhone"
+    case .notActivated:
+      return "Connecting…"
+    @unknown default:
+      return "Waiting for iPhone"
+    }
+  }
+
+  func refreshAccount() {
+    guard WCSession.isSupported() else {
+      return
+    }
+
+    let session = WCSession.default
+    applyAccountContext(session.receivedApplicationContext)
+    updateState(from: session)
+
+    guard session.activationState == .activated else {
+      session.activate()
+      return
+    }
+
+    guard session.isReachable else {
+      return
+    }
+
+    session.sendMessage(
+      ["schema_version": 1, "kind": "account_request"],
+      replyHandler: { [weak self] response in
+        DispatchQueue.main.async {
+          self?.applyAccountContext(response)
+        }
+      },
+      errorHandler: nil
+    )
+  }
+
+  func enqueueRecording(
+    url: URL,
+    recordedAt: Date,
+    accountUserId: String
+  ) {
+    let recording = PendingRecording(
+      id: url.deletingPathExtension().lastPathComponent,
+      url: url,
+      recordedAt: recordedAt,
+      accountUserId: accountUserId
+    )
+    if !pendingRecordings.contains(where: { $0.id == recording.id }) {
+      pendingRecordings.append(recording)
+      persistPendingRecordings()
+    }
+
+    flushPendingRecordings()
+  }
+
+  func syncNow() {
+    refreshAccount()
+    flushPendingRecordings()
+  }
+
+  private func activate() {
+    guard WCSession.isSupported() else {
+      return
+    }
+
+    let session = WCSession.default
+    session.delegate = self
+    session.activate()
+  }
+
+  private func flushPendingRecordings() {
+    pendingRecordings.removeAll {
+      !FileManager.default.fileExists(atPath: $0.url.path)
+    }
+    persistPendingRecordings()
+
+    guard WCSession.isSupported() else {
+      return
+    }
+
+    let session = WCSession.default
+    guard session.activationState == .activated else {
+      session.activate()
+      return
+    }
+
+    let outstandingIds = Set(
+      session.outstandingFileTransfers.compactMap {
+        $0.file.metadata?["id"] as? String
+      }
+    )
+    for recording in pendingRecordings
+    where !outstandingIds.contains(recording.id) {
+      session.transferFile(
+        recording.url,
+        metadata: [
+          "id": recording.id,
+          "recorded_at": iso8601Formatter.string(from: recording.recordedAt),
+          "account_user_id": recording.accountUserId,
+        ]
+      )
+    }
+    updateState(from: session)
+  }
+
+  private func applyAccountContext(_ context: [String: Any]) {
+    guard context["kind"] as? String == "account" else {
+      return
+    }
+
+    let signedIn = context["signed_in"] as? Bool ?? false
+    guard
+      signedIn,
+      let userId = context["user_id"] as? String,
+      !userId.isEmpty
+    else {
+      account = nil
+      defaults.removeObject(forKey: Self.accountDefaultsKey)
+      return
+    }
+
+    let nextAccount = AccountIdentity(
+      userId: userId,
+      email: context["email"] as? String
+    )
+    account = nextAccount
+    if let data = try? JSONEncoder().encode(nextAccount) {
+      defaults.set(data, forKey: Self.accountDefaultsKey)
+    }
+  }
+
+  private func updateState(from session: WCSession) {
+    activationState = session.activationState
+    isPhoneReachable =
+      session.activationState == .activated
+      && session.isReachable
+    pendingTransferCount = pendingRecordings.count
+  }
+
+  private func persistPendingRecordings() {
+    pendingTransferCount = pendingRecordings.count
+    if let data = try? JSONEncoder().encode(pendingRecordings) {
+      defaults.set(data, forKey: Self.pendingRecordingsDefaultsKey)
+    }
+  }
+}
+
+extension WatchSyncController: WCSessionDelegate {
+  func session(
+    _ session: WCSession,
+    activationDidCompleteWith activationState: WCSessionActivationState,
+    error: Error?
+  ) {
+    DispatchQueue.main.async { [weak self] in
+      self?.updateState(from: session)
+      if error == nil && activationState == .activated {
+        self?.applyAccountContext(session.receivedApplicationContext)
+        self?.refreshAccount()
+        self?.flushPendingRecordings()
+      }
+    }
+  }
+
+  func sessionReachabilityDidChange(_ session: WCSession) {
+    DispatchQueue.main.async { [weak self] in
+      self?.updateState(from: session)
+      if session.isReachable {
+        self?.refreshAccount()
+        self?.flushPendingRecordings()
+      }
+    }
+  }
+
+  func session(
+    _ session: WCSession,
+    didReceiveApplicationContext applicationContext: [String: Any]
+  ) {
+    DispatchQueue.main.async { [weak self] in
+      self?.applyAccountContext(applicationContext)
+      self?.updateState(from: session)
+    }
+  }
+
+  func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+    DispatchQueue.main.async { [weak self] in
+      self?.applyAccountContext(message)
+      self?.updateState(from: session)
+    }
+  }
+
+  func session(
+    _ session: WCSession,
+    didFinish fileTransfer: WCSessionFileTransfer,
+    error: Error?
+  ) {
+    DispatchQueue.main.async { [weak self] in
+      guard let self else {
+        return
+      }
+
+      if error == nil {
+        let id =
+          fileTransfer.file.metadata?["id"] as? String
+          ?? fileTransfer.file.fileURL.deletingPathExtension()
+          .lastPathComponent
+        self.pendingRecordings.removeAll(where: { $0.id == id })
+        self.persistPendingRecordings()
+        try? FileManager.default.removeItem(at: fileTransfer.file.fileURL)
+        self.flushPendingRecordings()
+      } else {
+        self.updateState(from: session)
+      }
+    }
+  }
+}

--- a/apps/watch/apple/AnarlogWatch/WatchSyncController.swift
+++ b/apps/watch/apple/AnarlogWatch/WatchSyncController.swift
@@ -23,13 +23,13 @@ final class WatchSyncController: NSObject, ObservableObject {
   private static let accountDefaultsKey = "watch-connectivity-account"
   private static let pendingRecordingsDefaultsKey =
     "watch-connectivity-pending-recordings"
-  private static let queuedRecordingIdsDefaultsKey =
-    "watch-connectivity-queued-recording-ids"
+  private static let acknowledgementTimeout: TimeInterval = 60
 
   private let defaults = UserDefaults.standard
   private let iso8601Formatter = ISO8601DateFormatter()
   private var pendingRecordings: [PendingRecording] = []
   private var queuedRecordingIds: Set<String> = []
+  private var acknowledgementWorkItems: [String: DispatchWorkItem] = [:]
   private var retryDelay: TimeInterval = 2
   private var retryWorkItem: DispatchWorkItem?
 
@@ -43,12 +43,6 @@ final class WatchSyncController: NSObject, ObservableObject {
       pendingRecordings =
         (try? JSONDecoder().decode([PendingRecording].self, from: data)) ?? []
     }
-    queuedRecordingIds = Set(
-      UserDefaults.standard.stringArray(
-        forKey: Self.queuedRecordingIdsDefaultsKey
-      ) ?? []
-    )
-    queuedRecordingIds.formIntersection(pendingRecordings.map(\.id))
     pendingTransferCount = pendingRecordings.count
 
     #if DEBUG
@@ -129,6 +123,11 @@ final class WatchSyncController: NSObject, ObservableObject {
 
   func syncNow() {
     refreshAccount()
+    for workItem in acknowledgementWorkItems.values {
+      workItem.cancel()
+    }
+    acknowledgementWorkItems.removeAll()
+    queuedRecordingIds.removeAll()
     flushPendingRecordings()
   }
 
@@ -148,7 +147,6 @@ final class WatchSyncController: NSObject, ObservableObject {
     }
     queuedRecordingIds.formIntersection(pendingRecordings.map(\.id))
     persistPendingRecordings()
-    persistQueuedRecordingIds()
 
     guard WCSession.isSupported() else {
       return
@@ -171,7 +169,6 @@ final class WatchSyncController: NSObject, ObservableObject {
       && !queuedRecordingIds.contains(recording.id)
     {
       queuedRecordingIds.insert(recording.id)
-      persistQueuedRecordingIds()
       session.transferFile(
         recording.url,
         metadata: [
@@ -225,33 +222,52 @@ final class WatchSyncController: NSObject, ObservableObject {
     }
   }
 
-  private func persistQueuedRecordingIds() {
-    defaults.set(
-      queuedRecordingIds.sorted(),
-      forKey: Self.queuedRecordingIdsDefaultsKey
-    )
-  }
-
   private func acknowledgeImportedRecording(id: String) {
     guard let index = pendingRecordings.firstIndex(where: { $0.id == id }) else {
       return
     }
 
     let recording = pendingRecordings.remove(at: index)
+    acknowledgementWorkItems.removeValue(forKey: id)?.cancel()
     queuedRecordingIds.remove(id)
     persistPendingRecordings()
-    persistQueuedRecordingIds()
     try? FileManager.default.removeItem(at: recording.url)
     retryDelay = 2
     flushPendingRecordings()
   }
 
   private func retryRecording(id: String) {
+    acknowledgementWorkItems.removeValue(forKey: id)?.cancel()
     guard queuedRecordingIds.remove(id) != nil else {
       return
     }
-    persistQueuedRecordingIds()
     scheduleRetry()
+  }
+
+  private func scheduleAcknowledgementRetry(id: String) {
+    guard
+      pendingRecordings.contains(where: { $0.id == id }),
+      acknowledgementWorkItems[id] == nil
+    else {
+      return
+    }
+
+    let workItem = DispatchWorkItem { [weak self] in
+      guard let self else {
+        return
+      }
+      acknowledgementWorkItems.removeValue(forKey: id)
+      guard pendingRecordings.contains(where: { $0.id == id }) else {
+        return
+      }
+      queuedRecordingIds.remove(id)
+      flushPendingRecordings()
+    }
+    acknowledgementWorkItems[id] = workItem
+    DispatchQueue.main.asyncAfter(
+      deadline: .now() + Self.acknowledgementTimeout,
+      execute: workItem
+    )
   }
 
   private func scheduleRetry() {
@@ -332,8 +348,10 @@ extension WatchSyncController: WCSessionDelegate {
           ?? fileTransfer.file.fileURL.deletingPathExtension()
           .lastPathComponent
         self.queuedRecordingIds.remove(id)
-        self.persistQueuedRecordingIds()
+        self.acknowledgementWorkItems.removeValue(forKey: id)?.cancel()
         self.scheduleRetry()
+      } else if let id = fileTransfer.file.metadata?["id"] as? String {
+        self.scheduleAcknowledgementRetry(id: id)
       }
       self.updateState(from: session)
     }


### PR DESCRIPTION
## Summary

- add a standalone SwiftUI watchOS app with a black-and-white recording interface, a pulsing record core, live waveform, native horizontal paging, and account/settings states
- add an Expo WatchConnectivity module that shares the signed-in iPhone account with the watch and receives completed watch recordings
- import received watch audio through the existing mobile session, audio catalog, analytics, and transcription pipeline
- persist transfers on both devices until delivery and import complete, scoped to the matching account

## Why

This establishes the first smartwatch recording path while keeping watch recordings in the same session-backed workflow as voice memo imports on mobile.

## Validation

- `pnpm exec dprint fmt`
- `pnpm fmt:check`
- `pnpm -F @hypr/mobile typecheck`
- `pnpm -F @hypr/mobile test:error-reporting`
- `pnpm -F @hypr/mobile exec expo-modules-autolinking search --platform apple`
- strict `swift-format` lint for the watch app and iPhone bridge
- watchOS build and static analysis with Xcode on the watchOS 26.4 simulator
- UI verification on Apple Watch Series 11 46 mm and Apple Watch SE 3 40 mm simulators
- plist, JSON, podspec syntax, and diff integrity checks

## Notes

- this is a draft foundation: physical paired-device WatchConnectivity testing and App Store companion-target packaging still need to be completed
- Wear OS and other smartwatch clients are follow-up work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cross-device sync and session/audio import paths touch auth identity, local DB ownership, and file lifecycle; failures are mitigated with retries and acks but paired-device behavior is still largely unvalidated per PR notes.
> 
> **Overview**
> Adds an **Apple Watch recording path** wired into the same mobile session, transcription, and analytics flow as voice memo imports.
> 
> A new **standalone watchOS SwiftUI app** records audio, shows pairing/listening/account UI, and **queues file transfers** to the iPhone via WatchConnectivity until the phone acknowledges import. On iOS, a new **Expo `watch-connectivity` module** pushes signed-in account context to the watch, receives audio into a persisted inbox, and emits events to JS.
> 
> Mobile **bootstraps watch sync at launch** and **pushes auth session changes** to the watch. **`importWatchRecording`** and generalized audio import support **stable session IDs**, **owner scoping**, **idempotent re-import**, and **abort on account switch**; **`createSession`** accepts preset IDs and restores soft-deleted sessions. A **`mobile_ci`** workflow builds watchOS, iOS, and Android on relevant path changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9bae9e43f19e312fe0749c0e051a61bdc37d4ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->