### PR TITLE
Keep model actions clear while deletion is pending

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -760,7 +760,7 @@ function ModelSelectItem({
 
   if (model.isDownloaded) {
     return (
-      <div className="group/model-row relative overflow-hidden rounded-full">
+      <div className="group/model-row relative overflow-hidden rounded-full has-[[data-model-actions-pending]]:[&>*:first-child>span:first-child]:opacity-0">
         <SelectItem
           key={model.id}
           value={model.id}
@@ -936,6 +936,7 @@ function LocalModelDropdownActions({ model }: { model: LocalModel }) {
 
   return (
     <div
+      data-model-actions-pending={deleteModel.isPending || undefined}
       className={cn([
         "absolute top-0 right-0 bottom-0 z-10 flex items-center justify-end gap-1 rounded-r-full pl-6",
         "pointer-events-none opacity-0 transition-opacity duration-150",


### PR DESCRIPTION
Hide the selected-model checkmark for the full lifetime of a pending deletion so it cannot overlap the visible action strip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind-only UI tweak in STT model settings; no auth, data, or transcription logic changes.
> 
> **Overview**
> Fixes a visual overlap in the STT model dropdown when a downloaded on-device model is being deleted.
> 
> While `deleteModel.isPending`, the action strip already stays visible; this PR marks that state with `data-model-actions-pending` on `LocalModelDropdownActions` and uses a `has-[[data-model-actions-pending]]` rule on the row wrapper to hide the `SelectItem`’s first child span (the selected checkmark) for the full pending window—not only on hover/focus—so it does not sit on top of the delete/open controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a851627b6d30a9e92242b57250f52f9bf6012452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->