### PR TITLE
Make Windows checksum files portable

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -628,7 +628,7 @@ jobs:
 
           $hash = (Get-FileHash -Algorithm SHA256 $installers[0].FullName).Hash.ToLowerInvariant()
           "$hash  $($installers[0].Name)" |
-            Out-File "$($installers[0].FullName).sha256" -Encoding ascii
+            Out-File "$($installers[0].FullName).sha256" -Encoding ascii -NoNewline
       - if: ${{ inputs.channel == 'stable' }}
         name: Verify Windows updater signature
         shell: bash

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -216,7 +216,7 @@ jobs:
 
           $hash = (Get-FileHash -Algorithm SHA256 $installer.FullName).Hash.ToLowerInvariant()
           "$hash  $($installer.Name)" |
-            Out-File "$($installer.FullName).sha256" -Encoding ascii
+            Out-File "$($installer.FullName).sha256" -Encoding ascii -NoNewline
       - if: github.event_name == 'workflow_dispatch'
         shell: pwsh
         timeout-minutes: 10


### PR DESCRIPTION
Write Windows installer SHA-256 manifests without CRLF so standard macOS and Linux checksum tools can verify them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to checksum file formatting; no application or signing logic is modified.
> 
> **Overview**
> Windows desktop **CD** and **CI** jobs now pass **`-NoNewline`** when writing NSIS installer `*.sha256` sidecars via PowerShell `Out-File`.
> 
> That avoids the default trailing CRLF, so the manifest matches the usual `hash  filename` line format and **`sha256sum -c`** / **`shasum -a 256 -c`** on macOS and Linux succeed next to the downloaded `.exe`, consistent with how Linux release artifacts already record basenames for checksum verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c29154425044faaabd44315fb4b7aacc8b4e0e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->