### PR TITLE
Clarify empty pre-meeting notes

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -1403,6 +1403,7 @@ msgstr "Meeting details access turned on"
 msgid "Meeting ends"
 msgstr "Meeting ends"
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr "Meeting notes"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -1403,6 +1403,7 @@ msgstr ""
 msgid "Meeting ends"
 msgstr ""
 
+#: src/session/components/note-input/raw.tsx
 #: src/templates/auto-form.tsx
 msgid "Meeting notes"
 msgstr ""

--- a/apps/desktop/src/session/components/note-input/header-raw.tsx
+++ b/apps/desktop/src/session/components/note-input/header-raw.tsx
@@ -25,10 +25,14 @@ export function HeaderViewRaw({
   sessionId: string;
   standalone?: boolean;
 }) {
+  const session = useSession(sessionId);
+  const standaloneLabel = standalone ? session?.title.trim() : undefined;
+
   if (!isActive) {
     return (
       <HeaderViewRawButton
         isActive={isActive}
+        label={standaloneLabel}
         onClick={onClick}
         standalone={standalone}
       />
@@ -38,7 +42,9 @@ export function HeaderViewRaw({
   return (
     <HeaderViewRawActive
       isActive={isActive}
+      label={standaloneLabel}
       onClick={onClick}
+      rawMd={session?.raw_md}
       sessionId={sessionId}
       standalone={standalone}
     />
@@ -47,11 +53,13 @@ export function HeaderViewRaw({
 
 function HeaderViewRawButton({
   isActive,
+  label,
   onClick,
   onContextMenu,
   standalone,
 }: {
   isActive: boolean;
+  label?: string;
   onClick?: () => void;
   onContextMenu?: React.MouseEventHandler<HTMLButtonElement>;
   standalone: boolean;
@@ -61,11 +69,12 @@ function HeaderViewRawButton({
   return (
     <IconHeaderView
       isActive={isActive}
-      label={t`Memos`}
+      label={label || t`Memos`}
       icon={<TextAlignLeft className="size-4" />}
       onClick={onClick}
       onContextMenu={onContextMenu}
       size={standalone ? "standalone" : "tray"}
+      title={label}
       className={standalone ? "border-0 shadow-none" : undefined}
     />
   );
@@ -73,16 +82,19 @@ function HeaderViewRawButton({
 
 function HeaderViewRawActive({
   isActive,
+  label,
   onClick,
+  rawMd,
   sessionId,
   standalone,
 }: {
   isActive: boolean;
+  label?: string;
   onClick?: () => void;
+  rawMd?: string;
   sessionId: string;
   standalone: boolean;
 }) {
-  const rawMd = useSession(sessionId)?.raw_md;
   const memoMarkdown = useMemo(() => getStoredNoteMarkdown(rawMd), [rawMd]);
   const contextMenu = useMemo<MenuItemDef[]>(
     () => [
@@ -105,6 +117,7 @@ function HeaderViewRawActive({
   return (
     <HeaderViewRawButton
       isActive={isActive}
+      label={label}
       onClick={onClick}
       onContextMenu={showContextMenu}
       standalone={standalone}

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -43,6 +43,7 @@ const hoisted = vi.hoisted(() => ({
   transcriptRenderDataCalls: 0,
   transcriptSegments: [{ speaker: "Speaker 1", text: "Hello transcript" }],
   isGenerating: false,
+  sessionTitle: "Weekly planning",
   nativeContextMenus: [] as CapturedMenuItem[][],
   userTemplates: [] as Array<{
     id: string;
@@ -189,7 +190,7 @@ vi.mock("~/session/queries", () => ({
     title: "Summary",
   }),
   useEnhancedNoteRecords: () => [{ id: "note-1" }],
-  useSession: () => ({ raw_md: "" }),
+  useSession: () => ({ raw_md: "", title: hoisted.sessionTitle }),
 }));
 
 vi.mock("~/session/components/note-input/transcript/actions", () => ({
@@ -334,6 +335,7 @@ describe("Header", () => {
       { speaker: "Speaker 1", text: "Hello transcript" },
     ];
     hoisted.isGenerating = false;
+    hoisted.sessionTitle = "Weekly planning";
     hoisted.nativeContextMenus = [];
     hoisted.userTemplates = [];
   });
@@ -458,7 +460,7 @@ describe("Header", () => {
       />,
     );
 
-    const memoTab = screen.getByRole("button", { name: "Memos" });
+    const memoTab = screen.getByRole("button", { name: "Weekly planning" });
     const viewSwitcher = screen.getByRole("group", {
       name: "Session note views",
     });
@@ -466,7 +468,9 @@ describe("Header", () => {
     expect(viewSwitcher.className).not.toContain("h-[30px]");
     expect(viewSwitcher.className).not.toContain("bg-foreground/10");
     expect(viewSwitcher.className).not.toContain("rounded-full");
-    expect(memoTab.textContent).toBe("Memos");
+    expect(memoTab.textContent).toBe("Weekly planning");
+    expect(memoTab.getAttribute("title")).toBe("Weekly planning");
+    expect(memoTab.querySelector("span")?.className).toContain("truncate");
     expect(memoTab.className).toContain("h-7");
     expect(memoTab.className).toContain("bg-white");
     expect(memoTab.className).toContain("border-0");

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -39,6 +39,12 @@ vi.mock("@anlg/editor/markdown", () => ({
   parseJsonContent: (value: string) => JSON.parse(value),
 }));
 
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    t: (input: TemplateStringsArray) => input.join(""),
+  }),
+}));
+
 vi.mock("@anlg/editor/note", () => ({
   normalizePortableAttachmentUrls: (value: unknown) => value,
   NoteEditor: (props: Record<string, unknown>) => {
@@ -171,6 +177,7 @@ describe("RawEditor", () => {
     expect(props?.className).toContain("session-note-editor");
     expect(props?.className).toContain("custom-editor-class");
     expect(props?.placeholderComponent).toEqual(expect.any(Function));
+    expect(props?.persistentPlaceholderComponent).toEqual(expect.any(Function));
     expect(props?.initialContent).toMatchObject({
       type: "doc",
       content: [

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -1,3 +1,4 @@
+import { useLingui } from "@lingui/react/macro";
 import type { EditorView } from "prosemirror-view";
 import { forwardRef, useCallback, useMemo, useRef } from "react";
 
@@ -25,6 +26,7 @@ import { hasStoredNoteContent } from "~/session/components/shared";
 import { useAttachmentResolver } from "~/session/hooks/useAttachmentResolver";
 import { useUpdateSession } from "~/session/queries";
 import {
+  createDocumentBodyPlaceholder,
   ensureFirstLineTitle,
   extractFirstLineTitle,
   documentTitlePlaceholder,
@@ -60,6 +62,7 @@ export const RawEditor = forwardRef<
     },
     ref,
   ) => {
+    const { t } = useLingui();
     const updateSession = useUpdateSession(sessionId);
     const resolveAttachment = useAttachmentResolver(sessionId);
     const { audioDropTargetProps, fileHandlerConfig, isAudioDragActive } =
@@ -124,6 +127,10 @@ export const RawEditor = forwardRef<
           : undefined,
       [syncTasks, sessionId],
     );
+    const persistentPlaceholderComponent = useMemo(
+      () => createDocumentBodyPlaceholder(t`Meeting notes`),
+      [t],
+    );
     return (
       <AudioDropTarget
         targetProps={audioDropTargetProps}
@@ -138,6 +145,7 @@ export const RawEditor = forwardRef<
             resolveAttachment={resolveAttachment}
             handleChange={handleChange}
             placeholderComponent={documentTitlePlaceholder}
+            persistentPlaceholderComponent={persistentPlaceholderComponent}
             mentionConfig={mentionConfig}
             sessionMentionDropConfig={sessionMentionDropConfig}
             onNavigateToTitle={onNavigateToTitle}

--- a/apps/desktop/src/session/title-content.test.ts
+++ b/apps/desktop/src/session/title-content.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { schema } from "@anlg/editor/note";
 
 import {
+  createDocumentBodyPlaceholder,
   documentTitlePlaceholder,
   ensureFirstLineTitle,
   ensureMarkdownFirstLineTitle,
@@ -23,6 +24,42 @@ describe("documentTitlePlaceholder", () => {
         node: schema.node("paragraph"),
         pos: 2,
         hasAnchor: true,
+      }),
+    ).toBe("");
+  });
+});
+
+describe("createDocumentBodyPlaceholder", () => {
+  it("shows a prompt only in the sole empty body block", () => {
+    const title = schema.node("heading", { level: 1 }, [
+      schema.text("Planning"),
+    ]);
+    const body = schema.node("paragraph");
+    const doc = schema.node("doc", null, [title, body]);
+    const placeholder = createDocumentBodyPlaceholder("Start writing...");
+
+    expect(placeholder({ doc, node: body, pos: title.nodeSize })).toBe(
+      "Start writing...",
+    );
+    expect(placeholder({ doc, node: title, pos: 0 })).toBe("");
+  });
+
+  it("hides the prompt once the note has another body block", () => {
+    const title = schema.node("heading", { level: 1 }, [
+      schema.text("Planning"),
+    ]);
+    const body = schema.node("paragraph");
+    const doc = schema.node("doc", null, [
+      title,
+      body,
+      schema.node("paragraph", null, [schema.text("Follow up")]),
+    ]);
+
+    expect(
+      createDocumentBodyPlaceholder("Start writing...")({
+        doc,
+        node: body,
+        pos: title.nodeSize,
       }),
     ).toBe("");
   });

--- a/apps/desktop/src/session/title-content.ts
+++ b/apps/desktop/src/session/title-content.ts
@@ -1,9 +1,32 @@
-import type { JSONContent, PlaceholderFunction } from "@anlg/editor/note";
+import type {
+  JSONContent,
+  PersistentPlaceholderFunction,
+  PlaceholderFunction,
+} from "@anlg/editor/note";
 
 export const documentTitlePlaceholder: PlaceholderFunction = ({ node, pos }) =>
   pos === 0 && node.type.name === "heading" && node.attrs.level === 1
     ? "Untitled"
     : "";
+
+export function createDocumentBodyPlaceholder(
+  label: string,
+): PersistentPlaceholderFunction {
+  return ({ doc, node, pos }) => {
+    const title = doc.firstChild;
+    const isOnlyBodyBlock =
+      doc.childCount === 2 &&
+      title?.type.name === "heading" &&
+      title.attrs.level === 1 &&
+      pos === title.nodeSize;
+
+    return isOnlyBodyBlock &&
+      node.type.name === "paragraph" &&
+      node.content.size === 0
+      ? label
+      : "";
+  };
+}
 
 export function extractFirstLineTitle(content: JSONContent) {
   const firstBlock = content.content?.[0];

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -65,6 +65,7 @@ import {
   linkBoundaryGuardPlugin,
   linkOpenPlugin,
   placeholderPlugin,
+  type PersistentPlaceholderFunction,
   searchPlugin,
   searchReplaceAll,
   searchReplaceCurrent,
@@ -99,7 +100,12 @@ import {
   trailingEmptyLineClickPlugin,
 } from "./trailing-empty-line-click";
 
-export type { MentionConfig, FileHandlerConfig, PlaceholderFunction };
+export type {
+  MentionConfig,
+  FileHandlerConfig,
+  PlaceholderFunction,
+  PersistentPlaceholderFunction,
+};
 export { normalizePortableAttachmentUrls } from "./portable-attachments";
 export { schema };
 export {
@@ -173,6 +179,7 @@ export interface NoteEditorProps {
   resolveAttachment?: AttachmentResolver;
   mentionConfig?: MentionConfig;
   placeholderComponent?: PlaceholderFunction;
+  persistentPlaceholderComponent?: PersistentPlaceholderFunction;
   fileHandlerConfig?: FileHandlerConfig;
   onNavigateToTitle?: (pixelWidth?: number) => void;
   onLinkOpen?: LinkOpenHandler;
@@ -581,6 +588,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       resolveAttachment,
       mentionConfig,
       placeholderComponent,
+      persistentPlaceholderComponent,
       fileHandlerConfig,
       onNavigateToTitle,
       onLinkOpen,
@@ -733,7 +741,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
           : []),
         imageTrailingParagraphPlugin(),
         searchPlugin(),
-        placeholderPlugin(placeholderComponent),
+        placeholderPlugin(placeholderComponent, persistentPlaceholderComponent),
         clearMarksOnEnterPlugin(),
         clipPastePlugin(),
         autolinkPlugin(),
@@ -747,6 +755,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       ],
       [
         placeholderComponent,
+        persistentPlaceholderComponent,
         fileHandlerConfig,
         mentionConfig,
         sessionMentionDropConfig,

--- a/packages/editor/src/plugins/index.ts
+++ b/packages/editor/src/plugins/index.ts
@@ -35,6 +35,7 @@ export {
 } from "./link-open";
 export {
   type PlaceholderFunction,
+  type PersistentPlaceholderFunction,
   placeholderPlugin,
   placeholderPluginKey,
 } from "./placeholder";

--- a/packages/editor/src/plugins/placeholder.test.ts
+++ b/packages/editor/src/plugins/placeholder.test.ts
@@ -54,6 +54,27 @@ describe("placeholderPlugin", () => {
     expect(plugin.props.decorations?.(state)?.find()).toHaveLength(0);
   });
 
+  it("decorates a persistent empty block without moving the selection", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("heading", { level: 1 }, [schema.text("Planning")]),
+      schema.node("paragraph"),
+    ]);
+    const bodyPos = doc.firstChild!.nodeSize;
+    const plugin = placeholderPlugin(undefined, ({ node, pos }) =>
+      node.type === schema.nodes.paragraph && pos === bodyPos
+        ? "Start writing..."
+        : "",
+    );
+    const state = EditorState.create({ schema, doc, plugins: [plugin] });
+
+    const decorations = plugin.props.decorations?.(state)?.find() ?? [];
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].from).toBe(bodyPos);
+    expect(decorations[0].type.attrs["data-placeholder"]).toBe(
+      "Start writing...",
+    );
+  });
+
   it("adds the editor-empty class for an empty document", () => {
     const plugin = placeholderPlugin(() => "Memo");
     const state = EditorState.create({

--- a/packages/editor/src/plugins/placeholder.ts
+++ b/packages/editor/src/plugins/placeholder.ts
@@ -8,6 +8,12 @@ export type PlaceholderFunction = (props: {
   hasAnchor: boolean;
 }) => string;
 
+export type PersistentPlaceholderFunction = (props: {
+  doc: PMNode;
+  node: PMNode;
+  pos: number;
+}) => string;
+
 export const placeholderPluginKey = new PluginKey("placeholder");
 
 function getPlaceholderTarget(doc: PMNode, $anchor: ResolvedPos) {
@@ -38,7 +44,10 @@ function getPlaceholderTarget(doc: PMNode, $anchor: ResolvedPos) {
   return null;
 }
 
-export function placeholderPlugin(placeholder?: PlaceholderFunction) {
+export function placeholderPlugin(
+  placeholder?: PlaceholderFunction,
+  persistentPlaceholder?: PersistentPlaceholderFunction,
+) {
   return new Plugin({
     key: placeholderPluginKey,
     props: {
@@ -47,39 +56,54 @@ export function placeholderPlugin(placeholder?: PlaceholderFunction) {
         const { $anchor } = selection;
 
         const target = getPlaceholderTarget(doc, $anchor);
-        if (!target) {
-          return DecorationSet.empty;
-        }
-
-        const { pos, node } = target;
-        const isEmpty = !node.isLeaf && node.content.size === 0;
-
-        if (!isEmpty) {
-          return DecorationSet.empty;
-        }
-
         const isEmptyDoc =
           doc.childCount === 1 &&
           doc.firstChild!.isTextblock &&
           doc.firstChild!.content.size === 0;
+        const decorations: Decoration[] = [];
+        const decoratedPositions = new Set<number>();
 
-        const classes = ["is-empty"];
-        if (isEmptyDoc) classes.push("is-editor-empty");
+        const addDecoration = (node: PMNode, pos: number, text: string) => {
+          if (!text || node.isLeaf || node.content.size > 0) {
+            return;
+          }
 
-        const text = placeholder
-          ? placeholder({ node, pos, hasAnchor: true })
-          : "";
+          const classes = ["is-empty"];
+          if (isEmptyDoc) classes.push("is-editor-empty");
+          decorations.push(
+            Decoration.node(pos, pos + node.nodeSize, {
+              class: classes.join(" "),
+              "data-placeholder": text,
+            }),
+          );
+          decoratedPositions.add(pos);
+        };
 
-        if (!text) {
-          return DecorationSet.empty;
+        if (target && placeholder) {
+          addDecoration(
+            target.node,
+            target.pos,
+            placeholder({
+              node: target.node,
+              pos: target.pos,
+              hasAnchor: true,
+            }),
+          );
         }
 
-        return DecorationSet.create(doc, [
-          Decoration.node(pos, pos + node.nodeSize, {
-            class: classes.join(" "),
-            "data-placeholder": text,
-          }),
-        ]);
+        if (persistentPlaceholder) {
+          doc.descendants((node, pos) => {
+            if (decoratedPositions.has(pos)) {
+              return;
+            }
+
+            addDecoration(node, pos, persistentPlaceholder({ doc, node, pos }));
+          });
+        }
+
+        return decorations.length > 0
+          ? DecorationSet.create(doc, decorations)
+          : DecorationSet.empty;
       },
     },
   });


### PR DESCRIPTION
Show scheduled meeting titles in raw-only headers and add a persistent empty-note prompt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI and editor placeholder behavior only; no auth, sync, or data-model changes.
> 
> **Overview**
> Improves how **scheduled, memo-only sessions** read before content exists: the raw-only header shows the **session title** (e.g. calendar meeting name) instead of the generic **Memos** label, with truncation and a `title` tooltip in standalone mode.
> 
> The raw note editor gains a **persistent “Meeting notes” placeholder** on the sole empty body paragraph under the title (via new `createDocumentBodyPlaceholder` and editor `persistentPlaceholderComponent` support). Selection-based placeholders are unchanged; the new decoration applies without requiring focus.
> 
> Locale catalogs pick up the **Meeting notes** string for `raw.tsx`; tests cover header labeling and placeholder wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90caa35057b5183bf03f815bb581032a537a6c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->