### PR TITLE
Avoid duplicate app icon choices

### DIFF
--- a/apps/desktop/src/settings/appearance/app-icon.test.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.test.tsx
@@ -57,8 +57,8 @@ describe("AppIconSelector", () => {
     expect(defaultOption.querySelector("img")?.getAttribute("src")).toBe(
       "/assets/app-icons/stable-light.png",
     );
-    expect(screen.getAllByRole("radio")).toHaveLength(5);
-    expect(screen.getByRole("radio", { name: "Production" })).toBeDefined();
+    expect(screen.getAllByRole("radio")).toHaveLength(4);
+    expect(screen.queryByRole("radio", { name: "Production" })).toBeNull();
     expect(screen.getByRole("radio", { name: "Blueprint" })).toBeDefined();
     expect(screen.getByRole("radio", { name: "Sketch" })).toBeDefined();
 
@@ -77,6 +77,21 @@ describe("AppIconSelector", () => {
     expect(defaultOption.querySelector("img")?.getAttribute("src")).toBe(
       "/assets/app-icons/staging-light.png",
     );
+    expect(screen.queryByRole("radio", { name: "Sketch" })).toBeNull();
+    expect(screen.getByRole("radio", { name: "Production" })).toBeDefined();
+  });
+
+  it("selects default for an equivalent channel-specific preference", () => {
+    mocks.appIcon = "stable";
+
+    render(<AppIconSelector />);
+
+    expect(
+      screen
+        .getByRole("radio", { name: "Default" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(screen.queryByRole("radio", { name: "Production" })).toBeNull();
   });
 
   it("is hidden on platforms that cannot change the running app icon", () => {

--- a/apps/desktop/src/settings/appearance/app-icon.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.tsx
@@ -39,6 +39,11 @@ export function AppIconSelector() {
     dev: t`Blueprint`,
     staging: t`Sketch`,
   };
+  const defaultIconName = resolveAppIconName("default", appIdentifier);
+  const selectedIconName = resolveAppIconName(value, appIdentifier);
+  const options = APP_ICON_OPTIONS.filter(
+    (option) => option === "default" || option !== defaultIconName,
+  );
 
   if (platform() !== "macos") {
     return null;
@@ -62,8 +67,9 @@ export function AppIconSelector() {
         aria-label={t`App icon`}
         className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
       >
-        {APP_ICON_OPTIONS.map((option) => {
-          const selected = option === value;
+        {options.map((option) => {
+          const selected =
+            resolveAppIconName(option, appIdentifier) === selectedIconName;
           const previewName = resolveAppIconName(option, appIdentifier);
 
           return (


### PR DESCRIPTION
Hide the explicit channel icon when it matches Default and keep equivalent saved preferences selected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only appearance settings on macOS with no auth, data, or backend impact.
> 
> **Overview**
> The macOS **App icon** picker no longer shows a separate option when it would look the same as **Default** for the current app channel (e.g. **Production** on stable builds, **Sketch** on staging).
> 
> Selection is based on the **resolved** icon name, so a saved channel-specific preference like `stable` still shows **Default** as selected when that channel is implicit. Tests cover the reduced option count, staging vs stable visibility, and equivalent-preference selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c214987cd8f26f78dbeb63ab20025d9f78215313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->