### PR TITLE
Add direct intelligence providers

### DIFF
--- a/apps/desktop/src/settings/ai/llm/configure.tsx
+++ b/apps/desktop/src/settings/ai/llm/configure.tsx
@@ -59,9 +59,13 @@ function ProviderContext({ providerId }: { providerId: ProviderId }) {
                   ? "Enter your **Azure AI Foundry endpoint** as the Base URL and your **API key**. Supports Claude and other models deployed via Azure AI Foundry. [Report issues](https://github.com/fastrepl/char/issues/3928)"
                   : providerId === "google_generative_ai"
                     ? "Visit [AI Studio](https://aistudio.google.com/api-keys) to create an API key."
-                    : providerId === "cloudflare_workers_ai"
-                      ? "Enter the Workers AI **OpenAI-compatible base URL** as `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1` and use a Cloudflare API token with Workers AI access."
-                      : "";
+                    : providerId === "amazon_bedrock"
+                      ? "Enter the regional **Bedrock Mantle OpenAI-compatible URL** (for example, `https://bedrock-mantle.us-east-1.api.aws/v1`) and a Bedrock long-term API key."
+                      : providerId === "google_vertex_ai"
+                        ? "Enter your project and location's **Vertex AI OpenAI-compatible endpoint** and a bearer access token. Vertex access tokens expire, so replace the saved token when Google Cloud refreshes it."
+                        : providerId === "cloudflare_workers_ai"
+                          ? "Enter the Workers AI **OpenAI-compatible base URL** as `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1` and use a Cloudflare API token with Workers AI access."
+                          : "";
 
   if (!content) {
     return null;

--- a/apps/desktop/src/settings/ai/llm/select.test.ts
+++ b/apps/desktop/src/settings/ai/llm/select.test.ts
@@ -36,6 +36,74 @@ describe("getLlmProviderStatus", () => {
     expect(status.listModels).toBeTypeOf("function");
   });
 
+  test.each([
+    ["cohere", "https://api.cohere.ai/compatibility/v1"],
+    ["groq", "https://api.groq.com/openai/v1"],
+    ["xai", "https://api.x.ai/v1"],
+    ["together", "https://api.together.xyz/v1"],
+    ["fireworks", "https://api.fireworks.ai/inference/v1"],
+    ["cerebras", "https://api.cerebras.ai/v1"],
+  ])("configures %s through its OpenAI-compatible endpoint", (id, baseUrl) => {
+    const definition = provider(id);
+    const status = getLlmProviderStatus({
+      provider: definition,
+      config: { api_key: "test-key" },
+      isAuthenticated: false,
+      isPaid: false,
+    });
+
+    expect(definition.baseUrl).toBe(baseUrl);
+    expect(status.configured).toBe(true);
+    expect(status.listModels).toBeTypeOf("function");
+  });
+
+  test.each(["amazon_bedrock", "google_vertex_ai"])(
+    "requires both an endpoint and credentials for %s",
+    (id) => {
+      const definition = provider(id);
+      const missingEndpoint = getLlmProviderStatus({
+        provider: definition,
+        config: { api_key: "test-key" },
+        isAuthenticated: false,
+        isPaid: false,
+      });
+      const configured = getLlmProviderStatus({
+        provider: definition,
+        config: {
+          base_url: "https://provider.example.com/v1",
+          api_key: "test-key",
+        },
+        isAuthenticated: false,
+        isPaid: false,
+      });
+
+      expect(missingEndpoint.configured).toBe(false);
+      expect(configured.configured).toBe(true);
+      expect(configured.listModels).toBeTypeOf("function");
+    },
+  );
+
+  test("uses curated models for Google Vertex AI", async () => {
+    const status = getLlmProviderStatus({
+      provider: provider("google_vertex_ai"),
+      config: {
+        base_url:
+          "https://aiplatform.googleapis.com/v1/projects/project/locations/global/endpoints/openapi",
+        api_key: "test-key",
+      },
+      isAuthenticated: false,
+      isPaid: false,
+    });
+
+    const result = await status.listModels?.();
+
+    expect(result?.models.slice(0, 3)).toEqual([
+      "google/gemini-3.6-flash",
+      "google/gemini-3.5-flash-lite",
+      "google/gemini-3.1-pro-preview",
+    ]);
+  });
+
   test("keeps local providers active without API keys", () => {
     const status = getLlmProviderStatus({
       provider: provider("ollama"),

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -502,6 +502,10 @@ export function getLlmProviderStatus({
     case "openai":
       listModelsFunc = () => listOpenAIModels(baseUrl, apiKey);
       break;
+    case "cohere":
+      listModelsFunc = () =>
+        listGenericModels(baseUrl, apiKey, { filterDateSnapshots: false });
+      break;
     case "cloudflare_workers_ai":
       listModelsFunc = () => listCloudflareWorkersAIModels(baseUrl, apiKey);
       break;

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -438,6 +438,15 @@ type ProviderConfig = {
   api_key?: unknown;
 };
 
+const GOOGLE_VERTEX_AI_MODELS = [
+  "google/gemini-3.6-flash",
+  "google/gemini-3.5-flash-lite",
+  "google/gemini-3.1-pro-preview",
+  "google/gemini-3.5-flash",
+  "google/gemini-3-flash-preview",
+  "google/gemini-3.1-flash-lite",
+] as const;
+
 export function getLlmProviderStatus({
   provider,
   config,
@@ -504,6 +513,18 @@ export function getLlmProviderStatus({
       break;
     case "google_generative_ai":
       listModelsFunc = () => listGoogleModels(baseUrl, apiKey);
+      break;
+    case "google_vertex_ai":
+      listModelsFunc = async () => ({
+        models: [...GOOGLE_VERTEX_AI_MODELS],
+        ignored: [],
+        metadata: Object.fromEntries(
+          GOOGLE_VERTEX_AI_MODELS.map((model) => [
+            model,
+            { input_modalities: ["text", "image"] as InputModality[] },
+          ]),
+        ),
+      });
       break;
     case "mistral":
       listModelsFunc = () => listMistralModels(baseUrl, apiKey);

--- a/apps/desktop/src/settings/ai/llm/shared.tsx
+++ b/apps/desktop/src/settings/ai/llm/shared.tsx
@@ -156,7 +156,7 @@ const _PROVIDERS = [
     id: "xai",
     displayName: "xAI",
     badge: null,
-    icon: <Icon icon="simple-icons:x" width={16} />,
+    icon: <Icon icon="bxl:xai" width={16} />,
     baseUrl: "https://api.x.ai/v1",
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
     links: {

--- a/apps/desktop/src/settings/ai/llm/shared.tsx
+++ b/apps/desktop/src/settings/ai/llm/shared.tsx
@@ -117,6 +117,154 @@ const _PROVIDERS = [
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
   },
   {
+    id: "cohere",
+    displayName: "Cohere",
+    badge: null,
+    icon: <Icon icon="simple-icons:cohere" width={16} />,
+    baseUrl: "https://api.cohere.ai/compatibility/v1",
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Available models",
+        url: "https://docs.cohere.com/docs/models",
+      },
+      setup: {
+        label: "OpenAI compatibility",
+        url: "https://docs.cohere.com/docs/compatibility-api",
+      },
+    },
+  },
+  {
+    id: "groq",
+    displayName: "Groq",
+    badge: null,
+    icon: <Icon icon="simple-icons:groq" width={16} />,
+    baseUrl: "https://api.groq.com/openai/v1",
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Available models",
+        url: "https://console.groq.com/docs/models",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://console.groq.com/keys",
+      },
+    },
+  },
+  {
+    id: "xai",
+    displayName: "xAI",
+    badge: null,
+    icon: <Icon icon="simple-icons:x" width={16} />,
+    baseUrl: "https://api.x.ai/v1",
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Available models",
+        url: "https://docs.x.ai/developers/models",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://console.x.ai/",
+      },
+    },
+  },
+  {
+    id: "together",
+    displayName: "Together AI",
+    badge: null,
+    icon: <Icon icon="simple-icons:together" width={16} />,
+    baseUrl: "https://api.together.xyz/v1",
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Available models",
+        url: "https://docs.together.ai/docs/serverless-models",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://api.together.ai/settings/api-keys",
+      },
+    },
+  },
+  {
+    id: "fireworks",
+    displayName: "Fireworks AI",
+    badge: null,
+    icon: <Icon icon="simple-icons:fireworks" width={16} />,
+    baseUrl: "https://api.fireworks.ai/inference/v1",
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Available models",
+        url: "https://fireworks.ai/models",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://fireworks.ai/account/api-keys",
+      },
+    },
+  },
+  {
+    id: "cerebras",
+    displayName: "Cerebras",
+    badge: null,
+    icon: <Icon icon="simple-icons:cerebras" width={16} />,
+    baseUrl: "https://api.cerebras.ai/v1",
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Available models",
+        url: "https://inference-docs.cerebras.ai/models/overview",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://cloud.cerebras.ai/",
+      },
+    },
+  },
+  {
+    id: "amazon_bedrock",
+    displayName: "Amazon Bedrock",
+    badge: "Beta",
+    icon: <Icon icon="simple-icons:amazonwebservices" width={16} />,
+    baseUrl: undefined,
+    requirements: [
+      { kind: "requires_config", fields: ["base_url", "api_key"] },
+    ],
+    links: {
+      models: {
+        label: "Supported models",
+        url: "https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html",
+      },
+      setup: {
+        label: "OpenAI-compatible APIs",
+        url: "https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html",
+      },
+    },
+  },
+  {
+    id: "google_vertex_ai",
+    displayName: "Google Vertex AI",
+    badge: "Beta",
+    icon: <Icon icon="simple-icons:googlecloud" width={16} />,
+    baseUrl: undefined,
+    requirements: [
+      { kind: "requires_config", fields: ["base_url", "api_key"] },
+    ],
+    links: {
+      models: {
+        label: "Available models",
+        url: "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models",
+      },
+      setup: {
+        label: "OpenAI compatibility",
+        url: "https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-vertex-using-openai-library",
+      },
+    },
+  },
+  {
     id: "cloudflare_workers_ai",
     displayName: "Cloudflare Workers AI",
     badge: null,

--- a/apps/desktop/src/settings/ai/shared/list-common.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  isDateSnapshot,
   isNonStreamingModel,
   isOldModel,
   removeNonStreamingModels,
   sortModelsByRecency,
 } from "./list-common";
+
+describe("isDateSnapshot", () => {
+  test("keeps provider version and context suffixes", () => {
+    expect(isDateSnapshot("llama-3.1-8b-instant-8192")).toBe(false);
+    expect(isDateSnapshot("grok-4-0709")).toBe(false);
+    expect(isDateSnapshot("command-a-plus-05-2026")).toBe(true);
+  });
+});
 
 describe("isNonStreamingModel", () => {
   test("filters GPT Pro models without hiding streaming-capable models", () => {

--- a/apps/desktop/src/settings/ai/shared/list-common.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.test.ts
@@ -105,4 +105,10 @@ describe("sortModelsByRecency", () => {
       "google/gemini-3.5-flash-lite",
     ]);
   });
+
+  test("prioritizes current models with dotted Bedrock prefixes", () => {
+    expect(
+      sortModelsByRecency(["custom-model", "anthropic.claude-sonnet-5"]),
+    ).toEqual(["anthropic.claude-sonnet-5", "custom-model"]);
+  });
 });

--- a/apps/desktop/src/settings/ai/shared/list-common.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.ts
@@ -101,9 +101,40 @@ export const isDateSnapshot = (id: string): boolean => {
   return false;
 };
 
+const modelName = (id: string): string => {
+  const name = id.toLowerCase().split("/").pop()!;
+  const segments = name.split(".");
+  const providerIndex = segments.findIndex((segment) =>
+    [
+      "ai21",
+      "amazon",
+      "anthropic",
+      "cohere",
+      "deepseek",
+      "google",
+      "meta",
+      "minimax",
+      "mistral",
+      "moonshot",
+      "nvidia",
+      "openai",
+      "qwen",
+      "stability",
+      "twelvelabs",
+      "writer",
+      "xai",
+      "zai",
+    ].includes(segment),
+  );
+
+  return providerIndex >= 0 && providerIndex < segments.length - 1
+    ? segments.slice(providerIndex + 1).join(".")
+    : name;
+};
+
 export const isNonChatModel = (id: string): boolean => {
   const lowerId = id.toLowerCase();
-  const name = lowerId.includes("/") ? lowerId.split("/").pop()! : lowerId;
+  const name = modelName(id);
 
   if (/^o\d/.test(name)) return true;
   if (/^gpt-4o-/.test(name)) return true;
@@ -116,7 +147,7 @@ export const isNonChatModel = (id: string): boolean => {
 };
 
 export const isNonStreamingModel = (id: string): boolean => {
-  const name = id.toLowerCase().split("/").pop()!;
+  const name = modelName(id);
   return /^gpt-\d+(?:\.\d+)*-pro(?:$|-)/.test(name);
 };
 
@@ -135,8 +166,7 @@ export const removeNonStreamingModels = (
 };
 
 export const isOldModel = (id: string): boolean => {
-  const lowerId = id.toLowerCase();
-  const name = lowerId.includes("/") ? lowerId.split("/").pop()! : lowerId;
+  const name = modelName(id);
   const dashedName = name.replace(/\./g, "-");
 
   if (/^gpt-3\.5/.test(name)) return true;

--- a/apps/desktop/src/settings/ai/shared/list-common.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.ts
@@ -1,6 +1,8 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { Effect } from "effect";
 
+import { modelName } from "./model-id";
+
 export type ModelIgnoreReason =
   | "common_keyword"
   | "old_model"
@@ -101,37 +103,6 @@ export const isDateSnapshot = (id: string): boolean => {
   return false;
 };
 
-const modelName = (id: string): string => {
-  const name = id.toLowerCase().split("/").pop()!;
-  const segments = name.split(".");
-  const providerIndex = segments.findIndex((segment) =>
-    [
-      "ai21",
-      "amazon",
-      "anthropic",
-      "cohere",
-      "deepseek",
-      "google",
-      "meta",
-      "minimax",
-      "mistral",
-      "moonshot",
-      "nvidia",
-      "openai",
-      "qwen",
-      "stability",
-      "twelvelabs",
-      "writer",
-      "xai",
-      "zai",
-    ].includes(segment),
-  );
-
-  return providerIndex >= 0 && providerIndex < segments.length - 1
-    ? segments.slice(providerIndex + 1).join(".")
-    : name;
-};
-
 export const isNonChatModel = (id: string): boolean => {
   const lowerId = id.toLowerCase();
   const name = modelName(id);
@@ -201,7 +172,7 @@ export const isOldModel = (id: string): boolean => {
 
 export const sortModelsByRecency = (models: string[]): string[] => {
   const priority = (model: string) => {
-    const normalized = model.toLowerCase();
+    const normalized = modelName(model);
     const index = modelPriorityPatterns.findIndex((pattern) =>
       pattern.test(normalized),
     );

--- a/apps/desktop/src/settings/ai/shared/list-common.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.ts
@@ -99,7 +99,7 @@ export const shouldIgnoreCommonKeywords = (id: string): boolean => {
 export const isDateSnapshot = (id: string): boolean => {
   if (/-\d{4}-\d{2}-\d{2}/.test(id)) return true;
   if (/-\d{8}$/.test(id)) return true;
-  if (/-\d{4}$/.test(id)) return true;
+  if (/-20\d{2}$/.test(id)) return true;
   return false;
 };
 
@@ -111,7 +111,6 @@ export const isNonChatModel = (id: string): boolean => {
   if (/^gpt-4o-/.test(name)) return true;
   if (/^gpt-4\.1/.test(name)) return true;
   if (name.startsWith("ft:") || lowerId.startsWith("ft:")) return true;
-  if (/^gemma/.test(name)) return true;
   if (/^nano-banana/.test(name)) return true;
 
   return false;

--- a/apps/desktop/src/settings/ai/shared/list-openai.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-openai.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import { processGenericModels } from "./list-openai";
+
+describe("processGenericModels", () => {
+  test("keeps Cohere model versions while still filtering non-chat models", () => {
+    const result = processGenericModels(
+      [{ id: "command-a-plus-05-2026" }, { id: "embed-v4.0" }],
+      { filterDateSnapshots: false },
+    );
+
+    expect(result.models).toEqual(["command-a-plus-05-2026"]);
+    expect(result.ignored).toEqual([
+      { id: "embed-v4.0", reasons: ["common_keyword"] },
+    ]);
+  });
+
+  test("filters date snapshots by default for generic providers", () => {
+    const result = processGenericModels([{ id: "model-05-2026" }]);
+
+    expect(result.models).toEqual([]);
+    expect(result.ignored).toEqual([
+      { id: "model-05-2026", reasons: ["date_snapshot"] },
+    ]);
+  });
+});

--- a/apps/desktop/src/settings/ai/shared/list-openai.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-openai.test.ts
@@ -23,4 +23,18 @@ describe("processGenericModels", () => {
       { id: "model-05-2026", reasons: ["date_snapshot"] },
     ]);
   });
+
+  test("filters dotted Bedrock model IDs by their model name", () => {
+    const result = processGenericModels([
+      { id: "anthropic.claude-opus-4.7" },
+      { id: "google.gemma-3-27b-it" },
+      { id: "anthropic.claude-opus-5" },
+    ]);
+
+    expect(result.models).toEqual(["anthropic.claude-opus-5"]);
+    expect(result.ignored).toEqual([
+      { id: "anthropic.claude-opus-4.7", reasons: ["old_model"] },
+      { id: "google.gemma-3-27b-it", reasons: ["not_chat_model"] },
+    ]);
+  });
 });

--- a/apps/desktop/src/settings/ai/shared/list-openai.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-openai.test.ts
@@ -31,10 +31,12 @@ describe("processGenericModels", () => {
       { id: "anthropic.claude-opus-5" },
     ]);
 
-    expect(result.models).toEqual(["anthropic.claude-opus-5"]);
+    expect(result.models).toEqual([
+      "anthropic.claude-opus-5",
+      "google.gemma-3-27b-it",
+    ]);
     expect(result.ignored).toEqual([
       { id: "anthropic.claude-opus-4.7", reasons: ["old_model"] },
-      { id: "google.gemma-3-27b-it", reasons: ["not_chat_model"] },
     ]);
   });
 });

--- a/apps/desktop/src/settings/ai/shared/list-openai.ts
+++ b/apps/desktop/src/settings/ai/shared/list-openai.ts
@@ -75,6 +75,7 @@ export async function listOpenAIModels(
 export async function listGenericModels(
   baseUrl: string,
   apiKey: string,
+  options?: { filterDateSnapshots?: boolean },
 ): Promise<ListModelsResult> {
   if (!baseUrl) {
     return DEFAULT_RESULT;
@@ -83,40 +84,45 @@ export async function listGenericModels(
   return pipe(
     fetchJson(`${baseUrl}/models`, { Authorization: `Bearer ${apiKey}` }),
     Effect.andThen((json) => Schema.decodeUnknown(OpenAIModelSchema)(json)),
-    Effect.map(({ data }) => {
-      const result = partition(
-        data,
-        (model) => {
-          const reasons: ModelIgnoreReason[] = [];
-          if (shouldIgnoreCommonKeywords(model.id)) {
-            reasons.push("common_keyword");
-          }
-          if (isNonChatModel(model.id)) {
-            reasons.push("not_chat_model");
-          }
-          if (isOldModel(model.id)) {
-            reasons.push("old_model");
-          }
-          if (isDateSnapshot(model.id)) {
-            reasons.push("date_snapshot");
-          }
-          return reasons.length > 0 ? reasons : null;
-        },
-        (model) => model.id,
-      );
-
-      return {
-        models: sortModelsByRecency(result.models),
-        ignored: result.ignored,
-        metadata: extractMetadataMap(
-          data,
-          (model) => model.id,
-          () => ({ input_modalities: ["text"] }),
-        ),
-      };
-    }),
+    Effect.map(({ data }) => processGenericModels(data, options)),
     Effect.timeout(REQUEST_TIMEOUT),
     Effect.catchAll(() => Effect.succeed(DEFAULT_RESULT)),
     Effect.runPromise,
   );
+}
+
+export function processGenericModels(
+  data: readonly { id: string }[],
+  options?: { filterDateSnapshots?: boolean },
+): ListModelsResult {
+  const result = partition(
+    data,
+    (model) => {
+      const reasons: ModelIgnoreReason[] = [];
+      if (shouldIgnoreCommonKeywords(model.id)) {
+        reasons.push("common_keyword");
+      }
+      if (isNonChatModel(model.id)) {
+        reasons.push("not_chat_model");
+      }
+      if (isOldModel(model.id)) {
+        reasons.push("old_model");
+      }
+      if (options?.filterDateSnapshots !== false && isDateSnapshot(model.id)) {
+        reasons.push("date_snapshot");
+      }
+      return reasons.length > 0 ? reasons : null;
+    },
+    (model) => model.id,
+  );
+
+  return {
+    models: sortModelsByRecency(result.models),
+    ignored: result.ignored,
+    metadata: extractMetadataMap(
+      data,
+      (model) => model.id,
+      () => ({ input_modalities: ["text"] }),
+    ),
+  };
 }

--- a/apps/desktop/src/settings/ai/shared/model-display.test.ts
+++ b/apps/desktop/src/settings/ai/shared/model-display.test.ts
@@ -20,6 +20,9 @@ describe("displayLlmModelId", () => {
     expect(displayLlmModelId("amazon_bedrock", "anthropic.claude-opus-5")).toBe(
       "Claude Opus 5",
     );
+    expect(displayLlmModelId("cohere", "command-a-plus-05-2026")).toBe(
+      "Command A Plus",
+    );
   });
 
   test("formats common model families without changing stored ids", () => {

--- a/apps/desktop/src/settings/ai/shared/model-display.test.ts
+++ b/apps/desktop/src/settings/ai/shared/model-display.test.ts
@@ -17,6 +17,9 @@ describe("displayLlmModelId", () => {
     expect(
       displayLlmModelId("openrouter", "mistralai/mistral-large-2512"),
     ).toBe("Mistral Large");
+    expect(displayLlmModelId("amazon_bedrock", "anthropic.claude-opus-5")).toBe(
+      "Claude Opus 5",
+    );
   });
 
   test("formats common model families without changing stored ids", () => {

--- a/apps/desktop/src/settings/ai/shared/model-display.ts
+++ b/apps/desktop/src/settings/ai/shared/model-display.ts
@@ -1,3 +1,5 @@
+import { modelName } from "./model-id";
+
 const MODEL_NAME_OVERRIDES: Record<string, string> = {
   "chat-latest": "Chat Latest",
   "gpt-chat-latest": "GPT Chat Latest",
@@ -10,8 +12,7 @@ export function displayLlmModelId(providerId: string, model: string): string {
     return "Pro (Cloud)";
   }
 
-  const modelId = lastModelPathSegment(model);
-  const normalized = stripReleaseDate(modelId.toLowerCase());
+  const normalized = stripReleaseDate(modelName(model));
 
   const override = MODEL_NAME_OVERRIDES[normalized];
   if (override) {
@@ -44,12 +45,6 @@ export function displayLlmModelId(providerId: string, model: string): string {
   }
 
   return titleizeModelId(normalized);
-}
-
-function lastModelPathSegment(model: string) {
-  return (
-    model.trim().replace(/^~/, "").split("/").filter(Boolean).pop() ?? model
-  );
 }
 
 function stripReleaseDate(modelId: string) {

--- a/apps/desktop/src/settings/ai/shared/model-display.ts
+++ b/apps/desktop/src/settings/ai/shared/model-display.ts
@@ -48,7 +48,10 @@ export function displayLlmModelId(providerId: string, model: string): string {
 }
 
 function stripReleaseDate(modelId: string) {
-  return modelId.replace(/-(?:20\d{6}|20\d{2}-\d{2}-\d{2}|2\d{3})$/, "");
+  return modelId.replace(
+    /-(?:\d{2}-20\d{2}|20\d{6}|20\d{2}-\d{2}-\d{2}|2\d{3})$/,
+    "",
+  );
 }
 
 function formatClaudeModel(modelId: string) {

--- a/apps/desktop/src/settings/ai/shared/model-id.ts
+++ b/apps/desktop/src/settings/ai/shared/model-id.ts
@@ -1,0 +1,32 @@
+const dottedModelProviders = new Set([
+  "ai21",
+  "amazon",
+  "anthropic",
+  "cohere",
+  "deepseek",
+  "google",
+  "meta",
+  "minimax",
+  "mistral",
+  "moonshot",
+  "nvidia",
+  "openai",
+  "qwen",
+  "stability",
+  "twelvelabs",
+  "writer",
+  "xai",
+  "zai",
+]);
+
+export const modelName = (id: string): string => {
+  const name = id.trim().replace(/^~/, "").toLowerCase().split("/").pop()!;
+  const segments = name.split(".");
+  const providerIndex = segments.findIndex((segment) =>
+    dottedModelProviders.has(segment),
+  );
+
+  return providerIndex >= 0 && providerIndex < segments.length - 1
+    ? segments.slice(providerIndex + 1).join(".")
+    : name;
+};


### PR DESCRIPTION
- Added support for direct intelligence providers (instead of relying solely on indirect integrations).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to desktop LLM provider configuration, model listing heuristics, and tests; no auth or inference pipeline changes beyond users picking new providers.
> 
> **Overview**
> Adds **eight new first-party LLM providers** in desktop AI settings: Cohere, Groq, xAI, Together, Fireworks, Cerebras (API key + fixed OpenAI-compatible base URLs), plus **Amazon Bedrock** and **Google Vertex AI** (beta; require custom base URL and credentials). Setup copy was added for Bedrock Mantle and Vertex bearer tokens.
> 
> **Model listing and UX** now route Cohere through generic OpenAI `/models` with date-snapshot filtering disabled; Vertex returns a **curated Gemini list** instead of live discovery; other new API-key hosts use the default generic lister. Shared logic gains `modelName()` for slash- and **Bedrock-style dotted** IDs so filtering, sorting, and display names work for IDs like `anthropic.claude-opus-5`. `isDateSnapshot` is tightened (e.g. `-8192` suffixes no longer treated as snapshots), and Cohere-style `MM-YYYY` dates are stripped for display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72601d1b1b03bc378d78d703d20a6aec3884cf01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->