### PR TITLE
Update the 1.4.0 changelog

### DIFF
--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -1,6 +1,6 @@
 ---
-date: "2026-07-29"
-summary: "Anarlog 1.4.0 expands to Windows Preview and Linux Beta, adds automatic updates, and improves note editing, transcription, privacy, and reliability."
+date: "2026-07-30"
+summary: "Anarlog 1.4.0 expands to Windows Preview and Linux Beta, adds automatic updates and more AI providers, and improves editing, transcription, privacy, and reliability."
 ---
 
 <banner title="Windows Preview and Linux Beta" variant="info">
@@ -36,6 +36,8 @@ are still pending.
   syncing service
 - Make a newly configured transcription or language-model provider current
   directly from the confirmation after saving its first API key
+- Connect directly to Cohere, Groq, xAI, Together AI, Fireworks AI, Cerebras,
+  Amazon Bedrock, or Google Vertex AI for summaries and chat
 - Choose newer hosted AI models, including Claude Opus 5, Gemini 3.6 Flash,
   Kimi K2.7 Code, and GLM 5.2
 - Restore excluded meeting apps reliably after startup and present cleaner,
@@ -51,6 +53,8 @@ are still pending.
   removed or a deletion cannot complete
 - Avoid macOS system-audio capture crashes during transient Core Audio setup
   and format changes
+- Prevent on-device Parakeet live transcription from unexpectedly quitting
+  Anarlog on macOS
 - Keep live speaker labels within the actual remote-participant count for each
   audio channel
 - Use compatible GPT-5.6 Terra settings and the corrected Parakeet CoreML batch


### PR DESCRIPTION
Document the expanded direct AI providers and the verified macOS on-device transcription crash fix. Refresh the release date and index summary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no application or infrastructure changes.
> 
> **Overview**
> **Updates the 1.4.0 changelog** to match the current release messaging: release date moves to **2026-07-30**, and the frontmatter summary now mentions **more AI providers**.
> 
> Under **Updates and settings**, documents direct connections to **Cohere, Groq, xAI, Together AI, Fireworks AI, Cerebras, Amazon Bedrock, and Google Vertex AI** for summaries and chat.
> 
> Under **Reliability and privacy**, adds a fix note for **on-device Parakeet live transcription** unexpectedly quitting Anarlog on macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c37dd333b362e03ee9f3c2cad19d5262cd0ebc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->