### PR TITLE
chore(changelog): call the Windows lane beta instead of preview

### DIFF
--- a/.github/reports/release-gates/windows.md
+++ b/.github/reports/release-gates/windows.md
@@ -6,7 +6,7 @@ It gates the first Windows release tracked by
 [ANLG-68](https://linear.app/fastrepl-inc/issue/ANLG-68/ship-windows-desktop-capture-notifications-and-overlay-support).
 
 Use the exact candidate artifact in every required run. Version 1.4.0 is a VM-first
-Windows preview: its explicitly listed VM scope may ship while physical-hardware and AEC
+Windows beta: its explicitly listed VM scope may ship while physical-hardware and AEC
 rows remain DEFERRED. VM evidence proves guest endpoint capture only; it does not prove
 AEC, real-device routing, hot-plug, suspend/resume, or mixed-DPI behavior.
 
@@ -31,7 +31,7 @@ different artifact hash.
 | -------------------- | ------------------------------------ |
 | Version              | 1.4.0                                |
 | Commit               | TBD                                  |
-| Release scope         | VM-first preview                     |
+| Release scope         | VM-first beta                        |
 | Cross-platform parity | Version and commit must match macOS and Linux |
 | Physical/AEC status   | DEFERRED; not evaluated              |
 | Installer artifact   | TBD                                  |
@@ -92,7 +92,7 @@ release notes, and do not claim mixed-DPI overlay support.
 
 ## 1.4.0 VM-first scope
 
-For this candidate only, the following tests are required for **VM-FIRST PREVIEW SHIP**:
+For this candidate only, the following tests are required for **VM-FIRST BETA SHIP**:
 W-ENV-X64-CLEAN; W-DSP-01; W-ART-01 through W-ART-03; W-INS-01 and W-INS-02;
 W-UPD-01 and W-UPD-02; W-UNINS-01; W-CORE-01 and W-CORE-02; W-CRED-01 and
 W-CRED-02; W-SYNC-01 and W-SYNC-02; W-AUD-05, W-AUD-06, W-AUD-09, and W-AUD-11;
@@ -369,7 +369,7 @@ Copy this section for each failure:
 
 ## Ship and no-ship rules
 
-Mark the candidate **VM-FIRST PREVIEW SHIP** only when all of the following are true:
+Mark the candidate **VM-FIRST BETA SHIP** only when all of the following are true:
 
 - Every test in the 1.4.0 VM-first scope is PASS for the exact published artifact hash.
 - Version and commit exactly match the macOS and Linux 1.4.0 candidate reports.
@@ -379,12 +379,12 @@ Mark the candidate **VM-FIRST PREVIEW SHIP** only when all of the following are 
   not reported as AEC evidence.
 - DPAPI-protected auth persistence, local SQLite durability, CloudSync, basic
   notifications, and W-PERM-01 capability gating pass.
-- The download page and release notes label Windows as a preview and list the deferred
+- The download page and release notes label Windows as beta and list the deferred
   physical-device, AEC, suspend/resume, and multi-display coverage.
 - Every physical row in the 1.4.0 waiver remains DEFERRED, and no open blocker remains in
-  the preview scope.
+  the beta scope.
 
-Mark the candidate **HARDWARE-VALIDATED SHIP** only after VM-FIRST PREVIEW SHIP and all
+Mark the candidate **HARDWARE-VALIDATED SHIP** only after VM-FIRST BETA SHIP and all
 of the following:
 
 - W-ENV-X64-AMD and the physical W-AUD-01 through W-AUD-03, W-AUD-07, W-AUD-08,
@@ -418,10 +418,10 @@ say so explicitly:
 - Meeting/app detection, mic-based auto-stop, floating controls, DND controls, and
   notification-history clearing while those controls remain hidden from Windows users.
 
-For the 1.4.0 VM-first preview only, the explicit physical and AEC rows above may be
+For the 1.4.0 VM-first beta only, the explicit physical and AEC rows above may be
 deferred. It may not defer signed x64 artifacts, clean install/update/uninstall, VM mic
 and system-audio capture, durable local data, secure credentials, CloudSync, or desktop
-behaviors advertised to Windows preview users.
+behaviors advertised to Windows beta users.
 
 ## Run ledger
 

--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -1,9 +1,9 @@
 ---
 date: "2026-07-31"
-summary: "Anarlog 1.4.0 expands to Windows Preview and Linux Beta, adds automatic updates and more AI providers, and improves editing, transcription, privacy, and reliability."
+summary: "Anarlog 1.4.0 expands to Windows and Linux in beta, adds automatic updates and more AI providers, and improves editing, transcription, privacy, and reliability."
 ---
 
-<banner title="Windows Preview and Linux Beta" variant="info">
+<banner title="Windows and Linux Beta" variant="info">
 Windows and Linux now ship alongside macOS with the same Anarlog version. Their
 virtual-machine release checks cover installation, launch, updates, sync, and
 basic audio capture; physical-device routing and echo-cancellation validation
@@ -86,10 +86,10 @@ are still pending.
   MCP access while the desktop app is closed; turning it off deletes the
   separate server-readable copies
 
-## Windows Preview
+## Windows Beta
 
 - Show native event reminders; notification click actions remain unavailable
-  in this preview
+  in this beta
 - Hide microphone-detection controls that are not yet supported on Windows
 - Protect signed-in sessions with Windows user encryption and migrate older
   plaintext session data


### PR DESCRIPTION
Windows and Linux are both pre-stable, but Windows was labelled Preview
while Linux was labelled Beta, so the site, the changelog, and the release
gate doc disagreed on what the lane is called. #6403 puts a Beta badge on
both platforms on the site, so this aligns the remaining copy.

- Rename the 1.4.0 banner, section heading, and summary to Beta
- Rename the Windows release-gate doc scope, ship gate, and waiver wording
  to VM-FIRST BETA SHIP, so its claim that the download page labels Windows
  as beta stays true

This gates the 1.4.0 stable release: the candidate SHA must include it.

Validated with `pnpm exec dprint fmt`, `pnpm fmt:check`, and
`pnpm -F @anlg/changelog typecheck`; changelog page and index verified in
the browser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and release-gate copy only; no application code, auth, or data paths change.
> 
> **Overview**
> Aligns **Windows** pre-stable labeling with **Linux** and the download site (Beta badge in #6403) by replacing **Preview** / **VM-first preview** wording with **Beta** / **VM-first beta** everywhere this PR touches docs.
> 
> In **`packages/changelog/content/1.4.0.md`**, the front-matter summary, info banner title, and **Windows Beta** section heading now say beta; the Windows bullets still describe the same limitations (e.g. notification click actions unavailable in this beta).
> 
> In **`.github/reports/release-gates/windows.md`**, release scope, ship gates (**VM-FIRST BETA SHIP**, prerequisite for hardware-validated ship), waiver text, and requirements that download/release notes label Windows as **beta** are updated so the gate doc matches what users see.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 819cf432eefcf96b87494344f4cf97db72557135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->