### PR TITLE
Add direct transcription providers and Pro E2E coverage

### DIFF
--- a/.github/workflows/stt_e2e.yaml
+++ b/.github/workflows/stt_e2e.yaml
@@ -11,6 +11,8 @@ on:
           - fireworks
           - openai
           - elevenlabs
+          - mistral
+          - dashscope
   push:
     branches:
       - main
@@ -50,6 +52,10 @@ jobs:
               - 'crates/owhisper-client/src/adapter/openai/**'
             elevenlabs:
               - 'crates/owhisper-client/src/adapter/elevenlabs/**'
+            mistral:
+              - 'crates/owhisper-client/src/adapter/mistral/**'
+            dashscope:
+              - 'crates/owhisper-client/src/adapter/dashscope/**'
       - id: detect
         run: |
           set -euo pipefail
@@ -63,12 +69,15 @@ jobs:
           if [ "${{ steps.filter.outputs.fireworks }}" == "true" ]; then providers+=("fireworks"); fi
           if [ "${{ steps.filter.outputs.openai }}" == "true" ]; then providers+=("openai"); fi
           if [ "${{ steps.filter.outputs.elevenlabs }}" == "true" ]; then providers+=("elevenlabs"); fi
+          if [ "${{ steps.filter.outputs.mistral }}" == "true" ]; then providers+=("mistral"); fi
+          if [ "${{ steps.filter.outputs.dashscope }}" == "true" ]; then providers+=("dashscope"); fi
 
           if [ ${#providers[@]} -eq 0 ]; then
             if [ "${{ steps.filter.outputs.transcribe_proxy }}" == "true" ]; then
               providers=("deepgram" "soniox")
             else
-              providers=("deepgram")
+              echo "providers=" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
           fi
 
@@ -132,6 +141,13 @@ jobs:
               elevenlabs)
                 : "${ELEVENLABS_API_KEY:?ELEVENLABS_API_KEY is required}"
                 ;;
+              mistral)
+                : "${MISTRAL_API_KEY:?MISTRAL_API_KEY is required}"
+                ;;
+              dashscope)
+                echo "DashScope is realtime-only; direct batch E2E is covered by the proxy live suites"
+                exit 0
+                ;;
               *)
                 echo "Unknown provider: $provider"
                 exit 1
@@ -188,6 +204,12 @@ jobs:
               elevenlabs)
                 : "${ELEVENLABS_API_KEY:?ELEVENLABS_API_KEY is required}"
                 ;;
+              mistral)
+                : "${MISTRAL_API_KEY:?MISTRAL_API_KEY is required}"
+                ;;
+              dashscope)
+                : "${DASHSCOPE_API_KEY:?DASHSCOPE_API_KEY is required}"
+                ;;
               *)
                 echo "Unknown provider: $provider"
                 exit 1
@@ -196,7 +218,12 @@ jobs:
 
             echo "Running transcribe-proxy provider e2e tests for $provider"
 
-            for suite in passthrough::live passthrough::batch anarlog::live anarlog::batch; do
+            suites=(passthrough::live anarlog::live)
+            if [ "$provider" != "dashscope" ]; then
+              suites+=(passthrough::batch anarlog::batch)
+            fi
+
+            for suite in "${suites[@]}"; do
               cargo test -p transcribe-proxy --test proxy_provider_e2e "${suite}::${provider}" -- --ignored --nocapture
             done
           '

--- a/apps/desktop/src/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/settings/ai/stt/configure.tsx
@@ -66,9 +66,19 @@ function ProviderContext({ providerId }: { providerId: ProviderId }) {
                       ? `Use [Mistral](https://mistral.ai) for transcriptions.`
                       : providerId === "cohere"
                         ? `Use [Cohere Transcribe](https://docs.cohere.com/docs/transcribe) for batch transcription. Files must be 25 MB or smaller and use one selected language. Cohere does not return timestamps or speaker labels, so Anarlog estimates word timing.`
-                        : providerId === "custom"
-                          ? `We only support **Deepgram compatible** endpoints for now.`
-                          : "";
+                        : providerId === "google_cloud"
+                          ? `Use [Google Cloud Speech-to-Text](https://cloud.google.com/speech-to-text) synchronous recognition for recordings up to one minute and 10 MB. Paste an OAuth access token in the API key field; refresh it when it expires.`
+                          : providerId === "azure_speech"
+                            ? `Use [Azure AI Speech](https://learn.microsoft.com/azure/ai-services/speech-service/rest-speech-to-text) fast transcription. Enter the regional Speech resource endpoint as the Base URL and its subscription key as the API key.`
+                            : providerId === "aws_transcribe"
+                              ? `Amazon Transcribe's native file API requires SigV4 plus an S3 object. Enter an OpenAI-compatible gateway URL that performs that AWS authentication and upload, then paste the gateway token as the API key.`
+                              : providerId === "speechmatics"
+                                ? `Use [Speechmatics](https://docs.speechmatics.com/speech-to-text/batch/quickstart) enhanced batch transcription. The default endpoint uses the EU region and can be changed under Advanced.`
+                                : providerId === "revai"
+                                  ? `Use [Rev AI](https://docs.rev.ai/api/asynchronous/get-started) asynchronous transcription. Anarlog uploads the recording, waits for the job, and retrieves word timestamps and speaker labels.`
+                                  : providerId === "custom"
+                                    ? `We only support **Deepgram compatible** endpoints for now.`
+                                    : "";
 
   if (!content.trim()) {
     return null;

--- a/apps/desktop/src/settings/ai/stt/selection.test.ts
+++ b/apps/desktop/src/settings/ai/stt/selection.test.ts
@@ -13,6 +13,15 @@ describe("getDefaultSttModel", () => {
     expect(getDefaultSttModel("deepgram")).toBe("nova-3-general");
     expect(getDefaultSttModel("soniox")).toBe("stt-rt-v5");
     expect(getDefaultSttModel("cohere")).toBe("cohere-transcribe-03-2026");
+    expect(getDefaultSttModel("groq")).toBe("whisper-large-v3-turbo");
+    expect(getDefaultSttModel("xai")).toBe("xai-stt");
+    expect(getDefaultSttModel("together")).toBe("openai/whisper-large-v3");
+    expect(getDefaultSttModel("speechmatics")).toBe("enhanced");
+    expect(getDefaultSttModel("azure_speech")).toBe("fast-transcription");
+    expect(getDefaultSttModel("google_cloud")).toBe("latest_long");
+    expect(getDefaultSttModel("aws_transcribe")).toBe("amazon-transcribe");
+    expect(getDefaultSttModel("revai")).toBe("machine");
+    expect(getDefaultSttModel("fireworks")).toBe("whisper-v3-turbo");
   });
 
   test("does not invent a model for custom or Anarlog providers", () => {

--- a/apps/desktop/src/settings/ai/stt/shared.test.ts
+++ b/apps/desktop/src/settings/ai/stt/shared.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { displayModelLabel, displayModelTitle } from "./shared";
+import { displayModelLabel, displayModelTitle, PROVIDERS } from "./shared";
 
 describe("STT model display labels", () => {
   test("keeps cloud model product-facing", () => {
@@ -21,6 +21,32 @@ describe("STT model display labels", () => {
     expect(displayModelLabel("cohere-transcribe-03-2026")).toBe(
       "Cohere Transcribe",
     );
+    expect(displayModelLabel("whisper-large-v3-turbo")).toBe(
+      "Whisper Large V3 Turbo",
+    );
+    expect(displayModelLabel("xai-stt")).toBe("xAI Speech to Text");
+    expect(displayModelLabel("fast-transcription")).toBe("Fast Transcription");
+  });
+
+  test("exposes all new providers with honest capability badges", () => {
+    const providers = Object.fromEntries(
+      PROVIDERS.map((provider) => [provider.id, provider]),
+    );
+
+    expect(providers.fireworks.disabled).toBe(false);
+    expect(providers.fireworks.models).toEqual(["whisper-v3-turbo"]);
+    expect(providers.xai.badge).toBeNull();
+    for (const provider of [
+      "groq",
+      "together",
+      "speechmatics",
+      "azure_speech",
+      "revai",
+    ]) {
+      expect(providers[provider]?.badge).toBe("Batch only");
+    }
+    expect(providers.google_cloud.badge).toBe("Short batch");
+    expect(providers.aws_transcribe.badge).toBe("Gateway");
   });
 
   test("treats apple speech as an on-device model", () => {

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -144,6 +144,42 @@ export const displayModelId = (model: string) => {
     return "Cohere Transcribe";
   }
 
+  if (model === "whisper-large-v3-turbo") {
+    return "Whisper Large V3 Turbo";
+  }
+
+  if (model === "whisper-large-v3") {
+    return "Whisper Large V3";
+  }
+
+  if (model === "openai/whisper-large-v3") {
+    return "Whisper Large V3";
+  }
+
+  if (model === "xai-stt") {
+    return "xAI Speech to Text";
+  }
+
+  if (model === "enhanced") {
+    return "Enhanced";
+  }
+
+  if (model === "fast-transcription") {
+    return "Fast Transcription";
+  }
+
+  if (model === "latest_long") {
+    return "Latest Long";
+  }
+
+  if (model === "amazon-transcribe") {
+    return "Amazon Transcribe";
+  }
+
+  if (model === "machine") {
+    return "Machine Transcription";
+  }
+
   if (model === "apple-speech") {
     return "Apple Speech";
   }
@@ -250,6 +286,192 @@ const _PROVIDERS = [
       "whisper-1",
     ],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+  },
+  {
+    disabled: false,
+    id: "groq",
+    displayName: "Groq",
+    badge: "Batch only",
+    icon: <Icon icon="simple-icons:groq" className="text-foreground size-4" />,
+    baseUrl: "https://api.groq.com/openai/v1",
+    models: ["whisper-large-v3-turbo", "whisper-large-v3"],
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Speech-to-text models",
+        url: "https://console.groq.com/docs/speech-to-text",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://console.groq.com/keys",
+      },
+    },
+  },
+  {
+    disabled: false,
+    id: "xai",
+    displayName: "xAI",
+    badge: null,
+    icon: <Icon icon="simple-icons:x" className="text-foreground size-4" />,
+    baseUrl: "https://api.x.ai/v1",
+    models: ["xai-stt"],
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Speech-to-text docs",
+        url: "https://docs.x.ai/developers/model-capabilities/audio/speech-to-text",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://console.x.ai/",
+      },
+    },
+  },
+  {
+    disabled: false,
+    id: "together",
+    displayName: "Together AI",
+    badge: "Batch only",
+    icon: (
+      <Icon icon="simple-icons:together" className="text-foreground size-4" />
+    ),
+    baseUrl: "https://api.together.xyz/v1",
+    models: ["openai/whisper-large-v3"],
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Transcription docs",
+        url: "https://docs.together.ai/docs/inference-transcription",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://api.together.ai/settings/api-keys",
+      },
+    },
+  },
+  {
+    disabled: false,
+    id: "speechmatics",
+    displayName: "Speechmatics",
+    badge: "Batch only",
+    icon: (
+      <Icon
+        icon="simple-icons:speechmatics"
+        className="text-foreground size-4"
+      />
+    ),
+    baseUrl: "https://eu1.asr.api.speechmatics.com/v2",
+    models: ["enhanced"],
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Batch transcription docs",
+        url: "https://docs.speechmatics.com/speech-to-text/batch/quickstart",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://portal.speechmatics.com/settings/api-keys",
+      },
+    },
+  },
+  {
+    disabled: false,
+    id: "azure_speech",
+    displayName: "Azure AI Speech",
+    badge: "Batch only",
+    icon: (
+      <Icon
+        icon="simple-icons:microsoftazure"
+        className="text-foreground size-4"
+      />
+    ),
+    baseUrl: undefined,
+    models: ["fast-transcription"],
+    requirements: [
+      { kind: "requires_config", fields: ["base_url", "api_key"] },
+    ],
+    links: {
+      models: {
+        label: "Fast transcription docs",
+        url: "https://learn.microsoft.com/azure/ai-services/speech-service/fast-transcription-create",
+      },
+      setup: {
+        label: "Speech resource setup",
+        url: "https://learn.microsoft.com/azure/ai-services/speech-service/get-started-speech-to-text",
+      },
+    },
+  },
+  {
+    disabled: false,
+    id: "google_cloud",
+    displayName: "Google Cloud Speech-to-Text",
+    badge: "Short batch",
+    icon: (
+      <Icon
+        icon="simple-icons:googlecloud"
+        className="text-foreground size-4"
+      />
+    ),
+    baseUrl: "https://speech.googleapis.com/v1",
+    models: ["latest_long"],
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Speech-to-Text models",
+        url: "https://cloud.google.com/speech-to-text/docs/transcription-model",
+      },
+      setup: {
+        label: "Authentication",
+        url: "https://cloud.google.com/speech-to-text/docs/authentication",
+      },
+    },
+  },
+  {
+    disabled: false,
+    id: "aws_transcribe",
+    displayName: "Amazon Transcribe",
+    badge: "Gateway",
+    icon: (
+      <Icon
+        icon="simple-icons:amazonwebservices"
+        className="text-foreground size-4"
+      />
+    ),
+    baseUrl: undefined,
+    models: ["amazon-transcribe"],
+    requirements: [
+      { kind: "requires_config", fields: ["base_url", "api_key"] },
+    ],
+    links: {
+      models: {
+        label: "Amazon Transcribe docs",
+        url: "https://docs.aws.amazon.com/transcribe/latest/dg/how-it-works.html",
+      },
+      setup: {
+        label: "Authentication requirements",
+        url: "https://docs.aws.amazon.com/transcribe/latest/dg/getting-started-http-websocket.html",
+      },
+    },
+  },
+  {
+    disabled: false,
+    id: "revai",
+    displayName: "Rev AI",
+    badge: "Batch only",
+    icon: <Icon icon="simple-icons:rev" className="text-foreground size-4" />,
+    baseUrl: "https://api.rev.ai/speechtotext/v1",
+    models: ["machine"],
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Asynchronous transcription docs",
+        url: "https://docs.rev.ai/api/asynchronous/get-started",
+      },
+      setup: {
+        label: "Access tokens",
+        url: "https://www.rev.ai/access_token",
+      },
+    },
   },
   {
     disabled: false,
@@ -418,14 +640,24 @@ const _PROVIDERS = [
     ],
   },
   {
-    disabled: true,
+    disabled: false,
     id: "fireworks",
     displayName: "Fireworks",
     badge: null,
     icon: <Fireworks size={14} />,
     baseUrl: "https://api.fireworks.ai",
-    models: ["Default"],
+    models: ["whisper-v3-turbo"],
     requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Audio transcription docs",
+        url: "https://docs.fireworks.ai/guides/querying-asr-models",
+      },
+      setup: {
+        label: "API keys",
+        url: "https://fireworks.ai/account/api-keys",
+      },
+    },
   },
 ] as const satisfies readonly Provider[];
 

