### PR TITLE
Keep live capture leased after marker exhaustion

### DIFF
--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -1538,6 +1538,30 @@ describe("useStartListening", () => {
     consoleError.mockRestore();
   });
 
+  test("keeps an attached capture leased when its marker retry budget is exhausted", async () => {
+    saveCaptureLifecycleMarkerMock.mockRejectedValue(
+      new Error("marker write failed"),
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useResumeListeningLifecycle("session-1"),
+    );
+
+    await act(async () => {
+      await expect(result.current({ abandonOnFailure: true })).resolves.toBe(
+        "attached",
+      );
+    });
+
+    expect(attachLiveSessionMock).toHaveBeenCalledOnce();
+    expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
+    expect(beginCloudsyncActivityMock).toHaveBeenCalledOnce();
+    expect(endCloudsyncActivityMock).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
   test("finalizes a durable capture when stop happens before listeners reattach", async () => {
     attachLiveSessionMock.mockResolvedValue("inactive");
     loadCaptureLifecycleMarkerMock

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -1046,7 +1046,7 @@ export function useResumeListeningLifecycle(sessionId: string) {
             "[listener] failed to prepare capture recovery state",
             error,
           );
-          return failRecovery();
+          return options?.abandonOnFailure ? result : ("error" as const);
         }
         return result;
       }


### PR DESCRIPTION
Treat a successfully reattached live capture as active when its marker retry budget is exhausted, preserving the CloudSync lease and avoiding cleanup of live durability state. Add regression coverage for the final retry boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes capture recovery and CloudSync lease behavior when marker writes fail after reattach; incorrect handling could leave stale leases or skip cleanup in other failure modes.
> 
> **Overview**
> When **capture recovery** successfully reattaches a live session but **cannot persist the lifecycle marker** (including after retries), the resume path no longer runs the same **abandon** cleanup as other failures.
> 
> If `abandonOnFailure` is set, `useResumeListeningLifecycle` now returns **`attached`** instead of clearing the marker and releasing the CloudSync capture lease. That keeps the live capture treated as active so durability state is not torn down at the retry boundary.
> 
> Adds a regression test for marker write failure with `abandonOnFailure: true` (lease held, marker not cleared).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b384a222396da761e634330cef5d08d4d9dc4521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->