### PR TITLE
Refresh native QA cache generation

### DIFF
--- a/.agents/skills/qa-critical-ux/SKILL.md
+++ b/.agents/skills/qa-critical-ux/SKILL.md
@@ -162,7 +162,7 @@ the app.
    inputs match the candidate commit. Record
    `git_head_sha`, which is the candidate commit rather than GitButler's
    synthetic workspace HEAD. The manifest is
-   `${ANARLOG_QA_TARGET_DIR:-$HOME/Library/Caches/anarlog/native-dev-qa-target}/.anarlog-native-dev-qa-manifest`.
+   `${ANARLOG_QA_TARGET_DIR:-$HOME/Library/Caches/anarlog/native-dev-qa-target-v2}/.anarlog-native-dev-qa-manifest`.
 2. Require every Dev gate to pass, then trigger `desktop_cd.yaml` with
    `channel=staging` from a branch or ref whose tip is that exact SHA. Verify
    the Actions run's head SHA matches the manifest before testing it.

--- a/.agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh
+++ b/.agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 umask 077
 
 qa_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
-qa_target_dir="${ANARLOG_QA_TARGET_DIR:-$HOME/Library/Caches/anarlog/native-dev-qa-target}"
+qa_target_dir="${ANARLOG_QA_TARGET_DIR:-$HOME/Library/Caches/anarlog/native-dev-qa-target-v2}"
 qa_target_parent="$(dirname "$qa_target_dir")"
 qa_bundle_dir="$qa_target_dir/debug/bundle/macos/Anarlog Dev.app"
 qa_bundle_executable="$qa_target_dir/debug/bundle/macos/Anarlog Dev.app/Contents/MacOS/anarlog-dev"
 qa_manifest="$qa_target_dir/.anarlog-native-dev-qa-manifest"
-qa_cache_marker="$qa_target_dir/.anarlog-native-dev-qa-cache-v1"
+qa_cache_marker="$qa_target_dir/.anarlog-native-dev-qa-cache-v2"
 qa_lock_dir="$qa_target_dir/.anarlog-native-dev-qa-lock"
 qa_frontend_dist="$qa_repo_root/apps/desktop/dist"
 qa_config_validator="$qa_repo_root/.agents/skills/qa-critical-ux/scripts/validate-native-dev-qa-config.mjs"
@@ -503,7 +503,7 @@ if [[ -e "$qa_target_dir" ]]; then
     fail "Refusing to use an existing directory not created by this helper: $qa_target_dir"
 else
   mkdir -m 700 "$qa_target_dir"
-  printf 'anarlog-native-dev-qa-cache-v1\n' >"$qa_cache_marker"
+  printf 'anarlog-native-dev-qa-cache-v2\n' >"$qa_cache_marker"
 fi
 chmod 700 "$qa_target_dir"
 


### PR DESCRIPTION
## Summary

- move the persistent native QA target to a v2 cache generation
- keep the QA skill manifest path aligned with the helper
- avoid cached Tauri build metadata that references deleted exact-SHA checkouts

## Validation

- `pnpm exec dprint fmt`
- `pnpm fmt:check`
- `bash -n .agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh`
- cold native QA bundle build and exploratory launch succeeded in the v2 cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and QA helper path defaults only; behavior is unchanged aside from forcing a cold cache location for new runs.
> 
> **Overview**
> **Bumps the native Dev QA persistent Cargo/build cache to a new generation** so QA runs use a fresh helper-owned directory instead of reusing stale Tauri/Cargo metadata tied to removed exact-SHA checkouts.
> 
> The default `ANARLOG_QA_TARGET_DIR` path changes from `native-dev-qa-target` to **`native-dev-qa-target-v2`**, and the cache ownership marker from **`anarlog-native-dev-qa-cache-v1`** to **`v2`**. The QA skill doc’s manifest path example is updated to match the helper script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a0051d688b5646bed4bbe7fafc0960f8ece9de8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->