### PR TITLE
Prevent Soniqo live transcription crashes

### DIFF
--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -275,10 +275,16 @@ private struct FileTranscriptionPayload: Codable {
   var error: String?
 }
 
-private struct LivePartialPayload: Codable {
-  var source: String
-  var text: String
-  var isFinal: Bool
+private final class LivePartialPayload: Codable {
+  let source: String
+  let text: String
+  let isFinal: Bool
+
+  init(source: String, text: String, isFinal: Bool) {
+    self.source = source
+    self.text = text
+    self.isFinal = isFinal
+  }
 }
 
 private struct LiveAppendPayload: Codable {


### PR DESCRIPTION
Use reference-backed live partial payloads so Swift JSON encoding does not copy invalid String-backed value storage. Verified with two live on-device captures, cargo check, and all transcribe-soniqo tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized Swift bridge change to a Codable payload type; no auth, data, or API contract changes beyond crash prevention.
> 
> **Overview**
> Fixes crashes during live Soniqo transcription when encoding partial results to JSON for the Rust bridge.
> 
> **`LivePartialPayload`** is changed from a value-type `struct` with mutable `var` fields to a **`final class`** with `let` properties and an explicit initializer. That keeps partial transcript strings on reference-backed storage so `JSONEncoder` no longer copies `String` values that can be invalid when bridging streaming ASR output in `appendLiveJSON` / `finalizeLiveJSON`. The encoded shape (`LiveAppendPayload` with `partials`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec86ea106a04f6b43244bdad9ef96bdabf1aea51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->