### PR TITLE
refactor(desktop): move devtools panel button into settings

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -9,8 +9,6 @@ import {
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { commands } from "~/types/tauri.gen";
-
 const mocks = vi.hoisted(() => ({
   runtimePlatform: null as "windows" | "linux" | null,
   currentTab: {
@@ -37,13 +35,6 @@ const mocks = vi.hoisted(() => ({
     resize: vi.fn(),
   },
   tabContentRenderCount: 0,
-  devtoolsPanelActionListeners: [] as Array<
-    (event: { payload: { action: string } }) => void
-  >,
-  windowsCommands: {
-    devtoolsPanelHide: vi.fn(async () => ({ status: "ok" as const })),
-    devtoolsPanelShow: vi.fn(async () => ({ status: "ok" as const })),
-  },
   upcomingMeetingStatus: null as null | {
     itemKey: string;
     label: string;
@@ -172,25 +163,6 @@ vi.mock("~/contexts/shell", () => ({
   }),
 }));
 
-vi.mock("@anlg/plugin-windows", () => ({
-  commands: mocks.windowsCommands,
-  events: {
-    devtoolsPanelAction: {
-      listen: vi.fn(
-        async (listener: (event: { payload: { action: string } }) => void) => {
-          mocks.devtoolsPanelActionListeners.push(listener);
-          return () => {
-            mocks.devtoolsPanelActionListeners =
-              mocks.devtoolsPanelActionListeners.filter(
-                (candidate) => candidate !== listener,
-              );
-          };
-        },
-      ),
-    },
-  },
-}));
-
 vi.mock("~/store/zustand/tabs", () => ({
   uniqueIdfromTab: (tab: { type: string }) => tab.type,
   useTabs: (
@@ -290,13 +262,8 @@ describe("ClassicMainBody", () => {
     mocks.leftSidebarPanelHandle.isExpanded.mockClear();
     mocks.leftSidebarPanelHandle.resize.mockClear();
     mocks.tabContentRenderCount = 0;
-    mocks.devtoolsPanelActionListeners = [];
-    mocks.windowsCommands.devtoolsPanelHide.mockClear();
-    mocks.windowsCommands.devtoolsPanelShow.mockClear();
     mocks.upcomingMeetingStatus = null;
     mocks.setUpcomingMeetingStatus = null;
-    vi.mocked(commands.showDevtool).mockClear();
-    vi.mocked(commands.showDevtool).mockResolvedValue(true);
   });
 
   it("wraps the expanded left sidebar in a persistent resizable panel", () => {
@@ -814,100 +781,6 @@ describe("ClassicMainBody", () => {
       screen.getAllByTestId("panel")[0]?.dataset.transition,
     ).toBeUndefined();
     expect(mocks.leftsidebar.toggleExpanded).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows the devtools button until the panel opens, then restores it when closed", async () => {
-    render(<ClassicMainBody />);
-
-    const searchButton = screen.getByRole("button", { name: "Search" });
-    const newNoteButton = screen.getByRole("button", { name: "New note" });
-    const devtoolsButton = await screen.findByRole("button", {
-      name: "Show devtools panel",
-    });
-
-    expect(searchButton.compareDocumentPosition(newNoteButton)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-    expect(newNoteButton.compareDocumentPosition(devtoolsButton)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
-    expect(devtoolsButton.parentElement).toBe(newNoteButton.parentElement);
-
-    fireEvent.click(devtoolsButton);
-
-    expect(mocks.windowsCommands.devtoolsPanelShow).toHaveBeenCalledTimes(1);
-    expect(mocks.windowsCommands.devtoolsPanelHide).not.toHaveBeenCalled();
-    expect(
-      screen.getByRole("button", { name: "Show devtools panel" }),
-    ).toBeTruthy();
-
-    act(() => {
-      for (const listener of mocks.devtoolsPanelActionListeners) {
-        listener({ payload: { action: "panel:opened" } });
-      }
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("button", { name: "Show devtools panel" }),
-      ).toBeNull();
-    });
-
-    act(() => {
-      for (const listener of mocks.devtoolsPanelActionListeners) {
-        listener({ payload: { action: "panel:closed" } });
-      }
-    });
-
-    expect(
-      await screen.findByRole("button", { name: "Show devtools panel" }),
-    ).toBeTruthy();
-  });
-
-  it("hides the devtools button when the native panel is opened outside the sidebar", async () => {
-    render(<ClassicMainBody />);
-
-    expect(
-      await screen.findByRole("button", { name: "Show devtools panel" }),
-    ).toBeTruthy();
-
-    await waitFor(() => {
-      expect(mocks.devtoolsPanelActionListeners).toHaveLength(1);
-    });
-
-    act(() => {
-      for (const listener of mocks.devtoolsPanelActionListeners) {
-        listener({ payload: { action: "panel:opened" } });
-      }
-    });
-
-    expect(
-      screen.queryByRole("button", { name: "Show devtools panel" }),
-    ).toBeNull();
-
-    act(() => {
-      for (const listener of mocks.devtoolsPanelActionListeners) {
-        listener({ payload: { action: "panel:closed" } });
-      }
-    });
-
-    expect(
-      await screen.findByRole("button", { name: "Show devtools panel" }),
-    ).toBeTruthy();
-  });
-
-  it("does not show the devtools button when devtools are disabled", async () => {
-    vi.mocked(commands.showDevtool).mockResolvedValue(false);
-
-    render(<ClassicMainBody />);
-
-    await waitFor(() => {
-      expect(commands.showDevtool).toHaveBeenCalledTimes(1);
-    });
-    expect(
-      screen.queryByRole("button", { name: "Show devtools panel" }),
-    ).toBeNull();
-    expect(mocks.devtoolsPanelActionListeners).toHaveLength(0);
   });
 
   it("renders expanded sidebar controls in the sidebar layout", () => {

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -9,10 +9,6 @@ import {
 } from "react";
 
 import {
-  commands as windowsCommands,
-  events as windowsEvents,
-} from "@anlg/plugin-windows";
-import {
   type ImperativePanelHandle,
   ResizableHandle,
   ResizablePanel,
@@ -56,7 +52,6 @@ import {
   hasLeftSurfaceCustomSidebarTab,
 } from "~/sidebar/use-custom-sidebar";
 import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
-import { commands } from "~/types/tauri.gen";
 
 type LeftSidebarSizeStyle = CSSProperties & {
   "--left-sidebar-panel-size": string;
@@ -84,57 +79,8 @@ export function ClassicMainBody() {
   const [showIgnoredTimelineEvents, setShowIgnoredTimelineEvents] =
     useState(false);
   const [noteFilter, setNoteFilter] = useState<SidebarNoteFilter>("all");
-  const [showDevtoolsPanelButton, setShowDevtoolsPanelButton] = useState(false);
-  const [devtoolsPanelOpen, setDevtoolsPanelOpen] = useState(false);
   const showWindowControlsGutter = useWindowControlsGutter();
   leftSidebarPanelConstraintsRef.current = leftSidebarPanelConstraints;
-
-  useMountEffect(() => {
-    let cancelled = false;
-    let unlistenDevtoolsAction: (() => void) | undefined;
-
-    const syncDevtoolsPanelButton = async () => {
-      const enabled = await commands.showDevtool().catch((error) => {
-        console.error("Failed to resolve devtools availability:", error);
-        return false;
-      });
-
-      if (cancelled) {
-        return;
-      }
-
-      setShowDevtoolsPanelButton(enabled);
-
-      if (!enabled) {
-        return;
-      }
-
-      windowsEvents.devtoolsPanelAction
-        .listen(({ payload }) => {
-          if (payload.action === "panel:opened") {
-            setDevtoolsPanelOpen(true);
-          }
-          if (payload.action === "panel:closed") {
-            setDevtoolsPanelOpen(false);
-          }
-        })
-        .then((unlisten) => {
-          if (cancelled) {
-            unlisten();
-            return;
-          }
-
-          unlistenDevtoolsAction = unlisten;
-        });
-    };
-
-    void syncDevtoolsPanelButton();
-
-    return () => {
-      cancelled = true;
-      unlistenDevtoolsAction?.();
-    };
-  });
 
   const isOnboarding = currentTab?.type === "onboarding";
   const reserveNoteSurfaceMinWidth = usesNoteSurfaceMinWidth(currentTab);
@@ -159,13 +105,6 @@ export function ClassicMainBody() {
   const handleOpenNoteDialog = useCallback(() => {
     openNoteDialog.open();
   }, [openNoteDialog]);
-  const handleOpenDevtoolsPanel = useCallback(async () => {
-    const result = await windowsCommands.devtoolsPanelShow();
-
-    if (result.status === "error") {
-      console.error("Failed to show devtools panel:", result.error);
-    }
-  }, []);
   const applyLeftSidebarPanelSize = useCallback((size: number) => {
     const bodyRoot = bodyRootRef.current;
     if (!bodyRoot) {
@@ -468,13 +407,10 @@ export function ClassicMainBody() {
           currentSessionId={currentSessionId}
           noteFilter={noteFilter}
           sidebarExpanded
-          showDevtoolsPanelButton={showDevtoolsPanelButton}
           showIgnoredTimelineEvents={showIgnoredTimelineEvents}
-          devtoolsPanelOpen={devtoolsPanelOpen}
           onNewNote={createNewNote}
           onNoteFilterChange={setNoteFilter}
           onSearch={handleOpenNoteDialog}
-          onOpenDevtools={handleOpenDevtoolsPanel}
           onToggleSidebar={handleToggleLeftSidebar}
         />
       ) : null}
@@ -509,13 +445,10 @@ export function ClassicMainBody() {
               currentSessionId={currentSessionId}
               noteFilter={noteFilter}
               sidebarExpanded={false}
-              showDevtoolsPanelButton={showDevtoolsPanelButton}
               showIgnoredTimelineEvents={showIgnoredTimelineEvents}
-              devtoolsPanelOpen={devtoolsPanelOpen}
               onNewNote={createNewNote}
               onNoteFilterChange={setNoteFilter}
               onSearch={handleOpenNoteDialog}
-              onOpenDevtools={handleOpenDevtoolsPanel}
               onToggleSidebar={handleToggleLeftSidebar}
             />
           </div>

--- a/apps/desktop/src/main/sidebar-timeline-chrome.tsx
+++ b/apps/desktop/src/main/sidebar-timeline-chrome.tsx
@@ -3,7 +3,6 @@ import {
   NotePencil,
   Sidebar,
   SidebarSimple,
-  Wrench,
 } from "@phosphor-icons/react";
 import { memo, type ReactNode } from "react";
 
@@ -16,27 +15,21 @@ import { useSidebarUpcomingMeetingStatus } from "~/sidebar/timeline/upcoming-mee
 export const SidebarTimelineChromeWithUpcomingMeeting = memo(
   function SidebarTimelineChromeWithUpcomingMeeting({
     currentSessionId,
-    devtoolsPanelOpen,
     noteFilter,
     onNewNote,
     onNoteFilterChange,
-    onOpenDevtools,
     onSearch,
     onToggleSidebar,
     sidebarExpanded,
-    showDevtoolsPanelButton,
     showIgnoredTimelineEvents,
   }: {
     currentSessionId?: string;
-    devtoolsPanelOpen: boolean;
     noteFilter: SidebarNoteFilter;
     onNewNote: () => void;
     onNoteFilterChange: (filter: SidebarNoteFilter) => void;
-    onOpenDevtools: () => void;
     onSearch: () => void;
     onToggleSidebar: () => void;
     sidebarExpanded: boolean;
-    showDevtoolsPanelButton: boolean;
     showIgnoredTimelineEvents: boolean;
   }) {
     const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus({
@@ -49,43 +42,34 @@ export const SidebarTimelineChromeWithUpcomingMeeting = memo(
 
     return (
       <SidebarTimelineChrome
-        devtoolsPanelOpen={devtoolsPanelOpen}
         hasUpcomingMeeting={hasUpcomingMeeting}
         noteFilter={noteFilter}
         onNewNote={onNewNote}
         onNoteFilterChange={onNoteFilterChange}
-        onOpenDevtools={onOpenDevtools}
         onSearch={onSearch}
         onToggleSidebar={onToggleSidebar}
         sidebarExpanded={sidebarExpanded}
-        showDevtoolsPanelButton={showDevtoolsPanelButton}
       />
     );
   },
 );
 
 function SidebarTimelineChrome({
-  devtoolsPanelOpen,
   hasUpcomingMeeting,
   noteFilter,
   onNewNote,
   onNoteFilterChange,
-  onOpenDevtools,
   onSearch,
   onToggleSidebar,
   sidebarExpanded,
-  showDevtoolsPanelButton,
 }: {
-  devtoolsPanelOpen: boolean;
   hasUpcomingMeeting: boolean;
   noteFilter: SidebarNoteFilter;
   onNewNote: () => void;
   onNoteFilterChange: (filter: SidebarNoteFilter) => void;
-  onOpenDevtools: () => void;
   onSearch: () => void;
   onToggleSidebar: () => void;
   sidebarExpanded: boolean;
-  showDevtoolsPanelButton: boolean;
 }) {
   const collapsedBadge = !sidebarExpanded
     ? hasUpcomingMeeting
@@ -119,14 +103,6 @@ function SidebarTimelineChrome({
               value={noteFilter}
               onValueChange={onNoteFilterChange}
             />
-            {showDevtoolsPanelButton && !devtoolsPanelOpen ? (
-              <LeftSurfaceChromeButton
-                ariaLabel="Show devtools panel"
-                onClick={onOpenDevtools}
-              >
-                <Wrench size={15} />
-              </LeftSurfaceChromeButton>
-            ) : null}
           </>
         ) : null}
       </div>

--- a/apps/desktop/src/settings/developers/devtools.tsx
+++ b/apps/desktop/src/settings/developers/devtools.tsx
@@ -1,0 +1,62 @@
+import { Wrench } from "@phosphor-icons/react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { commands as windowsCommands } from "@anlg/plugin-windows";
+import { Button } from "@anlg/ui/components/ui/button";
+import { sonnerToast } from "@anlg/ui/components/ui/toast";
+
+import { commands } from "~/types/tauri.gen";
+
+export function DevtoolsSection() {
+  const enabledQuery = useQuery({
+    queryKey: ["devtools-panel", "enabled"],
+    queryFn: commands.showDevtool,
+    staleTime: Infinity,
+  });
+  const openMutation = useMutation({
+    mutationFn: async () => {
+      const result = await windowsCommands.devtoolsPanelShow();
+      if (result.status === "error") {
+        throw new Error(result.error);
+      }
+    },
+    onError: (error) => sonnerToast.error(error.message),
+  });
+
+  if (enabledQuery.data !== true) {
+    return null;
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-muted-foreground text-sm font-medium">Devtools</h2>
+      <div className="border-border bg-card overflow-hidden rounded-2xl border">
+        <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex min-w-0 gap-3">
+            <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-xl">
+              <Wrench className="size-5" />
+            </div>
+            <div className="min-w-0">
+              <h3 className="font-medium">Devtools panel</h3>
+              <p className="text-muted-foreground mt-1 text-sm leading-5">
+                Preview notifications, toasts, updates, and billing dialogs.
+                Only available in dev and staging builds.
+              </p>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={openMutation.isPending}
+              onClick={() => openMutation.mutate()}
+            >
+              Open panel
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/settings/developers/index.test.tsx
+++ b/apps/desktop/src/settings/developers/index.test.tsx
@@ -12,6 +12,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   checkEmbeddedCli: vi.fn(),
   installEmbeddedCli: vi.fn(),
+  showDevtool: vi.fn(),
+  devtoolsPanelShow: vi.fn(),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
   getCloudApiSettings: vi.fn(),
@@ -24,6 +26,13 @@ vi.mock("~/types/tauri.gen", () => ({
   commands: {
     checkEmbeddedCli: mocks.checkEmbeddedCli,
     installEmbeddedCli: mocks.installEmbeddedCli,
+    showDevtool: mocks.showDevtool,
+  },
+}));
+
+vi.mock("@anlg/plugin-windows", () => ({
+  commands: {
+    devtoolsPanelShow: mocks.devtoolsPanelShow,
   },
 }));
 
@@ -116,6 +125,10 @@ describe("SettingsDevelopers", () => {
   beforeEach(() => {
     mocks.checkEmbeddedCli.mockReset();
     mocks.installEmbeddedCli.mockReset();
+    mocks.showDevtool.mockReset();
+    mocks.showDevtool.mockResolvedValue(false);
+    mocks.devtoolsPanelShow.mockReset();
+    mocks.devtoolsPanelShow.mockResolvedValue({ status: "ok" });
     mocks.toastError.mockReset();
     mocks.toastSuccess.mockReset();
     mocks.createApiKey.mockReset();
@@ -293,5 +306,61 @@ describe("SettingsDevelopers", () => {
     });
     expect(screen.getByText("REST API")).toBeTruthy();
     expect(screen.getByText("Remote MCP")).toBeTruthy();
+  });
+
+  it("hides the devtools section when devtools are disabled", async () => {
+    mocks.checkEmbeddedCli.mockResolvedValue({
+      status: "ok",
+      data: {
+        supported: false,
+        commandName: "anarlog",
+        installPath: "/Users/test/.local/bin/anarlog",
+        state: "unsupported",
+        details: "Unavailable.",
+      },
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SettingsDevelopers />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(mocks.showDevtool).toHaveBeenCalled());
+    expect(screen.queryByText("Devtools panel")).toBeNull();
+  });
+
+  it("opens the devtools panel from the settings button when enabled", async () => {
+    mocks.checkEmbeddedCli.mockResolvedValue({
+      status: "ok",
+      data: {
+        supported: false,
+        commandName: "anarlog",
+        installPath: "/Users/test/.local/bin/anarlog",
+        state: "unsupported",
+        details: "Unavailable.",
+      },
+    });
+    mocks.showDevtool.mockResolvedValue(true);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SettingsDevelopers />
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Devtools panel")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open panel" }));
+
+    await waitFor(() =>
+      expect(mocks.devtoolsPanelShow).toHaveBeenCalledTimes(1),
+    );
   });
 });

--- a/apps/desktop/src/settings/developers/index.tsx
+++ b/apps/desktop/src/settings/developers/index.tsx
@@ -1,5 +1,6 @@
 import { CliSettingsSections } from "./cli";
 import { CloudApiSection } from "./cloud-api";
+import { DevtoolsSection } from "./devtools";
 import { LocalApiSection } from "./local-api";
 
 import { SettingsPageTitle } from "~/settings/page-title";
@@ -13,6 +14,7 @@ export function SettingsDevelopers() {
       <CliSettingsSections />
       <CloudApiSection />
       <LocalApiSection />
+      <DevtoolsSection />
     </div>
   );
 }


### PR DESCRIPTION
The devtools panel was opened from a Wrench icon button in the left
sidebar chrome, which put a dev/staging-only affordance in the primary
note-taking surface for every build. Move it to Settings > Developers,
where the other build-conditional tooling already lives.

- Drop the devtools button, its props, and the panel:opened/panel:closed
  listener from the sidebar chrome and ClassicMainBody. ClassicMainBody
  no longer needs the plugin-windows or tauri.gen imports.
- Add a DevtoolsSection to Settings > Developers that renders only when
  showDevtool() is true, reusing the same query key as the panel host so
  the availability check is shared.
- Move the corresponding test coverage from body.test.tsx to the
  developers settings test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI relocation of a dev/staging-only affordance with no auth or data-path changes; behavior is preserved behind the same availability check.
> 
> **Overview**
> Removes the **Wrench** devtools control from the left sidebar timeline chrome and **ClassicMainBody**, including `showDevtool` gating, `devtoolsPanelShow`, and `panel:opened` / `panel:closed` listeners—so the main note-taking surface no longer imports `@anlg/plugin-windows` or Tauri devtools commands for that UI.
> 
> Adds a **Devtools** card under **Settings > Developers** with an **Open panel** action when `showDevtool()` is true, using the same React Query key `["devtools-panel", "enabled"]` as the devtools panel host. Tests for sidebar devtools behavior are removed from `body.test.tsx` and replaced with developers-settings coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb96623945fa646a75365cce19b245b491c31e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->