### PR TITLE
Clarify CLI, MCP, and API documentation

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,7 +5,7 @@
 - This is the Mintlify project published at `https://docs.anarlog.so`.
 - Write for Anarlog users, developers, and agents using the CLI or MCP server.
 - Configuration lives in `docs.json`; content pages are MDX.
-- The public agent skill is maintained in `../skills/anarlog/`.
+- The public agent skill is served from `skill.md`. Keep its workflow aligned with the packaged skill in `../skills/anarlog/`.
 
 ## Sources of truth
 
@@ -26,13 +26,14 @@
 
 - Document only commands, options, tools, resources, and output behavior present in the source.
 - Mark planned features and distribution channels as forthcoming.
-- Never describe Homebrew, desktop-bundled CLI, or Windows binaries as available until release automation publishes them.
+- Never describe Homebrew, standalone release binaries, or Windows package-manager installation as available until release automation publishes them.
+- Document desktop-bundled CLI installation only for platforms whose release workflow includes the CLI sidecar and installer UI.
 - Never tell users or agents to read, migrate, or modify the SQLite database directly.
 - Keep transcript examples bounded. CLI and MCP transcript pages default to 200 words and cap at 500 words.
 
 ## Verification
 
 - Check `docs.json` after adding or moving a page.
-- Run `pnpm exec dprint fmt docs skills` from the repository root.
-- Run `pnpm exec dprint check docs skills` before submitting.
+- Run `pnpm exec dprint fmt 'docs/**/*' 'skills/**/*'` from the repository root.
+- Run `pnpm exec dprint check 'docs/**/*' 'skills/**/*'` before submitting.
 - Run `mint validate` and `mint broken-links --check-anchors --check-redirects` from `docs/` before deploying.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ cd docs
 mint dev
 ```
 
-Update `docs.json` whenever a page is added, moved, or removed. Keep CLI and MCP reference content aligned with `apps/cli/src/cli.rs` and `apps/cli/src/mcp.rs`.
+Update `docs.json` whenever a page is added, moved, or removed. Keep CLI and MCP reference content aligned with `apps/cli/src/cli.rs` and `apps/cli/src/mcp.rs`. Mintlify publishes the custom agent skill from `skill.md`; keep it aligned with `../skills/anarlog/`.
 
 Before deploying, run:
 

--- a/docs/agents/cli.mdx
+++ b/docs/agents/cli.mdx
@@ -3,9 +3,9 @@ title: "CLI for agents"
 description: "Use structured Anarlog CLI output as an agent-friendly MCP fallback."
 ---
 
-Pass the global `--json` flag when an agent consumes CLI output.
+Use the global `--json` flag whenever an agent consumes CLI output.
 
-Every successful JSON response contains `schema_version`, `command`, `data`, and optional `pagination`. Read meeting results from `data` and continue from `pagination.next_offset` only when needed.
+A successful response contains `schema_version`, `command`, `data`, and optional `pagination`. Read results from `data`. Follow `pagination.next_offset` only when you need another page.
 
 ## Resolve meeting context
 
@@ -14,7 +14,7 @@ anarlog --json meetings list --query "weekly planning" --limit 10
 anarlog --json meetings get MEETING_ID
 ```
 
-Search is case-insensitive across meeting titles and IDs. If several results match, ask the user which meeting they mean.
+Search is case-insensitive across meeting titles and IDs. If several meetings match, ask the user to choose one.
 
 ## Read the smallest useful surface
 
@@ -32,7 +32,7 @@ Use `meetings get` when participants or action items matter. Use `meetings note`
 anarlog --json meetings transcript MEETING_ID --limit 200 --offset 0
 ```
 
-Transcript limits are measured in words. The default is 200 and the maximum is 500. Continue from `pagination.next_offset` only when the next page is necessary.
+Transcript limits are measured in words. A page defaults to 200 words and caps at 500. Stop paging once you have enough evidence.
 
 ## Diagnose setup
 
@@ -40,8 +40,7 @@ Transcript limits are measured in words. The default is 200 and the maximum is 5
 anarlog --json doctor
 ```
 
-The report includes the CLI version, resolved database path, read-only connection status, and schema readiness.
-The command exits with status 1 when `ready` is false while preserving the diagnostic report on standard output.
+The report includes the CLI version, resolved database path, read-only connection status, and schema readiness. When `ready` is false, the command still prints the report to standard output and exits with status 1.
 
 ## Exports
 

