### PR TITLE
Stop recovery from repeating failure toasts

### DIFF
--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -1762,7 +1762,7 @@ describe("useStartListening", () => {
     );
   });
 
-  test("keeps synthetic recovery ownership across a failed retry", async () => {
+  test("keeps synthetic recovery ownership without repeating failure toasts", async () => {
     attachLiveSessionMock.mockResolvedValue("inactive");
     runBatchMock
       .mockRejectedValueOnce(new Error("temporary repair failure"))
@@ -1794,6 +1794,8 @@ describe("useStartListening", () => {
     await act(async () => {
       await expect(result.current()).resolves.toBe("error");
     });
+    expect(sonnerToastErrorMock).not.toHaveBeenCalled();
+
     await act(async () => {
       await expect(result.current()).resolves.toBe("inactive");
     });

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -499,6 +499,11 @@ function useCaptureLifecycle(sessionId: string) {
         details: Parameters<OnStoppedCallback>[1],
         requestRecoveryOnFailure: boolean,
       ) => {
+        const notifyFailure = (message: string, id: string) => {
+          if (requestRecoveryOnFailure) {
+            sonnerToast.error(message, { id });
+          }
+        };
         const requestRecovery = async () => {
           recoveryPending = true;
           if (requestRecoveryOnFailure) {
@@ -606,14 +611,14 @@ function useCaptureLifecycle(sessionId: string) {
               failure_stage: "batch_repair",
             });
             if (transcriptWriteError || !details.liveTranscriptionActive) {
-              sonnerToast.error(
+              notifyFailure(
                 "Anarlog could not finish saving the transcript. The recording was kept so you can try again.",
-                { id: "post-capture-transcript-incomplete" },
+                "post-capture-transcript-incomplete",
               );
             } else {
-              sonnerToast.error(
+              notifyFailure(
                 "Post-meeting transcription failed. The recording was kept so you can try again.",
-                { id: "post-capture-batch-failed" },
+                "post-capture-batch-failed",
               );
             }
             if (isTerminalTranscriptionError(error)) {
@@ -639,15 +644,13 @@ function useCaptureLifecycle(sessionId: string) {
           transcriptWriteError &&
           postCaptureAction !== "batch_then_enhance"
         ) {
-          sonnerToast.error(
+          notifyFailure(
             details.audioPath
               ? "Anarlog could not finish saving the transcript. The recording was kept so you can try again."
               : "Anarlog could not save part of the live transcript.",
-            {
-              id: details.audioPath
-                ? "post-capture-transcript-incomplete"
-                : "live-transcript-persist-failed",
-            },
+            details.audioPath
+              ? "post-capture-transcript-incomplete"
+              : "live-transcript-persist-failed",
           );
         }
 
@@ -715,9 +718,9 @@ function useCaptureLifecycle(sessionId: string) {
                 "[listener] failed to persist summary recovery state",
                 error,
               );
-              sonnerToast.error(
+              notifyFailure(
                 "The transcript was saved, but Anarlog could not start the summary. Try generating it again.",
-                { id: "post-capture-summary-failed" },
+                "post-capture-summary-failed",
               );
               await requestRecovery();
               return;
@@ -733,9 +736,9 @@ function useCaptureLifecycle(sessionId: string) {
           } catch (error) {
             summaryScheduled = false;
             console.error("[listener] failed to schedule summary", error);
-            sonnerToast.error(
+            notifyFailure(
               "The transcript was saved, but Anarlog could not start the summary. Try generating it again.",
-              { id: "post-capture-summary-failed" },
+              "post-capture-summary-failed",
             );
           }
         }


### PR DESCRIPTION
Keep the initial capture error visible while background retries remain quiet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX change in post-stop finalization; first-failure toasts unchanged, only background recovery retries are muted.
> 
> **Overview**
> Post-capture failure toasts (transcript repair, persistence, summary scheduling) now go through a **`notifyFailure`** helper that only calls **`sonnerToast.error`** when **`requestRecoveryOnFailure`** is true.
> 
> The normal stop path still passes **`true`**, so users still see the first error. **Synthetic / background recovery** uses **`recoverStopped`**, which passes **`false`**, so retries stay quiet while recovery keeps running.
> 
> A test was updated to assert that a failed synthetic recovery attempt does **not** fire an error toast before a successful retry completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba50ace1cbf61af95312f8868aeb30f630d0572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->