### PR TITLE
Clarify responsibility for third-party charges

### DIFF
--- a/apps/web/content/legal/terms.mdx
+++ b/apps/web/content/legal/terms.mdx
@@ -1,10 +1,10 @@
 ---
-date: "2026-08-01"
+date: "2026-08-03"
 title: "Terms of Service"
 summary: "The agreement between you and us when you use Anarlog."
 ---
 
-> **The short version:** Anarlog is free and open source. Pro is a subscription you can cancel anytime, with a trial that never charges you automatically. Your content is yours. You're responsible for recording meetings lawfully. Encrypted sync means we can't recover your notes if you lose your recovery key. The full terms below are the ones that govern.
+> **The short version:** Anarlog is free and open source. Pro is a subscription you can cancel anytime, with a trial that never charges you automatically. Your content is yours. You're responsible for recording meetings lawfully. If you connect your own paid AI provider, its usage charges are your responsibility. Encrypted sync means we can't recover your notes if you lose your recovery key. The full terms below are the ones that govern.
 
 ## 1. Agreement to terms
 
@@ -94,6 +94,10 @@ Opt out of marketing anytime via the unsubscribe link in any marketing email, or
 Your use of the Service is also governed by our [Privacy Policy](/privacy) — please read it.
 
 Some features rely on third-party services: cloud transcription, AI summaries, payments, analytics. When you enable cloud features, your data may be processed by our sub-processors, and those features are subject to the third parties' own terms and privacy practices.
+
+### 10.1 Bring-your-own-key services and third-party charges
+
+If you connect your own API key or account for a third-party service, you are responsible for all fees that provider charges and for managing its usage, billing limits, and account. Software errors, retries, failed requests, or other unintended activity may cause the provider to charge you. To the maximum extent permitted by law, Fastrepl does not reimburse or credit charges imposed by third parties, including charges caused by an error or malfunction in the Service. Nothing in this section limits any rights or remedies that cannot be waived under applicable law.
 
 ## 11. Termination
 


### PR DESCRIPTION
Document responsibility for bring-your-own-key provider fees and non-reimbursement of third-party charges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only legal clarification with no application or data-handling code changes.
> 
> **Overview**
> Updates the **Terms of Service** (`terms.mdx`) effective date and clarifies who pays when users connect their own AI/API providers.
> 
> The **short version** now states that usage charges from a user-connected paid AI provider are the user’s responsibility. A new **§10.1 Bring-your-own-key services and third-party charges** assigns fee, usage, billing-limit, and account management to the user; notes that errors, retries, or unintended activity may still incur provider charges; and states that Fastrepl does not reimburse third-party charges (including those from Service errors), with a carve-out for non-waivable legal rights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 890b789077e3854f74fe28fb40812400be61a913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->