### PR TITLE
Limit diarization to speakers per channel

### DIFF
--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -394,18 +394,7 @@ fn build_listen_params(args: &ListenerArgs) -> owhisper_interface::ListenParams 
 }
 
 fn expected_speakers(args: &ListenerArgs) -> Option<u32> {
-    let mut participants = args.participant_human_ids.clone();
-
-    if let Some(self_human_id) = &args.self_human_id
-        && !participants.iter().any(|id| id == self_human_id)
-    {
-        participants.push(self_human_id.clone());
-    }
-
-    participants.sort();
-    participants.dedup();
-
-    (participants.len() > 1).then_some(participants.len() as u32)
+    crate::expected_speakers_per_channel(&args.participant_human_ids, args.self_human_id.as_deref())
 }
 
 fn format_languages(languages: &[anlg_language::Language]) -> String {
@@ -616,9 +605,14 @@ mod tests {
     }
 
     #[test]
-    fn expected_speakers_counts_distinct_participants() {
+    fn expected_speakers_counts_distinct_remote_participants() {
         let mut args = listener_args("https://api.assemblyai.com", "u3-rt-pro");
-        args.participant_human_ids = vec!["remote".to_string(), "self".to_string()];
+        args.participant_human_ids = vec![
+            "remote-a".to_string(),
+            "self".to_string(),
+            "remote-b".to_string(),
+            "remote-a".to_string(),
+        ];
         args.self_human_id = Some("self".to_string());
 
         assert_eq!(expected_speakers(&args), Some(2));
@@ -643,8 +637,8 @@ mod tests {
         let params = build_listen_params(&args);
         let custom_query = params.custom_query.expect("custom query");
 
-        assert_eq!(params.num_speakers, Some(2));
-        assert_eq!(params.max_speakers, Some(2));
+        assert_eq!(params.num_speakers, Some(1));
+        assert_eq!(params.max_speakers, Some(1));
         assert!(!custom_query.contains_key("speaker_labels"));
         assert!(!custom_query.contains_key("max_speakers"));
     }
@@ -658,10 +652,26 @@ mod tests {
         let params = build_listen_params(&args);
         let custom_query = params.custom_query.expect("custom query");
 
-        assert_eq!(params.num_speakers, Some(2));
-        assert_eq!(params.max_speakers, Some(2));
+        assert_eq!(params.num_speakers, Some(1));
+        assert_eq!(params.max_speakers, Some(1));
         assert!(!custom_query.contains_key("speaker_labels"));
         assert!(!custom_query.contains_key("max_speakers"));
+    }
+
+    #[test]
+    fn build_listen_params_limits_each_channel_to_remote_participants() {
+        let mut args = listener_args("https://api.anarlog.so/stt", "cloud");
+        args.participant_human_ids = vec![
+            "self".to_string(),
+            "remote-a".to_string(),
+            "remote-b".to_string(),
+        ];
+        args.self_human_id = Some("self".to_string());
+
+        let params = build_listen_params(&args);
+
+        assert_eq!(params.num_speakers, Some(2));
+        assert_eq!(params.max_speakers, Some(2));
     }
 
     #[test]

--- a/crates/listener-core/src/actors/session/supervisor.rs
+++ b/crates/listener-core/src/actors/session/supervisor.rs
@@ -361,18 +361,7 @@ fn expected_speaker_count(
     participant_human_ids: &[String],
     self_human_id: Option<&str>,
 ) -> Option<u32> {
-    let mut participants = participant_human_ids.to_vec();
-
-    if let Some(self_human_id) = self_human_id
-        && !participants.iter().any(|id| id == self_human_id)
-    {
-        participants.push(self_human_id.to_string());
-    }
-
-    participants.sort();
-    participants.dedup();
-
-    (participants.len() > 1).then_some(participants.len() as u32)
+    crate::expected_speakers_per_channel(participant_human_ids, self_human_id)
 }
 
 async fn handle_listener_failure(
@@ -705,7 +694,7 @@ mod tests {
         ctx.params.participant_human_ids = vec!["self".to_string()];
         ctx.params.self_human_id = Some("self".to_string());
         let state = test_state(ctx);
-        let update = test_update(vec![], vec!["self", "remote"], Some("self"));
+        let update = test_update(vec![], vec!["self", "remote-a", "remote-b"], Some("self"));
 
         assert!(update_requires_listener_refresh(&state.ctx.params, &update));
     }

--- a/crates/listener-core/src/lib.rs
+++ b/crates/listener-core/src/lib.rs
@@ -34,6 +34,27 @@ pub enum TranscriptionMode {
     Batch,
 }
 
+pub(crate) fn expected_speakers_per_channel(
+    participant_human_ids: &[String],
+    self_human_id: Option<&str>,
+) -> Option<u32> {
+    let mut remote_participants = participant_human_ids
+        .iter()
+        .filter(|participant| Some(participant.as_str()) != self_human_id)
+        .cloned()
+        .collect::<Vec<_>>();
+    remote_participants.sort();
+    remote_participants.dedup();
+
+    let count = if remote_participants.is_empty() && self_human_id.is_some() {
+        1
+    } else {
+        remote_participants.len()
+    };
+
+    u32::try_from(count).ok().filter(|count| *count > 0)
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 #[serde(tag = "type")]

--- a/crates/listener-core/src/live_transcript.rs
+++ b/crates/listener-core/src/live_transcript.rs
@@ -144,22 +144,9 @@ fn max_speaker_index_for_participants(
     participant_human_ids: &[String],
     self_human_id: Option<&str>,
 ) -> Option<i32> {
-    let mut participants = participant_human_ids.to_vec();
-
-    if let Some(self_human_id) = self_human_id
-        && !participants.iter().any(|id| id == self_human_id)
-    {
-        participants.push(self_human_id.to_string());
-    }
-
-    participants.sort();
-    participants.dedup();
-
-    if participants.len() <= 1 {
-        return None;
-    }
-
-    i32::try_from(participants.len() - 1).ok()
+    crate::expected_speakers_per_channel(participant_human_ids, self_human_id)
+        .and_then(|count| count.checked_sub(1))
+        .and_then(|index| i32::try_from(index).ok())
 }
 
 fn clamp_response_speaker_indices(response: &mut StreamResponse, max_speaker_index: Option<i32>) {
@@ -1328,8 +1315,14 @@ mod tests {
 
     #[test]
     fn clamps_provider_speakers_to_participant_count() {
-        let max_speaker_index =
-            max_speaker_index_for_participants(&["remote".to_string()], Some("self"));
+        let max_speaker_index = max_speaker_index_for_participants(
+            &[
+                "self".to_string(),
+                "remote-a".to_string(),
+                "remote-b".to_string(),
+            ],
+            Some("self"),
+        );
         let mut high_word = word("too-high", 0.0, 0.5);
         high_word.speaker = Some(2);
         let mut negative_word = word("negative", 0.5, 1.0);
@@ -1352,6 +1345,22 @@ mod tests {
 
         assert_eq!(words[0].speaker, Some(1));
         assert_eq!(words[1].speaker, Some(0));
+    }
+
+    #[test]
+    fn clamps_single_remote_speaker_to_zero() {
+        let max_speaker_index =
+            max_speaker_index_for_participants(&["remote".to_string()], Some("self"));
+        let mut high_word = word("too-high", 0.0, 0.5);
+        high_word.speaker = Some(2);
+        let mut response = transcript_response_at("too-high", vec![high_word], true, 1, 0.0, 0.5);
+
+        clamp_response_speaker_indices(&mut response, max_speaker_index);
+
+        let StreamResponse::TranscriptResponse { channel, .. } = response else {
+            panic!("expected transcript response");
+        };
+        assert_eq!(channel.alternatives[0].words[0].speaker, Some(0));
     }
 
     #[test]


### PR DESCRIPTION
Exclude the local participant when constraining remote-channel speaker counts, and clamp live transcript speaker indices to the same per-channel limit.

Validated with targeted formatting, 67 listener-core tests, 29 desktop Rust tests, cargo check, and the macOS workspace suite aside from one unrelated flaky Codex cleanup test that passed on direct rerun.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live diarization and listener reconnect behavior when participants update; wrong counts could mis-label speakers but scope is isolated to listener-core with solid test updates.
> 
> **Overview**
> **Speaker limits now ignore the local participant** and count only distinct remote `participant_human_ids` (with deduping). That shared rule lives in `expected_speakers_per_channel` and replaces three copies of “all participants including self” logic.
> 
> **STT listen params** (`num_speakers` / `max_speakers`) and **session listener refresh** when participant lists change both use the helper, so a call with one remote no longer asks the provider for two speakers. **Live transcript** derives max speaker index from the same count and keeps clamping provider word `speaker` indices to that range.
> 
> Tests were updated for the new counts and add coverage for multi-remote and single-remote clamping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc44f6dafb02027ad710df9d72d623b9ebb21e49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->