### PR TITLE
Finalize the 1.4.0 changelog

### DIFF
--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -31,6 +31,8 @@ are still pending.
 
 - Let Anarlog download updates in the background and install them the next time
   the app opens, with a new setting to turn automatic updates off
+- See upcoming meeting countdowns in a compact badge, and see **Saved locally**
+  while Cloud Sync waits for an active recording or chat to finish
 - Get a warning before combining Cloud Sync with an Anarlog storage folder
   managed by iCloud Drive, Dropbox, Google Drive, OneDrive, or another file
   syncing service


### PR DESCRIPTION
Document the merged meeting countdown badge and Cloud Sync saved-locally state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `packages/changelog/content/1.4.0.md` with no application or infrastructure impact.
> 
> **Overview**
> **Updates the 1.4.0 release notes** under *Updates and settings* with a new bullet that calls out two user-visible behaviors shipped in this release.
> 
> Users can **see upcoming meeting countdowns in a compact badge**, and see **Saved locally** while Cloud Sync defers sync until an active recording or chat finishes—aligning the public changelog with behavior already covered in tests (`outer-header` countdown badge, `sync-status` capture-deferred state).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a56dcaadd7409df7cf9b0ff240fbb04aaa1558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->