### PR TITLE
docs(blog): add Avoma, Notion, and HIPAA notetaker guides

### DIFF
--- a/apps/web/content/articles/avoma-alternatives.mdx
+++ b/apps/web/content/articles/avoma-alternatives.mdx
@@ -1,0 +1,229 @@
+---
+meta_title: "6 Best Avoma Alternatives in 2026"
+display_title: "6 Best Avoma Alternatives in 2026"
+meta_description: "Compare six Avoma alternatives by the layer you are actually replacing—meeting notes, conversation intelligence, or revenue intelligence—and what each one costs per seat."
+author:
+  - "John Jeong"
+featured: false
+category: "Comparisons"
+date: "2026-07-24"
+---
+
+Avoma is three products sold under one name: a meeting assistant that records and summarizes calls, a conversation intelligence layer that scores them, and a revenue intelligence layer that ties them to pipeline. Most teams adopt it for the first one and end up budgeting for the shape of all three.
+
+Avoma's current [pricing](https://www.avoma.com/pricing) puts the assistant at $19 per user per month on Startup with annual billing, $24 on Organization, and $39 on Enterprise. Conversation Intelligence and Revenue Intelligence are separate add-ons at $29 per seat per month each. A sales team that wants coaching scorecards and deal analytics is closer to $80 per seat than $19.
+
+That structure is why the useful question is not "what is better than Avoma." It is which of the three layers you actually need, and whether one vendor should own all of them.
+
+## The short answer
+
+- **Choose Anarlog** if the meeting record matters more than the sales analytics, and it should stay on your own machine.
+- **Choose Gong** if revenue intelligence is the real requirement and the budget exists to do it properly.
+- **Choose Grain** if you want conversation intelligence and CRM sync without enterprise pricing.
+- **Choose Fireflies** if you want one searchable meeting archive wired into many other tools.
+- **Choose Fathom** if a small team needs solid notes and the free tier has to carry real usage.
+- **Choose Sembly** if procurement, not the sales team, is driving the decision.
+- **Stay with Avoma** if you genuinely use the coaching and deal layers and value having them beside the transcript.
+
+## Work out which layer you are replacing
+
+Avoma's own packaging is the clearest map of what you might be paying for.
+
+| Layer | What it does | Who needs it | What it costs in Avoma |
+| --- | --- | --- | --- |
+| Meeting assistant | Records, transcribes, summarizes, organizes notes by topic | Everyone who takes meetings | $19–$39 per seat per month |
+| Conversation intelligence | Call scoring, custom scorecards, topic tracking, coaching dashboards | Sales managers coaching reps | +$29 per seat per month |
+| Revenue intelligence | Deal risk, forecasting, win-loss analysis, CRM field updates from call content | RevOps and sales leadership | +$29 per seat per month |
+
+Teams that only need the first row are paying platform prices for a notetaker. Teams that need all three usually find that a general meeting assistant cannot replace the second and third rows, and that a real revenue platform does those two better.
+
+Before comparing anything, count how many seats need each layer. Avoma keeps viewers and collaborators free, so the honest comparison is against paid seats doing paid work, not headcount.
+
+## Avoma alternatives compared
+
+| Tool | Capture model | Strongest layer | Where the record lives | Main tradeoff |
+| --- | --- | --- | --- | --- |
+| **Anarlog** | Desktop system audio, no meeting bot | Meeting record | Local SQLite with Markdown export | No sales coaching or forecasting layer |
+| **Gong** | Meeting bot plus call and email capture | Revenue intelligence | Gong platform | Highest cost and the longest rollout |
+| **Grain** | Meeting bot | Conversation intelligence | Grain workspace | Thinner forecasting than a full revenue platform |
+| **Fireflies** | Meeting bot, desktop, mobile, uploads | Searchable archive and integrations | Fireflies workspace | Compliance controls gated to Enterprise |
+| **Fathom** | Meeting bot and desktop capture | Notes on a generous free tier | Fathom workspace | Analytics depth well below Avoma |
+| **Sembly** | Meeting bot | Compliance posture | Sembly workspace | Interface and workflow are less refined |
+
+Pricing on all of these moves. Treat the numbers here as a starting point and confirm the current plan against your seat count, meeting volume, history retention, and integration list before committing.
+
+## 1. Anarlog: best for a local-first meeting record
+
+[Anarlog](/) is an open-source, local-first meeting notetaker. It captures microphone and system audio without joining the call as a participant, transcribes the conversation, and stores meeting data in local SQLite on your computer.
+
+The structural difference from Avoma is not the summary quality. It is what remains after the meeting and who holds it. Avoma's value builds inside its workspace, where transcripts, scorecards, and deal signals live together. Anarlog's value is a durable local record you can search, export to Markdown, back up, and feed into whatever else you use.
+
+Transcription can run entirely on-device, and summarization can use local models, your own provider keys, or Anarlog's hosted service. That matters for conversations that should not sit in a vendor's analytics database — candidate interviews, legal calls, internal reviews, anything under a retention policy you do not control.
+
+**Choose Anarlog when:**
+
+- the meeting record should be a local file you own, not a row in a sales platform;
+- capture should not add a visible participant to the call;
+- you want to pick which AI provider, if any, processes the transcript;
+- open-source code matters to your security review;
+- notes need to work in tools beyond the notetaker's own workspace.
+
+**Consider the tradeoffs:**
+
+- There is no coaching, scorecard, or forecasting layer. If those are the reason you bought Avoma, this is not a replacement for them.
+- The product experience is focused on macOS today.
+- Device capture cannot attend a meeting when your computer is absent.
+- Local ownership means backup, device encryption, and access control are your responsibility.
+
+If storage architecture is the deciding factor, our guide to [local AI meeting notes](/blog/local-ai-meeting-notes/) covers the design in more depth.
+
+## 2. Gong: best when revenue intelligence is the actual requirement
+
+[Gong](https://www.gong.io/) is the platform Avoma's revenue layer is measured against. It captures calls, emails, and deal activity, then models pipeline health across the whole go-to-market motion rather than summarizing individual meetings.
+
+The cost is the story. Gong is commonly quoted around $100 to $120 per seat per month before the platform fee, and bundled contracts that include engagement and forecasting modules run considerably higher. Enterprise agreements are negotiated, multi-year, and usually involve a platform fee on top of seats.
+
+**Choose Gong when:**
+
+- forecasting accuracy and deal risk are board-level problems;
+- you have enough call volume for the models to say something useful;
+- there is a RevOps owner who will run the deployment;
+- the budget can absorb a platform fee plus per-seat licensing.
+
+**Consider the tradeoffs:**
+
+- It is the most expensive option here by a wide margin.
+- Rollout and adoption take real work, not a weekend.
+- It is aimed at revenue teams. Buying it to get better meeting notes is a poor trade.
+
+Gong is the right answer when Avoma's revenue intelligence add-on is not deep enough. It is the wrong answer when the add-on was never the point.
+
+## 3. Grain: best for conversation intelligence at a lower price
+
+[Grain](https://grain.com/) sits close to Avoma's middle layer: it records meetings, produces summaries and highlight clips, syncs to CRM, and offers coaching features without enterprise contracting.
+
+Its plans start well below Gong, with a free tier for a single recorder seat and paid plans in the $15 to $29 per user per month range depending on whether you need CRM sync and coaching. For a team that wants Avoma's Conversation Intelligence behavior without the $29 add-on stacked on a $24 base, the arithmetic is straightforward.
+
+**Choose Grain when:**
+
+- call coaching and CRM sync are the features you actually use;
+- clips and shareable highlights help you circulate customer feedback;
+- you want conversation intelligence pricing to stay in notetaker territory;
+- forecasting is handled elsewhere or not at all.
+
+**Consider the tradeoffs:**
+
+- Pipeline forecasting and deal analytics are thinner than a dedicated revenue platform.
+- Capture is bot-based, so participants see a recorder join.
+- Free and entry tiers cap recordings, which small teams hit quickly.
+
+## 4. Fireflies: best for a centralized, well-connected archive
+
+[Fireflies](https://fireflies.ai/) is the strongest option when the goal is one searchable place for every meeting, wired into the rest of the stack. It supports Zoom, Google Meet, and Teams, plus desktop and mobile capture and uploads, with an API and a long integration list.
+
+Its Enterprise plan is where the controls live: SSO, private storage, custom data retention, and [HIPAA compliance with a Business Associate Agreement](https://fireflies.ai/hipaa). If your requirement is an archive that survives audit questions, that gating matters more than the feature grid.
+
+**Choose Fireflies when:**
+
+- meeting content should be centralized and searchable across the company;
+- integrations and API access are part of the workflow;
+- conversation analytics are useful but not the primary purchase;
+- Enterprise-tier controls are within reach.
+
+**Consider the tradeoffs:**
+
+- Capture is bot-based by default, with the social cost that carries.
+- Compliance features sit behind Enterprise, so the entry price is not the real price for regulated teams.
+- The archive is centered on the Fireflies workspace.
+
+Our [Fireflies alternatives guide](/blog/fireflies-ai-alternatives/) covers the capture and storage differences in more detail.
+
+## 5. Fathom: best when the free tier has to do real work
+
+[Fathom](https://fathom.video/) is the most generous free notetaker in this comparison. Individuals can run genuine meeting workloads on it rather than a trial-sized sample, and the summaries are competitive with paid tools.
+
+For a small sales team, Fathom covers the first layer of Avoma at a fraction of the cost. It does not seriously attempt the third. HIPAA coverage with a signed BAA sits on the Enterprise tier, so the free plan is not an option for protected health information.
+
+**Choose Fathom when:**
+
+- a small team needs solid notes without a procurement cycle;
+- CRM sync and call summaries cover the analytics requirement;
+- you want to prove the workflow before paying for anything;
+- Avoma's coaching and forecasting layers were never used.
+
+**Consider the tradeoffs:**
+
+- Analytics depth is well below Avoma's paid add-ons.
+- Compliance coverage requires an Enterprise plan.
+- The meeting record lives in Fathom's workspace.
+
+See our [Fathom alternatives guide](/blog/fathom-ai-alternatives/) if the free tier is the only reason you are considering it.
+
+## 6. Sembly: best when procurement drives the decision
+
+[Sembly AI](https://www.sembly.ai/) leads with certifications. SOC 2 Type II, HIPAA, GDPR, FERPA, and PCI DSS coverage make it easy to clear a security review, which is often the binding constraint in healthcare, education, and finance.
+
+It records, transcribes, and produces structured summaries with task extraction. The interface is less refined than Avoma's, and the analytics are not built around a sales motion, but neither is usually the reason it gets picked.
+
+**Choose Sembly when:**
+
+- a security questionnaire decides the purchase;
+- your industry imposes requirements most notetakers ignore;
+- structured task extraction matters more than coaching dashboards;
+- a compliance-ready default beats a configurable one.
+
+**Consider the tradeoffs:**
+
+- Product polish trails the category leaders.
+- Sales-specific analytics are limited compared to Avoma or Gong.
+- Certifications describe the vendor's controls, not your configuration.
+
+## How to choose the right Avoma alternative
+
+Work from the layer, then the record.
+
+- If you only ever used the notes, replace the notetaker and stop paying for the platform. **Anarlog**, **Fathom**, or **Fireflies**.
+- If coaching is the value and the price is the problem, test **Grain**.
+- If forecasting is the value and Avoma's add-on is too shallow, evaluate **Gong** and accept what it costs.
+- If the security review is the gate, start with **Sembly** or **Fireflies** Enterprise.
+- If the meeting record itself should outlive the vendor, start with **Anarlog**.
+
+Then run one real deal cycle through your two finalists, not a demo call. Use a meeting with overlapping speakers, product jargon, an accent mix, and at least two decisions that must survive the summary.
+
+Score five things:
+
+1. Did capture start without changing how people joined the call?
+2. Were speakers identified well enough to trust the transcript?
+3. Did the summary keep decisions, owners, and open questions intact?
+4. Can you export the complete record in a format that stays useful without the product?
+5. Do you know where audio, transcripts, and AI prompts are processed and retained?
+
+Those answers separate the tools more reliably than another feature grid.
+
+## Frequently asked questions
+
+### Is there a free alternative to Avoma?
+
+Fathom's free tier handles real meeting volume, and Grain offers a limited free recorder seat. Anarlog is open source and runs transcription locally, which removes per-seat cost from the notes layer entirely. None of them replicate Avoma's conversation or revenue intelligence add-ons.
+
+### What does Avoma actually cost per seat?
+
+The base assistant runs $19 to $39 per user per month on annual billing depending on plan. Conversation Intelligence and Revenue Intelligence are $29 per seat per month each, with a bundling discount when you take more than one. Monthly billing is higher across the board. A team using the full platform lands well above the advertised entry price.
+
+### Which Avoma alternatives do not use a meeting bot?
+
+Anarlog captures system audio from your device without joining the call as a participant. Fathom and Fireflies offer desktop capture alongside their bot workflows. Gong, Grain, and Sembly are bot-based. Our [bot-free meeting assistant guide](/blog/bot-free-ai-meeting-assistants/) explains why the capture method changes both the privacy surface and the social dynamic of the call.
+
+### Which alternative keeps meeting data out of a vendor workspace?
+
+Anarlog stores meeting data in local SQLite and can transcribe on-device. Every other tool here is a hosted platform where the workspace is the product. If keeping conversations off third-party infrastructure is a hard requirement, that narrows the field quickly — see [self-hosted AI notetakers](/blog/selfhosted-ai-notetakers/).
+
+### Can I replace Avoma with a notetaker plus a separate CRM workflow?
+
+Often, yes. Most teams use Avoma's assistant daily and its analytics occasionally. Pairing a cheaper notetaker with the reporting your CRM already provides covers that pattern at lower cost. The split stops working when managers rely on scorecards and call-level coaching data as a routine part of their week.
+
+### Is Avoma HIPAA compliant?
+
+Avoma lists HIPAA compliance, signed DPAs, SOC 2, and custom data retention on its Enterprise tier. Lower tiers do not carry those terms. As with every vendor in this category, the label matters less than a signed Business Associate Agreement and a configuration your compliance team has reviewed.
+
+If the reason you are leaving Avoma is that the meeting record should belong to you rather than to a sales platform, [try Anarlog](/). The notes stay in files you control, and you decide which AI stack touches them.

--- a/apps/web/content/articles/hipaa-compliant-ai-notetaker.mdx
+++ b/apps/web/content/articles/hipaa-compliant-ai-notetaker.mdx
@@ -1,0 +1,182 @@
+---
+meta_title: "HIPAA-Compliant AI Notetakers: A Buyer's Guide"
+display_title: "How to Choose a HIPAA-Compliant AI Notetaker"
+meta_description: "Why encryption does not exempt a notetaker from HIPAA, where the subprocessor chain breaks, which vendors sign a BAA and on which plans, and what local capture actually changes."
+author:
+  - "John Jeong"
+featured: false
+category: "Guides"
+date: "2026-07-30"
+---
+
+Search for a HIPAA-compliant AI notetaker and every vendor says yes. Most of them are describing a plan tier you are not on, a Business Associate Agreement you have not signed, or a certification that covers their infrastructure rather than your configuration.
+
+HIPAA does not certify products. It imposes obligations on covered entities and on the business associates they contract with. A notetaker can help you meet those obligations or make them harder, but no purchase makes you compliant on its own.
+
+This guide covers what the rules actually require of a meeting notetaker, where the vendor chain usually breaks, which products sign a BAA and on which plans, and what changes when the transcript never leaves your machine. It is not legal advice — review any deployment involving protected health information with your compliance team and counsel.
+
+## "HIPAA compliant" is not a product property
+
+Three claims get used interchangeably in vendor marketing, and they mean different things:
+
+| Claim | What it means | What it does not mean |
+| --- | --- | --- |
+| "SOC 2 Type II certified" | An auditor reviewed the vendor's security controls over a period | Nothing about HIPAA specifically |
+| "HIPAA compliant" | The vendor believes its controls can support a compliant deployment | That your use of it is compliant |
+| "We will sign a BAA" | The vendor accepts business associate liability, in writing, for defined services | That the BAA is active, or covers the plan you bought |
+
+Only the third is contractually meaningful, and it is meaningful only once executed. Several vendors here will sign a BAA that takes effect on specific plans and with specific settings enabled — Fireflies, for example, ties its arrangement to Private Storage. A signed BAA plus a misconfigured workspace is not coverage.
+
+## Encryption does not remove the obligation
+
+The most common misreading in this category is that strong encryption puts a vendor outside HIPAA's scope. It does not.
+
+HHS's [guidance on HIPAA and cloud computing](https://www.hhs.gov/hipaa/for-professionals/special-topics/health-information-technology/cloud-computing/index.html) addresses this directly. A cloud service provider that creates, receives, maintains, or transmits electronic protected health information on behalf of a covered entity is a business associate — even when the ePHI is encrypted and the provider does not hold the decryption key. Lacking the key does not exempt a provider from business associate status or the obligations that follow.
+
+The narrow carve-out people reach for is the conduit exception, and it is narrower than it sounds. It covers transmission-only services, including temporary storage incidental to transmission. Postal and telecommunications services fit. A platform that stores your meeting transcripts does not.
+
+This matters for meeting notetakers because it kills the shortcut. "The audio is encrypted in transit and at rest" describes a control, not a scope reduction. If a vendor holds your transcripts, they are a business associate and you need a BAA with them, whatever the encryption story is.
+
+The exception is genuinely local processing. If audio is captured, transcribed, and stored on a device the covered entity controls, and no third party creates, receives, maintains, or transmits it, there is no business associate for that step — because there is no third party in it. That is a scope question, not a compliance certificate, and it only holds for the parts of the pipeline that stay local.
+
+## The subprocessor chain is where most notetakers break
+
+A modern notetaker is rarely one vendor. It is a capture app, a transcription engine, and a language model that writes the summary — often three companies.
+
+Signing a BAA with the notetaker does not automatically cover the model provider behind it. That provider is receiving the transcript, which contains the PHI. The chain has to hold end to end.
+
+Where the major model providers stand:
+
+| Provider | BAA availability | Notes |
+| --- | --- | --- |
+| Anthropic | HIPAA-eligible services with a BAA for qualifying customers | Certain features, including web search, are disabled under the BAA. Consumer Claude is not covered. See our [Anthropic retention guide](/blog/anthropic-data-retention-policy/) |
+| Azure OpenAI | Covered under Microsoft's HIPAA BAA via the Data Protection Addendum | Requires qualifying enterprise licensing. Details in our [Azure OpenAI retention guide](/blog/azure-open-ai-data-retention-policy/) |
+| Gemini for Workspace | Included under Google's HIPAA Business Associate Addendum | Requires a signed BAA and the right Admin Console configuration. The consumer version is not covered — see our [Gemini retention guide](/blog/google-gemini-data-retention-policy/) |
+| OpenAI consumer ChatGPT | No BAA on Free, Plus, Pro, or Team | Not usable with PHI. See our [ChatGPT retention guide](/blog/chatgpt-data-retention-policy/) |
+| Mistral | No published HIPAA BAA | Confirm directly before assuming coverage — [Mistral retention guide](/blog/mistral-data-retention-policy/) |
+| OpenRouter | No published HIPAA BAA | A routing layer adds providers rather than removing them — [OpenRouter retention guide](/blog/openrouter-data-retention-policy/) |
+
+Two questions cut through most vendor conversations:
+
+1. Which subprocessors receive transcript content when a summary is generated?
+2. Is each of them covered by a BAA, and can you see the list?
+
+A vendor that cannot name its model provider cannot demonstrate an intact chain. A vendor that routes to whichever model is cheapest that week has a chain that changes without telling you.
+
+## Where the major notetakers currently stand
+
+Every product below can be part of a compliant deployment under the right plan and contract. The differences are which plan, what has to be enabled, and how much of the pipeline you can see.
+
+| Tool | BAA available | Plan gating | What to check |
+| --- | --- | --- | --- |
+| **Otter** | Yes | Enterprise | Confirm BAA execution before any PHI is recorded; free and Pro tiers are not covered |
+| **Fireflies** | Yes | Enterprise, on request | [Private Storage](https://fireflies.ai/hipaa) is a precondition for the arrangement to take effect |
+| **Fathom** | Yes | Enterprise+ | The generous free tier carries no BAA |
+| **Avoma** | Yes | Enterprise | HIPAA, DPAs, and custom retention are Enterprise-only; see our [Avoma alternatives guide](/blog/avoma-alternatives/) |
+| **Sembly** | Yes | Enterprise-oriented | Broad certification set including SOC 2 Type II, HIPAA, GDPR, FERPA |
+| **Zoom AI Companion** | No | Not applicable | Zoom's HIPAA-compliant instances do not offer AI Companion. Institutional guidance warns against using it for sensitive discussion |
+| **Anarlog** | Not applicable — no third party receives the data by default | Any | Local capture removes the vendor from the pipeline; your device controls become the safeguard |
+
+The pattern is consistent: HIPAA coverage lives on the top tier. If you evaluated a notetaker on its free plan and liked it, the price you will actually pay for a compliant deployment is a different number, usually with a seat minimum and an annual contract.
+
+Zoom is the case worth flagging. Teams often assume the AI summary comes with the HIPAA-configured meeting platform they already have. It does not, and the two are provisioned separately.
+
+## What changes when transcription runs on your device
+
+Local capture does not make you compliant. It changes which safeguards are in play.
+
+[Anarlog](/) captures microphone and system audio from your machine without joining the call as a participant, transcribes on-device, and stores the meeting in local SQLite. In that configuration, no third party creates, receives, maintains, or transmits the recording or transcript, so there is no business associate to contract with for those steps.
+
+What this removes:
+
+- A vendor BAA for capture, transcription, and storage, because there is no vendor in those steps
+- A hosted archive of PHI that persists under someone else's retention policy
+- A model provider receiving transcript content, when summarization runs locally or is not used
+- A visible bot in the participant list, which matters when patients or clients are on the call
+
+What it does not remove:
+
+- Device encryption, screen lock, and physical control of the machine
+- Access controls and unique user identification
+- Backup, and the encryption of those backups
+- Audit logging sufficient to reconstruct who accessed what
+- Workforce training, sanctions, and documented policies
+- Consent and recording obligations under state law, which are separate from HIPAA — see [is AI notetaking legal](/blog/is-ai-notetaking-legal/)
+
+If you enable a hosted AI provider for summaries, that provider is back in scope and needs a BAA like any other. Anarlog supports local models and your own provider keys precisely so this is a decision you make rather than a default you inherit, but the decision still has to be made deliberately.
+
+The honest framing: local processing reduces the number of parties who touch PHI and shrinks the contractual surface. It moves responsibility onto your device management rather than eliminating it. Organizations without endpoint controls may be worse off with unmanaged laptops holding transcripts than with a properly contracted hosted vendor.
+
+## An evaluation checklist
+
+Run every candidate through this before recording a single patient conversation.
+
+**Contract**
+
+1. Will the vendor sign a BAA, and on which plan?
+2. Is the BAA executed, or merely offered?
+3. What settings must be enabled for it to apply?
+4. Does it cover transcription, summarization, and storage, or only some of those?
+
+**Data path**
+
+5. Where is audio processed, and where is it stored?
+6. Which subprocessors receive transcripts, and are they each covered?
+7. What is the retention period, and can you set it?
+8. Can you delete a specific meeting and have it actually removed downstream?
+9. Is customer content excluded from model training by contract, not just by policy page?
+
+**Controls**
+
+10. Is there audit logging that shows who accessed a transcript?
+11. Does access control map to your existing identity provider?
+12. Can you restrict which meetings the tool is allowed to capture at all?
+
+**Practical**
+
+13. Does capture add a visible participant, and is that acceptable to the people on the call?
+14. Can you export the complete record in a portable format if you leave?
+15. What happens to existing transcripts when the contract ends?
+
+Questions 6 and 8 are where most vendors slow down. A confident answer to both is a better signal than any certification badge.
+
+## The simpler answer for many teams
+
+A large share of healthcare meetings are not clinical. Staff standups, vendor calls, budget reviews, and hiring conversations contain no PHI, and applying clinical controls to them is expensive friction.
+
+Segmenting is usually the cheaper design:
+
+- Conversations involving PHI use a tool and configuration your compliance team has approved, with an executed BAA or fully local processing.
+- Everything else uses whatever the organization prefers.
+
+The failure mode is a single tool configured for convenience that quietly captures a clinical conversation because it was already running. Whatever you choose, the capture rule has to be explicit and enforced, not left to whoever remembers to close the app.
+
+## Frequently asked questions
+
+### Is any AI notetaker HIPAA compliant out of the box?
+
+No. HIPAA compliance is a property of your organization's controls, contracts, and configuration, not of a product. Otter, Fireflies, Fathom, Avoma, and Sembly will each sign a BAA on their enterprise tiers, which makes a compliant deployment possible. Executing the BAA and configuring the tool correctly is the part that makes it real.
+
+### Does end-to-end encryption make a notetaker HIPAA compliant?
+
+No. HHS guidance is explicit that a cloud provider handling ePHI is a business associate even when the data is encrypted and the provider has no decryption key. Encryption is a required safeguard, not a scope exemption, and it does not remove the need for a BAA.
+
+### Can I use a free AI notetaker with patient information?
+
+No. Every vendor here gates HIPAA coverage to a paid enterprise tier. Fathom's free plan and Fireflies' free plan carry no BAA, which means recording PHI on them is a violation regardless of how the product behaves.
+
+### Is Zoom AI Companion HIPAA compliant?
+
+Zoom's HIPAA-configured instances do not offer AI Companion, and institutional guidance advises against using it in meetings involving sensitive or protected information. Having a HIPAA-configured Zoom deployment does not mean the AI summarization feature is covered by it.
+
+### Does running transcription locally satisfy HIPAA?
+
+It removes third parties from the capture and transcription steps, which eliminates the BAA requirement for those steps. It does not satisfy the Security Rule's requirements for device encryption, access control, audit logging, backup, and workforce training — those remain yours. Local processing narrows the problem rather than solving it.
+
+### What about attorney-client privilege and other confidential conversations?
+
+The analysis is similar and the stakes differ. Sharing a privileged conversation with a third-party processor can risk waiver, and AI-generated transcripts may be discoverable in ways contemporaneous human notes are not. Our guide to [whether AI notetaking is legal](/blog/is-ai-notetaking-legal/) covers consent, privilege, and recording law in more depth.
+
+### Which notetaker should a small clinic actually use?
+
+If PHI is involved, the shortlist is a vendor with an executed BAA on a plan you can afford, or a fully local setup on managed devices. Fathom Enterprise+ and Fireflies Enterprise with Private Storage are the common hosted answers. If the practice already manages its endpoints and would rather not add a business associate at all, [Anarlog](/) keeps capture, transcription, and storage on the clinician's own machine. Either way, the decision should be documented and reviewed by whoever signs off on your risk analysis.

--- a/apps/web/content/articles/notion-meeting-notes.mdx
+++ b/apps/web/content/articles/notion-meeting-notes.mdx
@@ -1,0 +1,212 @@
+---
+meta_title: "How to Use Notion for Meeting Notes"
+display_title: "How to Run Meeting Notes in Notion Without Losing the Transcript"
+meta_description: "Build a Notion meeting notes system with a proper database schema, relations, and action item rollups—then decide whether Notion AI Meeting Notes should do the capture."
+author:
+  - "John Jeong"
+featured: false
+category: "Guides"
+date: "2026-07-27"
+---
+
+Notion is good at the part most notetakers are bad at: connecting a meeting to the people, projects, and decisions around it. A transcript tells you what was said in one room. A Notion database can tell you every conversation you have had with a customer, which commitments came out of them, and which are still open.
+
+Notion is less good at capture. Its native AI Meeting Notes handles a specific set of situations well and degrades outside them, and it sits behind Business and Enterprise plans.
+
+This guide builds the database side first, because that is the part that keeps working regardless of which tool records the audio. Then it covers what Notion's own capture does, where it stops, and how to pair it with a local notetaker when the recording should not leave your machine.
+
+## What we're building
+
+A meeting notes system with four pieces:
+
+- A **Meetings** database with typed properties instead of free-text pages
+- **People** and **Projects** databases linked by relation, so history assembles itself
+- An **Action Items** database rolled up into both
+- Views that answer the three questions people actually ask after a meeting
+
+Everything here works on a free Notion plan. Only the AI capture step requires Business or Enterprise.
+
+## Step 1: Create the Meetings database
+
+Start with a database, not a page tree. A page tree gives you a folder of documents you have to remember the names of. A database gives you filters.
+
+Create a new database called `Meetings` with these properties:
+
+| Property | Type | Why it exists |
+| --- | --- | --- |
+| `Name` | Title | Format as `2026-07-27 · Acme kickoff` so sorting works |
+| `Date` | Date | Include time; you will filter on it constantly |
+| `Type` | Select | `1:1`, `Standup`, `Customer`, `Review`, `Interview`, `Other` |
+| `Attendees` | Relation → People | The property that makes history work |
+| `Project` | Relation → Projects | Groups meetings by the thing they are about |
+| `Status` | Select | `Scheduled`, `Held`, `Notes done` |
+| `Decisions` | Text | One line each, extracted after the meeting |
+| `Transcript` | Files or Text | Where the raw record lands |
+
+The `Type` property earns its place quickly. A 1:1 and a customer call need different templates, and once meetings are typed you can build a view per type instead of scrolling one list.
+
+## Step 2: Create People and Projects
+
+Both are small.
+
+`People` needs `Name`, `Company` or `Team`, `Role`, and a `Meetings` relation that Notion creates automatically when you add the relation from `Meetings`. That is the whole schema. Everything useful on a person page — every meeting you have had with them, in order — comes from the relation, not from anything you type.
+
+`Projects` needs `Name`, `Status`, `Owner` (relation to People), and the reverse `Meetings` relation.
+
+Once these exist, open any person's page and you have their full meeting history without maintaining it. This is the single biggest advantage Notion has over a folder of Markdown files, and it costs about ten minutes to set up.
+
+## Step 3: Build the meeting template
+
+Open the `Meetings` database, click the dropdown beside **New**, and choose **New template**. Name it `Meeting note`.
+
+Set the template body to this structure:
+
+```markdown
+## Context
+Why this meeting is happening. One or two lines, written before it starts.
+
+## Notes
+Raw notes during the conversation. Do not clean these up live.
+
+## Decisions
+- Decided: …
+  - Because: …
+  - Owner: …
+
+## Action items
+- [ ] Owner — task — due date
+
+## Open questions
+- …
+
+## Transcript
+```
+
+Keep `Context` above `Notes`. Written before the call, it takes thirty seconds and it is the field that makes the note readable six months later, when nobody remembers why the meeting was scheduled.
+
+The `Decisions` block matters more than the notes. A summary preserves discussion; it does not reliably preserve what the team committed to and why the alternatives were rejected. If decisions accumulate across many meetings, promote them to their own database — the reasoning is the same as in our [meeting decision log guide](/blog/meeting-decision-log/).
+
+## Step 4: Split action items into their own database
+
+Checkboxes inside a page are invisible. An action item written as `- [ ] Ship the migration` on the Acme kickoff page is findable only if you remember which meeting produced it.
+
+Create an `Action Items` database:
+
+| Property | Type |
+| --- | --- |
+| `Task` | Title |
+| `Owner` | Relation → People |
+| `Due` | Date |
+| `Status` | Select: `Open`, `Blocked`, `Done` |
+| `Source meeting` | Relation → Meetings |
+| `Project` | Relation → Projects |
+
+Then add a rollup on `Meetings` that counts open items from `Source meeting`. A meeting row now carries its own outstanding-commitment count, which is the number that tells you whether the meeting produced anything.
+
+One owner per item, always. An action item assigned to two people is assigned to nobody — see [how to write meeting action items people actually complete](/blog/meeting-action-items/) for the full pattern.
+
+## Step 5: Build the three views that get used
+
+Most Notion setups die from too many views. These three cover the real questions.
+
+**This week.** Filter `Meetings` where `Date` is within the next 7 days, sorted ascending. This is the view you open in the morning.
+
+**Needs notes.** Filter where `Status` is `Held` and the open-items rollup is empty, or `Status` is not `Notes done`. This catches meetings that happened and produced nothing, which is the most common failure in any notes system.
+
+**My open items.** On `Action Items`, filter `Owner` is me and `Status` is not `Done`, grouped by `Due`. Add a board view grouped by `Owner` for anyone running a team.
+
+Everything else — by project, by person, by type — you already get for free by opening the relevant page.
+
+## Step 6: Decide who does the capture
+
+The database above works with any recording source. The question is which one.
+
+### Notion AI Meeting Notes
+
+Notion's [built-in AI Meeting Notes](https://www.notion.com/help/ai-meeting-notes) records a meeting and writes a transcript and summary directly onto a page. Its behavior is worth knowing precisely before you build a workflow on it.
+
+**Where it captures well:**
+
+- The desktop app captures both system audio and your microphone, which is what you need for a video call. It requires macOS 13 or later, or a current Windows build, on desktop app version 4.7.0 or higher.
+- Speaker changes are detected and labeled. Notion's own documentation says this works best on virtual one-on-one meetings, and that linking the page to a calendar event lets it name the other participant.
+
+**Where it stops:**
+
+- The browser version captures microphone input only, not system audio. It is usable for an in-person conversation and not for a video call.
+- Speaker labeling is limited in group meetings, and in the browser and mobile apps. Labeling is available in English only.
+- Transcription covers 15 languages: English, Chinese, Spanish, French, German, Japanese, Korean, Portuguese, Russian, Thai, Vietnamese, Danish, Finnish, Norwegian, Dutch, and Swedish.
+- It requires a Business or Enterprise plan, or an eligible mobile subscription that includes Notion AI. There is no free path.
+- It will not join a meeting on your behalf. Your machine has to be in the call.
+
+**Where the audio goes:**
+
+Notion processes meeting audio through sub-processors including OpenAI, Anthropic, and Fireworks. On desktop and in the browser, audio is held locally during the session; if processing fails, it is uploaded to Notion's servers and kept for up to three days to retry. The mobile app uploads audio to Notion's servers as part of normal operation.
+
+None of that is unusual for a hosted notetaker, and for most internal meetings it is fine. It is worth knowing anyway, because "the recording stayed on my laptop" and "the recording went to three AI vendors" are different answers to a security questionnaire. Our guides to [Anthropic](/blog/anthropic-data-retention-policy/) and [ChatGPT](/blog/chatgpt-data-retention-policy/) retention cover what each provider does with content it receives.
+
+### A local notetaker feeding Notion
+
+The alternative is to record locally and send Notion the finished artifact rather than the raw audio.
+
+[Anarlog](/) captures microphone and system audio from your device without joining the call as a participant, transcribes it — on-device if you want — and keeps the meeting in local SQLite with Markdown export. You paste or export the transcript and summary into the Notion page, and the database, relations, and rollups work exactly as described above.
+
+This split is worth it when:
+
+- meetings include candidate interviews, legal calls, medical conversations, or anything under a retention policy you did not write;
+- you are not on a Notion Business plan and do not want to upgrade for capture alone;
+- transcription needs to work offline, or on a flight;
+- you want to choose which AI provider, if any, sees the transcript;
+- meetings happen in a language Notion does not transcribe.
+
+The tradeoff is one manual step. Notion's native capture writes onto the page by itself; an external notetaker means an export or a paste. In practice that step takes a few seconds and happens once per meeting, and you get to keep the raw record locally rather than only in a workspace.
+
+The same architecture works with [Obsidian](/blog/obsidian-meeting-notes/) if you would rather the whole system be local files. Notion buys you relations and shared views; Obsidian buys you plain files. Pick based on whether other people need to read the notes.
+
+## Step 7: Keep the transcript out of the note body
+
+Paste a 6,000-word transcript into a meeting page and every subsequent search returns that page for every term in it. The signal disappears.
+
+Two options that avoid this:
+
+- **Toggle block.** Put the transcript inside a collapsed toggle at the bottom under `## Transcript`. Notion still indexes it, but the page stays readable.
+- **Attached file.** Export the transcript as Markdown or text and attach it to the `Transcript` file property. The page holds notes, decisions, and action items only, and the raw record stays retrievable without polluting the page.
+
+The second is better once you have more than a few dozen meetings. It also keeps the durable record in a portable file rather than inside a Notion block, which matters if you ever move.
+
+## The workflow, end to end
+
+1. Meeting gets scheduled. Create the row from the `Meeting note` template, set `Type`, link `Attendees` and `Project`, write two lines of `Context`.
+2. Meeting happens. Capture runs — Notion AI, Anarlog, or whatever else. You take sparse notes on what matters to you rather than trying to transcribe.
+3. Within ten minutes of the call, fill `Decisions` and create `Action Items` rows with one owner and a date each.
+4. Attach the transcript, set `Status` to `Notes done`.
+5. The rollups, person histories, and project views update themselves.
+
+Step 3 is the one that decides whether any of this works. Every other step can be automated; that one cannot, because deciding what was actually committed to is judgment, not extraction. Ten minutes after the meeting you still remember the context. The next morning you do not.
+
+## Frequently asked questions
+
+### Does Notion have built-in meeting transcription?
+
+Yes. Notion AI Meeting Notes records and transcribes meetings on the desktop app and in the browser, then generates a summary on the page. The desktop app captures system audio and microphone; the browser captures microphone only. It requires a Business or Enterprise plan, or an eligible mobile subscription with Notion AI included.
+
+### Is Notion AI Meeting Notes free?
+
+No. It is gated to Business and Enterprise plans, and the standalone AI add-on that previously covered it is no longer offered to new users. The database, template, and relation setup in this guide works on a free plan; only the capture step requires an upgrade.
+
+### Can Notion identify who said what?
+
+It detects speaker changes and labels them, and it can name the other participant when the page is linked to a calendar event. Notion states this works best in virtual one-on-one meetings, and that labeling is limited in group meetings, in the browser, and on mobile. Speaker labeling is English-only.
+
+### Will Notion send my meeting audio to AI providers?
+
+Notion processes meeting audio through sub-processors including OpenAI, Anthropic, and Fireworks. On desktop and browser, audio is held locally during the session and uploaded to Notion's servers only if processing fails, where it is retained for up to three days. The mobile app uploads audio as part of normal operation.
+
+### How do I get meeting notes into Notion from another tool?
+
+Export the transcript and summary as Markdown and paste them into the meeting page, or attach the file to a `Transcript` property. Anarlog exports Markdown directly, which pastes into Notion with formatting intact. Keep the transcript in a toggle or an attached file so it does not swamp search.
+
+### Is Notion or Obsidian better for meeting notes?
+
+Notion is better when other people need to read, filter, or comment on the notes, and when relations between meetings, people, and projects carry real weight. Obsidian is better when the notes should be plain local files that outlive any product. Our [Obsidian meeting notes guide](/blog/obsidian-meeting-notes/) builds the equivalent system in files, and [Markdown note-taking apps](/blog/markdown-note-taking-apps/) compares the wider field.
+
+If you want the structure Notion gives you without handing the recording to a hosted service, [try Anarlog](/). It captures the meeting locally, transcribes on-device, and exports Markdown that drops straight into the databases above.


### PR DESCRIPTION
Fill three gaps where the corpus already referenced a topic repeatedly
but had no dedicated page: Avoma, Notion, and HIPAA. Publish dates are
spread across the gap since the last post on 2026-07-22.

- avoma-alternatives (07-24): compares six alternatives by which Avoma
  layer you are replacing (assistant, conversation intelligence, revenue
  intelligence), using current first-party pricing including the add-ons
  that dominate the real per-seat cost.
- notion-meeting-notes (07-27): builds the Meetings/People/Projects/
  Action Items schema first, then documents where Notion AI Meeting
  Notes captures well (desktop system audio, virtual 1:1 speaker labels)
  and where it stops (browser is mic-only, English-only labeling,
  Business plan gating, audio to OpenAI/Anthropic/Fireworks
  subprocessors).
- hipaa-compliant-ai-notetaker (07-30): leads on HHS cloud guidance that
  encryption does not exempt a vendor from business associate status,
  maps the model-provider BAA chain, and tables which notetakers sign a
  BAA on which plan. Positions local capture as narrowing scope rather
  than establishing compliance, matching the existing caveat in
  what-makes-reliable-ai-note-taker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX content with no application, auth, or data-handling code changes.
> 
> **Overview**
> Adds **three new blog articles** (July 2026 publish dates) to fill topics the corpus referenced without dedicated pages.
> 
> **`avoma-alternatives`** frames replacement around Avoma’s three layers—meeting assistant, conversation intelligence, and revenue intelligence—with current add-on pricing, compares six tools (Anarlog, Gong, Grain, Fireflies, Fathom, Sembly), and includes a practical evaluation checklist.
> 
> **`notion-meeting-notes`** documents a **Meetings / People / Projects / Action Items** Notion schema (templates, rollups, three views), then contrasts **Notion AI Meeting Notes** limits (Business plan, desktop vs browser capture, subprocessors) with **local capture + Markdown export** into Notion.
> 
> **`hipaa-compliant-ai-notetaker`** explains why encryption doesn’t remove business associate obligations (HHS cloud guidance), maps **model-provider BAA** coverage, tables **which notetakers sign BAAs on which plans**, and positions **local capture** as narrowing scope—not automatic compliance—with an evaluation checklist and PHI vs non-PHI segmentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbd6020c0626046cc58bffdf1c5f73f5d69dbe1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->