### PR TITLE
Show local sync status during capture

### DIFF
--- a/apps/desktop/src/main/sync-status.test.tsx
+++ b/apps/desktop/src/main/sync-status.test.tsx
@@ -383,6 +383,33 @@ describe("SyncStatusIndicator", () => {
     expect(screen.getByText("token rejected")).toBeTruthy();
   });
 
+  it("shows capture deferral instead of a transient sync issue during recording", async () => {
+    mocks.getCloudsyncStatus.mockResolvedValue(
+      syncedStatus({
+        activity_paused: true,
+        deferred_for_capture: true,
+        has_unsent_changes: true,
+        last_error: "connection reset",
+        last_error_kind: "transient",
+        consecutive_failures: 1,
+      }),
+    );
+
+    renderIndicator();
+    await openMenu();
+
+    expect(await screen.findByText("Saved locally")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Cloud sync resumes after this meeting finishes processing",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("Sync issue")).toBeNull();
+
+    const syncNowItem = screen.getByRole("menuitem", { name: "Sync now" });
+    expect(syncNowItem.getAttribute("data-disabled")).not.toBeNull();
+  });
+
   it("uses the last successful sync while native local status is busy", async () => {
     mocks.getCloudsyncStatus.mockResolvedValue(
       syncedStatus({ has_unsent_changes: null }),

--- a/apps/desktop/src/main/sync-status.tsx
+++ b/apps/desktop/src/main/sync-status.tsx
@@ -168,17 +168,12 @@ export function SyncStatusIndicator() {
 
     if (
       status &&
-      (status.last_error_kind === "auth" ||
-        status.last_error_kind === "fatal" ||
-        status.consecutive_failures > 0)
+      (status.last_error_kind === "auth" || status.last_error_kind === "fatal")
     ) {
       return {
         kind: "error" as const,
         label: t`Sync issue`,
-        description:
-          status.last_error_kind === "transient"
-            ? t`Anarlog will retry automatically. This does not affect your notes.`
-            : (status.last_error ?? t`Anarlog will keep retrying`),
+        description: status.last_error ?? t`Anarlog will keep retrying`,
       };
     }
 
@@ -195,6 +190,17 @@ export function SyncStatusIndicator() {
         kind: "deferred" as const,
         label: t`Saved locally`,
         description: t`Cloud sync resumes when the current activity finishes`,
+      };
+    }
+
+    if (status && status.consecutive_failures > 0) {
+      return {
+        kind: "error" as const,
+        label: t`Sync issue`,
+        description:
+          status.last_error_kind === "transient"
+            ? t`Anarlog will retry automatically. This does not affect your notes.`
+            : (status.last_error ?? t`Anarlog will keep retrying`),
       };
     }
 
@@ -252,7 +258,7 @@ export function SyncStatusIndicator() {
           aria-label={t`Cloud sync status: ${view.label}`}
           data-testid="sync-status-indicator"
           className={cn([
-            "fixed right-3 bottom-3 z-40",
+            "fixed right-2 bottom-2 z-40",
             "border-border/60 bg-background/90 flex size-8 items-center justify-center rounded-xl border shadow-sm backdrop-blur",
             "text-muted-foreground hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground outline-hidden transition-colors",
           ])}


### PR DESCRIPTION
Prioritize capture deferral over transient errors and move the control closer to the corner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and status-priority logic in the desktop sync indicator only; no auth or sync engine changes.
> 
> **Overview**
> During meeting capture/processing, the cloud sync indicator now shows **Saved locally** with copy that sync resumes after the meeting finishes—even when the backend also reports transient failures (e.g. connection reset). **Sync issue** for retries is evaluated only after capture/activity deferral, while **auth** and **fatal** errors still surface immediately.
> 
> The floating sync control is nudged closer to the corner (`right-2` / `bottom-2` instead of `right-3` / `bottom-3`). A test asserts deferral wins over transient errors and that **Sync now** stays disabled in that state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d3bb7dcfe69c0768d1a4ae12be71d35d4fa5bfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->