--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -94,12 +94,24 @@ describe("getSttModelTranscriptionMode", () => {
     expect(
       getSttModelTranscriptionMode("cohere", "cohere-transcribe-03-2026"),
     ).toBe("batch");
+    for (const [provider, model] of [
+      ["groq", "whisper-large-v3-turbo"],
+      ["together", "openai/whisper-large-v3"],
+      ["speechmatics", "enhanced"],
+      ["azure_speech", "fast-transcription"],
+      ["google_cloud", "latest_long"],
+      ["aws_transcribe", "amazon-transcribe"],
+      ["revai", "machine"],
+    ]) {
+      expect(getSttModelTranscriptionMode(provider, model)).toBe("batch");
+    }
   });
 
   test("leaves models without an explicit mode to provider inference", () => {
     expect(getSttModelTranscriptionMode("deepgram", "nova-3-general")).toBe(
       undefined,
     );
+    expect(getSttModelTranscriptionMode("xai", "xai-stt")).toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -144,6 +144,18 @@ export function getSttModelTranscriptionMode(
     return "batch";
   }
 
+  if (
+    provider === "groq" ||
+    provider === "together" ||
+    provider === "speechmatics" ||
+    provider === "azure_speech" ||
+    provider === "google_cloud" ||
+    provider === "aws_transcribe" ||
+    provider === "revai"
+  ) {
+    return "batch";
+  }
+
   if (provider === "openai") {
     if (model === "gpt-live-transcribe") return "live";
     if (

--- a/apps/desktop/src/stt/model-selection.ts
+++ b/apps/desktop/src/stt/model-selection.ts
@@ -21,7 +21,15 @@ const DEFAULT_EXTERNAL_STT_MODELS: Record<string, string> = {
   pyannote: "parakeet-tdt-0.6b-v3",
   aquavoice: "avalon-v1-en",
   cohere: "cohere-transcribe-03-2026",
-  fireworks: "Default",
+  fireworks: "whisper-v3-turbo",
+  groq: "whisper-large-v3-turbo",
+  xai: "xai-stt",
+  together: "openai/whisper-large-v3",
+  speechmatics: "enhanced",
+  azure_speech: "fast-transcription",
+  google_cloud: "latest_long",
+  aws_transcribe: "amazon-transcribe",
+  revai: "machine",
 };
 
 export function getDefaultSttModel(provider?: string | null) {

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -187,6 +187,19 @@ describe("getBatchProvider", () => {
     );
   });
 
+  test.each([
+    ["aws_transcribe", "amazon-transcribe"],
+    ["azure_speech", "fast-transcription"],
+    ["google_cloud", "latest_long"],
+    ["groq", "whisper-large-v3-turbo"],
+    ["revai", "machine"],
+    ["speechmatics", "enhanced"],
+    ["together", "openai/whisper-large-v3"],
+    ["xai", "xai-stt"],
+  ] as const)("maps %s to its direct batch provider", (provider, model) => {
+    expect(getBatchProvider(provider, model)).toBe(provider);
+  });
+
   test("maps Cloudflare Workers AI to the Deepgram-compatible batch provider", () => {
     expect(getBatchProvider("cloudflare_workers_ai", "nova-3")).toBe(
       "deepgram",

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -78,6 +78,14 @@ const DIRECT_BATCH_PROVIDERS: Set<TranscriptionParams["provider"]> = new Set([
   "pyannote",
   "aquavoice",
   "cohere",
+  "aws_transcribe",
+  "azure_speech",
+  "google_cloud",
+  "groq",
+  "revai",
+  "speechmatics",
+  "together",
+  "xai",
 ]);
 
 export const STOPPED_TRANSCRIPTION_ERROR_MESSAGE = "Transcription stopped.";

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -7,7 +7,7 @@ use ractor::{ActorProcessingErr, ActorRef};
 use owhisper_client::{
     AdapterKind, AnarlogAdapter, ArgmaxAdapter, AssemblyAIAdapter, CartesiaAdapter,
     DashScopeAdapter, DeepgramAdapter, DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter,
-    GladiaAdapter, MistralAdapter, OpenAIAdapter, RealtimeSttAdapter, SonioxAdapter,
+    GladiaAdapter, MistralAdapter, OpenAIAdapter, RealtimeSttAdapter, SonioxAdapter, XaiAdapter,
     anlg_ws_client,
 };
 use owhisper_interface::stream::Extra;
@@ -123,8 +123,20 @@ pub(super) async fn spawn_rx_task(
         ElevenLabs => ElevenLabsAdapter,
         DashScope => DashScopeAdapter,
         Mistral => MistralAdapter,
+        Xai => XaiAdapter,
         Anarlog => AnarlogAdapter,
-    }, batch_only: [AquaVoice, Pyannote, Cohere])?;
+    }, batch_only: [
+        AquaVoice,
+        Pyannote,
+        Cohere,
+        AwsTranscribe,
+        AzureSpeech,
+        GoogleCloud,
+        Groq,
+        RevAi,
+        Speechmatics,
+        Together
+    ])?;
 
     Ok((result.0, result.1, result.2, adapter_kind.to_string()))
 }

--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -38,6 +38,20 @@ pub enum BatchProvider {
     AquaVoice,
     Cartesia,
     Cohere,
+    #[serde(rename = "aws_transcribe")]
+    #[strum(serialize = "aws_transcribe")]
+    AwsTranscribe,
+    #[serde(rename = "azure_speech")]
+    #[strum(serialize = "azure_speech")]
+    AzureSpeech,
+    #[serde(rename = "google_cloud")]
+    #[strum(serialize = "google_cloud")]
+    GoogleCloud,
+    Groq,
+    RevAi,
+    Speechmatics,
+    Together,
+    Xai,
 }
 
 impl BatchProvider {
@@ -57,6 +71,14 @@ impl BatchProvider {
             Self::AquaVoice => Some(AdapterKind::AquaVoice),
             Self::Cartesia => Some(AdapterKind::Cartesia),
             Self::Cohere => Some(AdapterKind::Cohere),
+            Self::AwsTranscribe => Some(AdapterKind::AwsTranscribe),
+            Self::AzureSpeech => Some(AdapterKind::AzureSpeech),
+            Self::GoogleCloud => Some(AdapterKind::GoogleCloud),
+            Self::Groq => Some(AdapterKind::Groq),
+            Self::RevAi => Some(AdapterKind::RevAi),
+            Self::Speechmatics => Some(AdapterKind::Speechmatics),
+            Self::Together => Some(AdapterKind::Together),
+            Self::Xai => Some(AdapterKind::Xai),
             Self::Am | Self::WhisperLocal | Self::Soniqo | Self::AppleSpeech | Self::DashScope => {
                 None
             }

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -4,8 +4,10 @@ use std::time::{Duration, Instant};
 
 use owhisper_client::{
     AdapterKind, AnarlogAdapter, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter,
-    BatchSttAdapter, CartesiaAdapter, CohereAdapter, DeepgramAdapter, ElevenLabsAdapter,
-    FireworksAdapter, GladiaAdapter, MistralAdapter, OpenAIAdapter, PyannoteAdapter, SonioxAdapter,
+    AwsTranscribeAdapter, AzureSpeechAdapter, BatchSttAdapter, CartesiaAdapter, CohereAdapter,
+    DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, GoogleCloudAdapter,
+    GroqAdapter, MistralAdapter, OpenAIAdapter, PyannoteAdapter, RevAiAdapter, SonioxAdapter,
+    SpeechmaticsAdapter, TogetherAdapter, XaiAdapter,
 };
 use owhisper_interface::batch_stream::BatchStreamEvent;
 use tracing::Instrument;
@@ -66,6 +68,14 @@ pub(super) async fn run_direct_batch_for_adapter_kind(
         Anarlog => AnarlogAdapter,
         AquaVoice => AquaVoiceAdapter,
         Cohere => CohereAdapter,
+        AwsTranscribe => AwsTranscribeAdapter,
+        AzureSpeech => AzureSpeechAdapter,
+        GoogleCloud => GoogleCloudAdapter,
+        Groq => GroqAdapter,
+        RevAi => RevAiAdapter,
+        Speechmatics => SpeechmaticsAdapter,
+        Together => TogetherAdapter,
+        Xai => XaiAdapter,
     }, unsupported: [DashScope])
 }
 

--- a/crates/listener2-core/src/lib.rs
+++ b/crates/listener2-core/src/lib.rs
@@ -145,6 +145,14 @@ pub fn suggest_providers_for_languages_batch(languages: &[anlg_language::Languag
         AdapterKind::DashScope,
         AdapterKind::Mistral,
         AdapterKind::Cohere,
+        AdapterKind::AwsTranscribe,
+        AdapterKind::AzureSpeech,
+        AdapterKind::GoogleCloud,
+        AdapterKind::Groq,
+        AdapterKind::RevAi,
+        AdapterKind::Speechmatics,
+        AdapterKind::Together,
+        AdapterKind::Xai,
     ];
 
     let mut with_support: Vec<_> = all_providers

--- a/crates/owhisper-client/src/adapter/aws_transcribe/mod.rs
+++ b/crates/owhisper-client/src/adapter/aws_transcribe/mod.rs
@@ -1,0 +1,69 @@
+use std::path::Path;
+
+use owhisper_interface::ListenParams;
+
+use crate::adapter::openai_compatible_batch::{OpenAICompatibleBatchConfig, transcribe};
+use crate::adapter::{
+    BatchFuture, BatchSttAdapter, ClientWithMiddleware, LanguageQuality, LanguageSupport,
+};
+use crate::error::Error;
+
+#[derive(Clone, Default)]
+pub struct AwsTranscribeAdapter;
+
+impl AwsTranscribeAdapter {
+    pub fn language_support_batch(_languages: &[anlg_language::Language]) -> LanguageSupport {
+        LanguageSupport::Supported {
+            quality: LanguageQuality::NoData,
+        }
+    }
+}
+
+impl BatchSttAdapter for AwsTranscribeAdapter {
+    fn provider_name(&self) -> &'static str {
+        "aws_transcribe"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_batch(languages).is_supported()
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(async move {
+            if api_base.is_empty() {
+                return Err(Error::AudioProcessing(
+                    "Amazon Transcribe requires an OpenAI-compatible gateway URL because the native API requires SigV4 and S3"
+                        .to_string(),
+                ));
+            }
+
+            transcribe(
+                client,
+                api_base,
+                api_key,
+                params,
+                &path,
+                OpenAICompatibleBatchConfig {
+                    provider: "aws_transcribe",
+                    default_api_base: "",
+                    default_model: "amazon-transcribe",
+                    transcription_path: "audio/transcriptions",
+                    timestamp_field: Some("timestamp_granularities[]"),
+                },
+            )
+            .await
+        })
+    }
+}

--- a/crates/owhisper-client/src/adapter/azure_speech/mod.rs
+++ b/crates/owhisper-client/src/adapter/azure_speech/mod.rs
@@ -1,0 +1,224 @@
+use std::path::{Path, PathBuf};
+
+use owhisper_interface::ListenParams;
+use owhisper_interface::batch::{Alternatives, Channel, Response, Results, Word};
+use reqwest::multipart::Form;
+
+use crate::adapter::http::{ensure_success, streaming_file_part};
+use crate::adapter::{
+    BatchFuture, BatchSttAdapter, ClientWithMiddleware, LanguageQuality, LanguageSupport,
+    append_path_if_missing,
+};
+use crate::error::Error;
+
+#[derive(Clone, Default)]
+pub struct AzureSpeechAdapter;
+
+impl AzureSpeechAdapter {
+    pub fn language_support_batch(_languages: &[anlg_language::Language]) -> LanguageSupport {
+        LanguageSupport::Supported {
+            quality: LanguageQuality::NoData,
+        }
+    }
+}
+
+impl BatchSttAdapter for AzureSpeechAdapter {
+    fn provider_name(&self) -> &'static str {
+        "azure_speech"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_batch(languages).is_supported()
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(do_transcribe_file(client, api_base, api_key, params, path))
+    }
+}
+
+async fn do_transcribe_file(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    params: &ListenParams,
+    file_path: PathBuf,
+) -> Result<Response, Error> {
+    if api_base.is_empty() {
+        return Err(Error::AudioProcessing(
+            "Azure AI Speech requires a regional resource endpoint".to_string(),
+        ));
+    }
+
+    let locales = params
+        .languages
+        .iter()
+        .map(anlg_language::Language::bcp47_code)
+        .collect::<Vec<_>>();
+    let definition = if locales.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::json!({ "locales": locales })
+    };
+    let form = Form::new()
+        .text("definition", definition.to_string())
+        .part("audio", streaming_file_part(&file_path).await?);
+    let mut url: url::Url = api_base.parse().map_err(|error: url::ParseError| {
+        Error::AudioProcessing(format!("invalid api_base: {error}"))
+    })?;
+    append_path_if_missing(&mut url, "speechtotext/transcriptions:transcribe");
+    url.query_pairs_mut()
+        .append_pair("api-version", "2025-10-15");
+
+    let response = client
+        .post(url.to_string())
+        .header("Ocp-Apim-Subscription-Key", api_key)
+        .multipart(form)
+        .send()
+        .await?;
+    let payload: AzureSpeechResponse = ensure_success(response).await?.json().await?;
+
+    Ok(convert_response(payload))
+}
+
+#[derive(serde::Deserialize)]
+struct AzureSpeechResponse {
+    #[serde(default, rename = "durationMilliseconds")]
+    duration_ms: u64,
+    #[serde(default, rename = "combinedPhrases")]
+    combined_phrases: Vec<AzureCombinedPhrase>,
+    #[serde(default)]
+    phrases: Vec<AzurePhrase>,
+}
+
+#[derive(serde::Deserialize)]
+struct AzureCombinedPhrase {
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    channel: Option<i32>,
+}
+
+#[derive(serde::Deserialize)]
+struct AzurePhrase {
+    #[serde(default)]
+    confidence: f64,
+    #[serde(default)]
+    speaker: Option<usize>,
+    #[serde(default)]
+    channel: Option<i32>,
+    #[serde(default)]
+    words: Vec<AzureWord>,
+}
+
+#[derive(serde::Deserialize)]
+struct AzureWord {
+    text: String,
+    #[serde(rename = "offsetMilliseconds")]
+    offset_ms: u64,
+    #[serde(rename = "durationMilliseconds")]
+    duration_ms: u64,
+}
+
+fn convert_response(payload: AzureSpeechResponse) -> Response {
+    let channel_count = payload
+        .combined_phrases
+        .iter()
+        .filter_map(|phrase| phrase.channel)
+        .max()
+        .map(|channel| channel + 1)
+        .unwrap_or(1)
+        .max(1);
+    let mut channels = (0..channel_count)
+        .map(|channel_index| {
+            let transcript = payload
+                .combined_phrases
+                .iter()
+                .find(|phrase| phrase.channel.unwrap_or(0) == channel_index)
+                .map(|phrase| phrase.text.trim().to_string())
+                .unwrap_or_default();
+            let words = payload
+                .phrases
+                .iter()
+                .filter(|phrase| phrase.channel.unwrap_or(0) == channel_index)
+                .flat_map(|phrase| {
+                    phrase.words.iter().map(|word| Word {
+                        punctuated_word: Some(word.text.clone()),
+                        word: word.text.clone(),
+                        start: word.offset_ms as f64 / 1_000.0,
+                        end: (word.offset_ms + word.duration_ms) as f64 / 1_000.0,
+                        confidence: phrase.confidence,
+                        channel: channel_index,
+                        speaker: phrase.speaker,
+                    })
+                })
+                .collect();
+
+            Channel {
+                alternatives: vec![Alternatives {
+                    transcript,
+                    confidence: 1.0,
+                    words,
+                }],
+            }
+        })
+        .collect::<Vec<_>>();
+    if channels.is_empty() {
+        channels.push(Channel {
+            alternatives: vec![Alternatives {
+                transcript: String::new(),
+                confidence: 1.0,
+                words: Vec::new(),
+            }],
+        });
+    }
+
+    Response {
+        metadata: serde_json::json!({
+            "provider": "azure_speech",
+            "duration_ms": payload.duration_ms,
+        }),
+        results: Results { channels },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_fast_transcription_response() {
+        let payload: AzureSpeechResponse = serde_json::from_value(serde_json::json!({
+            "durationMilliseconds": 2000,
+            "combinedPhrases": [{ "text": "Weather" }],
+            "phrases": [{
+                "confidence": 0.8,
+                "speaker": 1,
+                "words": [{
+                    "text": "weather",
+                    "offsetMilliseconds": 40,
+                    "durationMilliseconds": 320
+                }]
+            }]
+        }))
+        .unwrap();
+
+        let response = convert_response(payload);
+        let alternative = &response.results.channels[0].alternatives[0];
+
+        assert_eq!(alternative.transcript, "Weather");
+        assert_eq!(alternative.words[0].start, 0.04);
+        assert_eq!(alternative.words[0].speaker, Some(1));
+    }
+}

--- a/crates/owhisper-client/src/adapter/google_cloud/mod.rs
+++ b/crates/owhisper-client/src/adapter/google_cloud/mod.rs
@@ -1,0 +1,268 @@
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use owhisper_interface::ListenParams;
+use owhisper_interface::batch::{Alternatives, Channel, Response, Results, Word};
+
+use crate::adapter::http::ensure_success;
+use crate::adapter::{
+    BatchFuture, BatchSttAdapter, ClientWithMiddleware, LanguageQuality, LanguageSupport,
+    append_path_if_missing,
+};
+use crate::error::Error;
+
+const INLINE_AUDIO_LIMIT_BYTES: u64 = 10 * 1024 * 1024;
+
+#[derive(Clone, Default)]
+pub struct GoogleCloudAdapter;
+
+impl GoogleCloudAdapter {
+    pub fn language_support_batch(_languages: &[anlg_language::Language]) -> LanguageSupport {
+        LanguageSupport::Supported {
+            quality: LanguageQuality::NoData,
+        }
+    }
+}
+
+impl BatchSttAdapter for GoogleCloudAdapter {
+    fn provider_name(&self) -> &'static str {
+        "google_cloud"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_batch(languages).is_supported()
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(do_transcribe_file(client, api_base, api_key, params, path))
+    }
+}
+
+async fn do_transcribe_file(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    access_token: &str,
+    params: &ListenParams,
+    file_path: PathBuf,
+) -> Result<Response, Error> {
+    let metadata = tokio::fs::metadata(&file_path)
+        .await
+        .map_err(|error| Error::AudioProcessing(error.to_string()))?;
+    if metadata.len() > INLINE_AUDIO_LIMIT_BYTES {
+        return Err(Error::AudioProcessing(
+            "Google Cloud synchronous transcription accepts inline audio up to 10 MB and one minute"
+                .to_string(),
+        ));
+    }
+    let audio = tokio::fs::read(&file_path)
+        .await
+        .map_err(|error| Error::AudioProcessing(error.to_string()))?;
+    let language_code = params
+        .languages
+        .first()
+        .map(anlg_language::Language::bcp47_code)
+        .filter(|code| !code.is_empty())
+        .unwrap_or_else(|| "en-US".to_string());
+    let model = match params.model.as_deref() {
+        Some(model) if !crate::providers::is_meta_model(model) => model,
+        _ => "latest_long",
+    };
+    let mut config = serde_json::json!({
+        "languageCode": language_code,
+        "model": model,
+        "enableAutomaticPunctuation": true,
+        "enableWordTimeOffsets": true,
+        "enableWordConfidence": true,
+        "audioChannelCount": params.channels,
+        "enableSeparateRecognitionPerChannel": params.channels > 1,
+    });
+    if params.num_speakers.is_some()
+        || params.min_speakers.is_some()
+        || params.max_speakers.is_some()
+    {
+        config["diarizationConfig"] = serde_json::json!({
+            "enableSpeakerDiarization": true,
+            "minSpeakerCount": params.min_speakers.or(params.num_speakers),
+            "maxSpeakerCount": params.max_speakers.or(params.num_speakers),
+        });
+    }
+    if !params.keywords.is_empty() {
+        config["speechContexts"] = serde_json::json!([{
+            "phrases": params.keywords,
+        }]);
+    }
+    let request = serde_json::json!({
+        "config": config,
+        "audio": {
+            "content": base64::engine::general_purpose::STANDARD.encode(audio),
+        },
+    });
+    let mut url: url::Url = if api_base.is_empty() {
+        "https://speech.googleapis.com/v1"
+            .parse()
+            .expect("invalid_default_google_cloud_api_base")
+    } else {
+        api_base.parse().map_err(|error: url::ParseError| {
+            Error::AudioProcessing(format!("invalid api_base: {error}"))
+        })?
+    };
+    append_path_if_missing(&mut url, "speech:recognize");
+
+    let response = client
+        .post(url.to_string())
+        .bearer_auth(access_token)
+        .json(&request)
+        .send()
+        .await?;
+    let payload: GoogleCloudResponse = ensure_success(response).await?.json().await?;
+
+    Ok(convert_response(payload))
+}
+
+#[derive(serde::Deserialize)]
+struct GoogleCloudResponse {
+    #[serde(default)]
+    results: Vec<GoogleCloudResult>,
+}
+
+#[derive(serde::Deserialize)]
+struct GoogleCloudResult {
+    #[serde(default)]
+    alternatives: Vec<GoogleCloudAlternative>,
+    #[serde(default, rename = "channelTag")]
+    channel_tag: Option<i32>,
+}
+
+#[derive(serde::Deserialize)]
+struct GoogleCloudAlternative {
+    #[serde(default)]
+    transcript: String,
+    #[serde(default)]
+    confidence: f64,
+    #[serde(default)]
+    words: Vec<GoogleCloudWord>,
+}
+
+#[derive(serde::Deserialize)]
+struct GoogleCloudWord {
+    word: String,
+    #[serde(default, rename = "startTime")]
+    start_time: String,
+    #[serde(default, rename = "endTime")]
+    end_time: String,
+    #[serde(default)]
+    confidence: f64,
+    #[serde(default, rename = "speakerTag")]
+    speaker_tag: Option<usize>,
+}
+
+fn parse_duration(value: &str) -> f64 {
+    value
+        .strip_suffix('s')
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_default()
+}
+
+fn convert_response(payload: GoogleCloudResponse) -> Response {
+    let channel_count = payload
+        .results
+        .iter()
+        .filter_map(|result| result.channel_tag)
+        .max()
+        .unwrap_or(1)
+        .max(1);
+    let channels = (1..=channel_count)
+        .map(|channel_tag| {
+            let matching_results = payload
+                .results
+                .iter()
+                .filter(|result| result.channel_tag.unwrap_or(1) == channel_tag)
+                .collect::<Vec<_>>();
+            let transcript = matching_results
+                .iter()
+                .filter_map(|result| result.alternatives.first())
+                .map(|alternative| alternative.transcript.trim())
+                .filter(|text| !text.is_empty())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let confidence = matching_results
+                .first()
+                .and_then(|result| result.alternatives.first())
+                .map(|alternative| alternative.confidence)
+                .unwrap_or(1.0);
+            let words = matching_results
+                .into_iter()
+                .filter_map(|result| result.alternatives.first())
+                .flat_map(|alternative| {
+                    alternative.words.iter().map(|word| Word {
+                        punctuated_word: Some(word.word.clone()),
+                        word: word.word.clone(),
+                        start: parse_duration(&word.start_time),
+                        end: parse_duration(&word.end_time),
+                        confidence: word.confidence,
+                        channel: channel_tag - 1,
+                        speaker: word.speaker_tag,
+                    })
+                })
+                .collect();
+
+            Channel {
+                alternatives: vec![Alternatives {
+                    transcript,
+                    confidence,
+                    words,
+                }],
+            }
+        })
+        .collect();
+
+    Response {
+        metadata: serde_json::json!({ "provider": "google_cloud" }),
+        results: Results { channels },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_google_durations_and_channels() {
+        let payload: GoogleCloudResponse = serde_json::from_value(serde_json::json!({
+            "results": [{
+                "channelTag": 1,
+                "alternatives": [{
+                    "transcript": "hello",
+                    "confidence": 0.9,
+                    "words": [{
+                        "word": "hello",
+                        "startTime": "0.100s",
+                        "endTime": "0.500s",
+                        "confidence": 0.8,
+                        "speakerTag": 2
+                    }]
+                }]
+            }]
+        }))
+        .unwrap();
+
+        let response = convert_response(payload);
+        let word = &response.results.channels[0].alternatives[0].words[0];
+
+        assert_eq!(word.start, 0.1);
+        assert_eq!(word.channel, 0);
+        assert_eq!(word.speaker, Some(2));
+    }
+}

--- a/crates/owhisper-client/src/adapter/groq/mod.rs
+++ b/crates/owhisper-client/src/adapter/groq/mod.rs
@@ -1,0 +1,61 @@
+use std::path::Path;
+
+use owhisper_interface::ListenParams;
+
+use crate::adapter::openai_compatible_batch::{OpenAICompatibleBatchConfig, transcribe};
+use crate::adapter::{
+    BatchFuture, BatchSttAdapter, ClientWithMiddleware, LanguageQuality, LanguageSupport,
+};
+
+#[derive(Clone, Default)]
+pub struct GroqAdapter;
+
+impl GroqAdapter {
+    pub fn language_support_batch(_languages: &[anlg_language::Language]) -> LanguageSupport {
+        LanguageSupport::Supported {
+            quality: LanguageQuality::NoData,
+        }
+    }
+}
+
+impl BatchSttAdapter for GroqAdapter {
+    fn provider_name(&self) -> &'static str {
+        "groq"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_batch(languages).is_supported()
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(async move {
+            transcribe(
+                client,
+                api_base,
+                api_key,
+                params,
+                &path,
+                OpenAICompatibleBatchConfig {
+                    provider: "groq",
+                    default_api_base: "https://api.groq.com/openai/v1",
+                    default_model: "whisper-large-v3-turbo",
+                    transcription_path: "audio/transcriptions",
+                    timestamp_field: Some("timestamp_granularities[]"),
+                },
+            )
+            .await
+        })
+    }
+}

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -5,6 +5,8 @@ mod anarlog;
 mod aquavoice;
 mod argmax;
 pub(crate) mod assemblyai;
+mod aws_transcribe;
+mod azure_speech;
 pub(crate) mod cartesia;
 mod cohere;
 mod dashscope;
@@ -13,20 +15,29 @@ mod deepgram_compat;
 pub(crate) mod elevenlabs;
 mod fireworks;
 mod gladia;
+mod google_cloud;
+mod groq;
 pub mod http;
 mod language;
 mod mistral;
 mod openai;
+mod openai_compatible_batch;
 mod owhisper;
 mod pyannote;
+mod revai;
 mod smallestai;
 pub(crate) mod soniox;
+mod speechmatics;
+mod together;
 mod whispercpp;
+mod xai;
 
 pub use anarlog::*;
 pub use aquavoice::*;
 pub use argmax::*;
 pub use assemblyai::*;
+pub use aws_transcribe::*;
+pub use azure_speech::*;
 pub use cartesia::*;
 pub use cohere::*;
 pub use dashscope::*;
@@ -34,13 +45,19 @@ pub use deepgram::*;
 pub use elevenlabs::*;
 pub use fireworks::*;
 pub use gladia::*;
+pub use google_cloud::*;
+pub use groq::*;
 pub use language::{LanguageQuality, LanguageSupport};
 pub use mistral::*;
 pub use openai::*;
 pub use pyannote::*;
+pub use revai::*;
 pub use smallestai::*;
 pub use soniox::*;
+pub use speechmatics::*;
+pub use together::*;
 pub use whispercpp::*;
+pub use xai::*;
 
 use std::collections::{BTreeSet, HashSet};
 use std::future::Future;
@@ -433,6 +450,22 @@ pub enum AdapterKind {
     Pyannote,
     #[strum(serialize = "cohere")]
     Cohere,
+    #[strum(serialize = "aws_transcribe")]
+    AwsTranscribe,
+    #[strum(serialize = "azure_speech")]
+    AzureSpeech,
+    #[strum(serialize = "google_cloud")]
+    GoogleCloud,
+    #[strum(serialize = "groq")]
+    Groq,
+    #[strum(serialize = "revai")]
+    RevAi,
+    #[strum(serialize = "speechmatics")]
+    Speechmatics,
+    #[strum(serialize = "together")]
+    Together,
+    #[strum(serialize = "xai")]
+    Xai,
     #[strum(serialize = "anarlog")]
     Anarlog,
 }
@@ -460,7 +493,17 @@ impl AdapterKind {
 
     pub fn has_live_mode(&self) -> bool {
         match self {
-            Self::AquaVoice | Self::Argmax | Self::Pyannote | Self::Cohere => false,
+            Self::AquaVoice
+            | Self::Argmax
+            | Self::Pyannote
+            | Self::Cohere
+            | Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together => false,
             Self::Soniox
             | Self::Cartesia
             | Self::Fireworks
@@ -471,6 +514,7 @@ impl AdapterKind {
             | Self::ElevenLabs
             | Self::DashScope
             | Self::Mistral
+            | Self::Xai
             | Self::Anarlog => true,
         }
     }
@@ -498,6 +542,14 @@ impl AdapterKind {
             Self::Mistral => MistralAdapter::language_support_live(languages),
             Self::Pyannote => LanguageSupport::NotSupported,
             Self::Cohere => LanguageSupport::NotSupported,
+            Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together => LanguageSupport::NotSupported,
+            Self::Xai => XaiAdapter::language_support_live(languages),
             Self::Anarlog => AnarlogAdapter::language_support_live(languages, model),
         }
     }
@@ -525,6 +577,14 @@ impl AdapterKind {
             Self::Mistral => MistralAdapter::language_support_batch(languages),
             Self::Pyannote => PyannoteAdapter::language_support_batch(languages, model),
             Self::Cohere => CohereAdapter::language_support_batch(languages),
+            Self::AwsTranscribe => AwsTranscribeAdapter::language_support_batch(languages),
+            Self::AzureSpeech => AzureSpeechAdapter::language_support_batch(languages),
+            Self::GoogleCloud => GoogleCloudAdapter::language_support_batch(languages),
+            Self::Groq => GroqAdapter::language_support_batch(languages),
+            Self::RevAi => RevAiAdapter::language_support_batch(languages),
+            Self::Speechmatics => SpeechmaticsAdapter::language_support_batch(languages),
+            Self::Together => TogetherAdapter::language_support_batch(languages),
+            Self::Xai => XaiAdapter::language_support_batch(languages),
             Self::Anarlog => AnarlogAdapter::language_support_batch(languages, model),
         }
     }
@@ -583,6 +643,14 @@ impl From<crate::providers::Provider> for AdapterKind {
             Provider::Mistral => Self::Mistral,
             Provider::Pyannote => Self::Pyannote,
             Provider::Cohere => Self::Cohere,
+            Provider::AwsTranscribe => Self::AwsTranscribe,
+            Provider::AzureSpeech => Self::AzureSpeech,
+            Provider::GoogleCloud => Self::GoogleCloud,
+            Provider::Groq => Self::Groq,
+            Provider::RevAi => Self::RevAi,
+            Provider::Speechmatics => Self::Speechmatics,
+            Provider::Together => Self::Together,
+            Provider::Xai => Self::Xai,
         }
     }
 }
