### PR TITLE
Align legal disclosures and telemetry consent

### DIFF
--- a/apps/desktop/src/error-reporting.test.ts
+++ b/apps/desktop/src/error-reporting.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   isDisabled: vi.fn(),
   listener: undefined as undefined | (() => void),
   listen: vi.fn(),
+  publicStopReplay: vi.fn(),
   replayIntegration: vi.fn(),
   stopReplay: vi.fn(),
 }));
@@ -48,7 +49,10 @@ beforeEach(() => {
   mocks.listener = undefined;
   mocks.emit.mockResolvedValue(undefined);
   mocks.getClient.mockReturnValue({
-    getIntegrationByName: () => ({ stop: mocks.stopReplay }),
+    getIntegrationByName: () => ({
+      _replay: { stop: mocks.stopReplay },
+      stop: mocks.publicStopReplay,
+    }),
   });
   mocks.isDisabled.mockResolvedValue({ status: "ok", data: false });
   mocks.listen.mockImplementation(async (_event, listener) => {
@@ -215,7 +219,11 @@ describe("session replay consent", () => {
 
     disableSessionReplay();
 
-    expect(mocks.stopReplay).toHaveBeenCalledOnce();
+    expect(mocks.stopReplay).toHaveBeenCalledWith({
+      forceFlush: false,
+      reason: "consent_revoked",
+    });
+    expect(mocks.publicStopReplay).not.toHaveBeenCalled();
     expect(mocks.emit).toHaveBeenCalledWith("anlg:session-replay-disabled");
   });
 

--- a/apps/desktop/src/error-reporting.test.ts
+++ b/apps/desktop/src/error-reporting.test.ts
@@ -1,10 +1,63 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addIntegration: vi.fn(),
+  emit: vi.fn(),
+  getClient: vi.fn(),
+  isDisabled: vi.fn(),
+  listener: undefined as undefined | (() => void),
+  listen: vi.fn(),
+  replayIntegration: vi.fn(),
+  stopReplay: vi.fn(),
+}));
+
+vi.mock("@sentry/react", () => ({
+  addIntegration: mocks.addIntegration,
+  captureException: vi.fn(),
+  getClient: mocks.getClient,
+  init: vi.fn(),
+  replayIntegration: mocks.replayIntegration,
+  setUser: vi.fn(),
+  withScope: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: mocks.emit,
+  listen: mocks.listen,
+}));
+
+vi.mock("@anlg/plugin-analytics", () => ({
+  commands: { isDisabled: mocks.isDisabled },
+}));
+
+vi.mock("./env", () => ({
+  env: {
+    VITE_APP_VERSION: "test",
+    VITE_SENTRY_DSN: "https://public@example.com/1",
+  },
+}));
 
 import {
   normalizeOperationalError,
   operationalErrorMetadata,
   sanitizeErrorEvent,
 } from "./error-reporting";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.listener = undefined;
+  mocks.emit.mockResolvedValue(undefined);
+  mocks.getClient.mockReturnValue({
+    getIntegrationByName: () => ({ stop: mocks.stopReplay }),
+  });
+  mocks.isDisabled.mockResolvedValue({ status: "ok", data: false });
+  mocks.listen.mockImplementation(async (_event, listener) => {
+    mocks.listener = listener;
+    return vi.fn();
+  });
+  mocks.replayIntegration.mockReturnValue({ name: "Replay" });
+  mocks.stopReplay.mockResolvedValue(undefined);
+});
 
 describe("normalizeOperationalError", () => {
   it("preserves useful fields from structured API failures", () => {
@@ -148,5 +201,52 @@ describe("sanitizeErrorEvent", () => {
         },
       },
     ]);
+  });
+});
+
+describe("session replay consent", () => {
+  it("broadcasts revocation and stops the local replay", async () => {
+    vi.resetModules();
+    const { disableSessionReplay, initializeErrorReporting } =
+      await import("./error-reporting");
+
+    initializeErrorReporting();
+    await vi.waitFor(() => expect(mocks.addIntegration).toHaveBeenCalledOnce());
+
+    disableSessionReplay();
+
+    expect(mocks.stopReplay).toHaveBeenCalledOnce();
+    expect(mocks.emit).toHaveBeenCalledWith("anlg:session-replay-disabled");
+  });
+
+  it("stops replay when another webview revokes consent", async () => {
+    vi.resetModules();
+    const { initializeErrorReporting } = await import("./error-reporting");
+
+    initializeErrorReporting();
+    await vi.waitFor(() => expect(mocks.addIntegration).toHaveBeenCalledOnce());
+
+    mocks.listener?.();
+
+    expect(mocks.stopReplay).toHaveBeenCalledOnce();
+  });
+
+  it("does not attach replay when revocation races with consent loading", async () => {
+    vi.resetModules();
+    let resolveConsent!: (value: { status: "ok"; data: boolean }) => void;
+    mocks.isDisabled.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveConsent = resolve;
+      }),
+    );
+    const { initializeErrorReporting } = await import("./error-reporting");
+
+    initializeErrorReporting();
+    await vi.waitFor(() => expect(mocks.isDisabled).toHaveBeenCalledOnce());
+    mocks.listener?.();
+    resolveConsent({ status: "ok", data: false });
+
+    await Promise.resolve();
+    expect(mocks.addIntegration).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/error-reporting.ts
+++ b/apps/desktop/src/error-reporting.ts
@@ -185,9 +185,20 @@ function stopSessionReplay() {
 
   sessionReplayAttached = false;
   const replay = Sentry.getClient()?.getIntegrationByName?.("Replay") as
-    | { stop?: () => Promise<void> }
+    | {
+        _replay?: {
+          stop?: (options: {
+            forceFlush: boolean;
+            reason: string;
+          }) => Promise<void>;
+        };
+      }
     | undefined;
-  void replay?.stop?.()?.catch(() => {});
+  // The public stop() force-flushes session recordings, so consent revocation
+  // must stop the internal controller without sending its buffered segment.
+  void replay?._replay
+    ?.stop?.({ forceFlush: false, reason: "consent_revoked" })
+    .catch(() => {});
 }
 
 // Turning consent back on takes effect on the next launch, so the

--- a/apps/desktop/src/error-reporting.ts
+++ b/apps/desktop/src/error-reporting.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/react";
 import type { ErrorEvent, SeverityLevel } from "@sentry/react";
+import { emit, listen } from "@tauri-apps/api/event";
 
 import { commands as analyticsCommands } from "@anlg/plugin-analytics";
 
@@ -7,6 +8,7 @@ import { env } from "./env";
 
 type ErrorContextValue = null | boolean | number | string;
 const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9_.:/-]{1,128}$/;
+const SESSION_REPLAY_DISABLED_EVENT = "anlg:session-replay-disabled";
 
 function safeIdentifier(value: unknown): string | undefined {
   return typeof value === "string" && SAFE_IDENTIFIER_RE.test(value)
@@ -153,15 +155,17 @@ export function initializeErrorReporting() {
     },
   });
 
-  void attachSessionReplayIfConsented();
+  void initializeSessionReplay();
 }
 
 let sessionReplayAttached = false;
+let sessionReplayDisabled = false;
 
