### PR TITLE
Add wordmark to website hero

### DIFF
--- a/apps/web/src/components/home-page/hero-section.tsx
+++ b/apps/web/src/components/home-page/hero-section.tsx
@@ -7,6 +7,7 @@ import { DancingSticks } from "@anlg/ui/components/ui/dancing-sticks";
 import { Spinner } from "@anlg/ui/components/ui/spinner";
 import { cn } from "@anlg/utils";
 
+import { AnarlogLogo } from "@/components/anarlog-logo";
 import { useAnalytics } from "@/hooks/use-posthog";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import {
@@ -20,9 +21,11 @@ import { CredibilityLogoMarquee } from "./social-proof-sections";
 export function HeroSection() {
   return (
     <section className="pt-10 pb-2 md:pt-12 md:pb-4">
-      <h1 className="font-hand mx-auto max-w-3xl text-5xl leading-[0.98] font-semibold tracking-normal text-balance md:text-7xl lg:relative lg:left-1/2 lg:w-max lg:max-w-none lg:-translate-x-1/2 lg:whitespace-nowrap">
-        <span className="font-hand block lg:inline">Anarlog is</span>{" "}
-        <span className="font-hand block lg:inline">the AI notepad for</span>{" "}
+      <Link to="/" aria-label="Anarlog home" className="inline-flex">
+        <AnarlogLogo className="h-8 w-auto md:h-9" />
+      </Link>
+      <h1 className="font-hand mx-auto mt-12 max-w-3xl text-5xl leading-[0.98] font-semibold tracking-normal text-balance md:mt-16 md:text-7xl lg:relative lg:left-1/2 lg:w-max lg:max-w-none lg:-translate-x-1/2 lg:whitespace-nowrap">
+        <span className="font-hand block lg:inline">The AI notepad for</span>{" "}
         <span className="font-hand block lg:inline">private meetings.</span>
       </h1>
       <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-[#4f4940]">


### PR DESCRIPTION
Center the official Anarlog wordmark above the simplified private-meetings headline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hero-only branding and copy layout changes with no auth, data, or backend impact.
> 
> **Overview**
> The homepage hero now leads with the **official Anarlog wordmark**, linked to `/` with an accessible home label, instead of spelling “Anarlog” in the headline.
> 
> The **H1 is simplified** to “The AI notepad for private meetings.” (capitalized “The”, no “Anarlog is” line), with extra top margin so spacing between the logo and headline stays consistent on mobile and desktop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 840d6b2d179437e0fcc7ad705f6b4aa3b738c7aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->