### PR TITLE
Run GitHub mirror for selective releases

### DIFF
--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -442,6 +442,7 @@ jobs:
 
   gh-release:
     needs: [parse, cn-publish]
+    if: ${{ !cancelled() && needs.parse.result == 'success' && needs.cn-publish.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
Allow the GitHub release job to run after an intentionally skipped platform-signature dependency when publication succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes GitHub Actions job conditions for the desktop publish workflow; no application or release artifact logic is modified.
> 
> **Overview**
> **Fixes selective desktop publishes** where Windows (and its signature check) is omitted but CrabNebula publication still completes—the GitHub mirror job was not running reliably in that path.
> 
> The `gh-release` job now uses the same style of guard as `cn-publish`: run when the workflow is not cancelled, `parse` succeeded, and `cn-publish` succeeded. That ties the mirror step to successful publication without requiring optional upstream jobs (such as `verify-windows-signature` when `include_windows` is false) to block the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04b59b89d63e1c37a7711a0fafa73f7bb1259798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->