### PR TITLE
Prevent duplicate auto-stop notifications

### DIFF
--- a/apps/desktop/src/stt/auto-stop-notification.test.ts
+++ b/apps/desktop/src/stt/auto-stop-notification.test.ts
@@ -7,19 +7,19 @@ import {
 } from "./auto-stop-notification";
 
 describe("auto-stop notification keys", () => {
-  test("creates unique keys that still parse to the session id", () => {
+  test("creates a stable key for duplicate prompts in the same session", () => {
     const firstKey = createAutoStopEndedNotificationKey("session-1");
     const secondKey = createAutoStopEndedNotificationKey("session-1");
 
-    expect(firstKey).not.toBe(secondKey);
+    expect(firstKey).toBe("auto-stop-ended:session-1");
+    expect(secondKey).toBe(firstKey);
     expect(parseAutoStopEndedNotificationKey(firstKey)).toBe("session-1");
-    expect(parseAutoStopEndedNotificationKey(secondKey)).toBe("session-1");
   });
 
-  test("parses legacy stable keys", () => {
+  test("parses legacy unique keys", () => {
     expect(
       parseAutoStopEndedNotificationKey(
-        `${AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX}session-1`,
+        `${AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX}session-1:prompt:nonce`,
       ),
     ).toBe("session-1");
   });

--- a/apps/desktop/src/stt/auto-stop-notification.ts
+++ b/apps/desktop/src/stt/auto-stop-notification.ts
@@ -5,7 +5,7 @@ export const AUTO_STOP_CONFIRM_TIMEOUT_SECONDS = 30;
 const AUTO_STOP_ENDED_NOTIFICATION_KEY_NONCE_SEPARATOR = ":prompt:";
 
 export function createAutoStopEndedNotificationKey(sessionId: string) {
-  return `${AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX}${sessionId}${AUTO_STOP_ENDED_NOTIFICATION_KEY_NONCE_SEPARATOR}${crypto.randomUUID()}`;
+  return `${AUTO_STOP_ENDED_NOTIFICATION_KEY_PREFIX}${sessionId}`;
 }
 
 export function parseAutoStopEndedNotificationKey(


### PR DESCRIPTION
Use a stable session key so repeated mic-stop events share the native dedupe window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small notification-key behavior change with backward-compatible parsing and updated unit tests only.
> 
> **Overview**
> **Auto-stop “meeting ended?” notifications** now use a **stable key per session** (`auto-stop-ended:{sessionId}`) instead of appending a random UUID on each prompt.
> 
> Repeated mic-stop events in the same session therefore share one notification key, so the **native layer can dedupe** within its window instead of stacking duplicate prompts. **`parseAutoStopEndedNotificationKey`** still accepts older keys that included a `:prompt:` nonce suffix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e04683cb97cfbfa6043a78927a321f63d52c3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->