### PR TITLE
Make blog date rendering timezone-stable

### DIFF
--- a/apps/web/src/lib/blog-date.test.ts
+++ b/apps/web/src/lib/blog-date.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatBlogDate } from "./blog-date.ts";
+
+test("formats blog dates in UTC for stable server and client output", () => {
+  assert.equal(formatBlogDate("2026-07-29", "long"), "July 29, 2026");
+  assert.equal(formatBlogDate("2026-07-29", "short"), "Jul 29, 2026");
+});
+
+test("preserves invalid dates", () => {
+  assert.equal(formatBlogDate("not-a-date", "long"), "not-a-date");
+});

--- a/apps/web/src/lib/blog-date.ts
+++ b/apps/web/src/lib/blog-date.ts
@@ -1,0 +1,14 @@
+export function formatBlogDate(date: string, month: "long" | "short") {
+  const parsed = new Date(date);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return date;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month,
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(parsed);
+}

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -13,6 +13,7 @@ import {
 
 import { mdxComponents } from "@/components/mdx-components";
 import { SiteFooter } from "@/components/site-footer";
+import { formatBlogDate } from "@/lib/blog-date";
 import { ANARLOG_SITE_URL, getBlogOgImageUrl } from "@/lib/seo";
 
 const blogMdxComponents = {
@@ -89,11 +90,7 @@ function Component() {
             <span>{authors}</span>
             <span>·</span>
             <time dateTime={article.date}>
-              {new Date(article.date).toLocaleDateString("en-US", {
-                month: "long",
-                day: "numeric",
-                year: "numeric",
-              })}
+              {formatBlogDate(article.date, "long")}
             </time>
           </div>
         </header>

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { allArticles } from "content-collections";
 
 import { SiteFooter } from "@/components/site-footer";
+import { formatBlogDate } from "@/lib/blog-date";
 import { ANARLOG_SITE_URL } from "@/lib/seo";
 
 export const Route = createFileRoute("/blog/")({
@@ -70,11 +71,7 @@ function Component() {
                     </span>
                     <span>·</span>
                     <time dateTime={article.date}>
-                      {new Date(article.date).toLocaleDateString("en-US", {
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                      })}
+                      {formatBlogDate(article.date, "short")}
                     </time>
                   </div>
                 </article>


### PR DESCRIPTION
## Summary
- format blog publication dates in UTC
- share one formatter between index and detail routes
- preserve invalid source values instead of throwing

## Validation
- pnpm -F @anlg/web test
- pnpm -F @anlg/web typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation-layer change limited to blog routes, with unit tests and no auth or data handling impact.
> 
> **Overview**
> Blog publication dates on the **index** and **article** routes no longer use locale-default `toLocaleDateString`, which could show different calendar days across server render, client hydration, and user timezones.
> 
> A shared **`formatBlogDate`** helper formats dates with **`Intl.DateTimeFormat`** and **`timeZone: "UTC"`**, with **long** month on detail pages and **short** on the listing. Unparseable date strings are returned unchanged instead of producing invalid output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f6634728ffa3a78bacb0cd7ab293f5865d829a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->