### PR TITLE
Propagate macOS speaker stream failures

### DIFF
--- a/crates/audio-actual/src/speaker/macos.rs
+++ b/crates/audio-actual/src/speaker/macos.rs
@@ -4,7 +4,7 @@ use std::task::Poll;
 
 use anlg_audio_interface::AsyncSource;
 use anlg_audio_utils::{pcm_f64_to_f32, pcm_i16_to_f32, pcm_i32_to_f32};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use futures_util::Stream;
 use futures_util::task::AtomicWaker;
 use pin_project::pin_project;
@@ -18,6 +18,7 @@ use cidre::{arc, av, cat, cf, core_audio as ca, ns, os};
 pub struct SpeakerInput {
     tap: ca::TapGuard,
     agg_desc: arc::Retained<cf::DictionaryOf<cf::String, cf::Type>>,
+    sample_rate: u32,
 }
 
 #[pin_project(PinnedDrop)]
@@ -52,10 +53,12 @@ impl SpeakerInput {
     pub fn new() -> Result<Self> {
         let tap_desc = ca::TapDesc::with_mono_global_tap_excluding_processes(&ns::Array::new());
         let tap = tap_desc.create_process_tap()?;
+        let tap_uid = tap.uid()?;
+        let sample_rate = tap.asbd()?.sample_rate as u32;
 
         let sub_tap = cf::DictionaryOf::with_keys_values(
             &[ca::sub_device_keys::uid()],
-            &[tap.uid().unwrap().as_type_ref()],
+            &[tap_uid.as_type_ref()],
         );
 
         let agg_desc = cf::DictionaryOf::with_keys_values(
@@ -75,11 +78,15 @@ impl SpeakerInput {
             ],
         );
 
-        Ok(Self { tap, agg_desc })
+        Ok(Self {
+            tap,
+            agg_desc,
+            sample_rate,
+        })
     }
 
     pub fn sample_rate(&self) -> u32 {
-        self.tap.asbd().unwrap().sample_rate as u32
+        self.sample_rate
     }
 
     fn start_device(
@@ -95,7 +102,9 @@ impl SpeakerInput {
             _output_time: &cat::AudioTimeStamp,
             ctx: Option<&mut Ctx>,
         ) -> os::Status {
-            let ctx = ctx.unwrap();
+            let Some(ctx) = ctx else {
+                return os::Status::NO_ERR;
+            };
 
             let first_buffer = &input_data.buffers[0];
 
@@ -131,10 +140,11 @@ impl SpeakerInput {
         Ok(started_device)
     }
 
-    pub fn stream(self) -> SpeakerStream {
-        let asbd = self.tap.asbd().unwrap();
+    pub fn stream(self) -> Result<SpeakerStream> {
+        let asbd = self.tap.asbd()?;
 
-        let format = av::AudioFormat::with_asbd(&asbd).unwrap();
+        let format =
+            av::AudioFormat::with_asbd(&asbd).context("unsupported system audio format")?;
         let common_format = format.common_format();
 
         let rb = HeapRb::<f32>::new(BUFFER_SIZE);
@@ -156,9 +166,9 @@ impl SpeakerInput {
             conversion_buffer: vec![0.0f32; crate::rt_ring::DEFAULT_SCRATCH_LEN],
         });
 
-        let device = self.start_device(&mut ctx).unwrap();
+        let device = self.start_device(&mut ctx)?;
 
-        SpeakerStream {
+        Ok(SpeakerStream {
             reader: RingbufAsyncReader::new(
                 consumer,
                 waker,
@@ -172,7 +182,7 @@ impl SpeakerInput {
             current_sample_rate,
             sample_rate_probe_counter: 0,
             buffer_rate: asbd.sample_rate as u32,
-        }
+        })
     }
 }
 
@@ -252,9 +262,11 @@ impl Stream for SpeakerStream {
                 .sample_rate_probe_counter
                 .is_multiple_of(SAMPLE_RATE_PROBE_INTERVAL)
             {
-                let after = this._tap.asbd().unwrap().sample_rate as u32;
-                if this.current_sample_rate != after {
-                    this.current_sample_rate = after;
+                if let Ok(asbd) = this._tap.asbd() {
+                    let after = asbd.sample_rate as u32;
+                    if this.current_sample_rate != after {
+                        this.current_sample_rate = after;
+                    }
                 }
             }
         }

--- a/crates/audio-actual/src/speaker/mod.rs
+++ b/crates/audio-actual/src/speaker/mod.rs
@@ -55,7 +55,7 @@ impl SpeakerInput {
 
     #[cfg(all(target_os = "macos", not(test)))]
     pub fn stream(self) -> Result<SpeakerStream> {
-        Ok(self.inner.stream())
+        self.inner.stream()
     }
 
     #[cfg(all(not(target_os = "macos"), not(test)))]


### PR DESCRIPTION
## Summary
- replace fallible Core Audio setup unwraps with contextual errors
- handle missing callback state without panicking
- tolerate transient sample-rate probe failures

## Validation
- cargo test -p audio-actual
- cargo check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized macOS speaker path with behavior preserved on success; callers already handle `Result` from `stream()`.
> 
> **Overview**
> macOS system-audio capture no longer panics on Core Audio setup or runtime edge cases; failures surface as **`Result`** errors with context.
> 
> **`SpeakerInput::stream()`** now returns **`Result<SpeakerStream>`** on macOS (aligned with other platforms). Tap UID, stream format (**`asbd`**), unsupported formats, and aggregate device start use **`?`** / **`anyhow::Context`** instead of **`unwrap`**. Sample rate is read once in **`new()`** and stored on **`SpeakerInput`** so **`sample_rate()`** does not re-query the tap.
> 
> The IO callback treats a missing **`ctx`** as a no-op instead of panicking. Periodic sample-rate probes ignore transient **`asbd()`** failures instead of unwrapping. The public **`SpeakerInput::stream`** wrapper forwards the platform **`Result`** instead of always wrapping success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86aae6f30e528561f88329aa25979d82bfe8d66b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->