### PR TITLE
Update desktop 1.4.2 changelog

### DIFF
--- a/packages/changelog/content/1.4.2.md
+++ b/packages/changelog/content/1.4.2.md
@@ -1,0 +1,30 @@
+---
+date: "2026-08-03"
+summary: "Anarlog 1.4.2 adds a dedicated Automations workspace, smoother chat and sharing, refined settings, and a macOS launch fix."
+---
+
+## Automations and chat
+
+- Open **Automations** as a dedicated workspace with Chat docked alongside it,
+  while keeping automation conversations separate from regular note chats
+- Start typing immediately when Chat opens, even when its editor takes a moment
+  to become ready
+- Return to an empty tab without Chat retaining the previously open note as
+  context
+
+## Meetings and sharing
+
+- Keep the sharing popover open while Anarlog prepares a share link, so the
+  operation can finish without being cancelled by an interface refresh
+- See upcoming meeting countdowns directly below **Join & record**, where they
+  no longer compete for space in the header
+
+## Settings and reliability
+
+- Navigate a cleaner, flatter Sync settings page with more consistent spacing
+- Choose a macOS app icon without seeing a duplicate of the icon already used
+  by **Default**
+- Tell AI providers and local transcription models apart more easily with
+  consistent icon sizing and presentation
+- Avoid a macOS startup crash that could occur while Anarlog prepared the app
+  menu


### PR DESCRIPTION
Summary:
- add the user-facing stable release notes for version 1.4.2
- document Automations, chat, sharing, settings, and macOS reliability improvements

Validation:
- pnpm exec dprint fmt
- pnpm fmt:check
- pnpm -F @anlg/changelog typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition to the changelog package with no application or runtime code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.2.md`** with user-facing stable release notes for **Anarlog 1.4.2** (dated 2026-08-03), following the same frontmatter + sectioned bullet format as other changelog entries.
> 
> The new entry covers **Automations** (dedicated workspace with docked Chat, separate automation vs note conversations), **chat** behavior (immediate typing, clearing context on empty tabs), **meetings/sharing** (share popover stability, countdown placement under Join & record), **settings** UI (Sync page layout, macOS icon picker, AI/transcription icon consistency), and a **macOS startup crash** fix during app menu preparation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e62e2f2fa1b71b9539c5bf8015b189e655cdfd9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->