### PR TITLE
Avoid store access during single-instance startup

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -14,9 +14,9 @@ use store::*;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 use tauri_plugin_permissions::{Permission, PermissionsPluginExt};
-use tauri_plugin_windows::{AppWindow, WindowsPluginExt};
+use tauri_plugin_windows::AppWindow;
 
 #[cfg(any(feature = "dev", feature = "devtools"))]
 const STAGING_BUNDLE_ID: &str = "com.hyprnote.staging";
@@ -140,7 +140,10 @@ pub async fn main() {
     // should always be the first plugin
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            app.windows().show(AppWindow::Main).unwrap();
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
         }));
     }
 


### PR DESCRIPTION
## Summary
- focus the main webview directly on a second launch
- avoid analytics and store access before plugin setup completes

## Validation
- cargo test -p desktop
- cargo check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to duplicate-launch window focus only; no auth, data, or core business logic touched.
> 
> **Overview**
> When a user launches a second instance, the **single-instance** handler now brings the existing app forward by resolving the `"main"` webview via Tauri’s `Manager` API and calling **`show`** plus **`set_focus`**, instead of routing through **`app.windows().show(AppWindow::Main)`**.
> 
> That swap avoids touching the windows plugin path (and related **store/analytics** work) while plugin setup may still be incomplete on a duplicate launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8001ce0460058fc537f43ded40d4fe218efabb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->