### PR TITLE
Add Cohere transcription provider

### DIFF
--- a/apps/desktop/src/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/settings/ai/stt/configure.tsx
@@ -64,9 +64,11 @@ function ProviderContext({ providerId }: { providerId: ProviderId }) {
                     ? `Use [Fireworks AI](https://fireworks.ai) for transcriptions.`
                     : providerId === "mistral"
                       ? `Use [Mistral](https://mistral.ai) for transcriptions.`
-                      : providerId === "custom"
-                        ? `We only support **Deepgram compatible** endpoints for now.`
-                        : "";
+                      : providerId === "cohere"
+                        ? `Use [Cohere Transcribe](https://docs.cohere.com/docs/transcribe) for batch transcription. Files must be 25 MB or smaller and use one selected language. Cohere does not return timestamps or speaker labels, so Anarlog estimates word timing.`
+                        : providerId === "custom"
+                          ? `We only support **Deepgram compatible** endpoints for now.`
+                          : "";
 
   if (!content.trim()) {
     return null;

--- a/apps/desktop/src/settings/ai/stt/selection.test.ts
+++ b/apps/desktop/src/settings/ai/stt/selection.test.ts
@@ -12,6 +12,7 @@ describe("getDefaultSttModel", () => {
   test("repairs external providers with their first supported model", () => {
     expect(getDefaultSttModel("deepgram")).toBe("nova-3-general");
     expect(getDefaultSttModel("soniox")).toBe("stt-rt-v5");
+    expect(getDefaultSttModel("cohere")).toBe("cohere-transcribe-03-2026");
   });
 
   test("does not invent a model for custom or Anarlog providers", () => {

--- a/apps/desktop/src/settings/ai/stt/shared.test.ts
+++ b/apps/desktop/src/settings/ai/stt/shared.test.ts
@@ -18,6 +18,9 @@ describe("STT model display labels", () => {
       "GPT Live Transcribe",
     );
     expect(displayModelLabel("gpt-transcribe")).toBe("GPT Transcribe");
+    expect(displayModelLabel("cohere-transcribe-03-2026")).toBe(
+      "Cohere Transcribe",
+    );
   });
 
   test("treats apple speech as an on-device model", () => {

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@iconify-icon/react";
 import {
   AssemblyAI,
   Cloudflare,
+  Cohere,
   ElevenLabs,
   Fireworks,
   Mistral,
@@ -137,6 +138,10 @@ export const displayModelId = (model: string) => {
 
   if (model === "avalon-v1-en") {
     return "Avalon V1";
+  }
+
+  if (model === "cohere-transcribe-03-2026") {
+    return "Cohere Transcribe";
   }
 
   if (model === "apple-speech") {
@@ -377,6 +382,26 @@ const _PROVIDERS = [
     baseUrl: "https://api.aquavoice.com/api/v1",
     models: ["avalon-v1-en"],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+  },
+  {
+    disabled: false,
+    id: "cohere",
+    displayName: "Cohere",
+    badge: "Batch only",
+    icon: <Cohere size={14} />,
+    baseUrl: "https://api.cohere.com/v2",
+    models: ["cohere-transcribe-03-2026"],
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Cohere Transcribe docs",
+        url: "https://docs.cohere.com/docs/transcribe",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://dashboard.cohere.com/api-keys",
+      },
+    },
   },
   {
     disabled: false,

--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -91,6 +91,9 @@ describe("getSttModelTranscriptionMode", () => {
       "live",
     );
     expect(getSttModelTranscriptionMode("gladia", "solaria-3")).toBe("batch");
+    expect(
+      getSttModelTranscriptionMode("cohere", "cohere-transcribe-03-2026"),
+    ).toBe("batch");
   });
 
   test("leaves models without an explicit mode to provider inference", () => {

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -140,6 +140,10 @@ export function getSttModelTranscriptionMode(
   provider?: string | null,
   model?: string | null,
 ): TranscriptionMode | undefined {
+  if (provider === "cohere" && model === "cohere-transcribe-03-2026") {
+    return "batch";
+  }
+
   if (provider === "openai") {
     if (model === "gpt-live-transcribe") return "live";
     if (

--- a/apps/desktop/src/stt/model-selection.ts
+++ b/apps/desktop/src/stt/model-selection.ts
@@ -20,6 +20,7 @@ const DEFAULT_EXTERNAL_STT_MODELS: Record<string, string> = {
   mistral: "voxtral-mini-2602",
   pyannote: "parakeet-tdt-0.6b-v3",
   aquavoice: "avalon-v1-en",
+  cohere: "cohere-transcribe-03-2026",
   fireworks: "Default",
 };
 

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -181,6 +181,12 @@ describe("getBatchProvider", () => {
     expect(getBatchProvider("cartesia", "ink-2")).toBe("cartesia");
   });
 
+  test("maps Cohere to the batch transcription provider", () => {
+    expect(getBatchProvider("cohere", "cohere-transcribe-03-2026")).toBe(
+      "cohere",
+    );
+  });
+
   test("maps Cloudflare Workers AI to the Deepgram-compatible batch provider", () => {
     expect(getBatchProvider("cloudflare_workers_ai", "nova-3")).toBe(
       "deepgram",

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -77,6 +77,7 @@ const DIRECT_BATCH_PROVIDERS: Set<TranscriptionParams["provider"]> = new Set([
   "fireworks",
   "pyannote",
   "aquavoice",
+  "cohere",
 ]);
 
 export const STOPPED_TRANSCRIPTION_ERROR_MESSAGE = "Transcription stopped.";

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -124,7 +124,7 @@ pub(super) async fn spawn_rx_task(
         DashScope => DashScopeAdapter,
         Mistral => MistralAdapter,
         Anarlog => AnarlogAdapter,
-    }, batch_only: [AquaVoice, Pyannote])?;
+    }, batch_only: [AquaVoice, Pyannote, Cohere])?;
 
     Ok((result.0, result.1, result.2, adapter_kind.to_string()))
 }

--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -37,6 +37,7 @@ pub enum BatchProvider {
     AppleSpeech,
     AquaVoice,
     Cartesia,
+    Cohere,
 }
 
 impl BatchProvider {
@@ -55,6 +56,7 @@ impl BatchProvider {
             Self::Anarlog => Some(AdapterKind::Anarlog),
             Self::AquaVoice => Some(AdapterKind::AquaVoice),
             Self::Cartesia => Some(AdapterKind::Cartesia),
+            Self::Cohere => Some(AdapterKind::Cohere),
             Self::Am | Self::WhisperLocal | Self::Soniqo | Self::AppleSpeech | Self::DashScope => {
                 None
             }

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -4,8 +4,8 @@ use std::time::{Duration, Instant};
 
 use owhisper_client::{
     AdapterKind, AnarlogAdapter, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter,
-    BatchSttAdapter, CartesiaAdapter, DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter,
-    GladiaAdapter, MistralAdapter, OpenAIAdapter, PyannoteAdapter, SonioxAdapter,
+    BatchSttAdapter, CartesiaAdapter, CohereAdapter, DeepgramAdapter, ElevenLabsAdapter,
+    FireworksAdapter, GladiaAdapter, MistralAdapter, OpenAIAdapter, PyannoteAdapter, SonioxAdapter,
 };
 use owhisper_interface::batch_stream::BatchStreamEvent;
 use tracing::Instrument;
@@ -65,6 +65,7 @@ pub(super) async fn run_direct_batch_for_adapter_kind(
         Mistral => MistralAdapter,
         Anarlog => AnarlogAdapter,
         AquaVoice => AquaVoiceAdapter,
+        Cohere => CohereAdapter,
     }, unsupported: [DashScope])
 }
 

--- a/crates/listener2-core/src/lib.rs
+++ b/crates/listener2-core/src/lib.rs
@@ -144,6 +144,7 @@ pub fn suggest_providers_for_languages_batch(languages: &[anlg_language::Languag
         AdapterKind::ElevenLabs,
         AdapterKind::DashScope,
         AdapterKind::Mistral,
+        AdapterKind::Cohere,
     ];
 
     let mut with_support: Vec<_> = all_providers

--- a/crates/owhisper-client/src/adapter/cohere/batch.rs
+++ b/crates/owhisper-client/src/adapter/cohere/batch.rs
@@ -1,0 +1,183 @@
+use std::path::{Path, PathBuf};
+
+use owhisper_interface::ListenParams;
+use owhisper_interface::batch::{Alternatives, Channel, Response as BatchResponse, Results};
+use reqwest::multipart::Form;
+
+use crate::adapter::http::{ensure_success, streaming_file_part};
+use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, append_path_if_missing};
+use crate::error::Error;
+
+use super::CohereAdapter;
+
+const DEFAULT_API_BASE: &str = "https://api.cohere.com/v2";
+const DEFAULT_MODEL: &str = "cohere-transcribe-03-2026";
+
+impl BatchSttAdapter for CohereAdapter {
+    fn provider_name(&self) -> &'static str {
+        "cohere"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        CohereAdapter::language_support_batch(languages).is_supported()
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(do_transcribe_file(client, api_base, api_key, params, path))
+    }
+}
+
+async fn do_transcribe_file(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    params: &ListenParams,
+    file_path: PathBuf,
+) -> Result<BatchResponse, Error> {
+    let language = language_code(params)?;
+    let form = Form::new()
+        .text(
+            "model",
+            params.model.as_deref().unwrap_or(DEFAULT_MODEL).to_string(),
+        )
+        .text("language", language.to_string())
+        .part("file", streaming_file_part(&file_path).await?);
+
+    let response = client
+        .post(transcription_url(api_base)?.to_string())
+        .bearer_auth(api_key)
+        .multipart(form)
+        .send()
+        .await?;
+    let response: CohereResponse = ensure_success(response).await?.json().await?;
+
+    Ok(build_batch_response(response.text, language))
+}
+
+#[derive(serde::Deserialize)]
+struct CohereResponse {
+    text: String,
+}
+
+fn language_code(params: &ListenParams) -> Result<&str, Error> {
+    if !CohereAdapter::language_support_batch(&params.languages).is_supported() {
+        return Err(Error::AudioProcessing(
+            "Cohere Transcribe requires one supported language".to_string(),
+        ));
+    }
+
+    Ok(params
+        .languages
+        .first()
+        .map(anlg_language::Language::iso639_code)
+        .unwrap_or("en"))
+}
+
+fn transcription_url(api_base: &str) -> Result<url::Url, Error> {
+    let mut url: url::Url = if api_base.is_empty() {
+        DEFAULT_API_BASE
+            .parse()
+            .expect("invalid_default_cohere_api_base")
+    } else {
+        api_base.parse().map_err(|e: url::ParseError| {
+            Error::AudioProcessing(format!("invalid api_base: {e}"))
+        })?
+    };
+    append_path_if_missing(&mut url, "audio/transcriptions");
+    Ok(url)
+}
+
+fn build_batch_response(transcript: String, language: &str) -> BatchResponse {
+    BatchResponse {
+        metadata: serde_json::json!({
+            "provider": "cohere",
+            "language": language,
+            "timing_source": "synthetic_text",
+        }),
+        results: Results {
+            channels: vec![Channel {
+                alternatives: vec![Alternatives {
+                    transcript: transcript.trim().to_string(),
+                    confidence: 1.0,
+                    words: Vec::new(),
+                }],
+            }],
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anlg_language::ISO639;
+
+    use super::*;
+
+    #[test]
+    fn builds_default_and_prefixed_urls() {
+        assert_eq!(
+            transcription_url("").unwrap().as_str(),
+            "https://api.cohere.com/v2/audio/transcriptions"
+        );
+        assert_eq!(
+            transcription_url("https://example.com/cohere/v2")
+                .unwrap()
+                .as_str(),
+            "https://example.com/cohere/v2/audio/transcriptions"
+        );
+    }
+
+    #[test]
+    fn defaults_to_english_and_uses_selected_language() {
+        assert_eq!(language_code(&ListenParams::default()).unwrap(), "en");
+        assert_eq!(
+            language_code(&ListenParams {
+                languages: vec![ISO639::Ko.into()],
+                ..Default::default()
+            })
+            .unwrap(),
+            "ko"
+        );
+    }
+
+    #[test]
+    fn rejects_multiple_or_unsupported_languages() {
+        assert!(
+            language_code(&ListenParams {
+                languages: vec![ISO639::En.into(), ISO639::Ko.into()],
+                ..Default::default()
+            })
+            .is_err()
+        );
+        assert!(
+            language_code(&ListenParams {
+                languages: vec![ISO639::Ru.into()],
+                ..Default::default()
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn normalizes_text_only_response() {
+        let response = build_batch_response(" hello world \n".to_string(), "en");
+        let alternative = &response.results.channels[0].alternatives[0];
+
+        assert_eq!(alternative.transcript, "hello world");
+        assert!(alternative.words.is_empty());
+        assert_eq!(response.metadata["provider"], "cohere");
+        assert_eq!(response.metadata["language"], "en");
+        assert_eq!(response.metadata["timing_source"], "synthetic_text");
+    }
+}

--- a/crates/owhisper-client/src/adapter/cohere/mod.rs
+++ b/crates/owhisper-client/src/adapter/cohere/mod.rs
@@ -1,0 +1,53 @@
+mod batch;
+
+use super::{LanguageQuality, LanguageSupport};
+
+#[derive(Clone, Default)]
+pub struct CohereAdapter;
+
+const SUPPORTED_LANGUAGE_CODES: &[&str] = &[
+    "ar", "de", "el", "en", "es", "fr", "it", "ja", "ko", "nl", "pl", "pt", "vi", "zh",
+];
+
+impl CohereAdapter {
+    pub fn language_support_batch(languages: &[anlg_language::Language]) -> LanguageSupport {
+        if languages.len() <= 1
+            && languages
+                .iter()
+                .all(|language| SUPPORTED_LANGUAGE_CODES.contains(&language.iso639_code()))
+        {
+            LanguageSupport::Supported {
+                quality: LanguageQuality::NoData,
+            }
+        } else {
+            LanguageSupport::NotSupported
+        }
+    }
+}
+
+pub(super) fn documented_language_codes() -> &'static [&'static str] {
+    SUPPORTED_LANGUAGE_CODES
+}
+
+#[cfg(test)]
+mod tests {
+    use anlg_language::ISO639;
+
+    use super::*;
+
+    #[test]
+    fn supports_one_documented_language() {
+        assert!(CohereAdapter::language_support_batch(&[]).is_supported());
+        assert!(CohereAdapter::language_support_batch(&[ISO639::En.into()]).is_supported());
+        assert!(CohereAdapter::language_support_batch(&[ISO639::Ko.into()]).is_supported());
+    }
+
+    #[test]
+    fn rejects_multiple_or_unsupported_languages() {
+        assert!(
+            !CohereAdapter::language_support_batch(&[ISO639::En.into(), ISO639::Ko.into()])
+                .is_supported()
+        );
+        assert!(!CohereAdapter::language_support_batch(&[ISO639::Ru.into()]).is_supported());
+    }
+}

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -6,6 +6,7 @@ mod aquavoice;
 mod argmax;
 pub(crate) mod assemblyai;
 pub(crate) mod cartesia;
+mod cohere;
 mod dashscope;
 pub mod deepgram;
 mod deepgram_compat;
@@ -27,6 +28,7 @@ pub use aquavoice::*;
 pub use argmax::*;
 pub use assemblyai::*;
 pub use cartesia::*;
+pub use cohere::*;
 pub use dashscope::*;
 pub use deepgram::*;
 pub use elevenlabs::*;
@@ -119,6 +121,7 @@ pub fn documented_language_codes_batch() -> Vec<String> {
     codes.extend(elevenlabs::documented_language_codes());
     codes.extend(argmax::PARAKEET_V3_LANGS.iter().copied());
     codes.extend(pyannote::documented_language_codes());
+    codes.extend(cohere::documented_language_codes().iter().copied());
 
     simple_documented_language_codes(codes)
 }
@@ -428,6 +431,8 @@ pub enum AdapterKind {
     Mistral,
     #[strum(serialize = "pyannote")]
     Pyannote,
+    #[strum(serialize = "cohere")]
+    Cohere,
     #[strum(serialize = "anarlog")]
     Anarlog,
 }
@@ -455,7 +460,7 @@ impl AdapterKind {
 
     pub fn has_live_mode(&self) -> bool {
         match self {
-            Self::AquaVoice | Self::Argmax | Self::Pyannote => false,
+            Self::AquaVoice | Self::Argmax | Self::Pyannote | Self::Cohere => false,
             Self::Soniox
             | Self::Cartesia
             | Self::Fireworks
@@ -492,6 +497,7 @@ impl AdapterKind {
             Self::Argmax => ArgmaxAdapter::language_support_live(languages, model),
             Self::Mistral => MistralAdapter::language_support_live(languages),
             Self::Pyannote => LanguageSupport::NotSupported,
+            Self::Cohere => LanguageSupport::NotSupported,
             Self::Anarlog => AnarlogAdapter::language_support_live(languages, model),
         }
     }
@@ -518,6 +524,7 @@ impl AdapterKind {
             Self::Argmax => ArgmaxAdapter::language_support_batch(languages, model),
             Self::Mistral => MistralAdapter::language_support_batch(languages),
             Self::Pyannote => PyannoteAdapter::language_support_batch(languages, model),
+            Self::Cohere => CohereAdapter::language_support_batch(languages),
             Self::Anarlog => AnarlogAdapter::language_support_batch(languages, model),
         }
     }
@@ -575,6 +582,7 @@ impl From<crate::providers::Provider> for AdapterKind {
             Provider::DashScope => Self::DashScope,
             Provider::Mistral => Self::Mistral,
             Provider::Pyannote => Self::Pyannote,
+            Provider::Cohere => Self::Cohere,
         }
     }
 }
@@ -816,6 +824,7 @@ mod tests {
             AdapterKind::AquaVoice,
             AdapterKind::Argmax,
             AdapterKind::Pyannote,
+            AdapterKind::Cohere,
         ];
         for kind in batch_only {
             assert!(
@@ -1006,6 +1015,10 @@ mod tests {
         assert_eq!(
             AdapterKind::from_url_and_languages("https://api.pyannote.ai", &en, None),
             AdapterKind::Pyannote,
+        );
+        assert_eq!(
+            AdapterKind::from_url_and_languages("https://api.cohere.com/v2", &en, None),
+            AdapterKind::Cohere,
         );
         assert_eq!(
             AdapterKind::from_url_and_languages("http://localhost:50060/v1", &en, None),

--- a/crates/owhisper-client/src/lib.rs
+++ b/crates/owhisper-client/src/lib.rs
@@ -23,12 +23,12 @@ pub use adapter::StreamingBatchConfig;
 pub use adapter::deepgram::DeepgramModel;
 pub use adapter::{
     AdapterKind, AnarlogAdapter, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter,
-    BatchSttAdapter, CallbackResult, CallbackSttAdapter, CartesiaAdapter, DashScopeAdapter,
-    DeepgramAdapter, DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter,
-    LanguageQuality, LanguageSupport, MistralAdapter, OpenAIAdapter, PyannoteAdapter,
-    RealtimeSttAdapter, SmallestAIAdapter, SonioxAdapter, WhisperCppAdapter, append_provider_param,
-    documented_language_codes_batch, documented_language_codes_live, is_anarlog_proxy,
-    is_local_host, normalize_languages,
+    BatchSttAdapter, CallbackResult, CallbackSttAdapter, CartesiaAdapter, CohereAdapter,
+    DashScopeAdapter, DeepgramAdapter, DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter,
+    GladiaAdapter, LanguageQuality, LanguageSupport, MistralAdapter, OpenAIAdapter,
+    PyannoteAdapter, RealtimeSttAdapter, SmallestAIAdapter, SonioxAdapter, WhisperCppAdapter,
+    append_provider_param, documented_language_codes_batch, documented_language_codes_live,
+    is_anarlog_proxy, is_local_host, normalize_languages,
 };
 pub use adapter::{StreamingBatchEvent, StreamingBatchStream};
 

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -91,10 +91,12 @@ pub enum Provider {
     Mistral,
     #[strum(serialize = "pyannote")]
     Pyannote,
+    #[strum(serialize = "cohere")]
+    Cohere,
 }
 
 impl Provider {
-    const ALL: [Provider; 12] = [
+    const ALL: [Provider; 13] = [
         Self::AquaVoice,
         Self::Cartesia,
         Self::Deepgram,
@@ -107,6 +109,7 @@ impl Provider {
         Self::DashScope,
         Self::Mistral,
         Self::Pyannote,
+        Self::Cohere,
     ];
 
     pub fn from_host(host: &str) -> Option<Self> {
@@ -161,6 +164,10 @@ impl Provider {
                 name: "Authorization",
                 prefix: Some("Bearer "),
             },
+            Self::Cohere => Auth::Header {
+                name: "Authorization",
+                prefix: Some("Bearer "),
+            },
         }
     }
 
@@ -186,6 +193,7 @@ impl Provider {
             Self::DashScope => "dashscope-intl.aliyuncs.com",
             Self::Mistral => "api.mistral.ai",
             Self::Pyannote => "api.pyannote.ai",
+            Self::Cohere => "api.cohere.com",
         }
     }
 
@@ -203,6 +211,7 @@ impl Provider {
             Self::DashScope => "dashscope-intl.aliyuncs.com",
             Self::Mistral => "api.mistral.ai",
             Self::Pyannote => "api.pyannote.ai",
+            Self::Cohere => "api.cohere.com",
         }
     }
 
@@ -220,6 +229,7 @@ impl Provider {
             Self::DashScope => "/api-ws/v1/realtime",
             Self::Mistral => "/v1/audio/transcriptions/realtime",
             Self::Pyannote => "/v1/diarize",
+            Self::Cohere => "",
         }
     }
 
@@ -237,6 +247,7 @@ impl Provider {
             Self::DashScope => None,
             Self::Mistral => None,
             Self::Pyannote => Some("https://api.pyannote.ai/v1"),
+            Self::Cohere => Some("https://api.cohere.com/v2"),
         }
     }
 
@@ -254,6 +265,7 @@ impl Provider {
             Self::DashScope => "https://dashscope-intl.aliyuncs.com",
             Self::Mistral => "https://api.mistral.ai/v1",
             Self::Pyannote => "https://api.pyannote.ai",
+            Self::Cohere => "https://api.cohere.com/v2",
         }
     }
 
@@ -271,6 +283,7 @@ impl Provider {
             Self::DashScope => "aliyuncs.com",
             Self::Mistral => "mistral.ai",
             Self::Pyannote => "pyannote.ai",
+            Self::Cohere => "cohere.com",
         }
     }
 
@@ -306,6 +319,7 @@ impl Provider {
             Self::DashScope => "DASHSCOPE_API_KEY",
             Self::Mistral => "MISTRAL_API_KEY",
             Self::Pyannote => "PYANNOTE_API_KEY",
+            Self::Cohere => "COHERE_API_KEY",
         }
     }
 
@@ -323,6 +337,7 @@ impl Provider {
             Self::DashScope => "qwen3-asr-flash-realtime",
             Self::Mistral => "voxtral-mini-transcribe-realtime-2602",
             Self::Pyannote => "parakeet-tdt-0.6b-v3",
+            Self::Cohere => "cohere-transcribe-03-2026",
         }
     }
 
@@ -330,7 +345,9 @@ impl Provider {
         match self {
             Self::AquaVoice => 16000,
             Self::OpenAI => 24000,
-            Self::ElevenLabs | Self::DashScope | Self::Mistral | Self::Pyannote => 16000,
+            Self::ElevenLabs | Self::DashScope | Self::Mistral | Self::Pyannote | Self::Cohere => {
+                16000
+            }
             _ => 16000,
         }
     }
@@ -349,6 +366,7 @@ impl Provider {
             Self::DashScope => "qwen3-asr-flash-filetrans",
             Self::Mistral => "voxtral-mini-2602",
             Self::Pyannote => "parakeet-tdt-0.6b-v3",
+            Self::Cohere => "cohere-transcribe-03-2026",
         }
     }
 
@@ -356,7 +374,9 @@ impl Provider {
         match self {
             Self::Deepgram => &[("model", "nova-3-general"), ("mip_opt_out", "false")],
             Self::OpenAI => &[("intent", "transcription")],
-            Self::AquaVoice | Self::DashScope | Self::Mistral | Self::Pyannote => &[],
+            Self::AquaVoice | Self::DashScope | Self::Mistral | Self::Pyannote | Self::Cohere => {
+                &[]
+            }
             _ => &[],
         }
     }
@@ -373,7 +393,8 @@ impl Provider {
             | Self::ElevenLabs
             | Self::DashScope
             | Self::Mistral
-            | Self::Pyannote => false,
+            | Self::Pyannote
+            | Self::Cohere => false,
         }
     }
 
@@ -388,7 +409,7 @@ impl Provider {
             Self::OpenAI => &[],
             Self::Gladia => &[],
             Self::ElevenLabs => &["commit"],
-            Self::DashScope | Self::Mistral | Self::Pyannote => &[],
+            Self::DashScope | Self::Mistral | Self::Pyannote | Self::Cohere => &[],
         }
     }
 
@@ -407,7 +428,9 @@ impl Provider {
                     "words_accurate_timestamps": true
                 }
             })),
-            Self::AquaVoice | Self::Cartesia | Self::Mistral | Self::Pyannote => None,
+            Self::AquaVoice | Self::Cartesia | Self::Mistral | Self::Pyannote | Self::Cohere => {
+                None
+            }
             _ => None,
         }
     }
@@ -448,6 +471,7 @@ impl Provider {
             Self::Cartesia => from_adapter(&crate::adapter::CartesiaAdapter, msg),
             Self::OpenAI => from_adapter(&crate::adapter::OpenAIAdapter::default(), msg),
             Self::Pyannote => None,
+            Self::Cohere => None,
         }
     }
 
@@ -464,7 +488,8 @@ impl Provider {
             | Self::Gladia
             | Self::DashScope
             | Self::Mistral
-            | Self::Pyannote => None,
+            | Self::Pyannote
+            | Self::Cohere => None,
         }
     }
 

--- a/crates/owhisper-client/tests/provider_batch_e2e.rs
+++ b/crates/owhisper-client/tests/provider_batch_e2e.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use owhisper_client::{
-    AssemblyAIAdapter, BatchClient, BatchSttAdapter, DeepgramAdapter, ElevenLabsAdapter,
-    FireworksAdapter, GladiaAdapter, OpenAIAdapter, Provider, SonioxAdapter,
+    AssemblyAIAdapter, BatchClient, BatchSttAdapter, CohereAdapter, DeepgramAdapter,
+    ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, OpenAIAdapter, Provider, SonioxAdapter,
 };
 use owhisper_interface::ListenParams;
 
@@ -65,4 +65,5 @@ mod direct_batch {
     direct_batch_test!(fireworks, FireworksAdapter, Provider::Fireworks);
     direct_batch_test!(openai, OpenAIAdapter, Provider::OpenAI);
     direct_batch_test!(elevenlabs, ElevenLabsAdapter, Provider::ElevenLabs);
+    direct_batch_test!(cohere, CohereAdapter, Provider::Cohere);
 }

--- a/crates/transcribe-proxy/src/env.rs
+++ b/crates/transcribe-proxy/src/env.rs
@@ -27,6 +27,8 @@ pub struct SttApiKeysEnv {
     pub mistral_api_key: Option<String>,
     #[serde(default)]
     pub aquavoice_api_key: Option<String>,
+    #[serde(default)]
+    pub cohere_api_key: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -97,6 +99,9 @@ impl From<&SttApiKeysEnv> for ApiKeys {
         }
         if let Some(key) = env.aquavoice_api_key.as_ref().filter(|s| !s.is_empty()) {
             map.insert(Provider::AquaVoice, key.clone());
+        }
+        if let Some(key) = env.cohere_api_key.as_ref().filter(|s| !s.is_empty()) {
+            map.insert(Provider::Cohere, key.clone());
         }
         Self(map)
     }

--- a/crates/transcribe-proxy/src/routes/batch/sync.rs
+++ b/crates/transcribe-proxy/src/routes/batch/sync.rs
@@ -8,9 +8,9 @@ use axum::{
 };
 use backon::{ExponentialBuilder, Retryable};
 use owhisper_client::{
-    AquaVoiceAdapter, AssemblyAIAdapter, BatchClient, CartesiaAdapter, DeepgramAdapter,
-    ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, MistralAdapter, OpenAIAdapter, Provider,
-    PyannoteAdapter, SonioxAdapter,
+    AquaVoiceAdapter, AssemblyAIAdapter, BatchClient, CartesiaAdapter, CohereAdapter,
+    DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, MistralAdapter,
+    OpenAIAdapter, Provider, PyannoteAdapter, SonioxAdapter,
 };
 use owhisper_interface::ListenParams;
 use owhisper_interface::batch::Response as BatchResponse;
@@ -296,6 +296,7 @@ pub(super) async fn transcribe_with_provider(
         Provider::Pyannote => batch_transcribe!(PyannoteAdapter),
         Provider::Fireworks => batch_transcribe!(FireworksAdapter),
         Provider::AquaVoice => batch_transcribe!(AquaVoiceAdapter),
+        Provider::Cohere => batch_transcribe!(CohereAdapter),
         Provider::DashScope => {
             return Err(BatchAttemptError::Unsupported(format!(
                 "{provider:?} does not support batch transcription",

--- a/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
@@ -62,6 +62,7 @@ fn build_upstream_url_with_adapter(
         Provider::Mistral => MistralAdapter::default().build_ws_url(api_base, params, channels),
         Provider::AquaVoice => unreachable!("aquavoice only supports batch transcription"),
         Provider::Pyannote => unreachable!("pyannote only supports batch transcription"),
+        Provider::Cohere => unreachable!("cohere only supports batch transcription"),
     }
 }
 
@@ -92,6 +93,7 @@ fn build_initial_message_with_adapter(
         Provider::Mistral => MistralAdapter::default().initial_message(api_key, params, channels),
         Provider::AquaVoice => unreachable!("aquavoice only supports batch transcription"),
         Provider::Pyannote => unreachable!("pyannote only supports batch transcription"),
+        Provider::Cohere => unreachable!("cohere only supports batch transcription"),
     };
 
     msg.and_then(|m| match m {
@@ -125,6 +127,7 @@ fn build_response_transformer(
                 unreachable!("aquavoice only supports batch transcription")
             }
             Provider::Pyannote => unreachable!("pyannote only supports batch transcription"),
+            Provider::Cohere => unreachable!("cohere only supports batch transcription"),
         };
 
         if provider == Provider::Soniox && proxy_debug_enabled() {
@@ -278,7 +281,10 @@ pub async fn build_proxy(
 ) -> Result<StreamingProxy, ProxyBuildError> {
     let provider = selected.provider();
     let channels: u8 = parse_param(params, "channels", 1);
-    if matches!(provider, Provider::AquaVoice | Provider::Pyannote) {
+    if matches!(
+        provider,
+        Provider::AquaVoice | Provider::Pyannote | Provider::Cohere
+    ) {
         return Err(ProxyBuildError::ProxyError(
             crate::ProxyError::InvalidRequest(format!(
                 "{provider} only supports batch transcription"

--- a/crates/transcribe-proxy/tests/common/mod.rs
+++ b/crates/transcribe-proxy/tests/common/mod.rs
@@ -115,6 +115,7 @@ pub fn env_with_provider(provider: Provider, api_key: String) -> transcribe_prox
         Provider::DashScope => env.stt.dashscope_api_key = Some(api_key),
         Provider::Mistral => env.stt.mistral_api_key = Some(api_key),
         Provider::AquaVoice => env.stt.aquavoice_api_key = Some(api_key),
+        Provider::Cohere => env.stt.cohere_api_key = Some(api_key),
         Provider::Pyannote => {}
     }
     env

--- a/plugins/transcription/js/bindings.gen.ts
+++ b/plugins/transcription/js/bindings.gen.ts
@@ -202,7 +202,7 @@ transcriptionEvent: "plugin:transcription:transcription-event"
 export type BatchAlternatives = { transcript: string; confidence: number; words?: BatchWord[] }
 export type BatchChannel = { alternatives: BatchAlternatives[] }
 export type BatchErrorCode = "unknown" | "timed_out" | "audio_metadata_join_failed" | "audio_metadata_read_failed" | "batch_capability_unsupported" | "direct_batch_unsupported" | "progressive_batch_unsupported" | "direct_request_failed" | "progressive_actor_spawn_failed" | "progressive_start_cancelled" | "progressive_stopped_without_completion_signal" | "progressive_finished_without_status" | "progressive_start_failed" | "progressive_stream_error" | "progressive_stream_timeout"
-export type BatchProvider = "argmax" | "whispercpp" | "deepgram" | "soniox" | "assemblyai" | "fireworks" | "openai" | "gladia" | "elevenlabs" | "pyannote" | "dashscope" | "mistral" | "anarlog" | "am" | "soniqo" | "applespeech" | "aquavoice" | "cartesia"
+export type BatchProvider = "argmax" | "whispercpp" | "deepgram" | "soniox" | "assemblyai" | "fireworks" | "openai" | "gladia" | "elevenlabs" | "pyannote" | "dashscope" | "mistral" | "anarlog" | "am" | "soniqo" | "applespeech" | "aquavoice" | "cartesia" | "cohere"
 export type BatchResponse = { metadata: JsonValue; results: BatchResults }
 export type BatchResults = { channels: BatchChannel[] }
 export type BatchRunMode = "direct" | "streamed"


### PR DESCRIPTION
Support Cohere batch transcription across the Rust adapter, desktop settings, and proxy.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6380 
- <kbd>&nbsp;1&nbsp;</kbd> #6379 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New third-party API integration and API key handling across client and proxy, but it follows existing batch-provider patterns and does not change auth or core data models.
> 
> **Overview**
> Adds **Cohere Transcribe** as a **batch-only** speech-to-text provider across the desktop app, Rust transcription stack, and transcribe proxy.
> 
> A new `CohereAdapter` posts audio to `https://api.cohere.com/v2/audio/transcriptions` (model `cohere-transcribe-03-2026`, single supported language) and maps Cohere’s text-only JSON into the shared batch response shape with **empty word timings** and metadata `timing_source: "synthetic_text"` so downstream can estimate timing. Live/streaming paths reject Cohere alongside other batch-only providers.
> 
> Desktop STT settings expose Cohere with a “Batch only” badge, API key setup links, and copy about the 25 MB limit and lack of timestamps/speaker labels. Batch routing, default model selection, and capabilities treat Cohere as batch-only. The proxy accepts `cohere_api_key` and routes sync batch requests through `CohereAdapter`; generated plugin types include `cohere` in `BatchProvider`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531a05c01d1f5e9ebb56236fe60291868f2d54be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->