### PR TITLE
Stabilize QA source attestation

### DIFF
--- a/.agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh
+++ b/.agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh
@@ -298,7 +298,12 @@ source_fingerprint() {
       done
     } |
       LC_ALL=C sort -u |
-      COPYFILE_DISABLE=1 tar -cf - --no-recursion -T - 2>/dev/null
+      COPYFILE_DISABLE=1 tar -cf - \
+        --format=mtree \
+        --options='!all,type,mode,link,sha256' \
+        --no-recursion \
+        -T - \
+        2>/dev/null
   ) |
     shasum -a 256 |
     awk '{print $1}'


### PR DESCRIPTION
Hash release QA inputs by path, mode, symlink target, and content so generated-file mtime rewrites do not invalidate otherwise identical builds.

Validated with bash syntax checks, repository formatting checks, and a full-input mtime stability test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-script change to QA cache fingerprinting; no production runtime or auth paths affected.
> 
> **Overview**
> **`source_fingerprint()`** in the native Dev QA helper no longer hashes a default `tar` stream of file bytes (which could also pick up unstable metadata). It now archives the same path list with **`tar --format=mtree`** and **`--options='!all,type,mode,link,sha256'`**, so attestation is based on path, file type, mode, symlink target, and content hash—not modification time.
> 
> That keeps manifest **`source_fingerprint`** stable when builds only rewrite mtimes on generated outputs, while still failing when real inputs change during or after a build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 873ed8e4c992520488193f5c8721ddcf8f5ad998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->