@@ -814,6 +882,7 @@ mod tests {
             AdapterKind::ElevenLabs,
             AdapterKind::DashScope,
             AdapterKind::Mistral,
+            AdapterKind::Xai,
             AdapterKind::Anarlog,
         ];
         for kind in live {
@@ -825,6 +894,13 @@ mod tests {
             AdapterKind::Argmax,
             AdapterKind::Pyannote,
             AdapterKind::Cohere,
+            AdapterKind::AwsTranscribe,
+            AdapterKind::AzureSpeech,
+            AdapterKind::GoogleCloud,
+            AdapterKind::Groq,
+            AdapterKind::RevAi,
+            AdapterKind::Speechmatics,
+            AdapterKind::Together,
         ];
         for kind in batch_only {
             assert!(
@@ -1019,6 +1095,50 @@ mod tests {
         assert_eq!(
             AdapterKind::from_url_and_languages("https://api.cohere.com/v2", &en, None),
             AdapterKind::Cohere,
+        );
+        assert_eq!(
+            AdapterKind::from_url_and_languages(
+                "https://transcribe.us-east-1.amazonaws.com",
+                &en,
+                None,
+            ),
+            AdapterKind::AwsTranscribe,
+        );
+        assert_eq!(
+            AdapterKind::from_url_and_languages(
+                "https://example.cognitiveservices.azure.com",
+                &en,
+                None,
+            ),
+            AdapterKind::AzureSpeech,
+        );
+        assert_eq!(
+            AdapterKind::from_url_and_languages("https://speech.googleapis.com/v1", &en, None,),
+            AdapterKind::GoogleCloud,
+        );
+        assert_eq!(
+            AdapterKind::from_url_and_languages("https://api.groq.com/openai/v1", &en, None,),
+            AdapterKind::Groq,
+        );
+        assert_eq!(
+            AdapterKind::from_url_and_languages("https://api.rev.ai/speechtotext/v1", &en, None,),
+            AdapterKind::RevAi,
+        );
+        assert_eq!(
+            AdapterKind::from_url_and_languages(
+                "https://eu1.asr.api.speechmatics.com/v2",
+                &en,
+                None,
+            ),
+            AdapterKind::Speechmatics,
+        );
+        assert_eq!(
+            AdapterKind::from_url_and_languages("https://api.together.xyz/v1", &en, None,),
+            AdapterKind::Together,
+        );
+        assert_eq!(
+            AdapterKind::from_url_and_languages("https://api.x.ai/v1", &en, None),
+            AdapterKind::Xai,
         );
         assert_eq!(
             AdapterKind::from_url_and_languages("http://localhost:50060/v1", &en, None),

--- a/crates/owhisper-client/src/adapter/openai_compatible_batch.rs
+++ b/crates/owhisper-client/src/adapter/openai_compatible_batch.rs
@@ -1,0 +1,214 @@
+use std::path::Path;
+
+use owhisper_interface::ListenParams;
+use owhisper_interface::batch::{Alternatives, Channel, Response, Results, Word};
+use reqwest::multipart::Form;
+use serde::Deserialize;
+
+use crate::adapter::http::{ensure_success, streaming_file_part};
+use crate::adapter::{ClientWithMiddleware, append_path_if_missing};
+use crate::error::Error;
+
+pub(crate) struct OpenAICompatibleBatchConfig<'a> {
+    pub provider: &'a str,
+    pub default_api_base: &'a str,
+    pub default_model: &'a str,
+    pub transcription_path: &'a str,
+    pub timestamp_field: Option<&'a str>,
+}
+
+pub(crate) async fn transcribe(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    params: &ListenParams,
+    file_path: &Path,
+    config: OpenAICompatibleBatchConfig<'_>,
+) -> Result<Response, Error> {
+    let model = match params.model.as_deref() {
+        Some(model) if !crate::providers::is_meta_model(model) => model,
+        _ => config.default_model,
+    };
+
+    let mut form = Form::new()
+        .text("model", model.to_string())
+        .text("response_format", "verbose_json");
+
+    if let Some(field) = config.timestamp_field {
+        form = form.text(field.to_string(), "word");
+    }
+    if let Some(language) = params.languages.first() {
+        form = form.text("language", language.iso639().code().to_string());
+    }
+    form = form.part("file", streaming_file_part(file_path).await?);
+
+    let mut url: url::Url = if api_base.is_empty() {
+        config
+            .default_api_base
+            .parse()
+            .expect("invalid_default_openai_compatible_api_base")
+    } else {
+        api_base.parse().map_err(|error: url::ParseError| {
+            Error::AudioProcessing(format!("invalid api_base: {error}"))
+        })?
+    };
+    append_path_if_missing(&mut url, config.transcription_path);
+
+    let response = client
+        .post(url.to_string())
+        .bearer_auth(api_key)
+        .multipart(form)
+        .send()
+        .await?;
+    let payload: CompatibleResponse = ensure_success(response).await?.json().await?;
+
+    Ok(convert_response(config.provider, payload))
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CompatibleResponse {
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    words: Vec<CompatibleWord>,
+    #[serde(default)]
+    segments: Vec<CompatibleSegment>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CompatibleSegment {
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    start: f64,
+    #[serde(default)]
+    end: f64,
+    #[serde(default)]
+    words: Vec<CompatibleWord>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+struct CompatibleWord {
+    #[serde(default, alias = "text")]
+    word: String,
+    #[serde(default)]
+    start: f64,
+    #[serde(default)]
+    end: f64,
+    #[serde(default = "default_confidence")]
+    confidence: f64,
+    #[serde(default, deserialize_with = "deserialize_optional_speaker")]
+    speaker: Option<usize>,
+}
+
+fn default_confidence() -> f64 {
+    1.0
+}
+
+fn deserialize_optional_speaker<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|value| match value {
+        serde_json::Value::Number(number) => number
+            .as_u64()
+            .and_then(|speaker| usize::try_from(speaker).ok()),
+        serde_json::Value::String(value) => value
+            .trim_start_matches(|character: char| !character.is_ascii_digit())
+            .parse()
+            .ok(),
+        _ => None,
+    }))
+}
+
+fn convert_response(provider: &str, payload: CompatibleResponse) -> Response {
+    let words = if payload.words.is_empty() {
+        payload
+            .segments
+            .iter()
+            .flat_map(|segment| {
+                if segment.words.is_empty() {
+                    vec![CompatibleWord {
+                        word: segment.text.clone(),
+                        start: segment.start,
+                        end: segment.end,
+                        confidence: 1.0,
+                        speaker: None,
+                    }]
+                } else {
+                    segment.words.clone()
+                }
+            })
+            .collect()
+    } else {
+        payload.words
+    };
+    let transcript = if payload.text.trim().is_empty() {
+        payload
+            .segments
+            .iter()
+            .map(|segment| segment.text.trim())
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ")
+    } else {
+        payload.text.trim().to_string()
+    };
+
+    Response {
+        metadata: serde_json::json!({ "provider": provider }),
+        results: Results {
+            channels: vec![Channel {
+                alternatives: vec![Alternatives {
+                    transcript,
+                    confidence: 1.0,
+                    words: words
+                        .into_iter()
+                        .filter(|word| !word.word.trim().is_empty())
+                        .map(|word| Word {
+                            punctuated_word: Some(word.word.clone()),
+                            word: word.word,
+                            start: word.start,
+                            end: word.end,
+                            confidence: word.confidence,
+                            channel: 0,
+                            speaker: word.speaker,
+                        })
+                        .collect(),
+                }],
+            }],
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_word_and_segment_response_shapes() {
+        let word_payload: CompatibleResponse = serde_json::from_value(serde_json::json!({
+            "text": "Hello world.",
+            "words": [
+                { "word": "Hello", "start": 0.1, "end": 0.4 },
+                { "text": "world.", "start": 0.4, "end": 0.8, "speaker": "speaker_2" }
+            ]
+        }))
+        .unwrap();
+        let segment_payload: CompatibleResponse = serde_json::from_value(serde_json::json!({
+            "segments": [{ "text": "Fallback segment.", "start": 1.0, "end": 2.0 }]
+        }))
+        .unwrap();
+
+        let word_response = convert_response("groq", word_payload);
+        let segment_response = convert_response("together", segment_payload);
+        let word_alternative = &word_response.results.channels[0].alternatives[0];
+        let segment_alternative = &segment_response.results.channels[0].alternatives[0];
+
+        assert_eq!(word_alternative.transcript, "Hello world.");
+        assert_eq!(word_alternative.words[1].speaker, Some(2));
+        assert_eq!(segment_alternative.transcript, "Fallback segment.");
+        assert_eq!(segment_alternative.words[0].start, 1.0);
+    }
+}

--- a/crates/owhisper-client/src/adapter/revai/mod.rs
+++ b/crates/owhisper-client/src/adapter/revai/mod.rs
@@ -1,0 +1,266 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use owhisper_interface::ListenParams;
+use owhisper_interface::batch::{Alternatives, Channel, Response, Results, Word};
+use reqwest::multipart::Form;
+
+use crate::adapter::http::{ensure_success, streaming_file_part};
+use crate::adapter::{
+    BatchFuture, BatchSttAdapter, ClientWithMiddleware, LanguageQuality, LanguageSupport,
+    append_path_if_missing,
+};
+use crate::error::Error;
+
+#[derive(Clone, Default)]
+pub struct RevAiAdapter;
+
+impl RevAiAdapter {
+    pub fn language_support_batch(_languages: &[anlg_language::Language]) -> LanguageSupport {
+        LanguageSupport::Supported {
+            quality: LanguageQuality::NoData,
+        }
+    }
+}
+
+impl BatchSttAdapter for RevAiAdapter {
+    fn provider_name(&self) -> &'static str {
+        "revai"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_batch(languages).is_supported()
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(do_transcribe_file(client, api_base, api_key, params, path))
+    }
+}
+
+async fn do_transcribe_file(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    params: &ListenParams,
+    file_path: PathBuf,
+) -> Result<Response, Error> {
+    let mut form = Form::new().part("media", streaming_file_part(&file_path).await?);
+    let mut options = serde_json::Map::new();
+    if let Some(language) = params.languages.first() {
+        options.insert(
+            "language".to_string(),
+            serde_json::Value::String(revai_language_code(language)),
+        );
+    }
+    if !params.keywords.is_empty() {
+        options.insert(
+            "custom_vocabularies".to_string(),
+            serde_json::json!([{
+                "phrases": params.keywords,
+            }]),
+        );
+    }
+    if !options.is_empty() {
+        form = form.text("options", serde_json::Value::Object(options).to_string());
+    }
+
+    let jobs_url = jobs_url(api_base)?;
+    let response = client
+        .post(jobs_url.to_string())
+        .bearer_auth(api_key)
+        .multipart(form)
+        .send()
+        .await?;
+    let job: RevJob = ensure_success(response).await?.json().await?;
+    wait_for_job(client, api_key, &jobs_url, &job.id).await?;
+
+    let mut transcript_url = jobs_url;
+    append_path_if_missing(&mut transcript_url, &format!("{}/transcript", job.id));
+    let response = client
+        .get(transcript_url.to_string())
+        .bearer_auth(api_key)
+        .header("Accept", "application/vnd.rev.transcript.v1.0+json")
+        .send()
+        .await?;
+    let transcript: RevTranscript = ensure_success(response).await?.json().await?;
+
+    Ok(convert_response(transcript))
+}
+
+fn revai_language_code(language: &anlg_language::Language) -> String {
+    language.bcp47_code().to_ascii_lowercase()
+}
+
+fn jobs_url(api_base: &str) -> Result<url::Url, Error> {
+    let mut url: url::Url = if api_base.is_empty() {
+        "https://api.rev.ai/speechtotext/v1"
+            .parse()
+            .expect("invalid_default_revai_api_base")
+    } else {
+        api_base.parse().map_err(|error: url::ParseError| {
+            Error::AudioProcessing(format!("invalid api_base: {error}"))
+        })?
+    };
+    append_path_if_missing(&mut url, "jobs");
+    Ok(url)
+}
+
+async fn wait_for_job(
+    client: &ClientWithMiddleware,
+    api_key: &str,
+    jobs_url: &url::Url,
+    job_id: &str,
+) -> Result<(), Error> {
+    let mut status_url = jobs_url.clone();
+    append_path_if_missing(&mut status_url, job_id);
+
+    for _ in 0..450 {
+        let response = client
+            .get(status_url.to_string())
+            .bearer_auth(api_key)
+            .send()
+            .await?;
+        let job: RevJob = ensure_success(response).await?.json().await?;
+        match job.status.as_str() {
+            "transcribed" => return Ok(()),
+            "failed" => {
+                return Err(Error::AudioProcessing(
+                    job.failure
+                        .unwrap_or_else(|| "Rev AI transcription failed".to_string()),
+                ));
+            }
+            _ => tokio::time::sleep(Duration::from_secs(2)).await,
+        }
+    }
+
+    Err(Error::AudioProcessing(
+        "Rev AI transcription did not finish before the polling limit".to_string(),
+    ))
+}
+
+#[derive(serde::Deserialize)]
+struct RevJob {
+    id: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default, alias = "failure_detail")]
+    failure: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct RevTranscript {
+    #[serde(default)]
+    monologues: Vec<RevMonologue>,
+}
+
+#[derive(serde::Deserialize)]
+struct RevMonologue {
+    #[serde(default)]
+    speaker: Option<usize>,
+    #[serde(default)]
+    elements: Vec<RevElement>,
+}
+
+#[derive(serde::Deserialize)]
+struct RevElement {
+    #[serde(rename = "type")]
+    element_type: String,
+    #[serde(default)]
+    value: String,
+    #[serde(default)]
+    ts: Option<f64>,
+    #[serde(default)]
+    end_ts: Option<f64>,
+    #[serde(default)]
+    confidence: Option<f64>,
+}
+
+fn convert_response(transcript: RevTranscript) -> Response {
+    let transcript_text = transcript
+        .monologues
+        .iter()
+        .flat_map(|monologue| monologue.elements.iter())
+        .map(|element| element.value.as_str())
+        .collect::<String>()
+        .trim()
+        .to_string();
+    let words = transcript
+        .monologues
+        .into_iter()
+        .flat_map(|monologue| {
+            monologue.elements.into_iter().filter_map(move |element| {
+                if element.element_type != "text" {
+                    return None;
+                }
+                Some(Word {
+                    punctuated_word: Some(element.value.clone()),
+                    word: element.value,
+                    start: element.ts.unwrap_or_default(),
+                    end: element.end_ts.unwrap_or_default(),
+                    confidence: element.confidence.unwrap_or(1.0),
+                    channel: 0,
+                    speaker: monologue.speaker,
+                })
+            })
+        })
+        .collect();
+
+    Response {
+        metadata: serde_json::json!({ "provider": "revai" }),
+        results: Results {
+            channels: vec![Channel {
+                alternatives: vec![Alternatives {
+                    transcript: transcript_text,
+                    confidence: 1.0,
+                    words,
+                }],
+            }],
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lowercases_regional_language_codes() {
+        let language: anlg_language::Language = "en-US".parse().unwrap();
+
+        assert_eq!(revai_language_code(&language), "en-us");
+    }
+
+    #[test]
+    fn converts_rev_monologues() {
+        let transcript: RevTranscript = serde_json::from_value(serde_json::json!({
+            "monologues": [{
+                "speaker": 1,
+                "elements": [
+                    { "type": "text", "value": "Hello", "ts": 0.1, "end_ts": 0.5, "confidence": 0.9 },
+                    { "type": "punct", "value": " " },
+                    { "type": "text", "value": "world.", "ts": 0.5, "end_ts": 1.0, "confidence": 0.8 }
+                ]
+            }]
+        }))
+        .unwrap();
+
+        let response = convert_response(transcript);
+        let alternative = &response.results.channels[0].alternatives[0];
+
+        assert_eq!(alternative.transcript, "Hello world.");
+        assert_eq!(alternative.words.len(), 2);
+        assert_eq!(alternative.words[0].speaker, Some(1));
+    }
+}

--- a/crates/owhisper-client/src/adapter/speechmatics/mod.rs
+++ b/crates/owhisper-client/src/adapter/speechmatics/mod.rs
@@ -1,0 +1,346 @@
+use std::path::{Path, PathBuf};
+
+use owhisper_interface::ListenParams;
+use owhisper_interface::batch::{Alternatives, Channel, Response, Results, Word};
+use reqwest::StatusCode;
+use reqwest::multipart::Form;
+
+use crate::adapter::http::{ensure_success, streaming_file_part};
+use crate::adapter::{
+    BatchFuture, BatchSttAdapter, ClientWithMiddleware, LanguageQuality, LanguageSupport,
+    append_path_if_missing,
+};
+use crate::error::Error;
+
+#[derive(Clone, Default)]
+pub struct SpeechmaticsAdapter;
+
+impl SpeechmaticsAdapter {
+    pub fn language_support_batch(_languages: &[anlg_language::Language]) -> LanguageSupport {
+        LanguageSupport::Supported {
+            quality: LanguageQuality::NoData,
+        }
+    }
+}
+
+impl BatchSttAdapter for SpeechmaticsAdapter {
+    fn provider_name(&self) -> &'static str {
+        "speechmatics"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_batch(languages).is_supported()
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(do_transcribe_file(client, api_base, api_key, params, path))
+    }
+}
+
+async fn do_transcribe_file(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    params: &ListenParams,
+    file_path: PathBuf,
+) -> Result<Response, Error> {
+    let language = params
+        .languages
+        .first()
+        .map(anlg_language::Language::iso639_code)
+        .unwrap_or("en");
+    let model = match params.model.as_deref() {
+        Some(model) if !crate::providers::is_meta_model(model) => model,
+        _ => "enhanced",
+    };
+    let mut transcription_config = serde_json::json!({
+        "language": language,
+        "model": model,
+    });
+    if params.num_speakers.is_some()
+        || params.min_speakers.is_some()
+        || params.max_speakers.is_some()
+    {
+        transcription_config["diarization"] = serde_json::json!("speaker");
+    }
+    if !params.keywords.is_empty() {
+        transcription_config["additional_vocab"] = serde_json::json!(
+            params
+                .keywords
+                .iter()
+                .map(|content| serde_json::json!({ "content": content }))
+                .collect::<Vec<_>>()
+        );
+    }
+    let config = serde_json::json!({
+        "type": "transcription",
+        "transcription_config": transcription_config,
+    });
+    let form = Form::new()
+        .text("config", config.to_string())
+        .part("data_file", streaming_file_part(&file_path).await?);
+
+    let mut url = jobs_url(api_base)?;
+    url.query_pairs_mut()
+        .append_pair("wait", "120")
+        .append_pair("format", "json-v2");
+    let response = client
+        .post(url.to_string())
+        .bearer_auth(api_key)
+        .multipart(form)
+        .send()
+        .await?;
+    let job: SpeechmaticsJob = ensure_success(response).await?.json().await?;
+
+    let transcript = match job.transcript {
+        Some(transcript) => transcript,
+        None if job.status == "done" => {
+            fetch_transcript(client, api_base, api_key, &job.id).await?
+        }
+        None if matches!(job.status.as_str(), "rejected" | "deleted") => {
+            return Err(Error::AudioProcessing(format!(
+                "Speechmatics job {}",
+                job.status
+            )));
+        }
+        None => wait_for_transcript(client, api_base, api_key, &job.id).await?,
+    };
+
+    Ok(convert_response(transcript))
+}
+
+fn jobs_url(api_base: &str) -> Result<url::Url, Error> {
+    let mut url: url::Url = if api_base.is_empty() {
+        "https://eu1.asr.api.speechmatics.com/v2"
+            .parse()
+            .expect("invalid_default_speechmatics_api_base")
+    } else {
+        api_base.parse().map_err(|error: url::ParseError| {
+            Error::AudioProcessing(format!("invalid api_base: {error}"))
+        })?
+    };
+    append_path_if_missing(&mut url, "jobs");
+    Ok(url)
+}
+
+async fn wait_for_transcript(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    job_id: &str,
+) -> Result<SpeechmaticsTranscript, Error> {
+    for _ in 0..30 {
+        match fetch_transcript(client, api_base, api_key, job_id).await {
+            Ok(transcript) => return Ok(transcript),
+            Err(Error::UnexpectedStatus { status, .. }) if status == StatusCode::NOT_FOUND => {}
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(Error::AudioProcessing(
+        "Speechmatics transcription did not finish before the polling limit".to_string(),
+    ))
+}
+
+async fn fetch_transcript(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    job_id: &str,
+) -> Result<SpeechmaticsTranscript, Error> {
+    let mut url = jobs_url(api_base)?;
+    append_path_if_missing(&mut url, &format!("{job_id}/transcript"));
+    url.query_pairs_mut()
+        .append_pair("wait", "60")
+        .append_pair("format", "json-v2");
+
+    let response = client
+        .get(url.to_string())
+        .bearer_auth(api_key)
+        .send()
+        .await?;
+    Ok(ensure_success(response).await?.json().await?)
+}
+
+#[derive(serde::Deserialize)]
+struct SpeechmaticsJob {
+    id: String,
+    status: String,
+    #[serde(default, rename = "json-v2")]
+    transcript: Option<SpeechmaticsTranscript>,
+}
+
+#[derive(serde::Deserialize)]
+struct SpeechmaticsTranscript {
+    #[serde(default)]
+    results: Vec<SpeechmaticsResult>,
+}
+
+#[derive(serde::Deserialize)]
+struct SpeechmaticsResult {
+    #[serde(default)]
+    alternatives: Vec<SpeechmaticsAlternative>,
+    #[serde(default)]
+    attaches_to: Option<String>,
+    #[serde(default)]
+    start_time: f64,
+    #[serde(default)]
+    end_time: f64,
+    #[serde(default, rename = "type")]
+    result_type: String,
+}
+
+#[derive(serde::Deserialize)]
+struct SpeechmaticsAlternative {
+    #[serde(default)]
+    content: String,
+    #[serde(default = "default_confidence")]
+    confidence: f64,
+    #[serde(default)]
+    speaker: Option<String>,
+}
+
+fn default_confidence() -> f64 {
+    1.0
+}
+
+fn convert_response(transcript: SpeechmaticsTranscript) -> Response {
+    let mut full_text = String::new();
+    let mut attach_next = false;
+    let mut next_word_prefix = String::new();
+    let mut words = Vec::<Word>::new();
+
+    for result in transcript.results {
+        let Some(alternative) = result.alternatives.into_iter().next() else {
+            continue;
+        };
+        let attach_previous = matches!(
+            result.attaches_to.as_deref(),
+            Some("previous") | Some("both")
+        ) || (result.result_type == "punctuation"
+            && result.attaches_to.is_none());
+
+        if !full_text.is_empty() && !attach_previous && !attach_next {
+            full_text.push(' ');
+        }
+        full_text.push_str(&alternative.content);
+        attach_next = matches!(result.attaches_to.as_deref(), Some("next") | Some("both"));
+
+        if result.result_type == "punctuation" {
+            if attach_previous {
+                if let Some(word) = words.last_mut() {
+                    word.punctuated_word
+                        .get_or_insert_with(|| word.word.clone())
+                        .push_str(&alternative.content);
+                }
+            } else if attach_next {
+                next_word_prefix.push_str(&alternative.content);
+            }
+        } else if result.result_type == "word" {
+            let punctuated_word = format!("{next_word_prefix}{}", alternative.content);
+            next_word_prefix.clear();
+            words.push(Word {
+                punctuated_word: Some(punctuated_word),
+                word: alternative.content,
+                start: result.start_time,
+                end: result.end_time,
+                confidence: alternative.confidence,
+                channel: 0,
+                speaker: alternative.speaker.as_deref().and_then(parse_speaker_label),
+            });
+        }
+    }
+
+    Response {
+        metadata: serde_json::json!({ "provider": "speechmatics" }),
+        results: Results {
+            channels: vec![Channel {
+                alternatives: vec![Alternatives {
+                    transcript: full_text,
+                    confidence: 1.0,
+                    words,
+                }],
+            }],
+        },
+    }
+}
+
+fn parse_speaker_label(label: &str) -> Option<usize> {
+    if label == "UU" {
+        return None;
+    }
+    label
+        .trim_start_matches(|character: char| !character.is_ascii_digit())
+        .parse()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_json_v2_words_and_speakers() {
+        let transcript: SpeechmaticsTranscript = serde_json::from_value(serde_json::json!({
+            "results": [
+                {
+                    "type": "word",
+                    "start_time": 0.1,
+                    "end_time": 0.4,
+                    "alternatives": [{
+                        "content": "Hello",
+                        "confidence": 0.9,
+                        "speaker": "S2"
+                    }]
+                },
+                {
+                    "type": "punctuation",
+                    "attaches_to": "previous",
+                    "alternatives": [{ "content": "," }]
+                },
+                {
+                    "type": "word",
+                    "start_time": 0.5,
+                    "end_time": 0.8,
+                    "alternatives": [{
+                        "content": "world",
+                        "confidence": 0.8,
+                        "speaker": "S2"
+                    }]
+                },
+                {
+                    "type": "punctuation",
+                    "attaches_to": "previous",
+                    "alternatives": [{ "content": "." }]
+                }
+            ]
+        }))
+        .unwrap();
+
+        let response = convert_response(transcript);
+        let alternative = &response.results.channels[0].alternatives[0];
+        let word = &alternative.words[0];
+
+        assert_eq!(alternative.transcript, "Hello, world.");
+        assert_eq!(alternative.words.len(), 2);
+        assert_eq!(word.word, "Hello");
+        assert_eq!(word.punctuated_word.as_deref(), Some("Hello,"));
+        assert_eq!(
+            alternative.words[1].punctuated_word.as_deref(),
+            Some("world.")
+        );
+        assert_eq!(word.speaker, Some(2));
+    }
+}

--- a/crates/owhisper-client/src/adapter/together/mod.rs
+++ b/crates/owhisper-client/src/adapter/together/mod.rs
@@ -1,0 +1,61 @@
+use std::path::Path;
+
+use owhisper_interface::ListenParams;
+
+use crate::adapter::openai_compatible_batch::{OpenAICompatibleBatchConfig, transcribe};
+use crate::adapter::{
+    BatchFuture, BatchSttAdapter, ClientWithMiddleware, LanguageQuality, LanguageSupport,
+};
+
+#[derive(Clone, Default)]
+pub struct TogetherAdapter;
+
+impl TogetherAdapter {
+    pub fn language_support_batch(_languages: &[anlg_language::Language]) -> LanguageSupport {
+        LanguageSupport::Supported {
+            quality: LanguageQuality::NoData,
+        }
+    }
+}
+
+impl BatchSttAdapter for TogetherAdapter {
+    fn provider_name(&self) -> &'static str {
+        "together"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_batch(languages).is_supported()
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(async move {
+            transcribe(
+                client,
+                api_base,
+                api_key,
+                params,
+                &path,
+                OpenAICompatibleBatchConfig {
+                    provider: "together",
+                    default_api_base: "https://api.together.xyz/v1",
+                    default_model: "openai/whisper-large-v3",
+                    transcription_path: "audio/transcriptions",
+                    timestamp_field: Some("timestamp_granularities"),
+                },
+            )
+            .await
+        })
+    }
+}

--- a/crates/owhisper-client/src/adapter/xai/batch.rs
+++ b/crates/owhisper-client/src/adapter/xai/batch.rs
@@ -1,0 +1,190 @@
+use std::path::{Path, PathBuf};
+
+use owhisper_interface::ListenParams;
+use owhisper_interface::batch::{Alternatives, Channel, Response, Results, Word};
+use reqwest::multipart::Form;
+
+use crate::adapter::http::{ensure_success, streaming_file_part};
+use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, append_path_if_missing};
+use crate::error::Error;
+
+use super::XaiAdapter;
+
+impl BatchSttAdapter for XaiAdapter {
+    fn provider_name(&self) -> &'static str {
+        "xai"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_batch(languages).is_supported()
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(do_transcribe_file(client, api_base, api_key, params, path))
+    }
+}
+
+async fn do_transcribe_file(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    params: &ListenParams,
+    file_path: PathBuf,
+) -> Result<Response, Error> {
+    let mut form = Form::new();
+    if let Some(language) = params.languages.first() {
+        form = form
+            .text("format", "true")
+            .text("language", language.iso639().code().to_string());
+    }
+    if params.num_speakers.is_some()
+        || params.min_speakers.is_some()
+        || params.max_speakers.is_some()
+    {
+        form = form.text("diarize", "true");
+    }
+    for keyword in &params.keywords {
+        form = form.text("keyterm", keyword.clone());
+    }
+
+    // xAI requires every option to precede the file part.
+    form = form.part("file", streaming_file_part(&file_path).await?);
+
+    let mut url: url::Url = if api_base.is_empty() {
+        "https://api.x.ai/v1"
+            .parse()
+            .expect("invalid_default_xai_api_base")
+    } else {
+        api_base.parse().map_err(|error: url::ParseError| {
+            Error::AudioProcessing(format!("invalid api_base: {error}"))
+        })?
+    };
+    append_path_if_missing(&mut url, "stt");
+
+    let response = client
+        .post(url.to_string())
+        .bearer_auth(api_key)
+        .multipart(form)
+        .send()
+        .await?;
+    let payload: XaiBatchResponse = ensure_success(response).await?.json().await?;
+
+    Ok(convert_response(payload))
+}
+
+#[derive(serde::Deserialize)]
+struct XaiBatchResponse {
+    text: String,
+    #[serde(default)]
+    language: Option<String>,
+    #[serde(default)]
+    duration: Option<f64>,
+    #[serde(default)]
+    words: Vec<XaiBatchWord>,
+    #[serde(default)]
+    channels: Vec<XaiBatchChannel>,
+}
+
+#[derive(serde::Deserialize)]
+struct XaiBatchChannel {
+    #[serde(default)]
+    index: i32,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    words: Vec<XaiBatchWord>,
+}
+
+#[derive(serde::Deserialize)]
+struct XaiBatchWord {
+    text: String,
+    start: f64,
+    end: f64,
+    #[serde(default)]
+    speaker: Option<usize>,
+}
+
+fn convert_words(words: Vec<XaiBatchWord>, channel: i32) -> Vec<Word> {
+    words
+        .into_iter()
+        .map(|word| Word {
+            punctuated_word: Some(word.text.clone()),
+            word: word.text,
+            start: word.start,
+            end: word.end,
+            confidence: 1.0,
+            channel,
+            speaker: word.speaker,
+        })
+        .collect()
+}
+
+fn convert_response(payload: XaiBatchResponse) -> Response {
+    let channels = if payload.channels.is_empty() {
+        vec![Channel {
+            alternatives: vec![Alternatives {
+                transcript: payload.text.trim().to_string(),
+                confidence: 1.0,
+                words: convert_words(payload.words, 0),
+            }],
+        }]
+    } else {
+        payload
+            .channels
+            .into_iter()
+            .map(|channel| Channel {
+                alternatives: vec![Alternatives {
+                    transcript: channel.text.trim().to_string(),
+                    confidence: 1.0,
+                    words: convert_words(channel.words, channel.index),
+                }],
+            })
+            .collect()
+    };
+
+    Response {
+        metadata: serde_json::json!({
+            "provider": "xai",
+            "language": payload.language,
+            "duration": payload.duration,
+        }),
+        results: Results { channels },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_diarized_words() {
+        let payload: XaiBatchResponse = serde_json::from_value(serde_json::json!({
+            "text": "Hello there.",
+            "duration": 1.5,
+            "words": [
+                { "text": "Hello", "start": 0.1, "end": 0.5, "speaker": 2 },
+                { "text": "there.", "start": 0.5, "end": 1.0, "speaker": 2 }
+            ]
+        }))
+        .unwrap();
+
+        let response = convert_response(payload);
+        let alternative = &response.results.channels[0].alternatives[0];
+
+        assert_eq!(alternative.transcript, "Hello there.");
+        assert_eq!(alternative.words[0].speaker, Some(2));
+        assert_eq!(response.metadata["provider"], "xai");
+    }
+}

--- a/crates/owhisper-client/src/adapter/xai/live.rs
+++ b/crates/owhisper-client/src/adapter/xai/live.rs
@@ -1,0 +1,234 @@
+use anlg_ws_client::client::Message;
+use owhisper_interface::ListenParams;
+use owhisper_interface::stream::{Alternatives, Channel, Metadata, StreamResponse, Word};
+
+use crate::adapter::{RealtimeSttAdapter, build_proxy_ws_url, build_url_with_scheme};
+use crate::providers::Provider;
+
+use super::XaiAdapter;
+
+impl RealtimeSttAdapter for XaiAdapter {
+    fn provider_name(&self) -> &'static str {
+        "xai"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_live(languages).is_supported()
+    }
+
+    fn supports_native_multichannel(&self) -> bool {
+        true
+    }
+
+    fn build_ws_url(&self, api_base: &str, params: &ListenParams, channels: u8) -> url::Url {
+        let (mut url, existing_params) = if let Some(result) = build_proxy_ws_url(api_base) {
+            result
+        } else {
+            let parsed: url::Url = if api_base.is_empty() {
+                Provider::Xai
+                    .default_api_base()
+                    .parse()
+                    .expect("invalid_default_xai_api_base")
+            } else {
+                api_base.parse().expect("invalid_xai_api_base")
+            };
+            (
+                build_url_with_scheme(
+                    &parsed,
+                    Provider::Xai.default_ws_host(),
+                    Provider::Xai.ws_path(),
+                    true,
+                ),
+                Vec::new(),
+            )
+        };
+
+        {
+            let mut query = url.query_pairs_mut();
+            query.extend_pairs(&existing_params);
+            query.append_pair("sample_rate", &params.sample_rate.to_string());
+            query.append_pair("encoding", "pcm");
+            query.append_pair("interim_results", "true");
+
+            if let Some(language) = params.languages.first() {
+                query.append_pair("language", language.iso639().code());
+            }
+            for keyword in &params.keywords {
+                query.append_pair("keyterm", keyword);
+            }
+            if channels > 1 {
+                query.append_pair("multichannel", "true");
+                query.append_pair("channels", &channels.to_string());
+            }
+            if params.num_speakers.is_some()
+                || params.min_speakers.is_some()
+                || params.max_speakers.is_some()
+            {
+                query.append_pair("diarize", "true");
+            }
+        }
+
+        url
+    }
+
+    fn build_auth_header(&self, api_key: Option<&str>) -> Option<(&'static str, String)> {
+        api_key.and_then(|key| Provider::Xai.build_auth_header(key))
+    }
+
+    fn keep_alive_message(&self) -> Option<Message> {
+        None
+    }
+
+    fn finalize_message(&self) -> Message {
+        Message::Text(r#"{"type":"audio.done"}"#.into())
+    }
+
+    fn parse_response(&self, raw: &str) -> Vec<StreamResponse> {
+        let event: XaiEvent = match serde_json::from_str(raw) {
+            Ok(event) => event,
+            Err(error) => {
+                tracing::warn!(
+                    error = ?error,
+                    anarlog.payload.size_bytes = raw.len() as u64,
+                    "xai_json_parse_failed"
+                );
+                return Vec::new();
+            }
+        };
+
+        match event.event_type.as_str() {
+            "transcript.created" => Vec::new(),
+            "error" => vec![StreamResponse::ErrorResponse {
+                error_code: None,
+                error_message: event
+                    .message
+                    .unwrap_or_else(|| "xAI transcription error".into()),
+                provider: "xai".to_string(),
+            }],
+            "transcript.done" if event.text.trim().is_empty() => {
+                vec![StreamResponse::TerminalResponse {
+                    request_id: String::new(),
+                    created: String::new(),
+                    duration: event.duration.unwrap_or_default(),
+                    channels: 1,
+                }]
+            }
+            "transcript.partial" | "transcript.done" => {
+                let is_done = event.event_type == "transcript.done";
+                let channel_index = event.channel_index.unwrap_or(0);
+                vec![StreamResponse::TranscriptResponse {
+                    start: event.start.unwrap_or_default(),
+                    duration: event.duration.unwrap_or_default(),
+                    is_final: is_done || event.is_final.unwrap_or(false),
+                    speech_final: is_done || event.speech_final.unwrap_or(false),
+                    from_finalize: is_done,
+                    channel: Channel {
+                        alternatives: vec![Alternatives {
+                            transcript: event.text,
+                            words: event
+                                .words
+                                .into_iter()
+                                .map(|word| Word {
+                                    punctuated_word: Some(word.text.clone()),
+                                    word: word.text,
+                                    start: word.start,
+                                    end: word.end,
+                                    confidence: 1.0,
+                                    speaker: word.speaker,
+                                    language: None,
+                                })
+                                .collect(),
+                            confidence: 1.0,
+                            languages: Vec::new(),
+                        }],
+                    },
+                    metadata: Metadata::default(),
+                    channel_index: vec![channel_index, 1],
+                }]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct XaiEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    words: Vec<XaiWord>,
+    #[serde(default)]
+    is_final: Option<bool>,
+    #[serde(default)]
+    speech_final: Option<bool>,
+    #[serde(default)]
+    start: Option<f64>,
+    #[serde(default)]
+    duration: Option<f64>,
+    #[serde(default)]
+    channel_index: Option<i32>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct XaiWord {
+    text: String,
+    start: f64,
+    end: f64,
+    #[serde(default)]
+    speaker: Option<i32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_direct_and_proxy_urls() {
+        let params = ListenParams {
+            sample_rate: 16_000,
+            languages: vec![anlg_language::ISO639::En.into()],
+            keywords: vec!["Anarlog".to_string()],
+            ..Default::default()
+        };
+
+        let direct = XaiAdapter.build_ws_url("https://api.x.ai/v1", &params, 2);
+        let proxy = XaiAdapter.build_ws_url("https://api.anarlog.so/stt?provider=xai", &params, 1);
+
+        assert_eq!(direct.scheme(), "wss");
+        assert_eq!(direct.path(), "/v1/stt");
+        assert!(direct.query().unwrap().contains("multichannel=true"));
+        assert_eq!(
+            proxy.as_str().split('?').next().unwrap(),
+            "wss://api.anarlog.so/stt/listen"
+        );
+        assert!(proxy.query().unwrap().contains("provider=xai"));
+    }
+
+    #[test]
+    fn parses_partial_transcript() {
+        let responses = XaiAdapter.parse_response(
+            r#"{"type":"transcript.partial","text":"hello","is_final":true,"speech_final":true,"start":0.1,"duration":0.5,"words":[{"text":"hello","start":0.1,"end":0.6,"speaker":1}]}"#,
+        );
+
+        let StreamResponse::TranscriptResponse {
+            is_final,
+            speech_final,
+            channel,
+            ..
+        } = &responses[0]
+        else {
+            panic!("expected transcript response");
+        };
+        assert!(*is_final);
+        assert!(*speech_final);
+        assert_eq!(channel.alternatives[0].words[0].speaker, Some(1));
+    }
+}

--- a/crates/owhisper-client/src/adapter/xai/mod.rs
+++ b/crates/owhisper-client/src/adapter/xai/mod.rs
@@ -1,0 +1,19 @@
+mod batch;
+mod live;
+
+use crate::adapter::{LanguageQuality, LanguageSupport};
+
+#[derive(Clone, Default)]
+pub struct XaiAdapter;
+
+impl XaiAdapter {
+    pub fn language_support_live(_languages: &[anlg_language::Language]) -> LanguageSupport {
+        LanguageSupport::Supported {
+            quality: LanguageQuality::NoData,
+        }
+    }
+
+    pub fn language_support_batch(languages: &[anlg_language::Language]) -> LanguageSupport {
+        Self::language_support_live(languages)
+    }
+}

--- a/crates/owhisper-client/src/lib.rs
+++ b/crates/owhisper-client/src/lib.rs
@@ -23,12 +23,14 @@ pub use adapter::StreamingBatchConfig;
 pub use adapter::deepgram::DeepgramModel;
 pub use adapter::{
     AdapterKind, AnarlogAdapter, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter,
-    BatchSttAdapter, CallbackResult, CallbackSttAdapter, CartesiaAdapter, CohereAdapter,
-    DashScopeAdapter, DeepgramAdapter, DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter,
-    GladiaAdapter, LanguageQuality, LanguageSupport, MistralAdapter, OpenAIAdapter,
-    PyannoteAdapter, RealtimeSttAdapter, SmallestAIAdapter, SonioxAdapter, WhisperCppAdapter,
-    append_provider_param, documented_language_codes_batch, documented_language_codes_live,
-    is_anarlog_proxy, is_local_host, normalize_languages,
+    AwsTranscribeAdapter, AzureSpeechAdapter, BatchSttAdapter, CallbackResult, CallbackSttAdapter,
+    CartesiaAdapter, CohereAdapter, DashScopeAdapter, DeepgramAdapter, DeepgramFluxAdapter,
+    ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, GoogleCloudAdapter, GroqAdapter,
+    LanguageQuality, LanguageSupport, MistralAdapter, OpenAIAdapter, PyannoteAdapter,
+    RealtimeSttAdapter, RevAiAdapter, SmallestAIAdapter, SonioxAdapter, SpeechmaticsAdapter,
+    TogetherAdapter, WhisperCppAdapter, XaiAdapter, append_provider_param,
+    documented_language_codes_batch, documented_language_codes_live, is_anarlog_proxy,
+    is_local_host, normalize_languages,
 };
 pub use adapter::{StreamingBatchEvent, StreamingBatchStream};
 

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -93,10 +93,26 @@ pub enum Provider {
     Pyannote,
     #[strum(serialize = "cohere")]
     Cohere,
+    #[strum(serialize = "aws_transcribe")]
+    AwsTranscribe,
+    #[strum(serialize = "azure_speech")]
+    AzureSpeech,
+    #[strum(serialize = "google_cloud")]
+    GoogleCloud,
+    #[strum(serialize = "groq")]
+    Groq,
+    #[strum(serialize = "revai")]
+    RevAi,
+    #[strum(serialize = "speechmatics")]
+    Speechmatics,
+    #[strum(serialize = "together")]
+    Together,
+    #[strum(serialize = "xai")]
+    Xai,
 }
 
 impl Provider {
-    const ALL: [Provider; 13] = [
+    const ALL: [Provider; 21] = [
         Self::AquaVoice,
         Self::Cartesia,
         Self::Deepgram,
@@ -110,6 +126,14 @@ impl Provider {
         Self::Mistral,
         Self::Pyannote,
         Self::Cohere,
+        Self::AwsTranscribe,
+        Self::AzureSpeech,
+        Self::GoogleCloud,
+        Self::Groq,
+        Self::RevAi,
+        Self::Speechmatics,
+        Self::Together,
+        Self::Xai,
     ];
 
     pub fn from_host(host: &str) -> Option<Self> {
@@ -168,6 +192,20 @@ impl Provider {
                 name: "Authorization",
                 prefix: Some("Bearer "),
             },
+            Self::AzureSpeech => Auth::Header {
+                name: "Ocp-Apim-Subscription-Key",
+                prefix: None,
+            },
+            Self::AwsTranscribe
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together
+            | Self::Xai => Auth::Header {
+                name: "Authorization",
+                prefix: Some("Bearer "),
+            },
         }
     }
 
@@ -194,6 +232,14 @@ impl Provider {
             Self::Mistral => "api.mistral.ai",
             Self::Pyannote => "api.pyannote.ai",
             Self::Cohere => "api.cohere.com",
+            Self::AwsTranscribe => "transcribe.us-east-1.amazonaws.com",
+            Self::AzureSpeech => "api.cognitive.microsoft.com",
+            Self::GoogleCloud => "speech.googleapis.com",
+            Self::Groq => "api.groq.com",
+            Self::RevAi => "api.rev.ai",
+            Self::Speechmatics => "eu1.asr.api.speechmatics.com",
+            Self::Together => "api.together.xyz",
+            Self::Xai => "api.x.ai",
         }
     }
 
@@ -212,6 +258,14 @@ impl Provider {
             Self::Mistral => "api.mistral.ai",
             Self::Pyannote => "api.pyannote.ai",
             Self::Cohere => "api.cohere.com",
+            Self::AwsTranscribe => "transcribestreaming.us-east-1.amazonaws.com",
+            Self::AzureSpeech => "api.cognitive.microsoft.com",
+            Self::GoogleCloud => "speech.googleapis.com",
+            Self::Groq => "api.groq.com",
+            Self::RevAi => "api.rev.ai",
+            Self::Speechmatics => "eu2.rt.speechmatics.com",
+            Self::Together => "api.together.xyz",
+            Self::Xai => "api.x.ai",
         }
     }
 
@@ -230,6 +284,14 @@ impl Provider {
             Self::Mistral => "/v1/audio/transcriptions/realtime",
             Self::Pyannote => "/v1/diarize",
             Self::Cohere => "",
+            Self::Xai => "/v1/stt",
+            Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together => "",
         }
     }
 
@@ -248,6 +310,14 @@ impl Provider {
             Self::Mistral => None,
             Self::Pyannote => Some("https://api.pyannote.ai/v1"),
             Self::Cohere => Some("https://api.cohere.com/v2"),
+            Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together
+            | Self::Xai => None,
         }
     }
 
@@ -266,6 +336,14 @@ impl Provider {
             Self::Mistral => "https://api.mistral.ai/v1",
             Self::Pyannote => "https://api.pyannote.ai",
             Self::Cohere => "https://api.cohere.com/v2",
+            Self::AwsTranscribe => "https://transcribe.us-east-1.amazonaws.com",
+            Self::AzureSpeech => "https://api.cognitive.microsoft.com",
+            Self::GoogleCloud => "https://speech.googleapis.com/v1",
+            Self::Groq => "https://api.groq.com/openai/v1",
+            Self::RevAi => "https://api.rev.ai/speechtotext/v1",
+            Self::Speechmatics => "https://eu1.asr.api.speechmatics.com/v2",
+            Self::Together => "https://api.together.xyz/v1",
+            Self::Xai => "https://api.x.ai/v1",
         }
     }
 
@@ -284,10 +362,24 @@ impl Provider {
             Self::Mistral => "mistral.ai",
             Self::Pyannote => "pyannote.ai",
             Self::Cohere => "cohere.com",
+            Self::AwsTranscribe => "amazonaws.com",
+            Self::AzureSpeech => "cognitive.microsoft.com",
+            Self::GoogleCloud => "googleapis.com",
+            Self::Groq => "groq.com",
+            Self::RevAi => "rev.ai",
+            Self::Speechmatics => "speechmatics.com",
+            Self::Together => "together.xyz",
+            Self::Xai => "x.ai",
         }
     }
 
     pub fn is_host(&self, host: &str) -> bool {
+        if *self == Self::AzureSpeech
+            && (host == "cognitiveservices.azure.com"
+                || host.ends_with(".cognitiveservices.azure.com"))
+        {
+            return true;
+        }
         let domain = self.domain();
         host == domain || host.ends_with(&format!(".{}", domain))
     }
@@ -320,6 +412,14 @@ impl Provider {
             Self::Mistral => "MISTRAL_API_KEY",
             Self::Pyannote => "PYANNOTE_API_KEY",
             Self::Cohere => "COHERE_API_KEY",
+            Self::AwsTranscribe => "AWS_TRANSCRIBE_API_KEY",
+            Self::AzureSpeech => "AZURE_SPEECH_API_KEY",
+            Self::GoogleCloud => "GOOGLE_CLOUD_ACCESS_TOKEN",
+            Self::Groq => "GROQ_API_KEY",
+            Self::RevAi => "REVAI_ACCESS_TOKEN",
+            Self::Speechmatics => "SPEECHMATICS_API_KEY",
+            Self::Together => "TOGETHER_API_KEY",
+            Self::Xai => "XAI_API_KEY",
         }
     }
 
@@ -338,6 +438,14 @@ impl Provider {
             Self::Mistral => "voxtral-mini-transcribe-realtime-2602",
             Self::Pyannote => "parakeet-tdt-0.6b-v3",
             Self::Cohere => "cohere-transcribe-03-2026",
+            Self::AwsTranscribe => "amazon-transcribe",
+            Self::AzureSpeech => "fast-transcription",
+            Self::GoogleCloud => "latest_long",
+            Self::Groq => "whisper-large-v3-turbo",
+            Self::RevAi => "machine",
+            Self::Speechmatics => "enhanced",
+            Self::Together => "openai/whisper-large-v3",
+            Self::Xai => "xai-stt",
         }
     }
 
@@ -345,9 +453,19 @@ impl Provider {
         match self {
             Self::AquaVoice => 16000,
             Self::OpenAI => 24000,
-            Self::ElevenLabs | Self::DashScope | Self::Mistral | Self::Pyannote | Self::Cohere => {
-                16000
-            }
+            Self::ElevenLabs
+            | Self::DashScope
+            | Self::Mistral
+            | Self::Pyannote
+            | Self::Cohere
+            | Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together
+            | Self::Xai => 16000,
             _ => 16000,
         }
     }
@@ -367,6 +485,14 @@ impl Provider {
             Self::Mistral => "voxtral-mini-2602",
             Self::Pyannote => "parakeet-tdt-0.6b-v3",
             Self::Cohere => "cohere-transcribe-03-2026",
+            Self::AwsTranscribe => "amazon-transcribe",
+            Self::AzureSpeech => "fast-transcription",
+            Self::GoogleCloud => "latest_long",
+            Self::Groq => "whisper-large-v3-turbo",
+            Self::RevAi => "machine",
+            Self::Speechmatics => "enhanced",
+            Self::Together => "openai/whisper-large-v3",
+            Self::Xai => "xai-stt",
         }
     }
 
@@ -374,16 +500,26 @@ impl Provider {
         match self {
             Self::Deepgram => &[("model", "nova-3-general"), ("mip_opt_out", "false")],
             Self::OpenAI => &[("intent", "transcription")],
-            Self::AquaVoice | Self::DashScope | Self::Mistral | Self::Pyannote | Self::Cohere => {
-                &[]
-            }
+            Self::AquaVoice
+            | Self::DashScope
+            | Self::Mistral
+            | Self::Pyannote
+            | Self::Cohere
+            | Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together
+            | Self::Xai => &[],
             _ => &[],
         }
     }
 
     pub fn supports_native_multichannel(&self) -> bool {
         match self {
-            Self::Deepgram | Self::Gladia => true,
+            Self::Deepgram | Self::Gladia | Self::Xai => true,
             Self::AquaVoice
             | Self::Cartesia
             | Self::Soniox
@@ -394,7 +530,14 @@ impl Provider {
             | Self::DashScope
             | Self::Mistral
             | Self::Pyannote
-            | Self::Cohere => false,
+            | Self::Cohere
+            | Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together => false,
         }
     }
 
@@ -409,7 +552,18 @@ impl Provider {
             Self::OpenAI => &[],
             Self::Gladia => &[],
             Self::ElevenLabs => &["commit"],
-            Self::DashScope | Self::Mistral | Self::Pyannote | Self::Cohere => &[],
+            Self::DashScope
+            | Self::Mistral
+            | Self::Pyannote
+            | Self::Cohere
+            | Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together
+            | Self::Xai => &[],
         }
     }
 
@@ -428,9 +582,19 @@ impl Provider {
                     "words_accurate_timestamps": true
                 }
             })),
