### PR TITLE
Fix selected model hover actions

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -766,7 +766,8 @@ function ModelSelectItem({
           value={model.id}
           className={cn([
             "group-hover/model-row:bg-accent group-hover/model-row:text-accent-foreground",
-            showLocalActions && "pr-20",
+            showLocalActions &&
+              "pr-20 group-focus-within/model-row:[&>span:first-child]:opacity-0 group-hover/model-row:[&>span:first-child]:opacity-0",
             isDeprecated && "text-muted-foreground focus:text-muted-foreground",
           ])}
         >


### PR DESCRIPTION
Hide the selected-model checkmark while downloaded-model actions are visible so the states do not overlap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class change in STT settings UI with no logic or data impact.
> 
> **Overview**
> Fixes overlapping UI in the STT model dropdown for **downloaded on-device models** that show **Finder/delete** actions on hover.
> 
> When `showLocalActions` is true, the `SelectItem` row now fades out its **first child span** (the selected-state checkmark) on **hover** and **focus-within** via `group-hover/model-row` and `group-focus-within/model-row` opacity utilities, while keeping the existing right padding for the action buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac21494c0509450aa96ea29bd7c98224e65e60f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->