### PR TITLE
Normalize AI icon presentation

### DIFF
--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -73,7 +73,7 @@ export function AnarlogProviderIcon() {
       src={ANARLOG_ICON_SRC}
       alt="Anarlog"
       data-slot="provider-logo"
-      className="size-4 object-contain object-center [clip-path:inset(6%_round_18%)]"
+      className="size-full object-contain object-center [clip-path:inset(6%_round_18%)]"
     />
   );
 }
@@ -100,26 +100,41 @@ export function ProviderBrandImage({
   );
 }
 
-export function ProviderIconSlot({ children }: { children: ReactNode }) {
+export function AiIconSlot({
+  children,
+  title,
+  className,
+}: {
+  children: ReactNode;
+  title?: string;
+  className?: string;
+}) {
   return (
     <span
-      data-slot="provider-icon"
+      title={title}
+      aria-label={title}
+      data-slot="ai-icon"
       className={cn([
-        "text-foreground flex size-5 shrink-0 items-center justify-center",
+        "bg-muted text-foreground flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-md",
         "[&_[data-slot=provider-brand-icon]]:[filter:var(--provider-brand-filter)]",
+        className,
       ])}
     >
       <span
-        data-slot="provider-icon-art"
+        data-slot="ai-icon-art"
         className={cn([
-          "flex size-4 items-center justify-center",
-          "[&>img]:size-full [&>svg]:block [&>svg]:size-full [&>svg]:text-inherit",
+          "flex size-3.5 items-center justify-center overflow-hidden",
+          "[&>img]:block [&>img]:size-full [&>svg]:block [&>svg]:size-full [&>svg]:text-inherit",
         ])}
       >
         {children}
       </span>
     </span>
   );
+}
+
+export function ProviderIconSlot({ children }: { children: ReactNode }) {
+  return <AiIconSlot>{children}</AiIconSlot>;
 }
 
 export function providerRowId(providerType: ProviderType, providerId: string) {

--- a/apps/desktop/src/settings/ai/stt/model-icon.tsx
+++ b/apps/desktop/src/settings/ai/stt/model-icon.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from "react";
 
 import { cn } from "@anlg/utils";
 
+import { AiIconSlot } from "~/settings/ai/shared";
+
 type ModelIconSpec = {
   title: string;
   label?: string;
@@ -22,18 +24,14 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "A",
       title: "Anarlog Pro",
-      className: "border-border bg-card text-muted-foreground",
       imageSrc: ANARLOG_ICON_SRC,
-      imageClassName: "size-4 object-contain",
     };
   }
 
   if (value === "apple-speech") {
     return {
       title: "Apple Speech",
-      // The Apple mark is full-bleed in its viewBox, so it renders smaller than the
-      // 20px slot to match the optical size of the padded brand logos.
-      node: <Apple size={16} />,
+      node: <Apple />,
     };
   }
 
@@ -41,9 +39,7 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "Q",
       title: "Qwen",
-      className: "border-border bg-card text-muted-foreground",
       imageSrc: `${MODEL_ICON_ASSET_BASE}/qwen-logo.svg`,
-      imageClassName: "size-4 object-contain",
     };
   }
 
@@ -51,9 +47,7 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "O",
       title: "Meta Omnilingual",
-      className: "border-border bg-card text-muted-foreground",
       imageSrc: `${MODEL_ICON_ASSET_BASE}/meta-logo.svg`,
-      imageClassName: "size-4 object-contain",
     };
   }
 
@@ -61,9 +55,7 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "W",
       title: "OpenAI Whisper",
-      className: "border-border bg-card text-muted-foreground",
       imageSrc: `${MODEL_ICON_ASSET_BASE}/openai-logo.svg`,
-      imageClassName: "size-4 object-contain",
     };
   }
 
@@ -71,9 +63,8 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "P",
       title: "NVIDIA Parakeet",
-      className: "border-border bg-card text-muted-foreground",
       imageSrc: `${MODEL_ICON_ASSET_BASE}/nvidia-logo.svg`,
-      imageClassName: "size-4 object-cover object-left",
+      imageClassName: "object-cover object-left",
     };
   }
 
@@ -150,37 +141,24 @@ export function LocalModelLabel({
       title={title}
       className={cn(["flex min-w-0 items-center gap-2", className])}
     >
-      {icon?.node ? (
-        <span
-          title={icon.title}
-          aria-label={icon.title}
-          className="flex size-5 shrink-0 items-center justify-center"
-        >
-          {icon.node}
-        </span>
-      ) : icon?.imageSrc ? (
-        <img
-          title={icon.title}
-          aria-label={icon.title}
-          src={icon.imageSrc}
-          alt=""
-          className={cn([
-            "shrink-0 object-contain object-center",
-            icon.imageClassName,
-            "size-5",
-          ])}
-        />
-      ) : icon ? (
-        <span
-          title={icon.title}
-          aria-label={icon.title}
-          className={cn([
-            "inline-flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-md text-[10px] leading-none font-semibold",
-            icon.className,
-          ])}
-        >
-          {icon.label}
-        </span>
+      {icon ? (
+        <AiIconSlot title={icon.title} className={icon.className}>
+          {icon.node ??
+            (icon.imageSrc ? (
+              <img
+                src={icon.imageSrc}
+                alt=""
+                className={cn([
+                  "object-contain object-center",
+                  icon.imageClassName,
+                ])}
+              />
+            ) : (
+              <span className="text-[10px] leading-none font-semibold">
+                {icon.label}
+              </span>
+            ))}
+        </AiIconSlot>
       ) : null}
       <span className={cn(["min-w-0 truncate", labelClassName])}>{label}</span>
     </div>


### PR DESCRIPTION
Use one fixed tile and artwork frame across provider and local model menus.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only refactor in AI settings UI; no auth, data, or provider configuration behavior changes.
> 
> **Overview**
> Introduces a shared **`AiIconSlot`** component that defines one fixed **20px muted, rounded tile** with a **14px inner artwork frame** (`data-slot="ai-icon"` / `ai-icon-art`). **`ProviderIconSlot`** now delegates to **`AiIconSlot`** so provider accordions and selects pick up the same chrome without call-site changes.
> 
> **STT local model rows** (`LocalModelLabel`) stop rendering ad-hoc icon spans and images and instead route all model icons through **`AiIconSlot`**, with optional per-model **`className`** only where needed (e.g. GGML). Per-model **`border-border bg-card`** and fixed **`size-4` / `size-5`** image classes are removed from **`getLocalModelIcon`** in favor of the slot’s layout. **`AnarlogProviderIcon`** fills the art frame with **`size-full`** instead of a fixed **`size-4`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5520552a8f2351d1f69c86d164bad44c0ba7d98c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->