### PR TITLE
docs(blog): add meeting notes templates and refresh Plaud comparison

### DIFF
--- a/apps/web/content/articles/meeting-notes-template.mdx
+++ b/apps/web/content/articles/meeting-notes-template.mdx
@@ -1,0 +1,301 @@
+---
+meta_title: "Meeting Notes Template: 7 Formats You Can Copy"
+display_title: "Meeting Notes Templates That Survive the Week"
+meta_description: "Copy-paste meeting notes templates for one-on-ones, standups, customer calls, kickoffs, retros, and formal minutes—plus the four rules that decide whether any of them work."
+author:
+  - "John Jeong"
+featured: false
+category: "Guides"
+date: "2026-07-31"
+---
+
+Most meeting notes templates fail for the same reason: they are designed to be filled in, not to be read later. They produce a tidy document that nobody opens again, while the three things people actually come back for — what we decided, who owns what, and what is still open — are buried in a wall of discussion.
+
+A template earns its place when someone can answer those three questions in ten seconds, three weeks later, without having been in the room.
+
+Below are seven templates for the meeting types that make up most calendars, plus the rules that make the difference between a format that holds and one that quietly stops being used by week three.
+
+## The default template
+
+If you only adopt one, use this. It works for most internal meetings.
+
+```markdown
+# 2026-07-31 · Acme kickoff
+**Attendees:** …
+**Purpose:** one line, written before the meeting
+
+## Decisions
+- Decided: …
+  - Why: …
+  - Owner: …
+
+## Action items
+- [ ] Owner — task — due date
+
+## Open questions
+- … (who needs to resolve it, by when)
+
+## Notes
+Raw discussion. Written during. Not cleaned up.
+```
+
+The ordering is the whole point. Decisions and action items sit above the notes because those are what people return for. Most templates put discussion first and outcomes last, which is backwards for every read after the first one.
+
+`Purpose` is written before the meeting starts. It takes fifteen seconds and it is the field that makes the note comprehensible later, when nobody remembers why the meeting was on the calendar.
+
+## Four rules that decide whether a template works
+
+Format matters less than these.
+
+**One owner per action item.** An item assigned to two people is assigned to nobody. If two people genuinely need to act, that is two items. This is the single most common failure in meeting notes, and no template fixes it for you.
+
+**Decisions are separate from discussion.** A summary preserves what was said. It does not reliably preserve what the group committed to, or which alternatives were rejected and why. Keeping decisions in their own block — with the reasoning attached — is what makes notes useful in a disagreement six weeks out. If your team makes enough consequential calls, promote them out of the notes entirely into a [meeting decision log](/blog/meeting-decision-log/).
+
+**Write outcomes within ten minutes of the call.** Everything else can wait. Ten minutes after, you still remember what the vague "we should probably look at that" actually referred to. The next morning you do not.
+
+**Raw notes stay raw.** Do not clean up during the meeting. Cleaning while listening costs you the thing you are there for. Capture messily, structure after.
+
+## Template 1: One-on-one
+
+The point of a 1:1 template is continuity. Most 1:1s fail because they restart from zero every time.
+
+```markdown
+# 1:1 — [Name] — 2026-07-31
+
+## Since last time
+- Carried over: …          ← pulled from last 1:1's open items
+- Landed: …
+
+## Their agenda
+- …
+
+## My agenda
+- …
+
+## Feedback
+- Gave: …
+- Received: …
+
+## Action items
+- [ ] Owner — task — due date
+
+## Next time
+- …
+```
+
+`Since last time` and `Next time` are what turn a series of disconnected chats into a thread. If you use nothing else here, use those two fields.
+
+Keep `Their agenda` above yours. It is a small ordering choice that changes who sets the direction of the conversation. More on the mechanics in [how to have productive one-on-one meetings](/blog/how-to-have-productive-one-on-one-meetings/).
+
+## Template 2: Standup
+
+Standup notes should take under a minute to write. If your template takes longer, people stop.
+
+```markdown
+# Standup — 2026-07-31
+
+| Person | Yesterday | Today | Blocked on |
+| --- | --- | --- | --- |
+| … | … | … | … |
+
+## Blockers needing someone outside this room
+- [ ] Owner — blocker — who can unblock
+```
+
+The second section is the only part that matters after the meeting ends. A blocker that stays inside the standup notes is a blocker nobody acted on.
+
+## Template 3: Customer or discovery call
+
+Structured for recall across many calls, not for a single conversation.
+
+```markdown
+# [Company] — discovery — 2026-07-31
+**Attendees:** … (roles matter more than names)
+**Stage:** …
+
+## Their situation
+- Current process: …
+- Tools in use: …
+
+## Problems, in their words
+- "…"
+- "…"
+
+## Requirements
+- Must have: …
+- Nice to have: …
+
+## Objections and concerns
+- …
+
+## Next step
+- [ ] Owner — what — by when
+```
+
+`Problems, in their words` should hold actual quotes. Paraphrased customer pain converges on generic language within two calls, and then every account sounds the same in your notes. Verbatim phrasing is also what you reuse in positioning later.
+
+`Next step` is a single committed action with a date, not a list of possibilities. A discovery call without one did not close.
+
+## Template 4: Project kickoff
+
+Kickoffs generate the most durable notes of any meeting type, because everything downstream refers back to them.
+
+```markdown
+# [Project] kickoff — 2026-07-31
+
+## Problem we are solving
+One paragraph. If this is hard to write, the project is not ready.
+
+## Success criteria
+- …  ← measurable, not "improve X"
+
+## Explicitly out of scope
+- …
+
+## Owners
+| Area | Owner | Backup |
+| --- | --- | --- |
+
+## Key dates
+| Milestone | Date | Depends on |
+| --- | --- | --- |
+
+## Risks
+| Risk | Likelihood | Mitigation | Owner |
+| --- | --- | --- | --- |
+
+## Open questions
+- [ ] Question — who resolves — by when
+```
+
+`Explicitly out of scope` prevents more rework than any other field on this page. Scope creep is rarely a decision; it is usually an assumption that was never written down and contradicted.
+
+## Template 5: Retrospective
+
+```markdown
+# Retro — [Sprint/Period] — 2026-07-31
+
+## What worked
+- …
+
+## What did not
+- …
+
+## What we are changing
+- [ ] Owner — change — review on [date]
+
+## Carried over from last retro
+- … ← did the change actually happen?
+```
+
+The last section is what separates a retro that improves things from a recurring venting session. If a change from the previous retro never happened, that is the most useful data point in the room.
+
+Keep `What we are changing` short. Three changes get done. Twelve do not.
+
+## Template 6: Formal minutes
+
+For board meetings, committees, HOAs, nonprofits, and anywhere the record may be reviewed externally. This is a different document from working notes — it records the proceeding, not the discussion.
+
+```markdown
+# [Organization] — [Body] — Minutes
+**Date:** 2026-07-31   **Time:** 14:00–15:30   **Location:** …
+**Present:** …
+**Absent:** …
+**Quorum:** Yes / No
+**Chair:** …   **Recorder:** …
+
+## 1. Call to order
+Called to order at 14:00 by [name].
+
+## 2. Approval of previous minutes
+Minutes of [date] approved / approved as amended.
+- Moved: [name]  Seconded: [name]  Result: Carried / Failed
+
+## 3. [Agenda item]
+Discussion: brief, neutral summary.
+**Motion:** [exact wording]
+- Moved: [name]  Seconded: [name]
+- Vote: For __ / Against __ / Abstain __
+- Result: Carried / Failed
+
+## 4. Action items
+| # | Action | Owner | Due |
+| --- | --- | --- | --- |
+
+## 5. Adjournment
+Adjourned at 15:30. Next meeting: [date].
+```
+
+Two things differ from working notes. Motions are recorded in their exact wording, because paraphrase changes meaning. And discussion summaries stay neutral — minutes record that a matter was debated, not who argued badly. If you need software rather than a file for this, see our comparison of [meeting minutes software](/blog/meeting-minutes-software/).
+
+## Template 7: Interview
+
+```markdown
+# [Candidate] — [Role] — [Round] — 2026-07-31
+**Interviewer:** …   **Focus area:** …
+
+## Questions and responses
+**Q:** …
+**A:** … (what they said, not your read of it)
+
+## Signals
+- Evidence for: …
+- Evidence against: …
+
+## Recommendation
+Strong hire / Hire / No hire / Strong no hire
+**Rationale:** …
+```
+
+Keep observation separate from judgment. Mixing them is how interview notes turn into a record of an impression formed in the first four minutes. Write what the candidate said, then decide.
+
+Interview notes are also the clearest case for keeping recordings and transcripts off third-party servers — they contain personal data about someone who did not choose your vendor.
+
+## Where to keep the template
+
+The template is only half the system. Retrieval is the other half.
+
+**Plain Markdown files.** The most portable option. Files you own, greppable, no vendor, and they still open in twenty years. Works well with [Obsidian](/blog/obsidian-meeting-notes/) if you want backlinks and person pages assembling themselves. Our [Markdown note-taking app comparison](/blog/markdown-note-taking-apps/) covers the editors.
+
+**A database.** [Notion](/blog/notion-meeting-notes/) and similar tools buy you relations — every meeting with a person, every meeting on a project — and shared views for a team. The cost is that your notes live inside a product.
+
+**Whatever your notetaker produces.** If an AI tool is generating the summary, the template still matters: it tells you what to keep. Most AI summaries are decent at discussion and weak at decisions and ownership, which is exactly the part these templates protect.
+
+If you want the transcript captured automatically but the notes to stay as files you control, [Anarlog](/) records microphone and system audio without joining the call as a participant, transcribes on-device, and exports Markdown that drops straight into any of the templates above.
+
+## Filling the template without transcribing the meeting
+
+The templates assume you are participating, not stenographing. In practice:
+
+1. Before the call, write `Purpose` and paste the template. Fifteen seconds.
+2. During, capture only in `Notes`, messily. Star anything that sounds like a commitment.
+3. In the ten minutes after, lift decisions and action items into their sections. Assign one owner and a date to each.
+4. Attach or link the transcript at the bottom, not inline — a 6,000-word transcript pasted into the note destroys search for every other note.
+
+Step 3 is judgment and cannot be automated. Deciding what the group actually committed to is different from extracting sentences that contain the word "will." That ten minutes is the difference between notes and a transcript.
+
+## Frequently asked questions
+
+### What should a meeting notes template include?
+
+At minimum: date, attendees, purpose, decisions, action items with one owner and a due date each, and open questions. Everything else is optional. If a field is not read after the meeting, remove it — unused fields are why templates get abandoned.
+
+### How detailed should meeting notes be?
+
+Detailed on outcomes, sparse on discussion. Nobody re-reads a full account of a conversation. They re-read what was decided and what they owe. If you find yourself transcribing, you are doing the machine's job and not your own — see [how to participate in meetings effectively](/blog/how-to-participate-in-meetings-effectively/).
+
+### What is the difference between meeting notes and meeting minutes?
+
+Meeting notes are a working document for the people involved: decisions, actions, context. Minutes are a formal record of a proceeding — attendance, quorum, motions in their exact wording, votes — often subject to approval at the next meeting. Use Template 6 for minutes and the default template for everything else.
+
+### Should I use a different template for every meeting type?
+
+Use the default for most things and add a specific template only where the meeting type has a recurring structure the default misses — 1:1s need continuity fields, kickoffs need scope and risks, minutes need motions. Three or four templates is usually the ceiling before people stop choosing correctly.
+
+### Can AI fill in a meeting notes template for me?
+
+It can draft the discussion summary and propose action items reliably. It is weaker at deciding which statements were real commitments and who owns them, which is the part that matters. Treat AI output as the raw material for steps 3 and 4 above, not as the finished note.
+
+### Where should meeting notes live?
+
+Somewhere searchable that you will still have access to in two years. Plain Markdown files are the safest default; a shared database is better when other people need to read and filter them. What matters more than the tool is that the notes are exportable — see [how to organize meeting notes](/blog/organize-meeting-notes/) for the retrieval side.

