### PR TITLE
Focus chat input when opened

### DIFF
--- a/apps/desktop/src/chat/components/input/hooks.ts
+++ b/apps/desktop/src/chat/components/input/hooks.ts
@@ -213,8 +213,7 @@ export function useAutoFocusEditor({
     const maxAttempts = 20;
 
     const tryFocus = () => {
-      if (editorRef.current) {
-        editorRef.current.focus();
+      if (editorRef.current?.focus()) {
         return;
       }
 

--- a/apps/desktop/src/chat/components/input/index.test.tsx
+++ b/apps/desktop/src/chat/components/input/index.test.tsx
@@ -7,26 +7,29 @@ import {
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { clearContentMock, editorState, shellState } = vi.hoisted(() => ({
-  clearContentMock: vi.fn(),
-  editorState: {
-    json: undefined as unknown,
-    onUpdate: undefined as undefined | ((json: unknown) => void),
-    onSubmit: undefined as undefined | (() => void),
-    onHistoryNavigate: undefined as
-      | undefined
-      | ((direction: "prev" | "next") => boolean),
-    initialContent: undefined as unknown,
-    replacementSelections: [] as Array<"start" | "end">,
-    submitShortcut: undefined as undefined | "mod-enter" | "enter",
-  },
-  shellState: {
-    mode: "FloatingOpen" as
-      | "FloatingClosed"
-      | "FloatingOpen"
-      | "RightPanelOpen",
-  },
-}));
+const { clearContentMock, editorState, focusMock, shellState } = vi.hoisted(
+  () => ({
+    clearContentMock: vi.fn(),
+    editorState: {
+      json: undefined as unknown,
+      onUpdate: undefined as undefined | ((json: unknown) => void),
+      onSubmit: undefined as undefined | (() => void),
+      onHistoryNavigate: undefined as
+        | undefined
+        | ((direction: "prev" | "next") => boolean),
+      initialContent: undefined as unknown,
+      replacementSelections: [] as Array<"start" | "end">,
+      submitShortcut: undefined as undefined | "mod-enter" | "enter",
+    },
+    focusMock: vi.fn(() => true),
+    shellState: {
+      mode: "FloatingOpen" as
+        | "FloatingClosed"
+        | "FloatingOpen"
+        | "RightPanelOpen",
+    },
+  }),
+);
 
 vi.mock("@anlg/editor/chat", async () => {
   const React = await vi.importActual<typeof import("react")>("react");
@@ -35,7 +38,7 @@ vi.mock("@anlg/editor/chat", async () => {
     ChatEditor: React.forwardRef<
       {
         clearContent: () => void;
-        focus: () => void;
+        focus: () => boolean;
         getJSON: () => unknown;
         replaceContent: (content: unknown, selection?: "start" | "end") => void;
       },
@@ -71,7 +74,7 @@ vi.mock("@anlg/editor/chat", async () => {
 
       React.useImperativeHandle(ref, () => ({
         clearContent: clearContentMock,
-        focus: vi.fn(),
+        focus: focusMock,
         getJSON: () => editorState.json,
         replaceContent: (
           content: unknown,
@@ -140,6 +143,8 @@ describe("ChatMessageInput", () => {
   beforeEach(() => {
     cleanup();
     clearContentMock.mockClear();
+    focusMock.mockReset();
+    focusMock.mockReturnValue(true);
     clearSentMessages();
     editorState.json = { type: "doc", content: [] };
     editorState.onSubmit = undefined;
@@ -277,6 +282,31 @@ describe("ChatMessageInput", () => {
     );
 
     expect(editorState.submitShortcut).toBe("enter");
+  });
+
+  it("retries focus until the editor view is ready", () => {
+    const animationFrames: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    focusMock.mockReturnValueOnce(false).mockReturnValue(true);
+
+    const { unmount } = render(
+      <ChatMessageInput draftKey="chat-input-focus" onSendMessage={vi.fn()} />,
+    );
+
+    expect(focusMock).toHaveBeenCalledOnce();
+
+    act(() => {
+      animationFrames.shift()?.(0);
+    });
+
+    expect(focusMock).toHaveBeenCalledTimes(2);
+
+    unmount();
+    vi.unstubAllGlobals();
   });
 
   it("marks the send control for disabled surface styling before the draft has content", () => {

--- a/packages/editor/src/chat/index.tsx
+++ b/packages/editor/src/chat/index.tsx
@@ -59,7 +59,7 @@ export interface JSONContent {
 }
 
 export interface ChatEditorHandle {
-  focus(): void;
+  focus(): boolean;
   getJSON(): JSONContent | undefined;
   clearContent(): void;
   replaceContent(content: JSONContent, selection?: "start" | "end"): void;
@@ -194,7 +194,11 @@ export const ChatEditor = forwardRef<ChatEditorHandle, ChatEditorProps>(
       ref,
       () => ({
         focus() {
-          viewRef.current?.focus();
+          const view = viewRef.current;
+          if (!view) return false;
+
+          view.focus();
+          return true;
         },
         getJSON() {
           return viewRef.current?.state.doc.toJSON() as JSONContent | undefined;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UX fix limited to chat input focus timing; API change on `ChatEditorHandle.focus()` is backward-compatible for callers that ignore the return value.
> 
> **Overview**
> When the chat input opens, **auto-focus** can run before the ProseMirror view is mounted, so the first `focus()` call did nothing and the retry loop stopped too early.
> 
> **`ChatEditor.focus()`** now returns **`boolean`** (`false` when there is no view, `true` after focusing). **`useAutoFocusEditor`** treats a successful return as done and keeps scheduling **`requestAnimationFrame`** retries (up to 20) until focus succeeds.
> 
> Tests mock `focus()` to fail once, then pass on the next frame, to lock in the retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2568dd392de5f51f1fa3add0472aab952cc4f5e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->