### PR TITLE
Mark Linux as coming soon for 1.4.0

### DIFF
--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -8,12 +8,12 @@ import {
   getOrderedDesktopDownloadSections,
 } from "./download.ts";
 
-test("offers macOS and Linux downloads while Windows is coming soon", () => {
+test("offers macOS downloads while Linux and Windows are coming soon", () => {
   assert.deepEqual(
     desktopDownloadSections.map((section) => section.platform),
-    ["macos", "linux"],
+    ["macos"],
   );
-  assert.equal(comingSoonPlatforms[0], "Windows");
+  assert.deepEqual(comingSoonPlatforms.slice(0, 2), ["Linux", "Windows"]);
 });
 
 test("detects supported desktop platforms from browser user agents", () => {
@@ -50,7 +50,7 @@ test("orders the detected platform first", () => {
     getOrderedDesktopDownloadSections("windows").map(
       (section) => section.platform,
     ),
-    ["macos", "linux"],
+    ["macos"],
   );
   assert.equal(
     getOrderedDesktopDownloadSections("macos")[0].downloads[0].name,

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -11,6 +11,7 @@ export const appleSiliconDownloadUrl = getStableDownloadUrl("dmg-aarch64");
 export const appleIntelDownloadUrl = getStableDownloadUrl("dmg-x86_64");
 
 export const comingSoonPlatforms = [
+  "Linux",
   "Windows",
   "iOS",
   "Android",
@@ -36,39 +37,6 @@ export const desktopDownloadSections = [
         detail: "Intel-based Mac · DMG",
         url: appleIntelDownloadUrl,
         showInMenu: true,
-      },
-    ],
-  },
-  {
-    platform: "linux",
-    name: "Linux",
-    status: "Beta",
-    description:
-      "Beta AppImage and Debian packages for x64 and ARM64. Physical audio and AEC validation is pending.",
-    downloads: [
-      {
-        name: "AppImage x64",
-        detail: "Intel or AMD 64-bit · AppImage",
-        url: getStableDownloadUrl("appimage-x86_64"),
-        showInMenu: true,
-      },
-      {
-        name: "Debian x64",
-        detail: "Debian or Ubuntu · DEB",
-        url: getStableDownloadUrl("debian-x86_64"),
-        showInMenu: true,
-      },
-      {
-        name: "AppImage ARM64",
-        detail: "64-bit ARM · AppImage",
-        url: getStableDownloadUrl("appimage-aarch64"),
-        showInMenu: false,
-      },
-      {
-        name: "Debian ARM64",
-        detail: "Debian or Ubuntu on 64-bit ARM · DEB",
-        url: getStableDownloadUrl("debian-aarch64"),
-        showInMenu: false,
       },
     ],
   },

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -53,7 +53,7 @@ export function getSoftwareApplicationJsonLd({
     url,
     description,
     applicationCategory: "ProductivityApplication",
-    operatingSystem: ["macOS", "Windows", "Linux"],
+    operatingSystem: ["macOS"],
     downloadUrl: `${ANARLOG_SITE_URL}/download`,
     publisher: getOrganizationJsonLd(),
     ...(featureList ? { featureList } : {}),

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/_view/download/")({
       {
         name: "description",
         content:
-          "Download Anarlog for macOS or try the Linux beta. Windows is coming soon.",
+          "Download Anarlog for macOS. Linux and Windows are coming soon.",
       },
       { property: "og:title", content: "Download Anarlog" },
       { property: "og:url", content: `${ANARLOG_SITE_URL}/download` },

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1297,9 +1297,9 @@ function DownloadButton() {
   const orderedSections = getOrderedDesktopDownloadSections(preferredPlatform);
   const preferredSection = orderedSections[0];
   const preferredDownload = preferredSection.downloads[0];
-  const preferredPlatformComingSoon = preferredPlatform === "windows";
+  const preferredPlatformComingSoon = preferredPlatform !== "macos";
   const preferredLabel = preferredPlatformComingSoon
-    ? "Windows — Coming soon"
+    ? `${preferredPlatform === "linux" ? "Linux" : "Windows"} — Coming soon`
     : preferredSection.platform === "macos"
       ? `Download for ${preferredDownload.name}`
       : `Download for ${preferredSection.name}`;

--- a/packages/changelog/content/1.4.0.md
+++ b/packages/changelog/content/1.4.0.md
@@ -1,20 +1,17 @@
 ---
 date: "2026-08-01"
-summary: "Anarlog 1.4.0 adds a Linux beta, automatic updates, more AI providers, and major editing, transcription, privacy, and reliability improvements."
+summary: "Anarlog 1.4.0 adds automatic updates, more AI providers, and major editing, transcription, privacy, and reliability improvements on macOS."
 ---
 
-<banner title="Linux Beta" variant="info">
-Linux now ships in beta alongside macOS after automated installation, launch,
-sync, updater, and virtual-audio checks. Physical-device routing and
-echo-cancellation validation are still pending. Windows is coming soon.
+<banner title="macOS release" variant="info">
+Anarlog 1.4.0 is available for Apple Silicon and Intel Macs. Linux and Windows
+are coming soon while platform release validation continues.
 </banner>
 
 ## Desktop downloads
 
-- Download macOS builds for Apple Silicon and Intel, or Linux AppImage and
-  Debian packages for x64 and ARM64
-- Receive matching `1.4.0` application and updater versions on macOS and Linux
-- Install the Anarlog CLI and MCP server with Linux packages
+- Download notarized macOS builds for Apple Silicon and Intel
+- Receive matching `1.4.0` application and updater versions on macOS
 
 ## Notes and editor
 
@@ -86,7 +83,10 @@ echo-cancellation validation are still pending. Windows is coming soon.
   MCP access while the desktop app is closed; turning it off deletes the
   separate server-readable copies
 
-## Linux Beta
+## Linux readiness
+
+These changes are being prepared for the upcoming Linux release and are not
+included in the macOS-only 1.4.0 release:
 
 - Detect active microphone streams more reliably and stop the detector cleanly
   when it is no longer needed
@@ -123,4 +123,5 @@ echo-cancellation validation are still pending. Windows is coming soon.
   the cloud upload limit
 
 On-device transcription remains available on supported Apple Silicon Macs.
-Windows and Linux currently use cloud transcription or your own provider key.
+The upcoming Windows and Linux releases will initially use cloud transcription
+or your own provider key.


### PR DESCRIPTION
Publish macOS downloads only and update the website, metadata, and changelog to show Linux and Windows as coming soon.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing and download-configuration changes only; no auth, payments, or backend behavior.
> 
> **Overview**
> **Scopes 1.4.0 to macOS downloads** by removing the Linux beta block (AppImage/Debian links) from `desktopDownloadSections` and listing **Linux** ahead of **Windows** in `comingSoonPlatforms`.
> 
> **Marketing and SEO** now say macOS is available and Linux/Windows are coming soon: download page meta, JSON-LD `operatingSystem` (macOS only), and the homepage download CTA treats any non-macOS detected platform as coming soon (including Linux).
> 
> **Changelog 1.4.0** is reframed as a macOS release; Linux beta banner and Linux download bullets are dropped, with Linux work called out under “Linux readiness” as not shipped in this release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d1a384b3abecd2e45b3c2926584c6c947c1858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->