### PR TITLE
Make QA skills risk-targeted

### DIFF
--- a/.agents/skills/qa-cli-mcp-api/SKILL.md
+++ b/.agents/skills/qa-cli-mcp-api/SKILL.md
@@ -1,12 +1,55 @@
 ---
 name: qa-cli-mcp-api
-description: QA-test Anarlog's programmatic interfaces end to end: the CLI, local REST API, stdio MCP server, hosted Cloud API, and remote MCP server. Use before a release or after changes to agent-access DTOs, API auth, API keys, snapshots, pagination, exports, webhooks, or MCP tools.
+description: Select and run risk-based QA for Anarlog's CLI, local REST API, stdio MCP, hosted Cloud API, and remote MCP. Test only affected lanes for a branch or regression; use every lane only for an explicit programmatic-interface release gate.
 ---
 
 # QA: CLI, MCP, and API
 
-Treat this as a release gate for Anarlog's programmatic interfaces. Automated
-tests are necessary but do not replace the live smoke tests below.
+Default to the smallest set of programmatic-interface lanes that can prove the
+change. Automated tests are necessary but do not replace a live smoke test when
+the changed boundary is only exercised by a real client or deployment.
+
+## Choose the scope first
+
+Inspect the exact branch, commit, or diff and map changed code to its direct
+consumers before creating fixtures or credentials. In a GitButler workspace,
+use `but status` and `but show <commit-or-branch>`; do not use the synthetic
+workspace `HEAD` as the candidate or combine unrelated applied branches.
+
+Find the original reproduction in the current or past Codex task, linked
+issue, PR, support report, or regression test. State the selected lanes and the
+reason for each before testing.
+
+### Targeted regression mode (default)
+
+Select lanes by behavior, not by the existence of this checklist:
+
+- CLI parsing, output, or local DB access → CLI plus the closest contract tests.
+- Local API routes, keys, loopback lifecycle, or webhooks → the affected local
+  REST/webhook cases only.
+- Shared agent-access DTOs, exports, filtering, or pagination → each direct
+  local consumer plus cross-surface parity only for the changed fields.
+- Hosted auth, snapshots, entitlements, isolation, purge, or Supabase policy →
+  the affected hosted REST lifecycle and negative cases.
+- Local or remote MCP protocol/tool changes → that MCP lane and its direct
+  transport/contract dependency.
+- Shared hosted REST/MCP behavior → both hosted consumers, but not unrelated
+  local surfaces.
+
+Run the closest affected automated tests, the original live reproduction, and
+only credible boundary cases. A Rust or shared-crate change does not trigger
+all lanes unless every lane consumes the changed behavior. Create only the
+minimum non-sensitive fixture required for the selected checks. If a required
+deployment, account, fixture, or client is unavailable, mark that check
+`BLOCKED`; do not substitute unrelated lanes. Stop when the mapped risks are
+covered.
+
+### Full interface release-gate mode
+
+Run every fixture, baseline, live lane, lifecycle case, privacy check, and
+cross-surface comparison below only when the user explicitly requests full
+programmatic-interface QA or a release is being gated. Any required `FAIL` or
+`BLOCKED` result prevents release approval.
 
 ## Safety and evidence
 
@@ -26,7 +69,7 @@ tests are necessary but do not replace the live smoke tests below.
 - Mark a lane `BLOCKED`, not `PASS`, when its required deployment, account,
   fixture, or client is unavailable.
 
-## Required fixture
+## Full release-gate fixture
 
 Create two completed QA meetings through the desktop app:
 
@@ -47,7 +90,7 @@ The fixture must include:
 Record the meeting IDs and expected visible values. Do not seed SQLite or
 Postgres directly for the live happy-path tests.
 
-## Automated baseline
+## Full release-gate automated baseline
 
 Run from the repository root:
 
@@ -216,7 +259,12 @@ or fields outside the disclosed server-readable copy.
 
 ## Reporting
 
-Produce one table with rows for:
+For targeted mode, report the candidate branch/commit, base, selected lane and
+risk, `PASS`/`FAIL`/`BLOCKED`, and a one-line evidence note. List unrelated
+lanes once as `NOT APPLICABLE`, and say explicitly that the result is not full
+interface release certification.
+
+For full release-gate mode, produce one table with rows for:
 
 - automated baseline;
 - CLI;

--- a/.agents/skills/qa-cli-mcp-api/SKILL.md
+++ b/.agents/skills/qa-cli-mcp-api/SKILL.md
@@ -27,8 +27,9 @@ Select lanes by behavior, not by the existence of this checklist:
 - CLI parsing, output, or local DB access → CLI plus the closest contract tests.
 - Local API routes, keys, loopback lifecycle, or webhooks → the affected local
   REST/webhook cases only.
-- Shared agent-access DTOs, exports, filtering, or pagination → each direct
-  local consumer plus cross-surface parity only for the changed fields.
+- Shared agent-access DTOs, exports, filtering, or pagination → every direct
+  consumer, including hosted REST or remote MCP when affected, plus
+  cross-surface parity only for the changed fields.
 - Hosted auth, snapshots, entitlements, isolation, purge, or Supabase policy →
   the affected hosted REST lifecycle and negative cases.
 - Local or remote MCP protocol/tool changes → that MCP lane and its direct

--- a/.agents/skills/qa-critical-ux/SKILL.md
+++ b/.agents/skills/qa-critical-ux/SKILL.md
@@ -1,14 +1,76 @@
 ---
 name: qa-critical-ux
