### PR TITLE
Enable Backspace for selected notes

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -20,6 +20,13 @@ const mocks = vi.hoisted(() => ({
   isIgnored: vi.fn(() => false),
   liveSessionId: null as string | null,
   liveStatus: "inactive" as "inactive" | "active" | "finalizing",
+  nativeContextMenuItems: [] as Array<{
+    id?: string;
+    text?: string;
+    accelerator?: string;
+    action?: () => void;
+    disabled?: boolean;
+  }>,
   selectAll: vi.fn(),
   smartCurrentTimeMs: undefined as number | undefined,
   timelineSelectionAnchorId: null as string | null,
@@ -128,7 +135,10 @@ vi.mock("~/session/hooks/useDeleteSession", () => ({
 }));
 
 vi.mock("~/shared/hooks/useNativeContextMenu", () => ({
-  useNativeContextMenu: () => vi.fn(),
+  useNativeContextMenu: (items: typeof mocks.nativeContextMenuItems) => {
+    mocks.nativeContextMenuItems = items;
+    return vi.fn();
+  },
 }));
 
 vi.mock("~/calendar/ignored-events", () => ({
@@ -244,6 +254,7 @@ describe("TimelineView", () => {
     mocks.liveSessionId = null;
     mocks.liveStatus = "inactive";
     mocks.currentTab = { type: "empty" };
+    mocks.nativeContextMenuItems = [];
     mocks.selectAll.mockClear();
     mocks.smartCurrentTimeMs = undefined;
     mocks.timelineSelectionAnchorId = null;
@@ -529,6 +540,85 @@ describe("TimelineView", () => {
       "session-selected-note",
       "session-other-note",
     ]);
+  });
+
+  it("deletes selected notes with Backspace", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T09:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.timelineSelectionSelectedIds = [
+      "session-selected-note",
+      "session-other-note",
+    ];
+    mocks.timelineSessionsTable = {
+      "selected-note": {
+        title: "Selected note",
+        created_at: "2024-01-15T12:00:00.000Z",
+      },
+      "other-note": {
+        title: "Other note",
+        created_at: "2024-01-15T11:00:00.000Z",
+      },
+    };
+
+    render(<TimelineView />);
+
+    fireEvent.keyDown(window, { key: "Backspace" });
+
+    expect(mocks.deleteSession).toHaveBeenCalledTimes(2);
+    expect(mocks.deleteSession).toHaveBeenCalledWith("selected-note", {
+      batchId: expect.any(String),
+      title: "Selected note",
+    });
+    expect(mocks.deleteSession).toHaveBeenCalledWith("other-note", {
+      batchId: expect.any(String),
+      title: "Other note",
+    });
+    expect(mocks.deleteSession.mock.calls[0]![1].batchId).toBe(
+      mocks.deleteSession.mock.calls[1]![1].batchId,
+    );
+    expect(mocks.clearSelection).toHaveBeenCalledOnce();
+  });
+
+  it("shows Backspace beside Delete Selected in the context menu", () => {
+    mocks.timelineSelectionSelectedIds = [
+      "session-selected-note",
+      "session-other-note",
+    ];
+
+    render(<TimelineView />);
+
+    expect(
+      mocks.nativeContextMenuItems.find(
+        (item) => item.id === "delete-selected",
+      ),
+    ).toMatchObject({
+      text: "Delete Selected (2)",
+      accelerator: "Backspace",
+      disabled: false,
+    });
+  });
+
+  it("does not delete selected notes when Backspace starts in the editor", () => {
+    mocks.timelineSelectionSelectedIds = [
+      "session-selected-note",
+      "session-other-note",
+    ];
+
+    render(<TimelineView />);
+
+    const editor = document.createElement("div");
+    editor.className = "ProseMirror";
+    editor.contentEditable = "true";
+    editor.tabIndex = 0;
+    document.body.appendChild(editor);
+    editor.focus();
+
+    fireEvent.keyDown(editor, { key: "Backspace" });
+
+    expect(mocks.deleteSession).not.toHaveBeenCalled();
+
+    editor.remove();
   });
 
   it("does not select sidebar notes while the mounted timeline is hidden", () => {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -19,6 +19,7 @@ import { TimelineNowChip, TimelineTopChip, UpcomingMeetingChip } from "./chips";
 import { getFallbackIndicatorIndex, useTimelineData } from "./data";
 import {
   hasSidebarNoteSelectionContext,
+  isDeleteSelectionShortcut,
   isSelectAllShortcut,
   isSessionItemKey,
   isTextEditingShortcutTarget,
@@ -140,6 +141,28 @@ export const TimelineView = memo(function TimelineView({
   const clearSelection = useTimelineSelection((s) => s.clear);
   const deleteSession = useDeleteSession();
 
+  const handleDeleteSelected = useCallback(() => {
+    const sessionIds = selectedIds
+      .filter(isSessionItemKey)
+      .map((key) => key.replace("session-", ""));
+
+    const batchId = sessionIds.length > 1 ? crypto.randomUUID() : undefined;
+
+    for (const sessionId of sessionIds) {
+      deleteSession(sessionId, {
+        batchId,
+        title: timelineSessionsTable?.[sessionId]?.title ?? undefined,
+      });
+    }
+
+    clearSelection();
+  }, [selectedIds, deleteSession, clearSelection, timelineSessionsTable]);
+
+  const sessionCount = useMemo(
+    () => selectedIds.filter(isSessionItemKey).length,
+    [selectedIds],
+  );
+
   const flatItemKeys = useMemo(() => {
     const keys: string[] = [];
     for (const bucket of buckets) {
@@ -156,16 +179,18 @@ export const TimelineView = memo(function TimelineView({
     () => flatItemKeys.filter(isSessionItemKey),
     [flatItemKeys],
   );
-  const selectAllShortcutStateRef = useRef({
+  const shortcutStateRef = useRef({
     anchorId,
     flatSessionItemKeys,
+    handleDeleteSelected,
     selectedIds,
     selectedSessionId,
     selectAll,
   });
-  selectAllShortcutStateRef.current = {
+  shortcutStateRef.current = {
     anchorId,
     flatSessionItemKeys,
+    handleDeleteSelected,
     selectedIds,
     selectedSessionId,
     selectAll,
@@ -287,7 +312,6 @@ export const TimelineView = memo(function TimelineView({
         !container ||
         container.closest("[inert], [aria-hidden='true']") ||
         event.defaultPrevented ||
-        !isSelectAllShortcut(event) ||
         isTextEditingShortcutTarget(event.target) ||
         isTextEditingShortcutTarget(document.activeElement)
       ) {
@@ -297,25 +321,38 @@ export const TimelineView = memo(function TimelineView({
       const {
         anchorId,
         flatSessionItemKeys,
+        handleDeleteSelected,
         selectedIds,
         selectedSessionId,
         selectAll,
-      } = selectAllShortcutStateRef.current;
+      } = shortcutStateRef.current;
 
-      if (
-        !selectedSessionId ||
-        flatSessionItemKeys.length === 0 ||
-        !hasSidebarNoteSelectionContext({
-          anchorId,
-          selectedIds,
-          selectedSessionId,
-        })
-      ) {
+      if (isDeleteSelectionShortcut(event)) {
+        if (!selectedIds.some(isSessionItemKey)) {
+          return;
+        }
+
+        event.preventDefault();
+        handleDeleteSelected();
         return;
       }
 
-      event.preventDefault();
-      selectAll(flatSessionItemKeys);
+      if (isSelectAllShortcut(event)) {
+        if (
+          !selectedSessionId ||
+          flatSessionItemKeys.length === 0 ||
+          !hasSidebarNoteSelectionContext({
+            anchorId,
+            selectedIds,
+            selectedSessionId,
+          })
+        ) {
+          return;
+        }
+
+        event.preventDefault();
+        selectAll(flatSessionItemKeys);
+      }
     };
 
     window.addEventListener("keydown", handleKeyDown, { capture: true });
@@ -346,28 +383,6 @@ export const TimelineView = memo(function TimelineView({
     openNew({ type: "calendar" });
   }, [openNew]);
 
-  const handleDeleteSelected = useCallback(() => {
-    const sessionIds = selectedIds
-      .filter((key) => key.startsWith("session-"))
-      .map((key) => key.replace("session-", ""));
-
-    const batchId = sessionIds.length > 1 ? crypto.randomUUID() : undefined;
-
-    for (const sessionId of sessionIds) {
-      deleteSession(sessionId, {
-        batchId,
-        title: timelineSessionsTable?.[sessionId]?.title ?? undefined,
-      });
-    }
-
-    clearSelection();
-  }, [selectedIds, deleteSession, clearSelection, timelineSessionsTable]);
-
-  const sessionCount = useMemo(
-    () => selectedIds.filter((key) => key.startsWith("session-")).length,
-    [selectedIds],
-  );
-
   const contextMenuItems = useMemo(
     () =>
       selectedIds.length > 0
@@ -376,6 +391,7 @@ export const TimelineView = memo(function TimelineView({
               id: "delete-selected",
               text: t`Delete Selected (${sessionCount})`,
               action: handleDeleteSelected,
+              accelerator: "Backspace",
               disabled: sessionCount === 0,
             },
           ]

--- a/apps/desktop/src/sidebar/timeline/interaction.ts
+++ b/apps/desktop/src/sidebar/timeline/interaction.ts
@@ -7,6 +7,16 @@ export function isSelectAllShortcut(event: KeyboardEvent) {
   );
 }
 
+export function isDeleteSelectionShortcut(event: KeyboardEvent) {
+  return (
+    event.key === "Backspace" &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey
+  );
+}
+
 export function isSessionItemKey(key: string) {
   return key.startsWith("session-");
 }


### PR DESCRIPTION
Wire the sidebar selection shortcut to batched deletion and show Backspace in the context menu.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a global destructive shortcut for note deletion, though it reuses existing soft-delete/undo plumbing and skips when typing in editors.
> 
> **Overview**
> Adds **Backspace** as a keyboard shortcut to delete the currently selected sidebar timeline notes, using the same batched `deleteSession` flow as the context menu and clearing selection afterward.
> 
> The timeline’s global key handler now treats delete separately from **Cmd/Ctrl+A**: it runs only when at least one selected item is a session note, respects hidden/inert timelines and text-editing targets (including ProseMirror), and **prevents default** so Backspace doesn’t navigate backward. The **Delete Selected** context menu item now shows **Backspace** as its accelerator.
> 
> `handleDeleteSelected` / session counting were moved up and session keys are filtered via `isDeleteSelectionShortcut` and `isSessionItemKey` in `interaction.ts`. Tests cover multi-note batch deletion, the menu accelerator, and no delete when focus is in the editor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e250ada2eeeddd9e76bf4edfe9907aca411ee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->