### PR TITLE
docs: tighten API key and error envelope wording

### DIFF
--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -17,9 +17,9 @@ curl -H "Authorization: Bearer anl_..." http://127.0.0.1:33443/v1/meetings
 
 ## Authentication
 
-Send the key as a bearer token: `Authorization: Bearer anl_...`. Keys are shown once at creation and stored hashed. Requests without a valid key receive `401` with an error body.
+Send the key as a bearer token: `Authorization: Bearer anl_...`. Keys are shown once and stored hashed. Requests without a valid key receive `401`.
 
-Errors always look like:
+Errors returned by Anarlog's endpoint handlers use this envelope:
 
 ```json
 { "error": { "code": "not_found", "message": "meeting 'x' not found" } }


### PR DESCRIPTION
Drop the claim that 401 responses carry an error body and scope the
error-envelope example to Anarlog's endpoint handlers, so the reference
matches actual API behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **local API reference** so auth and error documentation match real behavior instead of overstating guarantees.
> 
> For authentication, invalid keys are described as returning **`401` only**—the doc no longer claims those responses include the JSON error body. API key copy is slightly tightened (“shown once” without “at creation”).
> 
> For errors, the JSON `{ "error": { "code", "message" } }` example is explicitly scoped to responses from **Anarlog’s endpoint handlers**, aligning with the existing note that malformed JSON can yield a plain-text **`400`** before a handler runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e30aca5b693691fd9d41cc4f74763ba32bca3bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->