-            Self::AquaVoice | Self::Cartesia | Self::Mistral | Self::Pyannote | Self::Cohere => {
-                None
-            }
+            Self::AquaVoice
+            | Self::Cartesia
+            | Self::Mistral
+            | Self::Pyannote
+            | Self::Cohere
+            | Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together
+            | Self::Xai => None,
             _ => None,
         }
     }
@@ -472,6 +636,14 @@ impl Provider {
             Self::OpenAI => from_adapter(&crate::adapter::OpenAIAdapter::default(), msg),
             Self::Pyannote => None,
             Self::Cohere => None,
+            Self::Xai => from_adapter(&crate::adapter::XaiAdapter, msg),
+            Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together => None,
         }
     }
 
@@ -489,7 +661,15 @@ impl Provider {
             | Self::DashScope
             | Self::Mistral
             | Self::Pyannote
-            | Self::Cohere => None,
+            | Self::Cohere
+            | Self::AwsTranscribe
+            | Self::AzureSpeech
+            | Self::GoogleCloud
+            | Self::Groq
+            | Self::RevAi
+            | Self::Speechmatics
+            | Self::Together
+            | Self::Xai => None,
         }
     }
 

--- a/crates/owhisper-client/tests/provider_batch_e2e.rs
+++ b/crates/owhisper-client/tests/provider_batch_e2e.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 
 use owhisper_client::{
     AssemblyAIAdapter, BatchClient, BatchSttAdapter, CohereAdapter, DeepgramAdapter,
-    ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, OpenAIAdapter, Provider, SonioxAdapter,
+    ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, MistralAdapter, OpenAIAdapter, Provider,
+    SonioxAdapter,
 };
 use owhisper_interface::ListenParams;
 
