### PR TITLE
Prevent macOS menu icon panic

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -245,6 +245,11 @@ pub async fn main() {
         builder = builder.plugin(plugin);
     }
 
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder.menu(tauri_plugin_tray::build_app_menu);
+    }
+
     let specta_builder = make_specta_builder::<tauri::Wry>();
 
     let root_supervisor_ctx_for_run = root_supervisor_ctx.clone();
@@ -279,7 +284,6 @@ pub async fn main() {
                 if appearance_settings.show_tray_icon {
                     app_handle.tray().create_tray_menu().unwrap();
                 }
-                app_handle.tray().create_app_menu().unwrap();
             }
 
             {

--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -4,10 +4,12 @@ use std::sync::{
 };
 
 use tauri::async_runtime::JoinHandle;
+#[cfg(target_os = "macos")]
+use tauri::menu::{HELP_SUBMENU_ID, Submenu, WINDOW_SUBMENU_ID};
 use tauri::{
     AppHandle, Result,
     image::Image,
-    menu::{Menu, MenuItem, MenuItemKind, PredefinedMenuItem, Submenu},
+    menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::TrayIconBuilder,
 };
 
@@ -35,82 +37,97 @@ static SCHEDULE_TASK: Mutex<Option<JoinHandle<()>>> = Mutex::new(None);
 static SCHEDULE_TITLE: Mutex<Option<String>> = Mutex::new(None);
 static AGENDA_SECTIONS: Mutex<Vec<TrayAgendaSection>> = Mutex::new(Vec::new());
 
+#[cfg(target_os = "macos")]
+pub fn build_app_menu(app: &AppHandle<tauri::Wry>) -> Result<Menu<tauri::Wry>> {
+    let app_submenu = Submenu::with_items(
+        app,
+        app.package_info().name.clone(),
+        true,
+        &[
+            &AppInfo::build(app)?,
+            &TrayCheckUpdate::build(app)?,
+            &TraySettings::build(app)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::services(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::hide(app, None)?,
+            &PredefinedMenuItem::hide_others(app, None)?,
+            &PredefinedMenuItem::show_all(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &TrayQuit::build(app)?,
+        ],
+    )?;
+    let file_submenu = Submenu::with_items(
+        app,
+        "File",
+        true,
+        &[
+            &AppNew::build(app)?,
+            &PredefinedMenuItem::close_window(app, None)?,
+        ],
+    )?;
+    let edit_submenu = Submenu::with_items(
+        app,
+        "Edit",
+        true,
+        &[
+            &PredefinedMenuItem::undo(app, None)?,
+            &PredefinedMenuItem::redo(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::cut(app, None)?,
+            &PredefinedMenuItem::copy(app, None)?,
+            &PredefinedMenuItem::paste(app, None)?,
+            &PredefinedMenuItem::select_all(app, None)?,
+        ],
+    )?;
+    let view_submenu = Submenu::with_items(
+        app,
+        "View",
+        true,
+        &[&PredefinedMenuItem::fullscreen(app, None)?],
+    )?;
+    let window_submenu = Submenu::with_id_and_items(
+        app,
+        WINDOW_SUBMENU_ID,
+        "Window",
+        true,
+        &[
+            &PredefinedMenuItem::minimize(app, None)?,
+            &PredefinedMenuItem::maximize(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::close_window(app, None)?,
+        ],
+    )?;
+    let help_submenu = Submenu::with_id_and_items(
+        app,
+        HELP_SUBMENU_ID,
+        "Help",
+        true,
+        &[
+            &HelpReportBug::build(app)?,
+            &HelpSuggestFeature::build(app)?,
+        ],
+    )?;
+
+    Menu::with_items(
+        app,
+        &[
+            &app_submenu,
+            &file_submenu,
+            &edit_submenu,
+            &view_submenu,
+            &window_submenu,
+            &help_submenu,
+        ],
+    )
+}
+
 pub struct Tray<'a, R: tauri::Runtime, M: tauri::Manager<R>> {
     manager: &'a M,
     _runtime: std::marker::PhantomData<fn() -> R>,
 }
 
 impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
-    pub fn create_app_menu(&self) -> Result<()> {
-        let app = self.manager.app_handle();
-
-        let info_item = AppInfo::build(app)?;
-        let check_update_item = TrayCheckUpdate::build(app)?;
-        let settings_item = TraySettings::build(app)?;
-        let new_item = AppNew::build(app)?;
-        let report_bug_item = HelpReportBug::build(app)?;
-        let suggest_feature_item = HelpSuggestFeature::build(app)?;
-
-        if cfg!(target_os = "macos")
-            && let Some(menu) = app.menu()
-        {
-            let items = menu.items()?;
-
-            if !items.is_empty()
-                && let MenuItemKind::Submenu(old_submenu) = &items[0]
-            {
-                let app_name = old_submenu.text()?;
-
-                let new_app_submenu = Submenu::with_items(
-                    app,
-                    &app_name,
-                    true,
-                    &[
-                        &info_item,
-                        &check_update_item,
-                        &settings_item,
-                        &PredefinedMenuItem::separator(app)?,
-                        &PredefinedMenuItem::services(app, None)?,
-                        &PredefinedMenuItem::separator(app)?,
-                        &PredefinedMenuItem::hide(app, None)?,
-                        &PredefinedMenuItem::hide_others(app, None)?,
-                        &PredefinedMenuItem::show_all(app, None)?,
-                        &PredefinedMenuItem::separator(app)?,
-                        &TrayQuit::build(app)?,
-                    ],
-                )?;
-
-                menu.remove(old_submenu)?;
-                menu.prepend(&new_app_submenu)?;
-            }
-
-            if items.len() > 1
-                && let MenuItemKind::Submenu(submenu) = &items[1]
-            {
-                submenu.prepend(&new_item)?;
-            }
-
-            for item in &items {
-                if let MenuItemKind::Submenu(submenu) = item
-                    && submenu.text()? == "Help"
-                {
-                    menu.remove(submenu)?;
-                    break;
-                }
-            }
-
-            let help_submenu = Submenu::with_items(
-                app,
-                "Help",
-                true,
-                &[&report_bug_item, &suggest_feature_item],
-            )?;
-            menu.append(&help_submenu)?;
-        }
-
-        Ok(())
-    }
-
     pub fn create_tray_menu(&self) -> Result<()> {
         let app = self.manager.app_handle();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> macOS-only menu registration change with no auth or data impact; behavior should match prior menu items but wiring differs from the old mutate-in-setup path.
> 
> **Overview**
> Fixes a **macOS menu-bar panic** by stopping runtime surgery on the default menu and registering the full menu when the Tauri app is built instead.
> 
> On macOS, the desktop app now calls `.menu(tauri_plugin_tray::build_app_menu)` on the builder. **`create_app_menu()` is removed** from startup setup (it used to run whenever the tray was shown and rewrote existing submenus). Tray setup only creates the **tray icon menu** when `show_tray_icon` is enabled.
> 
> The tray plugin exposes **`build_app_menu`**, which assembles the standard macOS bar (App, File, Edit, View, Window, Help) with the same custom entries (info, updates, settings, New, help links, quit, etc.) in one place, using Tauri’s `WINDOW_SUBMENU_ID` and `HELP_SUBMENU_ID` where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b228b7d324ba61e8ee8ca1e6eac102fae8adf06c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->