### PR TITLE
Fix speaker attribution from mixed-name summaries

### DIFF
--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -243,6 +243,52 @@ describe("inferAutomaticSpeakerAssignments", () => {
     ]);
   });
 
+  it("uses an exclusive clause when a summary sentence names both candidates", async () => {
+    mocks.generateText.mockImplementation(({ prompt }: { prompt: string }) => {
+      const payload = JSON.parse(prompt) as {
+        candidate: { human_id: string };
+        clusters: Array<{
+          cluster_id: string;
+          evidence: { id: string };
+        }>;
+      };
+      expect(payload.candidate).toMatchObject({
+        human_id: "human-george",
+        summary_mentions: [
+          {
+            quote: "George Hotz argued open sourcing AI is safe",
+          },
+        ],
+      });
+      const cluster = payload.clusters.find((candidate) =>
+        candidate.cluster_id.endsWith(":1"),
+      )!;
+      return Promise.resolve({
+        text: JSON.stringify({
+          mapping: {
+            cluster_id: cluster.cluster_id,
+            confidence: 0.98,
+            evidence_id: cluster.evidence.id,
+          },
+        }),
+      });
+    });
+
+    const updates = await inferAutomaticSpeakerAssignments({
+      generatedSummary:
+        "George Hotz argued open sourcing AI is safe, and referenced Lex Fridman's recent conversation with Mark Zuckerberg.",
+      model: {} as LanguageModel,
+      snapshot: createSnapshot(),
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.generateText).toHaveBeenCalledOnce();
+    expect(automaticHumanIds(updates[0]!)).toEqual([
+      "human-lex",
+      "human-george",
+    ]);
+  });
+
   it("selects exclusive summary evidence and the most relevant cluster quote", async () => {
     const snapshot = createSnapshot();
     snapshot.transcripts[0]!.words[2]!.text = ` ${"irrelevant filler ".repeat(24)}OpenAI used AI safety to hype its company`;

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -566,12 +566,25 @@ function buildCandidateSummaryMentions(
     .split(/\r?\n/u)
     .flatMap((line) => line.match(/[^.!?]+[.!?]?/gu) ?? [])
     .map(normalizeWhitespace)
-    .filter((sentence) => {
+    .flatMap((sentence) => {
       const normalizedSentence = sentence.toLocaleLowerCase();
-      return (
-        normalizedSentence.includes(normalizedName) &&
-        otherNames.every((name) => !normalizedSentence.includes(name))
-      );
+      if (!normalizedSentence.includes(normalizedName)) {
+        return [];
+      }
+      if (otherNames.every((name) => !normalizedSentence.includes(name))) {
+        return [sentence];
+      }
+
+      return sentence
+        .split(/[,;]\s+(?:and\s+)?|\s+[—–]\s+/u)
+        .map(normalizeWhitespace)
+        .filter((clause) => {
+          const normalizedClause = clause.toLocaleLowerCase();
+          return (
+            normalizedClause.startsWith(normalizedName) &&
+            otherNames.every((name) => !normalizedClause.includes(name))
+          );
+        });
     });
 
   return Array.from(new Set(sentences))

--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -125,6 +125,8 @@ are still pending.
 - Separate remote speakers during on-device Parakeet batch transcription, then
   label diarized speakers with known participant names when the transcript
   provides a high-confidence identity match
+- Keep automatic speaker labels working when a summary mentions multiple
+  participants in the same sentence
 - Re-transcribe large legacy WAV recordings through Anarlog Pro without hitting
   the cloud upload limit
 


### PR DESCRIPTION
Extract exclusive subject clauses when a generated summary mentions multiple participants in one sentence. Add regression coverage for the release QA failure and update the 1.4.0 changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to summary mention parsing in speaker attribution plus tests and changelog; no auth, data, or API surface changes.
> 
> **Overview**
> **Automatic speaker labeling** no longer drops summary evidence when one sentence names several participants.
> 
> `buildCandidateSummaryMentions` used to require a whole sentence to mention only one candidate, so mixed sentences (e.g. George and Lex in the same line) yielded empty `summary_mentions` and attribution could fail. It now splits those sentences on commas, semicolons, optional **and**, and em/en dashes, and keeps clauses that **start with** the candidate’s name and do not mention other participants—so George still gets an exclusive quote like *"George Hotz argued open sourcing AI is safe"* even when Lex appears later in the sentence.
> 
> Adds a regression test for that scenario and notes the fix in the **1.4.0** changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ea5f84a9d94406864e12bc5355bec24273199f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->