@@ -65,5 +66,6 @@ mod direct_batch {
     direct_batch_test!(fireworks, FireworksAdapter, Provider::Fireworks);
     direct_batch_test!(openai, OpenAIAdapter, Provider::OpenAI);
     direct_batch_test!(elevenlabs, ElevenLabsAdapter, Provider::ElevenLabs);
+    direct_batch_test!(mistral, MistralAdapter, Provider::Mistral);
     direct_batch_test!(cohere, CohereAdapter, Provider::Cohere);
 }

--- a/crates/transcribe-proxy/src/routes/batch/sync.rs
+++ b/crates/transcribe-proxy/src/routes/batch/sync.rs
@@ -302,6 +302,18 @@ pub(super) async fn transcribe_with_provider(
                 "{provider:?} does not support batch transcription",
             )));
         }
+        Provider::AwsTranscribe
+        | Provider::AzureSpeech
+        | Provider::GoogleCloud
+        | Provider::Groq
+        | Provider::RevAi
+        | Provider::Speechmatics
+        | Provider::Together
+        | Provider::Xai => {
+            return Err(BatchAttemptError::Unsupported(format!(
+                "{provider:?} is a direct BYOK provider",
+            )));
+        }
     };
 
     result.map_err(map_provider_error)

--- a/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
@@ -63,6 +63,14 @@ fn build_upstream_url_with_adapter(
         Provider::AquaVoice => unreachable!("aquavoice only supports batch transcription"),
         Provider::Pyannote => unreachable!("pyannote only supports batch transcription"),
         Provider::Cohere => unreachable!("cohere only supports batch transcription"),
+        Provider::AwsTranscribe
+        | Provider::AzureSpeech
+        | Provider::GoogleCloud
+        | Provider::Groq
+        | Provider::RevAi
+        | Provider::Speechmatics
+        | Provider::Together
+        | Provider::Xai => unreachable!("direct BYOK provider is not configured in the proxy"),
     }
 }
 
