### PR TITLE
Stabilize on-device Parakeet transcription

### DIFF
--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -302,6 +302,7 @@ pub(super) async fn run_soniqo_batch(
             .first()
             .map(anlg_language::Language::bcp47_code);
         let language_hint = soniqo_language_hint(language.as_deref());
+        let num_speakers = listen_params.num_speakers;
         let language_label = language.as_deref().unwrap_or("auto").to_string();
         let language_hint_label = language_hint.as_deref().unwrap_or("auto").to_string();
         let started_at = Instant::now();
@@ -321,7 +322,13 @@ pub(super) async fn run_soniqo_batch(
                 runtime,
                 session_id,
             };
-            transcribe_soniqo_file(model, &file_path, language_hint.as_deref(), Some(&progress))
+            transcribe_soniqo_file(
+                model,
+                &file_path,
+                language_hint.as_deref(),
+                num_speakers,
+                Some(&progress),
+            )
         })
         .await
         .map_err(|e| {
@@ -375,6 +382,7 @@ fn transcribe_soniqo_file(
     model: anlg_transcribe_soniqo::SoniqoModel,
     file_path: &str,
     language: Option<&str>,
+    num_speakers: Option<u32>,
     progress: Option<&SoniqoProgressReporter>,
 ) -> std::result::Result<Vec<anlg_transcribe_soniqo::FileTranscript>, String> {
     let source = anlg_audio_utils::source_from_path(file_path).map_err(|e| e.to_string())?;
@@ -438,9 +446,9 @@ fn transcribe_soniqo_file(
     );
 
     let plans = channel_samples
-        .into_iter()
+        .iter()
         .enumerate()
-        .map(|(channel_index, samples)| soniqo_channel_plan(model, channel_index, &samples))
+        .map(|(channel_index, samples)| soniqo_channel_plan(model, channel_index, samples))
         .collect::<std::result::Result<Vec<_>, _>>()?;
     let total_chunks = plans.iter().map(|plan| plan.chunks.len()).sum::<usize>();
     let mut completed_chunks = 0usize;
@@ -449,14 +457,55 @@ fn transcribe_soniqo_file(
         progress.emit(soniqo_batch_progress(0, total_chunks));
     }
 
-    collect_soniqo_channel_transcripts(plans.into_iter().map(|plan| {
+    let mut transcripts = collect_soniqo_channel_transcripts(plans.into_iter().map(|plan| {
         transcribe_soniqo_channel_chunks(model, plan, language, || {
             completed_chunks += 1;
             if let Some(progress) = progress {
                 progress.emit(soniqo_batch_progress(completed_chunks, total_chunks));
             }
         })
-    }))
+    }))?;
+
+    for (channel_index, (transcript, samples)) in transcripts
+        .iter_mut()
+        .zip(channel_samples.iter())
+        .enumerate()
+    {
+        let Some(speaker_count) =
+            soniqo_diarization_speaker_count(num_speakers, channel_samples.len(), channel_index)
+        else {
+            continue;
+        };
+
+        let started_at = Instant::now();
+        match anlg_transcribe_soniqo::diarize_samples(model, samples, speaker_count) {
+            Ok(segments) => {
+                tracing::info!(
+                    anarlog.stt.provider.name = "soniqo",
+                    anarlog.stt.model = %model,
+                    channel.index = channel_index,
+                    speaker.count = speaker_count,
+                    segment.count = segments.len(),
+                    elapsed_ms = started_at.elapsed().as_millis() as u64,
+                    "soniqo_channel_diarization_completed"
+                );
+                transcript.speaker_segments = segments;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    anarlog.stt.provider.name = "soniqo",
+                    anarlog.stt.model = %model,
+                    channel.index = channel_index,
+                    speaker.count = speaker_count,
+                    elapsed_ms = started_at.elapsed().as_millis() as u64,
+                    error = %error,
+                    "soniqo_channel_diarization_failed"
+                );
+            }
+        }
+    }
+
+    Ok(transcripts)
 }
 
 struct SoniqoProgressReporter {
@@ -506,6 +555,22 @@ fn soniqo_batch_progress(completed_chunks: usize, total_chunks: usize) -> f64 {
 
     let ratio = completed_chunks as f64 / total_chunks as f64;
     (SONIQO_PROGRESS_PLANNED + ratio * SONIQO_PROGRESS_RANGE).min(SONIQO_PROGRESS_MAX)
+}
+
+fn soniqo_diarization_speaker_count(
+    num_speakers: Option<u32>,
+    channel_count: usize,
+    channel_index: usize,
+) -> Option<usize> {
+    let total = usize::try_from(num_speakers?).ok()?;
+
+    let count = match channel_count {
+        1 => total,
+        2 if channel_index == 1 => total.saturating_sub(1),
+        _ => return None,
+    };
+
+    (count >= 2).then_some(count)
 }
 
 fn collect_soniqo_channel_transcripts<I>(
@@ -984,6 +1049,19 @@ mod tests {
         assert!(!uses_resilient_soniqo_chunking(
             anlg_transcribe_soniqo::SoniqoModel::Omnilingual
         ));
+    }
+
+    #[test]
+    fn soniqo_diarization_uses_remote_count_for_system_channel() {
+        assert_eq!(soniqo_diarization_speaker_count(Some(3), 2, 0), None);
+        assert_eq!(soniqo_diarization_speaker_count(Some(3), 2, 1), Some(2));
+    }
+
+    #[test]
+    fn soniqo_diarization_uses_total_count_for_mono_audio() {
+        assert_eq!(soniqo_diarization_speaker_count(Some(2), 1, 0), Some(2));
+        assert_eq!(soniqo_diarization_speaker_count(Some(1), 1, 0), None);
+        assert_eq!(soniqo_diarization_speaker_count(None, 1, 0), None);
     }
 
     #[test]

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -124,7 +124,9 @@ impl SoniqoModel {
     pub const fn description(self) -> &'static str {
         match self {
             Self::ParakeetStreaming => "Realtime transcription for 25 European languages.",
-            Self::ParakeetBatch => "Batch transcription for 25 European languages.",
+            Self::ParakeetBatch => {
+                "Batch transcription with on-device speaker labels for 25 European languages."
+            }
             Self::Omnilingual => "Multilingual batch transcription.",
             Self::Qwen3Small => "Multilingual batch transcription.",
             Self::Qwen3Large => "Multilingual batch transcription.",
@@ -134,7 +136,7 @@ impl SoniqoModel {
     pub const fn size_bytes(self) -> u64 {
         match self {
             Self::ParakeetStreaming => 120 * 1024 * 1024,
-            Self::ParakeetBatch => 600 * 1024 * 1024,
+            Self::ParakeetBatch => 632 * 1024 * 1024,
             Self::Omnilingual => 300 * 1024 * 1024,
             Self::Qwen3Small => 600 * 1024 * 1024,
             Self::Qwen3Large => 1_700 * 1024 * 1024,
@@ -215,6 +217,8 @@ pub struct FileTranscript {
     pub duration_seconds: f64,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub chunks: Vec<FileTranscriptChunk>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub speaker_segments: Vec<DiarizationSegment>,
 }
 
 impl FileTranscript {
@@ -223,6 +227,7 @@ impl FileTranscript {
             text,
             duration_seconds,
             chunks: Vec::new(),
+            speaker_segments: Vec::new(),
         }
     }
 
@@ -237,6 +242,7 @@ impl FileTranscript {
             text,
             duration_seconds,
             chunks,
+            speaker_segments: Vec::new(),
         }
     }
 }
@@ -247,6 +253,14 @@ pub struct FileTranscriptChunk {
     pub text: String,
     pub start_seconds: f64,
     pub duration_seconds: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DiarizationSegment {
+    pub start_seconds: f64,
+    pub end_seconds: f64,
+    pub speaker_index: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -371,6 +385,12 @@ pub fn delete_model(model: SoniqoModel) -> Result<()> {
     if cache_dir.exists() {
         std::fs::remove_dir_all(&cache_dir).map_err(Error::Delete)?;
     }
+    if model == SoniqoModel::ParakeetBatch {
+        let cache_dir = platform::diarization_cache_dir()?;
+        if cache_dir.exists() {
+            std::fs::remove_dir_all(&cache_dir).map_err(Error::Delete)?;
+        }
+    }
 
     Ok(())
 }
@@ -429,6 +449,27 @@ pub fn transcribe_file(
     }
 
     result
+}
+
+pub fn diarize_samples(
+    model: SoniqoModel,
+    samples: &[f32],
+    exact_speakers: usize,
+) -> Result<Vec<DiarizationSegment>> {
+    ensure_supported_platform(model)?;
+    if model.batch_model() != SoniqoModel::ParakeetBatch {
+        return Err(Error::Bridge(format!(
+            "{} does not support speaker diarization",
+            model.display_name()
+        )));
+    }
+    if exact_speakers < 2 {
+        return Err(Error::Bridge(
+            "speaker diarization requires at least two speakers".to_string(),
+        ));
+    }
+
+    platform::diarize_samples(model.batch_model(), samples, exact_speakers)
 }
 
 pub struct LiveTranscriptionSession {
@@ -536,7 +577,15 @@ pub fn batch_response_from_channels(
         .iter()
         .map(|channel| channel.duration_seconds)
         .fold(0.05, f64::max);
-    let metadata = metadata_json(model, duration_seconds, channels.len() as u32);
+    let has_diarization = channels
+        .iter()
+        .any(|channel| !channel.speaker_segments.is_empty());
+    let metadata = metadata_json(
+        model,
+        duration_seconds,
+        channels.len() as u32,
+        has_diarization,
+    );
 
     batch::Response {
         metadata,
@@ -555,7 +604,11 @@ pub fn batch_response_from_channels(
                             channel_index as i32,
                         )
                     } else {
-                        batch_words_from_chunks(&channel.chunks, channel_index as i32)
+                        batch_words_from_chunks(
+                            &channel.chunks,
+                            &channel.speaker_segments,
+                            channel_index as i32,
+                        )
                     };
                     batch::Channel {
                         alternatives: vec![batch::Alternatives {
@@ -582,14 +635,23 @@ fn metadata(model: SoniqoModel) -> stream::Metadata {
     }
 }
 
-fn metadata_json(model: SoniqoModel, duration_seconds: f64, channels: u32) -> serde_json::Value {
+fn metadata_json(
+    model: SoniqoModel,
+    duration_seconds: f64,
+    channels: u32,
+    has_diarization: bool,
+) -> serde_json::Value {
     let mut value = serde_json::to_value(metadata(model)).unwrap_or_else(|_| serde_json::json!({}));
     if let Some(object) = value.as_object_mut() {
         object.insert("duration".to_string(), serde_json::json!(duration_seconds));
         object.insert("channels".to_string(), serde_json::json!(channels));
         object.insert(
             "timing_source".to_string(),
-            serde_json::json!("synthetic_text"),
+            serde_json::json!(if has_diarization {
+                "diarized_speech"
+            } else {
+                "synthetic_text"
+            }),
         );
     }
     value
@@ -627,15 +689,126 @@ fn stream_words_from_text(text: &str, start: f64, duration: f64) -> Vec<stream::
         .collect()
 }
 
-fn batch_words_from_chunks(chunks: &[FileTranscriptChunk], channel: i32) -> Vec<batch::Word> {
+fn batch_words_from_chunks(
+    chunks: &[FileTranscriptChunk],
+    speaker_segments: &[DiarizationSegment],
+    channel: i32,
+) -> Vec<batch::Word> {
     chunks
         .iter()
         .flat_map(|chunk| {
             let text = normalize_transcript_text(&chunk.text);
+            if !speaker_segments.is_empty() {
+                return batch_words_from_diarized_speech(
+                    &text,
+                    chunk.start_seconds,
+                    chunk.duration_seconds,
+                    channel,
+                    speaker_segments,
+                );
+            }
+
             let duration = synthetic_text_duration(&text)
                 .min(chunk.duration_seconds.max(MIN_SYNTHETIC_DURATION_SECONDS));
             let start = chunk.start_seconds.max(0.0);
             batch_words_from_text(&text, start, duration, channel)
+        })
+        .collect()
+}
+
+fn batch_words_from_diarized_speech(
+    text: &str,
+    start: f64,
+    duration: f64,
+    channel: i32,
+    speaker_segments: &[DiarizationSegment],
+) -> Vec<batch::Word> {
+    let words = split_words(text);
+    if words.is_empty() {
+        return Vec::new();
+    }
+
+    let chunk_start = start.max(0.0);
+    let chunk_end = chunk_start + duration.max(MIN_SYNTHETIC_DURATION_SECONDS);
+    let mut spans = speaker_segments
+        .iter()
+        .filter_map(|segment| {
+            let start = segment.start_seconds.max(chunk_start);
+            let end = segment.end_seconds.min(chunk_end);
+            (end > start).then_some((start, end, segment.speaker_index))
+        })
+        .collect::<Vec<_>>();
+    spans.sort_by(|left, right| {
+        left.0
+            .total_cmp(&right.0)
+            .then_with(|| left.1.total_cmp(&right.1))
+            .then_with(|| left.2.cmp(&right.2))
+    });
+    let mut non_overlapping = Vec::with_capacity(spans.len());
+    let mut previous_end = chunk_start;
+    for (start, end, speaker) in spans {
+        let start = start.max(previous_end);
+        if end > start {
+            non_overlapping.push((start, end, speaker));
+            previous_end = end;
+        }
+    }
+    let spans = non_overlapping;
+
+    let active_duration = spans.iter().map(|(start, end, _)| end - start).sum::<f64>();
+    if active_duration <= 0.0 {
+        let duration =
+            synthetic_text_duration(text).min(duration.max(MIN_SYNTHETIC_DURATION_SECONDS));
+        return batch_words_from_text(text, chunk_start, duration, channel);
+    }
+
+    let position = |offset: f64| {
+        let mut remaining = offset.clamp(0.0, active_duration);
+        for (index, (start, end, speaker)) in spans.iter().enumerate() {
+            let span_duration = end - start;
+            if remaining <= span_duration || index + 1 == spans.len() {
+                return ((start + remaining.min(span_duration)), index, *speaker);
+            }
+            remaining -= span_duration;
+        }
+        (chunk_end, spans.len() - 1, spans[spans.len() - 1].2)
+    };
+    let count = words.len();
+
+    words
+        .into_iter()
+        .enumerate()
+        .map(|(index, word)| {
+            let start_offset = index as f64 / count as f64 * active_duration;
+            let end_offset = (index + 1) as f64 / count as f64 * active_duration;
+            let midpoint_offset = (start_offset + end_offset) / 2.0;
+            let (mapped_start, _, _) = position(start_offset);
+            let (mapped_end, _, _) = position(end_offset);
+            let (midpoint, span_index, speaker) = position(midpoint_offset);
+            let (span_start, span_end, _) = spans[span_index];
+            let word_start = mapped_start.max(span_start).min(span_end);
+            let word_end = mapped_end
+                .min(span_end)
+                .max((word_start + MIN_SYNTHETIC_DURATION_SECONDS).min(span_end));
+            let (word_start, word_end) = if word_end > word_start {
+                (word_start, word_end)
+            } else {
+                let half = MIN_SYNTHETIC_DURATION_SECONDS / 2.0;
+                (
+                    (midpoint - half).max(span_start),
+                    (midpoint + half).min(span_end),
+                )
+            };
+
+            batch::Word {
+                word: word.to_string(),
+                start: word_start,
+                end: word_end.max(word_start + f64::EPSILON),
+                confidence: 1.0,
+                channel,
+                speaker: Some(speaker),
+                punctuated_word: Some(word.to_string()),
+            }
         })
         .collect()
 }
@@ -688,6 +861,7 @@ mod platform {
     use swift_rs::{Bool, SRData, SRString, swift};
 
     swift!(fn _soniqo_model_cache_dir(model_id: &SRString) -> SRString);
+    swift!(fn _soniqo_diarization_cache_dir() -> SRString);
     swift!(fn _soniqo_model_download_state(model_id: &SRString) -> SRString);
     swift!(fn _soniqo_model_start_download(model_id: &SRString) -> Bool);
     swift!(fn _soniqo_model_reset(model_id: &SRString) -> Bool);
@@ -695,6 +869,11 @@ mod platform {
         model_id: &SRString,
         audio_path: &SRString,
         language: &SRString
+    ) -> SRString);
+    swift!(fn _soniqo_diarize_audio(
+        model_id: &SRString,
+        samples: &SRData,
+        exact_speakers: &SRString
     ) -> SRString);
     swift!(fn _soniqo_live_start(model_id: &SRString) -> SRString);
     swift!(fn _soniqo_live_append(source: &SRString, samples: &SRData) -> SRString);
@@ -716,6 +895,14 @@ mod platform {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct DiarizationPayload {
+        segments: Vec<DiarizationSegment>,
+        num_speakers: usize,
+        error: Option<String>,
+    }
+
+    #[derive(serde::Deserialize)]
     struct StatusPayload {
         running: bool,
         error: Option<String>,
@@ -731,6 +918,19 @@ mod platform {
                 "cache path unavailable for {}",
                 model.as_str()
             )));
+        }
+
+        Ok(PathBuf::from(path))
+    }
+
+    pub(super) fn diarization_cache_dir() -> Result<PathBuf> {
+        let path = unsafe { _soniqo_diarization_cache_dir() };
+        let path = path.as_str().to_string();
+
+        if path.is_empty() {
+            return Err(Error::Bridge(
+                "Soniqo diarization cache path unavailable".to_string(),
+            ));
         }
 
         Ok(PathBuf::from(path))
@@ -787,7 +987,32 @@ mod platform {
             text: result.text,
             duration_seconds: result.duration_seconds,
             chunks: Vec::new(),
+            speaker_segments: Vec::new(),
         })
+    }
+
+    pub(super) fn diarize_samples(
+        model: SoniqoModel,
+        samples: &[f32],
+        exact_speakers: usize,
+    ) -> Result<Vec<DiarizationSegment>> {
+        let model_id = sr_string(model.as_str());
+        let samples = floats_to_sr_data(samples);
+        let exact_speakers_value = sr_string(&exact_speakers.to_string());
+        let payload = unsafe { _soniqo_diarize_audio(&model_id, &samples, &exact_speakers_value) };
+        let result: DiarizationPayload = serde_json::from_str(payload.as_str())?;
+
+        if let Some(error) = result.error {
+            return Err(Error::Bridge(error));
+        }
+        if result.num_speakers != exact_speakers {
+            return Err(Error::Bridge(format!(
+                "Soniqo diarization returned {} speakers instead of {}",
+                result.num_speakers, exact_speakers
+            )));
+        }
+
+        Ok(result.segments)
     }
 
     pub(super) fn live_start(model: SoniqoModel) -> Result<()> {
@@ -864,6 +1089,10 @@ mod platform {
         Err(Error::UnsupportedPlatform)
     }
 
+    pub(super) fn diarization_cache_dir() -> Result<PathBuf> {
+        Err(Error::UnsupportedPlatform)
+    }
+
     pub(super) fn model_download_state(_model: SoniqoModel) -> Result<ModelDownloadState> {
         Err(Error::UnsupportedPlatform)
     }
@@ -881,6 +1110,14 @@ mod platform {
         _path: &Path,
         _language: &str,
     ) -> Result<FileTranscript> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn diarize_samples(
+        _model: SoniqoModel,
+        _samples: &[f32],
+        _exact_speakers: usize,
+    ) -> Result<Vec<DiarizationSegment>> {
         Err(Error::UnsupportedPlatform)
     }
 
@@ -1093,6 +1330,42 @@ mod tests {
         assert_eq!(words[2].start, 29.5);
         assert_eq!(words[3].start, 29.5 + SYNTHETIC_BATCH_WORD_SECONDS);
         assert_eq!(response.metadata["timing_source"], "synthetic_text");
+    }
+
+    #[test]
+    fn batch_response_aligns_words_to_diarized_speech() {
+        let mut transcript = FileTranscript::from_chunks(
+            vec![FileTranscriptChunk {
+                text: "lex one two george three four".to_string(),
+                start_seconds: 0.0,
+                duration_seconds: 10.0,
+            }],
+            10.0,
+        );
+        transcript.speaker_segments = vec![
+            DiarizationSegment {
+                start_seconds: 1.0,
+                end_seconds: 4.0,
+                speaker_index: 0,
+            },
+            DiarizationSegment {
+                start_seconds: 6.0,
+                end_seconds: 9.0,
+                speaker_index: 1,
+            },
+        ];
+
+        let response = batch_response_from_channels(SoniqoModel::ParakeetBatch, vec![transcript]);
+        let words = &response.results.channels[0].alternatives[0].words;
+
+        assert_eq!(
+            words.iter().map(|word| word.speaker).collect::<Vec<_>>(),
+            vec![Some(0), Some(0), Some(0), Some(1), Some(1), Some(1)]
+        );
+        assert!(words.windows(2).all(|pair| pair[0].start <= pair[1].start));
+        assert!(words[0].start >= 1.0);
+        assert!(words[3].start >= 6.0);
+        assert_eq!(response.metadata["timing_source"], "diarized_speech");
     }
 
     #[test]

--- a/crates/transcribe-soniqo/swift-lib/Package.swift
+++ b/crates/transcribe-soniqo/swift-lib/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
         .product(name: "OmnilingualASR", package: "speech-swift"),
         .product(name: "ParakeetASR", package: "speech-swift"),
         .product(name: "ParakeetStreamingASR", package: "speech-swift"),
+        .product(name: "SpeechVAD", package: "speech-swift"),
         .product(name: "SwiftRs", package: "swift-rs"),
       ],
       path: "src"

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -1,8 +1,10 @@
 import AudioCommon
+import CoreML
 import Foundation
 import OmnilingualASR
 import ParakeetASR
 import ParakeetStreamingASR
+import SpeechVAD
 import SwiftRs
 
 private enum SoniqoBridgeError: LocalizedError {
@@ -19,6 +21,7 @@ private enum SoniqoBridgeError: LocalizedError {
 private let soniqoFileTranscriptionSampleRate = 16_000
 private let parakeetBatchMinimumChunkSeconds = 20.0
 private let parakeetBatchMaximumChunkSeconds = 29.5
+private let community1DiarizationRepo = Community1DiarizationPipeline.defaultModelId
 
 private enum SpeechModelKind: String, CaseIterable {
   case parakeetStreaming = "soniqo-parakeet-streaming"
@@ -103,6 +106,10 @@ private enum SpeechModelKind: String, CaseIterable {
   }
 
   func filesReady() -> Bool {
+    speechFilesReady() && (self != .parakeetBatch || Self.community1FilesReady())
+  }
+
+  private func speechFilesReady() -> Bool {
     guard let directory = try? cacheDirectoryURL() else {
       return false
     }
@@ -129,7 +136,7 @@ private enum SpeechModelKind: String, CaseIterable {
   }
 
   func load(progressHandler: ((Double, String) -> Void)?) async throws -> LoadedSpeechModel {
-    let offlineMode = filesReady()
+    let offlineMode = speechFilesReady()
 
     switch self {
     case .parakeetStreaming:
@@ -140,12 +147,24 @@ private enum SpeechModelKind: String, CaseIterable {
         )
       )
     case .parakeetBatch:
+      let model = try await ParakeetASRModel.fromPretrained(
+        modelId: repo,
+        offlineMode: offlineMode,
+        progressHandler: { fraction, status in
+          progressHandler?(fraction * 0.9, status)
+        }
+      )
+      let diarizer = try await Community1DiarizationPipeline.fromPretrained(
+        modelId: community1DiarizationRepo,
+        offlineMode: Self.community1FilesReady(),
+        computeUnits: .cpuOnly,
+        progressHandler: { fraction, status in
+          progressHandler?(0.9 + fraction * 0.1, status)
+        }
+      )
       return .parakeetBatch(
-        try await ParakeetASRModel.fromPretrained(
-          modelId: repo,
-          offlineMode: offlineMode,
-          progressHandler: progressHandler
-        )
+        model,
+        diarizer
       )
     case .omnilingual:
       return .omnilingual(
@@ -176,6 +195,25 @@ private enum SpeechModelKind: String, CaseIterable {
 
     return regularFileExists(at: directory.appendingPathComponent("model.mil"))
       && directoryContainsRegularFile(at: directory.appendingPathComponent("weights"))
+  }
+
+  static func community1CacheDirectoryPath() -> String {
+    (try? HuggingFaceDownloader.getCacheDirectory(for: community1DiarizationRepo).path) ?? ""
+  }
+
+  private static func community1FilesReady() -> Bool {
+    guard
+      let directory = try? HuggingFaceDownloader.getCacheDirectory(
+        for: community1DiarizationRepo
+      )
+    else {
+      return false
+    }
+
+    return regularFileExists(at: directory.appendingPathComponent("config.json"))
+      && regularFileExists(at: directory.appendingPathComponent("plda.safetensors"))
+      && compiledCoreMLModelReady(at: directory.appendingPathComponent("segmentation.mlmodelc"))
+      && compiledCoreMLModelReady(at: directory.appendingPathComponent("embedding.mlmodelc"))
   }
 
   private static func directoryContainsFile(withExtension pathExtension: String, in directory: URL)
@@ -229,7 +267,7 @@ private enum SpeechModelKind: String, CaseIterable {
 
 private enum LoadedSpeechModel {
   case streaming(ParakeetStreamingASRModel)
-  case parakeetBatch(ParakeetASRModel)
+  case parakeetBatch(ParakeetASRModel, Community1DiarizationPipeline)
   case omnilingual(OmnilingualASRModel)
 
   func asStreamingModel() throws -> ParakeetStreamingASRModel {
@@ -241,6 +279,15 @@ private enum LoadedSpeechModel {
     return model
   }
 
+  func asDiarizationPipeline() throws -> Community1DiarizationPipeline {
+    guard case .parakeetBatch(_, let pipeline) = self else {
+      throw SoniqoBridgeError.message(
+        "The selected Soniqo model does not support speaker diarization.")
+    }
+
+    return pipeline
+  }
+
   func transcribe(audio: [Float], sampleRate: Int, language: String?) throws -> String {
     let normalizedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)
     let languageHint = (normalizedLanguage?.isEmpty == false) ? normalizedLanguage : nil
@@ -248,7 +295,7 @@ private enum LoadedSpeechModel {
     switch self {
     case .streaming(let model):
       return try model.transcribeAudio(audio, sampleRate: sampleRate)
-    case .parakeetBatch(let model):
+    case .parakeetBatch(let model, _):
       return try model.transcribeAudio(audio, sampleRate: sampleRate, language: languageHint)
     case .omnilingual(let model):
       return try model.transcribeAudio(audio, sampleRate: sampleRate)
@@ -275,23 +322,6 @@ private struct FileTranscriptionPayload: Codable {
   var error: String?
 }
 
-private final class LivePartialPayload: Codable {
-  let source: String
-  let text: String
-  let isFinal: Bool
-
-  init(source: String, text: String, isFinal: Bool) {
-    self.source = source
-    self.text = text
-    self.isFinal = isFinal
-  }
-}
-
-private struct LiveAppendPayload: Codable {
-  var partials: [LivePartialPayload]
-  var error: String?
-}
-
 private struct StatusPayload: Codable {
   var running: Bool
   var error: String?
@@ -305,6 +335,58 @@ private func encodeJSON<T: Encodable>(_ value: T) -> String {
   }
 
   return string
+}
+
+private func encodeJSONObject(_ value: Any) -> String {
+  guard JSONSerialization.isValidJSONObject(value),
+    let data = try? JSONSerialization.data(withJSONObject: value),
+    let string = String(data: data, encoding: .utf8)
+  else {
+    return "{}"
+  }
+
+  return string
+}
+
+private func encodeLiveAppendJSON(
+  partials: [ParakeetStreamingASRModel.PartialTranscript],
+  source: String,
+  error: String? = nil
+) -> String {
+  var payload: [String: Any] = [
+    "partials": partials.map { partial in
+      [
+        "source": source,
+        "text": partial.text,
+        "isFinal": partial.isFinal,
+      ] as [String: Any]
+    }
+  ]
+  if let error {
+    payload["error"] = error
+  } else {
+    payload["error"] = NSNull()
+  }
+  return encodeJSONObject(payload)
+}
+
+private func encodeDiarizationJSON(_ result: DiarizationResult?, error: String? = nil) -> String {
+  var payload: [String: Any] = [
+    "segments": result?.segments.map { segment in
+      [
+        "startSeconds": Double(segment.startTime),
+        "endSeconds": Double(segment.endTime),
+        "speakerIndex": segment.speakerId,
+      ] as [String: Any]
+    } ?? [],
+    "numSpeakers": result?.numSpeakers ?? 0,
+  ]
+  if let error {
+    payload["error"] = error
+  } else {
+    payload["error"] = NSNull()
+  }
+  return encodeJSONObject(payload)
 }
 
 private func waitForValue<T>(_ operation: @escaping () async -> T) -> T {
@@ -355,6 +437,10 @@ private actor SoniqoBridge {
 
     refreshReadyState(for: kind)
     return kind.cacheDirectoryPath()
+  }
+
+  func diarizationCacheDirectory() -> String {
+    SpeechModelKind.community1CacheDirectoryPath()
   }
 
   func modelDownloadStateJSON(modelId: String) -> String {
@@ -482,16 +568,14 @@ private actor SoniqoBridge {
       }
 
       let samples = try decodeFloatSamples(from: samplesData)
-      let partials = try session.pushAudio(samples).map { partial in
-        LivePartialPayload(
-          source: transcriptSource.rawValue,
-          text: partial.text,
-          isFinal: partial.isFinal
-        )
-      }
-      return encodeJSON(LiveAppendPayload(partials: partials, error: nil))
+      let partials = try session.pushAudio(samples)
+      return encodeLiveAppendJSON(partials: partials, source: transcriptSource.rawValue)
     } catch {
-      return encodeJSON(LiveAppendPayload(partials: [], error: error.localizedDescription))
+      return encodeLiveAppendJSON(
+        partials: [],
+        source: source,
+        error: error.localizedDescription
+      )
     }
   }
 
@@ -504,16 +588,36 @@ private actor SoniqoBridge {
         throw SoniqoBridgeError.message("No active Soniqo transcription session.")
       }
 
-      let partials = try session.finalize().map { partial in
-        LivePartialPayload(
-          source: transcriptSource.rawValue,
-          text: partial.text,
-          isFinal: partial.isFinal
-        )
-      }
-      return encodeJSON(LiveAppendPayload(partials: partials, error: nil))
+      let partials = try session.finalize()
+      return encodeLiveAppendJSON(partials: partials, source: transcriptSource.rawValue)
     } catch {
-      return encodeJSON(LiveAppendPayload(partials: [], error: error.localizedDescription))
+      return encodeLiveAppendJSON(
+        partials: [],
+        source: source,
+        error: error.localizedDescription
+      )
+    }
+  }
+
+  func diarizeAudioJSON(modelId: String, samplesData: Data, exactSpeakers: String) async -> String {
+    do {
+      guard let kind = SpeechModelKind.resolve(modelId) else {
+        throw SoniqoBridgeError.message("Unsupported Soniqo model: \(modelId)")
+      }
+      guard let speakerCount = Int(exactSpeakers), speakerCount >= 2 else {
+        throw SoniqoBridgeError.message("Soniqo diarization requires at least two speakers.")
+      }
+
+      let samples = try decodeFloatSamples(from: samplesData)
+      let pipeline = try await ensureModelLoaded(kind).asDiarizationPipeline()
+      let result = try pipeline.diarize(
+        audio: samples,
+        sampleRate: soniqoFileTranscriptionSampleRate,
+        speakerBounds: Community1SpeakerBounds(exact: speakerCount)
+      )
+      return encodeDiarizationJSON(result)
+    } catch {
+      return encodeDiarizationJSON(nil, error: error.localizedDescription)
     }
   }
 
@@ -809,6 +913,14 @@ public func _soniqo_model_cache_dir(modelId: SRString) -> SRString {
     })
 }
 
+@_cdecl("_soniqo_diarization_cache_dir")
+public func _soniqo_diarization_cache_dir() -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.diarizationCacheDirectory()
+    })
+}
+
 @_cdecl("_soniqo_model_download_state")
 public func _soniqo_model_download_state(modelId: SRString) -> SRString {
   SRString(
@@ -845,6 +957,22 @@ public func _soniqo_transcribe_audio_file(
         modelId: modelId.toString(),
         audioPath: audioPath.toString(),
         language: language.toString()
+      )
+    })
+}
+
+@_cdecl("_soniqo_diarize_audio")
+public func _soniqo_diarize_audio(
+  modelId: SRString,
+  samples: SRData,
+  exactSpeakers: SRString
+) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.diarizeAudioJSON(
+        modelId: modelId.toString(),
+        samplesData: Data(samples.toArray()),
+        exactSpeakers: exactSpeakers.toString()
       )
     })
 }

--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -109,7 +109,8 @@ are still pending.
 - Avoid duplicate Apple Speech phrases when live hypotheses are revised
 - Detect the meeting language from your configured language choices instead of
   forcing multilingual recordings into code-switching mode
-- Label diarized speakers with known participant names when the transcript
+- Separate remote speakers during on-device Parakeet batch transcription, then
+  label diarized speakers with known participant names when the transcript
   provides a high-confidence identity match
 
 On-device transcription remains available on supported Apple Silicon Macs.


### PR DESCRIPTION
Avoid Swift live-payload copy faults, add exact-count local speaker diarization to Parakeet batch results, and update the 1.4.0 changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches batch transcript timing/speaker attribution and new on-device ML on macOS, but diarization is optional, failures are non-blocking, and scope is limited to Parakeet batch with num_speakers ≥ 2.
> 
> **Overview**
> **On-device Parakeet batch** now runs **Community1 speaker diarization** after transcription when `num_speakers` is at least 2, attaching segments to each channel transcript and emitting batch words with **per-word speaker indices** and metadata `timing_source: diarized_speech`.
> 
> Speaker budgeting follows the recording layout: **mono** uses the full remote count; **stereo** diarizes only the **system/remote channel** with `num_speakers - 1` (mic channel is skipped). Diarization errors are **logged and ignored** so transcription still completes.
> 
> The **macOS Swift bridge** loads the diarization model with Parakeet batch (separate cache, cleared on model delete), exposes `_soniqo_diarize_audio`, and **re-encodes live partial JSON** without fragile Codable types on streaming payloads. **1.4.0 changelog** notes separating remote speakers before participant name labeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd81771e93276a1d5376857f92b3ad38a4c09195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->