### PR TITLE
Use the corrected CoreML batch model artifact

### DIFF
--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -51,7 +51,7 @@ private enum SpeechModelKind: String, CaseIterable {
     case .parakeetStreaming:
       return "aufklarer/Parakeet-EOU-120M-CoreML-INT8"
     case .parakeetBatch:
-      return "aufklarer/Parakeet-TDT-v3-CoreML-INT8"
+      return "aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s"
     case .omnilingual:
       return "aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s"
     case .qwen3Small:


### PR DESCRIPTION
## Summary
- switch Parakeet batch transcription to the iOS 18-targeted model build
- force a distinct cache key so affected M5 devices do not reuse the crashing artifact

## Validation
- cargo test -p transcribe-soniqo
- cargo check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change for batch model resolution and cache keys; no logic or API changes beyond which artifact is loaded.
> 
> **Overview**
> **Parakeet batch** file transcription now downloads and caches **`aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s`** instead of **`Parakeet-TDT-v3-CoreML-INT8`**, via the `SpeechModelKind.parakeetBatch` Hugging Face repo id in the Soniqo Swift bridge.
> 
> Because the repo id drives `HuggingFaceDownloader` cache paths, devices that previously cached the old build (including crashes on some M5 hardware) will fetch the corrected iOS 18–targeted artifact rather than reusing the bad one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ce0f1bbe0b0e3bee9ba57834cbeb3d63e2aff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->