### PR TITLE
Preserve speaker identity after settled diarization

### DIFF
--- a/apps/desktop/src/stt/queries.ts
+++ b/apps/desktop/src/stt/queries.ts
@@ -8,10 +8,7 @@ import type {
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
 import type { RenderLabelContext, SegmentKey } from "~/stt/live-segment";
-import {
-  collectAssignedHumanIdsFromTranscriptRows,
-  type TranscriptRow,
-} from "~/stt/render-transcript";
+import { collectAssignedHumanIdsFromTranscriptRows } from "~/stt/render-transcript";
 import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
 import {
   applyLiveTranscriptDelta,
@@ -62,8 +59,8 @@ export type TranscriptRecord = {
   sessionId: string;
   startedAt: number;
   endedAt?: number;
-  words: NonNullable<TranscriptRow["words"]>;
-  speakerHints: NonNullable<TranscriptRow["speaker_hints"]>;
+  words: WordWithId[];
+  speakerHints: SpeakerHintWithId[];
 };
 
 const EMPTY_TRANSCRIPTS: TranscriptRecord[] = [];
@@ -114,6 +111,26 @@ export function useTranscript(transcriptId: string): TranscriptRecord | null {
     mapRows: (rows) => (rows[0] ? mapTranscriptRow(rows[0]) : null),
   });
   return transcriptId ? data : null;
+}
+
+export async function getTranscriptRecord(
+  transcriptId: string,
+): Promise<TranscriptRecord | null> {
+  if (!transcriptId) {
+    return null;
+  }
+
+  const rows = await liveQueryClient.execute<TranscriptSqlRow>(
+    `
+      SELECT ${TRANSCRIPT_COLUMNS}
+      FROM transcripts
+      WHERE id = ? AND deleted_at IS NULL
+      LIMIT 1
+    `,
+    [transcriptId],
+  );
+
+  return rows[0] ? mapTranscriptRow(rows[0]) : null;
 }
 
 export function useSessionParticipantHumanIds(sessionId: string): string[] {

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -10,6 +10,7 @@ import {
   getBatchProvider,
   getSessionSpeakerCount,
   isTerminalTranscriptionError,
+  transferAutomaticSpeakerAssignments,
 } from "./useRunBatch";
 import { useRunBatch } from "./useRunBatch";
 
@@ -28,6 +29,7 @@ const {
   deleteProcessedAudioForRetentionMock,
   markSessionAudioTranscriptionCompleteMock,
   createTranscriptMock,
+  getTranscriptRecordMock,
   idMock,
   archMock,
   platformMock,
@@ -46,6 +48,7 @@ const {
   deleteProcessedAudioForRetentionMock: vi.fn(),
   markSessionAudioTranscriptionCompleteMock: vi.fn(),
   createTranscriptMock: vi.fn(),
+  getTranscriptRecordMock: vi.fn(),
   idMock: vi.fn(),
   archMock: vi.fn(),
   platformMock: vi.fn(),
@@ -160,6 +163,7 @@ vi.mock("~/stt/capabilities", () => {
 
 vi.mock("~/stt/queries", () => ({
   createTranscript: createTranscriptMock,
+  getTranscriptRecord: getTranscriptRecordMock,
 }));
 
 describe("getBatchProvider", () => {
@@ -287,6 +291,171 @@ describe("getBatchFallbackTarget", () => {
   });
 });
 
+describe("transferAutomaticSpeakerAssignments", () => {
+  test("maps live identities onto improved batch clusters by time overlap", () => {
+    const source = {
+      id: "live-transcript",
+      ownerUserId: "user-1",
+      sessionId: "session-1",
+      startedAt: 0,
+      words: [
+        {
+          id: "live-lex-1",
+          text: "question",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 1,
+        },
+        {
+          id: "live-george-misclustered",
+          text: "answer",
+          start_ms: 100,
+          end_ms: 200,
+          channel: 1,
+        },
+        {
+          id: "live-lex-2",
+          text: "follow up",
+          start_ms: 200,
+          end_ms: 300,
+          channel: 1,
+        },
+        {
+          id: "live-george",
+          text: "response",
+          start_ms: 300,
+          end_ms: 500,
+          channel: 1,
+        },
+      ],
+      speakerHints: [
+        {
+          id: "live-lex-1-provider",
+          word_id: "live-lex-1",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+        },
+        {
+          id: "live-george-misclustered-provider",
+          word_id: "live-george-misclustered",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+        },
+        {
+          id: "live-lex-2-provider",
+          word_id: "live-lex-2",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+        },
+        {
+          id: "live-george-provider",
+          word_id: "live-george",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 1 }),
+        },
+        {
+          id: "live-lex-automatic",
+          word_id: "live-lex-1",
+          type: "automatic_speaker_assignment",
+          value: JSON.stringify({
+            human_id: "lex",
+            confidence: 0.93,
+            source: "enhance",
+          }),
+        },
+        {
+          id: "live-george-automatic",
+          word_id: "live-george",
+          type: "automatic_speaker_assignment",
+          value: JSON.stringify({
+            human_id: "george",
+            confidence: 0.93,
+            source: "enhance",
+          }),
+        },
+      ],
+    } satisfies Parameters<typeof transferAutomaticSpeakerAssignments>[0];
+    const words = [
+      {
+        id: "batch-lex-1",
+        text: "question",
+        start_ms: 0,
+        end_ms: 100,
+        channel: 1,
+      },
+      {
+        id: "batch-george-1",
+        text: "answer",
+        start_ms: 100,
+        end_ms: 200,
+        channel: 1,
+      },
+      {
+        id: "batch-lex-2",
+        text: "follow up",
+        start_ms: 200,
+        end_ms: 300,
+        channel: 1,
+      },
+      {
+        id: "batch-george-2",
+        text: "response",
+        start_ms: 300,
+        end_ms: 500,
+        channel: 1,
+      },
+    ];
+    const hints = [
+      {
+        id: "batch-lex-1-provider",
+        word_id: "batch-lex-1",
+        type: "provider_speaker_index" as const,
+        value: JSON.stringify({ channel: 1, speaker_index: 7 }),
+      },
+      {
+        id: "batch-george-1-provider",
+        word_id: "batch-george-1",
+        type: "provider_speaker_index" as const,
+        value: JSON.stringify({ channel: 1, speaker_index: 3 }),
+      },
+      {
+        id: "batch-lex-2-provider",
+        word_id: "batch-lex-2",
+        type: "provider_speaker_index" as const,
+        value: JSON.stringify({ channel: 1, speaker_index: 7 }),
+      },
+      {
+        id: "batch-george-2-provider",
+        word_id: "batch-george-2",
+        type: "provider_speaker_index" as const,
+        value: JSON.stringify({ channel: 1, speaker_index: 3 }),
+      },
+    ];
+
+    let nextId = 0;
+    const result = transferAutomaticSpeakerAssignments(
+      source,
+      words,
+      hints,
+      () => `automatic-${++nextId}`,
+    );
+    const assignments = result
+      .filter((hint) => hint.type === "automatic_speaker_assignment")
+      .map((hint) => ({
+        wordId: hint.word_id,
+        humanId: JSON.parse(hint.value).human_id,
+      }));
+
+    expect(assignments).toEqual(
+      expect.arrayContaining([
+        { wordId: "batch-lex-1", humanId: "lex" },
+        { wordId: "batch-george-1", humanId: "george" },
+      ]),
+    );
+    expect(assignments).toHaveLength(2);
+  });
+});
+
 describe("useRunBatch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -296,6 +465,7 @@ describe("useRunBatch", () => {
     let nextId = 0;
     idMock.mockImplementation(() => `generated-${++nextId}`);
     createTranscriptMock.mockResolvedValue(undefined);
+    getTranscriptRecordMock.mockResolvedValue(null);
     deleteProcessedAudioForRetentionMock.mockResolvedValue(undefined);
     markSessionAudioTranscriptionCompleteMock.mockResolvedValue(undefined);
     isSupportedLanguagesBatchMock.mockResolvedValue(true);
@@ -488,6 +658,142 @@ describe("useRunBatch", () => {
           }),
         ],
       }),
+    );
+  });
+
+  test("carries automatic speaker identities into a refined current capture", async () => {
+    getTranscriptRecordMock.mockResolvedValue({
+      id: "transcript-current-live",
+      ownerUserId: "user-1",
+      sessionId: "session-1",
+      startedAt: 123_000,
+      words: [
+        {
+          id: "live-lex",
+          text: "question",
+          start_ms: 100,
+          end_ms: 300,
+          channel: 1,
+        },
+        {
+          id: "live-george",
+          text: "answer",
+          start_ms: 300,
+          end_ms: 500,
+          channel: 1,
+        },
+      ],
+      speakerHints: [
+        {
+          id: "live-lex-provider",
+          word_id: "live-lex",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+        },
+        {
+          id: "live-george-provider",
+          word_id: "live-george",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 1 }),
+        },
+        {
+          id: "live-lex-identity",
+          word_id: "live-lex",
+          type: "automatic_speaker_assignment",
+          value: JSON.stringify({
+            human_id: "lex",
+            confidence: 0.93,
+            source: "enhance",
+          }),
+        },
+        {
+          id: "live-george-identity",
+          word_id: "live-george",
+          type: "automatic_speaker_assignment",
+          value: JSON.stringify({
+            human_id: "george",
+            confidence: 0.93,
+            source: "enhance",
+          }),
+        },
+      ],
+    });
+    startTranscriptionMock.mockImplementation(async (_params, options) => {
+      options.handlePersist(
+        [
+          {
+            text: "question",
+            start_ms: 60_100,
+            end_ms: 60_300,
+            channel: 1,
+          },
+          {
+            text: "answer",
+            start_ms: 60_300,
+            end_ms: 60_500,
+            channel: 1,
+          },
+        ],
+        [
+          {
+            wordIndex: 0,
+            data: {
+              type: "provider_speaker_index",
+              channel: 1,
+              speaker_index: 3,
+            },
+          },
+          {
+            wordIndex: 1,
+            data: {
+              type: "provider_speaker_index",
+              channel: 1,
+              speaker_index: 2,
+            },
+          },
+        ],
+        { mode: "replace" },
+      );
+    });
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav", {
+        promotion: {
+          scope: "current_capture",
+          audioOffsetMs: 60_000,
+          replaceTranscriptId: "transcript-current-live",
+          startedAt: 123_000,
+        },
+      });
+    });
+
+    expect(getTranscriptRecordMock).toHaveBeenCalledWith(
+      "transcript-current-live",
+    );
+    const created = createTranscriptMock.mock.calls[0]?.[0];
+    const wordsByText = new Map(
+      created.words.map((word: { id: string; text: string }) => [
+        word.text,
+        word.id,
+      ]),
+    );
+    const identities = created.speakerHints
+      .filter(
+        (hint: { type: string }) =>
+          hint.type === "automatic_speaker_assignment",
+      )
+      .map((hint: { word_id: string; value: string }) => ({
+        wordId: hint.word_id,
+        humanId: JSON.parse(hint.value).human_id,
+      }));
+
+    expect(identities).toEqual(
+      expect.arrayContaining([
+        { wordId: wordsByText.get("question"), humanId: "lex" },
+        { wordId: wordsByText.get("answer"), humanId: "george" },
+      ]),
     );
   });
 

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -28,7 +28,11 @@ import {
   isAnarlogLocalSttModel,
   isSupportedLanguagesBatch,
 } from "~/stt/capabilities";
