### PR TITLE
Clear chat context on empty view

### DIFF
--- a/apps/desktop/src/chat/components/use-session-tab.test.tsx
+++ b/apps/desktop/src/chat/components/use-session-tab.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Tab } from "~/store/zustand/tabs";
+
+const mocks = vi.hoisted(() => ({
+  currentTab: null as Tab | null,
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: () => ({ currentTab: mocks.currentTab }),
+}));
+
+import { useSessionTab } from "./use-session-tab";
+
+describe("useSessionTab", () => {
+  it("clears the retained session when the empty tab becomes active", () => {
+    mocks.currentTab = {
+      active: true,
+      id: "session-1",
+      pinned: false,
+      slotId: "slot-1",
+      state: { autoStart: null, view: null },
+      type: "sessions",
+    };
+    const { result, rerender } = renderHook(() => useSessionTab());
+
+    expect(result.current.currentSessionId).toBe("session-1");
+
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      requestId: "edit-1",
+      slotId: "slot-1",
+      type: "edit",
+    };
+    rerender();
+
+    expect(result.current.currentSessionId).toBe("session-1");
+
+    mocks.currentTab = {
+      active: true,
+      pinned: false,
+      slotId: "slot-1",
+      type: "empty",
+    };
+    rerender();
+
+    expect(result.current.currentSessionId).toBeUndefined();
+    expect(result.current.getSessionId()).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/chat/components/use-session-tab.ts
+++ b/apps/desktop/src/chat/components/use-session-tab.ts
@@ -14,7 +14,9 @@ export function useSessionTab() {
       : undefined;
 
   const stickySessionIdRef = useRef(sessionTabId);
-  if (sessionTabId) {
+  if (currentTab?.type === "empty") {
+    stickySessionIdRef.current = undefined;
+  } else if (sessionTabId) {
     stickySessionIdRef.current = sessionTabId;
   }
 


### PR DESCRIPTION
Reset the retained note attachment on the empty tab and cover edit-to-empty navigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small hook behavior change in desktop chat tab state; covered by a new unit test with no auth or data-layer impact.
> 
> **Overview**
> **Clears sticky chat session context** when the user lands on an **empty** tab, so note/session attachment does not linger after leaving the session UI.
> 
> `useSessionTab` now resets `stickySessionIdRef` when `currentTab.type === "empty"`. Navigating through a non-session tab (e.g. **edit**) still keeps the last session id until the empty tab is active.
> 
> Adds a hook test for **sessions → edit → empty**, asserting `currentSessionId` and `getSessionId()` become undefined on empty while edit preserves the session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09831afe74b9ad046dbdda09aa39ce906ca069e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->