### PR TITLE
Style meeting countdown as a badge

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -583,7 +583,7 @@ describe("OuterHeader", () => {
     });
   });
 
-  it("shows the meeting countdown to the left of the header action", () => {
+  it("shows the meeting countdown in a tooltip-style badge to the left of the header action", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-05T09:55:30.000Z"));
     mocks.nowMs = Date.now();
@@ -611,6 +611,10 @@ describe("OuterHeader", () => {
       "true",
     );
     expect(countdown.className).toContain("font-mono");
+    expect(countdown.className).toContain("rounded-md");
+    expect(countdown.className).toContain("border");
+    expect(countdown.className).toContain("shadow-sm");
+    expect(countdown.className).toContain("tabular-nums");
     expect(
       countdown.compareDocumentPosition(joinButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -312,7 +312,7 @@ function HeaderMeetingActionPill({
       {showCountdown ? (
         <div
           data-header-meeting-countdown
-          className="text-muted-foreground max-w-40 truncate font-mono text-xs whitespace-nowrap"
+          className="border-border bg-popover/80 text-popover-foreground max-w-40 truncate rounded-md border px-2.5 py-1 font-mono text-xs whitespace-nowrap tabular-nums shadow-sm backdrop-blur-sm"
         >
           {countdown.label}
         </div>


### PR DESCRIPTION
Give the header countdown a tooltip-inspired surface and lock its styling with a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Tailwind class changes on the header countdown with no logic or data-path changes.
> 
> **Overview**
> **Restyles the scheduled-meeting countdown** in `OuterHeader` from plain muted mono text to a small **tooltip-style badge** (border, popover surface, padding, shadow, backdrop blur, tabular nums) still shown to the left of the join/record pill.
> 
> The existing countdown test is renamed and extended to assert the new badge classes (`rounded-md`, `border`, `shadow-sm`, `tabular-nums`, etc.) so the look does not regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b601ef7778a85dd93a703d3c2de855ce0606bbe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->