--- a/apps/web/content/articles/plaud-ai-alternatives.mdx
+++ b/apps/web/content/articles/plaud-ai-alternatives.mdx
@@ -1,47 +1,54 @@
 ---
-meta_title: "6 Better Alternatives to Plaud AI (Hardware & Software)"
+meta_title: "6 Best Plaud AI Alternatives and Competitors in 2026"
 display_title: "6 Plaud AI Alternatives Worth Considering in 2026"
-meta_description: "Looking beyond Plaud? Compare 6 AI voice recorder alternatives. Hardware, software & specialized AI recorders reviewed."
+meta_description: "Compare six Plaud alternatives across hardware recorders and desktop software—updated for Plaud's Mac notetaker, current device lineup, and 2026 subscription tiers."
 author:
   - "John Jeong"
 featured: false
 category: "Comparisons"
-date: "2025-10-27"
+date: "2026-07-31"
 ---
 
-Plaud's credit card-sized recorder looked promising until you saw the subscription costs pile up. Or maybe you're tired of managing yet another piece of hardware. Perhaps you just want your meeting data to stay on your device instead of floating around in someone else's cloud.
+Plaud is no longer just a recorder you carry. Alongside the hardware, it now ships a Mac desktop notetaker that captures system audio from video calls — which means "what's the alternative to Plaud" depends on which Plaud you actually use.
 