@@ -94,6 +102,14 @@ fn build_initial_message_with_adapter(
         Provider::AquaVoice => unreachable!("aquavoice only supports batch transcription"),
         Provider::Pyannote => unreachable!("pyannote only supports batch transcription"),
         Provider::Cohere => unreachable!("cohere only supports batch transcription"),
+        Provider::AwsTranscribe
+        | Provider::AzureSpeech
+        | Provider::GoogleCloud
+        | Provider::Groq
+        | Provider::RevAi
+        | Provider::Speechmatics
+        | Provider::Together
+        | Provider::Xai => unreachable!("direct BYOK provider is not configured in the proxy"),
     };
 
     msg.and_then(|m| match m {
@@ -128,6 +144,14 @@ fn build_response_transformer(
             }
             Provider::Pyannote => unreachable!("pyannote only supports batch transcription"),
             Provider::Cohere => unreachable!("cohere only supports batch transcription"),
+            Provider::AwsTranscribe
+            | Provider::AzureSpeech
+            | Provider::GoogleCloud
+            | Provider::Groq
+            | Provider::RevAi
+            | Provider::Speechmatics
+            | Provider::Together
+            | Provider::Xai => unreachable!("direct BYOK provider is not configured in the proxy"),
         };
 
         if provider == Provider::Soniox && proxy_debug_enabled() {

--- a/crates/transcribe-proxy/tests/common/mod.rs
+++ b/crates/transcribe-proxy/tests/common/mod.rs
@@ -117,6 +117,14 @@ pub fn env_with_provider(provider: Provider, api_key: String) -> transcribe_prox
         Provider::AquaVoice => env.stt.aquavoice_api_key = Some(api_key),
         Provider::Cohere => env.stt.cohere_api_key = Some(api_key),
         Provider::Pyannote => {}
+        Provider::AwsTranscribe
+        | Provider::AzureSpeech
+        | Provider::GoogleCloud
+        | Provider::Groq
+        | Provider::RevAi
+        | Provider::Speechmatics
+        | Provider::Together
+        | Provider::Xai => panic!("{provider} is not configured in the Pro proxy"),
     }
     env
 }

