### PR TITLE
Fix menu bar event join and recording

### DIFF
--- a/apps/desktop/src/services/tray-schedule.test.ts
+++ b/apps/desktop/src/services/tray-schedule.test.ts
@@ -19,6 +19,7 @@ describe("buildTrayScheduleEvents", () => {
       {
         upcoming: event({
           title: "  Design sync  ",
+          meeting_link: "https://meet.example.com/design-sync",
           started_at: "2026-07-17T01:00:00.000Z",
           ended_at: "2026-07-17T02:00:00.000Z",
         }),
@@ -36,7 +37,9 @@ describe("buildTrayScheduleEvents", () => {
 
     expect(events).toEqual([
       {
+        id: "active",
         title: "Standup",
+        meetingLink: null,
         startsAtMs: Date.parse("2026-07-16T23:55:00.000Z"),
         endsAtMs: Date.parse("2026-07-17T00:25:00.000Z"),
         dayStartMs: Date.parse("2026-07-16T00:00:00.000Z"),
@@ -44,7 +47,9 @@ describe("buildTrayScheduleEvents", () => {
         timeLabel: "11:55 PM – 12:25 AM",
       },
       {
+        id: "upcoming",
         title: "Design sync",
+        meetingLink: "https://meet.example.com/design-sync",
         startsAtMs: Date.parse("2026-07-17T01:00:00.000Z"),
         endsAtMs: Date.parse("2026-07-17T02:00:00.000Z"),
         dayStartMs: NOW,

--- a/apps/desktop/src/services/tray-schedule.tsx
+++ b/apps/desktop/src/services/tray-schedule.tsx
@@ -33,8 +33,8 @@ export function buildTrayScheduleEvents(
     timeZone: timezone,
   });
 
-  return Object.values(rows ?? {})
-    .flatMap((row): TrayScheduleEvent[] => {
+  return Object.entries(rows ?? {})
+    .flatMap(([eventId, row]): TrayScheduleEvent[] => {
       if (
         row.is_all_day ||
         isIgnored(row.tracking_id_event, row.recurrence_series_id)
@@ -72,7 +72,9 @@ export function buildTrayScheduleEvents(
 
       return [
         {
+          id: eventId,
           title: row.title?.trim() || "Untitled event",
+          meetingLink: row.meeting_link || null,
           startsAtMs,
           endsAtMs,
           dayStartMs: dayStart.getTime(),

--- a/apps/desktop/src/shared/main-app-layout.tsx
+++ b/apps/desktop/src/shared/main-app-layout.tsx
@@ -1,14 +1,15 @@
 import { Outlet, useNavigate } from "@tanstack/react-router";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { useEffect } from "react";
 
 import { events as windowsEvents } from "@anlg/plugin-windows";
 
-import { useNewNote } from "./useNewNote";
+import { useNewNote, useNewNoteAndListen } from "./useNewNote";
 
 import { AuthProvider } from "~/auth";
 import { BillingProvider } from "~/auth/billing";
 import { DevtoolsFloatingPanelHost } from "~/devtools-panel/host";
+import { getOrCreateSessionForEventId } from "~/session/queries";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { UndoDeleteToast } from "~/sidebar/toast/undo-delete-toast";
 import { isTabInputSupported, useTabs } from "~/store/zustand/tabs";
 
@@ -38,8 +39,9 @@ const useNavigationEvents = () => {
   const navigate = useNavigate();
   const openNew = useTabs((state) => state.openNew);
   const openNewNote = useNewNote({ behavior: "new" });
+  const openNewNoteAndListen = useNewNoteAndListen({ behavior: "new" });
 
-  useEffect(() => {
+  useMountEffect(() => {
     (window as any).__ANARLOG_NAVIGATE__ = (path: string) => {
       const match = path.match(/^\/app\/([^/]+)\/(.+)$/);
       if (!match) return;
@@ -68,7 +70,32 @@ const useNavigationEvents = () => {
       .navigate(webview)
       .listen(({ payload }) => {
         if (payload.path === "/app/new") {
-          openNewNote();
+          const calendarEventId = payload.search?.calendarEventId;
+          const shouldRecord = payload.search?.record === "true";
+
+          if (typeof calendarEventId === "string" && calendarEventId) {
+            void getOrCreateSessionForEventId(calendarEventId)
+              .then((sessionId) => {
+                openNew({
+                  type: "sessions",
+                  id: sessionId,
+                  state: {
+                    view: null,
+                    autoStart: shouldRecord ? true : null,
+                  },
+                });
+              })
+              .catch((error) => {
+                console.error(
+                  "[navigation] failed to open calendar event",
+                  error,
+                );
+              });
+          } else if (shouldRecord) {
+            openNewNoteAndListen();
+          } else {
+            openNewNote();
+          }
         } else if (payload.path === "/app/settings") {
           const tab = (payload.search?.tab as string) ?? "app";
           openNew({ type: "settings", state: { tab } });
@@ -103,5 +130,5 @@ const useNavigationEvents = () => {
       unlistenNavigate?.();
       unlistenOpenTab?.();
     };
-  }, [navigate, openNew, openNewNote]);
+  });
 };

--- a/apps/desktop/src/shared/main-app-layout.tsx
+++ b/apps/desktop/src/shared/main-app-layout.tsx
@@ -3,7 +3,11 @@ import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 
 import { events as windowsEvents } from "@anlg/plugin-windows";
 
-import { openNewNoteAndListen, useNewNote } from "./useNewNote";
+import {
+  openNewNoteAndListen,
+  openSessionAndListen,
+  useNewNote,
+} from "./useNewNote";
 
 import { AuthProvider } from "~/auth";
 import { BillingProvider } from "~/auth/billing";
@@ -75,12 +79,17 @@ const useNavigationEvents = () => {
           if (typeof calendarEventId === "string" && calendarEventId) {
             void getOrCreateSessionForEventId(calendarEventId)
               .then((sessionId) => {
+                if (shouldRecord) {
+                  openSessionAndListen(sessionId, { behavior: "new" });
+                  return;
+                }
+
                 openNew({
                   type: "sessions",
                   id: sessionId,
                   state: {
                     view: null,
-                    autoStart: shouldRecord ? true : null,
+                    autoStart: null,
                   },
                 });
               })

--- a/apps/desktop/src/shared/main-app-layout.tsx
+++ b/apps/desktop/src/shared/main-app-layout.tsx
@@ -3,7 +3,7 @@ import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 
 import { events as windowsEvents } from "@anlg/plugin-windows";
 
-import { useNewNote, useNewNoteAndListen } from "./useNewNote";
+import { openNewNoteAndListen, useNewNote } from "./useNewNote";
 
 import { AuthProvider } from "~/auth";
 import { BillingProvider } from "~/auth/billing";
@@ -39,7 +39,6 @@ const useNavigationEvents = () => {
   const navigate = useNavigate();
   const openNew = useTabs((state) => state.openNew);
   const openNewNote = useNewNote({ behavior: "new" });
-  const openNewNoteAndListen = useNewNoteAndListen({ behavior: "new" });
 
   useMountEffect(() => {
     (window as any).__ANARLOG_NAVIGATE__ = (path: string) => {
@@ -92,7 +91,7 @@ const useNavigationEvents = () => {
                 );
               });
           } else if (shouldRecord) {
-            openNewNoteAndListen();
+            openNewNoteAndListen({ behavior: "new" });
           } else {
             openNewNote();
           }

--- a/apps/desktop/src/shared/useNewNote.test.tsx
+++ b/apps/desktop/src/shared/useNewNote.test.tsx
@@ -9,7 +9,7 @@ vi.mock("~/session/queries", () => ({
   createSession: mocks.createSession,
 }));
 
-import { useNewNoteAndListen } from "./useNewNote";
+import { openSessionAndListen, useNewNoteAndListen } from "./useNewNote";
 
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
@@ -52,5 +52,28 @@ it("reads the current live session when the handler runs", () => {
   expect(useTabs.getState().currentTab).toMatchObject({
     type: "sessions",
     id: "live-session",
+  });
+});
+
+it("does not rearm auto-start when opening the active live session", () => {
+  useTabs.getState().openNew({
+    type: "sessions",
+    id: "live-session",
+    state: { view: null, autoStart: null },
+  });
+  listenerStore.setState((state) => ({
+    live: {
+      ...state.live,
+      status: "active",
+      sessionId: "live-session",
+    },
+  }));
+
+  openSessionAndListen("live-session");
+
+  expect(useTabs.getState().currentTab).toMatchObject({
+    type: "sessions",
+    id: "live-session",
+    state: { autoStart: null },
   });
 });

--- a/apps/desktop/src/shared/useNewNote.test.tsx
+++ b/apps/desktop/src/shared/useNewNote.test.tsx
@@ -77,3 +77,21 @@ it("does not rearm auto-start when opening the active live session", () => {
     state: { autoStart: null },
   });
 });
+
+it("opens the requested session without auto-start while another is live", () => {
+  listenerStore.setState((state) => ({
+    live: {
+      ...state.live,
+      status: "active",
+      sessionId: "live-session",
+    },
+  }));
+
+  openSessionAndListen("calendar-session");
+
+  expect(useTabs.getState().currentTab).toMatchObject({
+    type: "sessions",
+    id: "calendar-session",
+    state: { autoStart: null },
+  });
+});

--- a/apps/desktop/src/shared/useNewNote.test.tsx
+++ b/apps/desktop/src/shared/useNewNote.test.tsx
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createSession: vi.fn(),
+}));
+
+vi.mock("~/session/queries", () => ({
+  createSession: mocks.createSession,
+}));
+
+import { useNewNoteAndListen } from "./useNewNote";
+
+import { listenerStore } from "~/store/zustand/listener/instance";
+import { useTabs } from "~/store/zustand/tabs";
+import { resetTabsStore } from "~/store/zustand/tabs/test-utils";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetTabsStore();
+  listenerStore.setState(listenerStore.getInitialState(), true);
+});
+
+it("can open a listening note without a listener provider", async () => {
+  mocks.createSession.mockResolvedValueOnce("new-session");
+  const { result } = renderHook(() => useNewNoteAndListen());
+
+  act(() => result.current());
+
+  await vi.waitFor(() => {
+    expect(useTabs.getState().currentTab).toMatchObject({
+      type: "sessions",
+      id: "new-session",
+      state: { autoStart: true },
+    });
+  });
+});
+
+it("reads the current live session when the handler runs", () => {
+  const { result } = renderHook(() => useNewNoteAndListen());
+
+  listenerStore.setState((state) => ({
+    live: {
+      ...state.live,
+      status: "active",
+      sessionId: "live-session",
+    },
+  }));
+  act(() => result.current());
+
+  expect(mocks.createSession).not.toHaveBeenCalled();
+  expect(useTabs.getState().currentTab).toMatchObject({
+    type: "sessions",
+    id: "live-session",
+  });
+});

--- a/apps/desktop/src/shared/useNewNote.ts
+++ b/apps/desktop/src/shared/useNewNote.ts
@@ -52,6 +52,32 @@ export function openNewNoteAndListen({
 }: {
   behavior?: "new" | "current";
 } = {}) {
+  const { status, sessionId: liveSessionId } = listenerStore.getState().live;
+
+  if (status === "active" && liveSessionId) {
+    const { openNew, openCurrent } = useTabs.getState();
+    const open = behavior === "new" ? openNew : openCurrent;
+    open({ type: "sessions", id: liveSessionId });
+    return;
+  }
+
+  void createSession()
+    .then((sessionId) => {
+      openSessionAndListen(sessionId, { behavior });
+    })
+    .catch((error) => {
+      console.error("[session] failed to create listening note", error);
+    });
+}
+
+export function openSessionAndListen(
+  sessionId: string,
+  {
+    behavior = "new",
+  }: {
+    behavior?: "new" | "current";
+  } = {},
+) {
   const { openNew, openCurrent } = useTabs.getState();
   const { status, sessionId: liveSessionId } = listenerStore.getState().live;
   const open = behavior === "new" ? openNew : openCurrent;
@@ -61,17 +87,11 @@ export function openNewNoteAndListen({
     return;
   }
 
-  void createSession()
-    .then((sessionId) => {
-      open({
-        type: "sessions",
-        id: sessionId,
-        state: { view: null, autoStart: true },
-      });
-    })
-    .catch((error) => {
-      console.error("[session] failed to create listening note", error);
-    });
+  open({
+    type: "sessions",
+    id: sessionId,
+    state: { view: null, autoStart: true },
+  });
 }
 
 const AUDIO_FILTERS = [

--- a/apps/desktop/src/shared/useNewNote.ts
+++ b/apps/desktop/src/shared/useNewNote.ts
@@ -79,11 +79,11 @@ export function openSessionAndListen(
   } = {},
 ) {
   const { openNew, openCurrent } = useTabs.getState();
-  const { status, sessionId: liveSessionId } = listenerStore.getState().live;
+  const { status } = listenerStore.getState().live;
   const open = behavior === "new" ? openNew : openCurrent;
 
-  if (status === "active" && liveSessionId) {
-    open({ type: "sessions", id: liveSessionId });
+  if (status === "active") {
+    open({ type: "sessions", id: sessionId });
     return;
   }
 

--- a/apps/desktop/src/shared/useNewNote.ts
+++ b/apps/desktop/src/shared/useNewNote.ts
@@ -4,8 +4,8 @@ import { useCallback } from "react";
 import { useShallow } from "zustand/shallow";
 
 import { createSession } from "~/session/queries";
+import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
-import { useListener } from "~/stt/contexts";
 import { setPendingUpload } from "~/stt/pending-upload";
 
 export function useNewNote({
@@ -39,39 +39,39 @@ export function useNewNoteAndListen({
 }: {
   behavior?: "new" | "current";
 } = {}) {
-  const { openNew, openCurrent } = useTabs(
-    useShallow((state) => ({
-      openNew: state.openNew,
-      openCurrent: state.openCurrent,
-    })),
+  const handler = useCallback(
+    () => openNewNoteAndListen({ behavior }),
+    [behavior],
   );
-  const { status, sessionId: liveSessionId } = useListener((state) => ({
-    status: state.live.status,
-    sessionId: state.live.sessionId,
-  }));
-
-  const handler = useCallback(() => {
-    if (status === "active" && liveSessionId) {
-      const ff = behavior === "new" ? openNew : openCurrent;
-      ff({ type: "sessions", id: liveSessionId });
-      return;
-    }
-
-    const ff = behavior === "new" ? openNew : openCurrent;
-    void createSession()
-      .then((sessionId) => {
-        ff({
-          type: "sessions",
-          id: sessionId,
-          state: { view: null, autoStart: true },
-        });
-      })
-      .catch((error) => {
-        console.error("[session] failed to create listening note", error);
-      });
-  }, [status, liveSessionId, openNew, openCurrent, behavior]);
 
   return handler;
+}
+
+export function openNewNoteAndListen({
+  behavior = "new",
+}: {
+  behavior?: "new" | "current";
+} = {}) {
+  const { openNew, openCurrent } = useTabs.getState();
+  const { status, sessionId: liveSessionId } = listenerStore.getState().live;
+  const open = behavior === "new" ? openNew : openCurrent;
+
+  if (status === "active" && liveSessionId) {
+    open({ type: "sessions", id: liveSessionId });
+    return;
+  }
+
+  void createSession()
+    .then((sessionId) => {
+      open({
+        type: "sessions",
+        id: sessionId,
+        state: { view: null, autoStart: true },
+      });
+    })
+    .catch((error) => {
+      console.error("[session] failed to create listening note", error);
+    });
 }
 
 const AUDIO_FILTERS = [

--- a/apps/desktop/src/store/zustand/tabs/basic.test.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.test.ts
@@ -100,6 +100,32 @@ describe("Basic Tab Actions", () => {
     expect(state).toHaveHistoryLength(1);
   });
 
+  test("openNew applies auto-start when reusing a session tab", () => {
+    useTabs.getState().openNew({
+      type: "sessions",
+      id: "tab1",
+      state: {
+        view: { type: "enhanced", id: "summary-1" },
+        autoStart: null,
+      },
+    });
+
+    useTabs.getState().openNew({
+      type: "sessions",
+      id: "tab1",
+      state: { view: null, autoStart: true },
+    });
+
+    expect(useTabs.getState()).toHaveCurrentTab({
+      id: "tab1",
+      state: {
+        view: { type: "enhanced", id: "summary-1" },
+        autoStart: true,
+      },
+    });
+    expect(useTabs.getState().tabs).toHaveLength(1);
+  });
+
   test("shared-note tabs are distinct, idempotent, and not pinnable", () => {
     useTabs.getState().openNew({ type: "shared_sessions", id: "share-1" });
     useTabs.getState().openNew({ type: "shared_sessions", id: "share-1" });

--- a/apps/desktop/src/store/zustand/tabs/basic.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.ts
@@ -467,6 +467,23 @@ const reuseExistingTab = (
     };
   }
 
+  if (
+    existingTab.type === "sessions" &&
+    requestedTab.type === "sessions" &&
+    requestedTab.state.autoStart
+  ) {
+    const nextTab = applyReturnOriginForReuse(
+      existingTab,
+      requestedTab,
+      preserveReturnOrigin,
+    );
+
+    return {
+      ...nextTab,
+      state: { ...nextTab.state, autoStart: true },
+    };
+  }
+
   return applyReturnOriginForReuse(
     existingTab,
     requestedTab,

--- a/plugins/tray/js/bindings.gen.ts
+++ b/plugins/tray/js/bindings.gen.ts
@@ -34,7 +34,7 @@ async setTraySchedule(events: TrayScheduleEvent[]) : Promise<Result<null, string
 
 /** user-defined types **/
 
-export type TrayScheduleEvent = { title: string; startsAtMs: number; endsAtMs: number | null; dayStartMs: number; previousDayStartMs: number; timeLabel: string }
+export type TrayScheduleEvent = { id: string; title: string; meetingLink: string | null; startsAtMs: number; endsAtMs: number | null; dayStartMs: number; previousDayStartMs: number; timeLabel: string }
 
 /** tauri-specta globals **/
 

--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -300,7 +300,6 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
         agenda: &[TrayAgendaSection],
     ) -> Result<Menu<tauri::Wry>> {
         let menu = Menu::new(app)?;
-        let mut agenda_index = 0;
 
         for (section_index, section) in agenda.iter().enumerate() {
             let heading = MenuItem::with_id(
@@ -313,9 +312,8 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
             menu.append(&heading)?;
 
             for event in &section.events {
-                let item = build_agenda_item(app, agenda_index, event)?;
+                let item = build_agenda_item(app, &event.id, &event.label)?;
                 menu.append(&item)?;
-                agenda_index += 1;
             }
         }
 
@@ -425,6 +423,15 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
         START_DISABLED.store(disabled, Ordering::SeqCst);
         Self::rebuild_menu(self.manager.app_handle())
     }
+}
+
+pub(crate) fn scheduled_event(event_id: &str) -> Option<TrayScheduleEvent> {
+    SCHEDULE
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|event| event.id == event_id)
+        .cloned()
 }
 
 pub trait TrayPluginExt<R: tauri::Runtime> {

--- a/plugins/tray/src/menu_items/tray_agenda.rs
+++ b/plugins/tray/src/menu_items/tray_agenda.rs
@@ -2,31 +2,79 @@ use tauri::{
     AppHandle, Result,
     menu::{MenuId, MenuItem, MenuItemKind},
 };
-use tauri_plugin_windows::{AppWindow, OpenTab, TabInput, WindowsPluginExt};
-use tauri_specta::Event;
+use tauri_plugin_windows::{AppWindow, Navigate, WindowsPluginExt};
+
+use crate::ext::scheduled_event;
 
 const ID_PREFIX: &str = "anlg_tray_agenda_";
 
 pub fn build_agenda_item(
     app: &AppHandle<tauri::Wry>,
-    index: usize,
+    event_id: &str,
     text: &str,
 ) -> Result<MenuItemKind<tauri::Wry>> {
-    let item = MenuItem::with_id(app, format!("{ID_PREFIX}{index}"), text, true, None::<&str>)?;
+    let item = MenuItem::with_id(
+        app,
+        format!("{ID_PREFIX}{event_id}"),
+        text,
+        true,
+        None::<&str>,
+    )?;
     Ok(MenuItemKind::MenuItem(item))
 }
 
 pub fn handle_agenda_menu_event(app: &AppHandle<tauri::Wry>, id: &MenuId) -> bool {
-    if !id.0.starts_with(ID_PREFIX) {
+    let Some(event_id) = id.0.strip_prefix(ID_PREFIX) else {
         return false;
-    }
+    };
+
+    let Some(event) = scheduled_event(event_id) else {
+        return true;
+    };
 
     if app.windows().show(AppWindow::Main).is_ok() {
-        let _ = OpenTab {
-            tab: TabInput::Calendar,
-        }
-        .emit(app);
+        let _ = app
+            .windows()
+            .emit_navigate(AppWindow::Main, event_navigation(event.id));
+    }
+
+    if let Some(meeting_link) = event.meeting_link.filter(|link| !link.trim().is_empty())
+        && let Err(error) = open::that(meeting_link)
+    {
+        tracing::warn!(%error, "failed to open meeting from tray agenda");
     }
 
     true
+}
+
+fn event_navigation(event_id: String) -> Navigate {
+    let mut search = serde_json::Map::new();
+    search.insert(
+        "calendarEventId".to_string(),
+        serde_json::Value::String(event_id),
+    );
+    search.insert(
+        "record".to_string(),
+        serde_json::Value::String("true".to_string()),
+    );
+
+    Navigate {
+        path: "/app/new".to_string(),
+        search: Some(search),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::event_navigation;
+
+    #[test]
+    fn opens_the_selected_calendar_event_with_recording_enabled() {
+        let navigation = event_navigation("event-123".to_string());
+        let search = navigation.search.unwrap();
+
+        assert_eq!(navigation.path, "/app/new");
+        assert_eq!(search["calendarEventId"], "event-123");
+        assert_eq!(search["record"], "true");
+    }
 }

--- a/plugins/tray/src/schedule.rs
+++ b/plugins/tray/src/schedule.rs
@@ -5,7 +5,9 @@ const MAX_MENU_BAR_LABEL_CHARS: usize = 30;
 #[derive(Debug, Clone, serde::Deserialize, specta::Type, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TrayScheduleEvent {
+    pub id: String,
     pub title: String,
+    pub meeting_link: Option<String>,
     pub starts_at_ms: f64,
     pub ends_at_ms: Option<f64>,
     pub day_start_ms: f64,
@@ -14,9 +16,15 @@ pub struct TrayScheduleEvent {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct TrayAgendaEvent {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(Debug, PartialEq)]
 pub struct TrayAgendaSection {
     pub label: String,
-    pub events: Vec<String>,
+    pub events: Vec<TrayAgendaEvent>,
 }
 
 pub fn agenda_sections(
@@ -47,11 +55,10 @@ pub fn agenda_sections(
             });
         }
 
-        sections
-            .last_mut()
-            .unwrap()
-            .events
-            .push(compact_agenda_label(event));
+        sections.last_mut().unwrap().events.push(TrayAgendaEvent {
+            id: event.id.clone(),
+            label: compact_agenda_label(event),
+        });
     }
 
     sections
@@ -184,7 +191,9 @@ mod tests {
 
     fn event(title: &str, starts_at_ms: f64, ends_at_ms: Option<f64>) -> TrayScheduleEvent {
         TrayScheduleEvent {
+            id: title.to_lowercase().replace(' ', "-"),
             title: title.to_string(),
+            meeting_link: None,
             starts_at_ms,
             ends_at_ms,
             day_start_ms: 0.0,
@@ -281,13 +290,22 @@ mod tests {
             vec![
                 TrayAgendaSection {
                     label: "Today".to_string(),
-                    events: vec!["Active · 9:00 AM".to_string()],
+                    events: vec![TrayAgendaEvent {
+                        id: "active".to_string(),
+                        label: "Active · 9:00 AM".to_string(),
+                    }],
                 },
                 TrayAgendaSection {
                     label: "Tomorrow".to_string(),
                     events: vec![
-                        "Next · 9:00 AM".to_string(),
-                        "Tomorrow one · 9:00 AM".to_string(),
+                        TrayAgendaEvent {
+                            id: "next".to_string(),
+                            label: "Next · 9:00 AM".to_string(),
+                        },
+                        TrayAgendaEvent {
+                            id: "tomorrow-one".to_string(),
+                            label: "Tomorrow one · 9:00 AM".to_string(),
+                        },
                     ],
                 },
             ]


### PR DESCRIPTION
Open the selected meeting link and navigate directly to its calendar-backed note with recording enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recording auto-start, session creation for calendar events, and external URL opening from the tray; behavior is guarded when a session is already live but wrong session/event mapping could still confuse users.
> 
> **Overview**
> **Tray agenda items** now carry stable calendar **event ids** and **meeting links**. Choosing an event shows the main window, navigates to `/app/new` with `calendarEventId` and `record=true`, and opens the meeting URL when present (replacing the old “open Calendar tab” behavior).
> 
> The desktop app **handles that navigation**: it resolves or creates a session for the event via `getOrCreateSessionForEventId`, then either opens the note with **auto-start recording** or opens the session without re-arming record when a live session is already active.
> 
> **Listen / record helpers** were pulled out of React context (`openNewNoteAndListen`, `openSessionAndListen` using `listenerStore`), and **reopening an existing session tab** with `autoStart: true` now merges auto-start into the tab state so tray-driven record requests work when the note is already open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4443ab5eb5437b9a9596fe9b3cce704422312369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->