-Whatever brought you here, you're looking for something different. This guide covers six alternatives that take different approaches to voice recording and AI transcription.
+If you bought the device for in-person conversations, your alternatives are other recorders. If you are using the desktop app for meetings, you are comparing against a completely different set of software. And if the subscription math is what brought you here, that is a third question again.
 
-We'll focus on what actually matters: how they work, what they cost, and whether they'll solve your specific problem better than Plaud.
+This guide covers six alternatives across both categories: how they work, what they cost, and which specific Plaud problem each one solves.
 
 ## Quick Plaud AI review
 
-Plaud is a hardware-first AI notetaking system built around physical voice recorders that sync with a mobile app for transcription and summarization.
+Plaud started as a hardware-first AI notetaking system and has since expanded into desktop software. The company reports more than 1.5 million devices sold across four launches.
 
-The lineup includes Plaud Note (a credit card-sized recorder at 0.12" thin), Plaud Note Pro (with four precision microphones for 16.4-foot pickup range), and Plaud NotePin (a wearable recorder you can clip, pin, or wear as a necklace).
+**The hardware lineup:**
 
-All devices use dual-mode recording, switching between phone call capture via vibration conduction and ambient recording for in-person conversations.
+| Device | Price | Form factor |
+| --- | --- | --- |
+| Plaud Note | $159 | Credit-card recorder, 0.12" thin |
+| Plaud NotePin | $159 | Wearable — clip, lanyard, or necklace |
+| Plaud NotePin S | $179 | Wearable with a physical record/highlight button, 64GB, 20-hour battery, Find My support |
+| Plaud Note Pro | $189 | Four microphones, 16.4-foot pickup range |
 
-The catch? After your 300 free minutes per month, you're paying $99.99/year for 1,200 minutes or $239.99/year for unlimited. Plus, there's the upfront hardware cost ($159-$179) and the fact that you need cloud processing for the AI features that make it useful.
+Devices use dual-mode recording, switching between phone-call capture via vibration conduction and ambient recording for in-person conversations.
 
-It works, but it's not for everyone. Let's look at what else is out there.
+**The desktop app.** In January 2026 Plaud launched a Mac meeting notetaker that captures system audio, detects active meetings and prompts you to record, and accepts images and typed notes alongside the transcript. Plaud positioned it directly against Granola, Fathom, and Fireflies. This is the change that dates most existing Plaud comparisons — the product is no longer confined to in-person capture.
+
+**The subscription.** A free Starter tier gives 300 transcription minutes per month. Pro is $99.99/year or $17.99/month for 1,200 minutes. Unlimited is $239.99/year or $29.99/month. Team runs $20 per user per month billed annually under a launch offer through August 31, 2026, rising to $25 after, or $35 monthly. Overage is sold in packs: 600 minutes for $12.99, 3,000 for $59.99, and 6,000 for $99.99, each valid two years.
+
+So the real cost is hardware plus a recurring minute allowance, and the AI features that make the device useful require cloud processing. That is the tradeoff people come here to escape.
 
 ## Comparison table: Plaud vs alternatives
 
-Here's how six AI transcription and note-taking tools compare with Plaud:
+| Tool | Best For | Type | Key Advantage | Main Limitation | Starting Price |
+| --- | --- | --- | --- | --- | --- |
+| Plaud | Portable recording plus Mac meetings | Hardware recorder + Mac app | Discreet in-person capture | Cloud processing, metered minutes | $159 hardware + $99.99/year |
+| Anarlog | Privacy-focused Mac users | Desktop software (macOS) | Local transcription, no metered minutes | macOS only, no hardware recorder | Free |
+| iFLYTEK Smart Recorder Pro | Professional field recording | Standalone hardware device | Standalone with touchscreen | Bulky form factor | $329.99 one-time |
+| Mobvoi TicNote | Casual wearable recording | Wearable hardware + app | Wearable convenience | Limited battery life | $169 + $8.99/month |
+| Notta Memo | Budget-conscious users | Pocket hardware + app | Affordable entry point | Requires phone for features | $69 + $13.49/month |
+| Deepscribe | Healthcare providers only | Healthcare AI scribe (iOS app) | Clinical documentation | Healthcare-only | $400-500/month per provider |
+| Avoma | Sales & revenue teams | Cloud-based software | Sales intelligence | Bot visibility, add-on pricing | $19/user/month + add-ons |
 
-
-| Tool                       | Best For                     | Type                           | Key Advantage               | Main Limitation             | Starting Price              |
-| -------------------------- | ---------------------------- | ------------------------------ | --------------------------- | --------------------------- | --------------------------- |
-| Plaud                      | Portable recording anywhere  | Hardware recorder + app        | Portable & discreet         | Cloud dependency for AI     | $159 hardware + $99.99/year |
-| Anarlog                       | Privacy-focused Mac users    | Desktop software (macOS)       | Zero cloud dependency       | macOS only                  | Free                        |
-| iFLYTEK Smart Recorder Pro | Professional field recording | Standalone hardware device     | Standalone with touchscreen | Bulky form factor           | $329.99 one-time            |
-| Mobvoi TicNote             | Casual wearable recording    | Wearable hardware + app        | Wearable convenience        | Limited battery life        | $169 + $8.99/month          |
-| Notta Memo                 | Budget-conscious users       | Pocket hardware + app          | Affordable entry point      | Requires phone for features | $69 + $13.49/month          |
-| Deepscribe                 | Healthcare providers only    | Healthcare AI scribe (iOS app) | Clinical documentation      | Healthcare-only             | $400-500/month per provider |
-| Avoma                      | Sales & revenue teams        | Cloud-based software           | Sales intelligence          | Bot visibility              | $29/user/month              |
-
+Pricing in this category changes often. Confirm the current plan against your actual recording volume before committing.
 
 Continue reading for detailed reviews of each of these tools.
 
@@ -352,24 +359,30 @@ The platform then pushes this data directly to your CRM, updating custom fields,
 #### Cons
 
 - Cloud-only with bot visibility that can affect conversation dynamics (vs Plaud's discreet recording)
-- Add-on costs stack up quickly—conversation and revenue intelligence each cost $35/user/month extra
+- Add-on costs stack up quickly—conversation and revenue intelligence each cost $29/user/month extra on annual billing, $35 monthly
 - Designed for sales teams, potentially overkill if you just need simple meeting notes
 - Requires annual billing for Enterprise features (SSO, HIPAA, advanced security)
 - Minimum seat requirements on higher tiers
 
 #### Pricing
 
-Avoma's pricing looks straightforward until you realize the good features cost extra. The base Organization plan starts at $29/user/month (billed annually) and includes unlimited transcription, AI notes, CRM automation, and scheduling. This handles core meeting needs without artificial limits.
+Avoma's pricing looks straightforward until you realize the good features cost extra. The base plans are Startup at $19 per user per month, Organization at $24, and Enterprise at $39, all billed annually — monthly billing is higher across the board. Those tiers include unlimited transcription, AI notes, CRM automation, and scheduling.
 
-But to unlock conversation intelligence features like call scoring, coaching insights, and keyword tracking, add another $29/user/month. Want revenue intelligence with deal risk alerts and pipeline tracking? That's another $29/user/month. Need advanced lead routing? Add $19/user/month for the Scheduler add-on.
+Unlocking conversation intelligence — call scoring, coaching insights, keyword tracking — adds $29 per seat per month on annual billing. Revenue intelligence with deal risk alerts and pipeline forecasting is another $29. Lead Router is $19. There is a bundling discount of 10% on any two add-ons and 15% on all three, and viewers and collaborators are free.
 
-For teams that actually need the full revenue intelligence stack, Avoma delivers legitimate ROI by replacing multiple tools. But if you're just looking for meeting transcription, this is expensive overkill.
+A team using the full platform lands closer to $80 per seat than the advertised $19. For teams that genuinely need the revenue stack, that replaces several tools. If you just want meeting notes, it is expensive overkill — we compare the options by which layer you actually need in our [Avoma alternatives guide](/blog/avoma-alternatives/).
 
 ## Which Plaud alternative should you choose?
 
-The right tool depends on what matters most to you:
+Start by naming which Plaud you are replacing.
 
-**Choose Anarlog** if you're on a Mac and want a local-first, bot-free meeting workflow with AI-provider choice. For sensitive work, configure local processing where appropriate and complete your own security and compliance review before adopting any tool.
+- **Replacing the device** — you record in-person conversations, walk-and-talks, or meetings without a laptop. Your alternatives are other recorders: iFLYTEK, TicNote, or Notta Memo.
+- **Replacing the Mac app** — you record video calls at a desk. Your alternatives are desktop notetakers, where Anarlog, Granola, Fathom, and Fireflies compete directly.
+- **Replacing the subscription** — the hardware is fine but metered minutes are not. Look for tools without a per-minute meter, which in practice means local transcription.
+
+Then pick on the specifics:
+
+**Choose Anarlog** if you're on a Mac and want a local-first, bot-free meeting workflow with AI-provider choice, with no monthly minute allowance to manage. It replaces Plaud's desktop app rather than its hardware — there is no device to carry, so it cannot capture a conversation away from your computer. For sensitive work, configure local processing where appropriate and complete your own security and compliance review before adopting any tool.
 
 **Choose iFLYTEK Smart Recorder Pro** if you need professional-grade field recording with a standalone device. The built-in touchscreen and 15-meter microphone range make it ideal for journalists, researchers, or anyone recording lectures and conferences where you can't rely on your phone or laptop.
 


### PR DESCRIPTION
Closes the July content calendar with the two remaining slots, retargeted
against live Semrush data now that Position Tracking is configured.

ANLG-120 was specified as a top-of-funnel post on private/bot-free/local
notetakers, but every premise keyword returns zero US volume and six
existing posts already cover that theme. Retargeted to 'meeting notes
template' (12,100 vol, KD 41) — the largest uncovered term in the set,
14x the volume of the next candidate at the same difficulty. The new post
ships seven copy-paste templates and links the existing action-item,
decision-log, and organize-notes guides.

ANLG-119 refreshes plaud-ai-alternatives, which was nine months stale and
framed Plaud as hardware-only. Plaud shipped a Mac desktop notetaker in
January 2026 that captures system audio, so the post now splits the
decision by which Plaud you are replacing (device, desktop app, or
subscription). Also corrects the device lineup and 2026 subscription
tiers, and fixes Avoma pricing, which was listed at a flat $29/user/month
against actual $19/$24/$39 tiers plus $29 add-ons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blog/MDX content and SEO metadata only; no application code, auth, or data paths change.
> 
> **Overview**
> Adds a new **Guides** post targeting “meeting notes template” with seven copy-paste Markdown formats (default, 1:1, standup, discovery, kickoff, retro, formal minutes, interview), usage rules, storage/AI workflow guidance, and FAQs wired to existing posts (decision log, organize notes, related guides).
> 
> **Refreshes** `plaud-ai-alternatives.mdx` for 2026: Plaud is framed as hardware **plus** Mac desktop notetaker, with an updated device table (including NotePin S), current subscription/overage tiers, and comparison-table copy tweaks. **Avoma** pricing is corrected to $19/$24/$39 base tiers and $29 add-ons, with a “which Plaud are you replacing?” decision path (device vs Mac app vs subscription).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0720266c2b9dade85559ee9c53ce7968549a2ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->