### PR TITLE
Restore Loops lifecycle delivery

### DIFF
--- a/.github/workflows/stripe_cd.yaml
+++ b/.github/workflows/stripe_cd.yaml
@@ -43,14 +43,32 @@ jobs:
               --output=json |
               python3 -c 'import json, sys; print(json.load(sys.stdin)[0]["secretValue"])'
           )"
+          loops_api_key="$(
+            infisical secrets get LOOPS_KEY \
+              --token="$INFISICAL_TOKEN" \
+              --env=prod \
+              --projectId="$project_id" \
+              --path=/anarlog/web \
+              --output=json |
+              python3 -c 'import json, sys; print(json.load(sys.stdin)[0]["secretValue"])'
+          )"
 
           echo "::add-mask::$posthog_api_key"
+          echo "::add-mask::$loops_api_key"
           if [[ "$posthog_api_key" != phc_* || ${#posthog_api_key} -lt 20 ]]; then
             echo "Invalid Anarlog PostHog project token" >&2
             exit 1
           fi
+          if [[ ${#loops_api_key} -lt 20 ]]; then
+            echo "Invalid Anarlog Loops API key" >&2
+            exit 1
+          fi
 
-          flyctl secrets set POSTHOG_API_KEY="$posthog_api_key" --stage --app hyprnote-stripe
+          flyctl secrets set \
+            POSTHOG_API_KEY="$posthog_api_key" \
+            LOOPS_API_KEY="$loops_api_key" \
+            --stage \
+            --app hyprnote-stripe
 
           flyctl deploy \
             --config apps/stripe/fly.toml \
@@ -67,6 +85,19 @@ jobs:
           )"
           if [[ "$actual_hash" != "$expected_hash" ]]; then
             echo "Deployed Stripe service has the wrong PostHog project token" >&2
+            exit 1
+          fi
+
+          expected_loops_hash="$(printf %s "$loops_api_key" | sha256sum | cut -d " " -f 1)"
+          actual_loops_hash="$(
+            flyctl ssh console \
+              --app hyprnote-stripe \
+              --command 'sh -lc '\''printf %s "$LOOPS_API_KEY" | sha256sum | cut -d " " -f 1'\''' |
+              grep -Eo '[0-9a-f]{64}' |
+              tail -n 1
+          )"
+          if [[ "$actual_loops_hash" != "$expected_loops_hash" ]]; then
+            echo "Deployed Stripe service has the wrong Loops API key" >&2
             exit 1
           fi
         env:

--- a/apps/stripe/fly.toml
+++ b/apps/stripe/fly.toml
@@ -16,7 +16,7 @@ dockerfile = 'Dockerfile'
 strategy = 'bluegreen'
 
 [env]
-BUN_ENV = 'production'
+NODE_ENV = 'production'
 PORT = '8080'
 
 [processes]

--- a/apps/stripe/src/env.ts
+++ b/apps/stripe/src/env.ts
@@ -1,6 +1,9 @@
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
+const requiredInProduction = <T extends z.ZodTypeAny>(schema: T) =>
+  Bun.env.NODE_ENV === "production" ? schema : schema.optional();
+
 export const env = createEnv({
   server: {
     PORT: z.coerce.number().default(8788),
@@ -13,8 +16,7 @@ export const env = createEnv({
     STRIPE_SECRET_KEY: z.string().min(1),
     STRIPE_WEBHOOK_SECRET: z.string().min(1),
     POSTHOG_API_KEY: z.string().min(1).optional(),
-    LOOPS_API_KEY: z.string().min(1).optional(),
-    LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID: z.string().min(1).optional(),
+    LOOPS_API_KEY: requiredInProduction(z.string().min(1)),
   },
   runtimeEnv: Bun.env,
   emptyStringAsUndefined: true,

--- a/apps/stripe/src/loops.test.ts
+++ b/apps/stripe/src/loops.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+
+import { sendLoopsTransactional } from "./loops";
+
+describe("sendLoopsTransactional", () => {
+  it("sends idempotency in the header", async () => {
+    let request: { url: string; init?: RequestInit } | undefined;
+
+    await sendLoopsTransactional({
+      apiKey: "loops-key",
+      transactionalId: "transactional-123",
+      email: "alex@example.com",
+      dataVariables: { firstName: "Alex" },
+      idempotencyKey: "stripe-event-123",
+      fetcher: async (url, init) => {
+        request = { url: String(url), init };
+        return Response.json({ success: true });
+      },
+    });
+
+    expect(request?.url).toBe("https://app.loops.so/api/v1/transactional");
+    expect(new Headers(request?.init?.headers).get("Idempotency-Key")).toBe(
+      "stripe-event-123",
+    );
+    expect(JSON.parse(String(request?.init?.body))).toEqual({
+      transactionalId: "transactional-123",
+      email: "alex@example.com",
+      dataVariables: { firstName: "Alex" },
+    });
+  });
+});

--- a/apps/stripe/src/loops.ts
+++ b/apps/stripe/src/loops.ts
@@ -1,0 +1,42 @@
+const LOOPS_TRANSACTIONAL_URL = "https://app.loops.so/api/v1/transactional";
+
+type Fetcher = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export async function sendLoopsTransactional({
+  apiKey,
+  transactionalId,
+  email,
+  dataVariables,
+  idempotencyKey,
+  fetcher = fetch,
+}: {
+  apiKey: string;
+  transactionalId: string;
+  email: string;
+  dataVariables: Record<string, string | number>;
+  idempotencyKey: string;
+  fetcher?: Fetcher;
+}) {
+  const response = await fetcher(LOOPS_TRANSACTIONAL_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "Idempotency-Key": idempotencyKey,
+    },
+    body: JSON.stringify({
+      transactionalId,
+      email,
+      dataVariables,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Loops transactional send failed (${response.status}): ${await response.text()}`,
+    );
+  }
+}

--- a/apps/stripe/src/trial-emails.ts
+++ b/apps/stripe/src/trial-emails.ts
@@ -6,9 +6,10 @@ import {
   getUserIdFromCustomer,
 } from "./billing-bridge";
 import { env } from "./env";
+import { sendLoopsTransactional } from "./loops";
 import { buildTrialEndingEmail } from "./trial-email-payload";
 
-const LOOPS_TRANSACTIONAL_URL = "https://app.loops.so/api/v1/transactional";
+const TRIAL_FINAL_REMINDER_TRANSACTIONAL_ID = "cmryjal6600130jvelcx1sol2";
 
 export type TrialEndingEmailReceipt = {
   transactionalId: string;
@@ -21,7 +22,7 @@ export async function sendTrialEndingEmail(event: Stripe.Event) {
     return null;
   }
 
-  if (!env.LOOPS_API_KEY || !env.LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID) {
+  if (!env.LOOPS_API_KEY) {
     return null;
   }
 
@@ -45,30 +46,16 @@ export async function sendTrialEndingEmail(event: Stripe.Event) {
     return null;
   }
 
-  const response = await fetch(LOOPS_TRANSACTIONAL_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${env.LOOPS_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      transactionalId: env.LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID,
-      email: payload.email,
-      dataVariables: payload.dataVariables,
-      // Loops takes idempotency in the body, not an Idempotency-Key header;
-      // this is what dedupes webhook retries into a single email.
-      idempotencyKey: event.id,
-    }),
+  await sendLoopsTransactional({
+    apiKey: env.LOOPS_API_KEY,
+    transactionalId: TRIAL_FINAL_REMINDER_TRANSACTIONAL_ID,
+    email: payload.email,
+    dataVariables: payload.dataVariables,
+    idempotencyKey: event.id,
   });
 
-  if (!response.ok) {
-    throw new Error(
-      `Loops transactional send failed (${response.status}): ${await response.text()}`,
-    );
-  }
-
   return {
-    transactionalId: env.LOOPS_TRIAL_ENDING_TRANSACTIONAL_ID,
+    transactionalId: TRIAL_FINAL_REMINDER_TRANSACTIONAL_ID,
     trialEnd: subscription.trial_end!,
     userId: getUserIdFromCustomer(customer),
   } satisfies TrialEndingEmailReceipt;

--- a/apps/web/netlify/functions/loops-account-onboarding.mts
+++ b/apps/web/netlify/functions/loops-account-onboarding.mts
@@ -1,0 +1,107 @@
+import { createClient } from "@supabase/supabase-js";
+
+import { sendLoopsEvent } from "../../src/lib/loops.ts";
+
+type AccountOnboardingEvent = {
+  id: string;
+  user_id: string;
+  email: string;
+  first_name: string;
+};
+
+function requireEnvironmentVariable(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export default async () => {
+  const supabase = createClient(
+    requireEnvironmentVariable("SUPABASE_URL"),
+    requireEnvironmentVariable("SUPABASE_SERVICE_ROLE_KEY"),
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );
+  const apiKey = requireEnvironmentVariable("LOOPS_KEY");
+  const leaseId = crypto.randomUUID();
+  const { data, error: claimError } = await supabase.rpc(
+    "claim_account_onboarding_events",
+    {
+      p_lease_id: leaseId,
+      p_limit: 100,
+      p_lease_seconds: 300,
+    },
+  );
+  if (claimError) {
+    throw claimError;
+  }
+
+  const events = (data ?? []) as AccountOnboardingEvent[];
+  const failures: Error[] = [];
+  let delivered = 0;
+
+  for (const event of events) {
+    try {
+      await sendLoopsEvent({
+        apiKey,
+        email: event.email,
+        userId: event.user_id,
+        eventName: "anarlogAccountConfirmed",
+        firstName: event.first_name,
+        idempotencyKey: `account-onboarding:${event.id}`,
+      });
+
+      const { data: completed, error: completionError } = await supabase.rpc(
+        "complete_account_onboarding_events",
+        {
+          p_lease_id: leaseId,
+          p_event_ids: [event.id],
+        },
+      );
+      if (completionError) {
+        throw completionError;
+      }
+      if (completed !== 1) {
+        throw new Error(`Failed to complete onboarding event ${event.id}`);
+      }
+      delivered += 1;
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      failures.push(failure);
+
+      const { error: failureError } = await supabase.rpc(
+        "fail_account_onboarding_events",
+        {
+          p_lease_id: leaseId,
+          p_event_ids: [event.id],
+          p_error: failure.message,
+        },
+      );
+      if (failureError) {
+        failures.push(failureError);
+      }
+    }
+  }
+
+  console.log(
+    JSON.stringify({
+      claimed: events.length,
+      delivered,
+      failed: events.length - delivered,
+    }),
+  );
+
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Account onboarding delivery failed");
+  }
+};
+
+export const config = {
+  schedule: "*/5 * * * *",
+};

--- a/apps/web/netlify/functions/loops-trial-ending-reminders.mts
+++ b/apps/web/netlify/functions/loops-trial-ending-reminders.mts
@@ -1,0 +1,75 @@
+import { createClient } from "@supabase/supabase-js";
+
+import { sendLoopsTransactional } from "../../src/lib/loops.ts";
+
+const TRIAL_ENDING_TRANSACTIONAL_ID = "cmruoy7ix00zg0j1g74a7cycv";
+
+type DueTrialReminder = {
+  subscription_id: string;
+  customer_email: string;
+  customer_name: string | null;
+  trial_end: number;
+};
+
+function requireEnvironmentVariable(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export default async () => {
+  const supabase = createClient(
+    requireEnvironmentVariable("SUPABASE_URL"),
+    requireEnvironmentVariable("SUPABASE_SERVICE_ROLE_KEY"),
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );
+  const apiKey = requireEnvironmentVariable("LOOPS_KEY");
+  const { data, error } = await supabase.rpc("list_due_trial_reminders");
+  if (error) {
+    throw error;
+  }
+
+  const reminders = (data ?? []) as DueTrialReminder[];
+  const failures: Error[] = [];
+  let delivered = 0;
+
+  for (const reminder of reminders) {
+    try {
+      await sendLoopsTransactional({
+        apiKey,
+        transactionalId: TRIAL_ENDING_TRANSACTIONAL_ID,
+        email: reminder.customer_email,
+        dataVariables: {
+          firstName: reminder.customer_name?.trim().split(/\s+/)[0] || "there",
+        },
+        idempotencyKey: `trial-ending:${reminder.subscription_id}:${reminder.trial_end}`,
+      });
+      delivered += 1;
+    } catch (error) {
+      failures.push(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  console.log(
+    JSON.stringify({
+      due: reminders.length,
+      delivered,
+      failed: reminders.length - delivered,
+    }),
+  );
+
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Trial reminder delivery failed");
+  }
+};
+
+export const config = {
+  schedule: "*/5 * * * *",
+};

--- a/apps/web/src/lib/loops.test.ts
+++ b/apps/web/src/lib/loops.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sendLoopsEvent, sendLoopsTransactional } from "./loops.ts";
+
+test("sends lifecycle events with contact data and idempotency", async () => {
+  let request: { url: string; init?: RequestInit } | undefined;
+
+  await sendLoopsEvent({
+    apiKey: "loops-key",
+    email: "alex@example.com",
+    userId: "user-123",
+    eventName: "anarlogAccountConfirmed",
+    firstName: "Alex",
+    idempotencyKey: "account-onboarding:event-123",
+    fetcher: async (url, init) => {
+      request = { url: String(url), init };
+      return Response.json({ success: true });
+    },
+  });
+
+  assert.equal(request?.url, "https://app.loops.so/api/v1/events/send");
+  assert.equal(
+    new Headers(request?.init?.headers).get("Idempotency-Key"),
+    "account-onboarding:event-123",
+  );
+  assert.deepEqual(JSON.parse(String(request?.init?.body)), {
+    email: "alex@example.com",
+    userId: "user-123",
+    eventName: "anarlogAccountConfirmed",
+    firstName: "Alex",
+  });
+});
+
+test("sends transactionals without putting idempotency in the body", async () => {
+  let request: { init?: RequestInit } | undefined;
+
+  await sendLoopsTransactional({
+    apiKey: "loops-key",
+    transactionalId: "transactional-123",
+    email: "alex@example.com",
+    dataVariables: { firstName: "Alex" },
+    idempotencyKey: "trial-ending:sub-123:1785945600",
+    fetcher: async (_url, init) => {
+      request = { init };
+      return Response.json({ success: true });
+    },
+  });
+
+  assert.equal(
+    new Headers(request?.init?.headers).get("Idempotency-Key"),
+    "trial-ending:sub-123:1785945600",
+  );
+  assert.deepEqual(JSON.parse(String(request?.init?.body)), {
+    transactionalId: "transactional-123",
+    email: "alex@example.com",
+    dataVariables: { firstName: "Alex" },
+  });
+});
+
+test("surfaces Loops API errors", async () => {
+  await assert.rejects(
+    sendLoopsEvent({
+      apiKey: "invalid-key",
+      email: "alex@example.com",
+      userId: "user-123",
+      eventName: "anarlogAccountConfirmed",
+      firstName: "Alex",
+      idempotencyKey: "account-onboarding:event-123",
+      fetcher: async () => new Response("invalid token", { status: 401 }),
+    }),
+    /Loops request failed \(401\): invalid token/,
+  );
+});

--- a/apps/web/src/lib/loops.ts
+++ b/apps/web/src/lib/loops.ts
@@ -1,0 +1,90 @@
+const LOOPS_API_URL = "https://app.loops.so/api/v1";
+
+async function sendLoopsRequest({
+  path,
+  apiKey,
+  idempotencyKey,
+  body,
+  fetcher,
+}: {
+  path: "/events/send" | "/transactional";
+  apiKey: string;
+  idempotencyKey: string;
+  body: Record<string, unknown>;
+  fetcher: typeof fetch;
+}) {
+  const response = await fetcher(`${LOOPS_API_URL}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "Idempotency-Key": idempotencyKey,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Loops request failed (${response.status}): ${await response.text()}`,
+    );
+  }
+}
+
+export function sendLoopsEvent({
+  apiKey,
+  email,
+  userId,
+  eventName,
+  firstName,
+  idempotencyKey,
+  fetcher = fetch,
+}: {
+  apiKey: string;
+  email: string;
+  userId: string;
+  eventName: string;
+  firstName: string;
+  idempotencyKey: string;
+  fetcher?: typeof fetch;
+}) {
+  return sendLoopsRequest({
+    path: "/events/send",
+    apiKey,
+    idempotencyKey,
+    body: {
+      email,
+      userId,
+      eventName,
+      firstName,
+    },
+    fetcher,
+  });
+}
+
+export function sendLoopsTransactional({
+  apiKey,
+  transactionalId,
+  email,
+  dataVariables,
+  idempotencyKey,
+  fetcher = fetch,
+}: {
+  apiKey: string;
+  transactionalId: string;
+  email: string;
+  dataVariables: Record<string, string | number>;
+  idempotencyKey: string;
+  fetcher?: typeof fetch;
+}) {
+  return sendLoopsRequest({
+    path: "/transactional",
+    apiKey,
+    idempotencyKey,
+    body: {
+      transactionalId,
+      email,
+      dataVariables,
+    },
+    fetcher,
+  });
+}

--- a/supabase/migrations/20260803120000_account_onboarding_and_trial_reminders.sql
+++ b/supabase/migrations/20260803120000_account_onboarding_and_trial_reminders.sql
@@ -1,0 +1,339 @@
+CREATE TABLE private.account_onboarding_outbox (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL UNIQUE REFERENCES auth.users (id) ON DELETE CASCADE,
+  email text NOT NULL,
+  first_name text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  attempt_count integer NOT NULL DEFAULT 0,
+  next_attempt_at timestamptz NOT NULL DEFAULT now(),
+  lease_id uuid,
+  lease_expires_at timestamptz,
+  delivered_at timestamptz,
+  last_error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX account_onboarding_outbox_claim_idx
+  ON private.account_onboarding_outbox (next_attempt_at, occurred_at)
+  WHERE delivered_at IS NULL;
+
+REVOKE ALL ON TABLE private.account_onboarding_outbox
+  FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION private.handle_account_onboarding_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  confirmation_time timestamptz;
+  display_name text;
+  first_name text;
+BEGIN
+  IF COALESCE(NEW.is_anonymous, false)
+    OR NULLIF(btrim(NEW.email), '') IS NULL
+  THEN
+    RETURN NEW;
+  END IF;
+
+  confirmation_time := COALESCE(
+    NEW.confirmed_at,
+    NEW.email_confirmed_at,
+    NEW.phone_confirmed_at
+  );
+  IF confirmation_time IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  display_name := COALESCE(
+    NULLIF(btrim(NEW.raw_user_meta_data ->> 'given_name'), ''),
+    NULLIF(btrim(NEW.raw_user_meta_data ->> 'full_name'), ''),
+    NULLIF(btrim(NEW.raw_user_meta_data ->> 'name'), '')
+  );
+  first_name := COALESCE(
+    split_part(regexp_replace(display_name, '\s+', ' ', 'g'), ' ', 1),
+    'there'
+  );
+
+  INSERT INTO private.account_onboarding_outbox (
+    user_id,
+    email,
+    first_name,
+    occurred_at
+  )
+  VALUES (
+    NEW.id,
+    btrim(NEW.email),
+    first_name,
+    confirmation_time
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    email = EXCLUDED.email,
+    first_name = EXCLUDED.first_name,
+    occurred_at = EXCLUDED.occurred_at,
+    updated_at = clock_timestamp()
+  WHERE private.account_onboarding_outbox.delivered_at IS NULL;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.handle_account_onboarding_user()
+  FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA private TO supabase_auth_admin;
+GRANT EXECUTE ON FUNCTION private.handle_account_onboarding_user()
+  TO supabase_auth_admin;
+
+CREATE TRIGGER on_auth_user_account_onboarding_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION private.handle_account_onboarding_user();
+
+CREATE TRIGGER on_auth_user_account_onboarding_confirmed
+  AFTER UPDATE OF confirmed_at, email_confirmed_at, phone_confirmed_at
+  ON auth.users
+  FOR EACH ROW
+  WHEN (
+    COALESCE(
+      OLD.confirmed_at,
+      OLD.email_confirmed_at,
+      OLD.phone_confirmed_at
+    ) IS NULL
+    AND COALESCE(
+      NEW.confirmed_at,
+      NEW.email_confirmed_at,
+      NEW.phone_confirmed_at
+    ) IS NOT NULL
+  )
+  EXECUTE FUNCTION private.handle_account_onboarding_user();
+
+CREATE OR REPLACE FUNCTION public.claim_account_onboarding_events(
+  p_lease_id uuid,
+  p_limit integer DEFAULT 100,
+  p_lease_seconds integer DEFAULT 300
+)
+RETURNS TABLE (
+  id uuid,
+  user_id uuid,
+  email text,
+  first_name text,
+  occurred_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  lease_now timestamptz := clock_timestamp();
+BEGIN
+  IF p_lease_id IS NULL
+    OR p_limit IS NULL
+    OR p_limit < 1
+    OR p_limit > 500
+    OR p_lease_seconds IS NULL
+    OR p_lease_seconds < 30
+    OR p_lease_seconds > 900
+  THEN
+    RAISE EXCEPTION 'invalid account onboarding lease'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  WITH candidates AS (
+    SELECT outbox.id
+    FROM private.account_onboarding_outbox AS outbox
+    WHERE outbox.delivered_at IS NULL
+      AND outbox.next_attempt_at <= lease_now
+      AND outbox.attempt_count < 20
+      AND (
+        outbox.lease_expires_at IS NULL
+        OR outbox.lease_expires_at <= lease_now
+      )
+    ORDER BY outbox.occurred_at, outbox.id
+    FOR UPDATE SKIP LOCKED
+    LIMIT p_limit
+  ), leased AS (
+    UPDATE private.account_onboarding_outbox AS outbox
+    SET
+      attempt_count = outbox.attempt_count + 1,
+      lease_id = p_lease_id,
+      lease_expires_at = lease_now
+        + make_interval(secs => p_lease_seconds),
+      updated_at = lease_now
+    FROM candidates
+    WHERE outbox.id = candidates.id
+    RETURNING outbox.*
+  )
+  SELECT
+    leased.id,
+    leased.user_id,
+    leased.email,
+    leased.first_name,
+    leased.occurred_at
+  FROM leased
+  ORDER BY leased.occurred_at, leased.id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.complete_account_onboarding_events(
+  p_lease_id uuid,
+  p_event_ids uuid[]
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  IF p_lease_id IS NULL
+    OR p_event_ids IS NULL
+    OR cardinality(p_event_ids) < 1
+    OR cardinality(p_event_ids) > 500
+  THEN
+    RAISE EXCEPTION 'invalid account onboarding completion'
+      USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE private.account_onboarding_outbox AS outbox
+  SET
+    delivered_at = clock_timestamp(),
+    lease_id = NULL,
+    lease_expires_at = NULL,
+    last_error = NULL,
+    updated_at = clock_timestamp()
+  WHERE outbox.id = ANY (p_event_ids)
+    AND outbox.lease_id = p_lease_id
+    AND outbox.delivered_at IS NULL;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fail_account_onboarding_events(
+  p_lease_id uuid,
+  p_event_ids uuid[],
+  p_error text
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  IF p_lease_id IS NULL
+    OR p_event_ids IS NULL
+    OR cardinality(p_event_ids) < 1
+    OR cardinality(p_event_ids) > 500
+  THEN
+    RAISE EXCEPTION 'invalid account onboarding failure'
+      USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE private.account_onboarding_outbox AS outbox
+  SET
+    next_attempt_at = clock_timestamp()
+      + make_interval(
+        secs => LEAST(3600, power(2, LEAST(outbox.attempt_count, 10))::integer)
+      ),
+    lease_id = NULL,
+    lease_expires_at = NULL,
+    last_error = left(COALESCE(p_error, 'unknown error'), 2000),
+    updated_at = clock_timestamp()
+  WHERE outbox.id = ANY (p_event_ids)
+    AND outbox.lease_id = p_lease_id
+    AND outbox.delivered_at IS NULL;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_due_trial_reminders(
+  p_now timestamptz DEFAULT clock_timestamp(),
+  p_window_seconds integer DEFAULT 82800
+)
+RETURNS TABLE (
+  subscription_id text,
+  customer_email text,
+  customer_name text,
+  trial_end bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_now IS NULL
+    OR p_window_seconds IS NULL
+    OR p_window_seconds < 300
+    OR p_window_seconds > 86400
+  THEN
+    RAISE EXCEPTION 'invalid trial reminder window'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    subscription.id,
+    btrim(customer.email),
+    customer.name,
+    trial.ending_at_epoch
+  FROM stripe.subscriptions AS subscription
+  JOIN stripe.customers AS customer
+    ON customer.id = subscription.customer
+  CROSS JOIN LATERAL (
+    SELECT CASE
+      WHEN jsonb_typeof(subscription.trial_end) = 'number'
+      THEN (subscription.trial_end #>> '{}')::bigint
+    END AS ending_at_epoch
+  ) AS trial
+  WHERE subscription.status = 'trialing'
+    AND trial.ending_at_epoch IS NOT NULL
+    AND NULLIF(btrim(customer.email), '') IS NOT NULL
+    AND subscription.default_payment_method IS NULL
+    AND customer.invoice_settings ->> 'default_payment_method' IS NULL
+    AND customer.default_source IS NULL
+    AND to_timestamp(trial.ending_at_epoch) > p_now
+    AND to_timestamp(trial.ending_at_epoch) - interval '7 days' <= p_now
+    AND to_timestamp(trial.ending_at_epoch) - interval '7 days'
+      > p_now - make_interval(secs => p_window_seconds)
+  ORDER BY subscription.id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_account_onboarding_events(
+  uuid,
+  integer,
+  integer
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.complete_account_onboarding_events(uuid, uuid[])
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.fail_account_onboarding_events(
+  uuid,
+  uuid[],
+  text
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_due_trial_reminders(timestamptz, integer)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.claim_account_onboarding_events(
+  uuid,
+  integer,
+  integer
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.complete_account_onboarding_events(uuid, uuid[])
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.fail_account_onboarding_events(
+  uuid,
+  uuid[],
+  text
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.list_due_trial_reminders(timestamptz, integer)
+  TO service_role;

--- a/supabase/tests/028-account-onboarding-and-trial-reminders.sql
+++ b/supabase/tests/028-account-onboarding-and-trial-reminders.sql
@@ -1,0 +1,279 @@
+begin;
+select plan(14);
+
+create temporary table account_onboarding_test_users (
+  kind text primary key,
+  id uuid not null,
+  created_at timestamptz not null
+);
+
+insert into account_onboarding_test_users (kind, id, created_at)
+values
+  ('confirmed', gen_random_uuid(), '2026-08-03 10:00:00+00'),
+  ('unconfirmed', gen_random_uuid(), '2026-08-03 10:01:00+00'),
+  ('anonymous', gen_random_uuid(), '2026-08-03 10:02:00+00');
+
+insert into auth.users (
+  id,
+  email,
+  raw_user_meta_data,
+  raw_app_meta_data,
+  is_anonymous,
+  email_confirmed_at,
+  created_at,
+  updated_at
+)
+select
+  id,
+  kind || '@example.com',
+  case
+    when kind = 'confirmed' then '{"full_name":"Alex Morgan"}'::jsonb
+    when kind = 'unconfirmed' then '{"given_name":"Riley"}'::jsonb
+    else '{}'::jsonb
+  end,
+  jsonb_build_object('provider', 'email'),
+  kind = 'anonymous',
+  case when kind = 'confirmed' then created_at else null end,
+  created_at,
+  created_at
+from account_onboarding_test_users;
+
+select ok(
+  to_regclass('private.account_onboarding_outbox') is not null,
+  'Account onboarding outbox is private'
+);
+
+select ok(
+  not has_table_privilege(
+    'anon',
+    'private.account_onboarding_outbox',
+    'SELECT'
+  )
+    and not has_table_privilege(
+      'authenticated',
+      'private.account_onboarding_outbox',
+      'SELECT'
+    ),
+  'Client roles cannot read account onboarding events'
+);
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    'public.claim_account_onboarding_events(uuid,integer,integer)',
+    'EXECUTE'
+  )
+    and not has_function_privilege(
+      'authenticated',
+      'public.claim_account_onboarding_events(uuid,integer,integer)',
+      'EXECUTE'
+    ),
+  'Only service code can claim account onboarding events'
+);
+
+select results_eq(
+  $$
+  select count(*)
+  from private.account_onboarding_outbox
+  where user_id = (
+    select id from account_onboarding_test_users where kind = 'confirmed'
+  )
+  $$,
+  array[1::bigint],
+  'Confirmed accounts are queued on insert'
+);
+
+select results_eq(
+  $$
+  select first_name
+  from private.account_onboarding_outbox
+  where user_id = (
+    select id from account_onboarding_test_users where kind = 'confirmed'
+  )
+  $$,
+  array['Alex'::text],
+  'The first name is derived from auth metadata'
+);
+
+select results_eq(
+  $$
+  select count(*)
+  from private.account_onboarding_outbox
+  where user_id = (
+    select id from account_onboarding_test_users where kind = 'unconfirmed'
+  )
+  $$,
+  array[0::bigint],
+  'Unconfirmed accounts are not queued'
+);
+
+select results_eq(
+  $$
+  select count(*)
+  from private.account_onboarding_outbox
+  where user_id = (
+    select id from account_onboarding_test_users where kind = 'anonymous'
+  )
+  $$,
+  array[0::bigint],
+  'Anonymous accounts are not queued'
+);
+
+update auth.users
+set email_confirmed_at = '2026-08-03 10:05:00+00'
+where id = (
+  select id from account_onboarding_test_users where kind = 'unconfirmed'
+);
+
+select results_eq(
+  $$
+  select first_name
+  from private.account_onboarding_outbox
+  where user_id = (
+    select id from account_onboarding_test_users where kind = 'unconfirmed'
+  )
+  $$,
+  array['Riley'::text],
+  'First confirmation queues an account once'
+);
+
+update auth.users
+set email_confirmed_at = email_confirmed_at + interval '1 minute'
+where id = (
+  select id from account_onboarding_test_users where kind = 'unconfirmed'
+);
+
+select results_eq(
+  $$
+  select count(*)
+  from private.account_onboarding_outbox
+  where user_id = (
+    select id from account_onboarding_test_users where kind = 'unconfirmed'
+  )
+  $$,
+  array[1::bigint],
+  'Later auth updates do not duplicate onboarding'
+);
+
+create temporary table account_onboarding_test_lease (id uuid primary key);
+insert into account_onboarding_test_lease values (gen_random_uuid());
+
+select results_eq(
+  $$
+  select count(*)
+  from public.claim_account_onboarding_events(
+    (select id from account_onboarding_test_lease),
+    100,
+    300
+  )
+  where user_id in (select id from account_onboarding_test_users)
+  $$,
+  array[2::bigint],
+  'Pending onboarding events can be leased'
+);
+
+select results_eq(
+  $$
+  select count(*)
+  from private.account_onboarding_outbox
+  where lease_id = (select id from account_onboarding_test_lease)
+    and first_name in ('Alex', 'Riley')
+  $$,
+  array[2::bigint],
+  'Leased events retain their delivery variables'
+);
+
+select results_eq(
+  $$
+  select public.complete_account_onboarding_events(
+    (select id from account_onboarding_test_lease),
+    array(
+      select id
+      from private.account_onboarding_outbox
+      where lease_id = (select id from account_onboarding_test_lease)
+    )
+  )
+  $$,
+  array[2],
+  'Leased onboarding events can be completed'
+);
+
+insert into stripe.customers (id, email, name, invoice_settings, default_source)
+values
+  ('cus_loops_due', 'due@example.com', 'Alex Morgan', '{}'::jsonb, null),
+  ('cus_loops_subscription_card', 'card@example.com', null, '{}'::jsonb, null),
+  (
+    'cus_loops_customer_card',
+    'customer-card@example.com',
+    null,
+    '{"default_payment_method":"pm_customer"}'::jsonb,
+    null
+  ),
+  ('cus_loops_future', 'future@example.com', null, '{}'::jsonb, null);
+
+insert into stripe.subscriptions (
+  id,
+  customer,
+  status,
+  trial_end,
+  default_payment_method
+)
+values
+  (
+    'sub_loops_due',
+    'cus_loops_due',
+    'trialing',
+    to_jsonb(extract(epoch from '2026-08-10 11:00:00+00'::timestamptz)::bigint),
+    null
+  ),
+  (
+    'sub_loops_subscription_card',
+    'cus_loops_subscription_card',
+    'trialing',
+    to_jsonb(extract(epoch from '2026-08-10 11:00:00+00'::timestamptz)::bigint),
+    'pm_subscription'
+  ),
+  (
+    'sub_loops_customer_card',
+    'cus_loops_customer_card',
+    'trialing',
+    to_jsonb(extract(epoch from '2026-08-10 11:00:00+00'::timestamptz)::bigint),
+    null
+  ),
+  (
+    'sub_loops_future',
+    'cus_loops_future',
+    'trialing',
+    to_jsonb(extract(epoch from '2026-08-10 13:00:00+00'::timestamptz)::bigint),
+    null
+  );
+
+select results_eq(
+  $$
+  select subscription_id
+  from public.list_due_trial_reminders(
+    '2026-08-03 12:00:00+00'::timestamptz,
+    82800
+  )
+  where subscription_id like 'sub_loops_%'
+  $$,
+  array['sub_loops_due'::text],
+  'Only due cardless trials are returned'
+);
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    'public.list_due_trial_reminders(timestamp with time zone,integer)',
+    'EXECUTE'
+  )
+    and not has_function_privilege(
+      'authenticated',
+      'public.list_due_trial_reminders(timestamp with time zone,integer)',
+      'EXECUTE'
+    ),
+  'Only service code can list due trial reminders'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Wire confirmed-account onboarding and cardless trial reminders through Loops, add durable delivery state and coverage, and require the verified Loops secret in Stripe production.

Checks: pnpm fmt:check; web typecheck/test; Stripe typecheck/test; Supabase package checks; supabase db reset and 934 pgTAP tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth triggers, billing/trial email delivery, and production secret wiring; misconfiguration or RPC bugs could miss or duplicate customer emails, though idempotency keys and outbox leasing reduce duplicate sends.
> 
> **Overview**
> Restores **Loops**-driven lifecycle email with durable delivery plumbing and stricter production configuration for the Stripe service.
> 
> A new **Supabase** migration adds a private **account onboarding outbox** fed by `auth.users` triggers (confirmed, non-anonymous users only), plus **lease-based** `claim` / `complete` / `fail` RPCs with backoff. A **`list_due_trial_reminders`** RPC selects **trialing, cardless** subscriptions entering the **7-day-before-trial-end** window from synced Stripe data. pgTAP coverage exercises outbox behavior, leasing, and reminder filtering.
> 
> **Netlify** scheduled functions (every 5 minutes) deliver **`anarlogAccountConfirmed`** events from the outbox and send **7-day trial-ending** transactionals from due reminders. Shared **`apps/web/src/lib/loops.ts`** helpers post to Loops with **`Idempotency-Key` headers** (not in the JSON body).
> 
> On **Stripe**, trial-ending sends move through a dedicated **`sendLoopsTransactional`** helper with a **fixed transactional template id** and **Stripe event id** idempotency; **`LOOPS_API_KEY` is required in production** (`NODE_ENV`), and the **Fly deploy workflow** now stages and **SHA-verifies** `LOOPS_API_KEY` alongside PostHog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 988258d8e6ee67388b023e9dc3eecde4ade477fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->