### PR TITLE
Prevent onboarding after transient store failures

### DIFF
--- a/plugins/store2/src/ext.rs
+++ b/plugins/store2/src/ext.rs
@@ -20,6 +20,16 @@ impl<R: tauri::Runtime> Default for Store2State<R> {
 
 pub const FILENAME: &str = "store.json";
 
+fn load_store_defaults(
+    path: &std::path::Path,
+) -> Result<HashMap<String, serde_json::Value>, crate::Error> {
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).map_err(Into::into),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(HashMap::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
 fn resolve_store_dir<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
 ) -> Result<PathBuf, crate::Error> {
@@ -79,7 +89,12 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Store2<'a, R, M> {
 
         use tauri_plugin_store::StoreExt;
 
-        let store = app.store_builder(&path).disable_auto_save().build()?;
+        let defaults = load_store_defaults(&path)?;
+        let store = app
+            .store_builder(&path)
+            .defaults(defaults)
+            .disable_auto_save()
+            .build()?;
         store.close_resource();
         retained.insert(path.clone(), Arc::clone(&store));
         Ok((store, path))

--- a/plugins/store2/src/lib.rs
+++ b/plugins/store2/src/lib.rs
@@ -229,6 +229,53 @@ mod test {
     }
 
     #[test]
+    fn retries_after_an_existing_store_cannot_be_read() -> anyhow::Result<()> {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let vault = TestVault::new("unreadable-store");
+        let path = vault.primary.join(FILENAME);
+        std::fs::create_dir(&path)?;
+        let app = create_app(tauri::test::mock_builder(), &vault.identifier);
+
+        let error = app.store2().store().err().expect("store read must fail");
+
+        assert!(matches!(error, Error::IoError(_)));
+        assert!(path.is_dir());
+
+        std::fs::remove_dir(&path)?;
+        let persisted_scope = serde_json::to_string(&serde_json::json!({
+            "key": "persisted"
+        }))?;
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "test": persisted_scope
+            }))?,
+        )?;
+
+        let recovered = app.store2().scoped_store::<String>("test")?;
+        assert_eq!(
+            recovered.get::<String>("key".to_string())?,
+            Some("persisted".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn refuses_to_open_a_malformed_existing_store() -> anyhow::Result<()> {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let vault = TestVault::new("malformed-store");
+        let path = vault.primary.join(FILENAME);
+        std::fs::write(&path, "not json")?;
+        let app = create_app(tauri::test::mock_builder(), &vault.identifier);
+
+        let error = app.store2().store().err().expect("store parse must fail");
+
+        assert!(matches!(error, Error::SerdeJsonError(_)));
+        assert_eq!(std::fs::read_to_string(path)?, "not json");
+        Ok(())
+    }
+
+    #[test]
     fn test_concurrent_set() -> anyhow::Result<()> {
         let _guard = TEST_MUTEX.lock().unwrap();
         let vault = TestVault::new("concurrent");


### PR DESCRIPTION
Validate persisted store data before caching it so startup I/O failures remain retriable and cannot look like a fresh install. Add recovery and malformed-store regression tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app startup persistence and onboarding-related state; behavior change is narrow but affects when the store is considered empty vs. failed.
> 
> **Overview**
> **Store open now pre-reads `store.json`** and only builds the in-memory store after the file is validated, instead of relying on `store_builder` alone.
> 
> `load_store_defaults` reads the path first: missing file yields an empty map (same as a fresh install), **I/O and JSON parse errors return immediately** without inserting anything into the retained cache. Parsed JSON is passed into `store_builder` via `.defaults(...)`, so a transient read failure no longer looks like an empty store and a later retry can succeed with persisted data.
> 
> Adds regression tests for **recovering after an unreadable store path** (e.g. directory at `store.json`) and for **refusing malformed JSON** while leaving the file unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fee5df83761647c03ce3c01914b6544f4a40129e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->