### PR TITLE
Prepare Anarlog 1.4.1 changelog

### DIFF
--- a/packages/changelog/content/1.4.1.md
+++ b/packages/changelog/content/1.4.1.md
@@ -1,0 +1,29 @@
+---
+date: "2026-08-02"
+summary: "Anarlog 1.4.1 adds selectable macOS app icons, hardware-aware on-device transcription, automation drafts, and privacy and reliability improvements."
+---
+
+## Personalization and workflows
+
+- Choose the **Default** or **Anagram** app icon on macOS and update the Dock
+  and app switcher immediately, with variants that follow the system's light or
+  dark appearance
+- Explore Pro automation starters for Slack recaps, Notion project notes,
+  Linear action items, and Markdown exports, then preview their steps and save
+  a local draft before execution is connected
+
+## Notes and transcription
+
+- Delete selected notes from the sidebar with Backspace while keeping the
+  shortcut inactive when you are typing in the editor
+- Choose Soniqo and Apple Speech as separate on-device transcription providers,
+  with a model recommendation based on the memory available on your Mac
+- Keep microphone and system-audio identities separate when Anarlog Pro refines
+  a stereo recording with cloud batch transcription
+
+## Privacy and reliability
+
+- Stop masked session replay across every app window as soon as **Share usage
+  data** is turned off, without sending the pending replay buffer
+- Avoid being sent through onboarding when Anarlog temporarily cannot read its
+  settings, and preserve malformed settings files instead of replacing them


### PR DESCRIPTION
Summarize the user-facing desktop changes since 1.4.0 and add the required stable-release changelog for 1.4.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application or infrastructure code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.1.md`** as the stable **1.4.1** changelog entry (dated 2026-08-02), with front matter `summary` and three user-facing sections.
> 
> **Personalization and workflows** documents selectable macOS **Default** / **Anagram** icons (Dock/app switcher, light/dark) and Pro automation starters (Slack, Notion, Linear, Markdown) with step preview and local drafts before execution is wired up.
> 
> **Notes and transcription** covers sidebar note deletion via Backspace (disabled while editing), separate on-device **Soniqo** vs **Apple Speech** providers with RAM-based model guidance, and separate mic/system-audio identities for Pro stereo cloud batch refinement.
> 
> **Privacy and reliability** notes immediate stop of masked session replay when **Share usage data** is off (no flush of pending buffer), and safer settings handling when reads fail (no spurious onboarding; malformed files preserved).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05b6ba40dc1462db8665824faa6b327138f99a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->