### PR TITLE
Show meeting metadata after scheduled end

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -53,8 +53,12 @@ vi.mock("./metadata", () => ({
     renderTrigger ? (
       renderTrigger({ open: false, label: "Open event metadata" })
     ) : (
-      <button type="button" aria-label="Open event metadata">
-        Metadata
+      <button
+        type="button"
+        data-tauri-drag-region="false"
+        aria-label="Open event metadata"
+      >
+        <svg aria-hidden="true" data-testid="metadata-calendar-icon" />
       </button>
     ),
 }));
@@ -845,7 +849,33 @@ describe("OuterHeader", () => {
     expect(mocks.stopListening).toHaveBeenCalledTimes(1);
   });
 
-  it("shows resume after the meeting is over", () => {
+  it("keeps stop available when recording runs past the scheduled end", () => {
+    mocks.sessionEvents = {
+      "session-1": {
+        title: "Design Review",
+        started_at: "2026-06-05T10:00:00.000Z",
+        ended_at: "2026-06-05T10:30:00.000Z",
+        meeting_link: "https://meet.google.com/abc-defg-hij",
+      },
+    };
+    mocks.sessionModes = { "session-1": "active" };
+    mocks.nowMs = new Date("2026-06-05T10:31:00.000Z").getTime();
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    expect(screen.queryByTestId("metadata-calendar-icon")).toBeNull();
+    expect(mocks.stopListening).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows only the calendar metadata button after the meeting is over", () => {
     mocks.sessionEvents = {
       "session-1": {
         title: "Design Review",
@@ -868,11 +898,10 @@ describe("OuterHeader", () => {
       name: "Open event metadata",
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
-
-    expect(screen.getByTestId("recording-icon")).not.toBeNull();
+    expect(screen.getByTestId("metadata-calendar-icon")).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Join & record" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
     expect(metadataButton.getAttribute("data-tauri-drag-region")).toBe("false");
-    expect(mocks.startListening).toHaveBeenCalledTimes(1);
+    expect(mocks.startListening).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -118,12 +118,25 @@ function HeaderMeetingControl({
 }) {
   const sessionEvent = useSessionEvent(sessionId);
   const now = useNow();
+  const endedAt = sessionEvent?.ended_at
+    ? safeParseDate(sessionEvent.ended_at)
+    : null;
+  const ended = !!endedAt && endedAt.getTime() <= now.getTime();
+  const isRecording =
+    sessionMode === "active" || sessionMode === "running_batch";
+
+  if (ended && !isRecording) {
+    return (
+      <div className="mr-1 shrink-0">
+        <MetadataButton sessionId={sessionId} />
+      </div>
+    );
+  }
 
   return (
     <HeaderMeetingActionPill
       sessionId={sessionId}
       event={sessionEvent}
-      now={now}
       sessionMode={sessionMode}
     />
   );
@@ -132,16 +145,13 @@ function HeaderMeetingControl({
 function HeaderMeetingActionPill({
   sessionId,
   event,
-  now,
   sessionMode,
 }: {
   sessionId: string;
   event: {
-    ended_at?: string;
     meeting_link?: string;
     tracking_id?: string;
   } | null;
-  now: Date;
   sessionMode: string;
 }) {
   const startListening = useStartListening(sessionId);
@@ -160,8 +170,6 @@ function HeaderMeetingActionPill({
   );
   const remote = getRemoteMeeting(event?.meeting_link);
   const meetingLink = event?.meeting_link || null;
-  const endedAt = event?.ended_at ? safeParseDate(event.ended_at) : null;
-  const ended = !!endedAt && endedAt.getTime() <= now.getTime();
   const hasTranscript = useHasTranscript(sessionId);
   const { audioExists } = useAudioPlayer();
   const canResume = audioExists || hasTranscript;
@@ -263,7 +271,7 @@ function HeaderMeetingActionPill({
       };
     }
 
-    if (meetingLink && !ended) {
+    if (meetingLink) {
       return {
         label: t`Join & record`,
         title: t`Join meeting and record`,
@@ -276,15 +284,6 @@ function HeaderMeetingActionPill({
         onClick: () => {
           void joinMeeting();
         },
-      };
-    }
-
-    if (ended) {
-      return {
-        label: t`Resume`,
-        title: t`Resume listening`,
-        icon: <RecordingIcon />,
-        onClick: start,
       };
     }
 


### PR DESCRIPTION
Replace the ended meeting action pill with the calendar metadata control while preserving stop actions for active recordings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop session header UI and meeting-action branching, covered by updated unit tests.
> 
> **Overview**
> **After a scheduled meeting’s end time**, the session header no longer shows the action pill (Join & record / Resume). Users see only the **calendar metadata** control when the session is not actively recording.
> 
> **While recording continues past the scheduled end**, the header still shows the **Stop** action in the pill instead of switching early to metadata-only or a post-meeting **Resume** shortcut.
> 
> `HeaderMeetingControl` now owns the ended-vs-recording branch; the pill no longer treats “past `ended_at`” as a separate **Resume** path or blocks **Join & record** solely because the slot has ended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05554f3baf284300dc824257b179ce2e3bcfe953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->