### PR TITLE
Open automations in a dedicated page

### DIFF
--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   )),
   chat: {
     groupId: "group-1",
+    scope: "general" as "general" | "automations",
     sessionId: "session-1",
     startNewChat: vi.fn(),
     selectChat: vi.fn(),
@@ -75,7 +76,8 @@ vi.mock("~/shared/owner-user", () => ({
 }));
 
 vi.mock("~/session/queries", () => ({
-  useSessionHasTranscript: () => mocks.hasAvailableTranscript,
+  useSessionHasTranscript: (sessionId: string) =>
+    Boolean(sessionId) && mocks.hasAvailableTranscript,
 }));
 
 vi.mock("~/stt/contexts", () => ({
@@ -96,6 +98,7 @@ describe("ChatView", () => {
   beforeEach(() => {
     cleanup();
     mocks.chatSession.mockClear();
+    mocks.chat.scope = "general";
     mocks.hasAvailableTranscript = false;
     mocks.sessionMode = "inactive";
     mocks.requestedLiveTranscription = null;
@@ -131,6 +134,25 @@ describe("ChatView", () => {
         hasAvailableTranscript: true,
         isBatchTranscriptionPending: true,
       }),
+    );
+  });
+
+  it("does not inherit note context in the automations scope", () => {
+    mocks.chat.scope = "automations";
+    mocks.hasAvailableTranscript = true;
+    mocks.sessionMode = "active";
+
+    render(<ChatView />);
+
+    expect(mocks.chatSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentSessionId: undefined,
+        hasAvailableTranscript: false,
+        isBatchTranscriptionPending: false,
+      }),
+    );
+    expect(mocks.toolbarControls).toHaveBeenCalledWith(
+      expect.objectContaining({ chatScope: "automations" }),
     );
   });
 

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -49,18 +49,20 @@ export function ChatSessionHost({
   const { chat } = useShell();
   const { groupId, sessionId } = chat;
   const { currentSessionId } = useSessionTab();
+  const contextSessionId =
+    chat.scope === "automations" ? undefined : currentSessionId;
   const ownerUserId = useOwnerUserId();
   const hasAvailableTranscript = useSessionHasTranscript(
-    currentSessionId ?? "",
+    contextSessionId ?? "",
   );
   const batchTranscriptionPending = useListener((state) => {
-    if (!currentSessionId) {
+    if (!contextSessionId) {
       return false;
     }
     return isBatchTranscriptionPending(
-      state.getSessionMode(currentSessionId),
+      state.getSessionMode(contextSessionId),
       state.live,
-      state.live.batchTranscriptionPendingBySession[currentSessionId],
+      state.live.batchTranscriptionPendingBySession[contextSessionId],
     );
   });
 
@@ -72,7 +74,7 @@ export function ChatSessionHost({
     <ChatSession
       sessionId={sessionId}
       chatGroupId={groupId}
-      currentSessionId={currentSessionId}
+      currentSessionId={contextSessionId}
       hasAvailableTranscript={hasAvailableTranscript}
       isBatchTranscriptionPending={batchTranscriptionPending}
       unstyled
@@ -116,6 +118,7 @@ export function ChatPanelFrame({
   );
 
   const { handleSendMessage } = useChatActions({
+    chatScope: chat.scope,
     groupId,
     onGroupCreated: handleGroupCreated,
     onGroupCreateFailed: handleGroupCreateFailed,
@@ -136,6 +139,7 @@ export function ChatPanelFrame({
         ])}
       >
         <ChatToolbarControls
+          chatScope={chat.scope}
           currentChatGroupId={groupId}
           layout={layout}
           onClose={() => chat.sendEvent({ type: "CLOSE" })}

--- a/apps/desktop/src/chat/components/session-provider.real-sdk.test.tsx
+++ b/apps/desktop/src/chat/components/session-provider.real-sdk.test.tsx
@@ -119,6 +119,7 @@ function NewGroupHarness({
   capture: (props: ChatSessionRenderProps, send: () => void) => void;
 }) {
   const { handleSendMessage } = useChatActions({
+    chatScope: "general",
     groupId: undefined,
     onGroupCreated: mocks.onGroupCreated,
     onGroupCreateFailed: mocks.onGroupCreateFailed,

--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -2,6 +2,10 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({
+  useRecentChatGroups: vi.fn(() => []),
+}));
+
 vi.mock("@anlg/ui/components/ui/button", () => ({
   Button: ({
     children,
@@ -61,7 +65,7 @@ vi.mock("@anlg/ui/components/ui/dropdown-menu", () => ({
 }));
 
 vi.mock("~/chat/store/queries", () => ({
-  useRecentChatGroups: () => [],
+  useRecentChatGroups: mocks.useRecentChatGroups,
 }));
 
 import { ChatToolbarControls } from "./toolbar-controls";
@@ -69,11 +73,13 @@ import { ChatToolbarControls } from "./toolbar-controls";
 describe("ChatToolbarControls", () => {
   beforeEach(() => {
     cleanup();
+    mocks.useRecentChatGroups.mockClear();
   });
 
   it("renders the dark chat history trigger as a pill button", () => {
     render(
       <ChatToolbarControls
+        chatScope="general"
         currentChatGroupId={undefined}
         onNewChat={vi.fn()}
         onOpenRightPanel={vi.fn()}
@@ -94,6 +100,7 @@ describe("ChatToolbarControls", () => {
   it("renders the light chat history trigger without title text", () => {
     const { container } = render(
       <ChatToolbarControls
+        chatScope="general"
         currentChatGroupId={undefined}
         onNewChat={vi.fn()}
         onOpenRightPanel={vi.fn()}
@@ -119,6 +126,7 @@ describe("ChatToolbarControls", () => {
   it("opens floating chat history to the right and adapts to viewport collisions", () => {
     render(
       <ChatToolbarControls
+        chatScope="general"
         currentChatGroupId={undefined}
         layout="floating"
         onNewChat={vi.fn()}
@@ -149,6 +157,7 @@ describe("ChatToolbarControls", () => {
   it("keeps right-panel chat history below the trigger", () => {
     render(
       <ChatToolbarControls
+        chatScope="general"
         currentChatGroupId={undefined}
         layout="right-panel"
         onNewChat={vi.fn()}
@@ -164,6 +173,7 @@ describe("ChatToolbarControls", () => {
   it("renders dark toolbar action buttons as circles without tooltips", () => {
     render(
       <ChatToolbarControls
+        chatScope="general"
         currentChatGroupId={undefined}
         onClose={vi.fn()}
         onNewChat={vi.fn()}
@@ -197,6 +207,7 @@ describe("ChatToolbarControls", () => {
 
     const { container } = render(
       <ChatToolbarControls
+        chatScope="general"
         currentChatGroupId={undefined}
         layout="floating"
         onClose={onClose}
@@ -227,6 +238,7 @@ describe("ChatToolbarControls", () => {
     const onOpenFloating = vi.fn();
     const { container } = render(
       <ChatToolbarControls
+        chatScope="general"
         currentChatGroupId={undefined}
         layout="right-panel"
         onClose={onClose}
@@ -266,5 +278,19 @@ describe("ChatToolbarControls", () => {
 
     expect(onOpenFloating).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("loads history for the active chat scope", () => {
+    render(
+      <ChatToolbarControls
+        chatScope="automations"
+        currentChatGroupId={undefined}
+        onNewChat={vi.fn()}
+        onOpenRightPanel={vi.fn()}
+        onSelectChat={vi.fn()}
+      />,
+    );
+
+    expect(mocks.useRecentChatGroups).toHaveBeenCalledWith("automations", 5);
   });
 });

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -23,8 +23,10 @@ import {
   type ChatGroupRecord,
   useRecentChatGroups,
 } from "~/chat/store/queries";
+import type { ChatScope } from "~/chat/types";
 
 export function ChatToolbarControls({
+  chatScope,
   currentChatGroupId,
   layout = "floating",
   onClose,
@@ -34,6 +36,7 @@ export function ChatToolbarControls({
   onSelectChat,
   surface = "light",
 }: {
+  chatScope: ChatScope;
   currentChatGroupId: string | undefined;
   layout?: "floating" | "right-panel";
   onClose?: () => void;
@@ -53,6 +56,7 @@ export function ChatToolbarControls({
     >
       <div className="flex min-w-0 flex-1 items-center gap-1">
         <ChatGroups
+          chatScope={chatScope}
           currentChatGroupId={currentChatGroupId}
           layout={layout}
           onSelectChat={onSelectChat}
@@ -144,11 +148,13 @@ function ChatActionButton({
 }
 
 function ChatGroups({
+  chatScope,
   currentChatGroupId,
   layout,
   onSelectChat,
   surface = "light",
 }: {
+  chatScope: ChatScope;
   currentChatGroupId: string | undefined;
   layout: "floating" | "right-panel";
   onSelectChat: (chatGroupId: string) => void;
@@ -158,7 +164,7 @@ function ChatGroups({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const isDark = surface === "dark";
 
-  const recentChatGroups = useRecentChatGroups(5);
+  const recentChatGroups = useRecentChatGroups(chatScope, 5);
 
   return (
     <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>

--- a/apps/desktop/src/chat/state/chat-context.test.ts
+++ b/apps/desktop/src/chat/state/chat-context.test.ts
@@ -5,29 +5,51 @@ import { useChatContext } from "./chat-context";
 describe("chat context", () => {
   beforeEach(() => {
     useChatContext.setState({
-      groupId: undefined,
-      sessionId: "session-initial",
+      chatByScope: {
+        general: { groupId: undefined, sessionId: "general-initial" },
+        automations: {
+          groupId: undefined,
+          sessionId: "automations-initial",
+        },
+      },
     });
   });
 
   test("startNewChat resets the group and rotates the session id", () => {
     useChatContext.setState({
-      groupId: "group-1",
-      sessionId: "session-1",
+      chatByScope: {
+        ...useChatContext.getState().chatByScope,
+        general: { groupId: "group-1", sessionId: "session-1" },
+      },
     });
 
-    useChatContext.getState().startNewChat();
+    useChatContext.getState().startNewChat("general");
 
-    const state = useChatContext.getState();
-    expect(state.groupId).toBeUndefined();
-    expect(state.sessionId).not.toBe("session-1");
+    const selection = useChatContext.getState().chatByScope.general;
+    expect(selection.groupId).toBeUndefined();
+    expect(selection.sessionId).not.toBe("session-1");
   });
 
   test("selectChat syncs the selected group and session id", () => {
-    useChatContext.getState().selectChat("group-2");
+    useChatContext.getState().selectChat("general", "group-2");
+
+    const selection = useChatContext.getState().chatByScope.general;
+    expect(selection.groupId).toBe("group-2");
+    expect(selection.sessionId).toBe("group-2");
+  });
+
+  test("keeps general and automation conversations separate", () => {
+    useChatContext.getState().selectChat("general", "general-group");
+    useChatContext.getState().selectChat("automations", "automation-group");
 
     const state = useChatContext.getState();
-    expect(state.groupId).toBe("group-2");
-    expect(state.sessionId).toBe("group-2");
+    expect(state.chatByScope.general).toEqual({
+      groupId: "general-group",
+      sessionId: "general-group",
+    });
+    expect(state.chatByScope.automations).toEqual({
+      groupId: "automation-group",
+      sessionId: "automation-group",
+    });
   });
 });

--- a/apps/desktop/src/chat/state/chat-context.ts
+++ b/apps/desktop/src/chat/state/chat-context.ts
@@ -1,31 +1,70 @@
 import { create } from "zustand";
 
+import type { ChatScope } from "~/chat/types";
 import { id } from "~/shared/utils";
 
-interface ChatContextState {
+type ChatSelection = {
   groupId: string | undefined;
   sessionId: string;
+};
+
+interface ChatContextState {
+  chatByScope: Record<ChatScope, ChatSelection>;
 }
 
 interface ChatContextActions {
-  setGroupId: (groupId: string | undefined) => void;
-  rollbackFailedGroup: (failedGroupId: string) => void;
-  startNewChat: () => void;
-  selectChat: (groupId: string) => void;
+  setGroupId: (scope: ChatScope, groupId: string | undefined) => void;
+  rollbackFailedGroup: (scope: ChatScope, failedGroupId: string) => void;
+  startNewChat: (scope: ChatScope) => void;
+  selectChat: (scope: ChatScope, groupId: string) => void;
 }
 
 export const useChatContext = create<ChatContextState & ChatContextActions>(
   (set) => ({
-    groupId: undefined,
-    sessionId: id(),
-    setGroupId: (groupId) => set({ groupId }),
+    chatByScope: {
+      general: createChatSelection(),
+      automations: createChatSelection(),
+    },
+    setGroupId: (scope, groupId) =>
+      set((state) => ({
+        chatByScope: {
+          ...state.chatByScope,
+          [scope]: { ...state.chatByScope[scope], groupId },
+        },
+      })),
     // Compares against the live groupId, not a value captured when the send
     // started — the failure lands after onGroupCreated already updated it.
-    rollbackFailedGroup: (failedGroupId) =>
-      set((state) =>
-        state.groupId === failedGroupId ? { groupId: undefined } : state,
-      ),
-    startNewChat: () => set({ groupId: undefined, sessionId: id() }),
-    selectChat: (groupId) => set({ groupId, sessionId: groupId }),
+    rollbackFailedGroup: (scope, failedGroupId) =>
+      set((state) => {
+        const selection = state.chatByScope[scope];
+        if (selection.groupId !== failedGroupId) {
+          return state;
+        }
+
+        return {
+          chatByScope: {
+            ...state.chatByScope,
+            [scope]: { ...selection, groupId: undefined },
+          },
+        };
+      }),
+    startNewChat: (scope) =>
+      set((state) => ({
+        chatByScope: {
+          ...state.chatByScope,
+          [scope]: createChatSelection(),
+        },
+      })),
+    selectChat: (scope, groupId) =>
+      set((state) => ({
+        chatByScope: {
+          ...state.chatByScope,
+          [scope]: { groupId, sessionId: groupId },
+        },
+      })),
   }),
 );
+
+function createChatSelection(): ChatSelection {
+  return { groupId: undefined, sessionId: id() };
+}

--- a/apps/desktop/src/chat/state/use-chat-mode.ts
+++ b/apps/desktop/src/chat/state/use-chat-mode.ts
@@ -1,7 +1,9 @@
+import { useCallback } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { useChatContext } from "./chat-context";
 
+import type { ChatScope } from "~/chat/types";
 import { useTabs } from "~/store/zustand/tabs";
 
 export type { ChatEvent, ChatMode } from "~/store/zustand/tabs";
@@ -9,15 +11,35 @@ export type { ChatEvent, ChatMode } from "~/store/zustand/tabs";
 export function useChatMode() {
   const mode = useTabs((state) => state.chatMode);
   const transitionChatMode = useTabs((state) => state.transitionChatMode);
+  const scope = useTabs(
+    (state): ChatScope =>
+      state.currentTab?.type === "automations" ? "automations" : "general",
+  );
 
-  const groupId = useChatContext((state) => state.groupId);
-  const sessionId = useChatContext((state) => state.sessionId);
-  const setGroupId = useChatContext((state) => state.setGroupId);
-  const rollbackFailedGroup = useChatContext(
+  const selection = useChatContext((state) => state.chatByScope[scope]);
+  const setScopedGroupId = useChatContext((state) => state.setGroupId);
+  const rollbackFailedScopedGroup = useChatContext(
     (state) => state.rollbackFailedGroup,
   );
-  const startNewChat = useChatContext((state) => state.startNewChat);
-  const selectChat = useChatContext((state) => state.selectChat);
+  const startNewScopedChat = useChatContext((state) => state.startNewChat);
+  const selectScopedChat = useChatContext((state) => state.selectChat);
+
+  const setGroupId = useCallback(
+    (groupId: string | undefined) => setScopedGroupId(scope, groupId),
+    [scope, setScopedGroupId],
+  );
+  const rollbackFailedGroup = useCallback(
+    (failedGroupId: string) => rollbackFailedScopedGroup(scope, failedGroupId),
+    [rollbackFailedScopedGroup, scope],
+  );
+  const startNewChat = useCallback(
+    () => startNewScopedChat(scope),
+    [scope, startNewScopedChat],
+  );
+  const selectChat = useCallback(
+    (groupId: string) => selectScopedChat(scope, groupId),
+    [scope, selectScopedChat],
+  );
 
   useHotkeys(
     "mod+j",
@@ -34,9 +56,10 @@ export function useChatMode() {
 
   return {
     mode,
+    scope,
     sendEvent: transitionChatMode,
-    groupId,
-    sessionId,
+    groupId: selection.groupId,
+    sessionId: selection.sessionId,
     setGroupId,
     rollbackFailedGroup,
     startNewChat,

--- a/apps/desktop/src/chat/store/queries.test.tsx
+++ b/apps/desktop/src/chat/store/queries.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   execute: vi.fn(),
   executeTransaction: vi.fn().mockResolvedValue([1]),
+  liveQueries: [] as Array<{ params?: unknown[]; sql: string }>,
   rows: [] as Array<Record<string, unknown>>,
 }));
 
@@ -13,8 +14,15 @@ vi.mock("~/db", () => ({
   useLiveQuery: (options: {
     enabled?: boolean;
     mapRows: (rows: Array<Record<string, unknown>>) => unknown;
+    params?: unknown[];
+    sql: string;
   }) => ({
-    data: options.enabled === false ? undefined : options.mapRows(mocks.rows),
+    data: (() => {
+      mocks.liveQueries.push(options);
+      return options.enabled === false
+        ? undefined
+        : options.mapRows(mocks.rows);
+    })(),
   }),
 }));
 
@@ -52,6 +60,7 @@ const message: ChatMessageRecord = {
 describe("chat SQLite queries", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.liveQueries = [];
     mocks.rows = [];
     mocks.execute.mockResolvedValue([]);
     mocks.executeTransaction.mockResolvedValue([1]);
@@ -68,8 +77,10 @@ describe("chat SQLite queries", () => {
       },
     ];
 
-    const recent = renderHook(() => useRecentChatGroups()).result.current;
-    const selected = renderHook(() => useChatGroup("group-1")).result.current;
+    const recent = renderHook(() => useRecentChatGroups("general")).result
+      .current;
+    const selected = renderHook(() => useChatGroup("group-1", "general")).result
+      .current;
 
     expect(recent).toEqual([
       {
@@ -81,6 +92,21 @@ describe("chat SQLite queries", () => {
       },
     ]);
     expect(selected?.id).toBe("group-1");
+  });
+
+  it("isolates general and automation chat history", () => {
+    renderHook(() => useRecentChatGroups("general"));
+    const generalQuery =
+      mocks.liveQueries[mocks.liveQueries.length - 1]?.sql ?? "";
+
+    renderHook(() => useRecentChatGroups("automations"));
+    const automationsQuery =
+      mocks.liveQueries[mocks.liveQueries.length - 1]?.sql ?? "";
+
+    expect(generalQuery).toMatch(/AND\s+NOT\s+EXISTS/);
+    expect(automationsQuery).toMatch(/AND\s+EXISTS/);
+    expect(generalQuery).toContain("'$.chatScope'");
+    expect(automationsQuery).toContain("'$.chatScope'");
   });
 
   it("maps chat messages in their durable order", () => {

--- a/apps/desktop/src/chat/store/queries.ts
+++ b/apps/desktop/src/chat/store/queries.ts
@@ -5,6 +5,7 @@ import {
   rowToPersistedChatMessage,
 } from "./persisted-messages";
 
+import type { ChatScope } from "~/chat/types";
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
 
@@ -27,16 +28,20 @@ export type ChatGroupRecord = {
 const EMPTY_CHAT_GROUPS: ChatGroupRecord[] = [];
 const EMPTY_CHAT_MESSAGES: PersistedChatMessage[] = [];
 
-export function useRecentChatGroups(limit = 5): ChatGroupRecord[] {
+export function useRecentChatGroups(
+  chatScope: ChatScope,
+  limit = 5,
+): ChatGroupRecord[] {
   const { data = EMPTY_CHAT_GROUPS } = useLiveQuery<
     ChatGroupSqlRow,
     ChatGroupRecord[]
   >({
     sql: `
-      SELECT id, owner_user_id, title, created_at, updated_at
-      FROM chat_groups
-      WHERE deleted_at IS NULL
-      ORDER BY created_at DESC, id DESC
+      SELECT g.id, g.owner_user_id, g.title, g.created_at, g.updated_at
+      FROM chat_groups AS g
+      WHERE g.deleted_at IS NULL
+        AND ${chatGroupScopePredicate(chatScope)}
+      ORDER BY g.created_at DESC, g.id DESC
       LIMIT ?
     `,
     params: [limit],
@@ -48,13 +53,16 @@ export function useRecentChatGroups(limit = 5): ChatGroupRecord[] {
 
 export function useChatGroup(
   chatGroupId: string | null | undefined,
+  chatScope: ChatScope,
 ): ChatGroupRecord | null {
   const { data = null } = useLiveQuery<ChatGroupSqlRow, ChatGroupRecord | null>(
     {
       sql: `
-      SELECT id, owner_user_id, title, created_at, updated_at
-      FROM chat_groups
-      WHERE id = ? AND deleted_at IS NULL
+      SELECT g.id, g.owner_user_id, g.title, g.created_at, g.updated_at
+      FROM chat_groups AS g
+      WHERE g.id = ?
+        AND g.deleted_at IS NULL
+        AND ${chatGroupScopePredicate(chatScope)}
       LIMIT 1
     `,
       params: [chatGroupId ?? ""],
@@ -256,6 +264,26 @@ function mapChatGroupRow(row: ChatGroupSqlRow): ChatGroupRecord {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+function chatGroupScopePredicate(chatScope: ChatScope) {
+  const automationsScopeExists = `
+    EXISTS (
+      SELECT 1
+      FROM chat_messages AS m
+      WHERE m.chat_group_id = g.id
+        AND m.deleted_at IS NULL
+        AND CASE
+          WHEN json_valid(m.metadata_json)
+            THEN json_extract(m.metadata_json, '$.chatScope')
+          ELSE NULL
+        END = 'automations'
+    )
+  `;
+
+  return chatScope === "automations"
+    ? automationsScopeExists
+    : `NOT ${automationsScopeExists}`;
 }
 
 function buildUpsertChatMessageStatement(

--- a/apps/desktop/src/chat/store/use-chat-actions.test.tsx
+++ b/apps/desktop/src/chat/store/use-chat-actions.test.tsx
@@ -44,7 +44,7 @@ import {
 } from "./pending-persists";
 import { useChatActions } from "./use-chat-actions";
 
-import type { ChatSendOptions } from "~/chat/types";
+import type { AnlgUIMessage, ChatSendOptions } from "~/chat/types";
 
 describe("useChatActions", () => {
   beforeEach(() => {
@@ -62,7 +62,11 @@ describe("useChatActions", () => {
     const onGroupCreated = vi.fn();
     const sendMessage = vi.fn();
     const { result } = renderHook(() =>
-      useChatActions({ groupId: undefined, onGroupCreated }),
+      useChatActions({
+        chatScope: "general",
+        groupId: undefined,
+        onGroupCreated,
+      }),
     );
 
     act(() => {
@@ -74,7 +78,11 @@ describe("useChatActions", () => {
     });
 
     expect(sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "message-1", role: "user" }),
+      expect.objectContaining({
+        id: "message-1",
+        role: "user",
+        metadata: expect.objectContaining({ chatScope: "general" }),
+      }),
       {
         chatGroupId: "group-1",
         beforeSend: expect.any(Function),
@@ -104,7 +112,11 @@ describe("useChatActions", () => {
   it("queues existing-group persistence until the transport preflight", async () => {
     const sendMessage = vi.fn();
     const { result } = renderHook(() =>
-      useChatActions({ groupId: "group-existing", onGroupCreated: vi.fn() }),
+      useChatActions({
+        chatScope: "general",
+        groupId: "group-existing",
+        onGroupCreated: vi.fn(),
+      }),
     );
 
     act(() => {
@@ -143,6 +155,7 @@ describe("useChatActions", () => {
     });
     const { result } = renderHook(() =>
       useChatActions({
+        chatScope: "general",
         groupId: undefined,
         onGroupCreated,
         onGroupCreateFailed,
@@ -192,6 +205,7 @@ describe("useChatActions", () => {
     const sendMessage = vi.fn();
     const { result } = renderHook(() =>
       useChatActions({
+        chatScope: "general",
         groupId: undefined,
         onGroupCreated: vi.fn(),
         onGroupCreateFailed,
@@ -226,7 +240,11 @@ describe("useChatActions", () => {
     const sendMessage = vi.fn();
     const trackCompletion = vi.fn();
     const { result } = renderHook(() =>
-      useChatActions({ groupId: undefined, onGroupCreated: vi.fn() }),
+      useChatActions({
+        chatScope: "general",
+        groupId: undefined,
+        onGroupCreated: vi.fn(),
+      }),
     );
 
     act(() => {
@@ -249,5 +267,38 @@ describe("useChatActions", () => {
       expectedTitle: "Hello",
       title: "Generated title",
     });
+  });
+
+  it("persists automation messages with their own scope", async () => {
+    const sendMessage = vi.fn();
+    const { result } = renderHook(() =>
+      useChatActions({
+        chatScope: "automations",
+        groupId: undefined,
+        onGroupCreated: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleSendMessage(
+        "Create a weekly recap",
+        [{ type: "text", text: "Create a weekly recap" }],
+        sendMessage,
+      );
+    });
+
+    const message = sendMessage.mock.calls[0]?.[0] as AnlgUIMessage;
+    expect(message.metadata?.chatScope).toBe("automations");
+
+    const options = sendMessage.mock.calls[0]?.[1] as ChatSendOptions;
+    await options.beforeSend?.(vi.fn());
+
+    expect(mocks.createChatGroupWithMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({
+          metadataJson: expect.stringContaining('"chatScope":"automations"'),
+        }),
+      }),
+    );
   });
 });

--- a/apps/desktop/src/chat/store/use-chat-actions.ts
+++ b/apps/desktop/src/chat/store/use-chat-actions.ts
@@ -17,7 +17,7 @@ import {
 
 import { useLanguageModel } from "~/ai/hooks";
 import type { ContextRef } from "~/chat/context/entities";
-import type { ChatMessageSender, AnlgUIMessage } from "~/chat/types";
+import type { ChatMessageSender, ChatScope, AnlgUIMessage } from "~/chat/types";
 import { useOwnerUserId } from "~/shared/owner-user";
 import { id } from "~/shared/utils";
 
@@ -43,10 +43,12 @@ async function persistWithRetry(run: () => Promise<unknown>) {
 }
 
 export function useChatActions({
+  chatScope,
   groupId,
   onGroupCreated,
   onGroupCreateFailed,
 }: {
+  chatScope: ChatScope;
   groupId: string | undefined;
   onGroupCreated: (newGroupId: string) => void;
   onGroupCreateFailed?: (failedGroupId: string) => void;
@@ -102,6 +104,7 @@ export function useChatActions({
 
       const messageId = id();
       const metadata = {
+        chatScope,
         createdAt: Date.now(),
         ...(contextRefs && contextRefs.length > 0 ? { contextRefs } : {}),
       };
@@ -166,6 +169,7 @@ export function useChatActions({
       });
     },
     [
+      chatScope,
       groupId,
       ownerUserId,
       onGroupCreated,

--- a/apps/desktop/src/chat/types.ts
+++ b/apps/desktop/src/chat/types.ts
@@ -4,7 +4,10 @@ import { z } from "zod";
 import { CONTEXT_ENTITY_SOURCES } from "~/chat/context/entities";
 import type { ContextRef } from "~/chat/context/entities";
 
+export type ChatScope = "general" | "automations";
+
 const messageMetadataSchema = z.object({
+  chatScope: z.enum(["general", "automations"]).optional(),
   createdAt: z.number().optional(),
   contextRefs: z
     .array(

--- a/apps/desktop/src/composer/index.tsx
+++ b/apps/desktop/src/composer/index.tsx
@@ -32,8 +32,9 @@ export function ComposerScreen() {
   const { chat } = useShell();
   const model = useLanguageModel("chat");
   const userId = useOwnerUserId();
-  const currentChatGroup = useChatGroup(chat.groupId);
+  const currentChatGroup = useChatGroup(chat.groupId, chat.scope);
   const { handleSendMessage } = useChatActions({
+    chatScope: chat.scope,
     groupId: chat.groupId,
     onGroupCreated: chat.setGroupId,
     onGroupCreateFailed: chat.rollbackFailedGroup,

--- a/apps/desktop/src/settings/automations/index.tsx
+++ b/apps/desktop/src/settings/automations/index.tsx
@@ -21,8 +21,24 @@ import { sonnerToast } from "@anlg/ui/components/ui/toast";
 import { cn } from "@anlg/utils";
 
 import { useBillingAccess } from "~/auth/billing-context";
+import { SettingsHydrationBoundary } from "~/settings/hydration-boundary";
 import { SettingsPageTitle } from "~/settings/page-title";
 import { setSettingValue, useStoredSettingValue } from "~/settings/queries";
+import { StandardContentWrapper } from "~/shared/main";
+
+export function TabContentAutomations() {
+  return (
+    <StandardContentWrapper>
+      <SettingsHydrationBoundary>
+        <div className="bg-card dark:bg-accent flex w-full flex-1 flex-col overflow-hidden">
+          <div className="scroll-fade-y scrollbar-hide h-full w-full flex-1 overflow-y-auto p-6">
+            <SettingsAutomations />
+          </div>
+        </div>
+      </SettingsHydrationBoundary>
+    </StandardContentWrapper>
+  );
+}
 
 export function SettingsAutomations() {
   const { t } = useLingui();

--- a/apps/desktop/src/settings/index.tsx
+++ b/apps/desktop/src/settings/index.tsx
@@ -11,7 +11,6 @@ import { SettingsTodo } from "./todo";
 import { LLM } from "~/settings/ai/llm";
 import { STT } from "~/settings/ai/stt";
 import { SettingsAppearance } from "~/settings/appearance";
-import { SettingsAutomations } from "~/settings/automations";
 import { SettingsDevelopers } from "~/settings/developers";
 import { SettingsDictionary } from "~/settings/dictionary";
 import { SettingsHydrationBoundary } from "~/settings/hydration-boundary";
@@ -50,8 +49,6 @@ function SettingsView({ tab }: { tab: Extract<Tab, { type: "settings" }> }) {
         return <SettingsApp />;
       case "appearance":
         return <SettingsAppearance />;
-      case "automations":
-        return <SettingsAutomations />;
       case "notifications":
         return <SettingsNotifications />;
       case "sync":

--- a/apps/desktop/src/shared/main/tab-content.tsx
+++ b/apps/desktop/src/shared/main/tab-content.tsx
@@ -6,6 +6,7 @@ import { TabContentEdit } from "~/edit";
 import { TabContentOnboarding } from "~/onboarding";
 import { TabContentNote } from "~/session";
 import { TabContentSettings } from "~/settings";
+import { TabContentAutomations } from "~/settings/automations";
 import {
   TabContentSharedNote,
   TabContentSharedNotePreview,
@@ -15,6 +16,9 @@ import { TabContentTask } from "~/task";
 import { TabContentTemplate } from "~/templates";
 
 export function MainTabContent({ tab }: { tab: Tab }) {
+  if (tab.type === "automations") {
+    return <TabContentAutomations />;
+  }
   if (tab.type === "sessions") {
     return <TabContentNote tab={tab} />;
   }

--- a/apps/desktop/src/sidebar/settings.test.tsx
+++ b/apps/desktop/src/sidebar/settings.test.tsx
@@ -236,26 +236,14 @@ describe("SettingsNav", () => {
     );
   });
 
-  it("opens Automations with Chat docked on the right", () => {
+  it("opens Automations as a separate page", () => {
     render(<SettingsNav />);
 
     fireEvent.click(screen.getByRole("button", { name: "Automations" }));
 
-    expect(mocks.updateSettingsTabState).toHaveBeenCalledWith(
-      mocks.currentTab,
-      { tab: "automations" },
-    );
-    expect(mocks.transitionChatMode).toHaveBeenCalledWith({
-      type: "OPEN_RIGHT_PANEL",
+    expect(mocks.openNew).toHaveBeenCalledWith({
+      type: "automations",
     });
-  });
-
-  it("closes the automation Chat panel when leaving the builder", () => {
-    mocks.currentTab = { type: "settings", state: { tab: "automations" } };
-    render(<SettingsNav />);
-
-    fireEvent.click(screen.getByRole("button", { name: "App" }));
-
-    expect(mocks.transitionChatMode).toHaveBeenCalledWith({ type: "CLOSE" });
+    expect(mocks.updateSettingsTabState).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -29,7 +29,11 @@ import { AUTO_TEMPLATE_ID, useOpenTemplatesTab } from "~/templates";
 type SettingsNavItem =
   | { id: SettingsTab; label: string; icon: Icon }
   | {
-      action: "open-templates" | "open-calendar" | "open-contacts";
+      action:
+        | "open-automations"
+        | "open-templates"
+        | "open-calendar"
+        | "open-contacts";
       label: string;
       icon: Icon;
     };
@@ -43,7 +47,6 @@ export function SettingsNav() {
   const updateSettingsTabState = useTabs(
     (state) => state.updateSettingsTabState,
   );
-  const transitionChatMode = useTabs((state) => state.transitionChatMode);
   const openTemplatesTab = useOpenTemplatesTab();
 
   const activeTab =
@@ -53,15 +56,14 @@ export function SettingsNav() {
     (tab: SettingsTab) => {
       if (currentTab?.type === "settings") {
         updateSettingsTabState(currentTab, { tab });
-        if (tab === "automations") {
-          transitionChatMode({ type: "OPEN_RIGHT_PANEL" });
-        } else if (activeTab === "automations") {
-          transitionChatMode({ type: "CLOSE" });
-        }
       }
     },
-    [activeTab, currentTab, transitionChatMode, updateSettingsTabState],
+    [currentTab, updateSettingsTabState],
   );
+
+  const handleOpenAutomations = useCallback(() => {
+    openNew({ type: "automations" });
+  }, [openNew]);
 
   const handleOpenTemplates = useCallback(() => {
     openTemplatesTab({
@@ -88,7 +90,11 @@ export function SettingsNav() {
         { id: "appearance", label: t`Appearance`, icon: Sun },
         { id: "account", label: t`Account`, icon: User },
         { id: "sync", label: t`Sync`, icon: ArrowsClockwise },
-        { id: "automations", label: t`Automations`, icon: Lightning },
+        {
+          action: "open-automations",
+          label: t`Automations`,
+          icon: Lightning,
+        },
         { id: "notifications", label: t`Notifications`, icon: Bell },
         { id: "permissions", label: t`Permissions`, icon: Lock },
         { id: "developers", label: t`Developers`, icon: Code },
@@ -146,7 +152,9 @@ export function SettingsNav() {
                     key={isSettingsItem ? item.id : item.action}
                     onClick={() => {
                       if (!isSettingsItem) {
-                        if (item.action === "open-templates") {
+                        if (item.action === "open-automations") {
+                          handleOpenAutomations();
+                        } else if (item.action === "open-templates") {
                           handleOpenTemplates();
                         } else if (item.action === "open-calendar") {
                           handleOpenCalendar();

--- a/apps/desktop/src/store/zustand/tabs/basic.test.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.test.ts
@@ -185,16 +185,22 @@ describe("Basic Tab Actions", () => {
     expect(useTabs.getState().chatMode).toBe("FloatingClosed");
   });
 
-  test("openNew docks Chat when opening automation settings", () => {
+  test("openNew docks Chat when opening Automations", () => {
+    useTabs.getState().openNew({ type: "automations" });
+
+    expect(useTabs.getState()).toHaveCurrentTab({
+      type: "automations",
+    });
+    expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
+  });
+
+  test("openNew redirects legacy automation settings links", () => {
     useTabs.getState().openNew({
       type: "settings",
       state: { tab: "automations" },
     });
 
-    expect(useTabs.getState()).toHaveCurrentTab({
-      type: "settings",
-      state: { tab: "automations" },
-    });
+    expect(useTabs.getState()).toHaveCurrentTab({ type: "automations" });
     expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
   });
 

--- a/apps/desktop/src/store/zustand/tabs/basic.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.ts
@@ -22,6 +22,7 @@ import { id } from "~/shared/utils";
 import { listenerStore } from "~/store/zustand/listener/instance";
 
 const RETURN_ORIGIN_TAB_TYPES: Tab["type"][] = [
+  "automations",
   "calendar",
   "contacts",
   "settings",
@@ -514,7 +515,10 @@ const getChatModeForNavigation = (
   targetTab: Tab | TabInput,
   chatMode: ChatModeState["chatMode"],
 ): ChatModeState["chatMode"] | null => {
-  if (targetTab.type === "settings" && targetTab.state?.tab === "automations") {
+  if (
+    targetTab.type === "automations" ||
+    (targetTab.type === "settings" && targetTab.state?.tab === "automations")
+  ) {
     return chatMode === "RightPanelOpen" ? null : "RightPanelOpen";
   }
 

--- a/apps/desktop/src/store/zustand/tabs/pinned-persistence.ts
+++ b/apps/desktop/src/store/zustand/tabs/pinned-persistence.ts
@@ -53,6 +53,7 @@ const deserializePinnedTabs = (data: string): PinnedTab[] => {
       const tabType = (tab as { type: string }).type;
       switch (tabType) {
         case "sessions":
+        case "automations":
         case "contacts":
         case "templates":
         case "humans":

--- a/apps/desktop/src/store/zustand/tabs/schema.ts
+++ b/apps/desktop/src/store/zustand/tabs/schema.ts
@@ -24,6 +24,7 @@ export type SupportedWindowTabInput = Exclude<
 
 export type TabInput =
   | SupportedWindowTabInput
+  | { type: "automations" }
   | { type: "shared_sessions"; id: string }
   | { type: "shared_note_preview"; id: string };
 
@@ -41,7 +42,6 @@ export type SettingsTab =
   | "account"
   | "app"
   | "appearance"
-  | "automations"
   | "sync"
   | "notifications"
   | "developers"
@@ -57,7 +57,6 @@ export const normalizeSettingsTab = (
   switch (tab) {
     case "app":
     case "appearance":
-    case "automations":
     case "sync":
     case "notifications":
     case "developers":
@@ -113,6 +112,7 @@ export type Tab =
       type: "templates";
       state: TemplatesState;
     })
+  | (BaseTab & { type: "automations" })
   | (BaseTab & {
       type: "humans";
       id: string;
@@ -176,6 +176,8 @@ export const getDefaultState = (tab: TabInput): Tab => {
           selectedWebIndex: null,
         },
       };
+    case "automations":
+      return { ...base, type: "automations" };
     case "humans":
       return { ...base, type: "humans", id: tab.id };
     case "organizations":
@@ -194,6 +196,9 @@ export const getDefaultState = (tab: TabInput): Tab => {
       const subtab = tab.state?.tab as string | null | undefined;
       if (subtab === "calendar") {
         return { ...base, type: "calendar" };
+      }
+      if (subtab === "automations") {
+        return { ...base, type: "automations" };
       }
       return {
         ...base,
@@ -229,6 +234,8 @@ export const uniqueIdfromTab = (tab: Tab): string => {
       return `contacts`;
     case "templates":
       return `templates`;
+    case "automations":
+      return `automations`;
     case "empty":
       return `empty-${tab.slotId}`;
     case "calendar":


### PR DESCRIPTION
Route the Settings navigation item to a reusable Automations tab while preserving the docked Chat layout and legacy links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tab routing, chat persistence queries, and message metadata classification—behavior changes if scope metadata is missing on older threads or the SQL predicate misclassifies groups.
> 
> **Overview**
> **Automations** moves out of Settings into its own main-window tab (`automations`), opened from the sidebar like Calendar/Templates. Legacy `settings?tab=automations` links normalize to that tab, and navigation still **opens Chat in the right panel** on Automations.
> 
> Chat is split by **`ChatScope`** (`general` | `automations`): separate group/session selection in context, scope derived from the active tab, and **automations chat does not attach** the open note’s session, transcript, or batch transcription state. Outgoing messages persist `metadata.chatScope`; recent history and group lookups filter groups via SQL on that metadata so automation threads stay separate from general chat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ea24440abeb85bba721701738f05be7a61509a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->