### PR TITLE
Match main area double-click behavior

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -837,6 +837,7 @@ function useMainAreaTopWindowDrag(enabled: boolean) {
         !enabled ||
         event.button !== 0 ||
         isInteractiveMainAreaDragTarget(event.target) ||
+        isNativeWindowDragTarget(event.target) ||
         !isWithinMainAreaTopDragRegion(event)
       ) {
         return;
@@ -890,6 +891,17 @@ function isInteractiveMainAreaDragTarget(target: EventTarget | null): boolean {
         "[role='textbox']",
       ].join(","),
     ),
+  );
+}
+
+function isNativeWindowDragTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  return (
+    target.hasAttribute("data-tauri-drag-region") &&
+    target.getAttribute("data-tauri-drag-region") !== "false"
   );
 }
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -654,6 +654,7 @@ export function ClassicMainBody() {
             data-main-content-panel
             className="h-full min-h-0 min-w-0 flex-1 overflow-auto"
             onClickCapture={mainAreaTopDrag.onClickCapture}
+            onDoubleClickCapture={mainAreaTopDrag.onDoubleClickCapture}
             onPointerCancel={mainAreaTopDrag.onPointerEnd}
             onPointerDown={mainAreaTopDrag.onPointerDown}
             onPointerMove={mainAreaTopDrag.onPointerMove}
@@ -830,8 +831,32 @@ function useMainAreaTopWindowDrag(enabled: boolean) {
     [],
   );
 
+  const handleDoubleClickCapture = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (
+        !enabled ||
+        event.button !== 0 ||
+        isInteractiveMainAreaDragTarget(event.target) ||
+        !isWithinMainAreaTopDragRegion(event)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (isTauri()) {
+        void getCurrentWindow()
+          .toggleMaximize()
+          .catch(() => {});
+      }
+    },
+    [enabled],
+  );
+
   return {
     onClickCapture: handleClickCapture,
+    onDoubleClickCapture: handleDoubleClickCapture,
     onPointerDown: handlePointerDown,
     onPointerEnd: handlePointerEnd,
     onPointerMove: handlePointerMove,
@@ -839,7 +864,7 @@ function useMainAreaTopWindowDrag(enabled: boolean) {
 }
 
 function isWithinMainAreaTopDragRegion(
-  event: PointerEvent<HTMLDivElement>,
+  event: MouseEvent<HTMLDivElement> | PointerEvent<HTMLDivElement>,
 ): boolean {
   const rect = event.currentTarget.getBoundingClientRect();
   const offsetY = event.clientY - rect.top;

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -119,6 +119,12 @@ vi.mock("~/main/tab-content", () => ({
       <div data-testid="main-tab-content">
         <input aria-label="Session title" />
       </div>
+    ) : tab.type === "empty" ? (
+      <div data-testid="main-tab-content">
+        <div data-tauri-drag-region data-testid="native-main-tab-drag-region">
+          <span data-testid="native-main-tab-drag-target">{tab.type}</span>
+        </div>
+      </div>
     ) : (
       <div data-testid="main-tab-content">{tab.type}</div>
     ),
@@ -648,6 +654,34 @@ describe("ClassicMainBody", () => {
     const mainContent = screen.getByTestId("main-tab-content");
 
     fireEvent.doubleClick(mainContent, {
+      button: 0,
+      clientX: 12,
+      clientY: 12,
+    });
+
+    expect(mocks.toggleMaximize).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves exact native drag-region double-clicks to Tauri", () => {
+    render(<ClassicMainBody />);
+
+    const nativeDragRegion = screen.getByTestId("native-main-tab-drag-region");
+
+    fireEvent.doubleClick(nativeDragRegion, {
+      button: 0,
+      clientX: 12,
+      clientY: 12,
+    });
+
+    expect(mocks.toggleMaximize).not.toHaveBeenCalled();
+  });
+
+  it("toggles maximization from children of a native drag region", () => {
+    render(<ClassicMainBody />);
+
+    const nativeDragTarget = screen.getByTestId("native-main-tab-drag-target");
+
+    fireEvent.doubleClick(nativeDragTarget, {
       button: 0,
       clientX: 12,
       clientY: 12,

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   platform: "macos" as "linux" | "macos" | "windows",
   resizeListeners: [] as Array<() => void>,
   startDragging: vi.fn().mockResolvedValue(undefined),
+  toggleMaximize: vi.fn().mockResolvedValue(undefined),
   devtoolsPanelActionListeners: [] as Array<
     (event: { payload: { action: string } }) => void
   >,
@@ -79,6 +80,7 @@ vi.mock("@tauri-apps/api/window", () => ({
       };
     }),
     startDragging: mocks.startDragging,
+    toggleMaximize: mocks.toggleMaximize,
   }),
 }));
 
@@ -204,6 +206,7 @@ describe("ClassicMainBody", () => {
     mocks.platform = "macos";
     mocks.resizeListeners = [];
     mocks.startDragging.mockClear();
+    mocks.toggleMaximize.mockClear();
     mocks.devtoolsPanelActionListeners = [];
     mocks.windowsCommands.devtoolsPanelHide.mockClear();
     mocks.windowsCommands.devtoolsPanelShow.mockClear();
@@ -639,6 +642,20 @@ describe("ClassicMainBody", () => {
     expect(mocks.startDragging).toHaveBeenCalledTimes(1);
   });
 
+  it("toggles window maximization from the top 48px of the main area", () => {
+    render(<ClassicMainBody />);
+
+    const mainContent = screen.getByTestId("main-tab-content");
+
+    fireEvent.doubleClick(mainContent, {
+      button: 0,
+      clientX: 12,
+      clientY: 12,
+    });
+
+    expect(mocks.toggleMaximize).toHaveBeenCalledTimes(1);
+  });
+
   it("does not start window dragging from an input in the top drag strip", () => {
     mocks.currentTab = {
       active: true,
@@ -666,6 +683,27 @@ describe("ClassicMainBody", () => {
     expect(mocks.startDragging).not.toHaveBeenCalled();
   });
 
+  it("does not toggle window maximization from an input in the top drag strip", () => {
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-1",
+      type: "sessions",
+    };
+
+    render(<ClassicMainBody />);
+
+    const titleInput = screen.getByRole("textbox", { name: "Session title" });
+
+    fireEvent.doubleClick(titleInput, {
+      button: 0,
+      clientX: 240,
+      clientY: 12,
+    });
+
+    expect(mocks.toggleMaximize).not.toHaveBeenCalled();
+  });
+
   it("does not start window dragging below the main area drag strip", () => {
     render(<ClassicMainBody />);
 
@@ -684,6 +722,20 @@ describe("ClassicMainBody", () => {
     });
 
     expect(mocks.startDragging).not.toHaveBeenCalled();
+  });
+
+  it("does not toggle window maximization below the main area drag strip", () => {
+    render(<ClassicMainBody />);
+
+    const mainContent = screen.getByTestId("main-tab-content");
+
+    fireEvent.doubleClick(mainContent, {
+      button: 0,
+      clientX: 12,
+      clientY: 56,
+    });
+
+    expect(mocks.toggleMaximize).not.toHaveBeenCalled();
   });
 
   it("renders the shell while the initial tab is still loading", async () => {


### PR DESCRIPTION
Toggle maximization for eligible double-clicks in the main drag strip and cover exclusions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop shell input handling only; no auth, data, or backend changes.
> 
> **Overview**
> Adds **double-click to toggle window maximization** in the desktop main content panel’s top **48px** drag strip, mirroring the existing pointer-drag window-move behavior on that region.
> 
> The main panel wires **`onDoubleClickCapture`** from `useMainAreaTopWindowDrag`. On eligible left-button double-clicks in the strip (when top-drag is enabled), the handler calls Tauri **`toggleMaximize`**, with the same **interactive control** exclusions as dragging. It also skips targets that **are** a `data-tauri-drag-region` element so native Tauri title-bar double-click still applies; **children inside** a drag region still trigger maximize.
> 
> Tests mock **`toggleMaximize`** and cover the happy path, native drag-region vs child behavior, inputs in the strip, and clicks below the strip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00dd0d1d26215644cd14c9b7381547e44e35cce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->