### PR TITLE
Position meeting countdown below action

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -583,7 +583,7 @@ describe("OuterHeader", () => {
     });
   });
 
-  it("shows the meeting countdown in a tooltip-style badge to the left of the header action", () => {
+  it("shows the meeting countdown in a callout below the header action", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-05T09:55:30.000Z"));
     mocks.nowMs = Date.now();
@@ -604,9 +604,13 @@ describe("OuterHeader", () => {
       />,
     );
 
-    const countdown = screen.getByText("starts in 4m 30s");
+    const countdown = screen
+      .getByText("starts in 4m 30s")
+      .closest("[data-header-meeting-countdown]");
     const joinButton = screen.getByRole("button", { name: "Join & record" });
 
+    expect(countdown).not.toBeNull();
+    if (!countdown) throw new Error("meeting countdown is missing");
     expect(countdown.getAttribute("data-header-meeting-countdown")).toBe(
       "true",
     );
@@ -615,10 +619,13 @@ describe("OuterHeader", () => {
     expect(countdown.className).toContain("border");
     expect(countdown.className).toContain("shadow-sm");
     expect(countdown.className).toContain("tabular-nums");
+    expect(countdown.className).toContain("absolute");
+    expect(countdown.className).toContain("top-full");
+    expect(countdown.className).toContain("left-1/2");
     expect(
-      countdown.compareDocumentPosition(joinButton) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      countdown.querySelector("[data-header-meeting-countdown-tail]"),
+    ).not.toBeNull();
+    expect(countdown.parentElement?.className).toContain("relative");
     expect(joinButton.textContent).not.toContain("starts in");
   });
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -303,15 +303,7 @@ function HeaderMeetingActionPill({
     sessionMode !== "finalizing";
 
   return (
-    <div className="mr-1 flex min-w-0 shrink-0 items-center gap-2">
-      {showCountdown ? (
-        <div
-          data-header-meeting-countdown
-          className="border-border bg-popover/80 text-popover-foreground max-w-40 truncate rounded-md border px-2.5 py-1 font-mono text-xs whitespace-nowrap tabular-nums shadow-sm backdrop-blur-sm"
-        >
-          {countdown.label}
-        </div>
-      ) : null}
+    <div className="relative mr-1 flex min-w-0 shrink-0 items-center">
       <div className="border-border bg-card text-foreground flex h-7 max-w-56 shrink-0 items-center overflow-hidden rounded-full border">
         <button
           type="button"
@@ -349,6 +341,19 @@ function HeaderMeetingActionPill({
           )}
         />
       </div>
+      {showCountdown ? (
+        <div
+          data-header-meeting-countdown
+          className="border-border bg-popover text-popover-foreground pointer-events-none absolute top-full left-1/2 z-20 mt-2 -translate-x-1/2 rounded-md border px-2.5 py-1 font-mono text-xs whitespace-nowrap tabular-nums shadow-sm"
+        >
+          <span
+            data-header-meeting-countdown-tail
+            aria-hidden="true"
+            className="border-border bg-popover absolute -top-1.5 left-1/2 size-3 -translate-x-1/2 rotate-45 border-t border-l"
+          />
+          <span className="relative">{countdown.label}</span>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Place the countdown callout under Join & record and add a pointer with regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session header presentation-only change with no logic or data-path updates beyond layout and styling.
> 
> **Overview**
> Moves the scheduled-meeting countdown in **OuterHeader** from a badge beside the **Join & record** pill to a centered callout **below** the action.
> 
> The wrapper is now `relative`, and the countdown uses absolute positioning (`top-full`, centered) with `pointer-events-none`, a rotated **pointer tail** (`data-header-meeting-countdown-tail`), and slightly adjusted popover styling (no backdrop blur / max-width truncate on the badge).
> 
> Tests now assert the callout placement, tail element, and `relative` parent instead of DOM order before the join button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e591e6f574f91def6662b7e444c7509329372a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->