### PR TITLE
Use CrabNebula Debian platform identifiers

### DIFF
--- a/.github/actions/cn_download/action.yaml
+++ b/.github/actions/cn_download/action.yaml
@@ -12,7 +12,7 @@ inputs:
     description: "Release channel (stable)"
     required: true
   platform:
-    description: "CrabNebula public platform (for example dmg-aarch64, nsis-x86_64, appimage-x86_64, or deb-x86_64)"
+    description: "CrabNebula public platform (for example dmg-aarch64, nsis-x86_64, appimage-x86_64, or debian-x86_64)"
     required: true
   output:
     description: "Output filename"

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -737,9 +737,9 @@ jobs:
           if [[ "${{ inputs.include_linux }}" == "true" ]]; then
             EXPECTED_PLATFORMS+=(
               "appimage-x86_64"
-              "deb-x86_64"
+              "debian-x86_64"
               "appimage-aarch64"
-              "deb-aarch64"
+              "debian-aarch64"
             )
           fi
           if [[ "${{ inputs.include_windows }}" == "true" ]]; then

--- a/.github/workflows/desktop_linux_audio_qa.yaml
+++ b/.github/workflows/desktop_linux_audio_qa.yaml
@@ -121,11 +121,11 @@ jobs:
         include:
           - runner: depot-ubuntu-24.04-8
             artifact_arch: x64
-            public_platform: deb-x86_64
+            public_platform: debian-x86_64
             debian_arch: amd64
           - runner: depot-ubuntu-24.04-arm-8
             artifact_arch: arm64
-            public_platform: deb-aarch64
+            public_platform: debian-aarch64
             debian_arch: arm64
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -301,9 +301,9 @@ jobs:
           if [[ "$INCLUDE_LINUX" == "true" ]]; then
             EXPECTED_PLATFORMS+=(
               "appimage-x86_64"
-              "deb-x86_64"
+              "debian-x86_64"
               "appimage-aarch64"
-              "deb-aarch64"
+              "debian-aarch64"
             )
           fi
           if [[ "$INCLUDE_WINDOWS" == "true" ]]; then
@@ -510,7 +510,7 @@ jobs:
           app: ${{ env.CN_APPLICATION }}
           version: ${{ needs.parse.outputs.version }}
           channel: ${{ needs.parse.outputs.channel }}
-          platform: deb-x86_64
+          platform: debian-x86_64
           output: anarlog-linux-x86_64.deb
           key: ${{ secrets.CN_API_KEY }}
       - id: download-linux-aarch64-appimage
@@ -530,7 +530,7 @@ jobs:
           app: ${{ env.CN_APPLICATION }}
           version: ${{ needs.parse.outputs.version }}
           channel: ${{ needs.parse.outputs.channel }}
-          platform: deb-aarch64
+          platform: debian-aarch64
           output: anarlog-linux-aarch64.deb
           key: ${{ secrets.CN_API_KEY }}
       - id: download-windows-x86_64
