### PR TITLE
Fix mixed-capture speaker attribution

### DIFF
--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -14,31 +14,31 @@ import { inferAutomaticSpeakerAssignments } from "./speaker-attribution";
 
 import type { SessionContentSnapshot } from "~/session/content-queries";
 
-function createSnapshot(): SessionContentSnapshot {
+function createSnapshot(channel = 1): SessionContentSnapshot {
   const speakerHints = [
     {
       id: "lex-1:provider_speaker_index",
       word_id: "lex-1",
       type: "provider_speaker_index",
-      value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+      value: JSON.stringify({ channel, speaker_index: 0 }),
     },
     {
       id: "lex-2:provider_speaker_index",
       word_id: "lex-2",
       type: "provider_speaker_index",
-      value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+      value: JSON.stringify({ channel, speaker_index: 0 }),
     },
     {
       id: "george-1:provider_speaker_index",
       word_id: "george-1",
       type: "provider_speaker_index",
-      value: JSON.stringify({ channel: 1, speaker_index: 1 }),
+      value: JSON.stringify({ channel, speaker_index: 1 }),
     },
     {
       id: "george-2:provider_speaker_index",
       word_id: "george-2",
       type: "provider_speaker_index",
-      value: JSON.stringify({ channel: 1, speaker_index: 1 }),
+      value: JSON.stringify({ channel, speaker_index: 1 }),
     },
   ];
 
@@ -68,28 +68,28 @@ function createSnapshot(): SessionContentSnapshot {
             text: " What do you think about open source Llama",
             start_ms: 0,
             end_ms: 500,
-            channel: 1,
+            channel,
           },
           {
             id: "lex-2",
             text: " and the future of AI?",
             start_ms: 500,
             end_ms: 1_000,
-            channel: 1,
+            channel,
           },
           {
             id: "george-1",
             text: " Zuckerberg is a good guy and open source matters",
             start_ms: 1_000,
             end_ms: 1_500,
-            channel: 1,
+            channel,
           },
           {
             id: "george-2",
             text: " undoubtedly.",
             start_ms: 1_500,
             end_ms: 2_000,
-            channel: 1,
+            channel,
           },
         ],
         speaker_hints: speakerHints,
@@ -201,6 +201,43 @@ ${JSON.stringify({
         }),
       },
     ]);
+  });
+
+  it("attributes diarized mixed-capture batch transcripts", async () => {
+    mocks.generateText.mockResolvedValue({
+      text: JSON.stringify({
+        mappings: [
+          {
+            cluster_id: "transcript-1:0",
+            human_id: "human-lex",
+            confidence: 0.98,
+            evidence_id: "evidence-1",
+          },
+          {
+            cluster_id: "transcript-1:1",
+            human_id: "human-george",
+            confidence: 0.97,
+            evidence_id: "evidence-1",
+          },
+        ],
+      }),
+    });
+
+    const updates = await inferAutomaticSpeakerAssignments({
+      generatedSummary:
+        "Lex Fridman asked about Llama. George Hotz discussed open source.",
+      model: {} as LanguageModel,
+      snapshot: createSnapshot(2),
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.generateText).toHaveBeenCalledOnce();
+    expect(
+      JSON.parse(updates[0]!.nextSpeakerHintsJson).filter(
+        (hint: { type: string }) =>
+          hint.type === "automatic_speaker_assignment",
+      ),
+    ).toHaveLength(2);
   });
 
   it("attributes recurring participants independently in each transcript", async () => {

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -9,7 +9,7 @@ import type { SpeakerHintWithId } from "~/stt/types";
 const AUTOMATIC_SPEAKER_ASSIGNMENT = "automatic_speaker_assignment";
 const USER_SPEAKER_ASSIGNMENT = "user_speaker_assignment";
 const PROVIDER_SPEAKER_INDEX = "provider_speaker_index";
-const REMOTE_PARTY_CHANNEL = 1;
+const ATTRIBUTABLE_SPEAKER_CHANNELS = new Set([1, 2]);
 const MIN_CLUSTER_TEXT_LENGTH = 40;
 const MAX_CLUSTER_TEXT_LENGTH = 4_000;
 const MAX_EVIDENCE_CANDIDATE_LENGTH = 320;
@@ -214,7 +214,7 @@ function buildSpeakerAttributionContext(
         continue;
       }
       const speaker = speakerByWordId.get(hint.word_id);
-      if (speaker?.channel === REMOTE_PARTY_CHANNEL) {
+      if (speaker && ATTRIBUTABLE_SPEAKER_CHANNELS.has(speaker.channel)) {
         assignedClusterIds.add(
           getClusterId(transcript.id, speaker.speakerIndex),
         );
@@ -227,7 +227,7 @@ function buildSpeakerAttributionContext(
     >();
     for (const word of transcript.words) {
       const speaker = speakerByWordId.get(word.id);
-      if (speaker?.channel !== REMOTE_PARTY_CHANNEL) {
+      if (!speaker || !ATTRIBUTABLE_SPEAKER_CHANNELS.has(speaker.channel)) {
         continue;
       }
 


### PR DESCRIPTION
Include diarized mixed-capture batch transcripts in automatic participant mapping and add regression coverage for channel-2 batch output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows which transcript channels participate in enhance-time speaker mapping; behavior change is limited to previously skipped channel-2 diarization, with test coverage.
> 
> **Overview**
> **Automatic speaker attribution** during enhance no longer ignores diarized words on **channel 2**, which is how mixed-capture batch transcripts are tagged.
> 
> `speaker-attribution.ts` replaces the single remote-party channel check with `ATTRIBUTABLE_SPEAKER_CHANNELS` (channels **1** and **2**) when deciding which clusters are already assigned and which words form attribution clusters.
> 
> Tests parameterize the snapshot fixture by channel and add a regression case that runs attribution with **channel 2** and expects two automatic speaker hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2240acbcfbff68a8ff77f46f33d408d2fd704dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->