### PR TITLE
Preserve STT proxy provider compatibility

### DIFF
--- a/crates/owhisper-client/src/adapter/anarlog/batch.rs
+++ b/crates/owhisper-client/src/adapter/anarlog/batch.rs
@@ -3,14 +3,14 @@ use std::path::{Path, PathBuf};
 use owhisper_interface::ListenParams;
 use owhisper_interface::batch::Response as BatchResponse;
 
-use super::AnarlogAdapter;
+use super::{AnarlogAdapter, STT_PROXY_PROVIDER_NAME};
 use crate::adapter::http::mime_type_from_extension;
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, append_path_if_missing};
 use crate::error::Error;
 
 impl BatchSttAdapter for AnarlogAdapter {
     fn provider_name(&self) -> &'static str {
-        "anarlog"
+        STT_PROXY_PROVIDER_NAME
     }
 
     fn is_supported_languages(

--- a/crates/owhisper-client/src/adapter/anarlog/live.rs
+++ b/crates/owhisper-client/src/adapter/anarlog/live.rs
@@ -2,12 +2,12 @@ use anlg_ws_client::client::Message;
 use owhisper_interface::ListenParams;
 use owhisper_interface::stream::StreamResponse;
 
-use super::AnarlogAdapter;
+use super::{AnarlogAdapter, STT_PROXY_PROVIDER_NAME};
 use crate::adapter::{RealtimeSttAdapter, append_path_if_missing, set_scheme_from_host};
 
 impl RealtimeSttAdapter for AnarlogAdapter {
     fn provider_name(&self) -> &'static str {
-        "anarlog"
+        STT_PROXY_PROVIDER_NAME
     }
 
     fn is_supported_languages(
@@ -105,6 +105,14 @@ mod tests {
     use crate::test_utils::{UrlTestCase, run_url_test_cases};
 
     const API_BASE: &str = "https://api.anarlog.so/stt";
+
+    #[test]
+    fn test_proxy_provider_name() {
+        assert_eq!(
+            RealtimeSttAdapter::provider_name(&AnarlogAdapter),
+            "hyprnote"
+        );
+    }
 
     #[test]
     fn test_url_structure() {

--- a/crates/owhisper-client/src/adapter/anarlog/mod.rs
+++ b/crates/owhisper-client/src/adapter/anarlog/mod.rs
@@ -3,6 +3,9 @@ mod live;
 
 use super::{LanguageQuality, LanguageSupport};
 
+// Keep the wire identifier compatible with proxy deployments that predate the Anarlog rename.
+const STT_PROXY_PROVIDER_NAME: &str = "hyprnote";
+
 #[derive(Clone, Default)]
 pub struct AnarlogAdapter;
 

--- a/crates/owhisper-client/src/batch.rs
+++ b/crates/owhisper-client/src/batch.rs
@@ -142,7 +142,7 @@ mod tests {
             .api_key("test")
             .build();
 
-        assert!(client.api_base.contains("provider=anarlog"));
+        assert!(client.api_base.contains("provider=hyprnote"));
     }
 
     #[test]


### PR DESCRIPTION
Use the legacy hyprnote wire alias for Anarlog live and batch proxy requests so desktop 1.4.0 works with both current and older production proxy deployments. Adds regression coverage for the injected provider parameter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow compatibility tweak to the provider query parameter for Anarlog proxy URLs; no auth, data, or routing logic beyond the wire alias.
> 
> **Overview**
> Anarlog live and batch adapters now report **`hyprnote`** as the proxy wire provider instead of **`anarlog`**, so clients talking to the Anarlog STT proxy send `provider=hyprnote` and stay compatible with older production proxies (e.g. desktop 1.4.0) that still expect the pre-rename identifier.
> 
> A shared **`STT_PROXY_PROVIDER_NAME`** constant documents that intent; batch client normalization and injected query params follow the adapter’s `provider_name()`. Regression tests assert realtime `provider_name` is **`hyprnote`** and that Anarlog proxy batch URLs include **`provider=hyprnote`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb3c018f8a9b2187177baf8d33d455b841e877f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->