### PR TITLE
Flatten Sync settings layout

### DIFF
--- a/apps/desktop/src/settings/sync/index.tsx
+++ b/apps/desktop/src/settings/sync/index.tsx
@@ -294,7 +294,7 @@ export function SettingsSync() {
     return (
       <div className="flex flex-col gap-8">
         <SettingsPageTitle title={<Trans>Sync</Trans>} />
-        <div className="border-border/70 bg-card/60 flex items-start justify-between gap-4 rounded-2xl border p-5">
+        <div className="flex items-start justify-between gap-4">
           <div className="flex gap-3">
             <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-full">
               <CloudSlash className="text-muted-foreground size-4" />
@@ -438,7 +438,7 @@ export function SettingsSync() {
     <div className="flex flex-col gap-8">
       <SettingsPageTitle title={<Trans>Sync</Trans>} />
 
-      <section className="border-border/70 bg-card/60 rounded-2xl border p-5">
+      <section className="flex flex-col gap-4">
         <div className="flex items-start justify-between gap-4">
           <div className="flex min-w-0 gap-3">
             <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-full">
@@ -470,10 +470,10 @@ export function SettingsSync() {
         </div>
 
         {mutationError && (
-          <p className="mt-4 text-xs text-red-500">{mutationError.message}</p>
+          <p className="text-xs text-red-500">{mutationError.message}</p>
         )}
 
-        <div className="border-border/60 mt-5 flex items-center justify-between border-t pt-4">
+        <div className="flex items-center justify-between gap-4">
           <p className="text-muted-foreground text-xs">
             <Trans>Sync runs automatically in the background.</Trans>
           </p>


### PR DESCRIPTION
Remove the card shell from sync status and access states so the page matches the flat settings sections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout changes on the Sync settings screen with no logic or data-handling impact.
> 
> **Overview**
> **Flattens the Sync settings page** so the main status area and the signed-out / non-Pro upsell no longer sit inside bordered card shells (`border`, `rounded-2xl`, `bg-card/60`, `p-5`).
> 
> The active sync block is now a simple `flex flex-col gap-4` section: spacing between the error line and the “Sync runs automatically” row uses gap instead of a top border and extra margins. Behavior and copy are unchanged; only layout classes differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78a9a0ef834fc248436c8aa98bb2b904bcb108d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->