### PR TITLE
Stop retrying permanent AI generation failures

### DIFF
--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   analyticsEvent: vi.fn().mockResolvedValue(undefined),
   loadSessionContentSnapshot: vi.fn(),
   loadPendingAutoEnhanceJobs: vi.fn(),
+  discardPendingAutoEnhanceJob: vi.fn(),
   ensurePendingAutoEnhanceDocument: vi.fn(),
   ensureSummaryDocument: vi.fn(),
   replaceSummaryDocumentTemplate: vi.fn().mockResolvedValue(undefined),
@@ -25,6 +26,7 @@ vi.mock("~/session/content-queries", () => ({
 }));
 
 vi.mock("./storage", () => ({
+  discardPendingAutoEnhanceJob: mocks.discardPendingAutoEnhanceJob,
   ensurePendingAutoEnhanceDocument: mocks.ensurePendingAutoEnhanceDocument,
   ensureSummaryDocument: mocks.ensureSummaryDocument,
   loadPendingAutoEnhanceJobs: mocks.loadPendingAutoEnhanceJobs,
@@ -628,6 +630,32 @@ describe("EnhancerService", () => {
       }),
     );
     expect(mocks.listenerSubscribe).toHaveBeenCalledOnce();
+    service.dispose();
+  });
+
+  it("retires a durable job after a permanent generation failure", async () => {
+    snapshot = createSnapshot({
+      notes: [createNote()],
+      wordCount: 40,
+    });
+    const pendingJob = createPendingJob();
+    mocks.loadPendingAutoEnhanceJobs.mockResolvedValue([pendingJob]);
+    const permanentError = new Error(
+      "temperature must be omitted for this model",
+    );
+    const ai = createMockAITaskStore(() => ({
+      status: "error",
+      error: permanentError,
+    }));
+    const service = new EnhancerService(createDeps({ aiTaskStore: ai.store }));
+
+    service.start();
+
+    await vi.waitFor(() => {
+      expect(mocks.discardPendingAutoEnhanceJob).toHaveBeenCalledWith(
+        pendingJob,
+      );
+    });
     service.dispose();
   });
 

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -2,6 +2,7 @@ import type { LanguageModel } from "ai";
 
 import { type EnhanceEligibilitySkipCode, getEligibility } from "./eligibility";
 import {
+  discardPendingAutoEnhanceJob,
   type EnhancerNote,
   type PendingAutoEnhanceJob,
   ensurePendingAutoEnhanceDocument,
@@ -18,7 +19,10 @@ import {
   type SessionContentSnapshot,
 } from "~/session/content-queries";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
-import type { TasksActions } from "~/store/zustand/ai-task/tasks";
+import {
+  isRetryableAIError,
+  type TasksActions,
+} from "~/store/zustand/ai-task/tasks";
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { getTemplateById } from "~/templates/queries";
 
@@ -534,16 +538,30 @@ export class EnhancerService {
           }
         },
       })