-description: QA-test the critical desktop user experience before a release — auth, CloudSync, calendar connect + notifications, note creation, recording, speaker identification, chat, and automated summaries across on-device and Pro providers. Use before cutting a stable release, after changes to auth/CloudSync/STT/enhance/calendar/billing flows, or when asked to "QA the app".
+description: Select and run risk-based desktop QA for a branch, commit, diff, or reported regression. Use the complete auth, CloudSync, calendar, note, recording, speaker, chat, summary, and provider matrix only for an explicit release gate or full-app QA request.
 ---
 
 # QA: Critical User Experience
 
-Gate releases on this checklist. Every item must pass (or be explicitly
-waived by the user) before running the release-new-version skill.
+Default to the smallest faithful QA scope for the change. The complete
+checklist remains the release gate, but it is not the default for ordinary
+branch or regression validation.
 
-## Setup
+## Choose the scope first
+
+Before building or launching anything:
+
+1. Inspect the exact candidate and its base. In a GitButler workspace, use
+   `but status` and `but show <commit-or-branch>`; do not treat the synthetic
+   workspace `HEAD` or every applied branch as the candidate.
+2. Trace changed files to user-visible behavior and failure boundaries. Find
+   the original reproduction in the current or past Codex task, linked issue,
+   PR, support report, or regression test when available.
+3. Write a short risk map with:
+   - behavior directly changed;
+   - plausible adjacent failures caused by the changed boundary;
+   - lifecycle or persistence transitions affected;
+   - checklist areas that are unrelated and will be skipped.
+4. State the selected live checks before running them. Do not expand the run
+   because a broad checklist is available.
+
+### Targeted regression mode (default)
+
+Use this mode for a branch, commit, diff, bug fix, or change isolated to one
+product area. Run only:
+
+- the closest automated tests required by the affected packages and CI paths;
+- the original user reproduction and the expected fixed outcome;
+- one bounded adjacent smoke check for each credible cross-cutting failure;
+- restart or persistence checks only when startup, durable state, migrations,
+  cleanup, or recovery behavior changed;
+- provider, account, platform, or model variants only when the changed code
+  branches on those variants.
+
+A Rust or native-code diff does not justify the full user-experience matrix by
+itself. It does justify checking that the exact candidate launches, remains
+responsive, completes the changed native operation without a crash or hang,
+and emits no relevant panic, deadlock, or repeated-error loop. Test recording,
+transcription, speaker identity, chat, calendar, auth, and provider matrices
+only when the diff can affect them.
+
+For example, a retained legacy-migration conflict that changes DB readiness
+and CloudSync gating should test: native launch and responsiveness; the
+conflict reproduction; the resulting Storage state and action; CloudSync
+readiness; retained recovery-file protection; and restart persistence. It
+should not run an in-meeting recording or provider matrix unless that code is
+also in the candidate.
+
+If the original fixture or required account is unavailable, mark that specific
+check `BLOCKED`. Do not replace missing targeted evidence with unrelated broad
+testing. Stop when the risk map is covered.
+
+### Full release-gate mode
+
+Use the complete setup, release-candidate order, and checklist below only when:
+
+- the user explicitly asks for full-app QA or a release gate;
+- the release-new-version skill is about to run; or
+- the candidate is broad enough that the risk map genuinely includes most of
+  the critical experience.
+
+Every applicable item must pass or be explicitly waived by the user before a
+release. A targeted run is evidence for its stated scope, not release approval.
+
+## Full release-gate setup
 
 1. Build and launch an authenticated native Dev bundle with AEC diagnostics:
 
@@ -373,9 +435,14 @@ tests alone is not cross-platform evidence.
 
 ## Reporting
 
-Produce a table: checklist item × provider config and on-device model →
-PASS/FAIL with a one-line note. Include the Dev manifest's Git SHA/dirty state, staging run
-URL and head SHA, staging artifact SHA-256, stable release URL and artifact
-SHA-256, app version, speaker-cluster count, speaker-name result, and any
-explicit waiver. Any FAIL or SHA mismatch blocks release; file or fix before
-cutting.
+For targeted mode, report the candidate branch/commit, base, selected risk,
+`PASS`/`FAIL`/`BLOCKED`, and one-line evidence for each selected check. List
+unrelated checklist lanes once as `NOT APPLICABLE`, and say explicitly that the
+result is not full release certification.
+
+For full release-gate mode, produce a table: checklist item × provider config
+and on-device model → PASS/FAIL with a one-line note. Include the Dev manifest's
+Git SHA/dirty state, staging run URL and head SHA, staging artifact SHA-256,
+stable release URL and artifact SHA-256, app version, speaker-cluster count,
+speaker-name result, and any explicit waiver. Any FAIL or SHA mismatch blocks
+release; file or fix before cutting.


### PR DESCRIPTION
Default branch QA to affected behaviors and reserve full matrices for explicit release gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skill instructions; no application code, auth, or deployment behavior is modified.
> 
> **Overview**
> **`qa-cli-mcp-api`** and **`qa-critical-ux`** now default to **targeted regression QA** instead of treating every run as a full release gate.
> 
> Each skill adds **“Choose the scope first”** guidance: map the branch/diff to affected behaviors, cite reproduction context, and pick the smallest faithful lane set (with GitButler-specific provenance rules). **Targeted mode** limits work to closest automated tests, the original repro, and credible adjacent checks; unrelated checklist lanes should be marked **`NOT APPLICABLE`**, and missing prerequisites **`BLOCKED`** rather than padded with broad testing. **Full release-gate mode** is reserved for explicit full QA or release certification—the existing fixture matrices, baselines, and checklists are relabeled under that mode and unchanged in substance.
> 
> Reporting is split so targeted runs document scope and explicitly state they are **not** full release certification; full-gate runs keep the existing comprehensive tables and pass/fail rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6af70d5a215c0062678ab81f4d28a52e85408fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->