### PR TITLE
Update the Anarlog 1.4.0 reliability changelog

### DIFF
--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -1,6 +1,6 @@
 ---
-date: "2026-07-28"
-summary: "Anarlog 1.4.0 expands to Windows Preview and Linux Beta, adds automatic updates, and refreshes note editing and desktop reliability."
+date: "2026-07-29"
+summary: "Anarlog 1.4.0 expands to Windows Preview and Linux Beta, adds automatic updates, and improves note editing, transcription, privacy, and reliability."
 ---
 
 <banner title="Windows Preview and Linux Beta" variant="info">
@@ -40,6 +40,23 @@ are still pending.
   Kimi K2.7 Code, and GLM 5.2
 - Restore excluded meeting apps reliably after startup and present cleaner,
   platform-aware settings and window controls
+
+## Reliability and privacy
+
+- Reopen Anarlog while it is already running without triggering startup-service
+  errors
+- Stop permanent AI generation and transcription failures from retrying
+  indefinitely while preserving recovery for temporary failures
+- Keep recording playback state and duration accurate when retained audio is
+  removed or a deletion cannot complete
+- Avoid macOS system-audio capture crashes during transient Core Audio setup
+  and format changes
+- Keep live speaker labels within the actual remote-participant count for each
+  audio channel
+- Use compatible GPT-5.6 Terra settings and the corrected Parakeet CoreML batch
+  model on affected M5 Macs
+- Remove free-form note, transcript, request, breadcrumb, and device context
+  from Sentry crash reports before they leave the app
 
 ## Local AI on macOS
 


### PR DESCRIPTION
## Summary
- add the user-visible reliability, transcription, and privacy fixes included in 1.4.0
- refresh the changelog date and release summary

## Validation
- pnpm exec dprint fmt
- pnpm fmt:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or deployment impact.
> 
> **Overview**
> **Changelog-only update** for `packages/changelog/content/1.4.0.md` — no application code changes.
> 
> The release **date** moves from `2026-07-28` to `2026-07-29`, and the top-level **summary** now calls out transcription, privacy, and reliability alongside the existing platform and editor themes.
> 
> A new **## Reliability and privacy** section documents what shipped in 1.4.0: safer behavior when reopening an already-running app, bounded retries for permanent AI/transcription failures, accurate playback when audio is deleted, fewer macOS Core Audio capture crashes, correct live speaker label counts, M5-specific GPT-5.6 Terra / Parakeet CoreML fixes, and stripping note/transcript/request context from **Sentry** crash payloads before upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84582dbd69004092e6493af73ad6d8031155f75a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->