-      .then(() => {
-        if (
-          aiTaskStore.getState().getState(enhanceTaskId)?.status === "error"
-        ) {
+      .then(async () => {
+        const taskState = aiTaskStore.getState().getState(enhanceTaskId);
+        if (taskState?.status === "error") {
           trackAnalyticsEvent("enhancement_failed", {
             is_auto: opts?.isAuto ?? false,
             llm_provider: llmConn?.providerId ?? "unknown",
             failure_stage: "generation",
           });
+          if (
+            opts?.pendingAutoEnhance &&
+            taskState.error &&
+            !isRetryableAIError(taskState.error)
+          ) {
+            await retryDatabaseLock(() =>
+              discardPendingAutoEnhanceJob(opts.pendingAutoEnhance!),
+            );
+          }
         }
+      })
+      .catch((error) => {
+        console.error(
+          "[enhancer] failed to finalize auto-enhance task state",
+          error,
+        );
       });
 
     return { type: "started", noteId: note.id };

--- a/apps/desktop/src/services/enhancer/storage.test.ts
+++ b/apps/desktop/src/services/enhancer/storage.test.ts
@@ -27,6 +27,7 @@ vi.mock("~/shared/utils", () => ({
 }));
 
 import {
+  discardPendingAutoEnhanceJob,
   ensurePendingAutoEnhanceDocument,
   ensureSummaryDocument,
   loadPendingAutoEnhanceJobs,
@@ -116,6 +117,32 @@ describe("enhancer SQLite storage", () => {
       expect.any(String),
     ]);
     expect(statement.expectedRowsAffected).toBe(1);
+  });
+
+  it("discards only the exact failed auto-enhance generation", async () => {
+    await discardPendingAutoEnhanceJob({
+      sessionId: "session-1",
+      noteId: "existing-note",
+      templateId: "template-1",
+      expectedBody: "",
+      expectedContentFormat: "prosemirror_json",
+      generation: "generation-1",
+    });
+
+    expect(mocks.enqueueDatabaseWrite).toHaveBeenCalledWith(
+      "session:session-1",
+      expect.any(Function),
+    );
+    const statement = mocks.executeTransaction.mock.calls[0][0][0];
+    expect(statement.sql).toContain("DELETE FROM app_settings");
+    expect(statement.sql).toContain("$.generation");
+    expect(statement.params).toEqual([
+      "auto_enhance_pending:session-1",
+      "existing-note",
+      "generation-1",
+      "",
+      "prosemirror_json",
+    ]);
   });
 
   it("persists the auto-enhance marker with a new empty summary", async () => {

--- a/apps/desktop/src/services/enhancer/storage.ts
+++ b/apps/desktop/src/services/enhancer/storage.ts
@@ -137,6 +137,33 @@ export async function loadPendingAutoEnhanceJobs(): Promise<
   }));
 }
 
+export function discardPendingAutoEnhanceJob(
+  job: PendingAutoEnhanceJob,
+): Promise<void> {
+  return enqueueDatabaseWrite(`session:${job.sessionId}`, async () => {
+    await executeTransaction([
+      {
+        sql: `
+          DELETE FROM app_settings
+          WHERE id = ?
+            AND json_valid(value_json)
+            AND json_extract(value_json, '$.noteId') = ?
+            AND json_extract(value_json, '$.generation') = ?
+            AND json_extract(value_json, '$.body') = ?
+            AND json_extract(value_json, '$.bodyFormat') = ?
+        `,
+        params: [
+          `${PENDING_AUTO_ENHANCE_SETTING_PREFIX}${job.sessionId}`,
+          job.noteId,
+          job.generation,
+          job.expectedBody,
+          job.expectedContentFormat,
+        ],
+      },
+    ]);
+  });
+}
+
 function ensureSummaryDocumentWithMetadata(
   sessionId: string,
   templateId: string | undefined,

--- a/apps/desktop/src/store/zustand/ai-task/tasks.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.ts
@@ -536,7 +536,7 @@ const TRANSIENT_AI_ERROR_PATTERNS = [
 ];
 
 function normalizeTaskError(error: Error): Error {
-  if (!isTransientAIError(error)) {
+  if (!isRetryableAIError(error)) {
     return error;
   }
 
@@ -545,7 +545,7 @@ function normalizeTaskError(error: Error): Error {
   return normalized;
 }
 
-function isTransientAIError(error: Error): boolean {
+export function isRetryableAIError(error: Error): boolean {
   if (APICallError.isInstance(error)) {
     if (error.statusCode === 409) {
       return false;


### PR DESCRIPTION
## Summary
- retry only transient API and transport failures
- retire durable enhancement jobs after permanent generation errors
- guard pending-job deletion by generation and source body

## Validation
- pnpm -F desktop test
- pnpm -F desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable job persistence and deletion predicates; a wrong retry classification could drop jobs that should retry or leave stuck markers, but behavior is covered by new unit tests.
> 
> **Overview**
> **Durable auto-enhance jobs** that fail with **non-retryable** AI errors (e.g. invalid request parameters) are now **retired** instead of being picked up again on every recovery scan.
> 
> After generation finishes in error, `EnhancerService` checks `isRetryableAIError` (exported from the AI task store, renamed from the internal transient helper). For auto-enhance runs with a pending job, a permanent failure triggers `discardPendingAutoEnhanceJob`, which deletes the `app_settings` marker only when **note id, generation, expected body, and body format** all match—so a newer regeneration is not cleared by mistake.
> 
> Finalize-step failures are logged via `.catch` on the enhance completion handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a2c1f4918090923c4337378926f4f25f62a9d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->