### PR TITLE
Fix direct transcription provider edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12785,6 +12785,7 @@ dependencies = [
  "transcribe-soniqo",
  "transcribe-speechanalyzer",
  "url",
+ "wiremock",
  "ws-client",
 ]
 

--- a/crates/owhisper-client/Cargo.toml
+++ b/crates/owhisper-client/Cargo.toml
@@ -46,3 +46,4 @@ rodio = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing-subscriber = { workspace = true }
+wiremock = { workspace = true }

--- a/crates/owhisper-client/src/adapter/speechmatics/mod.rs
+++ b/crates/owhisper-client/src/adapter/speechmatics/mod.rs
@@ -103,19 +103,17 @@ async fn do_transcribe_file(
         .send()
         .await?;
     let job: SpeechmaticsJob = ensure_success(response).await?.json().await?;
+    let terminal_error = terminal_job_error(&job);
 
     let transcript = match job.transcript {
         Some(transcript) => transcript,
         None if job.status == "done" => {
             fetch_transcript(client, api_base, api_key, &job.id).await?
         }
-        None if matches!(job.status.as_str(), "rejected" | "deleted") => {
-            return Err(Error::AudioProcessing(format!(
-                "Speechmatics job {}",
-                job.status
-            )));
-        }
-        None => wait_for_transcript(client, api_base, api_key, &job.id).await?,
+        None => match terminal_error {
+            Some(error) => return Err(error),
+            None => wait_for_transcript(client, api_base, api_key, &job.id).await?,
+        },
     };
 
     Ok(convert_response(transcript))
@@ -144,7 +142,12 @@ async fn wait_for_transcript(
     for _ in 0..30 {
         match fetch_transcript(client, api_base, api_key, job_id).await {
             Ok(transcript) => return Ok(transcript),
-            Err(Error::UnexpectedStatus { status, .. }) if status == StatusCode::NOT_FOUND => {}
+            Err(Error::UnexpectedStatus { status, .. }) if status == StatusCode::NOT_FOUND => {
+                let job = fetch_job(client, api_base, api_key, job_id).await?;
+                if let Some(error) = terminal_job_error(&job) {
+                    return Err(error);
+                }
+            }
             Err(error) => return Err(error),
         }
     }
@@ -152,6 +155,24 @@ async fn wait_for_transcript(
     Err(Error::AudioProcessing(
         "Speechmatics transcription did not finish before the polling limit".to_string(),
     ))
+}
+
+async fn fetch_job(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    job_id: &str,
+) -> Result<SpeechmaticsJob, Error> {
+    let mut url = jobs_url(api_base)?;
+    append_path_if_missing(&mut url, job_id);
+
+    let response = client
+        .get(url.to_string())
+        .bearer_auth(api_key)
+        .send()
+        .await?;
+    let payload: SpeechmaticsJobResponse = ensure_success(response).await?.json().await?;
+    Ok(payload.job)
 }
 
 async fn fetch_transcript(
@@ -178,8 +199,37 @@ async fn fetch_transcript(
 struct SpeechmaticsJob {
     id: String,
     status: String,
+    #[serde(default)]
+    errors: Vec<SpeechmaticsJobError>,
     #[serde(default, rename = "json-v2")]
     transcript: Option<SpeechmaticsTranscript>,
+}
+
+#[derive(serde::Deserialize)]
+struct SpeechmaticsJobResponse {
+    job: SpeechmaticsJob,
+}
+
+#[derive(serde::Deserialize)]
+struct SpeechmaticsJobError {
+    message: String,
+}
+
+fn terminal_job_error(job: &SpeechmaticsJob) -> Option<Error> {
+    if !matches!(job.status.as_str(), "rejected" | "deleted" | "expired") {
+        return None;
+    }
+
+    let detail = job
+        .errors
+        .last()
+        .map(|error| error.message.trim())
+        .filter(|message| !message.is_empty());
+    let message = match detail {
+        Some(detail) => format!("Speechmatics job {}: {detail}", job.status),
+        None => format!("Speechmatics job {}", job.status),
+    };
+    Some(Error::AudioProcessing(message))
 }
 
 #[derive(serde::Deserialize)]
@@ -290,6 +340,8 @@ fn parse_speaker_label(label: &str) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn converts_json_v2_words_and_speakers() {
@@ -342,5 +394,38 @@ mod tests {
             Some("world.")
         );
         assert_eq!(word.speaker, Some(2));
+    }
+
+    #[tokio::test]
+    async fn returns_rejected_job_details_while_polling() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/jobs/job-1/transcript"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/jobs/job-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "job": {
+                    "id": "job-1",
+                    "status": "rejected",
+                    "errors": [{ "message": "unsupported audio" }]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = crate::http_client::create_client();
+        let Err(error) = wait_for_transcript(&client, &server.uri(), "test-key", "job-1").await
+        else {
+            panic!("expected rejected job error");
+        };
+
+        assert!(matches!(
+            error,
+            Error::AudioProcessing(message)
+                if message == "Speechmatics job rejected: unsupported audio"
+        ));
     }
 }

--- a/crates/owhisper-client/src/adapter/xai/live.rs
+++ b/crates/owhisper-client/src/adapter/xai/live.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use anlg_ws_client::client::Message;
 use owhisper_interface::ListenParams;
 use owhisper_interface::stream::{Alternatives, Channel, Metadata, StreamResponse, Word};
@@ -25,6 +27,8 @@ impl RealtimeSttAdapter for XaiAdapter {
     }
 
     fn build_ws_url(&self, api_base: &str, params: &ListenParams, channels: u8) -> url::Url {
+        self.live_channels.store(channels.max(1), Ordering::Relaxed);
+
         let (mut url, existing_params) = if let Some(result) = build_proxy_ws_url(api_base) {
             result
         } else {
@@ -120,6 +124,7 @@ impl RealtimeSttAdapter for XaiAdapter {
             "transcript.partial" | "transcript.done" => {
                 let is_done = event.event_type == "transcript.done";
                 let channel_index = event.channel_index.unwrap_or(0);
+                let total_channels = self.live_channels.load(Ordering::Relaxed).max(1);
                 vec![StreamResponse::TranscriptResponse {
                     start: event.start.unwrap_or_default(),
                     duration: event.duration.unwrap_or_default(),
@@ -147,7 +152,7 @@ impl RealtimeSttAdapter for XaiAdapter {
                         }],
                     },
                     metadata: Metadata::default(),
-                    channel_index: vec![channel_index, 1],
+                    channel_index: vec![channel_index, i32::from(total_channels)],
                 }]
             }
             _ => Vec::new(),
@@ -199,8 +204,9 @@ mod tests {
             ..Default::default()
         };
 
-        let direct = XaiAdapter.build_ws_url("https://api.x.ai/v1", &params, 2);
-        let proxy = XaiAdapter.build_ws_url("https://api.anarlog.so/stt?provider=xai", &params, 1);
+        let adapter = XaiAdapter::default();
+        let direct = adapter.build_ws_url("https://api.x.ai/v1", &params, 2);
+        let proxy = adapter.build_ws_url("https://api.anarlog.so/stt?provider=xai", &params, 1);
 
         assert_eq!(direct.scheme(), "wss");
         assert_eq!(direct.path(), "/v1/stt");
@@ -214,7 +220,7 @@ mod tests {
 
     #[test]
     fn parses_partial_transcript() {
-        let responses = XaiAdapter.parse_response(
+        let responses = XaiAdapter::default().parse_response(
             r#"{"type":"transcript.partial","text":"hello","is_final":true,"speech_final":true,"start":0.1,"duration":0.5,"words":[{"text":"hello","start":0.1,"end":0.6,"speaker":1}]}"#,
         );
 
@@ -230,5 +236,19 @@ mod tests {
         assert!(*is_final);
         assert!(*speech_final);
         assert_eq!(channel.alternatives[0].words[0].speaker, Some(1));
+    }
+
+    #[test]
+    fn reports_the_configured_multichannel_total() {
+        let adapter = XaiAdapter::default();
+        adapter.build_ws_url("https://api.x.ai/v1", &ListenParams::default(), 2);
+
+        let responses = adapter
+            .parse_response(r#"{"type":"transcript.partial","text":"hello","channel_index":1}"#);
+
+        let StreamResponse::TranscriptResponse { channel_index, .. } = &responses[0] else {
+            panic!("expected transcript response");
+        };
+        assert_eq!(channel_index, &[1, 2]);
     }
 }

--- a/crates/owhisper-client/src/adapter/xai/mod.rs
+++ b/crates/owhisper-client/src/adapter/xai/mod.rs
@@ -1,10 +1,23 @@
 mod batch;
 mod live;
 
+use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+
 use crate::adapter::{LanguageQuality, LanguageSupport};
 
-#[derive(Clone, Default)]
-pub struct XaiAdapter;
+#[derive(Clone)]
+pub struct XaiAdapter {
+    live_channels: Arc<AtomicU8>,
+}
+
+impl Default for XaiAdapter {
+    fn default() -> Self {
+        Self {
+            live_channels: Arc::new(AtomicU8::new(1)),
+        }
+    }
+}
 
 impl XaiAdapter {
     pub fn language_support_live(_languages: &[anlg_language::Language]) -> LanguageSupport {

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -636,7 +636,7 @@ impl Provider {
             Self::OpenAI => from_adapter(&crate::adapter::OpenAIAdapter::default(), msg),
             Self::Pyannote => None,
             Self::Cohere => None,
-            Self::Xai => from_adapter(&crate::adapter::XaiAdapter, msg),
+            Self::Xai => from_adapter(&crate::adapter::XaiAdapter::default(), msg),
             Self::AwsTranscribe
             | Self::AzureSpeech
             | Self::GoogleCloud


### PR DESCRIPTION
Preserve the configured channel total in xAI live transcript responses. Recheck Speechmatics job state while polling so rejected, deleted, and expired jobs fail promptly with provider details.

Validation:
- pnpm fmt:check
- cargo test --locked -p owhisper-client
- cargo check --locked -p desktop
- cargo test -p desktop
- desktop CI macOS workspace test command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted adapter fixes with new unit tests; no auth or broad API surface changes.
> 
> **Overview**
> Fixes two direct-provider edge cases in **owhisper-client**.
> 
> **Speechmatics batch** now treats `rejected`, `deleted`, and **`expired`** jobs as terminal failures, including provider `errors` text when present. After the initial submit, that logic is shared via `terminal_job_error`; while **polling** for a transcript, a **404** triggers a **GET job** check so failed jobs fail fast instead of spinning until the poll limit. A **wiremock** test covers rejected jobs during polling.
> 
> **xAI live** stores the configured channel count when building the WebSocket URL and emits `channel_index` as `[active_channel, total_channels]` (e.g. `[1, 2]` for stereo) instead of always using `1` as the total. `XaiAdapter` is now a small stateful type (`Arc<AtomicU8>`) with `Default`, and provider wiring uses `XaiAdapter::default()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28cd94705f9084018f7a34ba98ee7f1dc5072c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->