### PR TITLE
Refresh 1.4.1 appearance changelog

### DIFF
--- a/packages/changelog/content/1.4.1.md
+++ b/packages/changelog/content/1.4.1.md
@@ -5,9 +5,10 @@ summary: "Anarlog 1.4.1 adds selectable macOS app icons, hardware-aware on-devic
 
 ## Personalization and workflows
 
-- Choose the **Production**, **Anagram**, **Blueprint**, or **Sketch** app icon
-  on macOS and update the Dock and app switcher immediately, with distinct
-  defaults for Stable, Staging, and Dev that follow the system's appearance
+- Use the new **Appearance** settings page to switch between visual Light,
+  Dark, and System themes and choose the **Production**, **Anagram**,
+  **Blueprint**, or **Sketch** app icon on macOS, with immediate updates and
+  distinct defaults for Stable, Staging, and Dev
 - Explore Pro automation starters for Slack recaps, Notion project notes,
   Linear action items, and Markdown exports, then preview their steps and save
   a local draft before execution is connected


### PR DESCRIPTION
Document the dedicated Appearance page and visual theme controls in the stable release notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to release notes with no application or infrastructure impact.
> 
> **Overview**
> Updates the **1.4.1** release notes so personalization is described as a dedicated **Appearance** settings experience, not only macOS icon selection.
> 
> The first bullet under **Personalization and workflows** now calls out the new Appearance page, **Light**, **Dark**, and **System** visual themes, and the existing **Production**, **Anagram**, **Blueprint**, and **Sketch** icon options with immediate Dock/switcher updates and channel-specific defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7be791935cc720c4a9502563103f070089c48466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->