### PR TITLE
Preserve stereo identity in cloud batch refinement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20474,6 +20474,7 @@ dependencies = [
  "codes-iso-639",
  "data",
  "futures-util",
+ "hound",
  "insta",
  "itertools 0.14.0",
  "language",

--- a/apps/api/openapi.gen.json
+++ b/apps/api/openapi.gen.json
@@ -1512,6 +1512,28 @@
             }
           },
           {
+            "name": "sample_rate",
+            "in": "query",
+            "description": "Audio sample rate in Hz (default: 16000)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "channels",
+            "in": "query",
+            "description": "Number of audio channels (default: 1)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
             "name": "callback",
             "in": "query",
             "description": "When set, enables async callback mode. Body should be JSON with a `url` field instead of raw audio",

--- a/apps/desktop/src/stt/queries.test.tsx
+++ b/apps/desktop/src/stt/queries.test.tsx
@@ -290,7 +290,7 @@ describe("transcript SQLite queries", () => {
     expect(statements[0]?.sql).not.toContain("UPDATE transcripts");
   });
 
-  it("replaces only the current partial capture in the insert transaction", async () => {
+  it("atomically replaces the live capture without a visible duplicate", async () => {
     await createTranscript({
       id: "transcript-new",
       sessionId: "session-1",
@@ -304,6 +304,7 @@ describe("transcript SQLite queries", () => {
       sql: string;
       params: unknown[];
     }>;
+    expect(mocks.executeTransaction).toHaveBeenCalledOnce();
     expect(statements).toHaveLength(2);
     expect(statements[0]?.sql).toContain("UPDATE transcripts");
     expect(statements[0]?.sql).toContain(

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -619,7 +619,7 @@ describe("useRunBatch", () => {
     expect(createTranscriptMock).not.toHaveBeenCalled();
   });
 
-  test("appends only the current capture when prior transcript audio is partial", async () => {
+  test("promotes post-stop batch by replacing the live current capture", async () => {
     startTranscriptionMock.mockImplementation(async (_params, options) => {
       options.handlePersist(
         [
@@ -659,6 +659,7 @@ describe("useRunBatch", () => {
       });
     });
 
+    expect(createTranscriptMock).toHaveBeenCalledOnce();
     expect(createTranscriptMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replaceSession: false,

--- a/crates/owhisper-client/src/adapter/anarlog/batch.rs
+++ b/crates/owhisper-client/src/adapter/anarlog/batch.rs
@@ -50,6 +50,8 @@ async fn do_transcribe_file(
         if let Some(model) = &params.model {
             q.append_pair("model", model);
         }
+        q.append_pair("channels", &params.channels.to_string());
+        q.append_pair("sample_rate", &params.sample_rate.to_string());
         for lang in &params.languages {
             q.append_pair("language", &lang.to_string());
         }
@@ -92,5 +94,44 @@ async fn do_transcribe_file(
             status,
             body: response.text().await.unwrap_or_default(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::http_client::create_client;
+
+    #[tokio::test]
+    async fn forwards_audio_format_to_proxy() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/listen"))
+            .and(query_param("channels", "2"))
+            .and(query_param("sample_rate", "48000"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "metadata": {},
+                "results": { "channels": [] }
+            })))
+            .mount(&server)
+            .await;
+        let params = ListenParams {
+            channels: 2,
+            sample_rate: 48_000,
+            ..Default::default()
+        };
+
+        do_transcribe_file(
+            &create_client(),
+            &server.uri(),
+            "test-key",
+            &params,
+            anlg_data::english_1::AUDIO_PATH.into(),
+        )
+        .await
+        .unwrap();
     }
 }

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -541,6 +541,10 @@ impl Provider {
         }
     }
 
+    pub fn preserves_batch_channel_identity(&self) -> bool {
+        matches!(self, Self::Deepgram | Self::AssemblyAI | Self::GoogleCloud)
+    }
+
     pub fn control_message_types(&self) -> &'static [&'static str] {
         match self {
             Self::AquaVoice => &[],

--- a/crates/owhisper-interface/src/openapi.rs
+++ b/crates/owhisper-interface/src/openapi.rs
@@ -25,17 +25,17 @@ pub struct CommonListenParams {
     /// Maximum expected number of speakers, when supported by the selected provider
     #[allow(dead_code)]
     max_speakers: Option<u32>,
-}
-
-#[derive(utoipa::IntoParams)]
-#[into_params(parameter_in = Query)]
-pub struct StreamListenParams {
     /// Audio sample rate in Hz (default: 16000)
     #[allow(dead_code)]
     sample_rate: Option<u32>,
     /// Number of audio channels (default: 1)
     #[allow(dead_code)]
     channels: Option<u8>,
+}
+
+#[derive(utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct StreamListenParams {
     /// Audio encoding: linear16, flac, mulaw, opus, ogg-opus, etc.
     #[allow(dead_code)]
     encoding: Option<String>,

--- a/crates/transcribe-proxy/Cargo.toml
+++ b/crates/transcribe-proxy/Cargo.toml
@@ -43,6 +43,7 @@ anlg-data = { workspace = true }
 anlg-language = { workspace = true }
 owhisper-interface = { workspace = true, features = ["openapi"] }
 
+hound = { workspace = true }
 rodio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/transcribe-proxy/src/routes/batch/mod.rs
+++ b/crates/transcribe-proxy/src/routes/batch/mod.rs
@@ -139,6 +139,11 @@ fn body_read_error_response(error: axum::Error) -> Response {
 pub(super) fn build_listen_params(params: &QueryParams) -> ListenParams {
     normalize_listen_params(ListenParams {
         model: params.get_first("model").map(|s| s.to_string()),
+        channels: params
+            .parse_optional_u32("channels")
+            .and_then(|channels| u8::try_from(channels).ok())
+            .unwrap_or(1),
+        sample_rate: params.parse_optional_u32("sample_rate").unwrap_or(16_000),
         languages: params.get_languages(),
         keywords: params.parse_keywords(),
         num_speakers: params.parse_optional_u32("num_speakers"),
@@ -295,6 +300,21 @@ mod tests {
         assert_eq!(listen_params.num_speakers, Some(3));
         assert_eq!(listen_params.min_speakers, Some(2));
         assert_eq!(listen_params.max_speakers, Some(4));
+    }
+
+    #[test]
+    fn test_build_listen_params_with_audio_format() {
+        let mut params = QueryParams::default();
+        params.insert("channels".to_string(), QueryValue::Single("2".to_string()));
+        params.insert(
+            "sample_rate".to_string(),
+            QueryValue::Single("48000".to_string()),
+        );
+
+        let listen_params = build_listen_params(&params);
+
+        assert_eq!(listen_params.channels, 2);
+        assert_eq!(listen_params.sample_rate, 48_000);
     }
 
     #[tokio::test]

--- a/crates/transcribe-proxy/src/routes/batch/sync.rs
+++ b/crates/transcribe-proxy/src/routes/batch/sync.rs
@@ -267,6 +267,11 @@ pub(super) async fn transcribe_with_provider(
     audio_path: &Path,
 ) -> Result<BatchResponse, BatchAttemptError> {
     let provider = selected.provider();
+    if params.channels > 1 && !provider.preserves_batch_channel_identity() {
+        return Err(BatchAttemptError::Unsupported(format!(
+            "{provider:?} does not preserve channel identity for multichannel batch audio",
+        )));
+    }
     let api_base = selected
         .upstream_url()
         .unwrap_or(provider.default_api_base());

--- a/crates/transcribe-proxy/tests/anarlog_client_contract_mock.rs
+++ b/crates/transcribe-proxy/tests/anarlog_client_contract_mock.rs
@@ -7,9 +7,10 @@ use common::{
     ClientStreamResult, MockUpstreamConfig, batch_upstream_url, close_only_recording,
     collect_streaming_via_client, collect_streaming_via_client_result, english, load_fixture,
     sample_response, send_batch_via_anarlog_client, send_batch_via_deepgram_client,
-    send_streaming_via_client, single_response_recording, start_mock_batch_upstream,
-    start_mock_server_with_config, start_mock_ws, start_proxy, start_proxy_under_stt,
-    wait_for_first_batch_query, wait_for_first_request,
+    send_stereo_batch_via_anarlog_client, send_streaming_via_client, single_response_recording,
+    start_mock_batch_upstream, start_mock_server_with_config, start_mock_stereo_batch_upstream,
+    start_mock_ws, start_proxy, start_proxy_under_stt, wait_for_first_batch_query,
+    wait_for_first_request,
 };
 use owhisper_client::Provider;
 use owhisper_interface::batch::Response;
@@ -284,6 +285,52 @@ async fn batch_client_anarlog_adapter_uses_proxy_sync_path_under_stt() {
         !query.contains("model=cloud"),
         "meta model should not leak upstream: {query}"
     );
+}
+
+#[tokio::test]
+async fn stereo_batch_skips_downmixing_provider_and_keeps_remote_party_identity() {
+    let batch = start_mock_stereo_batch_upstream().await;
+    let upstream_url = batch_upstream_url(batch.addr);
+    let proxy = start_proxy_under_stt(
+        Provider::Deepgram,
+        Some(&upstream_url),
+        Some("http://127.0.0.1:9"),
+    )
+    .await;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let audio_path = temp_dir.path().join("remote-party.wav");
+    let mut writer = hound::WavWriter::create(
+        &audio_path,
+        hound::WavSpec {
+            channels: 2,
+            sample_rate: 48_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        },
+    )
+    .unwrap();
+    for frame in 0..480 {
+        writer.write_sample(0i16).unwrap();
+        writer
+            .write_sample(if frame % 2 == 0 {
+                12_000i16
+            } else {
+                -12_000i16
+            })
+            .unwrap();
+    }
+    writer.finalize().unwrap();
+
+    let response = send_stereo_batch_via_anarlog_client(proxy, &audio_path).await;
+    let query = wait_for_first_batch_query(&batch, TIMEOUT).await;
+    let direct_mic_words = &response.results.channels[0].alternatives[0].words;
+    let remote_party_words = &response.results.channels[1].alternatives[0].words;
+
+    assert!(query.contains("multichannel=true"), "{query}");
+    assert!(direct_mic_words.is_empty());
+    assert_eq!(remote_party_words.len(), 1);
+    assert_eq!(remote_party_words[0].word, "remote");
+    assert_eq!(remote_party_words[0].channel, 1);
 }
 
 #[tokio::test]

--- a/crates/transcribe-proxy/tests/common/anarlog.rs
+++ b/crates/transcribe-proxy/tests/common/anarlog.rs
@@ -213,6 +213,26 @@ pub async fn send_batch_via_anarlog_client(
         .expect("anarlog batch request should succeed")
 }
 
+pub async fn send_stereo_batch_via_anarlog_client(
+    addr: SocketAddr,
+    file_path: impl AsRef<std::path::Path> + Send,
+) -> owhisper_interface::batch::Response {
+    BatchClient::<AnarlogAdapter>::builder()
+        .api_base(format!("http://{addr}/stt"))
+        .api_key("test-access-token")
+        .params(ListenParams {
+            model: Some("cloud".to_string()),
+            channels: 2,
+            sample_rate: 48_000,
+            languages: english(),
+            ..Default::default()
+        })
+        .build()
+        .transcribe_file(file_path)
+        .await
+        .expect("stereo Anarlog batch request should succeed")
+}
+
 pub async fn send_batch_via_deepgram_client(
     addr: SocketAddr,
     model: &str,

--- a/crates/transcribe-proxy/tests/common/mod.rs
+++ b/crates/transcribe-proxy/tests/common/mod.rs
@@ -11,11 +11,12 @@ pub mod ws;
 pub use anarlog::{
     ClientStreamResult, TranscriptEvent, batch_upstream_url, close_only_recording,
     collect_streaming_via_client, collect_streaming_via_client_result, english, sample_response,
-    send_batch, send_batch_via_anarlog_client, send_batch_via_deepgram_client, send_streaming,
-    send_streaming_via_client, single_response_recording, soniox_error_recording,
-    soniox_finalize_message, soniox_finalize_recording, soniox_finalize_ws_message,
-    soniox_partial_recording, soniox_partial_ws_message, split_test_audio_frame, start_mock_ws,
-    start_split_mock_ws, stereo_listen_url, terminal_finalize_count, transcript_events,
+    send_batch, send_batch_via_anarlog_client, send_batch_via_deepgram_client,
+    send_stereo_batch_via_anarlog_client, send_streaming, send_streaming_via_client,
+    single_response_recording, soniox_error_recording, soniox_finalize_message,
+    soniox_finalize_recording, soniox_finalize_ws_message, soniox_partial_recording,
+    soniox_partial_ws_message, split_test_audio_frame, start_mock_ws, start_split_mock_ws,
+    stereo_listen_url, terminal_finalize_count, transcript_events,
 };
 #[allow(unused_imports)]
 pub use fixtures::load_fixture;
@@ -26,8 +27,8 @@ pub use mock_upstream::{
 };
 #[allow(unused_imports)]
 pub use proxy::{
-    MockBatchUpstream, start_mock_batch_upstream, start_proxy, start_proxy_under_stt, wait_for,
-    wait_for_first_batch_query, wait_for_first_request,
+    MockBatchUpstream, start_mock_batch_upstream, start_mock_stereo_batch_upstream, start_proxy,
+    start_proxy_under_stt, wait_for, wait_for_first_batch_query, wait_for_first_request,
 };
 #[allow(unused_imports)]
 pub use recording::{Direction, MessageKind, WsMessage, WsRecording};

--- a/crates/transcribe-proxy/tests/common/proxy.rs
+++ b/crates/transcribe-proxy/tests/common/proxy.rs
@@ -2,7 +2,10 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use axum::{Json, Router, extract::RawQuery, response::IntoResponse, routing::post};
+use axum::{
+    Json, Router, body::Bytes, extract::RawQuery, http::StatusCode, response::IntoResponse,
+    routing::post,
+};
 use owhisper_client::Provider;
 use transcribe_proxy::{AnarlogRoutingConfig, SttProxyConfig};
 
@@ -72,6 +75,91 @@ pub async fn start_mock_batch_upstream() -> MockBatchUpstream {
 
     let addr = serve(app).await;
     MockBatchUpstream { addr, queries }
+}
+
+pub async fn start_mock_stereo_batch_upstream() -> MockBatchUpstream {
+    let queries: Arc<Mutex<Vec<String>>> = Default::default();
+    let captured_queries = queries.clone();
+
+    let app = Router::new().route(
+        "/v1/listen",
+        post(move |query: RawQuery, body: Bytes| {
+            let captured_queries = captured_queries.clone();
+            async move {
+                let query = query.0.unwrap_or_default();
+                if let Ok(mut queries) = captured_queries.lock() {
+                    queries.push(query.clone());
+                }
+
+                if !query.contains("multichannel=true") {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        "stereo batch request did not enable multichannel transcription",
+                    )
+                        .into_response();
+                }
+
+                if let Err(error) = validate_remote_party_stereo_wav(&body) {
+                    return (StatusCode::BAD_REQUEST, error).into_response();
+                }
+
+                Json(serde_json::json!({
+                    "metadata": { "channels": 2 },
+                    "results": {
+                        "channels": [
+                            {
+                                "alternatives": [{
+                                    "transcript": "",
+                                    "confidence": 1.0,
+                                    "words": []
+                                }]
+                            },
+                            {
+                                "alternatives": [{
+                                    "transcript": "remote",
+                                    "confidence": 1.0,
+                                    "words": [{
+                                        "word": "remote",
+                                        "punctuated_word": "remote",
+                                        "start": 0.0,
+                                        "end": 0.5,
+                                        "confidence": 1.0
+                                    }]
+                                }]
+                            }
+                        ]
+                    }
+                }))
+                .into_response()
+            }
+        }),
+    );
+
+    let addr = serve(app).await;
+    MockBatchUpstream { addr, queries }
+}
+
+fn validate_remote_party_stereo_wav(body: &[u8]) -> Result<(), String> {
+    let mut reader = hound::WavReader::new(std::io::Cursor::new(body))
+        .map_err(|error| format!("invalid WAV: {error}"))?;
+    if reader.spec().channels != 2 {
+        return Err("expected stereo WAV".to_string());
+    }
+
+    let samples = reader
+        .samples::<i16>()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("invalid PCM samples: {error}"))?;
+    let direct_mic_is_silent = samples.chunks_exact(2).all(|frame| frame[0] == 0);
+    let remote_party_has_audio = samples.chunks_exact(2).any(|frame| frame[1] != 0);
+
+    if !direct_mic_is_silent || !remote_party_has_audio {
+        return Err(
+            "expected silent direct-mic channel and active remote-party channel".to_string(),
+        );
+    }
+
+    Ok(())
 }
 
 pub async fn wait_for_first_request(mock: &MockServerHandle, timeout: Duration) -> String {

--- a/crates/transcribe-proxy/tests/pro_api_e2e.rs
+++ b/crates/transcribe-proxy/tests/pro_api_e2e.rs
@@ -73,13 +73,48 @@ async fn assert_live_transcription(addr: std::net::SocketAddr) {
     assert!(saw_transcript, "Pro live transcription should return text");
 }
 
-async fn assert_batch_transcription(addr: std::net::SocketAddr) {
-    let audio = tokio::fs::read(anlg_data::english_1::AUDIO_PATH)
-        .await
+fn remote_party_stereo_audio() -> Vec<u8> {
+    let mut reader = hound::WavReader::open(anlg_data::english_1::AUDIO_PATH)
         .expect("test audio should be readable");
+    let spec = reader.spec();
+    assert_eq!(spec.channels, 1, "test audio should be mono");
+    assert_eq!(spec.sample_rate, 16_000, "test audio should be 16 kHz");
+    assert_eq!(spec.bits_per_sample, 16, "test audio should be 16-bit");
+    assert_eq!(
+        spec.sample_format,
+        hound::SampleFormat::Int,
+        "test audio should use integer PCM",
+    );
+
+    let mut output = std::io::Cursor::new(Vec::new());
+    let mut writer = hound::WavWriter::new(
+        &mut output,
+        hound::WavSpec {
+            channels: 2,
+            ..spec
+        },
+    )
+    .expect("stereo test audio should be writable");
+    for sample in reader.samples::<i16>() {
+        writer
+            .write_sample(0i16)
+            .expect("direct-mic silence should be writable");
+        writer
+            .write_sample(sample.expect("test audio samples should be readable"))
+            .expect("remote-party audio should be writable");
+    }
+    writer
+        .finalize()
+        .expect("stereo test audio should finalize");
+
+    output.into_inner()
+}
+
+async fn assert_batch_transcription(addr: std::net::SocketAddr) {
+    let audio = remote_party_stereo_audio();
     let response = reqwest::Client::new()
         .post(format!(
-            "http://{addr}/listen?provider=anarlog&model=cloud&language=en"
+            "http://{addr}/listen?provider=anarlog&model=cloud&language=en&channels=2&sample_rate=16000"
         ))
         .header("content-type", "audio/wav")
         .body(audio)
@@ -99,16 +134,31 @@ async fn assert_batch_transcription(addr: std::net::SocketAddr) {
 
     let response: owhisper_interface::batch::Response =
         serde_json::from_str(&body).expect("Pro batch response should be valid");
-    let transcript = response
-        .results
-        .channels
+    assert_eq!(
+        response.results.channels.len(),
+        2,
+        "Pro batch transcription should preserve both input channels",
+    );
+    let direct_mic = response.results.channels[0]
+        .alternatives
         .first()
-        .and_then(|channel| channel.alternatives.first())
-        .map(|alternative| alternative.transcript.trim())
-        .unwrap_or_default();
+        .expect("direct-mic channel should include an alternative");
+    let remote_party = response.results.channels[1]
+        .alternatives
+        .first()
+        .expect("remote-party channel should include an alternative");
+
     assert!(
-        !transcript.is_empty(),
-        "Pro batch transcription should return text"
+        direct_mic.transcript.trim().is_empty() && direct_mic.words.is_empty(),
+        "silent direct-mic channel should not contain transcript words",
+    );
+    assert!(
+        !remote_party.transcript.trim().is_empty() && !remote_party.words.is_empty(),
+        "remote-party channel should contain transcript words",
+    );
+    assert!(
+        remote_party.words.iter().all(|word| word.channel == 1),
+        "remote-party words should remain on channel 1",
     );
 }
 


### PR DESCRIPTION
Forward audio metadata through the Anarlog batch proxy, reject downmix-only providers, and cover atomic desktop replacement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches batch routing and provider selection for multichannel audio; mis-routing could break refinement or return wrong channel transcripts, but behavior is guarded by explicit unsupported errors and expanded contract tests.
> 
> **Overview**
> **Stereo-aware cloud batch** — The `/listen` batch API and Anarlog client now carry **`channels`** and **`sample_rate`** (defaults 1 / 16 kHz) through the proxy to upstream transcription. Sync batch transcription **fails fast** when `channels > 1` and the selected provider does not **`preserves_batch_channel_identity`** (Deepgram, AssemblyAI, GoogleCloud only).
> 
> OpenAPI is updated so those format params apply to batch listen (not only streaming). Integration tests cover stereo WAV (silent mic + remote party), `multichannel=true` upstream queries, and Pro batch e2e expectations for per-channel results.
> 
> **Desktop** test names/assertions clarify that post-stop batch **promotion** **replaces** the live capture via `replaceTranscriptId` in a **single transaction** (soft-delete then insert), avoiding a visible duplicate transcript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 811ee3d55604c4504704236e268934b4e2c41688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->