### PR TITLE
Retry Loops rate limits

### DIFF
--- a/apps/stripe/src/loops.test.ts
+++ b/apps/stripe/src/loops.test.ts
@@ -48,4 +48,28 @@ describe("sendLoopsTransactional", () => {
       }),
     ).resolves.toBeUndefined();
   });
+
+  it("retries Loops rate limits", async () => {
+    let requests = 0;
+
+    await sendLoopsTransactional({
+      apiKey: "loops-key",
+      transactionalId: "transactional-123",
+      email: "alex@example.com",
+      dataVariables: { firstName: "Alex" },
+      idempotencyKey: "stripe-event-123",
+      fetcher: async () => {
+        requests += 1;
+        if (requests === 1) {
+          return Response.json(
+            { success: false, message: "Too many requests." },
+            { status: 429, headers: { "Retry-After": "0" } },
+          );
+        }
+        return Response.json({ success: true });
+      },
+    });
+
+    expect(requests).toBe(2);
+  });
 });

--- a/apps/stripe/src/loops.ts
+++ b/apps/stripe/src/loops.ts
@@ -1,9 +1,18 @@
 const LOOPS_TRANSACTIONAL_URL = "https://app.loops.so/api/v1/transactional";
+const MAX_RATE_LIMIT_RETRIES = 3;
 
 type Fetcher = (
   input: RequestInfo | URL,
   init?: RequestInit,
 ) => Promise<Response>;
+
+function getRetryDelayMs(response: Response) {
+  const retryAfterSeconds = Number(response.headers.get("Retry-After") ?? "1");
+  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds < 0) {
+    return 1_000;
+  }
+  return Math.min(retryAfterSeconds * 1_000, 5_000);
+}
 
 export async function sendLoopsTransactional({
   apiKey,
@@ -20,7 +29,7 @@ export async function sendLoopsTransactional({
   idempotencyKey: string;
   fetcher?: Fetcher;
 }) {
-  const response = await fetcher(LOOPS_TRANSACTIONAL_URL, {
+  const request = {
     method: "POST",
     headers: {
       Authorization: `Bearer ${apiKey}`,
@@ -32,9 +41,19 @@ export async function sendLoopsTransactional({
       email,
       dataVariables,
     }),
-  });
+  } satisfies RequestInit;
 
-  if (!response.ok && response.status !== 409) {
+  for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt += 1) {
+    const response = await fetcher(LOOPS_TRANSACTIONAL_URL, request);
+    if (response.ok || response.status === 409) {
+      return;
+    }
+    if (response.status === 429 && attempt < MAX_RATE_LIMIT_RETRIES) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, getRetryDelayMs(response)),
+      );
+      continue;
+    }
     throw new Error(
       `Loops transactional send failed (${response.status}): ${await response.text()}`,
     );

--- a/apps/web/src/lib/loops.test.ts
+++ b/apps/web/src/lib/loops.test.ts
@@ -87,3 +87,27 @@ test("accepts an already processed idempotency key", async () => {
       ),
   });
 });
+
+test("retries Loops rate limits", async () => {
+  let requests = 0;
+
+  await sendLoopsTransactional({
+    apiKey: "loops-key",
+    transactionalId: "transactional-123",
+    email: "alex@example.com",
+    dataVariables: { firstName: "Alex" },
+    idempotencyKey: "trial-ending:sub-123:1785945600",
+    fetcher: async () => {
+      requests += 1;
+      if (requests === 1) {
+        return Response.json(
+          { success: false, message: "Too many requests." },
+          { status: 429, headers: { "Retry-After": "0" } },
+        );
+      }
+      return Response.json({ success: true });
+    },
+  });
+
+  assert.equal(requests, 2);
+});

--- a/apps/web/src/lib/loops.ts
+++ b/apps/web/src/lib/loops.ts
@@ -1,4 +1,13 @@
 const LOOPS_API_URL = "https://app.loops.so/api/v1";
+const MAX_RATE_LIMIT_RETRIES = 3;
+
+function getRetryDelayMs(response: Response) {
+  const retryAfterSeconds = Number(response.headers.get("Retry-After") ?? "1");
+  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds < 0) {
+    return 1_000;
+  }
+  return Math.min(retryAfterSeconds * 1_000, 5_000);
+}
 
 async function sendLoopsRequest({
   path,
@@ -13,7 +22,7 @@ async function sendLoopsRequest({
   body: Record<string, unknown>;
   fetcher: typeof fetch;
 }) {
-  const response = await fetcher(`${LOOPS_API_URL}${path}`, {
+  const request = {
     method: "POST",
     headers: {
       Authorization: `Bearer ${apiKey}`,
@@ -21,9 +30,19 @@ async function sendLoopsRequest({
       "Idempotency-Key": idempotencyKey,
     },
     body: JSON.stringify(body),
-  });
+  } satisfies RequestInit;
 
-  if (!response.ok && response.status !== 409) {
+  for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt += 1) {
+    const response = await fetcher(`${LOOPS_API_URL}${path}`, request);
+    if (response.ok || response.status === 409) {
+      return;
+    }
+    if (response.status === 429 && attempt < MAX_RATE_LIMIT_RETRIES) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, getRetryDelayMs(response)),
+      );
+      continue;
+    }
     throw new Error(
       `Loops request failed (${response.status}): ${await response.text()}`,
     );


### PR DESCRIPTION
Loops allows 10 API requests per second. Retry 429 responses with bounded backoff in both web and Stripe senders so lifecycle batches complete cleanly without duplicate mail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded retries on external email API calls with unchanged success/error semantics and idempotency headers; no auth or data-model changes.
> 
> **Overview**
> Adds **automatic retry** for Loops **HTTP 429** responses in both the Stripe and web Loops senders, so lifecycle/transactional batches can finish when the API hits its ~10 req/s limit without manual reruns.
> 
> Each sender now loops up to **3 retries** after a 429, waiting from the **`Retry-After`** header (default 1s, capped at 5s) while reusing the same POST payload and **`Idempotency-Key`**. **200** and **409** (already processed) still exit successfully; other errors behave as before.
> 
> Tests assert a 429 followed by success results in **two** requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc88f61aa5fe01213e946fb857276ca4492a2bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->