### PR TITLE
Stop retrying completed transcriptions

### DIFF
--- a/apps/desktop/src/store/zustand/listener/general-batch.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./general-batch";
 
 import { parseBatchCompletedNotificationKey } from "~/stt/batch-completed-notification";
+import { BatchResponseProcessingError } from "~/stt/batch-response-processing-error";
 
 const {
   isFocusedMock,
@@ -406,6 +407,97 @@ describe("runBatchSession", () => {
     expect(handleBatchFailed).not.toHaveBeenCalled();
     expect(handleBatchResponseStreamed).not.toHaveBeenCalled();
     expect(showNotificationMock).not.toHaveBeenCalled();
+  });
+
+  test("marks response processing failures after completion as terminal", async () => {
+    const processingError = new Error("database is locked");
+    const handleBatchStarted = vi.fn();
+    const handleBatchResponse = vi.fn(() => {
+      throw processingError;
+    });
+    const handleBatchCompleted = vi.fn();
+    const clearBatchPersist = vi.fn();
+    const clearBatchSession = vi.fn();
+    const handleBatchResponseStreamed = vi.fn();
+    const handleBatchFailed = vi.fn();
+    const handleBatchStopped = vi.fn();
+    const updateBatchProgress = vi.fn();
+    const setBatchPersist = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    let handler:
+      | ((event: {
+          payload: {
+            type: string;
+            session_id: string;
+            response?: unknown;
+            mode?: "direct" | "streamed";
+          };
+        }) => void)
+      | undefined;
+
+    listenMock.mockImplementation(async (cb) => {
+      handler = cb;
+      return vi.fn();
+    });
+
+    startTranscriptionMock.mockImplementation(async () => {
+      queueMicrotask(() => {
+        handler?.({
+          payload: {
+            type: "completed",
+            session_id: "session-1",
+            mode: "direct",
+            response: {
+              metadata: null,
+              results: { channels: [] },
+            },
+          },
+        });
+      });
+      return { status: "ok", data: null };
+    });
+
+    const run = runBatchSession(
+      () => ({
+        batch: {},
+        batchPreview: {},
+        batchPersist: {},
+        handleBatchStarted,
+        handleBatchResponse,
+        handleBatchCompleted,
+        clearBatchPersist,
+        clearBatchSession,
+        handleBatchResponseStreamed,
+        handleBatchFailed,
+        handleBatchStopped,
+        updateBatchProgress,
+        setBatchPersist,
+      }),
+      "session-1",
+      {
+        session_id: "session-1",
+        provider: "deepgram",
+        file_path: "/tmp/session.wav",
+        base_url: "https://api.deepgram.com/v1",
+        api_key: "test-key",
+      },
+    );
+
+    await expect(run).rejects.toMatchObject({
+      name: BatchResponseProcessingError.name,
+      cause: processingError,
+    });
+    expect(startTranscriptionMock).toHaveBeenCalledOnce();
+    expect(handleBatchFailed).toHaveBeenCalledWith(
+      "session-1",
+      "database is locked",
+    );
+    expect(clearBatchPersist).toHaveBeenCalledWith("session-1");
+    expect(clearBatchSession).not.toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 
   test("shows a completion notification when the window is not focused", async () => {

--- a/apps/desktop/src/store/zustand/listener/general-batch.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.ts
@@ -17,6 +17,7 @@ import {
 
 import { trackAnalyticsEvent } from "~/analytics";
 import { createBatchCompletedNotificationKey } from "~/stt/batch-completed-notification";
+import { BatchResponseProcessingError } from "~/stt/batch-response-processing-error";
 
 type BatchStore = BatchActions & BatchState;
 
@@ -163,7 +164,11 @@ export const runBatchSession = async <T extends BatchStore>(
         failure_stage: "persist",
       });
       cleanup(false);
-      reject(error);
+      reject(
+        error instanceof Error && error.message === EMPTY_BATCH_TRANSCRIPT_ERROR
+          ? error
+          : new BatchResponseProcessingError(error),
+      );
       return;
     }
 

--- a/apps/desktop/src/stt/batch-response-processing-error.ts
+++ b/apps/desktop/src/stt/batch-response-processing-error.ts
@@ -1,0 +1,12 @@
+export const BATCH_RESPONSE_PROCESSING_ERROR_MESSAGE =
+  "Batch transcription completed, but Anarlog could not process the response.";
+
+export class BatchResponseProcessingError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(BATCH_RESPONSE_PROCESSING_ERROR_MESSAGE);
+    this.name = "BatchResponseProcessingError";
+    this.cause = cause;
+  }
+}

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { beginCloudsyncActivity, endCloudsyncActivity } from "@anlg/plugin-db";
 
+import { BatchResponseProcessingError } from "./batch-response-processing-error";
 import {
   canRunBatchTranscription,
   EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE,
@@ -234,6 +235,14 @@ describe("canRunBatchTranscription", () => {
 });
 
 describe("isTerminalTranscriptionError", () => {
+  test("stops retries after a provider response cannot be processed", () => {
+    expect(
+      isTerminalTranscriptionError(
+        new BatchResponseProcessingError(new Error("database is locked")),
+      ),
+    ).toBe(true);
+  });
+
   test.each([
     "Bad Request: failed to process audio: corrupt or unsupported data",
     "No speech detected",
@@ -842,6 +851,35 @@ describe("useRunBatch", () => {
 
     expect(createTranscriptMock).toHaveBeenCalledOnce();
     expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
+    expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
+  });
+
+  test("does not make completed provider work retryable when persistence fails", async () => {
+    startTranscriptionMock.mockImplementation(async (_params, options) => {
+      options.handlePersist(
+        [{ text: "recovered", start_ms: 0, end_ms: 100, channel: 0 }],
+        [],
+      );
+    });
+    createTranscriptMock.mockRejectedValueOnce(new Error("disk write failed"));
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+    let processingError: unknown;
+
+    await act(async () => {
+      try {
+        await result.current("/tmp/session.wav", {
+          deferAudioFinalization: true,
+          promotion: { scope: "whole_session" },
+        });
+      } catch (error) {
+        processingError = error;
+      }
+    });
+
+    expect(processingError).toBeInstanceOf(BatchResponseProcessingError);
+    expect(isTerminalTranscriptionError(processingError)).toBe(true);
+    expect(startTranscriptionMock).toHaveBeenCalledOnce();
     expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import type { TranscriptionParams } from "@anlg/plugin-transcription";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 
+import { BatchResponseProcessingError } from "./batch-response-processing-error";
 import { useListener } from "./contexts";
 import { persistTranscriptWrite } from "./persist-retry";
 import { getSessionKeywords } from "./useKeywords";
@@ -656,6 +657,7 @@ export function isTranscriptionAuthenticationError(error: unknown) {
 export function isTerminalTranscriptionError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   return (
+    error instanceof BatchResponseProcessingError ||
     message === EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE ||
     isTranscriptionAuthenticationError(error) ||
     /corrupt or unsupported|unsupported (?:audio|data)|invalid audio|no speech|empty transcript/i.test(
@@ -918,69 +920,81 @@ export const useRunBatch = (sessionId: string) => {
             );
           }
 
-          if (!handlePersist) {
-            const promoted = prepareTranscriptPromotion(
-              stagedWords,
-              stagedHints,
-              options?.promotion ?? { scope: "preserve_existing" },
-            );
-            if (
-              options?.promotion?.scope === "current_capture" &&
-              promoted.words.length === 0
-            ) {
-              throw new Error(EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE);
-            }
-            if (transcriptId) {
-              const completedTranscriptId = transcriptId;
-              if (promoted.words.length > 0) {
-                const reconciledSpeakerHints = refinedTranscriptSource
-                  ? reconcileRefinedSpeakerClusters(
-                      refinedTranscriptSource,
-                      promoted.words,
-                      promoted.hints,
-                    )
-                  : promoted.hints;
-                const speakerHints = refinedTranscriptSource
-                  ? transferAutomaticSpeakerAssignments(
-                      refinedTranscriptSource,
-                      promoted.words,
-                      reconciledSpeakerHints,
-                    )
-                  : reconciledSpeakerHints;
-                await persistTranscriptWrite(() =>
-                  createTranscript({
-                    id: completedTranscriptId,
-                    sessionId,
-                    ownerUserId: session?.user_id ?? "",
-                    createdAt,
-                    startedAt: promoted.startedAt ?? startedAt,
-                    memo: memoMd,
-                    source: "batch_transcription",
-                    provider: target.provider,
-                    model: target.model,
-                    words: promoted.words,
-                    speakerHints,
-                    replaceSession: promoted.replaceSession,
-                    replaceTranscriptId: promoted.replaceTranscriptId,
-                  }),
-                );
+          try {
+            if (!handlePersist) {
+              const promoted = prepareTranscriptPromotion(
+                stagedWords,
+                stagedHints,
+                options?.promotion ?? { scope: "preserve_existing" },
+              );
+              if (
+                options?.promotion?.scope === "current_capture" &&
+                promoted.words.length === 0
+              ) {
+                throw new Error(EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE);
+              }
+              if (transcriptId) {
+                const completedTranscriptId = transcriptId;
+                if (promoted.words.length > 0) {
+                  const reconciledSpeakerHints = refinedTranscriptSource
+                    ? reconcileRefinedSpeakerClusters(
+                        refinedTranscriptSource,
+                        promoted.words,
+                        promoted.hints,
+                      )
+                    : promoted.hints;
+                  const speakerHints = refinedTranscriptSource
+                    ? transferAutomaticSpeakerAssignments(
+                        refinedTranscriptSource,
+                        promoted.words,
+                        reconciledSpeakerHints,
+                      )
+                    : reconciledSpeakerHints;
+                  await persistTranscriptWrite(() =>
+                    createTranscript({
+                      id: completedTranscriptId,
+                      sessionId,
+                      ownerUserId: session?.user_id ?? "",
+                      createdAt,
+                      startedAt: promoted.startedAt ?? startedAt,
+                      memo: memoMd,
+                      source: "batch_transcription",
+                      provider: target.provider,
+                      model: target.model,
+                      words: promoted.words,
+                      speakerHints,
+                      replaceSession: promoted.replaceSession,
+                      replaceTranscriptId: promoted.replaceTranscriptId,
+                    }),
+                  );
+                }
+              }
+              if (!options?.deferAudioFinalization) {
+                try {
+                  await persistTranscriptWrite(() =>
+                    markSessionAudioTranscriptionComplete(sessionId),
+                  );
+                } catch (error) {
+                  console.error(
+                    "[runBatch] failed to mark session audio as processed",
+                    error,
+                  );
+                }
               }
             }
             if (!options?.deferAudioFinalization) {
-              try {
-                await persistTranscriptWrite(() =>
-                  markSessionAudioTranscriptionComplete(sessionId),
-                );
-              } catch (error) {
-                console.error(
-                  "[runBatch] failed to mark session audio as processed",
-                  error,
-                );
-              }
+              await deleteProcessedAudioForRetention(audioRetention, sessionId);
             }
-          }
-          if (!options?.deferAudioFinalization) {
-            await deleteProcessedAudioForRetention(audioRetention, sessionId);
+          } catch (error) {
+            if (
+              error instanceof BatchResponseProcessingError ||
+              (error instanceof Error &&
+                error.message ===
+                  EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE)
+            ) {
+              throw error;
+            }
+            throw new BatchResponseProcessingError(error);
           }
         },
       );


### PR DESCRIPTION
Treat response-processing and local persistence failures after provider completion as terminal automatic-recovery errors, with regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch failure and automatic-recovery behavior around transcript persistence; misclassification could either skip needed retries or repeat paid provider work, though tests target the main paths.
> 
> **Overview**
> After the STT provider finishes batch transcription, **local failures** (saving the transcript, handling the completed response) are no longer treated like transient provider errors that automatic recovery should retry.
> 
> A new **`BatchResponseProcessingError`** wraps those post-completion failures with a stable user-facing message while preserving the underlying `cause`. **`runBatchSession`** rejects with it when `handleBatchResponse` throws after a completed event (empty-transcript errors stay unchanged). **`useRunBatch`** wraps failures in the post-transcription persist/finalization path the same way.
> 
> **`isTerminalTranscriptionError`** now returns true for `BatchResponseProcessingError`, so capture recovery stops retrying instead of re-running batch transcription when persistence alone failed. Regression tests cover the listener path, terminal classification, and the case where `createTranscript` fails after a successful provider run (no audio retention cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ade00beb852bacc68037c6e08a61f58264267a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->