### PR TITLE
feat(web): mark Windows and Linux beta and list upcoming platforms

### DIFF
--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -10,40 +10,53 @@ export type DesktopPlatform = "linux" | "macos" | "windows";
 export const appleSiliconDownloadUrl = getStableDownloadUrl("dmg-aarch64");
 export const appleIntelDownloadUrl = getStableDownloadUrl("dmg-x86_64");
 
+export const comingSoonPlatforms = [
+  "iOS",
+  "Android",
+  "Apple Watch",
+  "Galaxy Watch",
+] as const;
+
 export const desktopDownloadSections = [
   {
     platform: "macos",
     name: "macOS",
+    status: null,
     description: "Choose the build that matches your Mac.",
     downloads: [
       {
         name: "Apple Silicon",
         detail: "M-series Mac · DMG",
         url: appleSiliconDownloadUrl,
+        showInMenu: true,
       },
       {
         name: "Intel",
         detail: "Intel-based Mac · DMG",
         url: appleIntelDownloadUrl,
+        showInMenu: true,
       },
     ],
   },
   {
     platform: "windows",
     name: "Windows",
+    status: "Beta",
     description:
-      "Preview installer for 64-bit Windows PCs. Physical audio and AEC validation is pending.",
+      "Beta installer for 64-bit Windows PCs. Physical audio and AEC validation is pending.",
     downloads: [
       {
         name: "Windows x64",
         detail: "NSIS installer · EXE",
         url: getStableDownloadUrl("nsis-x86_64"),
+        showInMenu: true,
       },
     ],
   },
   {
     platform: "linux",
     name: "Linux",
+    status: "Beta",
     description:
       "Beta AppImage and Debian packages for x64 and ARM64. Physical audio and AEC validation is pending.",
     downloads: [
@@ -51,21 +64,25 @@ export const desktopDownloadSections = [
         name: "AppImage x64",
         detail: "Intel or AMD 64-bit · AppImage",
         url: getStableDownloadUrl("appimage-x86_64"),
+        showInMenu: true,
       },
       {
         name: "Debian x64",
         detail: "Debian or Ubuntu · DEB",
         url: getStableDownloadUrl("deb-x86_64"),
+        showInMenu: true,
       },
       {
         name: "AppImage ARM64",
         detail: "64-bit ARM · AppImage",
         url: getStableDownloadUrl("appimage-aarch64"),
+        showInMenu: false,
       },
       {
         name: "Debian ARM64",
         detail: "Debian or Ubuntu on 64-bit ARM · DEB",
         url: getStableDownloadUrl("deb-aarch64"),
+        showInMenu: false,
       },
     ],
   },

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -4,7 +4,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { SiteFooter } from "@/components/site-footer";
 import { useAnalytics } from "@/hooks/use-posthog";
-import { desktopDownloadSections } from "@/lib/download";
+import { comingSoonPlatforms, desktopDownloadSections } from "@/lib/download";
 import { ANARLOG_SITE_URL } from "@/lib/seo";
 
 const platformIcons = {
@@ -64,6 +64,11 @@ function Component() {
                     aria-hidden="true"
                   />
                   {section.name}
+                  {section.status && (
+                    <span className="border-color-subtle text-color-muted rounded-full border px-2.5 py-1 font-sans text-xs leading-none font-medium tracking-wide uppercase">
+                      {section.status}
+                    </span>
+                  )}
                 </h2>
 
                 <ul className="border-color-subtle divide-y divide-[var(--color-border-subtle)] border-y">
@@ -93,6 +98,26 @@ function Component() {
               </section>
             );
           })}
+
+          <section aria-labelledby="coming-soon-platforms">
+            <h2
+              id="coming-soon-platforms"
+              className="font-hand mb-5 text-3xl leading-none font-semibold tracking-normal"
+            >
+              Coming soon
+            </h2>
+
+            <ul className="flex flex-wrap gap-2">
+              {comingSoonPlatforms.map((platform) => (
+                <li
+                  key={platform}
+                  className="border-color-subtle text-color-muted rounded-full border px-4 py-2 text-sm font-medium"
+                >
+                  {platform}
+                </li>
+              ))}
+            </ul>
+          </section>
         </div>
       </div>
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1369,6 +1369,7 @@ function DownloadButton() {
         >
           {orderedSections.map((section) =>
             section.downloads.map((download) => {
+              if (!download.showInMenu) return null;
               if (download.url === preferredDownload.url) return null;
 
               return (
@@ -1396,6 +1397,11 @@ function DownloadButton() {
                   <span>
                     {getDownloadOptionLabel(section.platform, download.name)}
                   </span>
+                  {section.status && (
+                    <span className="border-color-subtle text-color-muted ml-auto rounded-full border px-2 py-0.5 text-[11px] leading-none font-medium tracking-wide uppercase">
+                      {section.status}
+                    </span>
+                  )}
                 </a>
               );
             }),


### PR DESCRIPTION
Desktop downloads gave no signal that Windows and Linux are less mature
than macOS, and the site said nothing about mobile or watch support.

- Add a status field to the download sections and render a Beta badge on
  the Windows and Linux headings and in the homepage download menu
- Add a comingSoonPlatforms list and a Coming soon section on the
  download page for iOS, Android, Apple Watch, and Galaxy Watch
- Gate homepage menu entries behind showInMenu so the two Linux ARM64
  builds stay on the download page instead of crowding the menu
- Reword the Windows section description from Preview to Beta so it
  matches the badge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-site copy and UI only; no auth, data, or download URL logic changes beyond presentation and menu filtering.
> 
> **Overview**
> Desktop download UX now signals **maturity** and **roadmap**: Windows and Linux are labeled **Beta** (badges on the download page and homepage menu; Windows copy changes from “Preview” to “Beta”), while macOS stays unbadged.
> 
> The download page adds a **Coming soon** section (iOS, Android, Apple Watch, Galaxy Watch) driven by a shared `comingSoonPlatforms` list in `download.ts`.
> 
> Homepage alternate-download menu entries are filtered with **`showInMenu`**, so Linux ARM64 builds remain on the full download page only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c998185eb8047c9731be11e658c599a049fc4a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->