### PR TITLE
feat(desktop): show real names and marks for on-device STT models

### DIFF
--- a/apps/desktop/src/settings/ai/llm/shared.tsx
+++ b/apps/desktop/src/settings/ai/llm/shared.tsx
@@ -54,7 +54,9 @@ const _PROVIDERS = [
     id: "apple_foundation",
     displayName: "Apple Intelligence",
     badge: "Experimental",
-    icon: <Apple size={16} />,
+    // The Apple mark fills its viewBox edge to edge, so it needs an explicit size to
+    // escape the icon slot's `size-full` stretch and match the padded brand logos.
+    icon: <Apple className="!size-4" />,
     baseUrl: undefined,
     requirements: [],
     checkAvailability: checkAppleFoundationModelAvailability,

--- a/apps/desktop/src/settings/ai/stt/model-icon.test.ts
+++ b/apps/desktop/src/settings/ai/stt/model-icon.test.ts
@@ -30,6 +30,7 @@ describe("local model icons", () => {
 
   test("gives apple speech its own mark and no runtime badge", () => {
     expect(getLocalModelIcon("apple-speech")?.title).toBe("Apple Speech");
+    expect(getLocalModelIcon("apple-speech")?.node).toBeTruthy();
     expect(getLocalModelBackendBadge("apple-speech")).toBeNull();
   });
 

--- a/apps/desktop/src/settings/ai/stt/model-icon.tsx
+++ b/apps/desktop/src/settings/ai/stt/model-icon.tsx
@@ -1,11 +1,15 @@
+import { Apple } from "@lobehub/icons";
+import type { ReactNode } from "react";
+
 import { cn } from "@anlg/utils";
 
 type ModelIconSpec = {
-  label: string;
   title: string;
-  className: string;
+  label?: string;
+  className?: string;
   imageSrc?: string;
   imageClassName?: string;
+  node?: ReactNode;
 };
 
 const MODEL_ICON_ASSET_BASE = "/assets/model-icons";
@@ -26,9 +30,10 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
 
   if (value === "apple-speech") {
     return {
-      label: "",
       title: "Apple Speech",
-      className: "border-border bg-card text-foreground",
+      // The Apple mark is full-bleed in its viewBox, so it renders smaller than the
+      // 20px slot to match the optical size of the padded brand logos.
+      node: <Apple size={16} />,
     };
   }
 
@@ -145,7 +150,15 @@ export function LocalModelLabel({
       title={title}
       className={cn(["flex min-w-0 items-center gap-2", className])}
     >
-      {icon?.imageSrc ? (
+      {icon?.node ? (
+        <span
+          title={icon.title}
+          aria-label={icon.title}
+          className="flex size-5 shrink-0 items-center justify-center"
+        >
+          {icon.node}
+        </span>
+      ) : icon?.imageSrc ? (
         <img
           title={icon.title}
           aria-label={icon.title}

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -47,7 +47,6 @@ import {
 } from "./selection";
 import {
   displayModelLabel,
-  displayModelTitle,
   formatModelSize,
   type ProviderId,
   PROVIDERS,
@@ -693,7 +692,6 @@ function ModelSelectItem({
     !!downloadInfo || queuedDownloads.includes(model.id as LocalModel);
 
   const label = displayModelLabel(model.id, model.displayName);
-  const title = displayModelTitle(model.id, model.displayName);
   const sizeLabel = formatModelSize(model.sizeBytes);
   const showLocalActions = model.isDownloaded && isLocalModelId(model.id);
   const isDeprecated = model.isDeprecated === true;
@@ -702,7 +700,7 @@ function ModelSelectItem({
       <LocalModelLabel
         model={model.id}
         label={label}
-        title={title}
+        title={label}
         className="min-w-0 flex-1"
       />
       <div className="flex shrink-0 items-center gap-2 text-[11px]">
@@ -797,13 +795,14 @@ function ModelSelectItem({
 
 function ModelSelectedValue({ model }: { model: ModelEntry }) {
   const isDeprecated = model.isDeprecated === true;
+  const label = displayModelLabel(model.id, model.displayName);
 
   return (
     <div className="flex max-w-full min-w-0 items-center gap-2">
       <LocalModelLabel
         model={model.id}
-        label={displayModelLabel(model.id, model.displayName)}
-        title={displayModelTitle(model.id, model.displayName)}
+        label={label}
+        title={label}
         className={cn(["min-w-0", isDeprecated && "opacity-60"])}
         labelClassName={cn([isDeprecated && "text-muted-foreground"])}
       />

--- a/apps/desktop/src/settings/ai/stt/shared.test.ts
+++ b/apps/desktop/src/settings/ai/stt/shared.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test } from "vitest";
 
-import { displayModelLabel, displayModelTitle, PROVIDERS } from "./shared";
+import { displayModelLabel, PROVIDERS } from "./shared";
 
 describe("STT model display labels", () => {
   test("keeps cloud model product-facing", () => {
     expect(displayModelLabel("cloud")).toBe("Pro (Cloud)");
-    expect(displayModelTitle("cloud")).toBeUndefined();
   });
 
   test("uses product-facing labels for hosted provider models", () => {
@@ -49,25 +48,23 @@ describe("STT model display labels", () => {
     expect(providers.aws_transcribe.badge).toBe("Gateway");
   });
 
-  test("treats apple speech as an on-device model", () => {
-    expect(displayModelLabel("apple-speech", "Apple Speech")).toBe("On device");
-    expect(displayModelTitle("apple-speech", "Apple Speech")).toBe(
+  test("names on-device models instead of collapsing them", () => {
+    expect(displayModelLabel("apple-speech", "Apple Speech")).toBe(
       "Apple Speech",
     );
-  });
-
-  test("collapses local model names to on-device labels", () => {
     expect(
       displayModelLabel(
         "soniqo-parakeet-streaming",
         "Soniqo Parakeet Streaming",
       ),
-    ).toBe("On device");
-    expect(
-      displayModelTitle(
-        "soniqo-parakeet-streaming",
-        "Soniqo Parakeet Streaming",
-      ),
     ).toBe("Soniqo Parakeet Streaming");
+  });
+
+  test("names on-device models without a backend display name", () => {
+    expect(displayModelLabel("apple-speech")).toBe("Apple Speech");
+    expect(displayModelLabel("soniqo-parakeet-batch")).toBe(
+      "Soniqo Parakeet Batch",
+    );
+    expect(displayModelLabel("soniqo-omnilingual")).toBe("Soniqo Omnilingual");
   });
 });

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -184,6 +184,26 @@ export const displayModelId = (model: string) => {
     return "Apple Speech";
   }
 
+  if (model === "soniqo-parakeet-streaming") {
+    return "Soniqo Parakeet Streaming";
+  }
+
+  if (model === "soniqo-parakeet-batch") {
+    return "Soniqo Parakeet Batch";
+  }
+
+  if (model === "soniqo-omnilingual") {
+    return "Soniqo Omnilingual";
+  }
+
+  if (model === "soniqo-qwen3-small") {
+    return "Soniqo Qwen3 0.6B";
+  }
+
+  if (model === "soniqo-qwen3-large") {
+    return "Soniqo Qwen3 1.7B";
+  }
+
   if (model === "parakeet-tdt-0.6b-v3") {
     return "Parakeet TDT 0.6B V3";
   }
@@ -195,27 +215,8 @@ export const displayModelId = (model: string) => {
   return model;
 };
 
-function isOnDeviceModelId(model: string) {
-  return (
-    model.startsWith("soniqo-") ||
-    model === "apple-speech" ||
-    model.startsWith("am-") ||
-    model.startsWith("Quantized")
-  );
-}
-
 export function displayModelLabel(model: string, displayName?: string) {
-  if (isOnDeviceModelId(model)) {
-    return "On device";
-  }
-
   return displayName ?? displayModelId(model);
-}
-
-export function displayModelTitle(model: string, displayName?: string) {
-  const title = displayName ?? displayModelId(model);
-
-  return displayModelLabel(model, displayName) === title ? undefined : title;
 }
 
 export function formatModelSize(sizeBytes?: number | null) {


### PR DESCRIPTION
The transcription model picker collapsed every local model to "On device",
so the Soniqo and Apple Speech rows were indistinguishable and Apple Speech
rendered an empty icon box.

- Drop the on-device label collapse; models now use their backend display
  name, with Soniqo keys mapped in displayModelId for label-only callers
  such as the language warning toast
- Remove the now-dead displayModelTitle and use the full label as the
  title attribute so truncated names stay readable
- Give apple-speech the Apple mark via a ReactNode icon spec, sized at 16px
  so its full-bleed glyph matches the padded brand logos
- Size the Apple Intelligence provider icon explicitly so it escapes the
  icon slot's size-full stretch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop STT/LLM settings UI and display helpers only; no transcription or auth behavior changes.
> 
> **Overview**
> The STT model picker **no longer collapses local models to "On device"**—each row shows its real name (e.g. Soniqo Parakeet Streaming, Apple Speech), with Soniqo keys mapped in `displayModelId` for callers that only have the model id (such as language-warning toasts).
> 
> **`displayModelTitle` is removed**; truncated labels use the full display name as the `title` attribute on `LocalModelLabel`.
> 
> **Apple Speech** gets the Apple mark via a new optional `node` on the model icon spec (16px to match padded brand logos), and **Apple Intelligence** in LLM settings uses `!size-4` so the full-bleed glyph isn’t stretched by the provider icon slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b02b8afc552b504ff959a2c198906fc5c9d5c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->