### PR TITLE
Refresh 1.4.1 changelog

### DIFF
--- a/packages/changelog/content/1.4.1.md
+++ b/packages/changelog/content/1.4.1.md
@@ -27,6 +27,9 @@ summary: "Anarlog 1.4.1 adds selectable macOS app icons, hardware-aware on-devic
 
 ## Privacy and reliability
 
+- Avoid automatically rerunning a completed transcription when Anarlog cannot
+  save or process its result, preventing duplicate provider work while
+  surfacing the local failure for recovery
 - Stop masked session replay across every app window as soon as **Share usage
   data** is turned off, without sending the pending replay buffer
 - Avoid being sent through onboarding when Anarlog temporarily cannot read its

--- a/packages/changelog/content/1.4.1.md
+++ b/packages/changelog/content/1.4.1.md
@@ -19,8 +19,11 @@ summary: "Anarlog 1.4.1 adds selectable macOS app icons, hardware-aware on-devic
   shortcut inactive when you are typing in the editor
 - Choose Soniqo and Apple Speech as separate on-device transcription providers,
   with a model recommendation based on the memory available on your Mac
-- Keep microphone and system-audio identities separate when Anarlog Pro refines
-  a stereo recording with cloud batch transcription
+- Open downloaded on-device models in Finder or delete them without the
+  selected-model checkmark obscuring the action buttons
+- Keep microphone and system-audio identities separate and preserve live
+  speaker groupings when Anarlog Pro refines a recording with cloud batch
+  transcription
 
 ## Privacy and reliability
 
@@ -28,3 +31,6 @@ summary: "Anarlog 1.4.1 adds selectable macOS app icons, hardware-aware on-devic
   data** is turned off, without sending the pending replay buffer
 - Avoid being sent through onboarding when Anarlog temporarily cannot read its
   settings, and preserve malformed settings files instead of replacing them
+- Keep Cloud Sync available when a completed storage migration preserves older
+  files that differ from current data as recovery copies, without asking you to
+  retry


### PR DESCRIPTION
Document model action clarity, speaker-group preservation, and Cloud Sync migration recovery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changelog edits with no application, API, or data-path changes.
> 
> **Overview**
> **Refreshes the 1.4.1 release notes** so shipped behavior is documented more accurately for reviewers and users.
> 
> Under **Notes and transcription**, adds a bullet that downloaded on-device models can be opened in Finder or deleted without the selected-model checkmark covering the action buttons. Expands the Anarlog Pro cloud-batch bullet to call out **preserving live speaker groupings** in addition to keeping mic vs system-audio identities separate.
> 
> Under **Privacy and reliability**, adds that Anarlog **does not automatically rerun** a finished transcription when saving or processing the result fails, avoiding duplicate provider work while still surfacing the error for recovery. Adds that **Cloud Sync stays available** when a storage migration keeps older differing files as recovery copies, without prompting a retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ebb55d0d50749588671e33d1aabbd808848a343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->