--- a/crates/transcribe-proxy/tests/proxy_provider_e2e.rs
+++ b/crates/transcribe-proxy/tests/proxy_provider_e2e.rs
@@ -257,6 +257,12 @@ mod passthrough {
             owhisper_client::ElevenLabsAdapter,
             Provider::ElevenLabs
         );
+        passthrough_live_test!(mistral, owhisper_client::MistralAdapter, Provider::Mistral);
+        passthrough_live_test!(
+            dashscope,
+            owhisper_client::DashScopeAdapter,
+            Provider::DashScope
+        );
     }
 
     pub mod batch {
@@ -269,6 +275,7 @@ mod passthrough {
         passthrough_batch_test!(fireworks, Provider::Fireworks);
         passthrough_batch_test!(openai, Provider::OpenAI);
         passthrough_batch_test!(elevenlabs, Provider::ElevenLabs);
+        passthrough_batch_test!(mistral, Provider::Mistral);
     }
 }
 
@@ -284,6 +291,8 @@ mod anarlog {
         anarlog_live_test!(gladia, Provider::Gladia);
         anarlog_live_test!(fireworks, Provider::Fireworks);
         anarlog_live_test!(elevenlabs, Provider::ElevenLabs);
+        anarlog_live_test!(mistral, Provider::Mistral);
+        anarlog_live_test!(dashscope, Provider::DashScope);
     }
 
     pub mod batch {
@@ -296,5 +305,6 @@ mod anarlog {
         anarlog_batch_test!(fireworks, Provider::Fireworks);
         anarlog_batch_test!(openai, Provider::OpenAI);
         anarlog_batch_test!(elevenlabs, Provider::ElevenLabs);
+        anarlog_batch_test!(mistral, Provider::Mistral);
     }
 }