--- a/docs/agents/mcp.mdx
+++ b/docs/agents/mcp.mdx
@@ -3,7 +3,9 @@ title: "MCP for agents"
 description: "Connect an MCP client to local Anarlog meeting context over stdio."
 ---
 
-The MCP server runs inside the `anarlog` executable and communicates over standard input and output. It does not open a port or send meeting data to a hosted service.
+The local MCP server runs inside the `anarlog` executable and communicates over standard input and output. It opens no port and sends no meeting data to Anarlog's servers.
+
+Open the desktop app once so it can create the database. The app does not need to stay open after that.
 
 ## Configure a client
 
@@ -37,9 +39,9 @@ For a custom database path:
 
 ## Use tools deliberately
 
-Start with `list_meetings`, then pass the returned `id` to `get_meeting`. Only call `get_meeting_transcript` if notes and summaries do not contain the required evidence.
+Start with `list_meetings`, then pass a returned `id` to `get_meeting`. Call `get_meeting_transcript` only when the notes and summaries do not answer the question.
 
-Transcript pages default to 200 words and cap at 500 words. Continue from `pagination.next_offset` only when the next page is necessary.
+Transcript pages default to 200 words and cap at 500. Follow `pagination.next_offset` only when you need more context.
 
 Use `get_recurring_meeting_history` with a known meeting ID when a task depends on earlier meetings in the same series.
 

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -3,12 +3,13 @@ title: "Agent overview"
 description: "Give an agent useful Anarlog context without exposing storage internals or unbounded transcripts."
 ---
 
-Anarlog offers two local, read-only agent transports. They share the same meeting model.
+Anarlog gives agents three read-only ways to access meeting context. Choose based on where the agent runs.
 
 | Transport | Choose it when | Output |
 | --- | --- | --- |
-| MCP | The agent supports a local stdio MCP server | Structured tool results and contextual resources |
-| CLI | The agent can run shell commands but MCP is unavailable | JSON with `--json`, or Markdown for people |
+| Local MCP | The agent supports a stdio MCP server on your computer | Structured tool results and contextual resources |
+| CLI | The agent can run local shell commands | JSON with `--json`, or Markdown for people |
+| Cloud API or remote MCP | A remote agent needs access while your computer is offline | Hosted REST or MCP responses; requires Anarlog Pro and explicit opt-in |
 
 ## Recommended agent flow
 
@@ -18,13 +19,15 @@ Anarlog offers two local, read-only agent transports. They share the same meetin
 4. Fetch recurring history only when earlier meetings are relevant.
 5. Read transcript pages only until the task has enough evidence.
 
-Prefer MCP when it is connected because tools carry their input schemas and results directly. The CLI provides the same bounded transcript workflow when an agent only has shell access.
+Prefer MCP when it is connected because each tool carries its input schema. Use the CLI when the agent only has shell access. Both support the same bounded transcript workflow.
 
 ## Safety boundary
 
-Agents should use the CLI or MCP server, not SQLite. Those interfaces apply Anarlog's rules for canonical notes, generated summaries, excluded participants, recurring meetings, and transcript text.
+Agents should use an Anarlog interface, not SQLite. The supported interfaces apply Anarlog's rules for canonical notes, generated summaries, excluded participants, recurring meetings, and transcript text.
 
-All current Anarlog data operations are read-only. An agent cannot update a note, action item, or meeting through these interfaces. CLI export may create a separate file; replacing an existing file requires `--force`.
+The CLI and both MCP endpoints are read-only. An agent cannot update a note, action item, or meeting through them. CLI export can create a separate file; replacing a file requires `--force`.
+
+Local CLI and MCP access stays on your computer. Cloud access uploads a separate server-readable copy of your meeting data. Review the [Cloud API disclosure](/reference/api-cloud) before enabling it.
 
 <CardGroup cols={2}>
   <Card title="CLI for agents" icon="terminal" href="/agents/cli">
@@ -34,3 +37,5 @@ All current Anarlog data operations are read-only. An agent cannot update a note
     Configure the stdio server and use bounded transcript pages.
   </Card>
 </CardGroup>
+
+For hosted REST and remote MCP setup, see [Cloud API and connectors](/reference/api-cloud).

