### PR TITLE
Fix Linux staging artifact upload

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -453,6 +453,7 @@ jobs:
           upload_dir=$(mktemp -d)
           for bundle_dir in appimage deb; do
             for file in apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/$bundle_dir/*; do
+              [[ -f "$file" ]] || continue
               cp "$file" "$upload_dir/${prefix}-$(basename "$file")"
             done
           done


### PR DESCRIPTION
Skip the generated AppDir directory when copying Linux packages to R2 so staging dry-runs can complete on x64 and ARM64.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI guard in the staging upload path; no app, auth, or release logic changes.
> 
> **Overview**
> Fixes **Linux staging** uploads in `desktop_cd` when copying AppImage and `.deb` outputs to Cloudflare R2.
> 
> The staging step globs everything under `bundle/appimage` and `bundle/deb`. Tauri can leave **directories** there (e.g. AppDir), so `cp` used to fail on non-files. The loop now **only copies regular files** (`[[ -f "$file" ]] || continue`), so x64 and ARM64 staging dry-runs can finish without changing which artifacts are uploaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdedbd4d5e93c02c74612743debc36915ca534c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->