### PR TITLE
Complete the 1.4.0 release changelog

### DIFF
--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -111,6 +111,9 @@ are still pending.
   including language and keyword hints
 - Choose Deepgram Flux for live transcription or Gladia Solaria 3 for batch
   transcription
+- Connect directly to Cohere, Groq, xAI, Together AI, Speechmatics, Azure AI
+  Speech, Google Cloud Speech-to-Text, Amazon Transcribe, Rev AI, or Fireworks
+  AI for transcription
 - Use Apple Speech for private, on-device live and batch transcription on
   supported Apple Silicon Macs running macOS 26
 - Tell on-device transcription models apart in the picker, which now shows each


### PR DESCRIPTION
Document the direct transcription providers shipping in the stable desktop release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the release changelog; no application code or behavior is modified.
> 
> **Overview**
> Completes the **1.4.0** release notes by documenting **direct transcription provider** support in the **Transcription** section.
> 
> The new bullet states users can connect their own keys for Cohere, Groq, xAI, Together AI, Speechmatics, Azure AI Speech, Google Cloud Speech-to-Text, Amazon Transcribe, Rev AI, and Fireworks AI—aligning the changelog with the stable desktop release’s transcription integrations (separate from the existing **Updates and settings** bullet that covers the same vendor names for summaries and chat).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a89c555c3f721ee82d23796c0a1f6b51c4b56bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->