### PR TITLE
Synchronize audio deletion with playback

### DIFF
--- a/apps/desktop/src/audio-player/provider.tsx
+++ b/apps/desktop/src/audio-player/provider.tsx
@@ -17,8 +17,12 @@ import { commands as fsSyncCommands } from "@anlg/plugin-fs-sync";
 import { configureCenteredPlayback } from "./playback";
 
 import { useBillingAccess } from "~/auth/billing-context";
-import { isSessionAudioIdle } from "~/services/audio-retention";
+import {
+  isSessionAudioIdle,
+  subscribeToSessionAudioRetention,
+} from "~/services/audio-retention";
 import { deleteSessionAudio } from "~/session/attachments";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 const TIME_UPDATE_STEP_SECONDS = 0.1;
 
@@ -305,6 +309,41 @@ export function AudioPlayerProvider({
     }
   }, [wavesurfer]);
 
+  const markAudioDeleted = useCallback(() => {
+    timeStoreRef.current.reset();
+    queryClient.setQueryData(["audio", sessionId, "exist"], {
+      status: "ok",
+      data: false,
+    });
+    queryClient.setQueryData(["audio", sessionId, "url"], {
+      status: "error",
+      error: "audio_path_not_found",
+    });
+    void queryClient.invalidateQueries({
+      queryKey: ["audio", sessionId, "exist"],
+    });
+    void queryClient.invalidateQueries({
+      queryKey: ["audio", sessionId, "url"],
+    });
+  }, [queryClient, sessionId]);
+  const retentionHandlerRef = useRef(
+    (_event: { phase: "deleting" | "deleted"; sessionId: string }) => {},
+  );
+  retentionHandlerRef.current = (event) => {
+    if (event.sessionId !== sessionId) {
+      return;
+    }
+    stop();
+    if (event.phase === "deleted") {
+      markAudioDeleted();
+    }
+  };
+  useMountEffect(() =>
+    subscribeToSessionAudioRetention((event) =>
+      retentionHandlerRef.current(event),
+    ),
+  );
+
   const seek = useCallback(
     (timeInSeconds: number) => {
       if (wavesurfer) {
@@ -342,6 +381,7 @@ export function AudioPlayerProvider({
 
   const deleteRecordingMutation = useMutation({
     mutationFn: async () => {
+      stop();
       const deleted = await deleteSessionAudio(sessionId, () =>
         isSessionAudioIdle(sessionId),
       );
@@ -349,16 +389,7 @@ export function AudioPlayerProvider({
         throw new Error("audio_session_busy");
       }
     },
-    onSuccess: () => {
-      stop();
-      timeStoreRef.current.reset();
-      void queryClient.invalidateQueries({
-        queryKey: ["audio", sessionId, "exist"],
-      });
-      void queryClient.invalidateQueries({
-        queryKey: ["audio", sessionId, "url"],
-      });
-    },
+    onSuccess: markAudioDeleted,
   });
 
   const value = useMemo<AudioPlayerContextValue>(

--- a/apps/desktop/src/services/audio-retention.test.ts
+++ b/apps/desktop/src/services/audio-retention.test.ts
@@ -31,6 +31,7 @@ import {
   deleteProcessedAudioForRetention,
   normalizeAudioRetention,
   sessionAudioExpired,
+  subscribeToSessionAudioRetention,
 } from "./audio-retention";
 
 function mockCleanupRows(
@@ -164,6 +165,8 @@ describe("audio retention", () => {
 
   test("deletes processed audio immediately when retention is none", async () => {
     mocks.execute.mockResolvedValueOnce([{ has_words: 1 }]);
+    const listener = vi.fn();
+    const unsubscribe = subscribeToSessionAudioRetention(listener);
 
     await expect(
       deleteProcessedAudioForRetention("none", "processed"),
@@ -172,6 +175,15 @@ describe("audio retention", () => {
       "processed",
       expect.any(Function),
     );
+    expect(listener).toHaveBeenNthCalledWith(1, {
+      phase: "deleting",
+      sessionId: "processed",
+    });
+    expect(listener).toHaveBeenNthCalledWith(2, {
+      phase: "deleted",
+      sessionId: "processed",
+    });
+    unsubscribe();
   });
 
   test("keeps unprocessed audio when retention is none", async () => {

--- a/apps/desktop/src/services/audio-retention.ts
+++ b/apps/desktop/src/services/audio-retention.ts
@@ -13,6 +13,38 @@ import { listenerStore } from "~/store/zustand/listener/instance";
 export const AUDIO_RETENTION_TASK_ID = "audio-retention-cleanup";
 export const AUDIO_RETENTION_INTERVAL = 60 * 1000;
 
+type SessionAudioRetentionEvent = {
+  phase: "deleting" | "deleted";
+  sessionId: string;
+};
+
+const sessionAudioRetentionListeners = new Set<
+  (event: SessionAudioRetentionEvent) => void
+>();
+
+export function subscribeToSessionAudioRetention(
+  listener: (event: SessionAudioRetentionEvent) => void,
+) {
+  sessionAudioRetentionListeners.add(listener);
+  return () => sessionAudioRetentionListeners.delete(listener);
+}
+
+function emitSessionAudioRetention(event: SessionAudioRetentionEvent) {
+  sessionAudioRetentionListeners.forEach((listener) => listener(event));
+}
+
+async function deleteWithRetentionLifecycle(
+  sessionId: string,
+  deleteAudio: () => Promise<boolean>,
+) {
+  emitSessionAudioRetention({ phase: "deleting", sessionId });
+  const deleted = await deleteAudio();
+  if (deleted) {
+    emitSessionAudioRetention({ phase: "deleted", sessionId });
+  }
+  return deleted;
+}
+
 export {
   normalizeAudioRetention,
   type AudioRetentionPolicy,
@@ -99,8 +131,8 @@ export async function deleteProcessedAudioForRetention(
   }
 
   try {
-    return await deleteLocalSessionAudio(sessionId, () =>
-      isSessionAudioIdle(sessionId),
+    return await deleteWithRetentionLifecycle(sessionId, () =>
+      deleteLocalSessionAudio(sessionId, () => isSessionAudioIdle(sessionId)),
     );
   } catch (error) {
     console.error("[audio-retention] failed to delete audio", {
@@ -171,7 +203,11 @@ export async function cleanupExpiredAudio(
     }
 
     deletes.push(
-      deleteLocalSessionAudio(session.id, () => isSessionAudioIdle(session.id))
+      deleteWithRetentionLifecycle(session.id, () =>
+        deleteLocalSessionAudio(session.id, () =>
+          isSessionAudioIdle(session.id),
+        ),
+      )
         .then((deleted) => {
           if (deleted) {
             deletedSessionIds.push(session.id);
@@ -213,8 +249,10 @@ async function cleanupLogicallyDeletedAudio() {
 
       try {
         if (
-          await cleanupDeletedSessionAudio(sessionId, () =>
-            isSessionAudioIdle(sessionId),
+          await deleteWithRetentionLifecycle(sessionId, () =>
+            cleanupDeletedSessionAudio(sessionId, () =>
+              isSessionAudioIdle(sessionId),
+            ),
           )
         ) {
           deletedSessionIds.push(sessionId);


### PR DESCRIPTION
## Summary
- stop and reset playback before deleting session audio
- notify active players when retention cleanup removes audio
- update existence and URL caches after deletion

## Validation
- pnpm -F desktop test
- pnpm -F desktop typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches playback state and React Query cache during background retention deletes; behavior is scoped per sessionId but wrong cache updates could briefly show stale audio UI.
> 
> **Overview**
> Adds a **retention lifecycle pub/sub** so any path that removes session audio (`deleteProcessedAudioForRetention`, expired cleanup, logically deleted cleanup) emits `deleting` / `deleted` events around the actual file delete.
> 
> **`AudioPlayerProvider`** subscribes for its `sessionId`: it **stops playback** on `deleting`, and on `deleted` runs shared **`markAudioDeleted`** logic that resets the time store and **optimistically updates** React Query `exist` / `url` caches (including `audio_path_not_found` on URL) before invalidating. Manual delete now **stops before** the mutation and reuses `markAudioDeleted` on success instead of only invalidating queries.
> 
> Tests assert listeners receive both phases when retention deletes processed audio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9411afdcf6218be307a577c80d90ab39a5bf3d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->