### PR TITLE
Show automation history in sidebar

### DIFF
--- a/apps/desktop/src/chat/store/queries.test.tsx
+++ b/apps/desktop/src/chat/store/queries.test.tsx
@@ -41,6 +41,7 @@ import {
   setChatGroupTitleIfCurrent,
   upsertChatMessage,
   useChatGroup,
+  useChatGroups,
   usePersistedChatMessages,
   useRecentChatGroups,
 } from "./queries";
@@ -107,6 +108,15 @@ describe("chat SQLite queries", () => {
     expect(automationsQuery).toMatch(/AND\s+EXISTS/);
     expect(generalQuery).toContain("'$.chatScope'");
     expect(automationsQuery).toContain("'$.chatScope'");
+  });
+
+  it("loads the complete automation history for the sidebar", () => {
+    renderHook(() => useChatGroups("automations"));
+    const automationsQuery = mocks.liveQueries[mocks.liveQueries.length - 1];
+
+    expect(automationsQuery?.sql).not.toContain("LIMIT");
+    expect(automationsQuery?.params).toEqual([]);
+    expect(automationsQuery?.sql).toContain("'$.chatScope'");
   });
 
   it("maps chat messages in their durable order", () => {

--- a/apps/desktop/src/chat/store/queries.ts
+++ b/apps/desktop/src/chat/store/queries.ts
@@ -32,6 +32,17 @@ export function useRecentChatGroups(
   chatScope: ChatScope,
   limit = 5,
 ): ChatGroupRecord[] {
+  return useChatGroupsQuery(chatScope, limit);
+}
+
+export function useChatGroups(chatScope: ChatScope): ChatGroupRecord[] {
+  return useChatGroupsQuery(chatScope);
+}
+
+function useChatGroupsQuery(
+  chatScope: ChatScope,
+  limit?: number,
+): ChatGroupRecord[] {
   const { data = EMPTY_CHAT_GROUPS } = useLiveQuery<
     ChatGroupSqlRow,
     ChatGroupRecord[]
@@ -42,9 +53,9 @@ export function useRecentChatGroups(
       WHERE g.deleted_at IS NULL
         AND ${chatGroupScopePredicate(chatScope)}
       ORDER BY g.created_at DESC, g.id DESC
-      LIMIT ?
+      ${limit === undefined ? "" : "LIMIT ?"}
     `,
-    params: [limit],
+    params: limit === undefined ? [] : [limit],
     mapRows: (rows) => rows.map(mapChatGroupRow),
   });
 

--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -383,6 +383,7 @@ describe("ClassicMainBody", () => {
     ["calendar", {}],
     ["contacts", { state: { selected: null } }],
     ["templates", { state: { selectedMineId: null, selectedWebIndex: null } }],
+    ["automations", {}],
   ])("keeps the %s left sidebar fixed", (type, extraTabState) => {
     mocks.currentTab = {
       active: true,
@@ -440,6 +441,7 @@ describe("ClassicMainBody", () => {
     ["windows", "settings", { state: { tab: "app" } }],
     ["windows", "calendar", {}],
     ["windows", "contacts", { state: { selected: null } }],
+    ["windows", "automations", {}],
     [
       "windows",
       "templates",
@@ -448,6 +450,7 @@ describe("ClassicMainBody", () => {
     ["linux", "settings", { state: { tab: "app" } }],
     ["linux", "calendar", {}],
     ["linux", "contacts", { state: { selected: null } }],
+    ["linux", "automations", {}],
     [
       "linux",
       "templates",

--- a/apps/desktop/src/main/shell-frame.test.tsx
+++ b/apps/desktop/src/main/shell-frame.test.tsx
@@ -108,17 +108,20 @@ describe("ClassicMainShellFrame", () => {
     ).toBe("top-borderless");
   });
 
-  it("uses left-edge main surface chrome for custom sidebar tabs", () => {
-    mocks.currentTab = { type: "settings" };
+  it.each(["settings", "automations"])(
+    "uses left-edge main surface chrome for the %s custom sidebar",
+    (type) => {
+      mocks.currentTab = { type };
 
-    render(<ClassicMainShellFrame />);
+      render(<ClassicMainShellFrame />);
 
-    expect(
-      screen
-        .getByTestId("main-shell-scaffold")
-        .getAttribute("data-main-surface-chrome"),
-    ).toBe("left");
-  });
+      expect(
+        screen
+          .getByTestId("main-shell-scaffold")
+          .getAttribute("data-main-surface-chrome"),
+      ).toBe("left");
+    },
+  );
 
   it("keeps left-edge main surface chrome for changelog tabs while expanded", () => {
     mocks.currentTab = { type: "changelog" };

--- a/apps/desktop/src/shared/main/shell-sidebar.test.tsx
+++ b/apps/desktop/src/shared/main/shell-sidebar.test.tsx
@@ -9,7 +9,7 @@ const hoisted = vi.hoisted(() => ({
 const { setExpanded, setLocked } = hoisted;
 
 let mockCurrentTab: {
-  type: "settings" | "empty" | "onboarding" | "calendar";
+  type: "settings" | "empty" | "onboarding" | "calendar" | "automations";
 } | null = { type: "empty" };
 const mockLeftSidebar = {
   expanded: false,
@@ -72,6 +72,15 @@ describe("ClassicMainSidebar", () => {
 
     expect(setLocked).toHaveBeenLastCalledWith(false);
     expect(setExpanded).toHaveBeenLastCalledWith(false);
+  });
+
+  it("forces the Automations navigator open", () => {
+    mockCurrentTab = { type: "automations" };
+
+    render(<ClassicMainSidebar />);
+
+    expect(setExpanded).toHaveBeenCalledWith(true);
+    expect(setLocked).toHaveBeenCalledWith(true);
   });
 
   it("renders the default timeline sidebar when expanded", () => {

--- a/apps/desktop/src/sidebar/automations.test.tsx
+++ b/apps/desktop/src/sidebar/automations.test.tsx
@@ -1,0 +1,134 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  automations: [
+    {
+      id: "automation-1",
+      ownerUserId: "user-1",
+      title: "Share weekly recap",
+      createdAt: "2026-08-03T10:00:00.000Z",
+      updatedAt: "2026-08-03T10:00:00.000Z",
+    },
+    {
+      id: "automation-2",
+      ownerUserId: "user-1",
+      title: "Update project notes",
+      createdAt: "2026-08-02T10:00:00.000Z",
+      updatedAt: "2026-08-02T10:00:00.000Z",
+    },
+  ],
+  selectedAutomationId: "automation-1" as string | undefined,
+  selectChat: vi.fn(),
+  startNewChat: vi.fn(),
+}));
+
+vi.mock("~/chat/store/queries", () => ({
+  useChatGroups: () => mocks.automations,
+}));
+
+vi.mock("~/chat/state/chat-context", () => ({
+  useChatContext: (selector: (state: unknown) => unknown) =>
+    selector({
+      chatByScope: {
+        automations: { groupId: mocks.selectedAutomationId },
+      },
+      selectChat: mocks.selectChat,
+      startNewChat: mocks.startNewChat,
+    }),
+}));
+
+vi.mock("~/sidebar/custom-sidebar-header", () => ({
+  CustomSidebarHeader: ({
+    children,
+    title,
+  }: {
+    children?: React.ReactNode;
+    title: React.ReactNode;
+  }) => (
+    <header>
+      <span>{title}</span>
+      {children}
+    </header>
+  ),
+}));
+
+import { AutomationsNav } from "./automations";
+
+describe("AutomationsNav", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    mocks.automations = [
+      {
+        id: "automation-1",
+        ownerUserId: "user-1",
+        title: "Share weekly recap",
+        createdAt: "2026-08-03T10:00:00.000Z",
+        updatedAt: "2026-08-03T10:00:00.000Z",
+      },
+      {
+        id: "automation-2",
+        ownerUserId: "user-1",
+        title: "Update project notes",
+        createdAt: "2026-08-02T10:00:00.000Z",
+        updatedAt: "2026-08-02T10:00:00.000Z",
+      },
+    ];
+    mocks.selectedAutomationId = "automation-1";
+    mocks.selectChat.mockClear();
+    mocks.startNewChat.mockClear();
+  });
+
+  it("lists past automations and opens the selected automation conversation", () => {
+    render(<AutomationsNav />);
+
+    expect(screen.getByText("Share weekly recap")).toBeTruthy();
+    expect(screen.getByText("Update project notes")).toBeTruthy();
+    expect(
+      screen
+        .getByRole("button", { name: /Share weekly recap/ })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Update project notes/ }),
+    );
+
+    expect(mocks.selectChat).toHaveBeenCalledWith(
+      "automations",
+      "automation-2",
+    );
+  });
+
+  it("filters the automation list and clears the search", () => {
+    render(<AutomationsNav />);
+
+    fireEvent.change(screen.getByPlaceholderText("Search automations..."), {
+      target: { value: "project" },
+    });
+
+    expect(screen.queryByText("Share weekly recap")).toBeNull();
+    expect(screen.getByText("Update project notes")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+
+    expect(screen.getByText("Share weekly recap")).toBeTruthy();
+  });
+
+  it("starts a new automation conversation from the sidebar", () => {
+    render(<AutomationsNav />);
+
+    fireEvent.click(screen.getByRole("button", { name: "New automation" }));
+
+    expect(mocks.startNewChat).toHaveBeenCalledWith("automations");
+  });
+
+  it("shows an empty state when no automations exist", () => {
+    mocks.automations = [];
+
+    render(<AutomationsNav />);
+
+    expect(screen.getByText("No automations yet")).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/sidebar/automations.tsx
+++ b/apps/desktop/src/sidebar/automations.tsx
@@ -1,0 +1,138 @@
+import { Lightning, MagnifyingGlass, Plus, X } from "@phosphor-icons/react";
+import { useMemo, useState } from "react";
+
+import { Button } from "@anlg/ui/components/ui/button";
+import { cn, formatDistanceToNow } from "@anlg/utils";
+
+import { CustomSidebarHeader } from "./custom-sidebar-header";
+
+import { useChatContext } from "~/chat/state/chat-context";
+import { useChatGroups } from "~/chat/store/queries";
+
+export function AutomationsNav() {
+  const [search, setSearch] = useState("");
+  const automations = useChatGroups("automations");
+  const selectedAutomationId = useChatContext(
+    (state) => state.chatByScope.automations.groupId,
+  );
+  const selectChat = useChatContext((state) => state.selectChat);
+  const startNewChat = useChatContext((state) => state.startNewChat);
+
+  const filteredAutomations = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      return automations;
+    }
+
+    return automations.filter((automation) =>
+      automation.title.toLowerCase().includes(query),
+    );
+  }, [automations, search]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden pb-2">
+      <CustomSidebarHeader title="Automations">
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="text-muted-foreground relative z-[60] hover:text-black"
+          aria-label="New automation"
+          onClick={() => startNewChat("automations")}
+        >
+          <Plus size={16} />
+        </Button>
+      </CustomSidebarHeader>
+
+      <div className="pb-2">
+        <div
+          className={cn([
+            "border-border bg-accent/50 flex h-8 w-full shrink-0 items-center gap-2 rounded-lg border px-3",
+            "focus-within:bg-accent transition-colors",
+          ])}
+        >
+          <MagnifyingGlass className="text-muted-foreground h-4 w-4 shrink-0" />
+          <input
+            type="text"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                setSearch("");
+              }
+            }}
+            placeholder="Search automations..."
+            className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm placeholder:text-sm focus:outline-hidden"
+          />
+          {search ? (
+            <button
+              type="button"
+              onClick={() => setSearch("")}
+              className={cn([
+                "size-4 shrink-0",
+                "text-muted-foreground hover:text-foreground",
+                "transition-colors",
+              ])}
+              aria-label="Clear search"
+            >
+              <X className="size-4" />
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto pt-1">
+        {filteredAutomations.length > 0 ? (
+          filteredAutomations.map((automation) => {
+            const selected = automation.id === selectedAutomationId;
+            const createdAt = automation.createdAt
+              ? formatDistanceToNow(new Date(automation.createdAt), {
+                  addSuffix: true,
+                })
+              : "";
+
+            return (
+              <button
+                key={automation.id}
+                type="button"
+                aria-current={selected ? "page" : undefined}
+                onClick={() => selectChat("automations", automation.id)}
+                className={cn([
+                  "w-full rounded-lg px-3 py-2 text-left text-sm transition-colors select-none",
+                  selected ? "bg-accent" : "hover:bg-accent/50",
+                ])}
+              >
+                <span className="flex items-center gap-2">
+                  <Lightning
+                    className="size-4 shrink-0 text-violet-500"
+                    weight="fill"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-medium">
+                      {automation.title}
+                    </span>
+                    {createdAt ? (
+                      <span className="text-muted-foreground mt-0.5 block truncate text-xs">
+                        {createdAt}
+                      </span>
+                    ) : null}
+                  </span>
+                </span>
+              </button>
+            );
+          })
+        ) : (
+          <div className="text-muted-foreground px-3 py-8 text-center">
+            <Lightning
+              size={32}
+              className="text-muted-foreground/70 mx-auto mb-2"
+            />
+            <p className="text-sm">
+              {search ? "No automations found" : "No automations yet"}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/sidebar/index.test.tsx
+++ b/apps/desktop/src/sidebar/index.test.tsx
@@ -34,6 +34,10 @@ vi.mock("~/sidebar/calendar", () => ({
   CalendarNav: () => <div data-testid="calendar-nav" />,
 }));
 
+vi.mock("~/sidebar/automations", () => ({
+  AutomationsNav: () => <div data-testid="automations-nav" />,
+}));
+
 vi.mock("~/sidebar/contacts", () => ({
   ContactsNav: () => <div data-testid="contacts-nav" />,
 }));
@@ -107,6 +111,7 @@ describe("LeftSidebar", () => {
     ["calendar", "calendar-nav"],
     ["contacts", "contacts-nav"],
     ["templates", "templates-nav"],
+    ["automations", "automations-nav"],
   ])("keeps %s below the window chrome", (type, testId) => {
     mocks.currentTab = { type };
 

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 
 import { cn } from "@anlg/utils";
 
+import { AutomationsNav } from "./automations";
 import { CalendarNav } from "./calendar";
 import { ContactsNav } from "./contacts";
 import { SettingsNav } from "./settings";
@@ -26,8 +27,13 @@ export function LeftSidebar({
   const isCalendarMode = currentTab?.type === "calendar";
   const isContactsMode = currentTab?.type === "contacts";
   const isTemplatesMode = currentTab?.type === "templates";
+  const isAutomationsMode = currentTab?.type === "automations";
   const isSpecialMode =
-    isSettingsMode || isCalendarMode || isContactsMode || isTemplatesMode;
+    isSettingsMode ||
+    isCalendarMode ||
+    isContactsMode ||
+    isTemplatesMode ||
+    isAutomationsMode;
   const isTimelineSidebarLayout = !isSpecialMode;
 
   return (
@@ -49,6 +55,8 @@ export function LeftSidebar({
             <ContactsNav />
           ) : isTemplatesMode ? (
             <TemplatesNav />
+          ) : isAutomationsMode ? (
+            <AutomationsNav />
           ) : (
             <div className="flex h-full min-h-0 flex-col">
               <SharedNotesNav />

--- a/apps/desktop/src/sidebar/use-custom-sidebar.ts
+++ b/apps/desktop/src/sidebar/use-custom-sidebar.ts
@@ -7,6 +7,7 @@ const CUSTOM_SIDEBAR_TYPES: Tab["type"][] = [
   "settings",
   "contacts",
   "templates",
+  "automations",
 ];
 
 const LEFT_SURFACE_CUSTOM_SIDEBAR_TYPES: Tab["type"][] = [
@@ -14,6 +15,7 @@ const LEFT_SURFACE_CUSTOM_SIDEBAR_TYPES: Tab["type"][] = [
   "settings",
   "contacts",
   "templates",
+  "automations",
 ];
 
 export function hasCustomSidebarTab(tab: Tab | null): boolean {


### PR DESCRIPTION
Replace the notes timeline with a searchable automation conversation navigator.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and read-path query changes only; reuses existing chat scope filtering and sidebar patterns with broad test coverage.
> 
> **Overview**
> On the **automations** tab, the left sidebar now shows a dedicated **Automations** navigator instead of the notes timeline.
> 
> The navigator lists all automation-scoped chat groups (via new **`useChatGroups`**, which loads the full history without the recent-groups **`LIMIT`**), supports **search**, highlights the active conversation, and exposes **New automation** through existing chat context actions.
> 
> **Automations** is wired like other custom-sidebar tabs: fixed left panel width, locked expanded sidebar, and left-edge main surface chrome, with tests updated across shell, body, and sidebar routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 294a95e23569892033f725daa35a98d7174cc850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->