-import { createTranscript } from "~/stt/queries";
+import {
+  createTranscript,
+  getTranscriptRecord,
+  type TranscriptRecord,
+} from "~/stt/queries";
 import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
 
 type RunOptions = {
@@ -212,6 +216,201 @@ function prepareTranscriptPromotion(
   };
 }
 
+function parseHintValue(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object"
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function speakerKeysByWordId(hints: SpeakerHintWithId[]) {
+  const keys = new Map<string, string>();
+
+  for (const hint of hints) {
+    if (hint.type !== "provider_speaker_index" || !hint.word_id) {
+      continue;
+    }
+
+    const value = parseHintValue(hint.value);
+    const channel = value?.channel;
+    const speakerIndex = value?.speaker_index;
+    if (typeof channel !== "number" || typeof speakerIndex !== "number") {
+      continue;
+    }
+
+    keys.set(hint.word_id, `${channel}:${speakerIndex}`);
+  }
+
+  return keys;
+}
+
+export function transferAutomaticSpeakerAssignments(
+  source: TranscriptRecord,
+  words: WordWithId[],
+  hints: SpeakerHintWithId[],
+  createId: () => string = id,
+): SpeakerHintWithId[] {
+  if (hints.some((hint) => hint.type === "automatic_speaker_assignment")) {
+    return hints;
+  }
+
+  const sourceSpeakerKeys = speakerKeysByWordId(source.speakerHints);
+  const targetSpeakerKeys = speakerKeysByWordId(hints);
+  const sourceIdentityBySpeaker = new Map<
+    string,
+    { humanId: string; value: string }
+  >();
+
+  for (const hint of source.speakerHints) {
+    if (hint.type !== "automatic_speaker_assignment" || !hint.word_id) {
+      continue;
+    }
+
+    const speakerKey = sourceSpeakerKeys.get(hint.word_id);
+    const value = parseHintValue(hint.value);
+    const humanId = value?.human_id;
+    if (speakerKey && typeof humanId === "string" && humanId) {
+      sourceIdentityBySpeaker.set(speakerKey, {
+        humanId,
+        value: hint.value,
+      });
+    }
+  }
+
+  if (sourceIdentityBySpeaker.size === 0 || targetSpeakerKeys.size === 0) {
+    return hints;
+  }
+
+  const sourceIntervals = source.words.flatMap((word) => {
+    const speakerKey = sourceSpeakerKeys.get(word.id);
+    const identity = speakerKey
+      ? sourceIdentityBySpeaker.get(speakerKey)
+      : undefined;
+    if (!speakerKey || !identity) {
+      return [];
+    }
+
+    return [
+      {
+        speakerKey,
+        humanId: identity.humanId,
+        value: identity.value,
+        startMs: word.start_ms ?? 0,
+        endMs: word.end_ms ?? word.start_ms ?? 0,
+      },
+    ];
+  });
+  const firstTargetWordBySpeaker = new Map<string, string>();
+  const weights = new Map<string, Map<string, number>>();
+
+  for (const word of words) {
+    const targetSpeakerKey = targetSpeakerKeys.get(word.id);
+    if (!targetSpeakerKey) {
+      continue;
+    }
+
+    firstTargetWordBySpeaker.set(
+      targetSpeakerKey,
+      firstTargetWordBySpeaker.get(targetSpeakerKey) ?? word.id,
+    );
+    const targetStartMs = word.start_ms ?? 0;
+    const targetEndMs = word.end_ms ?? targetStartMs;
+
+    for (const sourceWord of sourceIntervals) {
+      if (
+        sourceWord.speakerKey.split(":", 1)[0] !==
+        targetSpeakerKey.split(":", 1)[0]
+      ) {
+        continue;
+      }
+
+      const overlapMs =
+        Math.min(targetEndMs, sourceWord.endMs) -
+        Math.max(targetStartMs, sourceWord.startMs);
+      if (overlapMs <= 0) {
+        continue;
+      }
+
+      const humanWeights =
+        weights.get(targetSpeakerKey) ?? new Map<string, number>();
+      humanWeights.set(
+        sourceWord.humanId,
+        (humanWeights.get(sourceWord.humanId) ?? 0) + overlapMs,
+      );
+      weights.set(targetSpeakerKey, humanWeights);
+    }
+  }
+
+  const identityByHumanId = new Map(
+    [...sourceIdentityBySpeaker.values()].map((identity) => [
+      identity.humanId,
+      identity,
+    ]),
+  );
+  const candidates = [...weights].flatMap(([speakerKey, humanWeights]) =>
+    [...humanWeights].map(([humanId, overlapMs]) => ({
+      speakerKey,
+      humanId,
+      overlapMs,
+    })),
+  );
+  candidates.sort(
+    (left, right) =>
+      right.overlapMs - left.overlapMs ||
+      left.speakerKey.localeCompare(right.speakerKey) ||
+      left.humanId.localeCompare(right.humanId),
+  );
+
+  const assignments = new Map<string, string>();
+  const assignedHumanIds = new Set<string>();
+  for (const candidate of candidates) {
+    if (
+      assignments.has(candidate.speakerKey) ||
+      assignedHumanIds.has(candidate.humanId)
+    ) {
+      continue;
+    }
+
+    assignments.set(candidate.speakerKey, candidate.humanId);
+    assignedHumanIds.add(candidate.humanId);
+  }
+
+  for (const speakerKey of firstTargetWordBySpeaker.keys()) {
+    const identity = sourceIdentityBySpeaker.get(speakerKey);
+    if (
+      !assignments.has(speakerKey) &&
+      identity &&
+      !assignedHumanIds.has(identity.humanId)
+    ) {
+      assignments.set(speakerKey, identity.humanId);
+      assignedHumanIds.add(identity.humanId);
+    }
+  }
+
+  const automaticHints = [...assignments].flatMap(([speakerKey, humanId]) => {
+    const wordId = firstTargetWordBySpeaker.get(speakerKey);
+    const identity = identityByHumanId.get(humanId);
+    if (!wordId || !identity) {
+      return [];
+    }
+
+    return [
+      {
+        id: createId(),
+        word_id: wordId,
+        type: "automatic_speaker_assignment" as const,
+        value: identity.value,
+      },
+    ];
+  });
+
+  return [...hints, ...automaticHints];
+}
+
 export function isStoppedTranscriptionError(error: unknown) {
   return (
     (error instanceof Error ? error.message : String(error)) ===
@@ -334,6 +533,23 @@ export const useRunBatch = (sessionId: string) => {
               : selectedProviderLabel(conn)
           } is not available for batch transcription. Using ${target.label} instead.`,
         });
+      }
+
+      let speakerIdentitySource: TranscriptRecord | null = null;
+      const replaceTranscriptId =
+        options?.promotion?.scope === "current_capture"
+          ? options.promotion.replaceTranscriptId
+          : undefined;
+      if (replaceTranscriptId) {
+        try {
+          speakerIdentitySource =
+            await getTranscriptRecord(replaceTranscriptId);
+        } catch (error) {
+          console.warn(
+            "[runBatch] failed to load automatic speaker assignments",
+            error,
+          );
+        }
       }
 
       const createdAt = new Date().toISOString();
@@ -489,6 +705,13 @@ export const useRunBatch = (sessionId: string) => {
             if (transcriptId) {
               const completedTranscriptId = transcriptId;
               if (promoted.words.length > 0) {
+                const speakerHints = speakerIdentitySource
+                  ? transferAutomaticSpeakerAssignments(
+                      speakerIdentitySource,
+                      promoted.words,
+                      promoted.hints,
+                    )
+                  : promoted.hints;
                 await persistTranscriptWrite(() =>
                   createTranscript({
                     id: completedTranscriptId,
@@ -501,7 +724,7 @@ export const useRunBatch = (sessionId: string) => {
                     provider: target.provider,
                     model: target.model,
                     words: promoted.words,
-                    speakerHints: promoted.hints,
+                    speakerHints,
                     replaceSession: promoted.replaceSession,
                     replaceTranscriptId: promoted.replaceTranscriptId,
                   }),

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -279,6 +279,17 @@ describe("getPostCaptureAction", () => {
     ).toEqual([]);
   });
 
+  test("reports settled diarization refinement for a multi-speaker cloud transcript", () => {
+    expect(
+      getPostCaptureRepairReasons({
+        audioPath: "/tmp/session.wav",
+        liveTranscriptionActive: true,
+        needsBatchRepair: false,
+        refineSpeakerDiarization: true,
+      }),
+    ).toEqual(["settled_speaker_diarization"]);
+  });
+
   test("runs batch then enhance after record-only capture finishes when audio is available", () => {
     expect(
       getPostCaptureAction(
@@ -301,6 +312,34 @@ describe("getPostCaptureAction", () => {
           needsBatchRepair: false,
         },
         true,
+      ),
+    ).toBe("enhance_only");
+  });
+
+  test("refines a complete live transcript when settled diarization is required", () => {
+    expect(
+      getPostCaptureAction(
+        {
+          audioPath: "/tmp/session.wav",
+          liveTranscriptionActive: true,
+          needsBatchRepair: false,
+          refineSpeakerDiarization: true,
+        },
+        true,
+      ),
+    ).toBe("batch_then_enhance");
+  });
+
+  test("keeps a complete live transcript when settled diarization cannot run", () => {
+    expect(
+      getPostCaptureAction(
+        {
+          audioPath: "/tmp/session.wav",
+          liveTranscriptionActive: true,
+          needsBatchRepair: false,
+          refineSpeakerDiarization: true,
+        },
+        false,
       ),
     ).toBe("enhance_only");
   });
@@ -820,6 +859,64 @@ describe("useStartListening", () => {
       clearCaptureLifecycleMarkerMock.mock.invocationCallOrder[0]!,
     ).toBeLessThan(
       deleteProcessedAudioForRetentionMock.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  test("refines complete multi-speaker Pro transcripts after stop", async () => {
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "anarlog",
+        model: "cloud",
+        baseUrl: "https://api.test/stt",
+        apiKey: "token",
+      },
+    });
+    useSessionParticipantHumanIdsMock.mockReturnValue([
+      "user-1",
+      "lex",
+      "george",
+    ]);
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const callbacks = startMock.mock.calls[0]?.[1];
+    callbacks?.handlePersist?.({
+      new_words: [
+        {
+          id: "live-word",
+          text: "hello",
+          start_ms: 0,
+          end_ms: 500,
+          channel: 1,
+        },
+      ],
+      replaced_ids: [],
+      partials: [],
+    });
+    await act(async () => {
+      await callbacks?.onStopped?.("session-1", {
+        durationSeconds: 42,
+        audioPath: "/tmp/session.wav",
+        requestedLiveTranscription: true,
+        liveTranscriptionActive: true,
+        needsBatchRepair: false,
+      });
+    });
+
+    expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav", {
+      deferAudioFinalization: true,
+      promotion: {
+        scope: "current_capture",
+        audioOffsetMs: 0,
+        replaceTranscriptId: "generated-id",
+        startedAt: expect.any(Number),
+      },
+    });
+    expect(queueAutoEnhanceIfSummaryEmptyMock).toHaveBeenCalledWith(
+      "session-1",
     );
   });
 

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -293,12 +293,14 @@ type PostCaptureDetails = {
   audioPath: string | null;
   liveTranscriptionActive: boolean;
   needsBatchRepair: boolean;
+  refineSpeakerDiarization?: boolean;
   transcriptWriteFailed?: boolean;
 };
 
 export type PostCaptureRepairReason =
   | "live_transcription_unavailable"
   | "live_stream_incomplete"
+  | "settled_speaker_diarization"
   | "transcript_persistence_failed";
 
 export function getPostCaptureRepairReasons(
@@ -311,6 +313,9 @@ export function getPostCaptureRepairReasons(
   if (details.needsBatchRepair) {
     reasons.push("live_stream_incomplete");
   }
+  if (details.refineSpeakerDiarization) {
+    reasons.push("settled_speaker_diarization");
+  }
   if (details.transcriptWriteFailed) {
     reasons.push("transcript_persistence_failed");
   }
@@ -321,16 +326,21 @@ export function getPostCaptureAction(
   details: PostCaptureDetails,
   canRunBatch: boolean,
 ) {
-  if (
+  const liveTranscriptComplete =
     details.liveTranscriptionActive &&
     !details.needsBatchRepair &&
-    !details.transcriptWriteFailed
-  ) {
+    !details.transcriptWriteFailed;
+
+  if (liveTranscriptComplete && !details.refineSpeakerDiarization) {
     return "enhance_only" as const;
   }
 
   if (!!details.audioPath && canRunBatch) {
     return "batch_then_enhance" as const;
+  }
+
+  if (liveTranscriptComplete) {
+    return "enhance_only" as const;
   }
 
   return "none" as const;
@@ -339,6 +349,7 @@ export function getPostCaptureAction(
 function useCaptureLifecycle(sessionId: string) {
   const session = useSession(sessionId);
   const transcriptExistence = useSessionTranscriptExistence(sessionId);
+  const participantHumanIds = useSessionParticipantHumanIds(sessionId);
   const audioRetention = normalizeAudioRetention(
     useConfigValue("audio_retention"),
   );
@@ -383,6 +394,14 @@ function useCaptureLifecycle(sessionId: string) {
         recoveredMarker?.ownerUserId ?? session?.user_id ?? "";
       const provider = recoveredMarker?.provider ?? conn?.provider;
       const model = recoveredMarker?.model ?? conn?.model;
+      const refineSpeakerDiarization =
+        provider === "anarlog" &&
+        model === "cloud" &&
+        new Set(
+          participantHumanIds.filter(
+            (humanId) => humanId && humanId !== ownerUserId,
+          ),
+        ).size > 1;
       const cloudsyncLeaseKey = `${sessionId}:${transcriptId}`;
       let pendingSummaryMode = recoveredMarker?.summaryMode;
       let completionTracked = false;
@@ -523,6 +542,7 @@ function useCaptureLifecycle(sessionId: string) {
           : getPostCaptureAction(
               {
                 ...details,
+                refineSpeakerDiarization,
                 transcriptWriteFailed: Boolean(transcriptWriteError),
               },
               canRunBatchRef.current,
@@ -531,6 +551,7 @@ function useCaptureLifecycle(sessionId: string) {
           ? []
           : getPostCaptureRepairReasons({
               ...details,
+              refineSpeakerDiarization,
               transcriptWriteFailed: Boolean(transcriptWriteError),
             });
 
@@ -553,16 +574,17 @@ function useCaptureLifecycle(sessionId: string) {
                 : 0;
             await runBatchRef.current(details.audioPath!, {
               deferAudioFinalization: true,
-              promotion: preserveExistingTranscript
-                ? {
-                    scope: "current_capture",
-                    audioOffsetMs,
-                    ...(transcriptCreated
-                      ? { replaceTranscriptId: transcriptId }
-                      : {}),
-                    startedAt,
-                  }
-                : { scope: "whole_session" },
+              promotion:
+                preserveExistingTranscript || transcriptCreated
+                  ? {
+                      scope: "current_capture",
+                      audioOffsetMs,
+                      ...(transcriptCreated
+                        ? { replaceTranscriptId: transcriptId }
+                        : {}),
+                      startedAt,
+                    }
+                  : { scope: "whole_session" },
             });
             batchCompleted = true;
             console.info("[listener] completed post-stop transcript repair", {
@@ -865,6 +887,7 @@ function useCaptureLifecycle(sessionId: string) {
       audioRetention,
       conn?.model,
       conn?.provider,
+      participantHumanIds,
       session?.raw_md,
       session?.user_id,
       sessionId,


### PR DESCRIPTION
Refines multi-speaker Pro transcripts after capture, then transfers automatic speaker assignments to the corrected transcript.

Checks:
- pnpm -F desktop test
- pnpm -F desktop typecheck
- pnpm fmt:check
- pnpm exec oxlint --quiet --format=github apps/desktop/src/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-capture transcription and speaker-hint persistence; wrong overlap mapping could mislabel speakers, but changes are gated to Pro multi-speaker refinement and covered by new unit/integration tests.
> 
> **Overview**
> After **multi-speaker Pro cloud** live capture, post-stop flow can now run **batch refinement** even when the live transcript is otherwise complete, so diarization can be re-clustered on the full recording.
> 
> When that batch pass **replaces the current capture**, the app loads the live transcript and runs **`transferAutomaticSpeakerAssignments`**, which maps `automatic_speaker_assignment` hints onto new batch speaker clusters using **time overlap** (not raw provider speaker indices), so named speakers survive corrected diarization.
> 
> Supporting changes: async **`getTranscriptRecord`** for the pre-replace transcript, updated post-capture action/repair reasons (`settled_speaker_diarization`), and broader **current_capture** promotion when a live transcript id exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d80adb8a16166f9d16d81d32536695826bc52478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->