### PR TITLE
chore(changelog): cover the last desktop changes in 1.4.0

### DIFF
--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-07-30"
+date: "2026-07-31"
 summary: "Anarlog 1.4.0 expands to Windows Preview and Linux Beta, adds automatic updates and more AI providers, and improves editing, transcription, privacy, and reliability."
 ---
 
@@ -28,6 +28,8 @@ are still pending.
   ellipses, and highlighted text with familiar shortcuts
 - Recall recently sent chat prompts with the Up and Down arrow keys while
   preserving the draft you were writing
+- Scroll notes only vertically; an enforced title no longer leaves a permanent
+  horizontal scrollbar across the note
 
 ## Updates and settings
 
@@ -46,6 +48,7 @@ are still pending.
   Kimi K2.7 Code, and GLM 5.2
 - Restore excluded meeting apps reliably after startup and present cleaner,
   platform-aware settings and window controls
+- See a refreshed, more consistent icon set throughout the app
 
 ## Reliability and privacy
 
@@ -110,6 +113,9 @@ are still pending.
   transcription
 - Use Apple Speech for private, on-device live and batch transcription on
   supported Apple Silicon Macs running macOS 26
+- Tell on-device transcription models apart in the picker, which now shows each
+  one by name, such as Soniqo Parakeet Streaming and Apple Speech, instead of a
+  single **On device** label, and gives Apple Speech its own mark
 - Avoid duplicate Apple Speech phrases when live hypotheses are revised
 - Detect the meeting language from your configured language choices instead of
   forcing multilingual recordings into code-switching mode


### PR DESCRIPTION
The 1.4.0 changelog was last edited at a3638b68b6, and three desktop
user-facing commits landed after it. This closes that gap so the stable
release gate can run from main.

- Note the note-scroll fix from the heading inset change (#6396)
- Note the on-device STT picker showing real model names and the Apple
  mark instead of a single On device label (#6400)
- Note the app-wide icon set refresh (#6401)
- Move the release date to 2026-07-31

Validated with `pnpm exec dprint fmt`, `pnpm fmt:check`, and
`pnpm -F @anlg/changelog typecheck`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or security impact.
> 
> **Overview**
> Updates **`packages/changelog/content/1.4.0.md`** so the stable release notes match three desktop commits that landed after the last changelog edit, and bumps the release **date** from `2026-07-30` to **`2026-07-31`**.
> 
> **Notes and editor:** adds a bullet that notes scroll only vertically and no longer show a permanent horizontal scrollbar when a title is enforced.
> 
> **Updates and settings:** adds a bullet for the refreshed, more consistent app-wide icon set.
> 
> **Transcription:** adds a bullet that the on-device STT picker lists models by name (e.g. Soniqo Parakeet Streaming, Apple Speech) instead of a single **On device** label, with a distinct mark for Apple Speech.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5d5f064dc9154740c459e30da5225e0eafbf2a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->