### PR TITLE
Prepare macOS-first 1.4.0 release

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -97,16 +97,26 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
       - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.compute-version.outputs.version }}"
-      - name: Verify stable signing credentials
+      - name: Verify stable signing configuration
         env:
-          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          AZURE_ARTIFACT_SIGNING_ENDPOINT: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          WINDOWS_SIGNER_ORGANIZATION: ${{ vars.WINDOWS_SIGNER_ORGANIZATION }}
         run: |
           missing=()
-          [[ -n "$WINDOWS_CERTIFICATE" ]] || missing+=("WINDOWS_CERTIFICATE")
-          [[ -n "$WINDOWS_CERTIFICATE_PASSWORD" ]] || missing+=("WINDOWS_CERTIFICATE_PASSWORD")
+          [[ -n "$AZURE_CLIENT_ID" ]] || missing+=("AZURE_CLIENT_ID")
+          [[ -n "$AZURE_TENANT_ID" ]] || missing+=("AZURE_TENANT_ID")
+          [[ -n "$AZURE_SUBSCRIPTION_ID" ]] || missing+=("AZURE_SUBSCRIPTION_ID")
+          [[ -n "$AZURE_ARTIFACT_SIGNING_ENDPOINT" ]] || missing+=("AZURE_ARTIFACT_SIGNING_ENDPOINT")
+          [[ -n "$AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME" ]] || missing+=("AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME")
+          [[ -n "$AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME" ]] || missing+=("AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME")
+          [[ -n "$WINDOWS_SIGNER_ORGANIZATION" ]] || missing+=("WINDOWS_SIGNER_ORGANIZATION")
           if [[ ${#missing[@]} -gt 0 ]]; then
-            echo "::error::Stable Windows release signing is missing: ${missing[*]}"
+            echo "::error::Stable Windows release signing configuration is missing: ${missing[*]}"
             exit 1
           fi
       - uses: ./.github/actions/cn_release
@@ -469,6 +479,9 @@ jobs:
   build-windows:
     needs: [compute-version, cn-draft]
     if: ${{ !cancelled() && (needs.cn-draft.result == 'success' || needs.cn-draft.result == 'skipped') }}
+    permissions:
+      contents: read
+      id-token: write
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -494,75 +507,19 @@ jobs:
           ./scripts/sidecar.sh \
             "./apps/desktop/${{ env.TAURI_CONF_PATH }}" \
             resources/cli/anarlog-cli
-      - if: ${{ inputs.channel == 'stable' }}
-        name: Import Windows signing certificate
-        shell: pwsh
-        env:
-          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
-        run: |
-          if (
-            [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE) -or
-            [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)
-          ) {
-            throw "Stable Windows releases require WINDOWS_CERTIFICATE and WINDOWS_CERTIFICATE_PASSWORD"
-          }
-
-          $encodedCertificate = Join-Path $env:RUNNER_TEMP "anarlog-windows-certificate.txt"
-          $certificatePath = Join-Path $env:RUNNER_TEMP "anarlog-windows-certificate.pfx"
-          Set-Content -Path $encodedCertificate -Value $env:WINDOWS_CERTIFICATE
-          certutil -decode $encodedCertificate $certificatePath
-          if ($LASTEXITCODE -ne 0) {
-            throw "Could not decode the Windows signing certificate"
-          }
-
-          $password = ConvertTo-SecureString `
-            -String $env:WINDOWS_CERTIFICATE_PASSWORD `
-            -Force `
-            -AsPlainText
-          $certificate = @(
-            Import-PfxCertificate `
-              -FilePath $certificatePath `
-              -CertStoreLocation Cert:\CurrentUser\My `
-              -Password $password
-          ) |
-            Where-Object { $_.HasPrivateKey } |
-            Select-Object -First 1
-          if (-not $certificate) {
-            throw "Could not import the Windows signing certificate"
-          }
-          Remove-Item $encodedCertificate, $certificatePath -Force
-
-          $signingConfigPath = Join-Path $env:RUNNER_TEMP "tauri.windows-signing.json"
-          @{
-            bundle = @{
-              windows = @{
-                certificateThumbprint = $certificate.Thumbprint
-                digestAlgorithm = "sha256"
-                timestampUrl = "http://timestamp.digicert.com"
-              }
-            }
-          } |
-            ConvertTo-Json -Depth 4 |
-            Set-Content -Path $signingConfigPath -Encoding utf8
-
-          "WINDOWS_SIGNING_CONFIG=$($signingConfigPath.Replace('\', '/'))" |
-            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "WINDOWS_SIGNING_THUMBPRINT=$($certificate.Thumbprint)" |
-            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - shell: bash
+      - name: Build Windows app
+        shell: bash
         run: |
           BUILD_ARGS=(
             --ci
-            --bundles nsis
             --target x86_64-pc-windows-msvc
             --config "${{ env.TAURI_CONF_PATH }}"
             --verbose
           )
           if [[ "${{ inputs.channel }}" == "staging" ]]; then
-            BUILD_ARGS+=(--features devtools --no-sign)
+            BUILD_ARGS+=(--bundles nsis --features devtools --no-sign)
           else
-            BUILD_ARGS+=(--config "$WINDOWS_SIGNING_CONFIG")
+            BUILD_ARGS+=(--no-bundle --no-sign)
           fi
           pnpm -F desktop tauri build "${BUILD_ARGS[@]}"
         env:
@@ -579,10 +536,82 @@ jobs:
           VITE_API_URL: https://api.anarlog.so
           VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
           VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Sign in to Azure
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Sign Windows binaries
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          files: |
+            ${{ github.workspace }}\apps\desktop\src-tauri\target\x86_64-pc-windows-msvc\release\anarlog.exe
+            ${{ github.workspace }}\apps\desktop\src-tauri\resources\cli\anarlog-cli-x86_64-pc-windows-msvc.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Bundle signed Windows app
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          pnpm -F desktop tauri bundle \
+            --ci \
+            --bundles nsis \
+            --target x86_64-pc-windows-msvc \
+            --config "${{ env.TAURI_CONF_PATH }}" \
+            --verbose \
+            --no-sign
+      - if: ${{ inputs.channel == 'stable' }}
+        id: windows-installer
+        name: Locate Windows installer
+        shell: pwsh
+        run: |
+          $bundleDir = "apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis"
+          $installers = @(Get-ChildItem $bundleDir -Filter "*.exe")
+          if ($installers.Count -ne 1) {
+            throw "Expected one NSIS installer in $bundleDir, found $($installers.Count)"
+          }
+          "path=$($installers[0].FullName)" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Sign Windows installer
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          files: ${{ steps.windows-installer.outputs.path }}
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Sign Windows updater artifact
+        shell: pwsh
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          $installer = "${{ steps.windows-installer.outputs.path }}"
+          $signaturePath = "$installer.sig"
+          Remove-Item $signaturePath -Force -ErrorAction SilentlyContinue
+          pnpm -F desktop tauri signer sign $installer
+          if ($LASTEXITCODE -ne 0 -or -not (Test-Path $signaturePath)) {
+            throw "Could not create the Windows updater signature"
+          }
       - shell: pwsh
         env:
           EXPECTED_VERSION: ${{ needs.compute-version.outputs.version }}
           RELEASE_CHANNEL: ${{ inputs.channel }}
+          WINDOWS_SIGNER_ORGANIZATION: ${{ vars.WINDOWS_SIGNER_ORGANIZATION }}
         run: |
           $config = Get-Content "apps/desktop/src-tauri/tauri.conf.json" | ConvertFrom-Json
           if ($config.version -ne $env:EXPECTED_VERSION) {
@@ -609,16 +638,21 @@ jobs:
             }
 
             $appBinary = "apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/anarlog.exe"
-            foreach ($signedFile in @($appBinary, $installers[0].FullName)) {
+            $sidecarBinary = "apps/desktop/src-tauri/resources/cli/anarlog-cli-x86_64-pc-windows-msvc.exe"
+            foreach ($signedFile in @($appBinary, $sidecarBinary, $installers[0].FullName)) {
               $signature = Get-AuthenticodeSignature $signedFile
               if ($signature.Status -ne "Valid") {
                 throw "Invalid Authenticode signature for $signedFile`: $($signature.Status)"
               }
-              if (
-                -not $signature.SignerCertificate -or
-                $signature.SignerCertificate.Thumbprint -ne $env:WINDOWS_SIGNING_THUMBPRINT
-              ) {
-                throw "Authenticode signer does not match the imported release certificate for $signedFile"
+              if (-not $signature.SignerCertificate) {
+                throw "Authenticode signer certificate is missing for $signedFile"
+              }
+              $signerOrganization = $signature.SignerCertificate.GetNameInfo(
+                [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName,
+                $false
+              )
+              if ($signerOrganization -ne $env:WINDOWS_SIGNER_ORGANIZATION) {
+                throw "Unexpected Authenticode signer '$signerOrganization' for $signedFile"
               }
               if (-not $signature.TimeStamperCertificate) {
                 throw "Authenticode signature is missing a trusted timestamp for $signedFile"

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -18,6 +18,14 @@ on:
         description: "Legacy compatibility input; stable publication must use desktop_publish"
         type: boolean
         default: false
+      include_linux:
+        description: "Build and include Linux beta artifacts"
+        type: boolean
+        default: true
+      include_windows:
+        description: "Build and include Windows artifacts"
+        type: boolean
+        default: true
       version:
         description: "Explicit semantic version required for stable releases"
         required: false
@@ -97,7 +105,8 @@ jobs:
         with:
           ref: ${{ inputs.candidate_sha || github.sha }}
       - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.compute-version.outputs.version }}"
-      - name: Verify stable signing configuration
+      - if: ${{ inputs.include_windows }}
+        name: Verify stable signing configuration
         env:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
@@ -284,7 +293,7 @@ jobs:
 
   build-linux:
     needs: [compute-version, cn-draft]
-    if: ${{ !cancelled() && (needs.cn-draft.result == 'success' || needs.cn-draft.result == 'skipped') }}
+    if: ${{ inputs.include_linux && !cancelled() && (needs.cn-draft.result == 'success' || needs.cn-draft.result == 'skipped') }}
     strategy:
       fail-fast: true
       matrix:
@@ -478,7 +487,7 @@ jobs:
 
   build-windows:
     needs: [compute-version, cn-draft]
-    if: ${{ !cancelled() && (needs.cn-draft.result == 'success' || needs.cn-draft.result == 'skipped') }}
+    if: ${{ inputs.include_windows && !cancelled() && (needs.cn-draft.result == 'success' || needs.cn-draft.result == 'skipped') }}
     permissions:
       contents: read
       id-token: write
@@ -697,7 +706,7 @@ jobs:
           working-directory: ./apps/desktop
 
   verify-cn-release:
-    if: ${{ inputs.channel != 'staging' && !cancelled() && needs.build-macos.result == 'success' && needs.build-windows.result == 'success' && needs.build-linux.result == 'success' }}
+    if: ${{ inputs.channel != 'staging' && !cancelled() && needs.build-macos.result == 'success' && (!inputs.include_linux || needs.build-linux.result == 'success') && (!inputs.include_windows || needs.build-windows.result == 'success') }}
     needs: [compute-version, build-macos, build-windows, build-linux]
     runs-on: ubuntu-latest
     steps:
@@ -724,12 +733,18 @@ jobs:
           EXPECTED_PLATFORMS=(
             "dmg-aarch64"
             "dmg-x86_64"
-            "nsis-x86_64"
-            "appimage-x86_64"
-            "deb-x86_64"
-            "appimage-aarch64"
-            "deb-aarch64"
           )
+          if [[ "${{ inputs.include_linux }}" == "true" ]]; then
+            EXPECTED_PLATFORMS+=(
+              "appimage-x86_64"
+              "deb-x86_64"
+              "appimage-aarch64"
+              "deb-aarch64"
+            )
+          fi
+          if [[ "${{ inputs.include_windows }}" == "true" ]]; then
+            EXPECTED_PLATFORMS+=("nsis-x86_64")
+          fi
 
           INVALID_PLATFORMS=()
           for platform in "${EXPECTED_PLATFORMS[@]}"; do
@@ -747,12 +762,18 @@ jobs:
           EXPECTED_UPDATE_PLATFORMS=(
             "darwin-aarch64"
             "darwin-x86_64"
-            "windows-x86_64-nsis"
-            "linux-x86_64-appimage"
-            "linux-x86_64-deb"
-            "linux-aarch64-appimage"
-            "linux-aarch64-deb"
           )
+          if [[ "${{ inputs.include_linux }}" == "true" ]]; then
+            EXPECTED_UPDATE_PLATFORMS+=(
+              "linux-x86_64-appimage"
+              "linux-x86_64-deb"
+              "linux-aarch64-appimage"
+              "linux-aarch64-deb"
+            )
+          fi
+          if [[ "${{ inputs.include_windows }}" == "true" ]]; then
+            EXPECTED_UPDATE_PLATFORMS+=("windows-x86_64-nsis")
+          fi
 
           INVALID_UPDATE_PLATFORMS=()
           for platform in "${EXPECTED_UPDATE_PLATFORMS[@]}"; do

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -13,10 +13,19 @@ on:
         description: "Successful publish=false desktop CD run that built the candidate"
         required: true
         type: string
+      include_linux:
+        description: "Publish Linux beta artifacts from the candidate"
+        type: boolean
+        default: true
+      include_windows:
+        description: "Publish Windows artifacts from the candidate"
+        type: boolean
+        default: true
       audio_qa_run_id:
         description: "Successful desktop Linux virtual-audio QA run for the candidate"
-        required: true
+        required: false
         type: string
+        default: ""
 
 concurrency:
   group: desktop-stable-release
@@ -33,6 +42,8 @@ jobs:
       channel: ${{ steps.parse.outputs.channel }}
       candidate_sha: ${{ steps.parse.outputs.candidate_sha }}
       dry_run_id: ${{ steps.parse.outputs.dry_run_id }}
+      include_linux: ${{ steps.parse.outputs.include_linux }}
+      include_windows: ${{ steps.parse.outputs.include_windows }}
       audio_qa_run_id: ${{ steps.parse.outputs.audio_qa_run_id }}
     steps:
       - id: parse
@@ -42,6 +53,8 @@ jobs:
           INPUT_AUDIO_QA_RUN_ID: ${{ inputs.audio_qa_run_id }}
           INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha }}
           INPUT_DRY_RUN_ID: ${{ inputs.dry_run_id }}
+          INPUT_INCLUDE_LINUX: ${{ inputs.include_linux }}
+          INPUT_INCLUDE_WINDOWS: ${{ inputs.include_windows }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -57,8 +70,13 @@ jobs:
             echo "::error::Dry-run workflow ID must be a positive integer"
             exit 1
           fi
-          if [[ ! "$INPUT_AUDIO_QA_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::Linux audio QA workflow ID must be a positive integer"
+          if [[ "$INPUT_INCLUDE_LINUX" == "true" ]]; then
+            if [[ ! "$INPUT_AUDIO_QA_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::Linux audio QA workflow ID must be a positive integer when Linux is included"
+              exit 1
+            fi
+          elif [[ -n "$INPUT_AUDIO_QA_RUN_ID" ]]; then
+            echo "::error::Linux audio QA workflow ID must be empty when Linux is excluded"
             exit 1
           fi
 
@@ -77,6 +95,8 @@ jobs:
           echo "channel=stable" >> $GITHUB_OUTPUT
           echo "candidate_sha=$CANDIDATE_SHA" >> $GITHUB_OUTPUT
           echo "dry_run_id=$INPUT_DRY_RUN_ID" >> $GITHUB_OUTPUT
+          echo "include_linux=$INPUT_INCLUDE_LINUX" >> $GITHUB_OUTPUT
+          echo "include_windows=$INPUT_INCLUDE_WINDOWS" >> $GITHUB_OUTPUT
           echo "audio_qa_run_id=$INPUT_AUDIO_QA_RUN_ID" >> $GITHUB_OUTPUT
 
   verify-candidate:
@@ -113,6 +133,7 @@ jobs:
           fi
 
   verify-windows-signature:
+    if: ${{ needs.parse.outputs.include_windows == 'true' }}
     needs: [parse, verify-candidate]
     runs-on: windows-latest
     steps:
@@ -151,6 +172,7 @@ jobs:
 
   cn-publish:
     needs: [parse, verify-candidate, verify-windows-signature]
+    if: ${{ !cancelled() && needs.parse.result == 'success' && needs.verify-candidate.result == 'success' && (needs.parse.outputs.include_windows != 'true' || needs.verify-windows-signature.result == 'success') }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -195,6 +217,7 @@ jobs:
             --name "desktop-release-provenance-$VERSION-$EXPECTED_SHA" \
             --dir release-provenance
       - name: Verify Linux virtual-audio QA evidence
+        if: ${{ needs.parse.outputs.include_linux == 'true' }}
         env:
           AUDIO_QA_RUN_ID: ${{ needs.parse.outputs.audio_qa_run_id }}
           DRY_RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
@@ -256,6 +279,8 @@ jobs:
         env:
           RELEASE: ${{ steps.release.outputs.raw }}
           EXPECTED_VERSION: ${{ needs.parse.outputs.version }}
+          INCLUDE_LINUX: ${{ needs.parse.outputs.include_linux }}
+          INCLUDE_WINDOWS: ${{ needs.parse.outputs.include_windows }}
         run: |
           ACTUAL_VERSION=$(echo "$RELEASE" | jq -r '.version // empty')
           if [[ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]]; then
@@ -265,17 +290,25 @@ jobs:
 
           printf '%s' "$RELEASE" > "$RUNNER_TEMP/crabnebula-release.json"
           node scripts/desktop-release-provenance.mjs verify-platforms \
-            --release "$RUNNER_TEMP/crabnebula-release.json"
+            --release "$RUNNER_TEMP/crabnebula-release.json" \
+            --include-linux "$INCLUDE_LINUX" \
+            --include-windows "$INCLUDE_WINDOWS"
 
           EXPECTED_PLATFORMS=(
             "dmg-aarch64"
             "dmg-x86_64"
-            "nsis-x86_64"
-            "appimage-x86_64"
-            "deb-x86_64"
-            "appimage-aarch64"
-            "deb-aarch64"
           )
+          if [[ "$INCLUDE_LINUX" == "true" ]]; then
+            EXPECTED_PLATFORMS+=(
+              "appimage-x86_64"
+              "deb-x86_64"
+              "appimage-aarch64"
+              "deb-aarch64"
+            )
+          fi
+          if [[ "$INCLUDE_WINDOWS" == "true" ]]; then
+            EXPECTED_PLATFORMS+=("nsis-x86_64")
+          fi
 
           INVALID_PLATFORMS=()
           for platform in "${EXPECTED_PLATFORMS[@]}"; do
@@ -293,12 +326,18 @@ jobs:
           EXPECTED_UPDATE_PLATFORMS=(
             "darwin-aarch64"
             "darwin-x86_64"
-            "windows-x86_64-nsis"
-            "linux-x86_64-appimage"
-            "linux-x86_64-deb"
-            "linux-aarch64-appimage"
-            "linux-aarch64-deb"
           )
+          if [[ "$INCLUDE_LINUX" == "true" ]]; then
+            EXPECTED_UPDATE_PLATFORMS+=(
+              "linux-x86_64-appimage"
+              "linux-x86_64-deb"
+              "linux-aarch64-appimage"
+              "linux-aarch64-deb"
+            )
+          fi
+          if [[ "$INCLUDE_WINDOWS" == "true" ]]; then
+            EXPECTED_UPDATE_PLATFORMS+=("windows-x86_64-nsis")
+          fi
 
           INVALID_UPDATE_PLATFORMS=()
           for platform in "${EXPECTED_UPDATE_PLATFORMS[@]}"; do
@@ -455,6 +494,7 @@ jobs:
           output: anarlog-macos-x86_64.dmg
           key: ${{ secrets.CN_API_KEY }}
       - id: download-linux-x86_64-appimage
+        if: ${{ needs.parse.outputs.include_linux == 'true' }}
         uses: ./.github/actions/cn_download
         with:
           app: ${{ env.CN_APPLICATION }}
@@ -464,6 +504,7 @@ jobs:
           output: anarlog-linux-x86_64.AppImage
           key: ${{ secrets.CN_API_KEY }}
       - id: download-linux-x86_64-deb
+        if: ${{ needs.parse.outputs.include_linux == 'true' }}
         uses: ./.github/actions/cn_download
         with:
           app: ${{ env.CN_APPLICATION }}
@@ -473,6 +514,7 @@ jobs:
           output: anarlog-linux-x86_64.deb
           key: ${{ secrets.CN_API_KEY }}
       - id: download-linux-aarch64-appimage
+        if: ${{ needs.parse.outputs.include_linux == 'true' }}
         uses: ./.github/actions/cn_download
         with:
           app: ${{ env.CN_APPLICATION }}
@@ -482,6 +524,7 @@ jobs:
           output: anarlog-linux-aarch64.AppImage
           key: ${{ secrets.CN_API_KEY }}
       - id: download-linux-aarch64-deb
+        if: ${{ needs.parse.outputs.include_linux == 'true' }}
         uses: ./.github/actions/cn_download
         with:
           app: ${{ env.CN_APPLICATION }}
@@ -491,6 +534,7 @@ jobs:
           output: anarlog-linux-aarch64.deb
           key: ${{ secrets.CN_API_KEY }}
       - id: download-windows-x86_64
+        if: ${{ needs.parse.outputs.include_windows == 'true' }}
         uses: ./.github/actions/cn_download
         with:
           app: ${{ env.CN_APPLICATION }}
@@ -505,6 +549,8 @@ jobs:
           CN_SHA256: ${{ steps.download-macos-aarch64.outputs.cli-sha256 }}
           CN_VERSION: ${{ steps.download-macos-aarch64.outputs.cli-version }}
           EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
+          INCLUDE_LINUX: ${{ needs.parse.outputs.include_linux }}
+          INCLUDE_WINDOWS: ${{ needs.parse.outputs.include_windows }}
           LINUX_ARM64_APPIMAGE_ID: ${{ steps.download-linux-aarch64-appimage.outputs.asset_id }}
           LINUX_ARM64_DEB_ID: ${{ steps.download-linux-aarch64-deb.outputs.asset_id }}
           LINUX_X64_APPIMAGE_ID: ${{ steps.download-linux-x86_64-appimage.outputs.asset_id }}
@@ -534,13 +580,19 @@ jobs:
 
           copy_asset "$MACOS_ARM64_ID" "anarlog-macos-aarch64.dmg"
           copy_asset "$MACOS_X64_ID" "anarlog-macos-x86_64.dmg"
-          copy_asset "$LINUX_X64_APPIMAGE_ID" "anarlog-linux-x86_64.AppImage"
-          copy_asset "$LINUX_X64_DEB_ID" "anarlog-linux-x86_64.deb"
-          copy_asset "$LINUX_ARM64_APPIMAGE_ID" "anarlog-linux-aarch64.AppImage"
-          copy_asset "$LINUX_ARM64_DEB_ID" "anarlog-linux-aarch64.deb"
-          copy_asset "$WINDOWS_X64_ID" "anarlog-windows-x86_64-setup.exe"
+          if [[ "$INCLUDE_LINUX" == "true" ]]; then
+            copy_asset "$LINUX_X64_APPIMAGE_ID" "anarlog-linux-x86_64.AppImage"
+            copy_asset "$LINUX_X64_DEB_ID" "anarlog-linux-x86_64.deb"
+            copy_asset "$LINUX_ARM64_APPIMAGE_ID" "anarlog-linux-aarch64.AppImage"
+            copy_asset "$LINUX_ARM64_DEB_ID" "anarlog-linux-aarch64.deb"
+          fi
+          if [[ "$INCLUDE_WINDOWS" == "true" ]]; then
+            copy_asset "$WINDOWS_X64_ID" "anarlog-windows-x86_64-setup.exe"
+          fi
 
           PLATFORM_ASSET_IDS=$(jq -cn \
+            --arg include_linux "$INCLUDE_LINUX" \
+            --arg include_windows "$INCLUDE_WINDOWS" \
             --arg dmg_aarch64 "$MACOS_ARM64_ID" \
             --arg dmg_x86_64 "$MACOS_X64_ID" \
             --arg appimage_x86_64 "$LINUX_X64_APPIMAGE_ID" \
@@ -550,13 +602,17 @@ jobs:
             --arg nsis_x86_64 "$WINDOWS_X64_ID" \
             '{
               "dmg-aarch64": $dmg_aarch64,
-              "dmg-x86_64": $dmg_x86_64,
-              "appimage-x86_64": $appimage_x86_64,
-              "deb-x86_64": $deb_x86_64,
-              "appimage-aarch64": $appimage_aarch64,
-              "deb-aarch64": $deb_aarch64,
-              "nsis-x86_64": $nsis_x86_64
-            }')
+              "dmg-x86_64": $dmg_x86_64
+            }
+            + if $include_linux == "true" then {
+                "appimage-x86_64": $appimage_x86_64,
+                "deb-x86_64": $deb_x86_64,
+                "appimage-aarch64": $appimage_aarch64,
+                "deb-aarch64": $deb_aarch64
+              } else {} end
+            + if $include_windows == "true" then {
+                "nsis-x86_64": $nsis_x86_64
+              } else {} end')
 
           node scripts/desktop-release-provenance.mjs verify-assets \
             --manifest release-provenance/manifest.json \
@@ -574,11 +630,35 @@ jobs:
           files: |
             anarlog-macos-aarch64.dmg
             anarlog-macos-x86_64.dmg
-            anarlog-linux-x86_64.AppImage
-            anarlog-linux-x86_64.deb
-            anarlog-linux-aarch64.AppImage
-            anarlog-linux-aarch64.deb
-            anarlog-windows-x86_64-setup.exe
+            ${{ needs.parse.outputs.include_linux == 'true' && 'anarlog-linux-x86_64.AppImage' || '' }}
+            ${{ needs.parse.outputs.include_linux == 'true' && 'anarlog-linux-x86_64.deb' || '' }}
+            ${{ needs.parse.outputs.include_linux == 'true' && 'anarlog-linux-aarch64.AppImage' || '' }}
+            ${{ needs.parse.outputs.include_linux == 'true' && 'anarlog-linux-aarch64.deb' || '' }}
+            ${{ needs.parse.outputs.include_windows == 'true' && 'anarlog-windows-x86_64-setup.exe' || '' }}
+      - id: release-assets
+        env:
+          CHECKSUM_FILES: ${{ steps.checksums.outputs.checksum_files }}
+          INCLUDE_LINUX: ${{ needs.parse.outputs.include_linux }}
+          INCLUDE_WINDOWS: ${{ needs.parse.outputs.include_windows }}
+        run: |
+          files=(
+            "anarlog-macos-aarch64.dmg"
+            "anarlog-macos-x86_64.dmg"
+          )
+          if [[ "$INCLUDE_LINUX" == "true" ]]; then
+            files+=(
+              "anarlog-linux-x86_64.AppImage"
+              "anarlog-linux-x86_64.deb"
+              "anarlog-linux-aarch64.AppImage"
+              "anarlog-linux-aarch64.deb"
+            )
+          fi
+          if [[ "$INCLUDE_WINDOWS" == "true" ]]; then
+            files+=("anarlog-windows-x86_64-setup.exe")
+          fi
+
+          artifact_files=$(IFS=,; echo "${files[*]}")
+          echo "artifacts=$artifact_files,$CHECKSUM_FILES" >> "$GITHUB_OUTPUT"
       - id: release-body
         run: |
           echo "value=https://anarlog.so/changelog/${{ needs.parse.outputs.version }}" >> "$GITHUB_OUTPUT"
@@ -588,7 +668,7 @@ jobs:
           name: desktop_v${{ needs.parse.outputs.version }}
           body: ${{ steps.release-body.outputs.value }}
           prerelease: false
-          artifacts: anarlog-macos-aarch64.dmg,anarlog-macos-x86_64.dmg,anarlog-linux-x86_64.AppImage,anarlog-linux-x86_64.deb,anarlog-linux-aarch64.AppImage,anarlog-linux-aarch64.deb,anarlog-windows-x86_64-setup.exe,${{ steps.checksums.outputs.checksum_files }}
+          artifacts: ${{ steps.release-assets.outputs.artifacts }}
           allowUpdates: true
           makeLatest: true
           replacesArtifacts: true

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -129,45 +129,21 @@ jobs:
           key: ${{ secrets.CN_API_KEY }}
       - shell: pwsh
         env:
-          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          WINDOWS_SIGNER_ORGANIZATION: ${{ vars.WINDOWS_SIGNER_ORGANIZATION }}
         run: |
-          if (
-            [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE) -or
-            [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)
-          ) {
-            throw "Windows signature verification requires WINDOWS_CERTIFICATE and WINDOWS_CERTIFICATE_PASSWORD"
-          }
-
-          $encodedCertificate = Join-Path $env:RUNNER_TEMP "anarlog-windows-certificate.txt"
-          $certificatePath = Join-Path $env:RUNNER_TEMP "anarlog-windows-certificate.pfx"
-          Set-Content -Path $encodedCertificate -Value $env:WINDOWS_CERTIFICATE
-          certutil -decode $encodedCertificate $certificatePath
-          if ($LASTEXITCODE -ne 0) {
-            throw "Could not decode the Windows signing certificate"
-          }
-
-          $password = ConvertTo-SecureString `
-            -String $env:WINDOWS_CERTIFICATE_PASSWORD `
-            -Force `
-            -AsPlainText
-          $expectedCertificate = @(
-            (Get-PfxData -FilePath $certificatePath -Password $password).EndEntityCertificates
-          ) | Select-Object -First 1
-          Remove-Item $encodedCertificate, $certificatePath -Force
-          if (-not $expectedCertificate) {
-            throw "Could not read the Windows signing certificate"
-          }
-
           $signature = Get-AuthenticodeSignature "anarlog-windows-x86_64-setup.exe"
           if ($signature.Status -ne "Valid") {
             throw "Invalid Windows Authenticode signature: $($signature.Status)"
           }
-          if (
-            -not $signature.SignerCertificate -or
-            $signature.SignerCertificate.Thumbprint -ne $expectedCertificate.Thumbprint
-          ) {
-            throw "Windows Authenticode signer does not match the release certificate"
+          if (-not $signature.SignerCertificate) {
+            throw "Windows Authenticode signer certificate is missing"
+          }
+          $signerOrganization = $signature.SignerCertificate.GetNameInfo(
+            [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName,
+            $false
+          )
+          if ($signerOrganization -ne $env:WINDOWS_SIGNER_ORGANIZATION) {
+            throw "Unexpected Windows Authenticode signer '$signerOrganization'"
           }
           if (-not $signature.TimeStamperCertificate) {
             throw "Windows Authenticode signature is missing a trusted timestamp"

--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -2,9 +2,19 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  comingSoonPlatforms,
+  desktopDownloadSections,
   detectDesktopPlatform,
   getOrderedDesktopDownloadSections,
 } from "./download.ts";
+
+test("offers macOS and Linux downloads while Windows is coming soon", () => {
+  assert.deepEqual(
+    desktopDownloadSections.map((section) => section.platform),
+    ["macos", "linux"],
+  );
+  assert.equal(comingSoonPlatforms[0], "Windows");
+});
 
 test("detects supported desktop platforms from browser user agents", () => {
   assert.equal(
@@ -40,7 +50,7 @@ test("orders the detected platform first", () => {
     getOrderedDesktopDownloadSections("windows").map(
       (section) => section.platform,
     ),
-    ["windows", "macos", "linux"],
+    ["macos", "linux"],
   );
   assert.equal(
     getOrderedDesktopDownloadSections("macos")[0].downloads[0].name,

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -11,6 +11,7 @@ export const appleSiliconDownloadUrl = getStableDownloadUrl("dmg-aarch64");
 export const appleIntelDownloadUrl = getStableDownloadUrl("dmg-x86_64");
 
 export const comingSoonPlatforms = [
+  "Windows",
   "iOS",
   "Android",
   "Apple Watch",
@@ -34,21 +35,6 @@ export const desktopDownloadSections = [
         name: "Intel",
         detail: "Intel-based Mac · DMG",
         url: appleIntelDownloadUrl,
-        showInMenu: true,
-      },
-    ],
-  },
-  {
-    platform: "windows",
-    name: "Windows",
-    status: "Beta",
-    description:
-      "Beta installer for 64-bit Windows PCs. Physical audio and AEC validation is pending.",
-    downloads: [
-      {
-        name: "Windows x64",
-        detail: "NSIS installer · EXE",
-        url: getStableDownloadUrl("nsis-x86_64"),
         showInMenu: true,
       },
     ],

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/_view/download/")({
       {
         name: "description",
         content:
-          "Download Anarlog for macOS, Windows, or Linux. Every desktop build uses the same release version.",
+          "Download Anarlog for macOS or try the Linux beta. Windows is coming soon.",
       },
       { property: "og:title", content: "Download Anarlog" },
       { property: "og:url", content: `${ANARLOG_SITE_URL}/download` },

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1297,8 +1297,10 @@ function DownloadButton() {
   const orderedSections = getOrderedDesktopDownloadSections(preferredPlatform);
   const preferredSection = orderedSections[0];
   const preferredDownload = preferredSection.downloads[0];
-  const preferredLabel =
-    preferredSection.platform === "macos"
+  const preferredPlatformComingSoon = preferredPlatform === "windows";
+  const preferredLabel = preferredPlatformComingSoon
+    ? "Windows — Coming soon"
+    : preferredSection.platform === "macos"
       ? `Download for ${preferredDownload.name}`
       : `Download for ${preferredSection.name}`;
 
@@ -1333,18 +1335,26 @@ function DownloadButton() {
       className="relative inline-flex text-sm font-medium"
     >
       <a
-        href={preferredDownload.url}
-        onClick={() =>
-          track("download_clicked", {
-            platform: preferredSection.platform,
-            spec: preferredDownload.name,
-            source: "homepage",
-          })
+        href={
+          preferredPlatformComingSoon ? "/download/" : preferredDownload.url
         }
+        onClick={() => {
+          if (!preferredPlatformComingSoon) {
+            track("download_clicked", {
+              platform: preferredSection.platform,
+              spec: preferredDownload.name,
+              source: "homepage",
+            });
+          }
+        }}
         className="inline-flex items-center gap-1.5 rounded-l-full bg-[#181613] py-3 pr-2 pl-4 text-[13px] text-white sm:pl-5 sm:text-sm"
       >
         <Icon
-          icon={getPlatformIcon(preferredSection.platform)}
+          icon={getPlatformIcon(
+            preferredPlatformComingSoon
+              ? preferredPlatform
+              : preferredSection.platform,
+          )}
           width={16}
           height={16}
           className="shrink-0"
@@ -1370,7 +1380,12 @@ function DownloadButton() {
           {orderedSections.map((section) =>
             section.downloads.map((download) => {
               if (!download.showInMenu) return null;
-              if (download.url === preferredDownload.url) return null;
+              if (
+                !preferredPlatformComingSoon &&
+                download.url === preferredDownload.url
+              ) {
+                return null;
+              }
 
               return (
                 <a

--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -1,22 +1,20 @@
 ---
-date: "2026-07-31"
-summary: "Anarlog 1.4.0 expands to Windows and Linux in beta, adds automatic updates and more AI providers, and improves editing, transcription, privacy, and reliability."
+date: "2026-08-01"
+summary: "Anarlog 1.4.0 adds a Linux beta, automatic updates, more AI providers, and major editing, transcription, privacy, and reliability improvements."
 ---
 
-<banner title="Windows and Linux Beta" variant="info">
-Windows and Linux now ship alongside macOS with the same Anarlog version. Their
-virtual-machine release checks cover installation, launch, updates, sync, and
-basic audio capture; physical-device routing and echo-cancellation validation
-are still pending.
+<banner title="Linux Beta" variant="info">
+Linux now ships in beta alongside macOS after automated installation, launch,
+sync, updater, and virtual-audio checks. Physical-device routing and
+echo-cancellation validation are still pending. Windows is coming soon.
 </banner>
 
 ## Desktop downloads
 
-- Download macOS builds for Apple Silicon and Intel, a Windows x64 installer,
-  or Linux AppImage and Debian packages for x64 and ARM64
-- Receive matching `1.4.0` application and updater versions on every supported
-  desktop platform
-- Install the Anarlog CLI and MCP server with Windows and Linux packages
+- Download macOS builds for Apple Silicon and Intel, or Linux AppImage and
+  Debian packages for x64 and ARM64
+- Receive matching `1.4.0` application and updater versions on macOS and Linux
+- Install the Anarlog CLI and MCP server with Linux packages
 
 ## Notes and editor
 
@@ -87,16 +85,6 @@ are still pending.
 - Opt in to Cloud API & Connectors with Anarlog Pro for hosted REST and remote
   MCP access while the desktop app is closed; turning it off deletes the
   separate server-readable copies
-
-## Windows Beta
-
-- Show native event reminders; notification click actions remain unavailable
-  in this beta
-- Hide microphone-detection controls that are not yet supported on Windows
-- Protect signed-in sessions with Windows user encryption and migrate older
-  plaintext session data
-- Stop stalled Cloud Sync requests cleanly so the app can recover without
-  hanging its local database
 
 ## Linux Beta
 

--- a/scripts/desktop-release-provenance.mjs
+++ b/scripts/desktop-release-provenance.mjs
@@ -6,24 +6,22 @@ import { pathToFileURL } from "node:url";
 
 const DEFAULT_ASSET_BASE_URL = "https://cdn.crabnebula.app/asset";
 const SOURCE_WORKFLOW = ".github/workflows/desktop_cd.yaml";
-const EXPECTED_PUBLIC_PLATFORMS = [
+const MACOS_PUBLIC_PLATFORMS = ["dmg-aarch64", "dmg-x86_64"];
+const LINUX_PUBLIC_PLATFORMS = [
   "appimage-aarch64",
   "appimage-x86_64",
   "deb-aarch64",
   "deb-x86_64",
-  "dmg-aarch64",
-  "dmg-x86_64",
-  "nsis-x86_64",
 ];
-const EXPECTED_UPDATE_PLATFORMS = [
-  "darwin-aarch64",
-  "darwin-x86_64",
+const WINDOWS_PUBLIC_PLATFORMS = ["nsis-x86_64"];
+const MACOS_UPDATE_PLATFORMS = ["darwin-aarch64", "darwin-x86_64"];
+const LINUX_UPDATE_PLATFORMS = [
   "linux-aarch64-appimage",
   "linux-aarch64-deb",
   "linux-x86_64-appimage",
   "linux-x86_64-deb",
-  "windows-x86_64-nsis",
 ];
+const WINDOWS_UPDATE_PLATFORMS = ["windows-x86_64-nsis"];
 
 function invariant(condition, message) {
   if (!condition) {
@@ -60,6 +58,14 @@ function normalizeRunId(value) {
     "Workflow run ID must be a positive integer",
   );
   return runId;
+}
+
+function normalizeBoolean(value, label) {
+  invariant(
+    value === "true" || value === "false",
+    `${label} must be true or false`,
+  );
+  return value === "true";
 }
 
 function normalizeCnVersion(value) {
@@ -142,11 +148,24 @@ function normalizeAssets(release) {
   return assets;
 }
 
-export function verifyDesktopPlatformSets(release) {
+export function verifyDesktopPlatformSets(
+  release,
+  { includeLinux = true, includeWindows = true } = {},
+) {
   const assets = normalizeAssets(release);
+  const expectedPublicPlatforms = [
+    ...MACOS_PUBLIC_PLATFORMS,
+    ...(includeLinux ? LINUX_PUBLIC_PLATFORMS : []),
+    ...(includeWindows ? WINDOWS_PUBLIC_PLATFORMS : []),
+  ].sort();
+  const expectedUpdatePlatforms = [
+    ...MACOS_UPDATE_PLATFORMS,
+    ...(includeLinux ? LINUX_UPDATE_PLATFORMS : []),
+    ...(includeWindows ? WINDOWS_UPDATE_PLATFORMS : []),
+  ].sort();
   invariant(
-    assets.length === EXPECTED_PUBLIC_PLATFORMS.length,
-    `Release must contain exactly ${EXPECTED_PUBLIC_PLATFORMS.length} desktop assets`,
+    assets.length === expectedPublicPlatforms.length,
+    `Release must contain exactly ${expectedPublicPlatforms.length} selected desktop assets`,
   );
 
   const publicPlatforms = assets
@@ -154,9 +173,8 @@ export function verifyDesktopPlatformSets(release) {
     .filter((platform) => platform !== null)
     .sort();
   invariant(
-    JSON.stringify(publicPlatforms) ===
-      JSON.stringify(EXPECTED_PUBLIC_PLATFORMS),
-    "Release public platforms do not match the desktop allowlist",
+    JSON.stringify(publicPlatforms) === JSON.stringify(expectedPublicPlatforms),
+    "Release public platforms do not match the selected desktop platforms",
   );
 
   const updatePlatforms = assets
@@ -164,9 +182,8 @@ export function verifyDesktopPlatformSets(release) {
     .filter((platform) => platform !== null)
     .sort();
   invariant(
-    JSON.stringify(updatePlatforms) ===
-      JSON.stringify(EXPECTED_UPDATE_PLATFORMS),
-    "Release update platforms do not match the desktop allowlist",
+    JSON.stringify(updatePlatforms) === JSON.stringify(expectedUpdatePlatforms),
+    "Release update platforms do not match the selected desktop platforms",
   );
 }
 
@@ -449,8 +466,17 @@ async function main() {
 
   if (command === "verify-platforms") {
     invariant(args.release, "Missing --release");
-    verifyDesktopPlatformSets(await readJson(args.release));
-    console.log("Release desktop platforms match the allowlist");
+    verifyDesktopPlatformSets(await readJson(args.release), {
+      includeLinux: normalizeBoolean(
+        args["include-linux"] ?? "true",
+        "include-linux",
+      ),
+      includeWindows: normalizeBoolean(
+        args["include-windows"] ?? "true",
+        "include-windows",
+      ),
+    });
+    console.log("Release desktop platforms match the selected release plan");
     return;
   }
 

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -17,41 +17,62 @@ const cnSha256 =
   "760b11d1ab9326dc78068ac8ef450685ea116e329903b14d94a5133641a54128";
 const cnVersion = "cn 0.13.2";
 
-function createDesktopRelease() {
-  const publicPlatforms = [
-    "dmg-aarch64",
-    "dmg-x86_64",
-    "nsis-x86_64",
-    "appimage-x86_64",
-    "deb-x86_64",
-    "appimage-aarch64",
-    "deb-aarch64",
-  ];
-  const updatePlatforms = [
-    "darwin-aarch64",
-    "darwin-x86_64",
-    "windows-x86_64-nsis",
-    "linux-x86_64-appimage",
-    "linux-x86_64-deb",
-    "linux-aarch64-appimage",
-    "linux-aarch64-deb",
+function createDesktopRelease({
+  includeLinux = true,
+  includeWindows = true,
+} = {}) {
+  const platformPairs = [
+    ["dmg-aarch64", "darwin-aarch64"],
+    ["dmg-x86_64", "darwin-x86_64"],
+    ...(includeLinux
+      ? [
+          ["appimage-x86_64", "linux-x86_64-appimage"],
+          ["deb-x86_64", "linux-x86_64-deb"],
+          ["appimage-aarch64", "linux-aarch64-appimage"],
+          ["deb-aarch64", "linux-aarch64-deb"],
+        ]
+      : []),
+    ...(includeWindows ? [["nsis-x86_64", "windows-x86_64-nsis"]] : []),
   ];
 
   return {
     version: "1.4.0",
     status: "draft",
-    assets: publicPlatforms.map((publicPlatform, index) => ({
+    assets: platformPairs.map(([publicPlatform, updatePlatform], index) => ({
       id: `asset-${index}`,
       publicPlatform,
-      updatePlatform: updatePlatforms[index],
+      updatePlatform,
       size: index + 1,
       signature: `signature-${index}`,
     })),
   };
 }
 
-test("accepts the exact desktop public and update platform sets", () => {
+test("accepts the complete desktop public and update platform sets", () => {
   verifyDesktopPlatformSets(createDesktopRelease());
+});
+
+test("accepts a macOS and Linux release without Windows", () => {
+  verifyDesktopPlatformSets(createDesktopRelease({ includeWindows: false }), {
+    includeWindows: false,
+  });
+});
+
+test("accepts a macOS-only release", () => {
+  verifyDesktopPlatformSets(
+    createDesktopRelease({ includeLinux: false, includeWindows: false }),
+    { includeLinux: false, includeWindows: false },
+  );
+});
+
+test("rejects an omitted selected platform", () => {
+  assert.throws(
+    () =>
+      verifyDesktopPlatformSets(
+        createDesktopRelease({ includeWindows: false }),
+      ),
+    /exactly 7 selected desktop assets/,
+  );
 });
 
 test("rejects an extra public desktop platform", () => {
@@ -66,7 +87,7 @@ test("rejects an extra public desktop platform", () => {
 
   assert.throws(
     () => verifyDesktopPlatformSets(release),
-    /exactly 7 desktop assets/,
+    /exactly 7 selected desktop assets/,
   );
 });
 
@@ -92,7 +113,7 @@ test("rejects an updater-only desktop platform", () => {
 
   assert.throws(
     () => verifyDesktopPlatformSets(release),
-    /exactly 7 desktop assets/,
+    /exactly 7 selected desktop assets/,
   );
 });
 
@@ -108,7 +129,7 @@ test("rejects an opaque desktop release asset", () => {
 
   assert.throws(
     () => verifyDesktopPlatformSets(release),
-    /exactly 7 desktop assets/,
+    /exactly 7 selected desktop assets/,
   );
 });
 


### PR DESCRIPTION
- migrate Windows signing to Azure Artifact Signing with GitHub OIDC
- make Linux and Windows selectable release platforms with provenance checks
- publish macOS and Linux beta availability while marking Windows coming soon

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes stable release signing, multi-platform gating, and provenance validation—mistakes could block releases or ship wrong artifacts; public download URLs also change for Windows users.
> 
> **Overview**
> Prepares a **macOS + Linux beta** public story for 1.4.0 while keeping Windows off the download site and reframing the changelog around Linux beta and “Windows coming soon.”
> 
> **Release CI** gains `include_linux` / `include_windows` inputs on `desktop_cd` and `desktop_publish`. Linux/Windows jobs, CrabNebula asset checks, Linux audio QA, GitHub release downloads, and `desktop-release-provenance.mjs` platform verification all respect those flags so a candidate can ship without every platform.
> 
> **Stable Windows signing** moves from imported PFX secrets to **Azure Artifact Signing** via `azure/login` and `azure/artifact-signing-action`: build unsigned, sign app + CLI sidecar, bundle NSIS, sign the installer, then Tauri-sign the updater. Pre-flight and publish-time Authenticode checks use `WINDOWS_SIGNER_ORGANIZATION` instead of certificate thumbprint.
> 
> **Marketing**: `desktopDownloadSections` drops Windows; homepage and `/download` copy and the hero download CTA send Windows visitors to “coming soon” instead of a stable NSIS URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a553798686cd7b631a8b53fcf54ecec0b5a6ed31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->