### PR TITLE
Resolve cached build-script paths at runtime

### DIFF
--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -23,7 +23,9 @@ fn build_check_permissions() {
     let triple = std::env::var("TARGET").unwrap();
     let swift_target = swift_target(&triple);
 
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(
+        std::env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by Cargo"),
+    );
     let build_rs = manifest_dir.join("build.rs");
     let swift_src = manifest_dir.join("../../../plugins/permissions/swift/check-permissions.swift");
     let binaries_dir = manifest_dir.join("binaries");

--- a/crates/api-client/build.rs
+++ b/crates/api-client/build.rs
@@ -1,4 +1,5 @@
 use progenitor_utils::OpenApiSpec;
+use std::path::PathBuf;
 
 const ALLOWED_PATH_PREFIXES: &[&str] = &[
     "/calendar",
@@ -32,18 +33,18 @@ const TYPE_REPLACEMENTS: &[(&str, &str)] = &[
 ];
 
 fn main() {
-    let src = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../../apps/api/openapi.gen.json"
+    let manifest_dir = PathBuf::from(
+        std::env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by Cargo"),
     );
-    println!("cargo:rerun-if-changed={src}");
+    let src = manifest_dir.join("../../apps/api/openapi.gen.json");
+    println!("cargo:rerun-if-changed={}", src.display());
 
-    OpenApiSpec::from_path(src)
+    OpenApiSpec::from_path(&src)
         .retain_paths(ALLOWED_PATH_PREFIXES)
         .normalize_responses()
         .flatten_all_of()
         .convert_31_to_30()
         .remove_unreferenced_schemas()
-        .write_filtered(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("openapi.gen.json"))
+        .write_filtered(manifest_dir.join("openapi.gen.json"))
         .generate_with_replacements("codegen.rs", TYPE_REPLACEMENTS);
 }

--- a/crates/progenitor-utils/src/lib.rs
+++ b/crates/progenitor-utils/src/lib.rs
@@ -14,7 +14,7 @@ impl OpenApiSpec {
         &mut self.inner
     }
 
-    pub fn from_path(path: &str) -> Self {
+    pub fn from_path(path: impl AsRef<Path>) -> Self {
         let raw = std::fs::read_to_string(path).expect("failed to read OpenAPI spec");
         let inner: Value = serde_json::from_str(&raw).expect("invalid JSON");
         Self { inner }

--- a/crates/pyannote-cloud/build.rs
+++ b/crates/pyannote-cloud/build.rs
@@ -1,4 +1,5 @@
 use progenitor_utils::OpenApiSpec;
+use std::path::PathBuf;
 
 const ALLOWED_PATH_PREFIXES: &[&str] = &["/v1/"];
 
@@ -18,17 +19,18 @@ fn fix_pyannote_schema(spec: &mut serde_json::Value) {
 }
 
 fn main() {
-    let src = concat!(env!("CARGO_MANIFEST_DIR"), "/openapi.gen.json");
-    println!("cargo:rerun-if-changed={src}");
+    let manifest_dir = PathBuf::from(
+        std::env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by Cargo"),
+    );
+    let src = manifest_dir.join("openapi.gen.json");
+    println!("cargo:rerun-if-changed={}", src.display());
 
-    let mut spec = OpenApiSpec::from_path(src);
+    let mut spec = OpenApiSpec::from_path(&src);
     spec.retain_paths(ALLOWED_PATH_PREFIXES)
         .normalize_responses()
         .flatten_all_of()
         .remove_unreferenced_schemas();
     fix_pyannote_schema(spec.inner_mut());
-    spec.write_filtered(
-        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("openapi-filtered.gen.json"),
-    )
-    .generate("codegen.rs");
+    spec.write_filtered(manifest_dir.join("openapi-filtered.gen.json"))
+        .generate("codegen.rs");
 }


### PR DESCRIPTION
Resolve Cargo manifest paths when build scripts execute so the persistent native-QA cache cannot reuse binaries with stale temporary-checkout paths. This covers the desktop Swift helper and both OpenAPI code generators.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time path resolution only; no runtime app logic, auth, or data handling changes.
> 
> **Overview**
> **Build scripts no longer bake in compile-time `CARGO_MANIFEST_DIR` paths**, so a persistent native-QA build cache cannot reuse artifacts that still point at stale temporary checkout directories.
> 
> Desktop macOS `build_check_permissions` now builds paths from `std::env::var_os("CARGO_MANIFEST_DIR")` (same pattern as existing `OUT_DIR` handling). **`api-client` and `pyannote-cloud` `build.rs`** use the same runtime manifest dir for OpenAPI inputs, `cargo:rerun-if-changed`, and filtered output paths instead of `concat!(env!(...), ...)`.
> 
> **`OpenApiSpec::from_path`** now takes `impl AsRef<Path>` so callers pass `PathBuf` references without string-only APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bfad223f8815ffd8789ce3636e7fb98b7cad0ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->