--- a/docs/agents/skills.mdx
+++ b/docs/agents/skills.mdx
@@ -3,7 +3,7 @@ title: "Anarlog skill"
 description: "Teach a compatible agent when and how to use Anarlog's MCP and CLI surfaces."
 ---
 
-The public Anarlog skill gives agents one transport-agnostic workflow:
+The public Anarlog skill teaches agents a single workflow across MCP and CLI:
 
 1. Prefer connected Anarlog MCP tools.
 2. Fall back to `anarlog --json` when MCP is unavailable.
@@ -11,16 +11,16 @@ The public Anarlog skill gives agents one transport-agnostic workflow:
 4. Fetch meeting detail before transcript text.
 5. Keep transcript reads bounded and never access SQLite directly.
 
-## Canonical sources
+## Sources
 
-- Public skill: `https://docs.anarlog.so/skill.md`
+- Published skill: `https://docs.anarlog.so/skill.md`
 - Repository package: [`skills/anarlog`](https://github.com/fastrepl/anarlog/tree/main/skills/anarlog)
 
-The repository package includes concise references for setup, CLI commands, MCP tools, and errors.
+The published file is self-contained. The repository package adds references for setup, CLI commands, MCP tools, and errors.
 
 ## Install in an agent
 
-Install from the public documentation with the open skills CLI:
+Install it from the documentation site with the skills CLI:
 
 ```bash
 npx skills add https://docs.anarlog.so

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -5,7 +5,7 @@ description: "Install the current Anarlog CLI and point it at local meeting data
 
 ## Current availability
 
-The CLI includes the `anarlog mcp` server in the same executable.
+The `anarlog` executable includes both the CLI and the local MCP server.
 
 <Warning>
   Homebrew, standalone release binaries, and Windows package-manager distribution are forthcoming. Do not rely on those channels yet.
@@ -13,7 +13,7 @@ The CLI includes the `anarlog mcp` server in the same executable.
 
 ## Install from the desktop app
 
-On macOS, open **Settings → Developers** and select **Install**. Anarlog installs the bundled command at `~/.local/bin/anarlog` without sending data anywhere.
+On macOS, open **Settings → Developers** and select **Install**. Anarlog copies its bundled CLI to `~/.local/bin/anarlog`.
 
 If your shell cannot find `anarlog`, add `~/.local/bin` to `PATH`:
 
@@ -38,7 +38,9 @@ anarlog --version
 
 By default, the CLI looks for `anarlog/app.db` in your operating system's application-data directory. It also recognizes legacy Anarlog locations.
 
-Open the desktop app once before using the CLI. For a custom database location, pass a global option or environment variable:
+Open the desktop app once so it can create the database. After that, the CLI and local MCP server work while the app is closed.
+
+For a custom database location, pass a global option or environment variable:
 
 ```bash
 anarlog --db-path /path/to/app.db --json meetings list

--- a/docs/reference/api-cloud.mdx
+++ b/docs/reference/api-cloud.mdx
@@ -3,7 +3,7 @@ title: "Cloud API and connectors"
 description: "Opt in to hosted REST and remote MCP access for your Anarlog meetings."
 ---
 
-The Cloud API lets remote agents read your Anarlog meetings while the desktop app is closed. It is available with Anarlog Pro and is off by default.
+The Cloud API lets remote agents read your Anarlog meetings while the desktop app is closed. It requires Anarlog Pro and stays off until you enable it.
 
 <Warning>
   Enabling Cloud API & Connectors uploads a separate server-readable copy of
@@ -39,11 +39,19 @@ The hosted API mirrors the read endpoints in the [local API](/reference/api):
 - `GET /v1/meetings/{meeting_id}/history`
 - `GET /v1/meetings/{meeting_id}/export?format=json|markdown`
 
-List limits, transcript pagination, response fields, and error envelopes match the local API. The hosted API can also return:
+Response fields, list limits, and history pagination match the local API. See the [OpenAPI document](https://api.anarlog.so/openapi.json) for the complete hosted schema.
+
+Most hosted errors use the local API's JSON envelope. The hosted API can also return:
 
 - `403 subscription_required` when the account does not have an active Pro subscription.
 - `403 cloud_api_not_enabled` when the account has opted out.
-- `429` with `retry-after` when you exceed the hosted request limit.
+- `429` with a plain-text `rate limit exceeded` body and `retry-after` header when you exceed the hosted request limit.
+
+The request limit allows a burst of 10 requests per account, then refills one request every 200 milliseconds.
+
+<Note>
+  Meeting snapshots are limited to 2 MB. When a snapshot is larger, Anarlog removes word-level transcript timing before upload but keeps the transcript text. If the snapshot is still larger than 2 MB, that meeting cannot upload. A hosted transcript without word timing returns the retained text with an empty `words` array.
+</Note>
 
 ## Remote MCP
 
@@ -99,7 +107,7 @@ Choose Streamable HTTP, use `https://api.anarlog.so/mcp` as the server URL, and 
 Authorization: Bearer anl_...
 ```
 
-Web connector setup in claude.ai and ChatGPT depends on the authentication methods those products allow. Anarlog's current endpoint supports static bearer headers. OAuth-based account connection is forthcoming.
+Web connector setup in claude.ai and ChatGPT depends on the authentication methods those products accept. Anarlog currently supports static bearer headers. OAuth account connection is forthcoming.
 
 ## Disable cloud access
 

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -3,7 +3,9 @@ title: "API reference"
 description: "Endpoints, authentication, and webhooks exposed by the Anarlog local API."
 ---
 
-The Anarlog API is a local REST server built into the desktop app, available on every plan. Enable it under **Settings → Developers → Local API**. It serves the same read-only meeting data as the CLI and MCP server, plus outbound webhooks — and because Anarlog is local-first with end-to-end encrypted sync, your notes are served from this device only and never pass through our servers.
+The local API is built into the desktop app and available on every plan. Enable it under **Settings → Developers → Local API**. It serves the same read-only meeting data as the CLI and MCP server and can send outbound webhooks.
+
+API reads stay on this device and do not pass through Anarlog's servers. Webhooks are different: Anarlog sends subscribed meeting data to the endpoint you configure.
 
 For hosted access that works while the desktop app is closed, see [Cloud API and connectors](/reference/api-cloud).
 
@@ -24,6 +26,8 @@ Errors always look like:
 ```
 
 Codes: `unauthorized`, `not_found`, `invalid_request`, `internal_error`.
+
+Malformed JSON can return a plain-text `400` before the endpoint handler runs.
 
 ## Endpoints
 
@@ -71,11 +75,11 @@ Manage webhook endpoints. Create with:
 { "url": "https://example.com/hooks", "events": ["note.enhanced"] }
 ```
 
-An empty `events` array subscribes to all events. The response includes the signing `secret` (`whsec_...`) exactly once; list responses omit it.
+An empty `events` array subscribes to all events. A successful create returns `201` and includes the signing `secret` (`whsec_...`) exactly once. List responses omit the secret. Delete returns `204`; test returns `delivered` and `status` for one delivery attempt.
 
 ## Webhooks
 
-Anarlog delivers events as JSON `POST` requests while the desktop app is running:
+Anarlog delivers events as JSON `POST` requests while the desktop app is running. Meeting events include the note, summaries, participants, action items, and full transcript text, so only use an endpoint you trust.
 
 | Event | Fires when |
 | --- | --- |
@@ -97,7 +101,7 @@ The payload envelope is:
 }
 ```
 
-Deliveries time out after 10 seconds and are retried twice (after 5s and 30s). Each request includes:
+Meeting event deliveries time out after 10 seconds. Failed attempts retry after 5 and 30 seconds. A `webhook.test` request makes one attempt. Each request includes:
 
 | Header | Content |
 | --- | --- |
@@ -114,11 +118,14 @@ import crypto from "node:crypto";
 const expected = `sha256=${
   crypto.createHmac("sha256", secret).update(rawBody).digest("hex")
 }`;
-const valid = crypto.timingSafeEqual(
-  Buffer.from(expected),
-  Buffer.from(request.headers["x-anarlog-signature"]),
-);
+const signature = request.headers["x-anarlog-signature"];
+const received = typeof signature === "string" ? signature : "";
+const valid =
+  Buffer.byteLength(received) === Buffer.byteLength(expected) &&
+  crypto.timingSafeEqual(Buffer.from(received), Buffer.from(expected));
 ```
+
+Verify the raw body before parsing it. For replay protection, reject stale signed `created_at` values and store each payload `id` so retries are processed once.
 
 ## Limits
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -21,12 +21,12 @@ anarlog [--base DIR] [--db-path FILE] [--json] <command>
 
 | Command | Options | Result |
 | --- | --- | --- |
-| `meetings list` | `--query TEXT`, `--series-id ID`, `--limit 1..200`, `--offset NUMBER` | Meetings ordered by the application query layer. Defaults to 20 results. |
+| `meetings list` | `-q, --query TEXT`, `--series-id ID`, `--limit 1..200`, `--offset NUMBER` | Meetings ordered by the application query layer. Defaults to 20 results. |
 | `meetings get ID` | — | Metadata, canonical note, summaries, participants, and action items. |
 | `meetings note ID` | `--kind note\|summary\|all` | The selected note documents. Defaults to `note`. |
 | `meetings transcript ID` | `--limit 1..500`, `--offset NUMBER` | A bounded transcript word page. Defaults to 200 words from offset 0. |
 | `meetings history ID` | `--limit 1..200`, `--offset NUMBER` | A page of meetings from the same recurring series. Defaults to 20 from offset 0. |
-| `meetings export ID` | `--format markdown\|json`, `--output FILE`, `--force` | A complete meeting export, including transcripts. Defaults to Markdown on stdout. Existing files require `--force`. |
+| `meetings export ID` | `--format markdown\|json`, `-o, --output FILE`, `--force` | A complete meeting export, including transcripts. Defaults to Markdown on stdout. Existing files require `--force`. |
 
 ## JSON response contract
 
@@ -47,8 +47,7 @@ Pagination includes `offset`, `limit`, `returned`, optional `total`, and optiona
 anarlog --json doctor
 ```
 
-Checks the resolved database path, read-only access, and required schema without changing data.
-It exits with status 0 when `ready` is true and status 1 when `ready` is false.
+Checks the resolved database path, read-only access, and required schema without changing data. It exits with status 0 when `ready` is true and status 1 when `ready` is false.
 
 ## MCP command
 

--- a/docs/reference/errors.mdx
+++ b/docs/reference/errors.mdx
@@ -8,9 +8,9 @@ Without `--json`, CLI errors are written to standard error as human-readable tex
 | Exit code | Meaning | Recovery |
 | --- | --- | --- |
 | `0` | Success | Consume stdout. |
-| `1` | Database or operation failure, or an unhealthy `doctor` report | Check the reported action or inspect the diagnostic report and confirm app and CLI compatibility. |
+| `1` | Database or operation failure, or an unhealthy `doctor` report | Read the reported action. For `doctor`, inspect the JSON report and confirm app and CLI compatibility. |
 | `2` | Meeting, note, or other requested data not found | List meetings again and use a returned ID. |
-| `3` | Database file not found | Open Anarlog once or provide the correct database path. |
+| `3` | Database file not found | Open Anarlog once to create it, or provide the correct database path. |
 | `4` | Export output already exists | Choose another path or explicitly pass `--force` to replace the file. |
 
 Invalid arguments use the `invalid_arguments` error code with Clap's nonzero exit code.

--- a/docs/reference/mcp.mdx
+++ b/docs/reference/mcp.mdx
@@ -3,7 +3,7 @@ title: "MCP reference"
 description: "Tools, resources, limits, and transport details exposed by Anarlog MCP."
 ---
 
-Run the server with `anarlog mcp`. It uses the MCP `2024-11-05` protocol over stdio. Every tool is read-only, non-destructive, idempotent, and local-only.
+Run the server with `anarlog mcp`. It uses the MCP `2024-11-05` protocol over stdio. Every tool is read-only, idempotent, and local to your computer. The desktop app only needs to have created the database once; it does not need to stay open.
 
 ## Tools
 

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -20,9 +20,7 @@ Never query or modify Anarlog's SQLite database directly. The CLI and MCP server
 1. List recent meetings or search by a short title fragment.
 2. Use a meeting ID returned by the search. Never guess one.
 3. Get the meeting before requesting its transcript. Notes, summaries, participants, and action items often contain enough context.
-4. Ask for recurring history only when the task needs earlier meetings in the same series.
-
-See [CLI commands](references/cli.md) and [MCP tools](references/mcp.md).
+4. Request recurring history only when the task needs earlier meetings in the same series.
 
 ## Keep context bounded
 
@@ -39,4 +37,4 @@ See [CLI commands](references/cli.md) and [MCP tools](references/mcp.md).
 - CLI export can create a file. Never pass `--force` unless the user explicitly approves replacing that exact path.
 - If search results are ambiguous, ask the user to choose a meeting.
 
-For setup and failures, see [setup](references/setup.md) and [errors](references/errors.md).
+See the [CLI reference](https://docs.anarlog.so/reference/cli), [MCP reference](https://docs.anarlog.so/reference/mcp), and [error guide](https://docs.anarlog.so/reference/errors).

--- a/dprint.json
+++ b/dprint.json
@@ -2,7 +2,9 @@
   "markdown": {
     "associations": [
       "**/*.jinja",
-      "crates/db-user/assets/**/*.md"
+      "crates/db-user/assets/**/*.md",
+      "docs/**/*.md",
+      "skills/**/*.md"
     ]
   },
   "markup": {

--- a/skills/anarlog/references/mcp.md
+++ b/skills/anarlog/references/mcp.md
@@ -2,12 +2,12 @@
 
 All tools are read-only and idempotent.
 
-| Tool | Use |
-| --- | --- |
-| `list_meetings` | Find recent meetings by title, ID fragment, or recurring series. |
-| `get_meeting` | Read metadata, canonical note, summaries, participants, and action items. |
-| `get_meeting_transcript` | Read a transcript page. Start with `limit: 200`; continue from `pagination.next_offset` only as needed. |
-| `get_recurring_meeting_history` | Find meetings from the same recurring series as a known meeting. |
+| Tool                            | Use                                                                                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `list_meetings`                 | Find recent meetings by title, ID fragment, or recurring series.                                        |
+| `get_meeting`                   | Read metadata, canonical note, summaries, participants, and action items.                               |
+| `get_meeting_transcript`        | Read a transcript page. Start with `limit: 200`; continue from `pagination.next_offset` only as needed. |
+| `get_recurring_meeting_history` | Find meetings from the same recurring series as a known meeting.                                        |
 
 Transcript limits are measured in words. The default is 200 and the maximum is 500.
 

--- a/skills/anarlog/references/setup.md
+++ b/skills/anarlog/references/setup.md
@@ -25,7 +25,9 @@ Restart the client after changing its MCP configuration.
 
 ## CLI
 
-The CLI currently installs from source:
+On macOS, open **Anarlog → Settings → Developers** and select **Install**. Anarlog installs the bundled command at `~/.local/bin/anarlog`.
+
+To build from source instead:
 
 ```bash
 git clone https://github.com/fastrepl/anarlog.git
@@ -34,6 +36,8 @@ cargo install --locked --path apps/cli
 anarlog --version
 ```
 
-Run the Anarlog desktop app at least once so its local database exists. Homebrew, desktop-bundled, and Windows binary distribution are planned but not yet available.
+Run the Anarlog desktop app once so its local database exists. The CLI and local MCP server work while the app is closed after that.
+
+Homebrew, standalone release binaries, Windows package-manager distribution, and bundled CLI installation on platforms other than macOS are not yet available.
 
 Use `--db-path FILE` or `ANARLOG_DB_PATH` only when the database is outside Anarlog's default application-data location.


### PR DESCRIPTION
Tighten public prose, correct documented behavior, and publish the reviewed Anarlog skill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and formatting config only; no runtime or API implementation changes.
> 
> **Overview**
> This PR **refreshes public documentation and agent guidance** for CLI, local MCP, local API, and Cloud API—mostly prose tightening, but with several **behavior and distribution corrections**.
> 
> The **agent overview** now frames **three read-only transports** (local MCP, CLI, and hosted Cloud API/remote MCP), with clearer safety boundaries between on-device access and opt-in cloud snapshots. **Installation** and **MCP** pages clarify that the desktop app only needs to run once to create the database, that macOS can install a bundled CLI, and that Homebrew/standalone/Windows package installs remain forthcoming.
> 
> **Reference pages** gain more precise contracts: CLI short flags (`-q`, `-o`), local API notes on malformed JSON `400`, webhook status codes/retries/payload sensitivity, safer webhook signature verification, and Cloud API **rate limits**, **429** body shape, **OpenAPI** pointer, and **2 MB snapshot** handling (including stripping word timing).
> 
> A new **`docs/skill.md`** publishes the reviewed Anarlog agent skill on the docs site, kept in sync with **`skills/anarlog`**. Contributor docs (`AGENTS.md`, `README.md`) and **`dprint.json`** now target `docs/**/*.md` and `skills/**/*.md` for formatting checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 308c02c33462dd1bb637f5e931e106c6f0cc3939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->