### PR TITLE
Treat Loops idempotency replays as success

### DIFF
--- a/apps/stripe/src/loops.test.ts
+++ b/apps/stripe/src/loops.test.ts
@@ -28,4 +28,24 @@ describe("sendLoopsTransactional", () => {
       dataVariables: { firstName: "Alex" },
     });
   });
+
+  it("accepts an already processed idempotency key", async () => {
+    await expect(
+      sendLoopsTransactional({
+        apiKey: "loops-key",
+        transactionalId: "transactional-123",
+        email: "alex@example.com",
+        dataVariables: { firstName: "Alex" },
+        idempotencyKey: "stripe-event-123",
+        fetcher: async () =>
+          Response.json(
+            {
+              success: false,
+              message: "Request has already been processed.",
+            },
+            { status: 409 },
+          ),
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/stripe/src/loops.ts
+++ b/apps/stripe/src/loops.ts
@@ -34,7 +34,7 @@ export async function sendLoopsTransactional({
     }),
   });
 
-  if (!response.ok) {
+  if (!response.ok && response.status !== 409) {
     throw new Error(
       `Loops transactional send failed (${response.status}): ${await response.text()}`,
     );

--- a/apps/web/src/lib/loops.test.ts
+++ b/apps/web/src/lib/loops.test.ts
@@ -72,3 +72,18 @@ test("surfaces Loops API errors", async () => {
     /Loops request failed \(401\): invalid token/,
   );
 });
+
+test("accepts an already processed idempotency key", async () => {
+  await sendLoopsTransactional({
+    apiKey: "loops-key",
+    transactionalId: "transactional-123",
+    email: "alex@example.com",
+    dataVariables: { firstName: "Alex" },
+    idempotencyKey: "trial-ending:sub-123:1785945600",
+    fetcher: async () =>
+      Response.json(
+        { success: false, message: "Request has already been processed." },
+        { status: 409 },
+      ),
+  });
+});

--- a/apps/web/src/lib/loops.ts
+++ b/apps/web/src/lib/loops.ts
@@ -23,7 +23,7 @@ async function sendLoopsRequest({
     body: JSON.stringify(body),
   });
 
-  if (!response.ok) {
+  if (!response.ok && response.status !== 409) {
     throw new Error(
       `Loops request failed (${response.status}): ${await response.text()}`,
     );


### PR DESCRIPTION
Loops returns 409 when an idempotency key has already been processed. Accept that response in both web and Stripe senders so scheduled and webhook retries remain successful without duplicate mail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Loops HTTP error handling; reduces false failures on retries without changing send behavior for new keys.
> 
> **Overview**
> **Loops** returns HTTP **409** when an **Idempotency-Key** was already processed. Both the **web** and **Stripe** Loops senders now treat **409** as a successful outcome instead of throwing, so webhook and scheduled retries do not fail after the email was already sent.
> 
> Shared request helpers in `apps/web/src/lib/loops.ts` and `apps/stripe/src/loops.ts` only error when the response is not OK **and** the status is not **409**. Tests cover a **409** body with `"Request has already been processed."` resolving without error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78dfb24aec2d4c73764787ed9ec6fc19b1518e53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->