@@ -606,9 +606,9 @@ jobs:
             }
             + if $include_linux == "true" then {
                 "appimage-x86_64": $appimage_x86_64,
-                "deb-x86_64": $deb_x86_64,
+                "debian-x86_64": $deb_x86_64,
                 "appimage-aarch64": $appimage_aarch64,
-                "deb-aarch64": $deb_aarch64
+                "debian-aarch64": $deb_aarch64
               } else {} end
             + if $include_windows == "true" then {
                 "nsis-x86_64": $nsis_x86_64

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -55,7 +55,7 @@ export const desktopDownloadSections = [
       {
         name: "Debian x64",
         detail: "Debian or Ubuntu · DEB",
-        url: getStableDownloadUrl("deb-x86_64"),
+        url: getStableDownloadUrl("debian-x86_64"),
         showInMenu: true,
       },
       {
@@ -67,7 +67,7 @@ export const desktopDownloadSections = [
       {
         name: "Debian ARM64",
         detail: "Debian or Ubuntu on 64-bit ARM · DEB",
-        url: getStableDownloadUrl("deb-aarch64"),
+        url: getStableDownloadUrl("debian-aarch64"),
         showInMenu: false,
       },
     ],

--- a/scripts/desktop-release-provenance.mjs
+++ b/scripts/desktop-release-provenance.mjs
@@ -10,8 +10,8 @@ const MACOS_PUBLIC_PLATFORMS = ["dmg-aarch64", "dmg-x86_64"];
 const LINUX_PUBLIC_PLATFORMS = [
   "appimage-aarch64",
   "appimage-x86_64",
-  "deb-aarch64",
-  "deb-x86_64",
+  "debian-aarch64",
+  "debian-x86_64",
 ];
 const WINDOWS_PUBLIC_PLATFORMS = ["nsis-x86_64"];
 const MACOS_UPDATE_PLATFORMS = ["darwin-aarch64", "darwin-x86_64"];

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -27,9 +27,9 @@ function createDesktopRelease({
     ...(includeLinux
       ? [
           ["appimage-x86_64", "linux-x86_64-appimage"],
-          ["deb-x86_64", "linux-x86_64-deb"],
+          ["debian-x86_64", "linux-x86_64-deb"],
           ["appimage-aarch64", "linux-aarch64-appimage"],
-          ["deb-aarch64", "linux-aarch64-deb"],
+          ["debian-aarch64", "linux-aarch64-deb"],
         ]
       : []),
     ...(includeWindows ? [["nsis-x86_64", "windows-x86_64-nsis"]] : []),

--- a/scripts/verify-linux-audio-qa-evidence.mjs
+++ b/scripts/verify-linux-audio-qa-evidence.mjs
@@ -7,12 +7,12 @@ const SOURCE_WORKFLOW = ".github/workflows/desktop_cd.yaml";
 const ARCHITECTURES = [
   {
     artifactArch: "x64",
-    publicPlatform: "deb-x86_64",
+    publicPlatform: "debian-x86_64",
     debianArch: "amd64",
   },
   {
     artifactArch: "arm64",
-    publicPlatform: "deb-aarch64",
+    publicPlatform: "debian-aarch64",
     debianArch: "arm64",
   },
 ];

--- a/scripts/verify-linux-audio-qa-evidence.test.mjs
+++ b/scripts/verify-linux-audio-qa-evidence.test.mjs
@@ -16,13 +16,13 @@ const hashes = {
 };
 const architectures = {
   x64: {
-    publicPlatform: "deb-x86_64",
+    publicPlatform: "debian-x86_64",
     updatePlatform: "linux-x86_64-deb",
     debianArch: "amd64",
     assetId: "asset-x64",
   },
   arm64: {
-    publicPlatform: "deb-aarch64",
+    publicPlatform: "debian-aarch64",
     updatePlatform: "linux-aarch64-deb",
     debianArch: "arm64",
     assetId: "asset-arm64",


### PR DESCRIPTION
Align release verification, Linux QA, provenance, publication, and download links with CrabNebula public platform IDs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stable release verification, publish downloads, and live download links—misalignment with CrabNebula would break Linux DEB gates and user downloads until fixed.
> 
> **Overview**
> CrabNebula now exposes Debian packages under **`debian-x86_64`** and **`debian-aarch64`** instead of **`deb-x86_64`** / **`deb-aarch64`**. This PR updates every place that selects or validates those **public** platform IDs so release checks, downloads, and user-facing links stay in sync.
> 
> **CI and release tooling** — `desktop_cd`, `desktop_publish`, and `desktop_linux_audio_qa` expect the new slugs when verifying CrabNebula assets, downloading DEBs via `cn_download`, and building the GitHub release platform→asset map. **`desktop-release-provenance.mjs`** and **`verify-linux-audio-qa-evidence.mjs`** (plus their tests) use the same identifiers.
> 
> **Web** — Stable Linux Debian download URLs in **`download.ts`** now call `getStableDownloadUrl` with the `debian-*` platforms.
> 
> Updater **`updatePlatform`** values (e.g. `linux-x86_64-deb`) are unchanged; only the public download/platform strings were renamed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79064022f5f530a4e27193bce352667eda3ddc2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->