### PR TITLE
Keep share popover open during preparation

### DIFF
--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -7,7 +7,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { StrictMode } from "react";
+import { cloneElement, StrictMode, type ReactElement, type Ref } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -195,9 +195,22 @@ vi.mock("@anlg/ui/components/ui/popover", () => ({
       {children}
     </div>
   ),
-  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
+  PopoverTrigger: ({
+    children,
+  }: {
+    children: ReactElement<{ ref?: Ref<HTMLButtonElement> }>;
+  }) => {
+    const childRef = children.props.ref;
+    return cloneElement(children, {
+      ref: (node: HTMLButtonElement | null) => {
+        if (typeof childRef === "function") {
+          childRef(node);
+        } else if (childRef) {
+          childRef.current = node;
+        }
+      },
+    });
+  },
 }));
 
 vi.mock("@anlg/ui/components/ui/select", async () => {
@@ -546,6 +559,38 @@ describe("SessionShareButton", () => {
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
     expect(screen.queryByTestId("share-popover")).toBeNull();
     expect(mocks.loadSessionShareSource).toHaveBeenCalledOnce();
+  });
+
+  it("keeps preparation open when the trigger ref is recomposed", async () => {
+    let resolveSource: ((value: any) => void) | undefined;
+    mocks.loadSessionShareSource.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSource = resolve;
+      }),
+    );
+    const view = renderShareButtonView();
+
+    const trigger = screen.getByRole("button", { name: "Share note" });
+    fireEvent.click(trigger);
+    expect(await screen.findByText("Loading access…")).not.toBeNull();
+
+    view.rerender();
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByTestId("share-popover")).not.toBeNull();
+
+    await act(async () => {
+      resolveSource?.({
+        sessionId: "session-1",
+        workspaceId: WORKSPACE_ID,
+        title: "Planning",
+        body: { type: "doc", content: [] },
+      });
+    });
+
+    expect(
+      await screen.findByRole("textbox", { name: "Invitee email" }),
+    ).not.toBeNull();
   });
 
   it("cancels preparation immediately when the pending popover is dismissed", async () => {

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -7,7 +7,7 @@ import {
   Users,
 } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import { Button } from "@anlg/ui/components/ui/button";
 import {
@@ -73,6 +73,9 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
     }
     prepareControllersRef.current.clear();
   };
+  useMountEffect(() => () => {
+    cancelSharePreparation();
+  });
   const isActiveSharePreparation = (identity: SharePreparationIdentity) => {
     const active = sharePreparationIdentityRef.current;
     return (
@@ -81,16 +84,6 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
       active.attemptId === identity.attemptId
     );
   };
-  const shareButtonLifecycleRef = useCallback(
-    (node: HTMLButtonElement | null) => {
-      if (node) return;
-      for (const controller of prepareControllersRef.current) {
-        controller.abort();
-      }
-      prepareControllersRef.current.clear();
-    },
-    [],
-  );
   const runPrepareOperation = async <T,>(
     operation: (signal: AbortSignal) => Promise<T>,
   ): Promise<T> => {
@@ -467,7 +460,6 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
       <PopoverTrigger asChild>
         <Button
           key={accountUserId ?? "signed-out"}
-          ref={shareButtonLifecycleRef}
           type="button"
           size="icon"
           variant="ghost"


### PR DESCRIPTION
Cancel share preparation only on true component unmount and cover trigger ref recomposition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX fix in session-sharing with clearer abort semantics and test coverage; no auth or API contract changes.
> 
> **Overview**
> Fixes the share popover **closing mid-preparation** when `PopoverTrigger` recomposes the trigger button’s ref on parent rerenders (e.g. while “Loading access…” is shown).
> 
> **`SessionShareButton`** no longer uses a callback ref on the share button that aborted in-flight preparation whenever the ref detached. Preparation is **cancelled only on real unmount** via `useMountEffect` cleanup, matching dismiss/account/note-switch paths that still call `cancelSharePreparation` explicitly.
> 
> Tests update the popover **`PopoverTrigger` mock** to merge refs like Radix, and add **“keeps preparation open when the trigger ref is recomposed”** (rerender during a pending `loadSessionShareSource`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b86f7c15293c5d77a42a25b6df46682666ea89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->