### PR TITLE
fix(editor): stop heading row inset from scrolling notes sideways

### DIFF
--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -346,7 +346,7 @@ const NoteInputContent = forwardRef<
               "pt-2",
               renderedCurrentTab.type === "transcript"
                 ? "overflow-hidden pb-0"
-                : "overflow-auto pb-6",
+                : "overflow-x-hidden overflow-y-auto pb-6",
             ])}
           >
             {renderedCurrentTab.type === "enhanced" && (

--- a/apps/desktop/src/styles/scrollbar.css
+++ b/apps/desktop/src/styles/scrollbar.css
@@ -1,5 +1,8 @@
+/* `height` covers horizontal bars; without it they fall back to WebKit's 15px
+ * default while vertical ones stay slim. */
 ::-webkit-scrollbar {
   width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {

--- a/packages/editor/src/styles/prosemirror/nodes/task-list.css
+++ b/packages/editor/src/styles/prosemirror/nodes/task-list.css
@@ -45,7 +45,7 @@
   ul[data-type="taskList"]
   > li
   > .task-checkbox-label {
-  left: 0.75em;
+  left: 0.75rem;
 }
 
 .note-typography input.task-checkbox {

--- a/packages/editor/src/styles/prosemirror/note-typography.css
+++ b/packages/editor/src/styles/prosemirror/note-typography.css
@@ -24,11 +24,15 @@
   padding-block: 0.125em;
 }
 
+/* The inset is `rem`, not `em`: it has to cancel against the scroll
+ * container's fixed `px-3`, so it must not scale with the block's own font
+ * size. With `em`, an h1 (1.5em) bled 18px into 12px of padding and the extra
+ * 6px scrolled the whole note sideways. */
 .note-typography.prosemirror-editor > * {
   transition: background-color 120ms ease;
-  margin-inline: -0.75em;
+  margin-inline: -0.75rem;
   border-radius: 0.5rem;
-  padding-inline: 0.75em;
+  padding-inline: 0.75rem;
 }
 
 /* font-size is explicit, not inherited: web's `@layer base` sets `p` to
@@ -148,7 +152,7 @@
 .note-typography.prosemirror-editor
   ul:not([data-type="taskList"])
   > li::before {
-  left: calc(0.5em + 0.75em);
+  left: calc(0.5em + 0.75rem);
 }
 
 /* Ordered markers cycle by depth: decimal -> lower-alpha -> lower-roman. */
@@ -201,7 +205,7 @@
   }
 }
 .note-typography.prosemirror-editor ol > li::before {
-  left: 0.75em;
+  left: 0.75rem;
 }
 
 /* Li layout. In the editor the margin extends past the text column for the
@@ -222,10 +226,10 @@
 
 .note-typography.prosemirror-editor li {
   transition: background-color 120ms ease;
-  margin-inline: -0.75em;
+  margin-inline: -0.75rem;
   border-radius: 0.5rem;
-  padding-right: 0.75em;
-  padding-left: calc(1.5em + 0.75em);
+  padding-right: 0.75rem;
+  padding-left: calc(1.5em + 0.75rem);
 }
 
 /* Guide rail centered under the parent li marker. Second selector handles
@@ -340,14 +344,14 @@
 }
 
 /* In the editor, the hover-row rule (higher specificity than the element
- * rules above) would drag these blocks into the -0.75em row inset. Their
+ * rules above) would drag these blocks into the -0.75rem row inset. Their
  * visible left edge — quote border, code background — belongs at the text
  * column, aligned with plain text. That rule's radius also rounds off the ends
  * of the quote border, so it is reset here too. */
 .note-typography.prosemirror-editor blockquote {
   margin-inline-start: 0;
   border-radius: 0;
-  padding-inline: 1em 0.75em;
+  padding-inline: 1em 0.75rem;
 }
 
 .note-typography.prosemirror-editor pre {


### PR DESCRIPTION
The ported note typography gives every top-level editor block a negative
inline margin so the focus backdrop bleeds past the text column. That inset
was em-based while the note scroll container's padding is a fixed px-3, so
they only cancelled at font-size 1em. Every note carries an enforced title
h1 (1.5em), whose 18px inset overran the 12px padding by 6px and gave the
note a permanent horizontal scrollbar.

Switch the inset and its marker offsets to rem so they cancel for every
block regardless of font size, clamp the note container to the vertical
axis, and give ::-webkit-scrollbar a height so horizontal bars are not left
at WebKit's 15px default while vertical ones are 6px.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout and scrollbar tweaks in note editor surfaces; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **unwanted horizontal scrolling** in session notes by aligning editor block hover insets with the scroll container’s fixed horizontal padding.
> 
> The ProseMirror **hover-row negative margins and matching padding** (plus list/task marker `left` offsets and blockquote padding) move from **`em` to `rem`**, so the inset no longer scales with heading size—e.g. a **1.5em title h1** no longer outgrows `px-3` and forces sideways scroll. A short comment in `note-typography.css` documents that rationale.
> 
> The desktop **note tab scroll area** uses **`overflow-x-hidden overflow-y-auto`** instead of `overflow-auto`, and global **`::-webkit-scrollbar`** gets **`height: 6px`** so any horizontal bar matches the slim vertical scrollbar instead of WebKit’s default width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5fdbb5001244f608dd88b0e2750a4e531a89b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->