### PR TITLE
Match unambiguous speaker given names

### DIFF
--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -277,6 +277,31 @@ describe("inferAutomaticSpeakerAssignments", () => {
     expect(mocks.generateText).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["Will Smith", "will"],
+    ["May Jones", "may"],
+  ])(
+    "does not treat common words as given-name evidence for %s",
+    async (participantName, commonWord) => {
+      const snapshot = createSnapshot();
+      snapshot.participants[0]!.name = participantName;
+      mocks.generateText.mockResolvedValue({
+        text: JSON.stringify({ mapping: null }),
+      });
+
+      await inferAutomaticSpeakerAssignments({
+        generatedSummary: `George Hotz ${commonWord} discuss open source AI.`,
+        model: {} as LanguageModel,
+        snapshot,
+        signal: new AbortController().signal,
+      });
+
+      expect(mocks.generateText).toHaveBeenCalledOnce();
+      const prompt = JSON.parse(mocks.generateText.mock.calls[0]![0].prompt);
+      expect(prompt.candidate.human_id).toBe("human-george");
+    },
+  );
+
   it("excludes shared given names that refer to another participant", async () => {
     const snapshot = createSnapshot();
     snapshot.participants[0]!.name = "Alex Smith";

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -340,6 +340,28 @@ describe("inferAutomaticSpeakerAssignments", () => {
     expect(prompt.candidate.human_id).toBe("human-george");
   });
 
+  it.each(["As", "When", "While"])(
+    "matches a standalone given name after %s",
+    async (prefix) => {
+      const snapshot = createSnapshot();
+      snapshot.participants[0]!.name = "Jane Doe";
+      mocks.generateText.mockResolvedValue({
+        text: JSON.stringify({ mapping: null }),
+      });
+
+      await inferAutomaticSpeakerAssignments({
+        generatedSummary: `${prefix} Jane discussed open source AI.`,
+        model: {} as LanguageModel,
+        snapshot,
+        signal: new AbortController().signal,
+      });
+
+      expect(mocks.generateText).toHaveBeenCalledOnce();
+      const prompt = JSON.parse(mocks.generateText.mock.calls[0]![0].prompt);
+      expect(prompt.candidate.human_id).toBe("human-lex");
+    },
+  );
+
   it("keeps standalone names distinct from joined given names", async () => {
     const snapshot = createSnapshot();
     snapshot.participants[0]!.name = "Mary-Jane Smith";

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -302,6 +302,45 @@ describe("inferAutomaticSpeakerAssignments", () => {
     },
   );
 
+  it("does not treat a third-party full name as given-name evidence", async () => {
+    const snapshot = createSnapshot();
+    snapshot.participants[0]!.name = "Mark Smith";
+    mocks.generateText.mockResolvedValue({
+      text: JSON.stringify({ mapping: null }),
+    });
+
+    await inferAutomaticSpeakerAssignments({
+      generatedSummary: "George Hotz discussed Mark Zuckerberg.",
+      model: {} as LanguageModel,
+      snapshot,
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.generateText).toHaveBeenCalledOnce();
+    const prompt = JSON.parse(mocks.generateText.mock.calls[0]![0].prompt);
+    expect(prompt.candidate.human_id).toBe("human-george");
+  });
+
+  it("does not let a hyphenated name hide another participant", async () => {
+    const snapshot = createSnapshot();
+    snapshot.participants[0]!.name = "Mary-Jane Smith";
+    snapshot.participants[1]!.name = "Jane Doe";
+    mocks.generateText.mockResolvedValue({
+      text: JSON.stringify({ mapping: null }),
+    });
+
+    await inferAutomaticSpeakerAssignments({
+      generatedSummary: "Jane Doe agreed with Mary-Jane.",
+      model: {} as LanguageModel,
+      snapshot,
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.generateText).toHaveBeenCalledOnce();
+    const prompt = JSON.parse(mocks.generateText.mock.calls[0]![0].prompt);
+    expect(prompt.candidate.human_id).toBe("human-george");
+  });
+
   it("excludes shared given names that refer to another participant", async () => {
     const snapshot = createSnapshot();
     snapshot.participants[0]!.name = "Alex Smith";

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -321,6 +321,25 @@ describe("inferAutomaticSpeakerAssignments", () => {
     expect(prompt.candidate.human_id).toBe("human-george");
   });
 
+  it("does not treat a third-party surname as given-name evidence", async () => {
+    const snapshot = createSnapshot();
+    snapshot.participants[0]!.name = "Jane Doe";
+    mocks.generateText.mockResolvedValue({
+      text: JSON.stringify({ mapping: null }),
+    });
+
+    await inferAutomaticSpeakerAssignments({
+      generatedSummary: "George Hotz discussed Mary Jane.",
+      model: {} as LanguageModel,
+      snapshot,
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.generateText).toHaveBeenCalledOnce();
+    const prompt = JSON.parse(mocks.generateText.mock.calls[0]![0].prompt);
+    expect(prompt.candidate.human_id).toBe("human-george");
+  });
+
   it("keeps standalone names distinct from joined given names", async () => {
     const snapshot = createSnapshot();
     snapshot.participants[0]!.name = "Mary-Jane Smith";

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -277,6 +277,34 @@ describe("inferAutomaticSpeakerAssignments", () => {
     expect(mocks.generateText).not.toHaveBeenCalled();
   });
 
+  it("excludes shared given names that refer to another participant", async () => {
+    const snapshot = createSnapshot();
+    snapshot.participants[0]!.name = "Alex Smith";
+    snapshot.participants[1]!.name = "Alex Jones";
+    mocks.generateText.mockResolvedValue({
+      text: JSON.stringify({ mapping: null }),
+    });
+
+    await inferAutomaticSpeakerAssignments({
+      generatedSummary:
+        "Alex Smith supported open source AI, and Alex disagreed with the approach.",
+      model: {} as LanguageModel,
+      snapshot,
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.generateText).toHaveBeenCalledOnce();
+    const prompt = JSON.parse(mocks.generateText.mock.calls[0]![0].prompt);
+    expect(prompt.candidate).toMatchObject({
+      human_id: "human-lex",
+      summary_mentions: [
+        {
+          quote: "Alex Smith supported open source AI",
+        },
+      ],
+    });
+  });
+
   it("uses an exclusive clause when a summary sentence names both candidates", async () => {
     mocks.generateText.mockImplementation(({ prompt }: { prompt: string }) => {
       const payload = JSON.parse(prompt) as {

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -243,6 +243,40 @@ describe("inferAutomaticSpeakerAssignments", () => {
     ]);
   });
 
+  it("matches unique given names in generated summaries", async () => {
+    mockDirectCandidateMatches();
+
+    const updates = await inferAutomaticSpeakerAssignments({
+      generatedSummary:
+        "Lex mentions his conversation with Mark Zuckerberg. George strongly endorses open source AI.",
+      model: {} as LanguageModel,
+      snapshot: createSnapshot(),
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.generateText).toHaveBeenCalledTimes(2);
+    expect(automaticHumanIds(updates[0]!)).toEqual([
+      "human-lex",
+      "human-george",
+    ]);
+  });
+
+  it("does not use a given name shared by multiple participants", async () => {
+    const snapshot = createSnapshot();
+    snapshot.participants[0]!.name = "Alex Smith";
+    snapshot.participants[1]!.name = "Alex Jones";
+
+    await expect(
+      inferAutomaticSpeakerAssignments({
+        generatedSummary: "Alex discussed open source AI.",
+        model: {} as LanguageModel,
+        snapshot,
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual([]);
+    expect(mocks.generateText).not.toHaveBeenCalled();
+  });
+
   it("uses an exclusive clause when a summary sentence names both candidates", async () => {
     mocks.generateText.mockImplementation(({ prompt }: { prompt: string }) => {
       const payload = JSON.parse(prompt) as {

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -341,6 +341,29 @@ describe("inferAutomaticSpeakerAssignments", () => {
     expect(prompt.candidate.human_id).toBe("human-george");
   });
 
+  it.each(["Mary-Jane Smith", "Mary'Jane Smith"])(
+    "does not use a joined name suffix as given-name evidence in %s",
+    async (joinedName) => {
+      const snapshot = createSnapshot();
+      snapshot.participants[0]!.name = joinedName;
+      snapshot.participants[1]!.name = "Jane Doe";
+      mocks.generateText.mockResolvedValue({
+        text: JSON.stringify({ mapping: null }),
+      });
+
+      await inferAutomaticSpeakerAssignments({
+        generatedSummary: `${joinedName} discussed open source AI.`,
+        model: {} as LanguageModel,
+        snapshot,
+        signal: new AbortController().signal,
+      });
+
+      expect(mocks.generateText).toHaveBeenCalledOnce();
+      const prompt = JSON.parse(mocks.generateText.mock.calls[0]![0].prompt);
+      expect(prompt.candidate.human_id).toBe("human-lex");
+    },
+  );
+
   it("excludes shared given names that refer to another participant", async () => {
     const snapshot = createSnapshot();
     snapshot.participants[0]!.name = "Alex Smith";

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -321,7 +321,7 @@ describe("inferAutomaticSpeakerAssignments", () => {
     expect(prompt.candidate.human_id).toBe("human-george");
   });
 
-  it("does not let a hyphenated name hide another participant", async () => {
+  it("keeps standalone names distinct from joined given names", async () => {
     const snapshot = createSnapshot();
     snapshot.participants[0]!.name = "Mary-Jane Smith";
     snapshot.participants[1]!.name = "Jane Doe";
@@ -330,7 +330,7 @@ describe("inferAutomaticSpeakerAssignments", () => {
     });
 
     await inferAutomaticSpeakerAssignments({
-      generatedSummary: "Jane Doe agreed with Mary-Jane.",
+      generatedSummary: "Jane discussed open source AI.",
       model: {} as LanguageModel,
       snapshot,
       signal: new AbortController().signal,
@@ -342,7 +342,7 @@ describe("inferAutomaticSpeakerAssignments", () => {
   });
 
   it.each(["Mary-Jane Smith", "Mary'Jane Smith"])(
-    "does not use a joined name suffix as given-name evidence in %s",
+    "uses the full joined given name as evidence in %s",
     async (joinedName) => {
       const snapshot = createSnapshot();
       snapshot.participants[0]!.name = joinedName;
@@ -352,7 +352,7 @@ describe("inferAutomaticSpeakerAssignments", () => {
       });
 
       await inferAutomaticSpeakerAssignments({
-        generatedSummary: `${joinedName} discussed open source AI.`,
+        generatedSummary: `${joinedName.split(" ")[0]} discussed open source AI.`,
         model: {} as LanguageModel,
         snapshot,
         signal: new AbortController().signal,
@@ -363,6 +363,21 @@ describe("inferAutomaticSpeakerAssignments", () => {
       expect(prompt.candidate.human_id).toBe("human-lex");
     },
   );
+
+  it("does not shorten a joined given name to its first token", async () => {
+    const snapshot = createSnapshot();
+    snapshot.participants[0]!.name = "Mary-Jane Smith";
+
+    await expect(
+      inferAutomaticSpeakerAssignments({
+        generatedSummary: "Mary discussed open source AI.",
+        model: {} as LanguageModel,
+        snapshot,
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual([]);
+    expect(mocks.generateText).not.toHaveBeenCalled();
+  });
 
   it("excludes shared given names that refer to another participant", async () => {
     const snapshot = createSnapshot();

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -561,9 +561,7 @@ function buildCandidateSummaryMentions(
   const candidateAliases = buildCandidateNameAliases(candidateName, candidates);
   const otherAliases = candidates
     .filter((candidate) => candidate.name !== candidateName)
-    .flatMap((candidate) =>
-      buildCandidateNameAliases(candidate.name, candidates),
-    );
+    .flatMap((candidate) => buildCandidateExclusionAliases(candidate.name));
   const sentences = summary
     .split(/\r?\n/u)
     .flatMap((line) => line.match(/[^.!?]+[.!?]?/gu) ?? [])
@@ -573,7 +571,12 @@ function buildCandidateSummaryMentions(
       if (!containsNameAlias(normalizedSentence, candidateAliases)) {
         return [];
       }
-      if (!containsNameAlias(normalizedSentence, otherAliases)) {
+      if (
+        !containsNameAlias(
+          removeNameAliases(normalizedSentence, candidateAliases),
+          otherAliases,
+        )
+      ) {
         return [sentence];
       }
 
@@ -584,7 +587,10 @@ function buildCandidateSummaryMentions(
           const normalizedClause = clause.toLocaleLowerCase();
           return (
             startsWithNameAlias(normalizedClause, candidateAliases) &&
-            !containsNameAlias(normalizedClause, otherAliases)
+            !containsNameAlias(
+              removeNameAliases(normalizedClause, candidateAliases),
+              otherAliases,
+            )
           );
         });
     });
@@ -618,6 +624,28 @@ function buildCandidateNameAliases(
     );
 
   return isUnique ? [normalizedName, givenName] : [normalizedName];
+}
+
+function buildCandidateExclusionAliases(candidateName: string) {
+  const normalizedName = normalizeWhitespace(candidateName).toLocaleLowerCase();
+  const givenName = normalizedName.match(/[\p{L}\p{N}]+/u)?.[0];
+  return givenName && givenName.length >= 3
+    ? [normalizedName, givenName]
+    : [normalizedName];
+}
+
+function removeNameAliases(value: string, aliases: string[]) {
+  return aliases.reduce(
+    (remaining, alias) =>
+      remaining.replace(
+        new RegExp(
+          `(?:^|[^\\p{L}\\p{N}])${escapeRegExp(alias)}(?=$|[^\\p{L}\\p{N}])`,
+          "gu",
+        ),
+        " ",
+      ),
+    value,
+  );
 }
 
 function containsNameAlias(value: string, aliases: string[]) {

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -724,10 +724,16 @@ function buildNameAliasRegExp(
 
 function hasProperNameAffix(value: string, start: number, end: number) {
   const prefix = value.slice(0, start);
+  const precedingToken = prefix.match(
+    /(?:^|[^\p{L}\p{N}])(\p{Lu}[\p{L}\p{N}]*(?:[-‐‑‒–—―'’][\p{L}\p{N}]+)*|\p{Lu}\.)\s+$/u,
+  )?.[1];
   return (
     /[\p{L}\p{N}][-‐‑‒–—―'’]$/u.test(prefix) ||
-    /(?:^|[^\p{L}\p{N}])(?:\p{Lu}[\p{L}\p{N}]*(?:[-‐‑‒–—―'’][\p{L}\p{N}]+)*|\p{Lu}\.)\s+$/u.test(
-      prefix,
+    Boolean(
+      precedingToken &&
+      !ATTRIBUTION_STOP_WORDS.has(
+        precedingToken.replace(/\.$/u, "").toLocaleLowerCase(),
+      ),
     ) ||
     /^(?:\s+\p{Lu}|[-‐‑‒–—―'’]\p{Lu})/u.test(value.slice(end))
   );
@@ -761,7 +767,7 @@ function selectRelevantEvidence(
 }
 
 const ATTRIBUTION_STOP_WORDS = new Set(
-  "about after again against all also among and any are around because been before being below between both but can could did does doing down during each few for from further had has have having here how into its itself just may more most other our ours out over own same should some such than that the their theirs them themselves then there these they this those through under until very was were what when where which while who whom why will with would you your yours yourself yourselves".split(
+  "about after again against all also among and any are around as because been before being below between both but can could did does doing down during each few for from further had has have having here how if into its itself just may more most once other our ours out over own same should since some such than that the their theirs them themselves then there these they this those though through under unless until very was were what when whenever where whereas whether which while who whom why will with would you your yours yourself yourselves".split(
     " ",
   ),
 );

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -615,10 +615,9 @@ function buildCandidateNameAliases(
     .filter((candidate) => candidate.name !== candidateName)
     .every(
       (candidate) =>
-        !candidate.name
-          .toLocaleLowerCase()
-          .match(/[\p{L}\p{N}]+/gu)
-          ?.includes(givenName),
+        getCandidateGivenNameAlias(
+          normalizeWhitespace(candidate.name).toLocaleLowerCase(),
+        ) !== givenName,
     );
 
   return isUnique
@@ -641,7 +640,9 @@ function buildCandidateExclusionAliases(candidateName: string) {
 }
 
 function getCandidateGivenNameAlias(normalizedName: string) {
-  const givenName = normalizedName.match(/[\p{L}\p{N}]+/u)?.[0];
+  const givenName = normalizedName.match(
+    /^[\p{L}\p{N}]+(?:[-‐‑‒–—―'’][\p{L}\p{N}]+)*/u,
+  )?.[0];
   return givenName &&
     givenName.length >= 3 &&
     !ATTRIBUTION_STOP_WORDS.has(givenName)

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -558,20 +558,22 @@ function buildCandidateSummaryMentions(
   candidateName: string,
   candidates: SpeakerAttributionContext["candidates"],
 ) {
-  const normalizedName = candidateName.toLocaleLowerCase();
-  const otherNames = candidates
+  const candidateAliases = buildCandidateNameAliases(candidateName, candidates);
+  const otherAliases = candidates
     .filter((candidate) => candidate.name !== candidateName)
-    .map((candidate) => candidate.name.toLocaleLowerCase());
+    .flatMap((candidate) =>
+      buildCandidateNameAliases(candidate.name, candidates),
+    );
   const sentences = summary
     .split(/\r?\n/u)
     .flatMap((line) => line.match(/[^.!?]+[.!?]?/gu) ?? [])
     .map(normalizeWhitespace)
     .flatMap((sentence) => {
       const normalizedSentence = sentence.toLocaleLowerCase();
-      if (!normalizedSentence.includes(normalizedName)) {
+      if (!containsNameAlias(normalizedSentence, candidateAliases)) {
         return [];
       }
-      if (otherNames.every((name) => !normalizedSentence.includes(name))) {
+      if (!containsNameAlias(normalizedSentence, otherAliases)) {
         return [sentence];
       }
 
@@ -581,8 +583,8 @@ function buildCandidateSummaryMentions(
         .filter((clause) => {
           const normalizedClause = clause.toLocaleLowerCase();
           return (
-            normalizedClause.startsWith(normalizedName) &&
-            otherNames.every((name) => !normalizedClause.includes(name))
+            startsWithNameAlias(normalizedClause, candidateAliases) &&
+            !containsNameAlias(normalizedClause, otherAliases)
           );
         });
     });
@@ -593,6 +595,48 @@ function buildCandidateSummaryMentions(
       id: `summary-${index + 1}`,
       quote: quote.slice(0, MAX_SUMMARY_MENTION_LENGTH),
     }));
+}
+
+function buildCandidateNameAliases(
+  candidateName: string,
+  candidates: SpeakerAttributionContext["candidates"],
+) {
+  const normalizedName = normalizeWhitespace(candidateName).toLocaleLowerCase();
+  const givenName = normalizedName.match(/[\p{L}\p{N}]+/u)?.[0];
+  if (!givenName || givenName.length < 3) {
+    return [normalizedName];
+  }
+
+  const isUnique = candidates
+    .filter((candidate) => candidate.name !== candidateName)
+    .every(
+      (candidate) =>
+        !candidate.name
+          .toLocaleLowerCase()
+          .match(/[\p{L}\p{N}]+/gu)
+          ?.includes(givenName),
+    );
+
+  return isUnique ? [normalizedName, givenName] : [normalizedName];
+}
+
+function containsNameAlias(value: string, aliases: string[]) {
+  return aliases.some((alias) =>
+    new RegExp(
+      `(?:^|[^\\p{L}\\p{N}])${escapeRegExp(alias)}(?=$|[^\\p{L}\\p{N}])`,
+      "u",
+    ).test(value),
+  );
+}
+
+function startsWithNameAlias(value: string, aliases: string[]) {
+  return aliases.some((alias) =>
+    new RegExp(`^${escapeRegExp(alias)}(?=$|[^\\p{L}\\p{N}])`, "u").test(value),
+  );
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function selectRelevantEvidence(

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -659,7 +659,11 @@ function removeNameAliases(
         buildNameAliasRegExp(alias, "giu"),
         (match, offset: number) =>
           alias.isGivenName &&
-          hasProperNameContinuation(remaining, offset + match.length)
+          hasProperNameAffix(
+            remaining,
+            offset + match.length - alias.value.length,
+            offset + match.length,
+          )
             ? match
             : " ",
       ),
@@ -677,7 +681,11 @@ function containsNameAlias(
     while (match) {
       if (
         !alias.isGivenName ||
-        !hasProperNameContinuation(value, pattern.lastIndex)
+        !hasProperNameAffix(
+          value,
+          pattern.lastIndex - alias.value.length,
+          pattern.lastIndex,
+        )
       ) {
         return true;
       }
@@ -698,8 +706,7 @@ function startsWithNameAlias(
     ).test(value);
     return (
       matches &&
-      (!alias.isGivenName ||
-        !hasProperNameContinuation(value, alias.value.length))
+      (!alias.isGivenName || !hasProperNameAffix(value, 0, alias.value.length))
     );
   });
 }
@@ -714,8 +721,11 @@ function buildNameAliasRegExp(
   );
 }
 
-function hasProperNameContinuation(value: string, offset: number) {
-  return /^(?:\s+\p{Lu}|[-‐‑‒–—―'’]\p{Lu})/u.test(value.slice(offset));
+function hasProperNameAffix(value: string, start: number, end: number) {
+  return (
+    /[\p{L}\p{N}][-‐‑‒–—―'’]$/u.test(value.slice(0, start)) ||
+    /^(?:\s+\p{Lu}|[-‐‑‒–—―'’]\p{Lu})/u.test(value.slice(end))
+  );
 }
 
 function escapeRegExp(value: string) {

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -608,8 +608,8 @@ function buildCandidateNameAliases(
   candidates: SpeakerAttributionContext["candidates"],
 ) {
   const normalizedName = normalizeWhitespace(candidateName).toLocaleLowerCase();
-  const givenName = normalizedName.match(/[\p{L}\p{N}]+/u)?.[0];
-  if (!givenName || givenName.length < 3) {
+  const givenName = getCandidateGivenNameAlias(normalizedName);
+  if (!givenName) {
     return [normalizedName];
   }
 
@@ -628,10 +628,17 @@ function buildCandidateNameAliases(
 
 function buildCandidateExclusionAliases(candidateName: string) {
   const normalizedName = normalizeWhitespace(candidateName).toLocaleLowerCase();
+  const givenName = getCandidateGivenNameAlias(normalizedName);
+  return givenName ? [normalizedName, givenName] : [normalizedName];
+}
+
+function getCandidateGivenNameAlias(normalizedName: string) {
   const givenName = normalizedName.match(/[\p{L}\p{N}]+/u)?.[0];
-  return givenName && givenName.length >= 3
-    ? [normalizedName, givenName]
-    : [normalizedName];
+  return givenName &&
+    givenName.length >= 3 &&
+    !ATTRIBUTION_STOP_WORDS.has(givenName)
+    ? givenName
+    : undefined;
 }
 
 function removeNameAliases(value: string, aliases: string[]) {
@@ -691,7 +698,7 @@ function selectRelevantEvidence(
 }
 
 const ATTRIBUTION_STOP_WORDS = new Set(
-  "about after again against all also among and any are around because been before being below between both but can could did does doing down during each few for from further had has have having here how into its itself just more most other our ours out over own same should some such than that the their theirs them themselves then there these they this those through under until very was were what when where which while who whom why will with would you your yours yourself yourselves".split(
+  "about after again against all also among and any are around because been before being below between both but can could did does doing down during each few for from further had has have having here how into its itself just may more most other our ours out over own same should some such than that the their theirs them themselves then there these they this those through under until very was were what when where which while who whom why will with would you your yours yourself yourselves".split(
     " ",
   ),
 );

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -567,13 +567,12 @@ function buildCandidateSummaryMentions(
     .flatMap((line) => line.match(/[^.!?]+[.!?]?/gu) ?? [])
     .map(normalizeWhitespace)
     .flatMap((sentence) => {
-      const normalizedSentence = sentence.toLocaleLowerCase();
-      if (!containsNameAlias(normalizedSentence, candidateAliases)) {
+      if (!containsNameAlias(sentence, candidateAliases)) {
         return [];
       }
       if (
         !containsNameAlias(
-          removeNameAliases(normalizedSentence, candidateAliases),
+          removeNameAliases(sentence, candidateAliases),
           otherAliases,
         )
       ) {
@@ -584,11 +583,10 @@ function buildCandidateSummaryMentions(
         .split(/[,;]\s+(?:and\s+)?|\s+[—–]\s+/u)
         .map(normalizeWhitespace)
         .filter((clause) => {
-          const normalizedClause = clause.toLocaleLowerCase();
           return (
-            startsWithNameAlias(normalizedClause, candidateAliases) &&
+            startsWithNameAlias(clause, candidateAliases) &&
             !containsNameAlias(
-              removeNameAliases(normalizedClause, candidateAliases),
+              removeNameAliases(clause, candidateAliases),
               otherAliases,
             )
           );
@@ -610,7 +608,7 @@ function buildCandidateNameAliases(
   const normalizedName = normalizeWhitespace(candidateName).toLocaleLowerCase();
   const givenName = getCandidateGivenNameAlias(normalizedName);
   if (!givenName) {
-    return [normalizedName];
+    return [{ value: normalizedName, isGivenName: false }];
   }
 
   const isUnique = candidates
@@ -623,13 +621,23 @@ function buildCandidateNameAliases(
           ?.includes(givenName),
     );
 
-  return isUnique ? [normalizedName, givenName] : [normalizedName];
+  return isUnique
+    ? [
+        { value: normalizedName, isGivenName: false },
+        { value: givenName, isGivenName: true },
+      ]
+    : [{ value: normalizedName, isGivenName: false }];
 }
 
 function buildCandidateExclusionAliases(candidateName: string) {
   const normalizedName = normalizeWhitespace(candidateName).toLocaleLowerCase();
   const givenName = getCandidateGivenNameAlias(normalizedName);
-  return givenName ? [normalizedName, givenName] : [normalizedName];
+  return givenName
+    ? [
+        { value: normalizedName, isGivenName: false },
+        { value: givenName, isGivenName: true },
+      ]
+    : [{ value: normalizedName, isGivenName: false }];
 }
 
 function getCandidateGivenNameAlias(normalizedName: string) {
@@ -641,33 +649,73 @@ function getCandidateGivenNameAlias(normalizedName: string) {
     : undefined;
 }
 
-function removeNameAliases(value: string, aliases: string[]) {
+function removeNameAliases(
+  value: string,
+  aliases: Array<{ value: string; isGivenName: boolean }>,
+) {
   return aliases.reduce(
     (remaining, alias) =>
       remaining.replace(
-        new RegExp(
-          `(?:^|[^\\p{L}\\p{N}])${escapeRegExp(alias)}(?=$|[^\\p{L}\\p{N}])`,
-          "gu",
-        ),
-        " ",
+        buildNameAliasRegExp(alias, "giu"),
+        (match, offset: number) =>
+          alias.isGivenName &&
+          hasProperNameContinuation(remaining, offset + match.length)
+            ? match
+            : " ",
       ),
     value,
   );
 }
 
-function containsNameAlias(value: string, aliases: string[]) {
-  return aliases.some((alias) =>
-    new RegExp(
-      `(?:^|[^\\p{L}\\p{N}])${escapeRegExp(alias)}(?=$|[^\\p{L}\\p{N}])`,
-      "u",
-    ).test(value),
+function containsNameAlias(
+  value: string,
+  aliases: Array<{ value: string; isGivenName: boolean }>,
+) {
+  return aliases.some((alias) => {
+    const pattern = buildNameAliasRegExp(alias, "giu");
+    let match = pattern.exec(value);
+    while (match) {
+      if (
+        !alias.isGivenName ||
+        !hasProperNameContinuation(value, pattern.lastIndex)
+      ) {
+        return true;
+      }
+      match = pattern.exec(value);
+    }
+    return false;
+  });
+}
+
+function startsWithNameAlias(
+  value: string,
+  aliases: Array<{ value: string; isGivenName: boolean }>,
+) {
+  return aliases.some((alias) => {
+    const matches = new RegExp(
+      `^${escapeRegExp(alias.value)}(?=$|[^\\p{L}\\p{N}])`,
+      "iu",
+    ).test(value);
+    return (
+      matches &&
+      (!alias.isGivenName ||
+        !hasProperNameContinuation(value, alias.value.length))
+    );
+  });
+}
+
+function buildNameAliasRegExp(
+  alias: { value: string; isGivenName: boolean },
+  flags: string,
+) {
+  return new RegExp(
+    `(?:^|[^\\p{L}\\p{N}])${escapeRegExp(alias.value)}(?=$|[^\\p{L}\\p{N}])`,
+    flags,
   );
 }
 
-function startsWithNameAlias(value: string, aliases: string[]) {
-  return aliases.some((alias) =>
-    new RegExp(`^${escapeRegExp(alias)}(?=$|[^\\p{L}\\p{N}])`, "u").test(value),
-  );
+function hasProperNameContinuation(value: string, offset: number) {
+  return /^(?:\s+\p{Lu}|[-‐‑‒–—―'’]\p{Lu})/u.test(value.slice(offset));
 }
 
 function escapeRegExp(value: string) {

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -723,8 +723,12 @@ function buildNameAliasRegExp(
 }
 
 function hasProperNameAffix(value: string, start: number, end: number) {
+  const prefix = value.slice(0, start);
   return (
-    /[\p{L}\p{N}][-‐‑‒–—―'’]$/u.test(value.slice(0, start)) ||
+    /[\p{L}\p{N}][-‐‑‒–—―'’]$/u.test(prefix) ||
+    /(?:^|[^\p{L}\p{N}])(?:\p{Lu}[\p{L}\p{N}]*(?:[-‐‑‒–—―'’][\p{L}\p{N}]+)*|\p{Lu}\.)\s+$/u.test(
+      prefix,
+    ) ||
     /^(?:\s+\p{Lu}|[-‐‑‒–—―'’]\p{Lu})/u.test(value.slice(end))
   );
 }


### PR DESCRIPTION
Recognize unique given-name references in generated summaries so automatic speaker attribution can reach the model, while continuing to reject aliases shared by multiple participants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heuristics that gate LLM speaker attribution and automatic transcript hints; wrong matches could mislabel speakers, though ambiguous cases still skip the model.
> 
> **Overview**
> **Automatic speaker attribution** now treats **unique given names** (e.g. “Lex”, “George”) as summary evidence when building `summary_mentions`, not only full participant names—so enhance can reach the LLM when summaries use first names alone.
> 
> Matching is **alias-based**: each candidate gets full-name plus optional given-name aliases only when no other participant shares that given name, the token is at least three characters, and it is not in an expanded **`ATTRIBUTION_STOP_WORDS`** set (e.g. “will”, “may”, “as”). **Joined given names** (hyphen/apostrophe) match as a whole, not shortened to the first token.
> 
> **False-positive guards** use Unicode word-boundary regex and **`hasProperNameAffix`** so given names inside third-party names (“Mark Zuckerberg”), surnames (“Mary Jane”), or substrings of hyphenated names do not count. Clause splitting for multi-speaker sentences strips the candidate’s aliases before checking for other participants, including when two people share a given name but only one full name appears in a clause.
> 
> Behavior is covered by a large new test suite in `speaker-attribution.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6837c664d5c1fd7a8f8615f12590cfa6bc779ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->