### PR TITLE
Fix CrabNebula CLI version output parsing

### DIFF
--- a/.github/actions/cn_install/action.yaml
+++ b/.github/actions/cn_install/action.yaml
@@ -94,7 +94,8 @@ runs:
         fi
 
         chmod +x "$CLI_PATH"
-        ACTUAL_VERSION=$("$CLI_PATH" --version | tr -d '\r')
+        VERSION_OUTPUT=$("$CLI_PATH" --version | tr -d '\r')
+        ACTUAL_VERSION=${VERSION_OUTPUT%%$'\n'*}
         if [[ "$ACTUAL_VERSION" != "cn 0.13.2" ]]; then
           echo "::error::Expected CrabNebula CLI cn 0.13.2, got $ACTUAL_VERSION"
           exit 1


### PR DESCRIPTION
Validate the pinned CLI version from the first output line so informational update notices do not block release workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only bash change to how version stdout is parsed; no runtime app or security impact.
> 
> **Overview**
> **CrabNebula install action** no longer treats the full `cn --version` stdout as the version string when validating the pinned `cn 0.13.2` build.
> 
> The composite step now strips carriage returns, then uses only the **first line** of `--version` output for the equality check and for the `version` GitHub Action output. Extra lines (e.g. update notices) are ignored so release workflows are not blocked by informational CLI messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7fc4db10d7eaa5af4838cc26f411403bba763b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->