### PR TITLE
Return JSON errors for invalid Local API queries

### DIFF
--- a/plugins/local-api/src/lib.rs
+++ b/plugins/local-api/src/lib.rs
@@ -254,6 +254,18 @@ mod test {
         assert_eq!(transcript["text"], "hello");
         assert_eq!(transcript["pagination"]["total"], 2);
 
+        let invalid_query = request(
+            port,
+            reqwest::Method::GET,
+            "/v1/meetings?limit=invalid",
+            Some(&generated.key),
+            None,
+        )
+        .await;
+        assert_eq!(invalid_query.status(), 400);
+        let invalid_query: serde_json::Value = invalid_query.json().await.unwrap();
+        assert_eq!(invalid_query["error"]["code"], "invalid_request");
+
         let markdown = request(
             port,
             reqwest::Method::GET,

--- a/plugins/local-api/src/server.rs
+++ b/plugins/local-api/src/server.rs
@@ -1,6 +1,6 @@
 use axum::{
     Json, Router,
-    extract::{Path, Query, Request, State},
+    extract::{Path, Query, Request, State, rejection::QueryRejection},
     http::{StatusCode, header},
     middleware::{self, Next},
     response::{IntoResponse, Response},
@@ -122,6 +122,12 @@ impl IntoResponse for ApiError {
     }
 }
 
+fn parse_query<T>(query: Result<Query<T>, QueryRejection>) -> Result<T, ApiError> {
+    query
+        .map(|Query(value)| value)
+        .map_err(|error| ApiError::BadRequest(error.body_text()))
+}
+
 async fn require_api_key(
     State(pool): State<SqlitePool>,
     request: Request,
@@ -164,8 +170,9 @@ struct ListMeetingsQuery {
 
 async fn list_meetings(
     State(pool): State<SqlitePool>,
-    Query(params): Query<ListMeetingsQuery>,
+    params: Result<Query<ListMeetingsQuery>, QueryRejection>,
 ) -> Result<Response, ApiError> {
+    let params = parse_query(params)?;
     let page = anlg_agent_access::list_meetings(
         &pool,
         anlg_agent_access::ListMeetingsInput {
@@ -198,8 +205,9 @@ struct TranscriptQuery {
 async fn get_transcript(
     State(pool): State<SqlitePool>,
     Path(meeting_id): Path<String>,
-    Query(params): Query<TranscriptQuery>,
+    params: Result<Query<TranscriptQuery>, QueryRejection>,
 ) -> Result<Response, ApiError> {
+    let params = parse_query(params)?;
     let page = anlg_agent_access::get_meeting_transcript(
         &pool,
         anlg_agent_access::GetMeetingTranscriptInput {
@@ -221,8 +229,9 @@ struct HistoryQuery {
 async fn get_history(
     State(pool): State<SqlitePool>,
     Path(meeting_id): Path<String>,
-    Query(params): Query<HistoryQuery>,
+    params: Result<Query<HistoryQuery>, QueryRejection>,
 ) -> Result<Response, ApiError> {
+    let params = parse_query(params)?;
     let page = anlg_agent_access::get_recurring_meeting_history(
         &pool,
         anlg_agent_access::GetRecurringMeetingHistoryInput {
@@ -243,8 +252,9 @@ struct ExportQuery {
 async fn export_meeting(
     State(pool): State<SqlitePool>,
     Path(meeting_id): Path<String>,
-    Query(params): Query<ExportQuery>,
+    params: Result<Query<ExportQuery>, QueryRejection>,
 ) -> Result<Response, ApiError> {
+    let params = parse_query(params)?;
     let format = params.format.as_deref().unwrap_or("json");
     let export = anlg_agent_access::get_meeting_export(&pool, meeting_id).await?;
     match format {


### PR DESCRIPTION
Route malformed query parameters through the existing invalid_request JSON envelope. Add a live-server regression assertion.

Validation:
- pnpm exec dprint fmt
- pnpm fmt:check
- cargo test --locked -p tauri-plugin-local-api
- cargo check --locked -p desktop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to query extraction and error mapping on read-only endpoints; valid requests behave the same.
> 
> **Overview**
> Malformed query strings on paginated Local API routes no longer fail as generic Axum rejections; they return **HTTP 400** with the existing `{ "error": { "code": "invalid_request", ... } }` envelope.
> 
> Handlers for **list meetings**, **transcript**, **history**, and **export** now accept `Result<Query<...>, QueryRejection>` and funnel failures through a shared `parse_query` helper that maps deserialization errors (e.g. non-numeric `limit`) to `ApiError::BadRequest`.
> 
> An integration test asserts `GET /v1/meetings?limit=invalid` responds with status 400 and `error.code` **`invalid_request`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb85cc220455a080b8f875518355fe39bd1a9d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->