### PR TITLE
Configure Anarlog uptime monitoring

### DIFF
--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -31,6 +31,9 @@ export function SiteFooter() {
         <Link to="/changelog/" className="hover:text-[#181613]">
           Changelog
         </Link>
+        <a href="https://status.anarlog.so" className="hover:text-[#181613]">
+          Status
+        </a>
         <Link to="/privacy/" className="hover:text-[#181613]">
           Privacy
         </Link>

--- a/openstatus.lock
+++ b/openstatus.lock
@@ -1,5 +1,5 @@
-"7697":
-  ID: 7697
+"11026":
+  ID: 11026
   Monitor:
     active: true
     assertions:
@@ -8,21 +8,22 @@
       target: 200
     frequency: 1m
     kind: http
-    name: Char Web
+    name: Anarlog API
     openTelemetry: {}
     regions:
-    - railway_europe-west4-drams3a
-    - lhr
-    - railway_asia-southeast1-eqsg3a
-    - nrt
-    - yyz
-    - koyeb_was
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
     request:
       method: GET
-      url: https://char.com
+      url: https://api.anarlog.so/health
     retry: 3
-"8351":
-  ID: 8351
+    timeout: 45000
+"11027":
+  ID: 11027
   Monitor:
     active: true
     assertions:
@@ -31,21 +32,22 @@
       target: 200
     frequency: 1m
     kind: http
-    name: Char API
+    name: Anarlog Web
     openTelemetry: {}
     regions:
-    - cdg
-    - lax
-    - koyeb_par
-    - koyeb_fra
-    - fra
-    - bom
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
     request:
       method: GET
-      url: https://api.char.com/health
+      url: https://anarlog.so
     retry: 3
-"8354":
-  ID: 8354
+    timeout: 45000
+"11028":
+  ID: 11028
   Monitor:
     active: true
     assertions:
@@ -54,39 +56,17 @@
       target: 200
     frequency: 1m
     kind: http
-    name: Char Web
+    name: Anarlog Docs
     openTelemetry: {}
     regions:
-    - railway_europe-west4-drams3a
-    - lhr
-    - railway_asia-southeast1-eqsg3a
-    - nrt
-    - yyz
-    - koyeb_was
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
     request:
       method: GET
-      url: https://char.com
+      url: https://docs.anarlog.so
     retry: 3
-"8355":
-  ID: 8355
-  Monitor:
-    active: true
-    assertions:
-    - compare: eq
-      kind: statusCode
-      target: 200
-    frequency: 1m
-    kind: http
-    name: Char API
-    openTelemetry: {}
-    regions:
-    - cdg
-    - lax
-    - koyeb_par
-    - koyeb_fra
-    - fra
-    - bom
-    request:
-      method: GET
-      url: https://api.char.com/health
-    retry: 3
+    timeout: 45000

--- a/openstatus.yaml
+++ b/openstatus.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://www.openstatus.dev/schema.json
 
-"7697":
+"11026":
   active: true
   assertions:
     - compare: eq
@@ -8,20 +8,21 @@
       target: 200
   frequency: 1m
   kind: http
-  name: Char Web
+  name: Anarlog API
   openTelemetry: {}
   regions:
-    - railway_europe-west4-drams3a
-    - lhr
-    - railway_asia-southeast1-eqsg3a
-    - nrt
-    - yyz
-    - koyeb_was
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
   request:
     method: GET
-    url: https://char.com
+    url: https://api.anarlog.so/health
   retry: 3
-"8351":
+  timeout: 45000
+"11027":
   active: true
   assertions:
     - compare: eq
@@ -29,20 +30,21 @@
       target: 200
   frequency: 1m
   kind: http
-  name: Char API
+  name: Anarlog Web
   openTelemetry: {}
   regions:
-    - cdg
-    - lax
-    - koyeb_par
-    - koyeb_fra
-    - fra
-    - bom
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
   request:
     method: GET
-    url: https://api.char.com/health
+    url: https://anarlog.so
   retry: 3
-"8354":
+  timeout: 45000
+"11028":
   active: true
   assertions:
     - compare: eq
@@ -50,37 +52,17 @@
       target: 200
   frequency: 1m
   kind: http
-  name: Char Web
+  name: Anarlog Docs
   openTelemetry: {}
   regions:
-    - railway_europe-west4-drams3a
-    - lhr
-    - railway_asia-southeast1-eqsg3a
-    - nrt
-    - yyz
-    - koyeb_was
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
   request:
     method: GET
-    url: https://char.com
+    url: https://docs.anarlog.so
   retry: 3
-"8355":
-  active: true
-  assertions:
-    - compare: eq
-      kind: statusCode
-      target: 200
-  frequency: 1m
-  kind: http
-  name: Char API
-  openTelemetry: {}
-  regions:
-    - cdg
-    - lax
-    - koyeb_par
-    - koyeb_fra
-    - fra
-    - bom
-  request:
-    method: GET
-    url: https://api.char.com/health
-  retry: 3
+  timeout: 45000


### PR DESCRIPTION
Track the production API, web app, and docs across six regions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Footer navigation and external monitoring configuration only; no runtime application or auth logic changes.
> 
> **Overview**
> **Replaces legacy Char uptime checks with Anarlog production monitoring** in `openstatus.yaml` and `openstatus.lock`: three HTTP monitors for the API (`/health`), marketing site, and docs, each polled every minute from six regions with a 45s timeout and 200 status assertions. Duplicate Char web/API monitor entries are removed in favor of these IDs.
> 
> **Adds a public Status entry** in the site footer linking to `https://status.anarlog.so`, alongside existing nav links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5557766361e1cfd411598826c50a0c9096572002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->