### PR TITLE
Beautify changelog pages

### DIFF
--- a/apps/web/src/routes/changelog/$version.tsx
+++ b/apps/web/src/routes/changelog/$version.tsx
@@ -50,7 +50,7 @@ function Component() {
 
   return (
     <main className="min-h-screen bg-white text-[#181613]">
-      <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
+      <div className="mx-auto w-full max-w-[860px] px-5 py-8 md:px-8 md:py-12">
         <header className="flex items-center justify-between gap-6">
           <Link to="/" aria-label="Anarlog home">
             <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
@@ -64,24 +64,34 @@ function Component() {
           ← Changelog
         </Link>
 
-        <header className="pt-10 pb-12">
-          <h1 className="font-hand text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
-            v{entry.version}
+        <header className="max-w-[760px] pt-10 pb-12 md:pt-14 md:pb-16">
+          <div className="flex flex-wrap items-center gap-2 text-sm text-[#756b5d]">
+            <span className="font-medium tracking-[0.14em] uppercase">
+              Release notes
+            </span>
+            {entry.date && (
+              <>
+                <span aria-hidden="true">·</span>
+                <time dateTime={entry.date}>
+                  {formatChangelogDate(entry.date)}
+                </time>
+              </>
+            )}
+          </div>
+          <h1 className="font-hand mt-5 text-5xl leading-[1.02] font-semibold tracking-normal text-balance text-black md:text-7xl">
+            Anarlog v{entry.version}
           </h1>
-          {entry.date && (
-            <time
-              dateTime={entry.date}
-              className="mt-6 block text-sm text-[#756b5d]"
-            >
-              {formatChangelogDate(entry.date)}
-            </time>
+          {entry.summary && (
+            <p className="mt-6 max-w-[720px] text-xl leading-8 text-[#4f4940] md:text-2xl md:leading-9">
+              {entry.summary}
+            </p>
           )}
         </header>
 
-        <article className="border-t border-[#eee8df] pt-8">
+        <article className="max-w-[760px] border-t border-[#eee8df] pt-10 md:pt-12">
           <ChangelogContent
             content={entry.content}
-            className="text-sm leading-7"
+            className="changelog-prose"
           />
         </article>
       </div>

--- a/apps/web/src/routes/changelog/index.tsx
+++ b/apps/web/src/routes/changelog/index.tsx
@@ -57,7 +57,7 @@ function Component() {
                     className="group grid gap-4 py-7 sm:grid-cols-[10rem_minmax(0,1fr)_1.5rem] sm:items-start sm:gap-6 md:py-9"
                   >
                     <header>
-                      <div className="flex items-center gap-2.5">
+                      <div className="flex flex-wrap items-center gap-2.5">
                         <h2 className="font-hand text-4xl leading-none font-semibold tracking-normal text-[#756b5d] transition-colors group-hover:text-[#181613]">
                           v{entry.version}
                         </h2>

--- a/apps/web/src/routes/changelog/index.tsx
+++ b/apps/web/src/routes/changelog/index.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight } from "@phosphor-icons/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { SiteFooter } from "@/components/site-footer";
@@ -25,7 +26,7 @@ export const Route = createFileRoute("/changelog/")({
 function Component() {
   return (
     <main className="min-h-screen bg-white text-[#181613]">
-      <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
+      <div className="mx-auto w-full max-w-[860px] px-5 py-8 md:px-8 md:py-12">
         <header className="flex items-center justify-between gap-6">
           <Link to="/" aria-label="Anarlog home">
             <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
@@ -42,42 +43,47 @@ function Component() {
         </section>
 
         {changelogEntries.length > 0 ? (
-          <ol className="grid gap-12">
-            {changelogEntries.map((entry) => (
+          <ol className="border-y border-[#eee8df]">
+            {changelogEntries.map((entry, index) => (
               <li
                 key={entry.version}
                 id={entry.version}
-                className="scroll-mt-8 border-t border-[#eee8df] pt-8"
+                className="scroll-mt-8 border-b border-[#eee8df] last:border-b-0"
               >
-                <article className="grid gap-4">
-                  <header className="flex flex-wrap items-baseline justify-between gap-x-5 gap-y-2">
-                    <Link
-                      to="/changelog/$version/"
-                      params={{ version: entry.version }}
-                      className="group"
-                    >
-                      <h2 className="font-hand text-4xl leading-none font-semibold tracking-normal text-[#756b5d] group-hover:text-[#4f4940]">
-                        v{entry.version}
-                      </h2>
-                    </Link>
-                    {entry.date && (
-                      <time
-                        dateTime={entry.date}
-                        className="text-sm text-[#756b5d]"
-                      >
-                        {formatChangelogDate(entry.date)}
-                      </time>
-                    )}
-                  </header>
-                  <p className="leading-7 text-[#4f4940]">
-                    {getEntrySummary(entry.summary ?? entry.content)}
-                  </p>
+                <article>
                   <Link
                     to="/changelog/$version/"
                     params={{ version: entry.version }}
-                    className="text-sm font-medium text-[#756b5d] hover:text-[#181613]"
+                    className="group grid gap-4 py-7 sm:grid-cols-[10rem_minmax(0,1fr)_1.5rem] sm:items-start sm:gap-6 md:py-9"
                   >
-                    Read release notes
+                    <header>
+                      <div className="flex items-center gap-2.5">
+                        <h2 className="font-hand text-4xl leading-none font-semibold tracking-normal text-[#756b5d] transition-colors group-hover:text-[#181613]">
+                          v{entry.version}
+                        </h2>
+                        {index === 0 && (
+                          <span className="rounded-full bg-[#f3eee6] px-2 py-1 text-[0.65rem] font-semibold tracking-[0.12em] text-[#756b5d] uppercase">
+                            Latest
+                          </span>
+                        )}
+                      </div>
+                      {entry.date && (
+                        <time
+                          dateTime={entry.date}
+                          className="mt-2 block text-xs text-[#756b5d]"
+                        >
+                          {formatChangelogDate(entry.date)}
+                        </time>
+                      )}
+                    </header>
+                    <p className="text-base leading-7 text-[#4f4940] transition-colors group-hover:text-[#363029] md:text-lg md:leading-8">
+                      {getEntrySummary(entry.summary ?? entry.content)}
+                    </p>
+                    <ArrowRight
+                      aria-hidden="true"
+                      className="mt-1 hidden text-[#9a9082] transition group-hover:translate-x-1 group-hover:text-[#181613] sm:block"
+                      size={20}
+                    />
                   </Link>
                 </article>
               </li>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -831,9 +831,7 @@
   font-size: 1.625rem;
 }
 
-.changelog-prose > h1:first-of-type,
-.changelog-prose > h2:first-of-type,
-.changelog-prose > h3:first-of-type {
+.changelog-prose > :first-child:is(h1, h2, h3) {
   margin-top: 0;
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -801,6 +801,147 @@
   }
 }
 
+.changelog-prose {
+  color: #4f4940;
+  font-size: 1.0625rem;
+  line-height: 1.75;
+}
+
+.changelog-prose h1,
+.changelog-prose h2,
+.changelog-prose h3,
+.changelog-prose h4,
+.changelog-prose h5,
+.changelog-prose h6 {
+  margin-top: 3.5rem;
+  margin-bottom: 1rem;
+  min-height: 0;
+  color: #756b5d;
+  font-family: var(--font-hand);
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.1 !important;
+}
+
+.changelog-prose h3,
+.changelog-prose h4,
+.changelog-prose h5,
+.changelog-prose h6 {
+  font-size: 1.625rem;
+}
+
+.changelog-prose > h1:first-of-type,
+.changelog-prose > h2:first-of-type,
+.changelog-prose > h3:first-of-type {
+  margin-top: 0;
+}
+
+.changelog-prose p,
+.changelog-prose li {
+  color: #4f4940;
+  font-size: 1.0625rem;
+  line-height: 1.75;
+}
+
+.changelog-prose p {
+  margin-bottom: 1.25rem;
+}
+
+.changelog-prose ul,
+.changelog-prose ol {
+  margin-bottom: 2rem;
+  padding-left: 1.5rem;
+  color: #4f4940;
+}
+
+.changelog-prose li {
+  margin-bottom: 0.75rem;
+  padding-left: 0.25rem;
+}
+
+.changelog-prose li::marker {
+  color: #b1a798;
+}
+
+.changelog-prose strong {
+  color: #181613;
+  font-weight: 650;
+}
+
+.changelog-prose code {
+  border-color: #ded7cc;
+  background: #f7f4ef;
+  color: #363029;
+  font-size: 0.875em;
+}
+
+.changelog-prose a {
+  color: #181613;
+  text-decoration-color: #b1a798;
+  text-underline-offset: 0.2em;
+}
+
+.changelog-prose a:hover {
+  color: #756b5d;
+}
+
+.changelog-prose blockquote {
+  margin: 2rem 0;
+  border-left-color: #b1a798;
+  padding-left: 1.25rem;
+  color: #756b5d;
+}
+
+.changelog-prose img {
+  width: 100%;
+  margin: 2.5rem 0;
+  border-color: #eee8df;
+  border-radius: 0.75rem;
+}
+
+.changelog-prose [data-changelog-banner] {
+  margin-bottom: 3rem;
+  border-color: #c9d9ec;
+  border-radius: 0.75rem;
+  background: #f3f7fc;
+  padding: 1.25rem 1.5rem;
+  color: #29466c;
+}
+
+.changelog-prose [data-changelog-banner][data-variant="warning"] {
+  border-color: #e8d6a8;
+  background: #fcf8ed;
+  color: #684f1e;
+}
+
+.changelog-prose [data-changelog-banner-title] {
+  margin-bottom: 0.375rem;
+  color: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.changelog-prose [data-changelog-banner-content],
+.changelog-prose [data-changelog-banner-content] p {
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.changelog-prose [data-changelog-banner-content] p:last-child {
+  margin-bottom: 0;
+}
+
+@media (min-width: 768px) {
+  .changelog-prose h1,
+  .changelog-prose h2 {
+    font-size: 2.25rem;
+  }
+}
+
 .border-around {
   box-shadow: var(--shadow-ring);
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -925,13 +925,35 @@
 }
 
 .changelog-prose [data-changelog-banner-content],
-.changelog-prose [data-changelog-banner-content] p {
+.changelog-prose [data-changelog-banner-content] p,
+.changelog-prose [data-changelog-banner-content] ul,
+.changelog-prose [data-changelog-banner-content] ol,
+.changelog-prose [data-changelog-banner-content] li,
+.changelog-prose [data-changelog-banner-content] strong,
+.changelog-prose [data-changelog-banner-content] a,
+.changelog-prose [data-changelog-banner-content] a:hover {
   color: inherit;
   font-size: 1rem;
   line-height: 1.6;
 }
 
-.changelog-prose [data-changelog-banner-content] p:last-child {
+.changelog-prose [data-changelog-banner-content] ul,
+.changelog-prose [data-changelog-banner-content] ol,
+.changelog-prose [data-changelog-banner-content] li {
+  margin-bottom: 0.25rem;
+}
+
+.changelog-prose [data-changelog-banner-content] li::marker {
+  color: inherit;
+}
+
+.changelog-prose [data-changelog-banner-content] a {
+  text-decoration-color: currentColor;
+}
+
+.changelog-prose [data-changelog-banner-content] p:last-child,
+.changelog-prose [data-changelog-banner-content] ul:last-child,
+.changelog-prose [data-changelog-banner-content] ol:last-child {
   margin-bottom: 0;
 }
 

--- a/packages/changelog/src/components.tsx
+++ b/packages/changelog/src/components.tsx
@@ -133,6 +133,8 @@ export const changelogComponents = {
     children?: React.ReactNode;
   }) => (
     <div
+      data-changelog-banner
+      data-variant={variant ?? "default"}
       className={cn([
         "mb-2 rounded-xl border px-5 pt-4 pb-4",
         variant === "warning"
@@ -144,6 +146,7 @@ export const changelogComponents = {
     >
       {title && (
         <div
+          data-changelog-banner-title
           className={cn([
             "mb-1 text-sm font-semibold",
             variant === "warning"
@@ -157,6 +160,7 @@ export const changelogComponents = {
         </div>
       )}
       <div
+        data-changelog-banner-content
         className={cn([
           "text-sm [&_p:last-child]:mb-0 [&_ul:last-child]:mb-0",
           changelogBodyClassName,


### PR DESCRIPTION
Improve release headers, prose typography, banners, and index rows across the changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to public changelog routes and shared banner markup; no auth, data, or business logic.
> 
> **Overview**
> **Changelog pages get a wider layout (860px) and clearer release presentation.**
> 
> On individual release pages, the header now shows a “Release notes” label with the date, an **Anarlog v{version}** title, and an optional **summary** blurb when present. Body content uses a new **`changelog-prose`** style instead of small inline typography.
> 
> The changelog index turns each version into a single clickable row: version/date (with a **Latest** badge on the newest entry), summary text, and a hover **arrow**—replacing the old stacked layout and separate “Read release notes” link.
> 
> A dedicated **`changelog-prose`** block in site CSS styles headings, lists, code, links, and images. Changelog **banner** components gain `data-changelog-banner` hooks so the marketing site can override banner colors (including warning variants) without changing in-app Tailwind classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a08edeef0ef808952273ab32a0769ea64623cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->