### PR TITLE
Dismiss notifications when meetings become active

### DIFF
--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -15,6 +15,7 @@ import { createListenerStore } from "~/store/zustand/listener";
 const {
   listMicUsingApplicationsMock,
   listenMock,
+  clearNotificationsMock,
   showNotificationMock,
   useStoreMock,
   useConfigValueMock,
@@ -23,6 +24,7 @@ const {
 } = vi.hoisted(() => ({
   listMicUsingApplicationsMock: vi.fn(),
   listenMock: vi.fn(),
+  clearNotificationsMock: vi.fn(),
   showNotificationMock: vi.fn(),
   useStoreMock: vi.fn(() => null),
   useConfigValueMock: vi.fn((_key: string) => true),
@@ -43,6 +45,7 @@ vi.mock("@anlg/plugin-detect", () => ({
 
 vi.mock("@anlg/plugin-notification", () => ({
   commands: {
+    clearNotifications: clearNotificationsMock,
     showNotification: showNotificationMock,
   },
 }));
@@ -208,6 +211,7 @@ async function readConfiguredNearbyEvents(nowMs: number, windowMs: number) {
 describe("ListenerProvider detect events", () => {
   beforeEach(() => {
     listenMock.mockReset();
+    clearNotificationsMock.mockReset();
     showNotificationMock.mockReset();
     useStoreMock.mockReset();
     useConfigValueMock.mockReset();
@@ -230,6 +234,24 @@ describe("ListenerProvider detect events", () => {
     cleanup();
     vi.clearAllTimers();
     vi.useRealTimers();
+  });
+
+  test("clears pending notifications when listening becomes active", async () => {
+    const store = createListenerStore();
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    expect(clearNotificationsMock).not.toHaveBeenCalled();
+
+    setStoreActive(store);
+
+    await vi.waitFor(() =>
+      expect(clearNotificationsMock).toHaveBeenCalledTimes(1),
+    );
   });
 
   test("does not stop listening on MicStopped when no trigger apps are set (manual session — regression: #5120)", async () => {

--- a/apps/desktop/src/stt/detect-events.ts
+++ b/apps/desktop/src/stt/detect-events.ts
@@ -78,6 +78,20 @@ export const useHandleDetectEvents = (store: ListenerStore) => {
     let unlistenDetect: (() => void) | undefined;
     let cancelled = false;
     isOnlineRef.current = navigator.onLine;
+    const clearNotificationsIfActive = () => {
+      if (store.getState().live.status === "active") {
+        void notificationCommands.clearNotifications();
+      }
+    };
+    clearNotificationsIfActive();
+    const unsubscribeStore = store.subscribe((state, previousState) => {
+      if (
+        state.live.status === "active" &&
+        previousState.live.status !== "active"
+      ) {
+        void notificationCommands.clearNotifications();
+      }
+    });
     const clearPendingAutoStop = () => {
       if (pendingAutoStopRef.current) {
         if (pendingAutoStopRef.current.timeout) {
@@ -393,6 +407,7 @@ export const useHandleDetectEvents = (store: ListenerStore) => {
       clearPendingAutoStop();
       window.removeEventListener("offline", handleOffline);
       window.removeEventListener("online", handleOnline);
+      unsubscribeStore();
       unlistenDetect?.();
     };
   });


### PR DESCRIPTION
Clear pending desktop notifications on the listening transition and cover it with a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX change in STT detect-event wiring; only invokes existing clear-notifications when status is active.
> 
> **Overview**
> **Clears pending desktop notifications when a listening session is active**, so mic-detected or other prompts do not linger after the user is already in a meeting.
> 
> In `useHandleDetectEvents`, the mount effect now calls `notificationCommands.clearNotifications()` when `live.status` is already `"active"`, and **subscribes to the listener store** to clear again on any transition into `"active"`. The subscription is torn down on unmount.
> 
> Tests mock `clearNotifications` and add a regression case that expects a single clear when the store moves to active after `ListenerProvider` mounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc3843a4afe983f002749dc9c8a0b1107e1f3e0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->