### PR TITLE
Omit temperature for GPT-5.6 Terra

### DIFF
--- a/apps/desktop/src/ai/model-settings.test.ts
+++ b/apps/desktop/src/ai/model-settings.test.ts
@@ -44,6 +44,19 @@ describe("deterministicGenerationSettings", () => {
     ).toEqual({});
   });
 
+  it("omits temperature for GPT-5.6 Terra models", () => {
+    expect(
+      deterministicGenerationSettings(
+        model("openai.responses", "gpt-5.6-terra"),
+      ),
+    ).toEqual({});
+    expect(
+      deterministicGenerationSettings(
+        model("anarlog", "openai/gpt-5.6-terra-2026-07-28"),
+      ),
+    ).toEqual({});
+  });
+
   it("keeps deterministic temperature for other models", () => {
     expect(
       deterministicGenerationSettings(model("anthropic", "claude-opus-4-5")),

--- a/apps/desktop/src/ai/model-settings.ts
+++ b/apps/desktop/src/ai/model-settings.ts
@@ -3,14 +3,14 @@ import type { LanguageModel } from "ai";
 export function deterministicGenerationSettings(model: LanguageModel): {
   temperature?: number;
 } {
-  if (usesDeprecatedTemperature(model)) {
+  if (requiresDefaultTemperature(model)) {
     return {};
   }
 
   return { temperature: 0 };
 }
 
-function usesDeprecatedTemperature(model: LanguageModel): boolean {
+function requiresDefaultTemperature(model: LanguageModel): boolean {
   if (typeof model === "string") {
     return false;
   }
@@ -22,9 +22,11 @@ function usesDeprecatedTemperature(model: LanguageModel): boolean {
     ? normalizedModelId.split("/").pop()!
     : normalizedModelId;
 
-  return (
+  const isClaude48 =
     (provider.startsWith("anthropic") ||
       normalizedModelId.startsWith("anthropic/")) &&
-    /^claude-(?:opus|sonnet|haiku)-4-8(?:$|-)/.test(modelName)
-  );
+    /^claude-(?:opus|sonnet|haiku)-4-8(?:$|-)/.test(modelName);
+  const isGpt56Terra = /^gpt-5-6-terra(?:$|-)/.test(modelName);
+
+  return isClaude48 || isGpt56Terra;
 }


### PR DESCRIPTION
## Summary
- use provider defaults for GPT-5.6 Terra variants
- cover direct and routed model IDs

## Validation
- pnpm -F desktop test
- pnpm -F desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to model-specific generation settings with unit test coverage; no auth, data, or infrastructure impact.
> 
> **Overview**
> **GPT-5.6 Terra** variants no longer get `temperature: 0` in deterministic generation settings; they now use provider defaults (empty settings object), matching the existing Claude 4.8 behavior.
> 
> Detection uses normalized model IDs (`gpt-5.6-terra` → `gpt-5-6-terra`) for both direct providers (e.g. `openai.responses`) and routed IDs (e.g. `anarlog` / `openai/gpt-5.6-terra-…`). The internal helper was renamed from `usesDeprecatedTemperature` to `requiresDefaultTemperature`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f588e8662153a92dfcdbfa71c0fe59f29f2d03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->