### PR TITLE
Bound transcription recovery retries

### DIFF
--- a/apps/desktop/src/stt/live-capture-recovery.test.tsx
+++ b/apps/desktop/src/stt/live-capture-recovery.test.tsx
@@ -214,6 +214,51 @@ test("retries durable capture recovery when the native snapshot is unavailable",
   vi.useRealTimers();
 });
 
+test("stops automatic recovery after the bounded retry budget", async () => {
+  vi.useFakeTimers();
+  const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  mocks.getCaptureSnapshot.mockResolvedValue({
+    status: "ok",
+    data: {
+      activeSessionId: null,
+      finalizingSessionIds: [],
+      liveTranscriptionActive: null,
+      requestedLiveTranscription: null,
+      state: "inactive",
+    },
+  });
+  mocks.loadCaptureLifecycleMarkers.mockResolvedValue([
+    { sessionId: "session-terminal" },
+  ]);
+  const resume = vi.fn().mockResolvedValue("error");
+  mocks.resumeBySession.set("session-terminal", resume);
+
+  render(<LiveCaptureRecovery />);
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(60_000);
+  });
+  expect(resume).toHaveBeenCalledTimes(5);
+  expect(resume).toHaveBeenNthCalledWith(5, {
+    abandonOnFailure: true,
+  });
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(60_000);
+  });
+  expect(resume).toHaveBeenCalledTimes(5);
+  expect(consoleWarn).toHaveBeenCalledWith(
+    "[listener] capture recovery retry budget exhausted",
+    { sessionId: "session-terminal" },
+  );
+  consoleWarn.mockRestore();
+  vi.useRealTimers();
+});
+
 test("recovers durable markers when the native snapshot command rejects", async () => {
   const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
   mocks.getCaptureSnapshot.mockRejectedValue(

--- a/apps/desktop/src/stt/live-capture-recovery.tsx
+++ b/apps/desktop/src/stt/live-capture-recovery.tsx
@@ -6,7 +6,8 @@ import { loadCaptureLifecycleMarkers } from "./capture-lifecycle-storage";
 import { listenCaptureRecoveryRequests } from "./capture-recovery-requests";
 import { useResumeListeningLifecycle } from "./useStartListening";
 
-const CAPTURE_RECOVERY_RETRY_MS = 2_000;
+const CAPTURE_RECOVERY_BASE_RETRY_MS = 2_000;
+const CAPTURE_RECOVERY_MAX_ATTEMPTS = 5;
 
 export function LiveCaptureRecovery() {
   const [recoveryTokens, setRecoveryTokens] = useState<Record<string, number>>(
@@ -129,10 +130,12 @@ function LiveCaptureSessionRecovery({
     let active = true;
     let retryTimer: ReturnType<typeof setTimeout> | undefined;
 
-    const recover = async () => {
+    const recover = async (attempt: number) => {
       let result: "attached" | "inactive" | "error";
       try {
-        result = await resumeListeningLifecycle();
+        result = await resumeListeningLifecycle({
+          abandonOnFailure: attempt >= CAPTURE_RECOVERY_MAX_ATTEMPTS,
+        });
       } catch (error) {
         console.error("[listener] capture recovery attempt failed", error);
         result = "error";
@@ -141,15 +144,25 @@ function LiveCaptureSessionRecovery({
         return;
       }
       if (result === "error") {
-        retryTimer = setTimeout(() => {
-          void recover();
-        }, CAPTURE_RECOVERY_RETRY_MS);
+        if (attempt >= CAPTURE_RECOVERY_MAX_ATTEMPTS) {
+          console.warn("[listener] capture recovery retry budget exhausted", {
+            sessionId,
+          });
+          onComplete(sessionId, recoveryToken);
+          return;
+        }
+        retryTimer = setTimeout(
+          () => {
+            void recover(attempt + 1);
+          },
+          CAPTURE_RECOVERY_BASE_RETRY_MS * 2 ** (attempt - 1),
+        );
         return;
       }
       onComplete(sessionId, recoveryToken);
     };
 
-    void recover();
+    void recover(1);
 
     return () => {
       active = false;

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -9,6 +9,7 @@ import {
   getBatchFallbackTarget,
   getBatchProvider,
   getSessionSpeakerCount,
+  isTerminalTranscriptionError,
 } from "./useRunBatch";
 import { useRunBatch } from "./useRunBatch";
 
@@ -196,6 +197,28 @@ describe("canRunBatchTranscription", () => {
         model: "realtime-only",
       }),
     ).toBe(true);
+  });
+});
+
+describe("isTerminalTranscriptionError", () => {
+  test.each([
+    "Bad Request: failed to process audio: corrupt or unsupported data",
+    "No speech detected",
+    "Authentication failed: 401 Unauthorized",
+    EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE,
+  ])("classifies permanent failures: %s", (message) => {
+    expect(isTerminalTranscriptionError(new Error(message))).toBe(true);
+  });
+
+  test.each([
+    "request timed out",
+    "429 Too Many Requests",
+    "503 Service Unavailable",
+    "database is locked",
+    "nova-3 is not available for batch transcription",
+    "STT connection is not available",
+  ])("leaves transient failures retryable: %s", (message) => {
+    expect(isTerminalTranscriptionError(new Error(message))).toBe(false);
   });
 });
 

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -226,6 +226,18 @@ export function isTranscriptionAuthenticationError(error: unknown) {
   );
 }
 
+export function isTerminalTranscriptionError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message === EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE ||
+    isTranscriptionAuthenticationError(error) ||
+    /corrupt or unsupported|unsupported (?:audio|data)|invalid audio|no speech|empty transcript/i.test(
+      message,
+    ) ||
+    /\b(?:400|403|404|413|415|422)\b|bad request|invalid api key/i.test(message)
+  );
+}
+
 export function getSessionSpeakerCount(
   participantHumanIds: Iterable<string>,
   selfHumanId?: string | null,

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -165,6 +165,11 @@ vi.mock("./useRunBatch", () => ({
       (error instanceof Error ? error.message : String(error)) ===
       "Transcription stopped.",
   ),
+  isTerminalTranscriptionError: vi.fn((error: unknown) =>
+    /corrupt or unsupported|no speech|authentication failed/i.test(
+      error instanceof Error ? error.message : String(error),
+    ),
+  ),
   useRunBatch: vi.fn(() => runBatchMock),
 }));
 
@@ -1680,6 +1685,91 @@ describe("useStartListening", () => {
     consoleError.mockRestore();
   });
 
+  test("preserves and reloads recovery after a transient marker read failure", async () => {
+    attachLiveSessionMock.mockResolvedValue("inactive");
+    const marker = {
+      version: 1 as const,
+      sessionId: "session-1",
+      transcriptId: "transcript-before-reload",
+      startedAt: 1_000,
+      createdAt: "2026-07-24T00:00:00.000Z",
+      audioOffsetMs: 10_000,
+      preserveExistingTranscript: true,
+      ownerUserId: "user-1",
+      memo: "Existing memo",
+    };
+    loadCaptureLifecycleMarkerMock
+      .mockRejectedValueOnce(new Error("database is locked"))
+      .mockResolvedValueOnce(marker)
+      .mockResolvedValueOnce(marker)
+      .mockResolvedValueOnce(null);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useResumeListeningLifecycle("session-1"),
+    );
+
+    await act(async () => {
+      await expect(result.current({ abandonOnFailure: true })).resolves.toBe(
+        "error",
+      );
+    });
+    expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await expect(result.current()).resolves.toBe("inactive");
+    });
+
+    expect(runBatchMock).toHaveBeenCalledOnce();
+    expect(beginCaptureRecoveryFinalizationMock).toHaveBeenCalledOnce();
+    expect(finishCaptureRecoveryFinalizationMock).toHaveBeenCalledOnce();
+    expect(beginCloudsyncActivityMock).toHaveBeenCalledOnce();
+    expect(endCloudsyncActivityMock).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+
+  test("releases recovery ownership after the retry budget is exhausted", async () => {
+    attachLiveSessionMock.mockResolvedValue("inactive");
+    runBatchMock.mockRejectedValue(new Error("temporary repair failure"));
+    const marker = {
+      version: 1 as const,
+      sessionId: "session-1",
+      transcriptId: "transcript-before-reload",
+      startedAt: 1_000,
+      createdAt: "2026-07-24T00:00:00.000Z",
+      audioOffsetMs: 10_000,
+      preserveExistingTranscript: true,
+      ownerUserId: "user-1",
+      memo: "Existing memo",
+    };
+    loadCaptureLifecycleMarkerMock.mockResolvedValue(marker);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useResumeListeningLifecycle("session-1"),
+    );
+
+    await act(async () => {
+      await expect(result.current({ abandonOnFailure: true })).resolves.toBe(
+        "error",
+      );
+    });
+
+    expect(clearCaptureLifecycleMarkerMock).toHaveBeenCalledWith(
+      "session-1",
+      "transcript-before-reload",
+    );
+    expect(beginCaptureRecoveryFinalizationMock).toHaveBeenCalledOnce();
+    expect(finishCaptureRecoveryFinalizationMock).toHaveBeenCalledWith(
+      "session-1",
+    );
+    expect(beginCloudsyncActivityMock).toHaveBeenCalledOnce();
+    expect(endCloudsyncActivityMock).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+
   test("hands a failed capture to recovery without ending its native lease", async () => {
     runBatchMock
       .mockRejectedValueOnce(new Error("temporary repair failure"))
@@ -2002,6 +2092,37 @@ describe("useStartListening", () => {
     expect(beginCaptureRecoveryFinalizationMock).toHaveBeenCalledTimes(2);
     expect(runBatchMock).toHaveBeenCalledOnce();
     expect(finishCaptureRecoveryFinalizationMock).toHaveBeenCalledOnce();
+  });
+
+  test("preserves recovery state when another worker owns finalization", async () => {
+    attachLiveSessionMock.mockResolvedValue("inactive");
+    beginCaptureRecoveryFinalizationMock.mockReturnValue(false);
+    const marker = {
+      version: 1 as const,
+      sessionId: "session-1",
+      transcriptId: "transcript-before-reload",
+      startedAt: 1_000,
+      createdAt: "2026-07-24T00:00:00.000Z",
+      audioOffsetMs: 10_000,
+      preserveExistingTranscript: true,
+      ownerUserId: "user-1",
+      memo: "Existing memo",
+    };
+    loadCaptureLifecycleMarkerMock.mockResolvedValue(marker);
+    const { result } = renderHook(() =>
+      useResumeListeningLifecycle("session-1"),
+    );
+
+    await act(async () => {
+      await expect(result.current({ abandonOnFailure: true })).resolves.toBe(
+        "error",
+      );
+    });
+
+    expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
+    expect(finishCaptureRecoveryFinalizationMock).not.toHaveBeenCalled();
+    expect(beginCloudsyncActivityMock).toHaveBeenCalledOnce();
+    expect(endCloudsyncActivityMock).toHaveBeenCalledOnce();
   });
 
   test("reuses the same recovery attempt when stop arrives after a snapshot error", async () => {
@@ -2337,6 +2458,47 @@ describe("useStartListening", () => {
     );
     expect(endCloudsyncActivityMock).not.toHaveBeenCalled();
     expect(requestCaptureRecoveryMock).toHaveBeenCalledWith("session-1");
+    consoleError.mockRestore();
+  });
+
+  test("stops automatic recovery for a terminal batch repair failure", async () => {
+    useSessionHasTranscriptMock.mockReturnValue(true);
+    runBatchMock.mockRejectedValueOnce(
+      new Error(
+        "Bad Request: failed to process audio: corrupt or unsupported data",
+      ),
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const onStopped = startMock.mock.calls[0]?.[1]?.onStopped;
+    await act(async () => {
+      await onStopped?.("session-1", {
+        durationSeconds: 42,
+        audioPath: "/tmp/session.wav",
+        requestedLiveTranscription: true,
+        liveTranscriptionActive: true,
+        needsBatchRepair: true,
+      });
+    });
+
+    expect(clearCaptureLifecycleMarkerMock).toHaveBeenCalledWith(
+      "session-1",
+      "generated-id",
+    );
+    expect(requestCaptureRecoveryMock).not.toHaveBeenCalled();
+    expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
+    expect(endCloudsyncActivityMock).toHaveBeenCalledWith(
+      "capture",
+      "session-1:generated-id",
+    );
     consoleError.mockRestore();
   });
 

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -13,6 +13,7 @@ import { getSessionKeywords } from "./useKeywords";
 import {
   canRunBatchTranscription,
   isStoppedTranscriptionError,
+  isTerminalTranscriptionError,
   useRunBatch,
 } from "./useRunBatch";
 import { useSTTConnection } from "./useSTTConnection";
@@ -593,6 +594,20 @@ function useCaptureLifecycle(sessionId: string) {
                 { id: "post-capture-batch-failed" },
               );
             }
+            if (isTerminalTranscriptionError(error)) {
+              try {
+                await clearCaptureLifecycleMarker(sessionId, transcriptId);
+                recoveryPending = false;
+                recoveryStateCleared = true;
+              } catch (clearError) {
+                console.error(
+                  "[listener] failed to stop automatic capture recovery",
+                  clearError,
+                );
+                await requestRecovery();
+              }
+              return;
+            }
             await requestRecovery();
             return;
           }
@@ -889,108 +904,171 @@ export function useResumeListeningLifecycle(sessionId: string) {
   } | null>(null);
   const ownsRecoveryFinalizationRef = useRef(false);
 
-  return useCallback(async () => {
-    let attempt = recoveryAttemptRef.current;
-    if (!attempt || attempt.sessionId !== sessionId) {
-      const stoppedProcessingRef = {
-        current: null as Promise<void> | null,
-      };
-      const lifecycleState = loadCaptureLifecycleMarker(sessionId).then(
-        (recoveredMarker) => {
-          let markerInstalled = Boolean(recoveredMarker);
-          let markerWrite: Promise<void> | null = null;
-          const lifecycle = createCaptureLifecycleRef.current(
-            recoveredMarker ?? undefined,
-          );
-          return {
-            lifecycle,
-            hasMarker: () => markerInstalled,
-            ensureMarker: () => {
-              if (markerInstalled) {
-                return Promise.resolve();
-              }
-              markerWrite ??= lifecycle.persistMarker().then(
-                () => {
-                  markerInstalled = true;
-                },
-                (error) => {
-                  markerWrite = null;
-                  throw error;
-                },
-              );
-              return markerWrite;
-            },
-          };
-        },
-      );
-      attempt = { sessionId, lifecycleState, stoppedProcessingRef };
-      recoveryAttemptRef.current = attempt;
-      void lifecycleState.catch((error) => {
-        console.error(
-          "[listener] failed to load capture recovery state",
-          error,
+  return useCallback(
+    async (options?: { abandonOnFailure?: boolean }) => {
+      let attempt = recoveryAttemptRef.current;
+      if (!attempt || attempt.sessionId !== sessionId) {
+        const stoppedProcessingRef = {
+          current: null as Promise<void> | null,
+        };
+        const lifecycleState = loadCaptureLifecycleMarker(sessionId).then(
+          (recoveredMarker) => {
+            let markerInstalled = Boolean(recoveredMarker);
+            let markerWrite: Promise<void> | null = null;
+            const lifecycle = createCaptureLifecycleRef.current(
+              recoveredMarker ?? undefined,
+            );
+            return {
+              lifecycle,
+              hasMarker: () => markerInstalled,
+              ensureMarker: () => {
+                if (markerInstalled) {
+                  return Promise.resolve();
+                }
+                markerWrite ??= lifecycle.persistMarker().then(
+                  () => {
+                    markerInstalled = true;
+                  },
+                  (error) => {
+                    markerWrite = null;
+                    throw error;
+                  },
+                );
+                return markerWrite;
+              },
+            };
+          },
         );
-      });
-    }
-
-    const { lifecycleState, stoppedProcessingRef } = attempt;
-    let state: Awaited<typeof lifecycleState>;
-    try {
-      state = await lifecycleState;
-      await state.lifecycle.acquireCloudsyncLease();
-    } catch (error) {
-      console.error(
-        "[listener] failed to prepare capture recovery state",
-        error,
-      );
-      return "error" as const;
-    }
-
-    let result: Awaited<ReturnType<typeof attachLiveSession>>;
-    try {
-      result = await attachLiveSession(sessionId, {
-        handlePersist: (delta) => {
-          void state.lifecycle
-            .acquireCloudsyncLease()
-            .then(() => state.lifecycle.handlePersist(delta))
-            .catch((error) => {
-              console.error(
-                "[listener] failed to recover transcript persistence",
-                error,
-              );
-            });
-        },
-        onStopped: (stoppedSessionId, details) => {
-          const processing = state.lifecycle.acquireCloudsyncLease().then(() =>
-            state.lifecycle.onStopped(stoppedSessionId, {
-              ...details,
-              needsBatchRepair: true,
-            }),
+        attempt = { sessionId, lifecycleState, stoppedProcessingRef };
+        recoveryAttemptRef.current = attempt;
+        void lifecycleState.catch((error) => {
+          console.error(
+            "[listener] failed to load capture recovery state",
+            error,
           );
-          stoppedProcessingRef.current = processing;
-          return processing;
-        },
-      });
-    } catch (error) {
-      console.error("[listener] failed to attach capture recovery", error);
-      return "error" as const;
-    }
+        });
+      }
 
-    if (result === "attached") {
+      const { lifecycleState, stoppedProcessingRef } = attempt;
+      let state: Awaited<typeof lifecycleState> | undefined;
+      const failRecovery = async ({
+        clearMarker = true,
+      }: { clearMarker?: boolean } = {}) => {
+        if (!options?.abandonOnFailure) {
+          return "error" as const;
+        }
+
+        if (clearMarker) {
+          try {
+            const marker = await loadCaptureLifecycleMarker(sessionId);
+            if (marker) {
+              await clearCaptureLifecycleMarker(sessionId, marker.transcriptId);
+            }
+          } catch (error) {
+            console.error(
+              "[listener] failed to clear exhausted capture recovery",
+              error,
+            );
+          }
+        }
+
+        try {
+          await state?.lifecycle.releaseCloudsyncLease();
+        } catch (error) {
+          console.error(
+            "[listener] failed to release exhausted capture recovery",
+            error,
+          );
+        }
+
+        if (ownsRecoveryFinalizationRef.current) {
+          finishCaptureRecoveryFinalization(sessionId);
+          ownsRecoveryFinalizationRef.current = false;
+        }
+        recoveryAttemptRef.current = null;
+        return "error" as const;
+      };
       try {
-        await state.ensureMarker();
+        state = await lifecycleState;
+        await state.lifecycle.acquireCloudsyncLease();
       } catch (error) {
         console.error(
           "[listener] failed to prepare capture recovery state",
           error,
         );
-        return "error" as const;
+        const lifecycleStateUnavailable = !state;
+        if (
+          lifecycleStateUnavailable &&
+          recoveryAttemptRef.current === attempt
+        ) {
+          recoveryAttemptRef.current = null;
+        }
+        return failRecovery({ clearMarker: !lifecycleStateUnavailable });
       }
-      return result;
-    }
-    if (result === "error") {
-      const stoppedProcessing = stoppedProcessingRef.current;
-      if (stoppedProcessing) {
+
+      let result: Awaited<ReturnType<typeof attachLiveSession>>;
+      try {
+        result = await attachLiveSession(sessionId, {
+          handlePersist: (delta) => {
+            void state.lifecycle
+              .acquireCloudsyncLease()
+              .then(() => state.lifecycle.handlePersist(delta))
+              .catch((error) => {
+                console.error(
+                  "[listener] failed to recover transcript persistence",
+                  error,
+                );
+              });
+          },
+          onStopped: (stoppedSessionId, details) => {
+            const processing = state.lifecycle
+              .acquireCloudsyncLease()
+              .then(() =>
+                state.lifecycle.onStopped(stoppedSessionId, {
+                  ...details,
+                  needsBatchRepair: true,
+                }),
+              );
+            stoppedProcessingRef.current = processing;
+            return processing;
+          },
+        });
+      } catch (error) {
+        console.error("[listener] failed to attach capture recovery", error);
+        return failRecovery();
+      }
+
+      if (result === "attached") {
+        try {
+          await state.ensureMarker();
+        } catch (error) {
+          console.error(
+            "[listener] failed to prepare capture recovery state",
+            error,
+          );
+          return failRecovery();
+        }
+        return result;
+      }
+      if (result === "error") {
+        const stoppedProcessing = stoppedProcessingRef.current;
+        if (stoppedProcessing) {
+          try {
+            await stoppedProcessing;
+          } catch (error) {
+            console.error(
+              "[listener] failed to recover stopped capture",
+              error,
+            );
+            if (stoppedProcessingRef.current === stoppedProcessing) {
+              stoppedProcessingRef.current = null;
+            }
+          }
+        }
+        return failRecovery();
+      }
+      if (stoppedProcessingRef.current) {
+        const stoppedProcessing = stoppedProcessingRef.current;
         try {
           await stoppedProcessing;
         } catch (error) {
@@ -998,85 +1076,77 @@ export function useResumeListeningLifecycle(sessionId: string) {
           if (stoppedProcessingRef.current === stoppedProcessing) {
             stoppedProcessingRef.current = null;
           }
+          return failRecovery();
+        }
+        if (await loadCaptureLifecycleMarker(sessionId)) {
+          if (stoppedProcessingRef.current === stoppedProcessing) {
+            stoppedProcessingRef.current = null;
+          }
+        } else {
+          if (ownsRecoveryFinalizationRef.current) {
+            finishCaptureRecoveryFinalization(sessionId);
+            ownsRecoveryFinalizationRef.current = false;
+          }
+          return "inactive" as const;
         }
       }
-      return "error" as const;
-    }
-    if (stoppedProcessingRef.current) {
-      const stoppedProcessing = stoppedProcessingRef.current;
-      try {
-        await stoppedProcessing;
-      } catch (error) {
-        console.error("[listener] failed to recover stopped capture", error);
-        if (stoppedProcessingRef.current === stoppedProcessing) {
-          stoppedProcessingRef.current = null;
-        }
-        return "error" as const;
-      }
-      if (await loadCaptureLifecycleMarker(sessionId)) {
-        if (stoppedProcessingRef.current === stoppedProcessing) {
-          stoppedProcessingRef.current = null;
-        }
-      } else {
+
+      if (
+        !state.hasMarker() ||
+        !(await loadCaptureLifecycleMarker(sessionId))
+      ) {
         if (ownsRecoveryFinalizationRef.current) {
           finishCaptureRecoveryFinalization(sessionId);
           ownsRecoveryFinalizationRef.current = false;
         }
+        await state.lifecycle.releaseCloudsyncLease();
         return "inactive" as const;
       }
-    }
 
-    if (!state.hasMarker() || !(await loadCaptureLifecycleMarker(sessionId))) {
-      if (ownsRecoveryFinalizationRef.current) {
-        finishCaptureRecoveryFinalization(sessionId);
-        ownsRecoveryFinalizationRef.current = false;
+      if (!ownsRecoveryFinalizationRef.current) {
+        if (!beginCaptureRecoveryFinalization(sessionId)) {
+          return failRecovery({ clearMarker: false });
+        }
+        ownsRecoveryFinalizationRef.current = true;
       }
-      await state.lifecycle.releaseCloudsyncLease();
+
+      let audioPath: string | null = null;
+      let durationSeconds = 0;
+      try {
+        const pathResult = await fsSyncCommands.audioPath(sessionId);
+        if (pathResult.status === "ok") {
+          audioPath = pathResult.data;
+          durationSeconds =
+            ((await getAudioDurationMs(pathResult.data)) ?? 0) / 1_000;
+        } else if (pathResult.error !== "audio_path_not_found") {
+          throw new Error(pathResult.error);
+        }
+        await state.lifecycle.recoverStopped(sessionId, {
+          durationSeconds,
+          audioPath,
+          requestedLiveTranscription: true,
+          liveTranscriptionActive: false,
+          needsBatchRepair: true,
+        });
+      } catch (error) {
+        console.error("[listener] failed to recover stopped capture", error);
+        return failRecovery();
+      }
+
+      if (await loadCaptureLifecycleMarker(sessionId)) {
+        return failRecovery();
+      }
+      finishCaptureRecoveryFinalization(sessionId);
+      ownsRecoveryFinalizationRef.current = false;
       return "inactive" as const;
-    }
-
-    if (!ownsRecoveryFinalizationRef.current) {
-      if (!beginCaptureRecoveryFinalization(sessionId)) {
-        return "error" as const;
-      }
-      ownsRecoveryFinalizationRef.current = true;
-    }
-
-    let audioPath: string | null = null;
-    let durationSeconds = 0;
-    try {
-      const pathResult = await fsSyncCommands.audioPath(sessionId);
-      if (pathResult.status === "ok") {
-        audioPath = pathResult.data;
-        durationSeconds =
-          ((await getAudioDurationMs(pathResult.data)) ?? 0) / 1_000;
-      } else if (pathResult.error !== "audio_path_not_found") {
-        throw new Error(pathResult.error);
-      }
-      await state.lifecycle.recoverStopped(sessionId, {
-        durationSeconds,
-        audioPath,
-        requestedLiveTranscription: true,
-        liveTranscriptionActive: false,
-        needsBatchRepair: true,
-      });
-    } catch (error) {
-      console.error("[listener] failed to recover stopped capture", error);
-      return "error" as const;
-    }
-
-    if (await loadCaptureLifecycleMarker(sessionId)) {
-      return "error" as const;
-    }
-    finishCaptureRecoveryFinalization(sessionId);
-    ownsRecoveryFinalizationRef.current = false;
-    return "inactive" as const;
-  }, [
-    attachLiveSession,
-    beginCaptureRecoveryFinalization,
-    finishCaptureRecoveryFinalization,
-    sessionId,
-  ]);
+    },
+    [
+      attachLiveSession,
+      beginCaptureRecoveryFinalization,
+      finishCaptureRecoveryFinalization,
+      sessionId,
+    ],
+  );
 }
 
 export function useStartListening(sessionId: string) {


### PR DESCRIPTION
## Summary
- stop requeueing terminal batch transcription failures
- retain retry behavior for transient service and database errors
- cap live-capture recovery with exponential backoff

## Validation
- pnpm -F desktop test
- pnpm -F desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-stop transcription and capture lifecycle cleanup paths; incorrect terminal-error classification could stop recovery too early or retry forever on the wrong errors.
> 
> **Overview**
> **Post-capture batch repair** now distinguishes **permanent** transcription failures from **transient** ones via new `isTerminalTranscriptionError`. Corrupt/unsupported audio, no speech, auth/4xx-style errors stop automatic recovery: the durable capture marker is cleared and `requestCaptureRecovery` is not fired. Timeouts, rate limits, DB locks, and similar errors still requeue recovery as before.
> 
> **Live capture recovery** no longer retries indefinitely on a fixed interval. It uses **exponential backoff** (base 2s, up to **5 attempts**), passes `abandonOnFailure: true` on the final attempt, logs when the budget is exhausted, and stops scheduling further retries.
> 
> **`useResumeListeningLifecycle`** accepts optional `abandonOnFailure` to **tear down** recovery state after the budget is spent (clear marker, release cloudsync, finish finalization) while **preserving** markers on transient failures (e.g. marker read errors, another worker owning finalization) when abandonment is not requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a868e45d6149b8064cb6d9494fc9a14d4c965483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->