### PR TITLE
Handle Bedrock models that require default temperature

### DIFF
--- a/apps/desktop/src/ai/model-settings.test.ts
+++ b/apps/desktop/src/ai/model-settings.test.ts
@@ -42,6 +42,11 @@ describe("deterministicGenerationSettings", () => {
     expect(
       deterministicGenerationSettings(model("anthropic", "claude-opus-4.8")),
     ).toEqual({});
+    expect(
+      deterministicGenerationSettings(
+        model("amazon_bedrock", "anthropic.claude-opus-4-8"),
+      ),
+    ).toEqual({});
   });
 
   it("omits temperature for GPT-5.6 Terra models", () => {
@@ -53,6 +58,11 @@ describe("deterministicGenerationSettings", () => {
     expect(
       deterministicGenerationSettings(
         model("anarlog", "openai/gpt-5.6-terra-2026-07-28"),
+      ),
+    ).toEqual({});
+    expect(
+      deterministicGenerationSettings(
+        model("amazon_bedrock", "openai.gpt-5.6-terra"),
       ),
     ).toEqual({});
   });

--- a/apps/desktop/src/ai/model-settings.ts
+++ b/apps/desktop/src/ai/model-settings.ts
@@ -20,11 +20,11 @@ function requiresDefaultTemperature(model: LanguageModel): boolean {
   const normalizedModelId = modelId.toLowerCase().replace(/\./g, "-");
   const modelName = normalizedModelId.includes("/")
     ? normalizedModelId.split("/").pop()!
-    : normalizedModelId;
+    : normalizedModelId.replace(/^(?:anthropic|openai)-/, "");
 
   const isClaude48 =
     (provider.startsWith("anthropic") ||
-      normalizedModelId.startsWith("anthropic/")) &&
+      /(?:^|[./])anthropic[./]/.test(modelId.toLowerCase())) &&
     /^claude-(?:opus|sonnet|haiku)-4-8(?:$|-)/.test(modelName);
   const isGpt56Terra = /^gpt-5-6-terra(?:$|-)/.test(modelName);
 


### PR DESCRIPTION
Recognize dotted Anthropic and OpenAI Bedrock model IDs when deciding whether to omit deterministic temperature settings.

Add regression coverage for Claude 4.8 and GPT-5.6 Terra through Amazon Bedrock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small heuristic change in model ID parsing with added unit tests; only affects whether temperature is omitted for specific model families.
> 
> **Overview**
> **`requiresDefaultTemperature`** now treats Amazon Bedrock IDs such as `anthropic.claude-opus-4-8` and `openai.gpt-5.6-terra` like other Claude 4.8 and GPT-5.6 Terra models, so **`deterministicGenerationSettings`** omits `temperature: 0` instead of forcing it.
> 
> Detection changes: Claude 4.8 is recognized when the raw `modelId` contains an `anthropic` segment with `.` or `/` (not only `anthropic/` prefixes), and the derived model name strips leading `anthropic-` / `openai-` prefixes so dotted Bedrock-style IDs normalize correctly.
> 
> Regression tests cover both Bedrock model shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a01dc669e38e93ca586ca3779284f78d892dde1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->