### PR TITLE
Preserve speaker clusters through transcript refinement

### DIFF
--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -10,6 +10,7 @@ import {
   getBatchProvider,
   getSessionSpeakerCount,
   isTerminalTranscriptionError,
+  reconcileRefinedSpeakerClusters,
   transferAutomaticSpeakerAssignments,
 } from "./useRunBatch";
 import { useRunBatch } from "./useRunBatch";
@@ -316,6 +317,179 @@ describe("getBatchFallbackTarget", () => {
         currentArch: "x86_64",
       }),
     ).toBeNull();
+  });
+});
+
+describe("reconcileRefinedSpeakerClusters", () => {
+  test("collapses split batch clusters onto dominant live clusters", () => {
+    const source = {
+      id: "live-transcript",
+      ownerUserId: "user-1",
+      sessionId: "session-1",
+      startedAt: 0,
+      words: [
+        {
+          id: "live-lex-1",
+          text: "question",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 1,
+        },
+        {
+          id: "live-george-1",
+          text: "answer",
+          start_ms: 100,
+          end_ms: 200,
+          channel: 1,
+        },
+        {
+          id: "live-lex-2",
+          text: "follow up",
+          start_ms: 200,
+          end_ms: 300,
+          channel: 1,
+        },
+        {
+          id: "live-george-2",
+          text: "response",
+          start_ms: 300,
+          end_ms: 400,
+          channel: 1,
+        },
+      ],
+      speakerHints: [
+        {
+          id: "live-lex-1-provider",
+          word_id: "live-lex-1",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+        },
+        {
+          id: "live-george-1-provider",
+          word_id: "live-george-1",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 1 }),
+        },
+        {
+          id: "live-lex-2-provider",
+          word_id: "live-lex-2",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+        },
+        {
+          id: "live-george-2-provider",
+          word_id: "live-george-2",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 1 }),
+        },
+      ],
+    } satisfies Parameters<typeof reconcileRefinedSpeakerClusters>[0];
+    const words = [
+      {
+        id: "batch-lex-primary",
+        text: "question",
+        start_ms: 0,
+        end_ms: 100,
+        channel: 1,
+      },
+      {
+        id: "batch-george-primary",
+        text: "answer",
+        start_ms: 100,
+        end_ms: 200,
+        channel: 1,
+      },
+      {
+        id: "batch-lex-split",
+        text: "follow up",
+        start_ms: 200,
+        end_ms: 300,
+        channel: 1,
+      },
+      {
+        id: "batch-george-split",
+        text: "response",
+        start_ms: 300,
+        end_ms: 400,
+        channel: 1,
+      },
+    ];
+    const hints = words.map((word, index) => ({
+      id: `${word.id}-provider`,
+      word_id: word.id,
+      type: "provider_speaker_index" as const,
+      value: JSON.stringify({
+        provider: "anarlog",
+        channel: 1,
+        speaker_index: index,
+      }),
+    }));
+
+    const result = reconcileRefinedSpeakerClusters(source, words, hints);
+
+    expect(result.map((hint) => JSON.parse(hint.value).speaker_index)).toEqual([
+      0, 1, 0, 1,
+    ]);
+  });
+
+  test("keeps an ambiguous batch cluster unchanged", () => {
+    const source = {
+      id: "live-transcript",
+      ownerUserId: "user-1",
+      sessionId: "session-1",
+      startedAt: 0,
+      words: [
+        {
+          id: "live-a",
+          text: "one",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 1,
+        },
+        {
+          id: "live-b",
+          text: "two",
+          start_ms: 100,
+          end_ms: 200,
+          channel: 1,
+        },
+      ],
+      speakerHints: [
+        {
+          id: "live-a-provider",
+          word_id: "live-a",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+        },
+        {
+          id: "live-b-provider",
+          word_id: "live-b",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 1 }),
+        },
+      ],
+    } satisfies Parameters<typeof reconcileRefinedSpeakerClusters>[0];
+    const words = [
+      {
+        id: "batch-ambiguous",
+        text: "one two",
+        start_ms: 0,
+        end_ms: 200,
+        channel: 1,
+      },
+    ];
+    const hints = [
+      {
+        id: "batch-ambiguous-provider",
+        word_id: "batch-ambiguous",
+        type: "provider_speaker_index" as const,
+        value: JSON.stringify({ channel: 1, speaker_index: 4 }),
+      },
+    ];
+
+    const result = reconcileRefinedSpeakerClusters(source, words, hints);
+
+    expect(JSON.parse(result[0].value).speaker_index).toBe(4);
   });
 });
 

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -491,6 +491,68 @@ describe("reconcileRefinedSpeakerClusters", () => {
 
     expect(JSON.parse(result[0].value).speaker_index).toBe(4);
   });
