### PR TITLE
refactor(settings): simplify theme and app icon previews

### DIFF
--- a/apps/desktop/src/settings/appearance/app-icon.test.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.test.tsx
@@ -61,6 +61,7 @@ describe("AppIconSelector", () => {
     expect(screen.queryByRole("radio", { name: "Production" })).toBeNull();
     expect(screen.getByRole("radio", { name: "Blueprint" })).toBeDefined();
     expect(screen.getByRole("radio", { name: "Sketch" })).toBeDefined();
+    expect(screen.queryByText("Blueprint")).toBeNull();
 
     fireEvent.click(screen.getByRole("radio", { name: "Blueprint" }));
 

--- a/apps/desktop/src/settings/appearance/app-icon.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.tsx
@@ -62,7 +62,7 @@ export function AppIconSelector() {
       <div
         role="radiogroup"
         aria-label={t`App icon`}
-        className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
+        className="grid grid-cols-4 gap-3"
       >
         {options.map((option) => {
           const selected =
@@ -76,8 +76,9 @@ export function AppIconSelector() {
               role="radio"
               aria-checked={selected}
               aria-label={labels[option]}
+              title={labels[option]}
               className={cn([
-                "group bg-background text-foreground focus-visible:ring-ring focus-visible:ring-offset-background relative flex cursor-pointer flex-col items-center gap-3 rounded-2xl border p-4 transition-[background-color,border-color,box-shadow,scale] duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.98]",
+                "group bg-background text-foreground focus-visible:ring-ring focus-visible:ring-offset-background relative flex aspect-square cursor-pointer flex-col items-center justify-center rounded-2xl border p-4 transition-[background-color,border-color,box-shadow,scale] duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.98]",
                 selected
                   ? "border-foreground/50 bg-accent/40 shadow-xs"
                   : "border-border hover:border-foreground/30 hover:bg-accent/20",
@@ -110,9 +111,6 @@ export function AppIconSelector() {
                   className="size-16 transition-transform duration-150 select-none group-hover:scale-105"
                 />
               </picture>
-              <span className="w-full truncate text-center text-sm font-medium">
-                {labels[option]}
-              </span>
             </button>
           );
         })}

--- a/apps/desktop/src/settings/appearance/theme.tsx
+++ b/apps/desktop/src/settings/appearance/theme.tsx
@@ -128,15 +128,12 @@ function PreviewCanvas({ dark }: { dark: boolean }) {
           ])}
         />
         <div className="flex flex-1 flex-col gap-2 py-1">
-          <div className="flex items-center gap-1.5">
-            <span className="size-2.5 rounded-sm bg-red-400" />
-            <span
-              className={cn([
-                "h-1.5 w-10 rounded-full",
-                dark ? "bg-neutral-300" : "bg-neutral-700",
-              ])}
-            />
-          </div>
+          <span
+            className={cn([
+              "h-1.5 w-10 rounded-full",
+              dark ? "bg-neutral-300" : "bg-neutral-700",
+            ])}
+          />
           <span
             className={cn([
               "h-1 w-4/5 rounded-full",


### PR DESCRIPTION
The theme preview mockup had a red square standing in for a favicon next
to the title bar, which read as an error dot rather than window chrome.
Drop it so the title skeleton sits inline with the body lines.

The app icon grid wrapped four options onto two rows and stretched each
card into a rectangle. Fix the grid at four columns and make the cards
aspect-square, and drop the visible per-icon label now that the icons
carry the distinction themselves. The names stay reachable via aria-label
and a new title tooltip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic layout and preview changes only; selection behavior and accessibility labels are unchanged.
> 
> **Overview**
> **Appearance settings** get a visual polish pass on the theme and app icon pickers—no behavior changes to how preferences are stored or applied.
> 
> The **app icon** grid is fixed at four columns with **square** cards instead of a responsive multi-row layout with stretched rectangles. Visible text labels under each icon are removed; names remain on **`aria-label`** and a new **`title`** tooltip. Tests now assert labels like "Blueprint" are not rendered as visible text.
> 
> The **theme** preview mockup drops the red square beside the title-bar skeleton (it read like an error indicator) so the title line sits inline with the body placeholder lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05ff110749b2b14cf43e2e15aabdec029356142e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->