-async function attachSessionReplayIfConsented() {
+async function initializeSessionReplay() {
   try {
+    await listen(SESSION_REPLAY_DISABLED_EVENT, stopSessionReplay);
     const disabled = await analyticsCommands.isDisabled();
-    if (disabled.status === "ok" && !disabled.data) {
+    if (disabled.status === "ok" && !disabled.data && !sessionReplayDisabled) {
       Sentry.addIntegration(
         Sentry.replayIntegration({
           blockAllMedia: true,
@@ -175,15 +179,22 @@ async function attachSessionReplayIfConsented() {
   }
 }
 
-// Turning consent back on takes effect on the next launch, so the
-// session sampling decision is only ever made at startup.
-export function disableSessionReplay() {
+function stopSessionReplay() {
+  sessionReplayDisabled = true;
   if (!sessionReplayAttached) return;
 
+  sessionReplayAttached = false;
   const replay = Sentry.getClient()?.getIntegrationByName?.("Replay") as
     | { stop?: () => Promise<void> }
     | undefined;
   void replay?.stop?.()?.catch(() => {});
+}
+
+// Turning consent back on takes effect on the next launch, so the
+// session sampling decision is only ever made at startup.
+export function disableSessionReplay() {
+  stopSessionReplay();
+  void emit(SESSION_REPLAY_DISABLED_EVENT).catch(() => {});
 }
 
 export function captureOperationalError(

--- a/apps/desktop/src/error-reporting.ts
+++ b/apps/desktop/src/error-reporting.ts
@@ -1,6 +1,8 @@
 import * as Sentry from "@sentry/react";
 import type { ErrorEvent, SeverityLevel } from "@sentry/react";
 
+import { commands as analyticsCommands } from "@anlg/plugin-analytics";
+
 import { env } from "./env";
 
 type ErrorContextValue = null | boolean | number | string;
@@ -140,12 +142,6 @@ export function initializeErrorReporting() {
     sendDefaultPii: false,
     tracePropagationTargets: [],
     beforeSend: sanitizeErrorEvent,
-    integrations: [
-      Sentry.replayIntegration({
-        blockAllMedia: true,
-        maskAllText: true,
-      }),
-    ],
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1.0,
     initialScope: {
@@ -156,6 +152,38 @@ export function initializeErrorReporting() {
       },
     },
   });
+
+  void attachSessionReplayIfConsented();
+}
+
+let sessionReplayAttached = false;
+
+async function attachSessionReplayIfConsented() {
+  try {
+    const disabled = await analyticsCommands.isDisabled();
+    if (disabled.status === "ok" && !disabled.data) {
+      Sentry.addIntegration(
+        Sentry.replayIntegration({
+          blockAllMedia: true,
+          maskAllText: true,
+        }),
+      );
+      sessionReplayAttached = true;
+    }
+  } catch {
+    // Without a readable consent state, keep replay off.
+  }
+}
+
+// Turning consent back on takes effect on the next launch, so the
+// session sampling decision is only ever made at startup.
+export function disableSessionReplay() {
+  if (!sessionReplayAttached) return;
+
+  const replay = Sentry.getClient()?.getIntegrationByName?.("Replay") as
+    | { stop?: () => Promise<void> }
+    | undefined;
+  void replay?.stop?.()?.catch(() => {});
 }
 
 export function captureOperationalError(

--- a/apps/desktop/src/settings/queries.test.tsx
+++ b/apps/desktop/src/settings/queries.test.tsx
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   execute: vi.fn(),
+  disableSessionReplay: vi.fn(),
   getPreferredLanguages: vi.fn(),
   getTemplateSource: vi.fn(),
+  setDisabled: vi.fn(async () => ({ status: "ok", data: null })),
   setAutomaticUpdatesEnabled: vi.fn(async () => undefined),
   setProperties: vi.fn(async () => undefined),
   executeTransaction: vi.fn(
@@ -14,9 +16,13 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@anlg/plugin-analytics", () => ({
   commands: {
-    setDisabled: vi.fn(async () => undefined),
+    setDisabled: mocks.setDisabled,
     setProperties: mocks.setProperties,
   },
+}));
+
+vi.mock("~/error-reporting", () => ({
+  disableSessionReplay: mocks.disableSessionReplay,
 }));
 
 vi.mock("@anlg/plugin-detect", () => ({
@@ -58,6 +64,7 @@ import {
 describe("SQLite settings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.setDisabled.mockResolvedValue({ status: "ok", data: null });
     mocks.execute.mockResolvedValue([]);
     mocks.getPreferredLanguages.mockResolvedValue({
       status: "error",
@@ -159,6 +166,25 @@ describe("SQLite settings", () => {
     await setSettingValues({ automatic_updates: false });
 
     expect(mocks.setAutomaticUpdatesEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("broadcasts replay revocation after persisting telemetry opt-out", async () => {
+    let resolveDisabled!: (value: { status: "ok"; data: null }) => void;
+    mocks.setDisabled.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDisabled = resolve;
+      }),
+    );
+
+    await setSettingValues({ telemetry_consent: false });
+
+    expect(mocks.setDisabled).toHaveBeenCalledWith(true);
+    expect(mocks.disableSessionReplay).not.toHaveBeenCalled();
+
+    resolveDisabled({ status: "ok", data: null });
+    await vi.waitFor(() =>
+      expect(mocks.disableSessionReplay).toHaveBeenCalledOnce(),
+    );
   });
 
   it("migrates and persists the consent chat auto-send setting", async () => {

--- a/apps/desktop/src/settings/queries.ts
+++ b/apps/desktop/src/settings/queries.ts
@@ -414,12 +414,13 @@ function applySettingSideEffects(values: SettingValues): void {
       .catch(console.error);
   }
   if (values.telemetry_consent !== undefined) {
+    const telemetryConsent = values.telemetry_consent;
     void analyticsCommands
-      .setDisabled(!values.telemetry_consent)
-      .catch(console.error);
-    if (!values.telemetry_consent) {
-      disableSessionReplay();
-    }
+      .setDisabled(!telemetryConsent)
+      .catch(console.error)
+      .finally(() => {
+        if (!telemetryConsent) disableSessionReplay();
+      });
   }
   if (values.show_app_in_dock !== undefined) {
     void windowsCommands

--- a/apps/desktop/src/settings/queries.ts
+++ b/apps/desktop/src/settings/queries.ts
@@ -11,6 +11,7 @@ import { commands as windowsCommands } from "@anlg/plugin-windows";
 
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
+import { disableSessionReplay } from "~/error-reporting";
 import { normalizeAudioRetention } from "~/services/audio-retention-policy";
 import {
   LEGACY_MAIN_VALUES_ID,
@@ -416,6 +417,9 @@ function applySettingSideEffects(values: SettingValues): void {
     void analyticsCommands
       .setDisabled(!values.telemetry_consent)
       .catch(console.error);
+    if (!values.telemetry_consent) {
+      disableSessionReplay();
+    }
   }
   if (values.show_app_in_dock !== undefined) {
     void windowsCommands

--- a/apps/web/content/legal/privacy.mdx
+++ b/apps/web/content/legal/privacy.mdx
@@ -1,121 +1,121 @@
 ---
 date: "2026-08-01"
 title: "Privacy Policy"
-summary: "How we collect, use, and protect your personal information"
+summary: "What we collect, what stays on your device, and the choices you have."
 ---
 
-## 1. Introduction
+> **The short version:** Anarlog is local-first. Your notes live on your device, and you can use the app entirely offline. Cloud features are optional, and this policy tells you exactly what each one sends off your device. Encrypted sync is built so we can't read your notes. We don't sell your data. The full policy below is the one that governs.
 
-Fastrepl, Inc. ("we," "our," or "us") operates Anarlog. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our application and services.
+## 1. Who we are
 
-## 2. Local-First Design
+Anarlog is made by Fastrepl, Inc. ("we," "our," or "us"). This policy explains what information we collect when you use Anarlog, how we use it, and the choices you have.
 
-Anarlog is a local-first, open-source application. Your notes, transcripts, and meeting data are stored locally on your device. You can use Anarlog entirely offline with local transcription and a local language model. Cloud-powered features — such as cloud transcription, AI summarization, Cloud Sync, sharing, and the Cloud API — are optional, require an account, and are described individually below so you can see exactly what each one sends off your device. If you no longer wish to maintain an account, you can delete it at any time (see Section 9.2).
+## 2. Local-first by design
 
-## 3. Information We Collect
+Your notes, transcripts, and meeting data are stored locally, on your device. You can use Anarlog entirely offline with local transcription and a local language model — nothing leaves your computer.
 
-### 3.1 Information You Provide
+Cloud features — cloud transcription, AI summaries, Cloud Sync, sharing, and the Cloud API — are optional and require an account. Each one is described below, so you can see exactly what it sends and decide for yourself. If you no longer want an account, you can delete it at any time (see Section 9.2).
 
-We collect information that you directly provide to us, including:
+## 3. What we collect
 
-- **Account Information:** Email address, plus your name and profile picture when you provide them or when your sign-in provider (Google or GitHub) shares them. Passwords are handled by our authentication provider and stored only in hashed form; we also store a billing customer identifier linking your account to our payment processor.
-- **User Content:** Notes, transcripts, attachments, and other content you choose to send to the cloud features described in Sections 4 and 5
-- **Payment Information:** Billing details and payment card information, processed securely through third-party payment processors; we do not store card numbers
-- **Communications:** Information you provide when you contact us for support or feedback
+### 3.1 Things you give us
 
-### 3.2 Information Collected Automatically
+- **Account details.** Your email address, plus your name and profile picture when you provide them or your sign-in provider (Google or GitHub) shares them. Passwords are handled by our authentication provider and stored only in hashed form. We also keep a billing customer identifier that links your account to our payment processor.
+- **Your content.** Notes, transcripts, attachments, and anything else you choose to send to the cloud features described in Sections 4 and 5.
+- **Payment details.** Handled by our payment processor. We never see or store your card number.
+- **Messages to us.** Whatever you include when you reach out for support or send feedback.
 
-When you use the Service, we may automatically collect:
+### 3.2 Things collected automatically
 
-- **Usage Data:** Pseudonymous information about how you interact with the Service, including product interaction events (such as onboarding, downloads, note creation, transcription, summary generation, exports, and settings interactions). If you sign in, usage data is associated with your account.
-- **Device Information:** Device type, operating system, browser type, IP address, and a stable device identifier
-- **Log Data:** Access times, pages viewed, system activity, and technical diagnostics (latency, status codes, error events)
-- **Website Analytics Data:** On Anarlog-owned websites, behavioral metrics, click and scroll activity, referrers, approximate location derived from IP address, browser/device information, and similar interaction metadata, including session replays of website visits collected by our website analytics providers
-- **Service Telemetry Metadata:** Pseudonymous identifiers, app/browser version metadata, and cloud feature usage metadata (speech-to-text duration, AI token counts, AI latency, provider/model metadata) used for operations, billing, product improvement, and abuse prevention
-- **Error and Crash Reports:** Error events with messages and content stripped, sanitized diagnostic breadcrumbs, and crash reports. On a small sample of desktop sessions we record masked session replays (all text hidden, all media blocked) to diagnose issues; these are recorded only while the `Share usage data` setting is enabled (see Section 9.4).
+- **Usage data.** Pseudonymous events about how you use the app — onboarding, downloads, note creation, transcription, summaries, exports, settings. If you're signed in, these are associated with your account.
+- **Device information.** Device type, operating system, browser type, IP address, and a stable device identifier.
+- **Log data.** Access times, pages viewed, and technical diagnostics like latency, status codes, and errors.
+- **Website analytics.** On our websites: page views, clicks and scrolling, referrers, rough location from your IP address, and browser details — including session replays collected by our website analytics providers.
+- **Service telemetry.** Pseudonymous identifiers, app version, and cloud usage metadata (transcription minutes, AI token counts, latency, which provider and model served a request). We use this to run the service, bill correctly, improve the product, and prevent abuse.
+- **Error and crash reports.** Error events with messages and content stripped out, sanitized diagnostics, and crash reports. On a small sample of desktop sessions we record a masked session replay — all text hidden, all media blocked — to diagnose issues. These replays only happen while `Share usage data` is on (see Section 9.4).
 
-Analytics and telemetry events are designed to avoid raw meeting audio, transcript text, note content, and summary text.
+Analytics and telemetry are designed to never include your meeting audio, transcripts, notes, or summaries.
 
-### 3.3 Google Calendar and Microsoft Outlook Calendar Accounts
+### 3.3 Google Calendar and Microsoft Outlook Calendar
 
 If you connect Google Calendar or Microsoft Outlook Calendar, we use the Google Calendar API or Microsoft Graph, respectively, to collect and process the data needed to display your calendars and upcoming events in Anarlog and let you create personal notes and memos associated with those events. This may include:
 
-- **Calendar Information:** Calendar IDs, names, colors, access or ownership metadata, and source or account identifiers
-- **Event Information:** Event IDs, titles, descriptions, locations, meeting links, start and end times, time zones, recurrence metadata, organizer details, and attendee details such as names, email addresses, and RSVP status
-- **Connection Information:** Provider connection IDs, connection status, and the Google or Microsoft account identity associated with the connection
+- **Calendar information:** Calendar IDs, names, colors, access or ownership metadata, and source or account identifiers
+- **Event information:** Event IDs, titles, descriptions, locations, meeting links, start and end times, time zones, recurrence metadata, organizer details, and attendee details such as names, email addresses, and RSVP status
+- **Connection information:** Provider connection IDs, connection status, and the Google or Microsoft account identity associated with the connection
 
 We use connected calendar data to display calendars and upcoming events and to support the personal notes and memos you create for those events. Calendar API responses pass through Nango's encrypted API proxy before reaching Anarlog. We do not use connected calendar data for advertising, marketing personalization, sale to data brokers, or training generalized AI models. The use of information received from Google Workspace APIs adheres to the [Google Workspace API User Data and Developer Policy](https://developers.google.com/workspace/workspace-api-user-data-developer-policy), including the Limited Use requirements.
 
-### 3.4 Other Connected Accounts
+### 3.4 Other connected accounts
 
-If you connect an issue tracker such as Linear or GitHub, we access the issues, pull requests, and related metadata needed to provide the features you enable, through the same encrypted integration proxy. Connected-account data is used only to provide those features, and the commitments in Section 8.3 apply to it as well.
+If you connect an issue tracker like Linear or GitHub, we access the issues, pull requests, and related metadata needed for the features you enable, through the same encrypted integration proxy. We use connected-account data only to provide those features, and the commitments in Section 8.3 apply to it too.
 
-## 4. Meeting Audio, Transcription, and AI Features
+## 4. Meeting audio, transcription, and AI
 
-- **Recording is local.** Anarlog captures microphone and system audio on your device, without adding a bot to the call. Recordings may include the voices of other meeting participants; you are responsible for providing any notice and obtaining any consent required by the laws that apply to your meetings.
-- **Local options.** You can transcribe with on-device models and use a local language model, in which case meeting content does not leave your device.
-- **Hosted transcription.** If you use cloud transcription, the audio needed to create the transcript is sent through our servers to our speech-to-text providers, and a request may fail over among the providers listed in Section 8.2. Uploaded audio is deleted from our storage once the transcription job completes; the transcription result is stored so your devices can retrieve it and is deleted with your account.
-- **Hosted AI features.** If you use cloud AI features (such as summaries or chat), the text and instructions needed to fulfill the request are sent through our AI gateway to the model providers listed in Section 8.2. If you use AI chat with web search, your search queries are sent to our search providers. We do not use your notes, transcripts, or audio to train AI models.
-- **Your own providers.** If you configure your own API key or a local endpoint, content is sent directly to the provider you chose under your agreement with them.
+- **Recording happens on your device.** Anarlog captures microphone and system audio locally, without adding a bot to your call. Recordings can include other people's voices — you're responsible for giving any notice and getting any consent the law requires for your meetings.
+- **Local options.** Use on-device transcription and a local language model, and meeting content never leaves your device.
+- **Cloud transcription.** If you use it, the audio needed for the transcript travels through our servers to our speech-to-text providers, and a request may fail over between the providers listed in Section 8.2. We delete uploaded audio from our storage once the job completes. The transcript result is stored so your devices can fetch it, and deleted with your account.
+- **Cloud AI.** If you use cloud summaries or chat, the text and instructions needed for the request go through our AI gateway to the model providers listed in Section 8.2. If you use AI chat with web search, your search queries go to our search providers. We never use your notes, transcripts, or audio to train AI models.
+- **Your own providers.** If you bring your own API key or a local endpoint, content goes directly to the provider you chose, under your agreement with them.
 
-## 5. Cloud Sync, Sharing, and Cloud API
+## 5. Cloud Sync, sharing, and the Cloud API
 
-### 5.1 End-to-End Encrypted Cloud Sync
+### 5.1 Cloud Sync is end-to-end encrypted
 
-Cloud Sync is end-to-end encrypted. Synced notes, transcripts, and attachments are encrypted on your device with keys derived from a recovery key that is stored in your operating system's keychain and never sent to us. **We cannot read your synced content, and we cannot recover it if you lose your recovery key.** Our sync infrastructure stores only encrypted records together with limited operational metadata: your account and workspace identifier, record timestamps and sizes, and the names of your registered devices — not content, titles, or field names.
+Synced notes, transcripts, and attachments are encrypted on your device before upload, with keys derived from a recovery key that lives in your operating system's keychain and never reaches us. **We cannot read your synced content, and we cannot recover it if you lose your recovery key.** Our sync servers see only encrypted records plus limited operational metadata — your account and workspace identifier, record timestamps and sizes, and your device names. Not content, not titles, not field names.
 
-### 5.2 Shared Notes
+### 5.2 Shared notes are different
 
-Sharing is different from Cloud Sync: when you share a note or create a share link, a server-readable copy of that note's title, content, and attachments is stored on our servers so recipients can view it in the browser. We also collect view metadata for shared notes (such as when a shared note is opened) to provide sharing features like view tracking. When you stop sharing, the note is no longer accessible to recipients.
+When you share a note or create a share link, a server-readable copy of that note — title, content, attachments — is stored on our servers so recipients can open it in a browser. We also collect view metadata (like when a shared note is opened) to power features like view tracking. When you stop sharing, recipients lose access.
 
-### 5.3 Cloud API & Connectors
+### 5.3 Cloud API & Connectors is opt-in
 
-Cloud API & Connectors is an optional feature that is off by default. If you enable it, Anarlog uploads a separate server-readable copy of your meeting titles, notes, summaries, participants, action items, and transcripts so that agents and API clients you authorize can access them while your desktop is offline. It does not weaken Cloud Sync's end-to-end encryption. Turning the feature off deletes the server-readable copies.
+Off by default. If you turn it on, Anarlog uploads a separate server-readable copy of your meeting titles, notes, summaries, participants, action items, and transcripts, so agents and API clients you authorize can reach them while your desktop is offline. It doesn't weaken Cloud Sync's encryption. Turn it off and the server-readable copies are deleted.
 
-## 6. How We Use Your Information
+## 6. How we use your information
 
 We use your information to:
 
-- Provide, maintain, and improve the Service
-- Operate the optional cloud features you enable, as described in Sections 4 and 5
-- Process transactions and manage your account
+- Provide, maintain, and improve Anarlog
+- Run the optional cloud features you enable, as described in Sections 4 and 5
+- Process payments and manage your account
 - Send technical notices, updates, and support messages
-- Send marketing communications (newsletters, product announcements, updates) — you may opt out at any time
-- Display calendars and upcoming events and support event-related notes and memos when you connect Google Calendar or Microsoft Outlook Calendar
-- Respond to your comments, questions, and requests
-- Protect against fraud and other illegal activities
-- Comply with legal obligations
+- Send marketing emails like newsletters and product announcements — you can opt out anytime
+- Show your calendars and upcoming events, and support event-related notes, when you connect a calendar
+- Answer your questions and requests
+- Protect against fraud and abuse
+- Meet our legal obligations
 
-## 7. Data Storage and Security
+## 7. Storage and security
 
-We implement appropriate technical and organizational security measures to protect your information against unauthorized access, alteration, disclosure, or destruction. We use HTTPS/TLS to protect data transmitted over external networks, and Cloud Sync content is additionally end-to-end encrypted as described in Section 5.1. The operating system controls at-rest protection for data stored locally on your device, including any device-level encryption you enable.
+We use appropriate technical and organizational measures to protect your information from unauthorized access, alteration, disclosure, or destruction. Data in transit is protected with HTTPS/TLS, and Cloud Sync content is additionally end-to-end encrypted as described in Section 5.1. Data on your device is protected by your operating system, including any device-level encryption you've turned on.
 
-For connected calendars, calendar and event data is primarily stored in Anarlog's local application database on your device. Nango, our integration provider, stores the OAuth access and refresh tokens needed to maintain the connection. Nango encrypts these credentials at rest using AES-256-GCM and protects data in transit using TLS. We store limited connection metadata on our backend (integration ID, connection ID, connection status, error state, and timestamps) needed to operate the integration securely.
+For connected calendars, calendar and event data lives primarily in Anarlog's local database on your device. Nango, our integration provider, stores the OAuth tokens needed to keep the connection alive — encrypted at rest with AES-256-GCM and in transit with TLS. On our backend we keep only the connection metadata needed to operate the integration securely: integration ID, connection ID, status, error state, and timestamps.
 
-No method of transmission over the Internet or electronic storage is 100% secure. While we strive to use commercially acceptable means to protect your information, we cannot guarantee its absolute security.
+No system is perfectly secure. We work to protect your information with commercially reasonable means, but we can't guarantee absolute security.
 
-## 8. Data Sharing and Disclosure
+## 8. When we share information
 
-### 8.1 We Do Not Sell Your Data
+### 8.1 We don't sell your data
 
-We do not sell, trade, or rent your personal information to third parties, including connected calendar data. We also do not share personal information for cross-context behavioral advertising.
+We don't sell, trade, or rent your personal information — including connected calendar data. We also don't share it for cross-context behavioral advertising.
 
-### 8.2 Service Providers
+### 8.2 Service providers
 
-We may share your information with third-party service providers who perform services on our behalf, such as:
+We share information with providers who do work on our behalf:
 
-- **Cloud hosting and infrastructure providers** (e.g., Fly.io, Netlify, Supabase, Render, Amazon Web Services, Cloudflare) for hosting our application, storing data securely, and delivering downloads
+- **Hosting and infrastructure** (e.g., Fly.io, Netlify, Supabase, Render, Amazon Web Services, Cloudflare) for running the service, storing data securely, and delivering downloads
 - **Sync storage** (SQLite Cloud) for storing end-to-end encrypted Cloud Sync records
-- **Integration providers** (e.g., Nango) for encrypted OAuth credential storage, token refresh, and the API proxy used to retrieve connected-account data
-- **Payment processors** (e.g., Stripe) for processing payments securely
-- **Analytics services** (e.g., PostHog, Google Analytics, Microsoft Clarity) for understanding how users interact with our Service, including website session replay
-- **Error monitoring and observability services** (e.g., Sentry, Honeycomb) for identifying and fixing issues and monitoring performance
-- **Speech-to-text providers** (e.g., Deepgram, Soniox, AssemblyAI, Gladia, ElevenLabs, Fireworks AI, OpenAI, Mistral, Alibaba Cloud) for cloud-based transcription when you enable it; a request may be routed to any of these for reliability
-- **AI gateway and model providers** (OpenRouter, routing to models from providers such as Anthropic, Google, and Mistral) for cloud-based AI features when you enable them
-- **Web search providers** (e.g., Exa, Jina) when you use AI features that search the web
-- **Email services** (e.g., Loops) for sending transactional and marketing communications
+- **Integrations** (e.g., Nango) for encrypted OAuth credential storage, token refresh, and the proxy that retrieves connected-account data
+- **Payments** (e.g., Stripe)
+- **Analytics** (e.g., PostHog, Google Analytics, Microsoft Clarity) for understanding how people use Anarlog, including website session replay
+- **Error monitoring and observability** (e.g., Sentry, Honeycomb) for finding and fixing issues
+- **Speech-to-text** (e.g., Deepgram, Soniox, AssemblyAI, Gladia, ElevenLabs, Fireworks AI, OpenAI, Mistral, Alibaba Cloud) for cloud transcription; a request may be routed to any of these for reliability
+- **AI gateway and models** (OpenRouter, routing to models from providers such as Anthropic, Google, and Mistral) for cloud AI features
+- **Web search** (e.g., Exa, Jina) when you use AI features that search the web
+- **Email** (e.g., Loops) for transactional and marketing messages
 
-### 8.3 Connected Calendar Data Sharing
+### 8.3 Connected calendar data
 
 When you connect Google Calendar or Microsoft Outlook Calendar, we may share connected calendar data only:
 
@@ -129,63 +129,62 @@ We do not sell connected calendar data or transfer it to third parties for adver
 
 We do not permit employees, contractors, or other people to read connected calendar data unless you give explicit consent for support involving specific data, access is necessary to investigate a security issue or abuse, or access is required by applicable law.
 
-### 8.4 Legal Requirements
+### 8.4 Legal requirements
 
-We may disclose your information if required by law or in response to valid requests by public authorities (court orders or government agencies).
+We may disclose your information if the law requires it, or in response to valid requests from public authorities like courts or government agencies.
 
-## 9. Your Rights and Choices
+## 9. Your rights and choices
 
-### 9.1 Access and Portability
+### 9.1 Access and portability
 
-Your notes are stored locally on your device. You can access them in Anarlog and use Anarlog's export tools to create portable copies.
+Your notes are on your device. Open them in Anarlog anytime, and use the export tools to make portable copies.
 
-### 9.2 Correction and Deletion
+### 9.2 Correction and deletion
 
-You can delete your account yourself from the Account page in the web app (`anarlog.so/app/account`), or request deletion by contacting us at hello@anarlog.so. Your locally stored data remains on your device and is not affected by account deletion.
+Delete your account yourself from the Account page in the web app (`anarlog.so/app/account`), or email us at founders@anarlog.so and we'll do it. Your local data stays on your device — account deletion doesn't touch it.
 
-### 9.3 Data Retention
+### 9.3 How long we keep things
 
 - **Local data** stays on your device until you remove it.
-- **Cloud-stored data controlled by Anarlog** (including Cloud Sync records, transcription results, shared notes, and Cloud API copies) is deleted within 30 days of account deletion, except where required to retain it for legal purposes.
-- **Audio uploaded for cloud transcription** is deleted from our storage once the transcription job completes.
+- **Cloud data we control** — Cloud Sync records, transcription results, shared notes, Cloud API copies — is deleted within 30 days of account deletion, unless the law requires us to keep it.
+- **Audio uploaded for cloud transcription** is deleted from our storage once the job completes.
 - **Cloud API & Connectors copies** are deleted when you turn the feature off.
-- **Shared notes** remain available until you stop sharing them or delete your account.
+- **Shared notes** stay available until you stop sharing them or delete your account.
 - **Connected calendar data** is retained locally on your device. Disconnecting stops future access and removes the data from active calendar views after Anarlog refreshes, but underlying local records and event context already associated with notes may remain until you remove local Anarlog app data. When a connection is deleted, our integration provider makes it inaccessible immediately and permanently deletes its credentials and associated metadata after its default 31-day retention period. Before requesting account deletion, disconnect each connected calendar account. If you cannot access the app, contact us so we can delete the connection for you.
 
-### 9.4 Analytics and Telemetry Controls
+### 9.4 Analytics controls
 
-- **Desktop app setting:** You can disable desktop usage analytics in Settings (`Share usage data`). Disabling it stops product analytics events and desktop session replay. Error and crash reporting operates independently of this setting so we can keep the app reliable; error reports are sanitized as described in Section 3.2.
-- **Global Privacy Control:** We honor Global Privacy Control (GPC) for non-essential website tracking, including our website analytics, session replay, and tracing providers.
+- **In the desktop app:** turn off `Share usage data` in Settings. That stops product analytics events and desktop session replay. Error and crash reporting stays on so we can keep the app reliable — reports are sanitized as described in Section 3.2.
+- **On our websites:** we honor Global Privacy Control (GPC) for non-essential tracking, including analytics, session replay, and tracing.
 
-### 9.5 Connected Account Controls
+### 9.5 Connected account controls
 
 You can choose which calendars Anarlog displays or disconnect an account from the Calendar sidebar. Disconnecting stops future access and syncs; it does not delete personal notes or memos you created. Follow our [connected calendar data instructions](https://docs.anarlog.so/calendar#manage-or-delete-connected-calendar-data) to manage calendars, disconnect an account, revoke provider access, or permanently remove locally retained calendar data. Permanently removing local calendar data currently requires removing all local Anarlog app data from that device.
 
 ### 9.6 Cookies
 
-Our websites use cookies and similar technologies for signing you in and keeping your session (essential) and for the analytics described in Section 3.2 (non-essential). We do not use advertising cookies or pixels. You can limit non-essential cookies through your browser settings or by enabling Global Privacy Control.
+Our websites use cookies for signing you in and keeping your session (essential), and for the analytics described in Section 3.2 (non-essential). No advertising cookies, no pixels. Limit non-essential cookies through your browser settings or by turning on Global Privacy Control.
 
-## 10. Regional Privacy Rights
+## 10. Your regional rights
 
-**European Economic Area and United Kingdom.** We process personal data to perform our contract with you (providing the Service), for our legitimate interests (such as securing and improving the Service), with your consent (such as marketing emails), and to comply with legal obligations. You have the right to access, correct, delete, restrict, or object to our processing of your personal data, the right to data portability, the right to withdraw consent at any time, and the right to lodge a complaint with your local supervisory authority. Contact us at hello@anarlog.so to exercise these rights.
+**European Economic Area and United Kingdom.** We process personal data to perform our contract with you (providing the service), for our legitimate interests (like securing and improving it), with your consent (like marketing emails), and to comply with legal obligations. You can access, correct, delete, restrict, or object to our processing of your data; take your data with you; withdraw consent at any time; and lodge a complaint with your local supervisory authority. Email founders@anarlog.so to exercise any of these.
 
-**California.** You have the right to know what personal information we collect (Section 3), to delete it (Section 9.2), to correct it, and to not be discriminated against for exercising these rights. We do not sell personal information or share it for cross-context behavioral advertising, and we honor Global Privacy Control as an opt-out signal.
+**California.** You have the right to know what we collect (Section 3), delete it (Section 9.2), correct it, and never be treated worse for exercising those rights. We don't sell personal information or share it for cross-context behavioral advertising, and we honor Global Privacy Control as an opt-out signal.
 
-## 11. International Data Transfers
+## 11. International transfers
 
-Your information may be transferred to and maintained on computers located outside of your jurisdiction where data protection laws may differ. Where required, we rely on appropriate safeguards for such transfers, such as our providers' data processing agreements incorporating standard contractual clauses.
+Your information may be processed on computers outside your jurisdiction, where data protection laws differ. Where required, we rely on appropriate safeguards — like our providers' data processing agreements incorporating standard contractual clauses.
 
-## 12. Children's Privacy
+## 12. Children
 
-Our Service is not intended for children under 13. We do not knowingly collect personal information from children under 13.
+Anarlog isn't for children under 13, and we don't knowingly collect their personal information.
 
-## 13. Changes to This Privacy Policy
+## 13. Changes to this policy
 
-We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the date above.
+When we update this policy, we'll post the new version here and update the date above.
 
-## 14. Contact Us
+## 14. Contact us
 
-If you have any questions about this Privacy Policy, please contact us at:
+Questions about this policy? Email us at [founders@anarlog.so](mailto:founders@anarlog.so).
 
 **Fastrepl, Inc.**
-Email: hello@anarlog.so

--- a/apps/web/content/legal/privacy.mdx
+++ b/apps/web/content/legal/privacy.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2026-07-17"
+date: "2026-08-01"
 title: "Privacy Policy"
 summary: "How we collect, use, and protect your personal information"
 ---
@@ -10,7 +10,7 @@ Fastrepl, Inc. ("we," "our," or "us") operates Anarlog. This Privacy Policy expl
 
 ## 2. Local-First Design
 
-Anarlog is a local-first, open-source application. Your notes, transcripts, and meeting data are stored locally on your device. You can use Anarlog entirely offline with a local language model. Optional cloud-powered features (such as cloud transcription and AI summarization) require an account; if you no longer wish to maintain one, you can request deletion at any time by contacting us at hello@anarlog.so.
+Anarlog is a local-first, open-source application. Your notes, transcripts, and meeting data are stored locally on your device. You can use Anarlog entirely offline with local transcription and a local language model. Cloud-powered features — such as cloud transcription, AI summarization, Cloud Sync, sharing, and the Cloud API — are optional, require an account, and are described individually below so you can see exactly what each one sends off your device. If you no longer wish to maintain an account, you can delete it at any time (see Section 9.2).
 
 ## 3. Information We Collect
 
@@ -18,20 +18,21 @@ Anarlog is a local-first, open-source application. Your notes, transcripts, and 
 
 We collect information that you directly provide to us, including:
 
-- **Account Information:** Name, email address, password, and profile information (only if you create an account for cloud features)
-- **User Content:** Notes, documents, and other content you choose to sync to cloud features
-- **Payment Information:** Billing details and payment card information, processed securely through third-party payment processors
+- **Account Information:** Email address, plus your name and profile picture when you provide them or when your sign-in provider (Google or GitHub) shares them. Passwords are handled by our authentication provider and stored only in hashed form; we also store a billing customer identifier linking your account to our payment processor.
+- **User Content:** Notes, transcripts, attachments, and other content you choose to send to the cloud features described in Sections 4 and 5
+- **Payment Information:** Billing details and payment card information, processed securely through third-party payment processors; we do not store card numbers
 - **Communications:** Information you provide when you contact us for support or feedback
 
 ### 3.2 Information Collected Automatically
 
 When you use the Service, we may automatically collect:
 
-- **Usage Data:** Anonymous information about how you interact with the Service, including product interaction events (such as onboarding, downloads, note creation, transcription, summary generation, exports, and settings interactions)
-- **Device Information:** Device type, operating system, browser type, and IP address
+- **Usage Data:** Pseudonymous information about how you interact with the Service, including product interaction events (such as onboarding, downloads, note creation, transcription, summary generation, exports, and settings interactions). If you sign in, usage data is associated with your account.
+- **Device Information:** Device type, operating system, browser type, IP address, and a stable device identifier
 - **Log Data:** Access times, pages viewed, system activity, and technical diagnostics (latency, status codes, error events)
-- **Website Analytics Data:** On Anarlog-owned websites, behavioral metrics, click and scroll activity, referrers, approximate location derived from IP address, browser/device information, and similar interaction metadata
+- **Website Analytics Data:** On Anarlog-owned websites, behavioral metrics, click and scroll activity, referrers, approximate location derived from IP address, browser/device information, and similar interaction metadata, including session replays of website visits collected by our website analytics providers
 - **Service Telemetry Metadata:** Pseudonymous identifiers, app/browser version metadata, and cloud feature usage metadata (speech-to-text duration, AI token counts, AI latency, provider/model metadata) used for operations, billing, product improvement, and abuse prevention
+- **Error and Crash Reports:** Error events with messages and content stripped, sanitized diagnostic breadcrumbs, and crash reports. On a small sample of desktop sessions we record masked session replays (all text hidden, all media blocked) to diagnose issues; these are recorded only while the `Share usage data` setting is enabled (see Section 9.4).
 
 Analytics and telemetry events are designed to avoid raw meeting audio, transcript text, note content, and summary text.
 
@@ -45,11 +46,38 @@ If you connect Google Calendar or Microsoft Outlook Calendar, we use the Google 
 
 We use connected calendar data to display calendars and upcoming events and to support the personal notes and memos you create for those events. Calendar API responses pass through Nango's encrypted API proxy before reaching Anarlog. We do not use connected calendar data for advertising, marketing personalization, sale to data brokers, or training generalized AI models. The use of information received from Google Workspace APIs adheres to the [Google Workspace API User Data and Developer Policy](https://developers.google.com/workspace/workspace-api-user-data-developer-policy), including the Limited Use requirements.
 
-## 4. How We Use Your Information
+### 3.4 Other Connected Accounts
+
+If you connect an issue tracker such as Linear or GitHub, we access the issues, pull requests, and related metadata needed to provide the features you enable, through the same encrypted integration proxy. Connected-account data is used only to provide those features, and the commitments in Section 8.3 apply to it as well.
+
+## 4. Meeting Audio, Transcription, and AI Features
+
+- **Recording is local.** Anarlog captures microphone and system audio on your device, without adding a bot to the call. Recordings may include the voices of other meeting participants; you are responsible for providing any notice and obtaining any consent required by the laws that apply to your meetings.
+- **Local options.** You can transcribe with on-device models and use a local language model, in which case meeting content does not leave your device.
+- **Hosted transcription.** If you use cloud transcription, the audio needed to create the transcript is sent through our servers to our speech-to-text providers, and a request may fail over among the providers listed in Section 8.2. Uploaded audio is deleted from our storage once the transcription job completes; the transcription result is stored so your devices can retrieve it and is deleted with your account.
+- **Hosted AI features.** If you use cloud AI features (such as summaries or chat), the text and instructions needed to fulfill the request are sent through our AI gateway to the model providers listed in Section 8.2. If you use AI chat with web search, your search queries are sent to our search providers. We do not use your notes, transcripts, or audio to train AI models.
+- **Your own providers.** If you configure your own API key or a local endpoint, content is sent directly to the provider you chose under your agreement with them.
+
+## 5. Cloud Sync, Sharing, and Cloud API
+
+### 5.1 End-to-End Encrypted Cloud Sync
+
+Cloud Sync is end-to-end encrypted. Synced notes, transcripts, and attachments are encrypted on your device with keys derived from a recovery key that is stored in your operating system's keychain and never sent to us. **We cannot read your synced content, and we cannot recover it if you lose your recovery key.** Our sync infrastructure stores only encrypted records together with limited operational metadata: your account and workspace identifier, record timestamps and sizes, and the names of your registered devices — not content, titles, or field names.
+
+### 5.2 Shared Notes
+
+Sharing is different from Cloud Sync: when you share a note or create a share link, a server-readable copy of that note's title, content, and attachments is stored on our servers so recipients can view it in the browser. We also collect view metadata for shared notes (such as when a shared note is opened) to provide sharing features like view tracking. When you stop sharing, the note is no longer accessible to recipients.
+
+### 5.3 Cloud API & Connectors
+
+Cloud API & Connectors is an optional feature that is off by default. If you enable it, Anarlog uploads a separate server-readable copy of your meeting titles, notes, summaries, participants, action items, and transcripts so that agents and API clients you authorize can access them while your desktop is offline. It does not weaken Cloud Sync's end-to-end encryption. Turning the feature off deletes the server-readable copies.
+
+## 6. How We Use Your Information
 
 We use your information to:
 
 - Provide, maintain, and improve the Service
+- Operate the optional cloud features you enable, as described in Sections 4 and 5
 - Process transactions and manage your account
 - Send technical notices, updates, and support messages
 - Send marketing communications (newsletters, product announcements, updates) — you may opt out at any time
@@ -58,34 +86,36 @@ We use your information to:
 - Protect against fraud and other illegal activities
 - Comply with legal obligations
 
-## 5. Data Storage and Security
+## 7. Data Storage and Security
 
-We implement appropriate technical and organizational security measures to protect your information against unauthorized access, alteration, disclosure, or destruction. We use HTTPS/TLS to protect data transmitted over external networks. The operating system controls at-rest protection for data stored locally on your device, including any device-level encryption you enable.
+We implement appropriate technical and organizational security measures to protect your information against unauthorized access, alteration, disclosure, or destruction. We use HTTPS/TLS to protect data transmitted over external networks, and Cloud Sync content is additionally end-to-end encrypted as described in Section 5.1. The operating system controls at-rest protection for data stored locally on your device, including any device-level encryption you enable.
 
 For connected calendars, calendar and event data is primarily stored in Anarlog's local application database on your device. Nango, our integration provider, stores the OAuth access and refresh tokens needed to maintain the connection. Nango encrypts these credentials at rest using AES-256-GCM and protects data in transit using TLS. We store limited connection metadata on our backend (integration ID, connection ID, connection status, error state, and timestamps) needed to operate the integration securely.
 
 No method of transmission over the Internet or electronic storage is 100% secure. While we strive to use commercially acceptable means to protect your information, we cannot guarantee its absolute security.
 
-## 6. Data Sharing and Disclosure
+## 8. Data Sharing and Disclosure
 
-### 6.1 We Do Not Sell Your Data
+### 8.1 We Do Not Sell Your Data
 
-We do not sell, trade, or rent your personal information to third parties, including connected calendar data.
+We do not sell, trade, or rent your personal information to third parties, including connected calendar data. We also do not share personal information for cross-context behavioral advertising.
 
-### 6.2 Service Providers
+### 8.2 Service Providers
 
 We may share your information with third-party service providers who perform services on our behalf, such as:
 
-- **Cloud hosting and infrastructure providers** (e.g., Fly.io, Netlify, Cloudflare, Supabase) for hosting our application and storing data securely
-- **Integration providers** (e.g., Nango) for encrypted OAuth credential storage, token refresh, and the API proxy used to retrieve calendar data
+- **Cloud hosting and infrastructure providers** (e.g., Fly.io, Netlify, Supabase, Render, Amazon Web Services, Cloudflare) for hosting our application, storing data securely, and delivering downloads
+- **Sync storage** (SQLite Cloud) for storing end-to-end encrypted Cloud Sync records
+- **Integration providers** (e.g., Nango) for encrypted OAuth credential storage, token refresh, and the API proxy used to retrieve connected-account data
 - **Payment processors** (e.g., Stripe) for processing payments securely
-- **Analytics services** (e.g., PostHog, Google Analytics) for understanding how users interact with our Service
-- **Speech-to-text providers** (e.g., Deepgram, AssemblyAI, Soniox) for cloud-based transcription when you enable this feature
-- **AI model providers** for optional cloud-based AI features when you enable them
-- **Error monitoring services** (e.g., Sentry) for identifying and fixing issues
+- **Analytics services** (e.g., PostHog, Google Analytics, Microsoft Clarity) for understanding how users interact with our Service, including website session replay
+- **Error monitoring and observability services** (e.g., Sentry, Honeycomb) for identifying and fixing issues and monitoring performance
+- **Speech-to-text providers** (e.g., Deepgram, Soniox, AssemblyAI, Gladia, ElevenLabs, Fireworks AI, OpenAI, Mistral, Alibaba Cloud) for cloud-based transcription when you enable it; a request may be routed to any of these for reliability
+- **AI gateway and model providers** (OpenRouter, routing to models from providers such as Anthropic, Google, and Mistral) for cloud-based AI features when you enable them
+- **Web search providers** (e.g., Exa, Jina) when you use AI features that search the web
 - **Email services** (e.g., Loops) for sending transactional and marketing communications
 
-### 6.3 Connected Calendar Data Sharing
+### 8.3 Connected Calendar Data Sharing
 
 When you connect Google Calendar or Microsoft Outlook Calendar, we may share connected calendar data only:
 
@@ -99,46 +129,61 @@ We do not sell connected calendar data or transfer it to third parties for adver
 
 We do not permit employees, contractors, or other people to read connected calendar data unless you give explicit consent for support involving specific data, access is necessary to investigate a security issue or abuse, or access is required by applicable law.
 
-### 6.4 Legal Requirements
+### 8.4 Legal Requirements
 
 We may disclose your information if required by law or in response to valid requests by public authorities (court orders or government agencies).
 
-## 7. Your Rights and Choices
+## 9. Your Rights and Choices
 
-### 7.1 Access and Portability
+### 9.1 Access and Portability
 
 Your notes are stored locally on your device. You can access them in Anarlog and use Anarlog's export tools to create portable copies.
 
-### 7.2 Correction and Deletion
+### 9.2 Correction and Deletion
 
-You may request account deletion at any time by contacting us at hello@anarlog.so. Your locally stored data remains on your device and is not affected by account deletion.
+You can delete your account yourself from the Account page in the web app (`anarlog.so/app/account`), or request deletion by contacting us at hello@anarlog.so. Your locally stored data remains on your device and is not affected by account deletion.
 
-### 7.3 Data Retention
+### 9.3 Data Retention
 
-If you connect Google Calendar or Microsoft Outlook Calendar, calendar and event data is retained locally on your device. Disconnecting stops future access and removes the data from active calendar views after Anarlog refreshes, but underlying local records and event context already associated with notes may remain until you remove local Anarlog app data. When a connection is deleted, our integration provider makes it inaccessible immediately and permanently deletes its credentials and associated metadata after its default 31-day retention period. Before requesting account deletion, disconnect each connected calendar account. If you cannot access the app, contact us so we can delete the connection for you. We delete cloud-stored data controlled by Anarlog within 30 days, except where required to retain it for legal purposes.
+- **Local data** stays on your device until you remove it.
+- **Cloud-stored data controlled by Anarlog** (including Cloud Sync records, transcription results, shared notes, and Cloud API copies) is deleted within 30 days of account deletion, except where required to retain it for legal purposes.
+- **Audio uploaded for cloud transcription** is deleted from our storage once the transcription job completes.
+- **Cloud API & Connectors copies** are deleted when you turn the feature off.
+- **Shared notes** remain available until you stop sharing them or delete your account.
+- **Connected calendar data** is retained locally on your device. Disconnecting stops future access and removes the data from active calendar views after Anarlog refreshes, but underlying local records and event context already associated with notes may remain until you remove local Anarlog app data. When a connection is deleted, our integration provider makes it inaccessible immediately and permanently deletes its credentials and associated metadata after its default 31-day retention period. Before requesting account deletion, disconnect each connected calendar account. If you cannot access the app, contact us so we can delete the connection for you.
 
-### 7.4 Analytics and Telemetry Controls
+### 9.4 Analytics and Telemetry Controls
 
-- **Desktop app setting:** You can disable desktop usage analytics in Settings (`Share usage data`).
-- **Global Privacy Control:** We honor Global Privacy Control (GPC) for non-essential website tracking.
+- **Desktop app setting:** You can disable desktop usage analytics in Settings (`Share usage data`). Disabling it stops product analytics events and desktop session replay. Error and crash reporting operates independently of this setting so we can keep the app reliable; error reports are sanitized as described in Section 3.2.
+- **Global Privacy Control:** We honor Global Privacy Control (GPC) for non-essential website tracking, including our website analytics, session replay, and tracing providers.
 
-### 7.5 Connected Account Controls
+### 9.5 Connected Account Controls
 
 You can choose which calendars Anarlog displays or disconnect an account from the Calendar sidebar. Disconnecting stops future access and syncs; it does not delete personal notes or memos you created. Follow our [connected calendar data instructions](https://docs.anarlog.so/calendar#manage-or-delete-connected-calendar-data) to manage calendars, disconnect an account, revoke provider access, or permanently remove locally retained calendar data. Permanently removing local calendar data currently requires removing all local Anarlog app data from that device.
 
-## 8. International Data Transfers
+### 9.6 Cookies
 
-Your information may be transferred to and maintained on computers located outside of your jurisdiction where data protection laws may differ. By using the Service, you consent to such transfers.
+Our websites use cookies and similar technologies for signing you in and keeping your session (essential) and for the analytics described in Section 3.2 (non-essential). We do not use advertising cookies or pixels. You can limit non-essential cookies through your browser settings or by enabling Global Privacy Control.
 
-## 9. Children's Privacy
+## 10. Regional Privacy Rights
+
+**European Economic Area and United Kingdom.** We process personal data to perform our contract with you (providing the Service), for our legitimate interests (such as securing and improving the Service), with your consent (such as marketing emails), and to comply with legal obligations. You have the right to access, correct, delete, restrict, or object to our processing of your personal data, the right to data portability, the right to withdraw consent at any time, and the right to lodge a complaint with your local supervisory authority. Contact us at hello@anarlog.so to exercise these rights.
+
+**California.** You have the right to know what personal information we collect (Section 3), to delete it (Section 9.2), to correct it, and to not be discriminated against for exercising these rights. We do not sell personal information or share it for cross-context behavioral advertising, and we honor Global Privacy Control as an opt-out signal.
+
+## 11. International Data Transfers
+
+Your information may be transferred to and maintained on computers located outside of your jurisdiction where data protection laws may differ. Where required, we rely on appropriate safeguards for such transfers, such as our providers' data processing agreements incorporating standard contractual clauses.
+
+## 12. Children's Privacy
 
 Our Service is not intended for children under 13. We do not knowingly collect personal information from children under 13.
 
-## 10. Changes to This Privacy Policy
+## 13. Changes to This Privacy Policy
 
 We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the date above.
 
-## 11. Contact Us
+## 14. Contact Us
 
 If you have any questions about this Privacy Policy, please contact us at:
 

--- a/apps/web/content/legal/terms.mdx
+++ b/apps/web/content/legal/terms.mdx
@@ -1,131 +1,132 @@
 ---
 date: "2026-08-01"
 title: "Terms of Service"
-summary: "Terms and conditions for using Anarlog"
+summary: "The agreement between you and us when you use Anarlog."
 ---
 
-## 1. Agreement to Terms
+> **The short version:** Anarlog is free and open source. Pro is a subscription you can cancel anytime, with a trial that never charges you automatically. Your content is yours. You're responsible for recording meetings lawfully. Encrypted sync means we can't recover your notes if you lose your recovery key. The full terms below are the ones that govern.
 
-By accessing or using Anarlog ("the Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you may not access or use the Service. You must be at least 13 years old and legally capable of entering into these Terms to use the Service.
+## 1. Agreement to terms
 
-## 2. Description of Service
+By using Anarlog ("the Service"), you agree to these Terms of Service. If you don't agree, don't use the Service. You must be at least 13 years old and legally able to enter into these Terms.
+
+## 2. What Anarlog is
 
 Anarlog is an open-source note-taking and meeting transcription application. It helps you capture, organize, and manage your notes and meeting context.
 
-### 2.1 Local-First Architecture
+### 2.1 Local-first architecture
 
-Anarlog is designed as a local-first application. Your canonical notes, transcripts, and meeting data are stored locally on your device in SQLite; attachments and recordings are stored as local files. You can export Markdown and other formats. You can run Anarlog completely offline with local transcription and a local language model (for example, via LM Studio or Ollama). Cloud-based features — such as cloud transcription, AI summarization, Cloud Sync, sharing, and the Cloud API — are optional and require an internet connection.
+Anarlog is built local-first. Your canonical notes, transcripts, and meeting data are stored on your device in SQLite; attachments and recordings are local files. You can export Markdown and other formats. You can run Anarlog completely offline with local transcription and a local language model (for example, via LM Studio or Ollama). Cloud features — cloud transcription, AI summaries, Cloud Sync, sharing, and the Cloud API — are optional and need an internet connection.
 
-### 2.2 Account and Cloud Features
+### 2.2 Accounts and cloud features
 
-You can use Anarlog without an account by running it in fully local mode. Creating an account is offered during onboarding and is required only for cloud-powered features such as cloud transcription and summarization. If you no longer wish to maintain an account, you can delete it at any time (see Section 3.3).
+You can use Anarlog without an account in fully local mode. We offer to create an account during onboarding, but you only need one for cloud features like cloud transcription and summaries. If you no longer want an account, delete it anytime (see Section 3.3).
 
-## 3. User Accounts
+## 3. Your account
 
-### 3.1 Account Creation
+### 3.1 Creating one
 
-To use cloud features of the Service, you must register for an account. You agree to provide accurate, current, and complete information during the registration process.
+Cloud features require an account. Give us accurate, current, and complete information when you register.
 
-### 3.2 Account Security
+### 3.2 Keeping it secure
 
-You are responsible for maintaining the confidentiality of your account credentials and for all activities that occur under your account.
+Your credentials are your responsibility, and so is everything that happens under your account.
 
-### 3.3 Account Deletion
+### 3.3 Deleting it
 
-You may delete your account at any time from the Account page in the web app (`anarlog.so/app/account`) or by contacting us at hello@anarlog.so. Upon account deletion, your cloud-stored data will be removed within 30 days. Your locally stored data remains on your device and is not affected by account deletion. After deleting your account, Anarlog will continue to function with local-only features.
+Delete your account anytime from the Account page in the web app (`anarlog.so/app/account`), or email us at founders@anarlog.so. We remove your cloud-stored data within 30 days. Your local data stays on your device, and Anarlog keeps working in local-only mode.
 
-## 4. Subscriptions, Trials, and Payment
+## 4. Subscriptions, trials, and payment
 
-Anarlog is free and open source. Optional cloud features require a paid subscription ("Anarlog Pro").
+Anarlog is free and open source. Cloud features require a paid subscription — Anarlog Pro.
 
-- **Billing and renewal.** Subscriptions are billed in advance on a monthly or yearly basis and renew automatically at the end of each billing period until canceled. You authorize our payment processor to charge your payment method for each renewal.
-- **Cancellation.** You can cancel at any time from the billing portal linked in the app's account settings. Cancellation takes effect at the end of the current billing period, and you keep access to paid features until then.
-- **Free trials.** We may offer a free trial of paid features for the period presented when you start it. Trials do not require a payment method, and we do not charge you automatically when a trial ends; paid features simply stop until you subscribe.
-- **Price changes.** We may change subscription prices with at least 30 days' notice before the change applies to you; continued use after renewal constitutes acceptance of the new price.
-- **Refunds.** Except where required by applicable law, fees are non-refundable.
-- **Taxes.** Fees exclude taxes, which you are responsible for where applicable.
+- **Billing and renewal.** Subscriptions are billed in advance, monthly or yearly, and renew automatically until you cancel. You authorize our payment processor to charge your payment method each renewal.
+- **Cancellation.** Cancel anytime from the billing portal in the app's account settings. You keep paid features until the end of the current billing period.
+- **Trials.** We may offer a free trial for the period shown when you start it. Trials don't require a payment method, and we never charge you automatically when one ends — paid features simply stop until you subscribe.
+- **Price changes.** If we change prices, we'll give you at least 30 days' notice before the change applies to you. Continuing past your next renewal means you accept the new price.
+- **Refunds.** Fees are non-refundable, except where the law says otherwise.
+- **Taxes.** Prices don't include taxes; those are on you where applicable.
 
-## 5. Acceptable Use
+## 5. Acceptable use
 
-You agree not to:
+Don't:
 
-- Use the Service for any illegal purpose or in violation of any local, state, national, or international law
-- Violate or encourage others to violate any right of a third party, including intellectual property rights
-- Post, upload, or distribute any content that is unlawful, defamatory, libelous, or infringing
-- Distribute viruses, malware, or other harmful computer code
-- Attempt to gain unauthorized access to the Service or its related systems or networks
+- Use the Service for anything illegal
+- Violate anyone's rights, including intellectual property rights, or encourage others to
+- Post or distribute content that is unlawful, defamatory, or infringing
+- Distribute viruses, malware, or other harmful code
+- Try to gain unauthorized access to the Service or its systems
 
-## 6. Recording Consent
+## 6. Recording consent
 
-Anarlog can record meeting audio, which may include the voices of other participants. Laws on recording conversations vary by jurisdiction, and some require the consent of all participants. You are solely responsible for providing any required notice, obtaining any required consent from meeting participants, and otherwise complying with the laws that apply to your recordings. We are not responsible for your failure to do so.
+Anarlog can record meeting audio, which may include other people's voices. Recording laws differ by place, and some require everyone's consent. You are solely responsible for giving any required notice, getting any required consent from participants, and otherwise recording lawfully. We're not responsible if you don't.
 
-## 7. Intellectual Property
+## 7. Intellectual property
 
-The Anarlog source code is open source and licensed under the MIT License. Anarlog also includes and interoperates with third-party components that are licensed under their own terms. The Anarlog name, logo, and trademarks are owned by Fastrepl, Inc. The Anarlog cloud service and any proprietary components are protected by international copyright, trademark, patent, trade secret, and other intellectual property laws.
+The Anarlog source code is open source under the MIT License. Anarlog also includes and works with third-party components under their own licenses. The Anarlog name, logo, and trademarks belong to Fastrepl, Inc. The Anarlog cloud service and any proprietary components are protected by copyright, trademark, patent, trade secret, and other intellectual property laws.
 
-## 8. User Content
+## 8. Your content
 
-### 8.1 Ownership
+### 8.1 It's yours
 
-You retain all rights to the content you create, upload, or store using the Service ("User Content").
+You keep all rights to the content you create, upload, or store with Anarlog ("User Content").
 
-### 8.2 License
+### 8.2 The license you give us
 
-By uploading User Content to the Service's cloud features, you grant us a non-exclusive, worldwide, royalty-free license to use, store, and process your User Content solely for the purpose of providing the Service to you.
+When you send User Content to cloud features, you grant us a non-exclusive, worldwide, royalty-free license to use, store, and process it — solely to provide the Service to you.
 
-### 8.3 End-to-End Encrypted Sync
+### 8.3 End-to-end encrypted sync
 
-Content synced through Cloud Sync is end-to-end encrypted on your device using a recovery key that only you hold. We cannot read that content, and **we cannot recover it if you lose your recovery key**. You are responsible for keeping your recovery key safe.
+Content synced through Cloud Sync is end-to-end encrypted on your device with a recovery key only you hold. We can't read it, and **we can't recover it if you lose your recovery key**. Keep your recovery key safe.
 
-## 9. Communications and Marketing
+## 9. Communications
 
-By providing your email address to us — whether through account registration, download reminders, or any other form on our website — you consent to receive communications from us. These communications may include:
+By giving us your email address — through account registration, download reminders, or any form on our website — you consent to hear from us:
 
-- **Transactional messages:** Account confirmations, password resets, and service-related notices
-- **Product updates:** Information about new features, improvements, and releases
-- **Marketing communications:** Newsletters, promotional content, and other updates about Anarlog and related offerings
+- **Transactional messages:** account confirmations, password resets, service notices
+- **Product updates:** new features, improvements, releases
+- **Marketing:** newsletters, promotions, and other Anarlog news
 
-You may opt out of marketing communications at any time by clicking the "unsubscribe" link in any marketing email or by contacting us at hello@anarlog.so. Opting out of marketing communications will not affect transactional or service-related messages.
+Opt out of marketing anytime via the unsubscribe link in any marketing email, or by emailing founders@anarlog.so. Opting out doesn't affect transactional or service messages.
 
-## 10. Privacy and Third-Party Services
+## 10. Privacy and third-party services
 
-Your use of the Service is also governed by our [Privacy Policy](/privacy). Please review it to understand our practices.
+Your use of the Service is also governed by our [Privacy Policy](/privacy) — please read it.
 
-The Service may integrate with third-party services to provide certain features, including cloud-based transcription, AI-powered summarization, payment processing, and analytics. When you enable cloud-based features, your data may be processed by our sub-processors. You acknowledge and agree that your use of these features is subject to the terms and privacy practices of such third-party services.
+Some features rely on third-party services: cloud transcription, AI summaries, payments, analytics. When you enable cloud features, your data may be processed by our sub-processors, and those features are subject to the third parties' own terms and privacy practices.
 
 ## 11. Termination
 
-We may terminate or suspend your account and access to cloud features immediately, without prior notice or liability, for any reason, including if you breach these Terms. Your locally stored data and the open-source application itself are unaffected by termination.
+We may suspend or terminate your account and access to cloud features immediately, without notice, for any reason — including breaking these Terms. Your local data and the open-source app itself are unaffected.
 
 ## 12. Disclaimers
 
-THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+**The Service is provided "as is" and "as available," without warranties of any kind, express or implied — including implied warranties of merchantability, fitness for a particular purpose, and non-infringement.**
 
-Transcripts, summaries, and other AI-generated output are produced automatically and may be inaccurate, incomplete, or misattributed. You are responsible for reviewing AI output before relying on it or sharing it.
+Transcripts, summaries, and other AI-generated output are produced automatically and can be inaccurate, incomplete, or misattributed. Review AI output before you rely on it or share it.
 
-## 13. Limitation of Liability
+## 13. Limitation of liability
 
-TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL FASTREPL, INC., ITS AFFILIATES, DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING OUT OF OR RELATED TO YOUR USE OF THE SERVICE. TO THE MAXIMUM EXTENT PERMITTED BY LAW, OUR TOTAL AGGREGATE LIABILITY ARISING OUT OF OR RELATED TO THE SERVICE SHALL NOT EXCEED THE GREATER OF THE AMOUNTS YOU PAID US IN THE TWELVE MONTHS BEFORE THE CLAIM AROSE OR ONE HUNDRED U.S. DOLLARS ($100).
+**To the maximum extent the law allows: Fastrepl, Inc. and its affiliates, directors, employees, and agents are not liable for any indirect, incidental, special, consequential, or punitive damages arising out of or related to your use of the Service. Our total aggregate liability for all claims related to the Service is capped at the greater of what you paid us in the twelve months before the claim arose, or one hundred U.S. dollars ($100).**
 
 ## 14. Indemnification
 
-You agree to indemnify and hold harmless Fastrepl, Inc. and its officers, directors, employees, and agents from any claims, damages, liabilities, and expenses (including reasonable attorneys' fees) arising out of your User Content, your recordings, your violation of these Terms, or your violation of any law or third-party right.
+You agree to indemnify and hold harmless Fastrepl, Inc. and its officers, directors, employees, and agents from claims, damages, liabilities, and expenses (including reasonable attorneys' fees) arising out of your User Content, your recordings, your violation of these Terms, or your violation of any law or third-party right.
 
-## 15. Governing Law and Disputes
+## 15. Governing law and disputes
 
-These Terms are governed by the laws of the State of Delaware, without regard to its conflict-of-laws rules. Before filing a claim, you agree to try to resolve the dispute informally by contacting us at hello@anarlog.so and allowing 30 days for us to respond. Any dispute not resolved informally shall be brought exclusively in the state or federal courts located in Delaware, and both parties consent to their jurisdiction. If you are a consumer in a jurisdiction whose laws grant you mandatory rights or a different forum, nothing in this section limits those rights.
+These Terms are governed by the laws of the State of Delaware, without regard to its conflict-of-laws rules. Before filing a claim, contact us at founders@anarlog.so and give us 30 days to work it out informally. Any dispute we can't resolve that way must be brought exclusively in the state or federal courts in Delaware, and both of us consent to their jurisdiction. If you're a consumer somewhere whose laws give you mandatory rights or a different forum, nothing here limits those rights.
 
 ## 16. General
 
-If any provision of these Terms is found unenforceable, the remaining provisions remain in full effect. These Terms, together with the Privacy Policy, are the entire agreement between you and us regarding the Service. You may not assign these Terms without our prior written consent; we may assign them in connection with a merger, acquisition, or sale of assets. Our failure to enforce any provision is not a waiver of it.
+If part of these Terms turns out to be unenforceable, the rest still stands. These Terms plus the Privacy Policy are the entire agreement between you and us about the Service. You can't assign these Terms without our written consent; we may assign them in a merger, acquisition, or sale of assets. If we don't enforce a provision, that's not a waiver.
 
-## 17. Changes to Terms
+## 17. Changes to these terms
 
-We reserve the right to modify these Terms at any time. We will notify you of any changes by posting the new Terms on this page and updating the date above. Material changes to these Terms will be effective upon posting or a later stated date.
+We may update these Terms. We'll post the new version here and update the date above; material changes take effect when posted or on a later stated date.
 
-## 18. Contact Us
+## 18. Contact us
 
-If you have any questions about these Terms, please contact us at:
+Questions about these terms? Email us at [founders@anarlog.so](mailto:founders@anarlog.so).
 
 **Fastrepl, Inc.**
-Email: hello@anarlog.so

--- a/apps/web/content/legal/terms.mdx
+++ b/apps/web/content/legal/terms.mdx
@@ -1,12 +1,12 @@
 ---
-date: "2026-05-03"
+date: "2026-08-01"
 title: "Terms of Service"
 summary: "Terms and conditions for using Anarlog"
 ---
 
 ## 1. Agreement to Terms
 
-By accessing or using Anarlog ("the Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you may not access or use the Service.
+By accessing or using Anarlog ("the Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you may not access or use the Service. You must be at least 13 years old and legally capable of entering into these Terms to use the Service.
 
 ## 2. Description of Service
 
@@ -14,11 +14,11 @@ Anarlog is an open-source note-taking and meeting transcription application. It 
 
 ### 2.1 Local-First Architecture
 
-Anarlog is designed as a local-first application. Your canonical notes, transcripts, and meeting data are stored locally on your device in SQLite; attachments and recordings are stored as local files. You can export Markdown and other formats. You can run Anarlog completely offline with local transcription and a local language model (for example, via LM Studio or Ollama). Cloud-based features — such as cloud transcription, AI summarization, CloudSync, and sharing — are optional and require an internet connection.
+Anarlog is designed as a local-first application. Your canonical notes, transcripts, and meeting data are stored locally on your device in SQLite; attachments and recordings are stored as local files. You can export Markdown and other formats. You can run Anarlog completely offline with local transcription and a local language model (for example, via LM Studio or Ollama). Cloud-based features — such as cloud transcription, AI summarization, Cloud Sync, sharing, and the Cloud API — are optional and require an internet connection.
 
 ### 2.2 Account and Cloud Features
 
-You can use Anarlog without an account by running it in fully local mode. If you want to use cloud-powered transcription and summarization, an account is created during onboarding so you can experience the full product. If you no longer wish to maintain an account, you can request account deletion at any time (see Section 3.3).
+You can use Anarlog without an account by running it in fully local mode. Creating an account is offered during onboarding and is required only for cloud-powered features such as cloud transcription and summarization. If you no longer wish to maintain an account, you can delete it at any time (see Section 3.3).
 
 ## 3. User Accounts
 
@@ -32,9 +32,20 @@ You are responsible for maintaining the confidentiality of your account credenti
 
 ### 3.3 Account Deletion
 
-You may request deletion of your account at any time by contacting us at hello@anarlog.so. Upon account deletion, your cloud-stored data will be removed within 30 days. Your locally stored data remains on your device and is not affected by account deletion. After deleting your account, Anarlog will continue to function with local-only features.
+You may delete your account at any time from the Account page in the web app (`anarlog.so/app/account`) or by contacting us at hello@anarlog.so. Upon account deletion, your cloud-stored data will be removed within 30 days. Your locally stored data remains on your device and is not affected by account deletion. After deleting your account, Anarlog will continue to function with local-only features.
 
-## 4. Acceptable Use
+## 4. Subscriptions, Trials, and Payment
+
+Anarlog is free and open source. Optional cloud features require a paid subscription ("Anarlog Pro").
+
+- **Billing and renewal.** Subscriptions are billed in advance on a monthly or yearly basis and renew automatically at the end of each billing period until canceled. You authorize our payment processor to charge your payment method for each renewal.
+- **Cancellation.** You can cancel at any time from the billing portal linked in the app's account settings. Cancellation takes effect at the end of the current billing period, and you keep access to paid features until then.
+- **Free trials.** We may offer a free trial of paid features for the period presented when you start it. Trials do not require a payment method, and we do not charge you automatically when a trial ends; paid features simply stop until you subscribe.
+- **Price changes.** We may change subscription prices with at least 30 days' notice before the change applies to you; continued use after renewal constitutes acceptance of the new price.
+- **Refunds.** Except where required by applicable law, fees are non-refundable.
+- **Taxes.** Fees exclude taxes, which you are responsible for where applicable.
+
+## 5. Acceptable Use
 
 You agree not to:
 
@@ -44,27 +55,31 @@ You agree not to:
 - Distribute viruses, malware, or other harmful computer code
 - Attempt to gain unauthorized access to the Service or its related systems or networks
 
-## 5. Intellectual Property
+## 6. Recording Consent
 
-The Anarlog source code is open source and licensed under the MIT License. The Anarlog name, logo, and trademarks are owned by Fastrepl, Inc. The Anarlog cloud service and any proprietary components are protected by international copyright, trademark, patent, trade secret, and other intellectual property laws.
+Anarlog can record meeting audio, which may include the voices of other participants. Laws on recording conversations vary by jurisdiction, and some require the consent of all participants. You are solely responsible for providing any required notice, obtaining any required consent from meeting participants, and otherwise complying with the laws that apply to your recordings. We are not responsible for your failure to do so.
 
-## 6. User Content
+## 7. Intellectual Property
 
-### 6.1 Ownership
+The Anarlog source code is open source and licensed under the MIT License. Anarlog also includes and interoperates with third-party components that are licensed under their own terms. The Anarlog name, logo, and trademarks are owned by Fastrepl, Inc. The Anarlog cloud service and any proprietary components are protected by international copyright, trademark, patent, trade secret, and other intellectual property laws.
+
+## 8. User Content
+
+### 8.1 Ownership
 
 You retain all rights to the content you create, upload, or store using the Service ("User Content").
 
-### 6.2 License
+### 8.2 License
 
 By uploading User Content to the Service's cloud features, you grant us a non-exclusive, worldwide, royalty-free license to use, store, and process your User Content solely for the purpose of providing the Service to you.
 
-## 7. Payment Terms
+### 8.3 End-to-End Encrypted Sync
 
-Anarlog is free and open source. Optional cloud features may require payment. You agree to pay all fees associated with your use of paid features. All fees are non-refundable unless otherwise specified.
+Content synced through Cloud Sync is end-to-end encrypted on your device using a recovery key that only you hold. We cannot read that content, and **we cannot recover it if you lose your recovery key**. You are responsible for keeping your recovery key safe.
 
-## 8. Communications and Marketing
+## 9. Communications and Marketing
 
-By providing your email address to us — whether through account registration, waitlist sign-ups, download reminders, or any other form on our website — you consent to receive communications from us. These communications may include:
+By providing your email address to us — whether through account registration, download reminders, or any other form on our website — you consent to receive communications from us. These communications may include:
 
 - **Transactional messages:** Account confirmations, password resets, and service-related notices
 - **Product updates:** Information about new features, improvements, and releases
@@ -72,29 +87,43 @@ By providing your email address to us — whether through account registration, 
 
 You may opt out of marketing communications at any time by clicking the "unsubscribe" link in any marketing email or by contacting us at hello@anarlog.so. Opting out of marketing communications will not affect transactional or service-related messages.
 
-## 9. Privacy and Third-Party Services
+## 10. Privacy and Third-Party Services
 
 Your use of the Service is also governed by our [Privacy Policy](/privacy). Please review it to understand our practices.
 
 The Service may integrate with third-party services to provide certain features, including cloud-based transcription, AI-powered summarization, payment processing, and analytics. When you enable cloud-based features, your data may be processed by our sub-processors. You acknowledge and agree that your use of these features is subject to the terms and privacy practices of such third-party services.
 
-## 10. Termination
+## 11. Termination
 
 We may terminate or suspend your account and access to cloud features immediately, without prior notice or liability, for any reason, including if you breach these Terms. Your locally stored data and the open-source application itself are unaffected by termination.
 
-## 11. Disclaimers
+## 12. Disclaimers
 
 THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
 
-## 12. Limitation of Liability
+Transcripts, summaries, and other AI-generated output are produced automatically and may be inaccurate, incomplete, or misattributed. You are responsible for reviewing AI output before relying on it or sharing it.
 
-TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL FASTREPL, INC., ITS AFFILIATES, DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING OUT OF OR RELATED TO YOUR USE OF THE SERVICE.
+## 13. Limitation of Liability
 
-## 13. Changes to Terms
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL FASTREPL, INC., ITS AFFILIATES, DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING OUT OF OR RELATED TO YOUR USE OF THE SERVICE. TO THE MAXIMUM EXTENT PERMITTED BY LAW, OUR TOTAL AGGREGATE LIABILITY ARISING OUT OF OR RELATED TO THE SERVICE SHALL NOT EXCEED THE GREATER OF THE AMOUNTS YOU PAID US IN THE TWELVE MONTHS BEFORE THE CLAIM AROSE OR ONE HUNDRED U.S. DOLLARS ($100).
 
-We reserve the right to modify these Terms at any time. We will notify you of any changes by posting the new Terms on this page and updating the date above.
+## 14. Indemnification
 
-## 14. Contact Us
+You agree to indemnify and hold harmless Fastrepl, Inc. and its officers, directors, employees, and agents from any claims, damages, liabilities, and expenses (including reasonable attorneys' fees) arising out of your User Content, your recordings, your violation of these Terms, or your violation of any law or third-party right.
+
+## 15. Governing Law and Disputes
+
+These Terms are governed by the laws of the State of Delaware, without regard to its conflict-of-laws rules. Before filing a claim, you agree to try to resolve the dispute informally by contacting us at hello@anarlog.so and allowing 30 days for us to respond. Any dispute not resolved informally shall be brought exclusively in the state or federal courts located in Delaware, and both parties consent to their jurisdiction. If you are a consumer in a jurisdiction whose laws grant you mandatory rights or a different forum, nothing in this section limits those rights.
+
+## 16. General
+
+If any provision of these Terms is found unenforceable, the remaining provisions remain in full effect. These Terms, together with the Privacy Policy, are the entire agreement between you and us regarding the Service. You may not assign these Terms without our prior written consent; we may assign them in connection with a merger, acquisition, or sale of assets. Our failure to enforce any provision is not a waiver of it.
+
+## 17. Changes to Terms
+
+We reserve the right to modify these Terms at any time. We will notify you of any changes by posting the new Terms on this page and updating the date above. Material changes to these Terms will be effective upon posting or a later stated date.
+
+## 18. Contact Us
 
 If you have any questions about these Terms, please contact us at:
 

--- a/apps/web/src/components/legal-document.tsx
+++ b/apps/web/src/components/legal-document.tsx
@@ -2,6 +2,8 @@ import { MDXContent } from "@content-collections/mdx/react";
 import { Link } from "@tanstack/react-router";
 import type { Legal } from "content-collections";
 
+import { cn } from "@anlg/utils";
+
 import { ANARLOG_SITE_URL } from "@/lib/seo";
 
 import { mdxComponents } from "./mdx-components";
@@ -23,31 +25,50 @@ export function legalHead(doc: Legal, path: "/privacy" | "/terms") {
 
 export function LegalDocument({ doc }: { doc: Legal }) {
   return (
-    <main className="mx-auto max-w-3xl px-6 py-16">
-      <Link
-        to="/"
-        className="mb-8 inline-block text-sm text-neutral-500 hover:text-neutral-800"
-      >
-        ← Home
-      </Link>
+    <main className="min-h-screen bg-white text-[#181613]">
+      <div className="mx-auto w-full max-w-[700px] px-5 py-14 md:px-8 md:py-16">
+        <Link
+          to="/"
+          className="mb-10 inline-block text-sm text-[#756b5d] transition-colors hover:text-[#181613]"
+        >
+          ← Home
+        </Link>
 
-      <header className="mb-10">
-        <h1 className="mb-2 font-mono text-3xl leading-tight text-stone-800 sm:text-4xl">
-          {doc.title}
-        </h1>
-        <time dateTime={doc.date} className="text-sm text-neutral-500">
-          Last updated{" "}
-          {new Date(doc.date).toLocaleDateString("en-US", {
-            month: "long",
-            day: "numeric",
-            year: "numeric",
-          })}
-        </time>
-      </header>
+        <header className="mb-10">
+          <h1 className="font-hand text-5xl leading-none font-semibold text-[#181613]">
+            {doc.title}
+          </h1>
+          {doc.summary ? (
+            <p className="mt-5 max-w-2xl text-lg leading-8 text-[#4f4940]">
+              {doc.summary}
+            </p>
+          ) : null}
+          <time
+            dateTime={doc.date}
+            className="mt-3 block text-sm text-[#756b5d]"
+          >
+            Last updated{" "}
+            {new Date(doc.date).toLocaleDateString("en-US", {
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+            })}
+          </time>
+        </header>
 
-      <article className="prose prose-stone prose-headings:font-mono prose-headings:text-stone-800 prose-a:text-stone-800 prose-a:underline hover:prose-a:text-stone-600 max-w-none">
-        <MDXContent code={doc.mdx} components={mdxComponents} />
-      </article>
+        <article
+          className={cn([
+            "prose prose-lg prose-stone max-w-none",
+            "prose-headings:font-hand prose-headings:font-semibold prose-headings:text-[#181613] prose-h2:text-4xl prose-h3:text-2xl",
+            "prose-p:text-[#4f4940] prose-li:text-[#4f4940] prose-strong:text-[#181613]",
+            "prose-a:text-[#181613] prose-a:underline hover:prose-a:text-[#4f4940]",
+            "prose-blockquote:rounded-[3px] prose-blockquote:border prose-blockquote:border-[#eadfce] prose-blockquote:bg-[#fffaf0] prose-blockquote:px-6 prose-blockquote:py-1 prose-blockquote:font-normal prose-blockquote:not-italic prose-blockquote:text-[#363029] prose-blockquote:shadow-[0_18px_50px_rgba(68,54,36,0.08)]",
+            "[&_blockquote_p]:before:content-none [&_blockquote_p]:after:content-none",
+          ])}
+        >
+          <MDXContent code={doc.mdx} components={mdxComponents} />
+        </article>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/components/web-providers.tsx
+++ b/apps/web/src/components/web-providers.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { useMountEffect } from "@/hooks/useMountEffect";
 import { isTelemetryPrivateLocation } from "@/lib/auth-route-privacy";
+import { hasGlobalPrivacyControl } from "@/lib/global-privacy-control";
 import { PostHogProvider } from "@/providers/posthog";
 import { bootstrapBrowserTelemetry, stopBrowserTelemetry } from "@/telemetry";
 
@@ -29,6 +30,7 @@ function GoogleAnalyticsScript() {
     if (
       typeof document === "undefined" ||
       import.meta.env.DEV ||
+      hasGlobalPrivacyControl() ||
       window.location.pathname.startsWith("/admin") ||
       isTelemetryPrivateLocation(
         window.location.pathname,
@@ -71,6 +73,7 @@ function MicrosoftClarityScript() {
     if (
       typeof document === "undefined" ||
       import.meta.env.DEV ||
+      hasGlobalPrivacyControl() ||
       window.location.pathname.startsWith("/admin") ||
       isTelemetryPrivateLocation(
         window.location.pathname,

--- a/apps/web/src/lib/global-privacy-control.ts
+++ b/apps/web/src/lib/global-privacy-control.ts
@@ -1,0 +1,7 @@
+export function hasGlobalPrivacyControl(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    (navigator as Navigator & { globalPrivacyControl?: boolean })
+      .globalPrivacyControl === true
+  );
+}

--- a/apps/web/src/lib/private-route-analytics.ts
+++ b/apps/web/src/lib/private-route-analytics.ts
@@ -1,4 +1,5 @@
 import { env } from "@/env";
+import { hasGlobalPrivacyControl } from "@/lib/global-privacy-control";
 
 const PRIVATE_ANALYTICS_ID_KEY = "anarlog.private-analytics-id";
 let fallbackDistinctId: string | null = null;
@@ -25,8 +26,7 @@ export function capturePrivateRouteEvent(
     typeof window === "undefined" ||
     import.meta.env.DEV ||
     !env.VITE_POSTHOG_API_KEY ||
-    (navigator as Navigator & { globalPrivacyControl?: boolean })
-      .globalPrivacyControl === true
+    hasGlobalPrivacyControl()
   ) {
     return;
   }

--- a/apps/web/src/providers/posthog.tsx
+++ b/apps/web/src/providers/posthog.tsx
@@ -11,6 +11,7 @@ import {
 
 import { env } from "../env";
 import { isTelemetryPrivateLocation } from "../lib/auth-route-privacy";
+import { hasGlobalPrivacyControl } from "../lib/global-privacy-control";
 
 const isDev = import.meta.env.DEV;
 
@@ -40,10 +41,7 @@ export function PostHogProvider({
   const routeDisabledRef = useRef(false);
   const pendingOperationsRef = useRef<PendingAnalyticsOperation[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
-  const globalPrivacyControl =
-    typeof navigator !== "undefined" &&
-    (navigator as Navigator & { globalPrivacyControl?: boolean })
-      .globalPrivacyControl === true;
+  const globalPrivacyControl = hasGlobalPrivacyControl();
   const analyticsAvailable =
     typeof window !== "undefined" &&
     Boolean(env.VITE_POSTHOG_API_KEY) &&

--- a/apps/web/src/telemetry.ts
+++ b/apps/web/src/telemetry.ts
@@ -3,6 +3,7 @@ import { getWebAutoInstrumentations } from "@opentelemetry/auto-instrumentations
 
 import { env } from "./env";
 import { isTelemetryPrivateLocation } from "./lib/auth-route-privacy";
+import { hasGlobalPrivacyControl } from "./lib/global-privacy-control";
 
 declare global {
   interface Window {
@@ -79,6 +80,7 @@ function getPropagationTargets(): string[] {
 export function bootstrapBrowserTelemetry() {
   if (
     typeof window === "undefined" ||
+    hasGlobalPrivacyControl() ||
     isTelemetryPrivateLocation(window.location.pathname, window.location.search)
   ) {
     return;

--- a/docs/calendar.mdx
+++ b/docs/calendar.mdx
@@ -55,7 +55,7 @@ To permanently remove calendar-derived data retained on a Mac, you currently nee
    - `~/Library/Application Support/com.hyprnote.stable`
 4. Empty Trash before reopening Anarlog.
 
-This removes Anarlog's local database and settings on that Mac, including cached calendar data and event context stored with local records. It can also remove other Anarlog data stored in those folders. It does not delete files you exported or copies you chose to sync or share. You can request deletion of your Anarlog account and cloud-stored data at [hello@anarlog.so](mailto:hello@anarlog.so). Contact us before deleting anything if you need help identifying the correct folder.
+This removes Anarlog's local database and settings on that Mac, including cached calendar data and event context stored with local records. It can also remove other Anarlog data stored in those folders. It does not delete files you exported or copies you chose to sync or share. You can request deletion of your Anarlog account and cloud-stored data at [founders@anarlog.so](mailto:founders@anarlog.so). Contact us before deleting anything if you need help identifying the correct folder.
 
 <Note>
   Google and Outlook connections are included with Anarlog Pro. Apple Calendar uses the calendar accounts already connected to your Mac.

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -46,7 +46,7 @@ Deleting retained audio does not remove the meeting note or transcript. If you n
 
 ## Turn off usage analytics
 
-Open **Settings → App** and disable **Share usage data**. This controls anonymous product analytics, not the meeting content sent to a provider you selected.
+Open **Settings → App** and disable **Share usage data**. This controls product analytics and desktop session replay, not the meeting content sent to a provider you selected.
 
 <Warning>
   Recording-consent rules depend on where you and the other participants are located. Make sure you have permission before recording.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -88,7 +88,7 @@
     "links": [
       {
         "label": "Support",
-        "href": "mailto:hello@anarlog.so"
+        "href": "mailto:founders@anarlog.so"
       }
     ],
     "primary": {

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -30,4 +30,4 @@ description: "Find the right guide for the questions people ask most often about
   </Card>
 </CardGroup>
 
-If something is not working, go to [Troubleshooting](/troubleshooting). For a question not covered here, email [hello@anarlog.so](mailto:hello@anarlog.so) or [join Discord](https://anarlog.so/discord).
+If something is not working, go to [Troubleshooting](/troubleshooting). For a question not covered here, email [founders@anarlog.so](mailto:founders@anarlog.so) or [join Discord](https://anarlog.so/discord).

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -44,6 +44,6 @@ For audio, confirm that a Transcription model is selected and that a local provi
 
 ## Get more help
 
-Email [hello@anarlog.so](mailto:hello@anarlog.so), [join Discord](https://anarlog.so/discord), or [open a GitHub issue](https://github.com/fastrepl/anarlog/issues).
+Email [founders@anarlog.so](mailto:founders@anarlog.so), [join Discord](https://anarlog.so/discord), or [open a GitHub issue](https://github.com/fastrepl/anarlog/issues).
 
 For CLI and MCP errors, use the [error reference](/reference/errors).


### PR DESCRIPTION
Update the privacy policy and terms to match shipped product behavior, honor Global Privacy Control across website analytics, gate desktop session replay on consent, and bring the legal pages in line with the site design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch consent-gated telemetry and Sentry replay lifecycle (including internal `_replay.stop`), so regressions could affect privacy compliance or multi-webview behavior; legal copy is substantive but not executable code.
> 
> **Overview**
> **Desktop telemetry:** Sentry session replay is no longer registered at init. It attaches only when analytics are enabled (`isDisabled`), listens for `anlg:session-replay-disabled` across webviews, and `disableSessionReplay()` stops replay without flushing buffered segments then broadcasts that event. Turning **Share usage data** off persists via `setDisabled` and then calls `disableSessionReplay()` in a `finally` block.
> 
> **Web privacy:** Adds `hasGlobalPrivacyControl()` and skips Google Analytics, Microsoft Clarity, PostHog, Honeycomb OTEL, and private-route capture when GPC is set.
> 
> **Legal & docs:** Rewrites **Privacy Policy** and **Terms** (local-first, cloud features, E2E sync vs sharing/API, trials/billing, masked desktop replay tied to the setting, GPC, regional rights) and refreshes the legal page layout (summary, typography, blockquotes). Docs and support links move contact email to `founders@anarlog.so`; data-and-privacy notes that opting out stops session replay too.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 410eb16f48a847f6bd4e57e1450db16fd8abc85d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->