### PR TITLE
Persist compound transcript corrections

### DIFF
--- a/apps/desktop/src/chat/tools/session-correction.test.ts
+++ b/apps/desktop/src/chat/tools/session-correction.test.ts
@@ -237,6 +237,46 @@ describe("session correction chat tool", () => {
     ]);
   });
 
+  it("keeps compound transcript words and memo text in sync", () => {
+    const plan = sessionCorrectionTestInternals.planTranscriptCorrections({
+      transcripts: [
+        transcript({
+          words: [
+            {
+              id: "w1",
+              text: "mini-tara",
+              start_ms: 0,
+              end_ms: 100,
+              channel: 0,
+            },
+            {
+              id: "w2",
+              text: "Tarantino",
+              start_ms: 100,
+              end_ms: 200,
+              channel: 0,
+            },
+          ],
+          memo: "Speaker 1: mini-tara, not Tarantino",
+        }),
+      ] as any,
+      oldText: "Tara",
+      newText: "Char",
+    });
+
+    expect(plan.changes[0]).toMatchObject({
+      wordReplacements: 1,
+      memoReplacements: 1,
+    });
+    expect(JSON.parse(plan.updates[0]!.nextWordsJson)).toMatchObject([
+      { text: "mini-Char" },
+      { text: "Tarantino" },
+    ]);
+    expect(plan.updates[0]?.nextMemo).toBe(
+      "Speaker 1: mini-Char, not Tarantino",
+    );
+  });
+
   it("does not plan a partial transcript row update", () => {
     const plan = sessionCorrectionTestInternals.planTranscriptCorrections({
       transcripts: [

--- a/apps/desktop/src/chat/tools/session-correction.test.ts
+++ b/apps/desktop/src/chat/tools/session-correction.test.ts
@@ -277,6 +277,36 @@ describe("session correction chat tool", () => {
     );
   });
 
+  it("falls back to normalized matching for transcript memos", () => {
+    const plan = sessionCorrectionTestInternals.planTranscriptCorrections({
+      transcripts: [
+        transcript({
+          words: [
+            {
+              id: "w1",
+              text: "Ta-ra",
+              start_ms: 0,
+              end_ms: 100,
+              channel: 0,
+            },
+          ],
+          memo: "Speaker 1: Ta-ra",
+        }),
+      ] as any,
+      oldText: "Tara",
+      newText: "Char",
+    });
+
+    expect(plan.changes[0]).toMatchObject({
+      wordReplacements: 1,
+      memoReplacements: 1,
+    });
+    expect(JSON.parse(plan.updates[0]!.nextWordsJson)).toMatchObject([
+      { text: "Char" },
+    ]);
+    expect(plan.updates[0]?.nextMemo).toBe("Speaker 1: Char");
+  });
+
   it("does not plan a partial transcript row update", () => {
     const plan = sessionCorrectionTestInternals.planTranscriptCorrections({
       transcripts: [

--- a/apps/desktop/src/chat/tools/session-correction.test.ts
+++ b/apps/desktop/src/chat/tools/session-correction.test.ts
@@ -182,6 +182,61 @@ describe("session correction chat tool", () => {
     expect(plan.updates[0]?.nextMemo).toBe("Speaker 1: Y then Y");
   });
 
+  it("replaces bounded terms inside compound transcript words", () => {
+    const result = sessionCorrectionTestInternals.replaceTranscriptWords(
+      [
+        {
+          id: "w1",
+          text: " mini-Tara,",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 0,
+        },
+        {
+          id: "w2",
+          text: "Tara",
+          start_ms: 100,
+          end_ms: 200,
+          channel: 0,
+        },
+        {
+          id: "w3",
+          text: "Tarantino",
+          start_ms: 200,
+          end_ms: 300,
+          channel: 0,
+        },
+      ],
+      "Tara",
+      "Char",
+    );
+
+    expect(result.count).toBe(2);
+    expect(result.words).toEqual([
+      {
+        id: "w1",
+        text: " mini-Char,",
+        start_ms: 0,
+        end_ms: 100,
+        channel: 0,
+      },
+      {
+        id: "w2",
+        text: "Char",
+        start_ms: 100,
+        end_ms: 200,
+        channel: 0,
+      },
+      {
+        id: "w3",
+        text: "Tarantino",
+        start_ms: 200,
+        end_ms: 300,
+        channel: 0,
+      },
+    ]);
+  });
+
   it("does not plan a partial transcript row update", () => {
     const plan = sessionCorrectionTestInternals.planTranscriptCorrections({
       transcripts: [

--- a/apps/desktop/src/chat/tools/session-correction.ts
+++ b/apps/desktop/src/chat/tools/session-correction.ts
@@ -327,7 +327,10 @@ function replaceTranscriptText(
     tokenizeComparable(oldText).length === 1 &&
     tokenizeReplacement(newText).length === 1
   ) {
-    return replaceBoundedExact(value, oldText, newText);
+    const bounded = replaceBoundedExact(value, oldText, newText);
+    return bounded.count > 0
+      ? bounded
+      : replaceLoosePhrase(value, oldText, newText);
   }
 
   const exact = replaceExact(value, oldText, newText);

--- a/apps/desktop/src/chat/tools/session-correction.ts
+++ b/apps/desktop/src/chat/tools/session-correction.ts
@@ -323,6 +323,13 @@ function replaceTranscriptText(
   oldText: string,
   newText: string,
 ): ReplacementResult {
+  if (
+    tokenizeComparable(oldText).length === 1 &&
+    tokenizeReplacement(newText).length === 1
+  ) {
+    return replaceBoundedExact(value, oldText, newText);
+  }
+
   const exact = replaceExact(value, oldText, newText);
   return exact.count > 0 ? exact : replaceLoosePhrase(value, oldText, newText);
 }

--- a/apps/desktop/src/chat/tools/session-correction.ts
+++ b/apps/desktop/src/chat/tools/session-correction.ts
@@ -80,6 +80,29 @@ function replaceExact(
   };
 }
 
+function replaceBoundedExact(
+  value: string,
+  oldText: string,
+  newText: string,
+): ReplacementResult {
+  if (!oldText) {
+    return { text: value, count: 0 };
+  }
+
+  const escaped = oldText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `(^|[^\\p{L}\\p{N}])${escaped}(?=$|[^\\p{L}\\p{N}])`,
+    "giu",
+  );
+  let count = 0;
+  const text = value.replace(pattern, (_match, prefix: string) => {
+    count++;
+    return `${prefix}${newText}`;
+  });
+
+  return { text, count };
+}
+
 function planSummaryCorrections({
   notes,
   enhancedNoteId,
@@ -213,6 +236,17 @@ function replaceTranscriptWords(
   const nextWords: TranscriptWord[] = [];
   let count = 0;
   for (let index = 0; index < words.length; ) {
+    if (target.length === 1 && replacementTokens.length === 1) {
+      const word = words[index];
+      const replaced = replaceBoundedExact(word.text ?? "", oldText, newText);
+      if (replaced.count > 0) {
+        nextWords.push({ ...word, text: replaced.text });
+        count += replaced.count;
+        index++;
+        continue;
+      }
+    }
+
     if (wordRangeMatchesAt(words, target, index)) {
       const original = words.slice(index, index + target.length);
       nextWords.push(...buildReplacementWords(original, newText));


### PR DESCRIPTION
Preserve token formatting while correcting bounded terms inside hyphenated transcript words, with regression coverage for regenerated summaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes correction matching behavior for transcripts and memos; wrong boundaries could miss or over-replace text, though scope is limited to the session-correction tool with new tests.
> 
> **Overview**
> **Transcript corrections** for single-token `oldText` → `newText` now use a new **`replaceBoundedExact`** path (Unicode letter/number boundaries) instead of only whole-word token matching or naive string split.
> 
> In **`replaceTranscriptWords`**, each word’s text can be partially updated (e.g. `mini-Tara` → `mini-Char`) while leaving unrelated compounds intact (`Tarantino` unchanged). **`replaceTranscriptText`** tries bounded replacement on memos first, then falls back to existing loose/normalized phrase matching (e.g. memo `Ta-ra` still matches correction target `Tara`).
> 
> Regression tests cover compound words, word/memo consistency, and normalized memo fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bded6b0732db3dd9648925e6071f09234ad0d051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->