### PR TITLE
Fix desktop release asset verification

### DIFF
--- a/scripts/desktop-release-provenance.mjs
+++ b/scripts/desktop-release-provenance.mjs
@@ -163,9 +163,11 @@ export function verifyDesktopPlatformSets(
     ...(includeLinux ? LINUX_UPDATE_PLATFORMS : []),
     ...(includeWindows ? WINDOWS_UPDATE_PLATFORMS : []),
   ].sort();
+  const expectedAssetCount =
+    expectedPublicPlatforms.length + expectedUpdatePlatforms.length;
   invariant(
-    assets.length === expectedPublicPlatforms.length,
-    `Release must contain exactly ${expectedPublicPlatforms.length} selected desktop assets`,
+    assets.length === expectedAssetCount,
+    `Release must contain exactly ${expectedAssetCount} selected desktop assets`,
   );
 
   const publicPlatforms = assets

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -38,13 +38,22 @@ function createDesktopRelease({
   return {
     version: "1.4.0",
     status: "draft",
-    assets: platformPairs.map(([publicPlatform, updatePlatform], index) => ({
-      id: `asset-${index}`,
-      publicPlatform,
-      updatePlatform,
-      size: index + 1,
-      signature: `signature-${index}`,
-    })),
+    assets: platformPairs.flatMap(([publicPlatform, updatePlatform], index) => [
+      {
+        id: `asset-public-${index}`,
+        publicPlatform,
+        updatePlatform: null,
+        size: index + 1,
+        signature: null,
+      },
+      {
+        id: `asset-update-${index}`,
+        publicPlatform: null,
+        updatePlatform,
+        size: index + 1,
+        signature: `signature-${index}`,
+      },
+    ]),
   };
 }
 
@@ -71,7 +80,7 @@ test("rejects an omitted selected platform", () => {
       verifyDesktopPlatformSets(
         createDesktopRelease({ includeWindows: false }),
       ),
-    /exactly 7 selected desktop assets/,
+    /exactly 14 selected desktop assets/,
   );
 });
 
@@ -87,7 +96,7 @@ test("rejects an extra public desktop platform", () => {
 
   assert.throws(
     () => verifyDesktopPlatformSets(release),
-    /exactly 7 selected desktop assets/,
+    /exactly 14 selected desktop assets/,
   );
 });
 
@@ -113,7 +122,7 @@ test("rejects an updater-only desktop platform", () => {
 
   assert.throws(
     () => verifyDesktopPlatformSets(release),
-    /exactly 7 selected desktop assets/,
+    /exactly 14 selected desktop assets/,
   );
 });
 
@@ -129,7 +138,7 @@ test("rejects an opaque desktop release asset", () => {
 
   assert.throws(
     () => verifyDesktopPlatformSets(release),
-    /exactly 7 selected desktop assets/,
+    /exactly 14 selected desktop assets/,
   );
 });
 


### PR DESCRIPTION
Count public downloads and signed updater archives separately so macOS-only releases validate against CrabNebula’s actual asset layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release provenance validation and its unit tests; no app runtime, auth, or data paths are affected.
> 
> **Overview**
> **`verifyDesktopPlatformSets`** no longer equates release asset count with the number of public platforms. It now requires **`expectedPublicPlatforms.length + expectedUpdatePlatforms.length`** assets, because CrabNebula exposes public installers and signed updater artifacts as **separate** release entries (not one combined row per platform).
> 
> Test fixtures in **`desktop-release-provenance.test.mjs`** were updated to **`flatMap`** each platform pair into two assets—public-only (`updatePlatform: null`) and update-only (`publicPlatform: null`)—so expectations align with a full desktop release (e.g. **14** assets instead of **7** when all platforms are selected). Platform-set checks for public and update lists are unchanged; only the total-count invariant and related error messages were corrected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a35b573e43471b9077f3acca8faed5548027c8e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->