### PR TITLE
Fix account analytics scheduled delivery

### DIFF
--- a/apps/web/netlify/functions/posthog-account-events.mts
+++ b/apps/web/netlify/functions/posthog-account-events.mts
@@ -15,10 +15,6 @@ function requireEnvironmentVariable(name: string) {
 }
 
 export default async () => {
-  if (process.env.CONTEXT !== "production") {
-    throw new Error("Account analytics delivery is production-only");
-  }
-
   const supabase = createClient(
     requireEnvironmentVariable("SUPABASE_URL"),
     requireEnvironmentVariable("SUPABASE_SERVICE_ROLE_KEY"),


### PR DESCRIPTION
## Summary
- remove the runtime `CONTEXT` guard from the scheduled account analytics function
- Netlify scheduled invocations do not receive that build-context variable, so every run was rejected as non-production

## Production evidence
- function logs show `Account analytics delivery is production-only` beginning immediately after the guard shipped
- manually replayed 296 pending canonical account events successfully
- pending outbox is now zero

## Validation
- web TypeScript check passes
- `account-analytics.test.ts`: 5/5 pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard removal in a background analytics job; no auth or user-facing path changes, and production-only behavior is still implied by deployed env secrets and schedule.
> 
> **Overview**
> **Fixes broken scheduled delivery** for canonical account analytics events to PostHog by removing an early guard that threw when `process.env.CONTEXT !== "production"`.
> 
> Netlify **scheduled function invocations do not expose** the build-time `CONTEXT` variable, so every cron run was failing with “Account analytics delivery is production-only” and events stayed in the outbox. The handler now proceeds directly to Supabase reconcile/claim/deliver logic (unchanged aside from dropping that check).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c9f5e98a9b2b797640d180d56394480f28807f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->