+
+  test("moves an unmapped batch cluster that collides with a live cluster", () => {
+    const source = {
+      id: "live-transcript",
+      ownerUserId: "user-1",
+      sessionId: "session-1",
+      startedAt: 0,
+      words: [
+        {
+          id: "live-speaker",
+          text: "mapped",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 1,
+        },
+      ],
+      speakerHints: [
+        {
+          id: "live-speaker-provider",
+          word_id: "live-speaker",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 1, speaker_index: 1 }),
+        },
+      ],
+    } satisfies Parameters<typeof reconcileRefinedSpeakerClusters>[0];
+    const words = [
+      {
+        id: "batch-mapped",
+        text: "mapped",
+        start_ms: 0,
+        end_ms: 100,
+        channel: 1,
+      },
+      {
+        id: "batch-unmapped",
+        text: "unmapped",
+        start_ms: 200,
+        end_ms: 300,
+        channel: 1,
+      },
+    ];
+    const hints = [
+      {
+        id: "batch-mapped-provider",
+        word_id: "batch-mapped",
+        type: "provider_speaker_index" as const,
+        value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+      },
+      {
+        id: "batch-unmapped-provider",
+        word_id: "batch-unmapped",
+        type: "provider_speaker_index" as const,
+        value: JSON.stringify({ channel: 1, speaker_index: 1 }),
+      },
+    ];
+
+    const result = reconcileRefinedSpeakerClusters(source, words, hints);
+
+    expect(result.map((hint) => JSON.parse(hint.value).speaker_index)).toEqual([
+      1, 2,
+    ]);
+  });
 });
 
 describe("transferAutomaticSpeakerAssignments", () => {

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -401,6 +401,60 @@ export function reconcileRefinedSpeakerClusters(
     }
   }
 
+  const usedSpeakerIndicesByChannel = new Map<number, Set<number>>();
+  for (const [targetSpeakerKey, speakerIndex] of sourceSpeakerByTarget) {
+    const targetSpeaker = parseSpeakerKey(targetSpeakerKey);
+    if (!targetSpeaker) {
+      continue;
+    }
+
+    const usedSpeakerIndices =
+      usedSpeakerIndicesByChannel.get(targetSpeaker.channel) ?? new Set();
+    usedSpeakerIndices.add(speakerIndex);
+    usedSpeakerIndicesByChannel.set(targetSpeaker.channel, usedSpeakerIndices);
+  }
+
+  const collidingTargetSpeakers: Array<{
+    speakerKey: string;
+    channel: number;
+  }> = [];
+  for (const targetSpeakerKey of new Set(targetSpeakerKeys.values())) {
+    if (sourceSpeakerByTarget.has(targetSpeakerKey)) {
+      continue;
+    }
+
+    const targetSpeaker = parseSpeakerKey(targetSpeakerKey);
+    if (!targetSpeaker) {
+      continue;
+    }
+
+    const usedSpeakerIndices =
+      usedSpeakerIndicesByChannel.get(targetSpeaker.channel) ?? new Set();
+    if (usedSpeakerIndices.has(targetSpeaker.speakerIndex)) {
+      collidingTargetSpeakers.push({
+        speakerKey: targetSpeakerKey,
+        channel: targetSpeaker.channel,
+      });
+    } else {
+      usedSpeakerIndices.add(targetSpeaker.speakerIndex);
+    }
+    usedSpeakerIndicesByChannel.set(targetSpeaker.channel, usedSpeakerIndices);
+  }
+
+  for (const { speakerKey, channel } of collidingTargetSpeakers) {
+    const usedSpeakerIndices = usedSpeakerIndicesByChannel.get(channel);
+    if (!usedSpeakerIndices) {
+      continue;
+    }
+
+    let speakerIndex = Math.max(...usedSpeakerIndices) + 1;
+    while (usedSpeakerIndices.has(speakerIndex)) {
+      speakerIndex += 1;
+    }
+    usedSpeakerIndices.add(speakerIndex);
+    sourceSpeakerByTarget.set(speakerKey, speakerIndex);
+  }
+
   return hints.map((hint) => {
     if (hint.type !== "provider_speaker_index" || !hint.word_id) {
       return hint;

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -91,6 +91,7 @@ const DIRECT_BATCH_PROVIDERS: Set<TranscriptionParams["provider"]> = new Set([
 export const STOPPED_TRANSCRIPTION_ERROR_MESSAGE = "Transcription stopped.";
 export const EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE =
   "Batch transcription did not include the current recording.";
+const MIN_REFINED_SPEAKER_OVERLAP_RATIO = 0.6;
 const LOCAL_SONIQO_BATCH_TARGET = {
   provider: "soniqo",
   model: "soniqo-parakeet-batch",
@@ -260,6 +261,165 @@ function speakerKeysByWordId(hints: SpeakerHintWithId[]) {
   }
 
   return keys;
+}
+
+function parseSpeakerKey(key: string) {
+  const separator = key.indexOf(":");
+  if (separator <= 0 || separator === key.length - 1) {
+    return null;
+  }
+
+  const channel = Number(key.slice(0, separator));
+  const speakerIndex = Number(key.slice(separator + 1));
+
+  return Number.isFinite(channel) && Number.isFinite(speakerIndex)
+    ? { channel, speakerIndex }
+    : null;
+}
+
+export function reconcileRefinedSpeakerClusters(
+  source: TranscriptRecord,
+  words: WordWithId[],
+  hints: SpeakerHintWithId[],
+): SpeakerHintWithId[] {
+  const sourceSpeakerKeys = speakerKeysByWordId(source.speakerHints);
+  const targetSpeakerKeys = speakerKeysByWordId(hints);
+  if (sourceSpeakerKeys.size === 0 || targetSpeakerKeys.size === 0) {
+    return hints;
+  }
+
+  const sourceIntervalsByChannel = new Map<
+    number,
+    Array<{
+      speakerKey: string;
+      startMs: number;
+      endMs: number;
+    }>
+  >();
+
+  for (const word of source.words) {
+    const speakerKey = sourceSpeakerKeys.get(word.id);
+    const speaker = speakerKey ? parseSpeakerKey(speakerKey) : null;
+    if (!speakerKey || !speaker) {
+      continue;
+    }
+
+    const startMs = word.start_ms ?? 0;
+    const endMs = Math.max(startMs + 1, word.end_ms ?? startMs);
+    const intervals = sourceIntervalsByChannel.get(speaker.channel) ?? [];
+    intervals.push({ speakerKey, startMs, endMs });
+    sourceIntervalsByChannel.set(speaker.channel, intervals);
+  }
+
+  for (const intervals of sourceIntervalsByChannel.values()) {
+    intervals.sort((left, right) => left.startMs - right.startMs);
+  }
+
+  const targetWords = words
+    .flatMap((word) => {
+      const speakerKey = targetSpeakerKeys.get(word.id);
+      const speaker = speakerKey ? parseSpeakerKey(speakerKey) : null;
+      if (!speakerKey || !speaker) {
+        return [];
+      }
+
+      const startMs = word.start_ms ?? 0;
+      return [
+        {
+          speakerKey,
+          channel: speaker.channel,
+          startMs,
+          endMs: Math.max(startMs + 1, word.end_ms ?? startMs),
+        },
+      ];
+    })
+    .sort(
+      (left, right) =>
+        left.channel - right.channel || left.startMs - right.startMs,
+    );
+  const cursors = new Map<number, number>();
+  const weights = new Map<string, Map<string, number>>();
+
+  for (const word of targetWords) {
+    const sourceIntervals = sourceIntervalsByChannel.get(word.channel);
+    if (!sourceIntervals) {
+      continue;
+    }
+
+    let cursor = cursors.get(word.channel) ?? 0;
+    while (
+      cursor < sourceIntervals.length &&
+      sourceIntervals[cursor].endMs <= word.startMs
+    ) {
+      cursor += 1;
+    }
+    cursors.set(word.channel, cursor);
+
+    for (
+      let index = cursor;
+      index < sourceIntervals.length &&
+      sourceIntervals[index].startMs < word.endMs;
+      index += 1
+    ) {
+      const source = sourceIntervals[index];
+      const overlapMs =
+        Math.min(word.endMs, source.endMs) -
+        Math.max(word.startMs, source.startMs);
+      if (overlapMs <= 0) {
+        continue;
+      }
+
+      const sourceWeights = weights.get(word.speakerKey) ?? new Map();
+      sourceWeights.set(
+        source.speakerKey,
+        (sourceWeights.get(source.speakerKey) ?? 0) + overlapMs,
+      );
+      weights.set(word.speakerKey, sourceWeights);
+    }
+  }
+
+  const sourceSpeakerByTarget = new Map<string, number>();
+  for (const [targetSpeakerKey, sourceWeights] of weights) {
+    const candidates = [...sourceWeights].sort(
+      ([leftKey, leftWeight], [rightKey, rightWeight]) =>
+        rightWeight - leftWeight || leftKey.localeCompare(rightKey),
+    );
+    const totalOverlapMs = candidates.reduce(
+      (total, [, overlapMs]) => total + overlapMs,
+      0,
+    );
+    const [sourceSpeakerKey, overlapMs] = candidates[0] ?? [];
+    const sourceSpeaker = sourceSpeakerKey
+      ? parseSpeakerKey(sourceSpeakerKey)
+      : null;
+    if (
+      sourceSpeaker &&
+      totalOverlapMs > 0 &&
+      overlapMs / totalOverlapMs >= MIN_REFINED_SPEAKER_OVERLAP_RATIO
+    ) {
+      sourceSpeakerByTarget.set(targetSpeakerKey, sourceSpeaker.speakerIndex);
+    }
+  }
+
+  return hints.map((hint) => {
+    if (hint.type !== "provider_speaker_index" || !hint.word_id) {
+      return hint;
+    }
+
+    const targetSpeakerKey = targetSpeakerKeys.get(hint.word_id);
+    const speakerIndex = targetSpeakerKey
+      ? sourceSpeakerByTarget.get(targetSpeakerKey)
+      : undefined;
+    const value = parseHintValue(hint.value);
+    if (speakerIndex === undefined || !value) {
+      return hint;
+    }
+
+    return {
+      ...hint,
+      value: JSON.stringify({ ...value, speaker_index: speakerIndex }),
+    };
+  });
 }
 
 export function transferAutomaticSpeakerAssignments(
@@ -549,14 +709,14 @@ export const useRunBatch = (sessionId: string) => {
         });
       }
 
-      let speakerIdentitySource: TranscriptRecord | null = null;
+      let refinedTranscriptSource: TranscriptRecord | null = null;
       const replaceTranscriptId =
         options?.promotion?.scope === "current_capture"
           ? options.promotion.replaceTranscriptId
           : undefined;
       if (replaceTranscriptId) {
         try {
-          speakerIdentitySource =
+          refinedTranscriptSource =
             await getTranscriptRecord(replaceTranscriptId);
         } catch (error) {
           console.warn(
@@ -719,13 +879,20 @@ export const useRunBatch = (sessionId: string) => {
             if (transcriptId) {
               const completedTranscriptId = transcriptId;
               if (promoted.words.length > 0) {
-                const speakerHints = speakerIdentitySource
-                  ? transferAutomaticSpeakerAssignments(
-                      speakerIdentitySource,
+                const reconciledSpeakerHints = refinedTranscriptSource
+                  ? reconcileRefinedSpeakerClusters(
+                      refinedTranscriptSource,
                       promoted.words,
                       promoted.hints,
                     )
                   : promoted.hints;
+                const speakerHints = refinedTranscriptSource
+                  ? transferAutomaticSpeakerAssignments(
+                      refinedTranscriptSource,
+                      promoted.words,
+                      reconciledSpeakerHints,
+                    )
+                  : reconciledSpeakerHints;
                 await persistTranscriptWrite(() =>
                   createTranscript({
                     id: completedTranscriptId,


### PR DESCRIPTION
Reconcile refined batch diarization with the live transcript by dominant time overlap so post-processing cannot split two stable speakers into extra clusters. Ambiguous mappings remain unchanged, and focused regression tests cover both paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes speaker-hint persistence during current-capture batch promotion; wrong overlap logic could mislabel speakers, but ambiguous cases are preserved and behavior is covered by new tests.
> 
> **Overview**
> When batch transcription replaces a **current-capture** live transcript, refined diarization can assign extra `provider_speaker_index` clusters even when the live pass already had stable speakers. This PR adds **`reconcileRefinedSpeakerClusters`**, which aligns batch clusters to the live transcript using **dominant time overlap** (≥60% of overlap mass), rewrites matching hints to the live speaker indices, and **bumps colliding unmapped clusters** to free indices.
> 
> **`useRunBatch`** now runs reconciliation on the promoted batch hints **before** `transferAutomaticSpeakerAssignments`, so automatic identities attach to the corrected clusters. Ambiguous mappings (overlap below the threshold) are left unchanged.
> 
> Unit tests cover collapse-after-split, ambiguous no-op, and collision reassignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e0894f6112a1f252cce326b2f48cf765f1469ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->