### PR TITLE
Remove Account page dividers

### DIFF
--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -433,7 +433,7 @@ function GuestPlanSection({ onSignIn }: { onSignIn: () => Promise<void> }) {
   };
 
   return (
-    <section className="border-border border-t pt-6">
+    <section>
       <div className="mb-4 flex flex-col gap-1">
         <h2 className="font-sans text-lg font-semibold">
           <Trans>Plans</Trans>
@@ -481,7 +481,7 @@ function PlanTierList({
   return (
     <div ref={containerRef}>
       {isWide ? (
-        <div className="divide-border grid grid-cols-2 divide-x">
+        <div className="grid grid-cols-2">
           {PLAN_TIERS.map((tier) => {
             const isCurrent = tier.id === currentTier;
             const action = getActionForTier(
@@ -539,10 +539,7 @@ function PlanTierList({
             );
 
             return (
-              <div
-                key={tier.id}
-                className="border-border border-b py-3 last:border-b-0"
-              >
+              <div key={tier.id} className="py-3">
                 <div className="flex items-center justify-between gap-3">
                   <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
                     <span className="text-foreground text-sm font-medium">


### PR DESCRIPTION
Remove plan section and tier separators across responsive layouts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout changes on the Account settings page with no billing, auth, or data logic touched.
> 
> **Overview**
> **Removes visual separators** on the desktop Settings **Account** plans UI so Free/Pro comparison reads as one block instead of boxed sections.
> 
> In **GuestPlanSection**, drops the top border and extra top padding on the Plans block. In **PlanTierList**, removes the vertical divider between columns on wide layouts and the bottom borders between tier rows on narrow layouts; spacing stays via existing padding (`py-3`, grid padding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 368ecf4331ed2db81f929c5864dbe300072c3323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->