--- a/plugins/transcription/js/bindings.gen.ts
+++ b/plugins/transcription/js/bindings.gen.ts
@@ -202,7 +202,7 @@ transcriptionEvent: "plugin:transcription:transcription-event"
 export type BatchAlternatives = { transcript: string; confidence: number; words?: BatchWord[] }
 export type BatchChannel = { alternatives: BatchAlternatives[] }
 export type BatchErrorCode = "unknown" | "timed_out" | "audio_metadata_join_failed" | "audio_metadata_read_failed" | "batch_capability_unsupported" | "direct_batch_unsupported" | "progressive_batch_unsupported" | "direct_request_failed" | "progressive_actor_spawn_failed" | "progressive_start_cancelled" | "progressive_stopped_without_completion_signal" | "progressive_finished_without_status" | "progressive_start_failed" | "progressive_stream_error" | "progressive_stream_timeout"
-export type BatchProvider = "argmax" | "whispercpp" | "deepgram" | "soniox" | "assemblyai" | "fireworks" | "openai" | "gladia" | "elevenlabs" | "pyannote" | "dashscope" | "mistral" | "anarlog" | "am" | "soniqo" | "applespeech" | "aquavoice" | "cartesia" | "cohere"
+export type BatchProvider = "argmax" | "whispercpp" | "deepgram" | "soniox" | "assemblyai" | "fireworks" | "openai" | "gladia" | "elevenlabs" | "pyannote" | "dashscope" | "mistral" | "anarlog" | "am" | "soniqo" | "applespeech" | "aquavoice" | "cartesia" | "cohere" | "aws_transcribe" | "azure_speech" | "google_cloud" | "groq" | "revai" | "speechmatics" | "together" | "xai"
 export type BatchResponse = { metadata: JsonValue; results: BatchResults }
 export type BatchResults = { channels: BatchChannel[] }
 export type BatchRunMode = "direct" | "streamed"

--- a/plugins/transcription/src/listener/commands.rs
+++ b/plugins/transcription/src/listener/commands.rs
@@ -136,6 +136,7 @@ pub async fn suggest_providers_for_languages_live<R: tauri::Runtime>(
         AdapterKind::ElevenLabs,
         AdapterKind::DashScope,
         AdapterKind::Mistral,
+        AdapterKind::Xai,
     ];
 
     let mut with_support: Vec<_> = all_providers


### PR DESCRIPTION
- Added direct transcription providers
- Expanded end-to-end (Pro) coverage to ensure transcription flows work end-to-end

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6380 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6379 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive change across transcription adapters and desktop provider wiring; credentials and varied vendor APIs increase integration risk, but Pro proxy paths are explicitly excluded for the new BYOK providers.
> 
> **Overview**
> **Direct BYOK speech-to-text** is extended with Groq, xAI, Together, Speechmatics, Azure AI Speech, Google Cloud, Amazon Transcribe (via an OpenAI-compatible gateway), and Rev AI. Rust adds batch adapters (plus **xAI live** WebSocket), wires them through `listener2-core` batch routing, and marks them **batch-only** in the listener except xAI realtime. The **transcribe-proxy** treats these as direct BYOK and does not route them through Pro batch or Anarlog streaming.
> 
> The **desktop STT settings** expose the new providers with capability badges (batch-only, short batch, gateway), default models, configure copy, and batch transcription routing. **Fireworks** is enabled with `whisper-v3-turbo` instead of a placeholder model.
> 
> **CI (`stt_e2e`)** adds Mistral and DashScope to path filters and manual runs; change detection can emit an empty provider list instead of defaulting to Deepgram; DashScope skips direct batch E2E and proxy batch suites while still running live tests.
> 
> **Pro E2E** gains Mistral batch/direct tests and DashScope/Mistral live proxy suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 421997593b8627da7e677489a58acc1a8208289b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->