### PR TITLE
chore(web): restore Napkin figure workflow and run it as a batch

### DIFF
--- a/.github/workflows/web_ci.yaml
+++ b/.github/workflows/web_ci.yaml
@@ -25,3 +25,7 @@ jobs:
       - run: pnpm -F @anlg/supabase test
       - run: pnpm -F web typecheck
       - run: pnpm -F web test
+      # Fails when a new article has no content/articles/figures.json entry.
+      # A declared-but-ungenerated figure only warns; use --strict to gate on it.
+      # Public HEAD requests only, so no Napkin or Supabase credentials needed.
+      - run: pnpm -F web media:figures:check

--- a/apps/web/content/articles/figures.json
+++ b/apps/web/content/articles/figures.json
@@ -1,0 +1,101 @@
+{
+  "ai-meeting-notes-without-bot": [],
+  "ai-meeting-summary-tools": [],
+  "anthropic-data-retention-policy": [],
+  "avoma-alternatives": [
+    {
+      "filename": "avoma-three-layers.png",
+      "content": "Meeting assistant\nConversation intelligence\nRevenue intelligence",
+      "context": "Vertical stacked-layer diagram for an Anarlog blog post showing the three product layers bundled into Avoma, so a reader can identify which layer they actually need to replace.",
+      "orientation": "vertical",
+      "width": 1000
+    }
+  ],
+  "azure-open-ai-data-retention-policy": [],
+  "best-ai-meeting-assistant-for-taking-notes": [],
+  "best-ai-notetaker": [],
+  "best-ai-notetaker-for-in-person-meetings": [],
+  "best-ai-notetaker-for-microsoft-teams": [],
+  "best-ai-notetaker-for-zoom": [],
+  "best-ai-notetakers-google-meet": [],
+  "bot-free-ai-meeting-assistants": [],
+  "can-you-transcribe-meetings-without-sending-data-to-cloud": [],
+  "char-is-now-anarlog": [],
+  "char-vs-meetily": [],
+  "chatgpt-data-retention-policy": [],
+  "enterprise-ai-notetaking-tools": [],
+  "fathom-ai-alternatives": [],
+  "filesystem-is-coretex": [],
+  "fireflies-ai-alternatives": [],
+  "free-ai-notetakers": [],
+  "free-transcription-software": [],
+  "google-gemini-data-retention-policy": [],
+  "google-gemini-meeting-notes": [],
+  "granola-ai-alternatives": [],
+  "hipaa-compliant-ai-notetaker": [
+    {
+      "filename": "baa-chain.png",
+      "content": "Covered entity\nAI notetaker vendor\nTranscription provider\nLanguage model provider",
+      "context": "Horizontal chain diagram for an Anarlog blog post. Show that every party that receives protected health information becomes a business associate needing its own signed BAA. Neutral and professional, not alarming.",
+      "visualQuery": "flowchart",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
+  "how-to-have-productive-one-on-one-meetings": [],
+  "how-to-participate-in-meetings-effectively": [],
+  "how-to-reduce-meeting-fatigue": [],
+  "how-to-transcribe-zoom-calls": [],
+  "is-ai-notetaking-legal": [],
+  "is-fireflies-ai-safe": [],
+  "is-otter-ai-safe": [],
+  "local-ai-meeting-notes": [],
+  "local-ai-privacy-tools": [],
+  "mac-productivity-apps": [],
+  "markdown-note-taking-apps": [],
+  "meetgeek-alternatives": [],
+  "meetily-review": [],
+  "meeting-action-items": [],
+  "meeting-decision-log": [],
+  "meeting-minutes-software": [],
+  "meeting-notes-template": [
+    {
+      "filename": "meeting-note-anatomy.png",
+      "content": "Purpose\nDecisions\nAction items\nOpen questions\nRaw notes",
+      "context": "Vertical diagram for an Anarlog blog post showing the anatomy of a meeting note, ordered so outcomes sit above raw discussion.",
+      "orientation": "vertical",
+      "width": 1000
+    }
+  ],
+  "meeting-preparation-checklist": [],
+  "meeting-productivity-tools": [],
+  "mistral-api-key": [],
+  "mistral-data-retention-policy": [],
+  "notetakers-for-developers": [],
+  "notion-meeting-notes": [
+    {
+      "filename": "notion-relations.png",
+      "content": "Meetings\nPeople\nProjects\nAction items",
+      "context": "Relationship diagram for an Anarlog blog post showing a Notion Meetings database linked by relation to People, Projects, and Action Items.",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
+  "notta-ai-alternative": [],
+  "obsidian-meeting-notes": [],
+  "open-source-meeting-transcription-software": [],
+  "openrouter-data-retention-policy": [],
+  "organize-meeting-notes": [],
+  "otter-ai-alternatives": [],
+  "otter-ai-review": [],
+  "plaud-ai-alternatives": [],
+  "read-ai-alternatives": [],
+  "see-zoom-meeting-history": [],
+  "selfhosted-ai-notetakers": [],
+  "tactiq-alternatives": [],
+  "tldv-alternatives": [],
+  "tldv-review": [],
+  "transcription-software-mac": [],
+  "what-makes-reliable-ai-note-taker": [],
+  "zoom-ai-companion-review": []
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' VITE_APP_URL=\"http://localhost:3000\" VITE_API_URL=\"http://localhost:3001\" dotenvx run --ignore MISSING_ENV_FILE -f ../../.env.supabase -f .env -- vite dev --port 3000",
     "build": "NODE_OPTIONS='--max-old-space-size=8192' vite build && cp public/sitemap.xml dist/client/sitemap.xml && pagefind --site ./dist/client",
+    "media:napkin": "node scripts/napkin-to-supabase.mjs",
+    "media:figures": "node scripts/napkin-batch.mjs",
+    "media:figures:check": "node scripts/napkin-batch.mjs --check",
     "serve": "vite preview",
     "test": "node --test",
     "typecheck": "tsc --project tsconfig.json --noEmit"

--- a/apps/web/scripts/napkin-batch.mjs
+++ b/apps/web/scripts/napkin-batch.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const webDir = resolve(scriptDir, "..");
+const ARTICLES_DIR = resolve(webDir, "content/articles");
+const MANIFEST_PATH = resolve(ARTICLES_DIR, "figures.json");
+const SINGLE_SCRIPT = resolve(scriptDir, "napkin-to-supabase.mjs");
+
+// Mirrors STORAGE_BUCKETS.blog in src/routes/api/assets.$.ts. Public, so the
+// existence check needs no credentials and is safe to run in CI.
+const PUBLIC_BLOG_BASE =
+  "https://auth.hyprnote.com/storage/v1/object/public/blog";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) throw new Error(`Unexpected argument: ${arg}`);
+    const [rawKey, inline] = arg.slice(2).split("=", 2);
+    const key = rawKey.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+    if (inline !== undefined) {
+      args[key] = inline;
+      continue;
+    }
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    i += 1;
+  }
+  return args;
+}
+
+function usage() {
+  return `Usage:
+  pnpm -F @anlg/web media:figures            Generate every declared figure that is missing
+  pnpm -F @anlg/web media:figures:check      Report missing figures, generate nothing
+
+Options:
+  --check          Report only, generate nothing. Needs no credentials, so it is
+                   safe in CI. Exits 1 when an article has no manifest entry or
+                   the manifest names a slug with no article. A declared but
+                   not-yet-generated figure only warns.
+  --strict         With --check, also exit 1 on not-yet-generated figures.
+  --slug <slug>    Limit to one article.
+  --upsert         Regenerate and replace figures that already exist.
+  --dry-run        Print what each generation would request.
+
+Declare figures in content/articles/figures.json:
+
+  {
+    "my-post-slug": [
+      {
+        "filename": "capture-flow.png",
+        "content": "Meeting audio\\nLocal transcription\\nMarkdown note",
+        "context": "Horizontal flow diagram for an Anarlog blog post.",
+        "visualQuery": "flowchart",
+        "orientation": "horizontal",
+        "width": 1200
+      }
+    ]
+  }
+
+An empty array marks a post as deliberately figure-less and satisfies --check.
+
+Generation requires NAPKIN_API_TOKEN, SUPABASE_URL, and SUPABASE_SERVICE_ROLE_KEY;
+see napkin-to-supabase.md for the Infisical command.
+`;
+}
+
+async function readArticleSlugs() {
+  const entries = await readdir(ARTICLES_DIR);
+  return entries
+    .filter((f) => f.endsWith(".mdx"))
+    .map((f) => f.replace(/\.mdx$/, ""))
+    .sort();
+}
+
+async function readManifest() {
+  let raw;
+  try {
+    raw = await readFile(MANIFEST_PATH, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") return {};
+    throw error;
+  }
+  const parsed = JSON.parse(raw);
+  if (Array.isArray(parsed) || typeof parsed !== "object" || parsed === null) {
+    throw new Error("figures.json must be an object keyed by article slug");
+  }
+  return parsed;
+}
+
+function storagePath(slug, filename) {
+  return `articles/${slug}/${filename}`;
+}
+
+async function figureExists(slug, filename) {
+  const url = `${PUBLIC_BLOG_BASE}/${storagePath(slug, filename)}`;
+  try {
+    const response = await fetch(url, { method: "HEAD" });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function runSingle(slug, figure, { upsert, dryRun }) {
+  const args = [
+    SINGLE_SCRIPT,
+    "--slug",
+    slug,
+    "--filename",
+    figure.filename,
+    "--content",
+    figure.content,
+  ];
+
+  const passthrough = {
+    context: "--context",
+    visualQuery: "--visual-query",
+    orientation: "--orientation",
+    width: "--width",
+    height: "--height",
+    format: "--format",
+    styleId: "--style-id",
+    language: "--language",
+    numberOfVisuals: "--number-of-visuals",
+    fileIndex: "--file-index",
+    colorMode: "--color-mode",
+  };
+
+  for (const [key, flag] of Object.entries(passthrough)) {
+    if (figure[key] !== undefined) args.push(flag, String(figure[key]));
+  }
+  if (figure.transparentBackground) args.push("--transparent-background");
+  if (upsert) args.push("--upsert");
+  if (dryRun) args.push("--dry-run");
+
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: webDir,
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`napkin-to-supabase exited with code ${code}`));
+    });
+  });
+}
+
+function validateFigure(slug, figure, index) {
+  const where = `${slug}[${index}]`;
+  if (!figure || typeof figure !== "object") {
+    throw new Error(`${where} must be an object`);
+  }
+  if (!figure.filename) throw new Error(`${where} is missing "filename"`);
+  if (!figure.content) throw new Error(`${where} is missing "content"`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  const checkOnly = Boolean(args.check);
+  const onlySlug = typeof args.slug === "string" ? args.slug : null;
+
+  const [slugs, manifest] = await Promise.all([
+    readArticleSlugs(),
+    readManifest(),
+  ]);
+
+  const undeclared = slugs.filter(
+    (slug) => !Object.prototype.hasOwnProperty.call(manifest, slug),
+  );
+  const orphaned = Object.keys(manifest).filter(
+    (slug) => !slugs.includes(slug),
+  );
+
+  const targets = [];
+  for (const [slug, figures] of Object.entries(manifest)) {
+    if (onlySlug && slug !== onlySlug) continue;
+    if (!Array.isArray(figures)) {
+      throw new Error(`figures.json: "${slug}" must map to an array`);
+    }
+    figures.forEach((figure, index) => {
+      validateFigure(slug, figure, index);
+      targets.push({ slug, figure });
+    });
+  }
+
+  const missing = [];
+  for (const target of targets) {
+    const exists = await figureExists(target.slug, target.figure.filename);
+    if (!exists || args.upsert) missing.push(target);
+  }
+
+  if (orphaned.length > 0) {
+    console.error(
+      `figures.json declares ${orphaned.length} slug(s) with no matching article:`,
+    );
+    for (const slug of orphaned) console.error(`  - ${slug}`);
+  }
+
+  if (checkOnly) {
+    // Undeclared articles and stale entries fail the build: those are authoring
+    // mistakes. A generation backlog only warns unless --strict, so an unrun
+    // batch never turns CI red on its own.
+    const strict = Boolean(args.strict);
+
+    if (undeclared.length > 0) {
+      console.error(
+        `\n${undeclared.length} article(s) not declared in figures.json:`,
+      );
+      for (const slug of undeclared) console.error(`  - ${slug}`);
+      console.error(
+        "\nAdd an entry for each. Use [] to mark a post as deliberately figure-less.",
+      );
+    }
+    if (missing.length > 0) {
+      console.error(
+        `\n${missing.length} declared figure(s) not yet uploaded${strict ? "" : " (warning)"}:`,
+      );
+      for (const { slug, figure } of missing) {
+        console.error(`  - ${storagePath(slug, figure.filename)}`);
+      }
+      console.error(
+        "\nRun `pnpm -F @anlg/web media:figures` with Napkin and Supabase credentials.",
+      );
+    }
+
+    const failed =
+      undeclared.length > 0 ||
+      orphaned.length > 0 ||
+      (strict && missing.length > 0);
+
+    if (!failed && missing.length === 0) {
+      console.log(
+        `All ${targets.length} declared figure(s) present across ${slugs.length} article(s).`,
+      );
+    }
+    if (failed) process.exit(1);
+    return;
+  }
+
+  if (undeclared.length > 0) {
+    console.error(
+      `Note: ${undeclared.length} article(s) have no figures.json entry and will be skipped.`,
+    );
+  }
+
+  if (missing.length === 0) {
+    console.log("Nothing to generate; every declared figure already exists.");
+    return;
+  }
+
+  console.error(`Generating ${missing.length} figure(s)...\n`);
+
+  const failures = [];
+  for (const [index, { slug, figure }] of missing.entries()) {
+    const label = storagePath(slug, figure.filename);
+    console.error(`[${index + 1}/${missing.length}] ${label}`);
+    try {
+      await runSingle(slug, figure, {
+        upsert: Boolean(args.upsert),
+        dryRun: Boolean(args.dryRun),
+      });
+    } catch (error) {
+      failures.push({ label, message: error.message });
+      console.error(`  failed: ${error.message}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} figure(s) failed:`);
+    for (const failure of failures) {
+      console.error(`  - ${failure.label}: ${failure.message}`);
+    }
+    process.exit(1);
+  }
+
+  console.error(`\nGenerated ${missing.length} figure(s).`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/apps/web/scripts/napkin-to-supabase.md
+++ b/apps/web/scripts/napkin-to-supabase.md
@@ -1,0 +1,124 @@
+# Napkin Figures for Blog Posts
+
+Use Napkin for blog conceptual figures: workflows, privacy/data-flow diagrams,
+decision trees, comparison visuals, and abstract explainers. Blog diagrams
+should come from Napkin rather than hand-rolled SVG/PNG assets unless the user
+explicitly asks for a non-Napkin figure. Do not use it to fake product UI. If a
+post needs product screenshots and official/current screenshots are not
+available, ask for real screenshots or app access.
+
+Generated Napkin file URLs expire after 30 minutes, so every accepted figure
+must be downloaded immediately and rehosted in the Supabase `blog` bucket under
+`articles/<slug>/...`.
+
+## Batch usage (preferred)
+
+Figures are declared per article in `content/articles/figures.json`, keyed by
+slug. `napkin-batch.mjs` reads that manifest, skips figures already present in
+the bucket, and generates only what is missing.
+
+```bash
+infisical run --silent \
+  --env=prod \
+  --projectId=87dad7b5-72a6-4791-9228-b3b86b169db1 \
+  --path=/anarlog/web \
+  -- pnpm -F @anlg/web media:figures
+```
+
+Add `--slug <slug>` to limit it to one article, `--upsert` to regenerate
+existing figures, or `--dry-run` to print the requests without calling Napkin.
+
+Declare a figure like this:
+
+```json
+{
+  "my-post-slug": [
+    {
+      "filename": "capture-flow.png",
+      "content": "Meeting audio\nLocal transcription\nMarkdown note",
+      "context": "Horizontal flow diagram for an Anarlog blog post.",
+      "visualQuery": "flowchart",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ]
+}
+```
+
+An empty array marks a post as deliberately figure-less.
+
+### The check
+
+```bash
+pnpm -F @anlg/web media:figures:check
+```
+
+Needs no credentials — it only makes public HEAD requests — so `web_ci` runs it
+on every PR touching `apps/web/`. It **fails** when an article has no manifest
+entry, or when the manifest names a slug that no longer exists. A declared but
+not-yet-generated figure only warns, so a generation backlog does not turn CI
+red; pass `--strict` to gate on that too.
+
+The effect is that adding a new post forces a decision about its figure, without
+requiring Napkin credentials in CI.
+
+## Single-figure usage
+
+Run through Infisical so the script can read `NAPKIN_API_TOKEN`,
+`SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY`:
+
+```bash
+infisical run --silent \
+  --env=prod \
+  --projectId=87dad7b5-72a6-4791-9228-b3b86b169db1 \
+  --path=/anarlog/web \
+  -- pnpm --dir apps/web exec node scripts/napkin-to-supabase.mjs \
+    --slug meeting-minutes-software \
+    --filename meeting-minutes-workflow.png \
+    --content-file /tmp/meeting-minutes-workflow.txt \
+    --context "Anarlog blog figure for private, bot-free meeting notes" \
+    --visual-query flowchart \
+    --orientation horizontal \
+    --width 1200
+```
+
+The script prints:
+
+- the Napkin request ID
+- the selected generated file metadata
+- the Supabase storage path
+- the public Supabase URL
+- the `/api/assets/blog/...` media URL to use in MDX
+
+## Defaults
+
+- Format defaults from the filename extension.
+- Style defaults to Anarlog's Napkin brand ID:
+  `CDQPRVVJCSTPRBBCD5Q6AWSDE8S0`.
+- Language defaults to `en-US`.
+- Upload path is always `articles/<slug>/<filename>`.
+- Uploads do not overwrite existing objects unless `--upsert` is passed.
+
+## Prompt Shape
+
+Keep `--content` or `--content-file` limited to the text that should appear in
+the visual. Put editorial instructions, audience, and brand context in
+`--context`.
+
+Good content example:
+
+```text
+Meeting recording
+Local transcription
+AI summary
+Human review
+Published meeting minutes
+```
+
+Good context example:
+
+```text
+Create a clean horizontal workflow diagram for an Anarlog blog post. The figure
+should explain a private, bot-free meeting minutes workflow for teams evaluating
+meeting minutes software.
+```

--- a/apps/web/scripts/napkin-to-supabase.mjs
+++ b/apps/web/scripts/napkin-to-supabase.mjs
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+import { createClient } from "@supabase/supabase-js";
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
+
+const NAPKIN_API_BASE = "https://api.napkin.ai";
+const BLOG_BUCKET = "blog";
+const DEFAULT_STYLE_ID = "CDQPRVVJCSTPRBBCD5Q6AWSDE8S0";
+const DEFAULT_LANGUAGE = "en-US";
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const DEFAULT_TIMEOUT_MS = 180000;
+
+const MIME_BY_FORMAT = {
+  png: "image/png",
+  svg: "image/svg+xml",
+  ppt: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+};
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") continue;
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${arg}`);
+    }
+
+    const [rawKey, inlineValue] = arg.slice(2).split("=", 2);
+    const key = rawKey.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+
+    if (inlineValue !== undefined) {
+      args[key] = inlineValue;
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+
+    args[key] = next;
+    index += 1;
+  }
+  return args;
+}
+
+function usage() {
+  return `Usage:
+  pnpm --dir apps/web exec node scripts/napkin-to-supabase.mjs \\
+    --slug meeting-minutes-software \\
+    --filename meeting-minutes-workflow.png \\
+    --content-file /tmp/figure-prompt.txt \\
+    --context "Anarlog blog figure for private, bot-free meeting notes"
+
+Required:
+  --slug           Blog article slug. Uploads to articles/<slug>/<filename>.
+  --filename       Output filename. Extension should match --format.
+  --content        Text to visualize, or use --content-file.
+  --content-file   File containing text to visualize.
+
+Useful options:
+  --format png|svg|ppt              Defaults from filename extension, then png.
+  --context "..."                   Additional generation context.
+  --style-id <id>                   Napkin style/brand ID. Defaults to Anarlog brand.
+  --visual-query flowchart|timeline Optional layout hint.
+  --orientation auto|horizontal|vertical|square
+  --width 1200                      PNG width hint.
+  --height 800                      PNG height hint. Width takes precedence in Napkin.
+  --language en-US                  Defaults to en-US.
+  --number-of-visuals 1             1-4. Defaults to 1.
+  --file-index 0                    Which generated file to upload. Defaults to 0.
+  --upsert                          Replace existing Supabase object.
+  --dry-run                         Create/download nothing; print request and target.
+
+Environment:
+  NAPKIN_API_TOKEN
+  SUPABASE_URL
+  SUPABASE_SERVICE_ROLE_KEY
+`;
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+function normalizeSlug(value) {
+  const slug = String(value || "")
+    .trim()
+    .replace(/^\/+|\/+$/g, "");
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+    throw new Error(`Invalid slug: ${value}`);
+  }
+  return slug;
+}
+
+function normalizeFilename(value, format) {
+  const name = basename(String(value || "").trim());
+  if (!name || name === "." || name === "..") {
+    throw new Error("Invalid filename");
+  }
+  if (!/^[a-z0-9][a-z0-9._-]*\.(png|svg|ppt)$/i.test(name)) {
+    throw new Error("Filename must be a simple .png, .svg, or .ppt file");
+  }
+  const extension = extname(name).slice(1).toLowerCase();
+  if (extension !== format) {
+    throw new Error(
+      `Filename extension .${extension} does not match format ${format}`,
+    );
+  }
+  return name;
+}
+
+function normalizeFormat(args) {
+  const explicit = args.format && String(args.format).toLowerCase();
+  const inferred =
+    args.filename && extname(String(args.filename)).slice(1).toLowerCase();
+  const format = explicit || inferred || "png";
+  if (!["png", "svg", "ppt"].includes(format)) {
+    throw new Error(`Unsupported format: ${format}`);
+  }
+  return format;
+}
+
+function asOptionalInteger(value, name) {
+  if (value === undefined || value === true || value === "") return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) throw new Error(`${name} must be an integer`);
+  return parsed;
+}
+
+async function readContent(args) {
+  if (args.content && args.contentFile) {
+    throw new Error("Use either --content or --content-file, not both");
+  }
+  if (args.content) return String(args.content).trim();
+  if (args.contentFile)
+    return (await readFile(String(args.contentFile), "utf8")).trim();
+  throw new Error("Missing --content or --content-file");
+}
+
+async function napkinFetch(pathOrUrl, options = {}) {
+  const token = requireEnv("NAPKIN_API_TOKEN");
+  const url = pathOrUrl.startsWith("http")
+    ? pathOrUrl
+    : `${NAPKIN_API_BASE}${pathOrUrl}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Napkin request failed ${response.status}: ${body}`);
+  }
+
+  return response;
+}
+
+async function createNapkinVisual(request) {
+  const response = await napkinFetch("/v1/visual", {
+    method: "POST",
+    body: JSON.stringify(request),
+  });
+  const json = await response.json();
+  const id = json.id || json.request_id || json.requestId;
+  if (!id) {
+    throw new Error(
+      `Napkin create response did not include request id: ${JSON.stringify(json)}`,
+    );
+  }
+  return { id, json };
+}
+
+async function pollNapkinVisual(requestId, timeoutMs) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const response = await napkinFetch(`/v1/visual/${requestId}/status`);
+    const json = await response.json();
+
+    if (json.status === "completed") return json;
+    if (json.status === "failed") {
+      throw new Error(
+        `Napkin generation failed: ${JSON.stringify(json.error || json)}`,
+      );
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, DEFAULT_POLL_INTERVAL_MS),
+    );
+  }
+
+  throw new Error(`Napkin generation timed out after ${timeoutMs}ms`);
+}
+
+async function downloadGeneratedFile(file) {
+  if (!file?.url) throw new Error("Selected generated file has no URL");
+  const response = await napkinFetch(file.url);
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  return {
+    bytes,
+    contentType: response.headers.get("content-type"),
+  };
+}
+
+function getSupabaseClient() {
+  return createClient(
+    requireEnv("SUPABASE_URL"),
+    requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    },
+  );
+}
+
+async function uploadToSupabase({ storagePath, bytes, contentType, upsert }) {
+  const supabase = getSupabaseClient();
+  const { error } = await supabase.storage
+    .from(BLOG_BUCKET)
+    .upload(storagePath, bytes, {
+      cacheControl: "31536000",
+      contentType,
+      upsert,
+    });
+
+  if (error) throw error;
+
+  const { data } = supabase.storage.from(BLOG_BUCKET).getPublicUrl(storagePath);
+  return data.publicUrl;
+}
+
+async function checkPublicUrl(url) {
+  const response = await fetch(url, { method: "HEAD" });
+  if (!response.ok) {
+    throw new Error(
+      `Uploaded public URL check failed ${response.status}: ${url}`,
+    );
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  const format = normalizeFormat(args);
+  const slug = normalizeSlug(args.slug);
+  const filename = normalizeFilename(args.filename, format);
+  const content = await readContent(args);
+  const storagePath = `articles/${slug}/${filename}`;
+  const fileIndex = asOptionalInteger(args.fileIndex, "file-index") ?? 0;
+  const numberOfVisuals =
+    asOptionalInteger(args.numberOfVisuals, "number-of-visuals") ?? 1;
+  const width = asOptionalInteger(args.width, "width");
+  const height = asOptionalInteger(args.height, "height");
+  const timeoutMs =
+    asOptionalInteger(args.timeoutMs, "timeout-ms") ?? DEFAULT_TIMEOUT_MS;
+
+  const request = {
+    format,
+    content,
+    language: args.language || DEFAULT_LANGUAGE,
+    style_id: args.styleId || DEFAULT_STYLE_ID,
+    number_of_visuals: numberOfVisuals,
+    text_extraction_mode: args.textExtractionMode || "auto",
+    sort_strategy: args.sortStrategy || "relevance",
+  };
+
+  if (args.context) request.context = String(args.context);
+  if (args.visualQuery) request.visual_query = String(args.visualQuery);
+  if (args.orientation) request.orientation = String(args.orientation);
+  if (width !== undefined) request.width = width;
+  if (height !== undefined) request.height = height;
+  if (args.transparentBackground) request.transparent_background = true;
+  if (args.colorMode) request.color_mode = String(args.colorMode);
+
+  const target = {
+    bucket: BLOG_BUCKET,
+    storagePath,
+    mediaUrl: `/api/assets/blog/${storagePath}`,
+    format,
+    contentType: MIME_BY_FORMAT[format],
+    upsert: Boolean(args.upsert),
+  };
+
+  if (args.dryRun) {
+    console.log(JSON.stringify({ request, target }, null, 2));
+    return;
+  }
+
+  const created = await createNapkinVisual(request);
+  console.error(`Napkin request created: ${created.id}`);
+
+  const completed = await pollNapkinVisual(created.id, timeoutMs);
+  const files = completed.generated_files || [];
+  if (!files[fileIndex]) {
+    throw new Error(
+      `No generated file at index ${fileIndex}; received ${files.length} file(s)`,
+    );
+  }
+
+  const downloaded = await downloadGeneratedFile(files[fileIndex]);
+  const contentType = downloaded.contentType || MIME_BY_FORMAT[format];
+  const publicUrl = await uploadToSupabase({
+    storagePath,
+    bytes: downloaded.bytes,
+    contentType,
+    upsert: Boolean(args.upsert),
+  });
+  await checkPublicUrl(publicUrl);
+
+  console.log(
+    JSON.stringify(
+      {
+        napkinRequestId: created.id,
+        selectedFile: files[fileIndex],
+        bucket: BLOG_BUCKET,
+        storagePath,
+        publicUrl,
+        mediaUrl: `/api/assets/blog/${storagePath}`,
+        bytes: downloaded.bytes.length,
+        contentType,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Restores the Napkin-to-Supabase figure tooling removed in #5989 and adds a manifest-driven batch layer so new blog posts get figures by default.

**Stacked on #6397.** The manifest declares all 66 article slugs, including `meeting-notes-template`, which is added in that PR. On `main` alone the check would flag it as an orphaned entry and fail, so this must merge after #6397.

## What was restored

`napkin-to-supabase.mjs` and `napkin-to-supabase.md` are restored verbatim from the pre-#5989 tree, plus the `media:napkin` script entry. The script was already credential-free — it reads `NAPKIN_API_TOKEN`, `SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY` from the environment. `@supabase/supabase-js` is still a dependency, so nothing else was needed.

The two `.agents/specs/` files deleted in the same PR are deliberately **not** restored. This repo is public and those were internal content strategy.

## The batch

`napkin-batch.mjs` reads `content/articles/figures.json`, HEAD-checks each declared figure against the public blog bucket, and shells out to the single-figure script only for what is missing. Spawning per figure keeps the restored script untouched and isolates failures.

```bash
infisical run --silent --env=prod \
  --projectId=87dad7b5-72a6-4791-9228-b3b86b169db1 --path=/anarlog/web \
  -- pnpm -F @anlg/web media:figures
```

## Why the check is in CI but generation is not

`media:figures:check` makes public HEAD requests only, so it needs no credentials and is safe to gate on. Generation is left manual: it needs a service-role key in CI, costs Napkin credits per run, and figure quality deserves a human look before it lands on a public post.

Failure severity is split so an ungenerated backlog cannot turn `main` red:

| Condition | Default | `--strict` |
| --- | --- | --- |
| Article missing from manifest | **fail** | fail |
| Manifest names a nonexistent slug | **fail** | fail |
| Declared figure not yet generated | warn | **fail** |

An empty array marks a post as deliberately figure-less.

## Verification

Tested all three paths against the real bucket: an existing figure is skipped (declared `meeting-to-decision.png`, correctly not reported), a missing figure is detected, and an undeclared post is detected. `--check` exits 0 on the current backlog; `--check --strict` exits 1. dprint and oxlint clean.

## Follow-up

Four figures are declared and not yet generated — for `avoma-alternatives`, `notion-meeting-notes`, `hipaa-compliant-ai-notetaker`, and `meeting-notes-template`. The `content` and `context` prompts are my drafts and worth reviewing before spending credits. Running `media:figures` closes the asset gap noted on ANLG-189.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are dev tooling, content manifest, and CI checks; generation uses existing service-role upload only when run manually with credentials.
> 
> **Overview**
> Restores the **Napkin → Supabase** blog figure pipeline and adds a **manifest-driven batch** layer so every article slug is accounted for in `content/articles/figures.json`.
> 
> `napkin-to-supabase.mjs` generates a visual via Napkin, polls until complete, downloads the asset, and uploads to the public `blog` bucket under `articles/<slug>/`. `napkin-batch.mjs` reads the manifest, **HEAD-checks** the public bucket for each declared file, and only spawns the single-figure script for missing assets (or all with `--upsert`). New pnpm scripts: `media:napkin`, `media:figures`, and `media:figures:check`.
> 
> **CI** runs `pnpm -F web media:figures:check` in `web_ci` (credential-free). It **fails** on undeclared articles or orphaned manifest slugs; declared-but-not-uploaded figures **warn** unless `--strict`. The manifest seeds all article slugs (mostly `[]`) plus four pending figure definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 647f948ce6c7302fa9390e47ac48fb0057c13a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->