### PR TITLE
Make download buttons the only row action

### DIFF
--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -73,6 +73,7 @@ function Component() {
                         <span className="font-medium">{download.name}</span>
                         <a
                           href={download.url}
+                          aria-label={`Download ${download.name} for ${section.name}`}
                           onClick={() =>
                             track("download_clicked", {
                               platform: section.platform,

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -69,27 +69,27 @@ function Component() {
                 <ul className="border-color-subtle divide-y divide-[var(--color-border-subtle)] border-y">
                   {section.downloads.map((download) => (
                     <li key={download.name}>
-                      <a
-                        href={download.url}
-                        onClick={() =>
-                          track("download_clicked", {
-                            platform: section.platform,
-                            spec: download.name,
-                            source: "download_page",
-                          })
-                        }
-                        className="hover:bg-surface-subtle flex items-center justify-between gap-6 px-1 py-5 transition-colors"
-                      >
+                      <div className="flex items-center justify-between gap-6 px-1 py-5">
                         <span className="font-medium">{download.name}</span>
-                        <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[#181613] px-4 py-3 text-[13px] font-medium text-white sm:px-5 sm:text-sm">
+                        <a
+                          href={download.url}
+                          onClick={() =>
+                            track("download_clicked", {
+                              platform: section.platform,
+                              spec: download.name,
+                              source: "download_page",
+                            })
+                          }
+                          className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[#181613] px-4 py-3 text-[13px] font-medium text-white sm:px-5 sm:text-sm"
+                        >
                           Download
                           <Download
                             size={16}
                             strokeWidth={2}
                             aria-hidden="true"
                           />
-                        </span>
-                      </a>
+                        </a>
+                      </div>
                     </li>
                   ))}
                 </ul>


### PR DESCRIPTION
Keep platform titles static and move each download URL and analytics handler onto its button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-page markup and a11y tweak on the marketing download route with no backend or shared logic changes.
> 
> **Overview**
> On the download page, each platform row is no longer one big link. The **spec label** stays plain text in a flex row, and only the **Download** pill is an `<a>` with the file URL, the existing `download_clicked` analytics, and a new `aria-label` (`Download {spec} for {platform}`).
> 
> Layout and styling move from the outer anchor to the button so the visual treatment is unchanged while click/focus targets match the intended action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b99950d16ac87f9919c1accaf5f5c57133ebfdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->