### PR TITLE
Update desktop 1.4.3 changelog

### DIFF
--- a/packages/changelog/content/1.4.3.md
+++ b/packages/changelog/content/1.4.3.md
@@ -1,0 +1,36 @@
+---
+date: "2026-08-04"
+summary: "Anarlog 1.4.3 makes sharing safer, improves navigation and meeting workflows, refreshes the app, and strengthens long-session reliability."
+---
+
+## Sharing and safety
+
+- Open sharing controls without publishing anything until you explicitly
+  invite someone, copy a link, or change access, then choose invited-only,
+  workspace, link, or public access
+- Share generated meeting summaries instead of private notes, with shared-page
+  edits reconciled without changing the original memo
+- Confirm before deleting a note or signing out, with clearer and more
+  consistent confirmation dialogs
+
+## Meetings and navigation
+
+- Filter the sidebar between all notes, your notes, notes you shared, notes
+  shared with you, and accessible workspaces
+- Browse and search your full automation conversation history from a dedicated
+  Automations sidebar
+- Find settings faster with search and clearer sections for meeting, audio,
+  appearance, AI, and developer controls
+- See calendar metadata after a scheduled meeting ends while keeping **Stop**
+  available when a recording runs overtime
+- Avoid stale or duplicate desktop notifications when a meeting becomes active
+  or microphone activity stops
+
+## Design and reliability
+
+- Use the current Anarlog artwork throughout the app and menu bar, with event
+  titles sized correctly across Latin and wide-character scripts
+- See scheduled meeting titles and a persistent notes prompt before a meeting
+  begins
+- Keep long recordings, transcription, chat, uploads, and background activity
+  responsive with bounded memory, queues, and file handling


### PR DESCRIPTION
Summarize the desktop changes shipping in 1.4.3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application or infrastructure code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.3.md`** with front matter (`date`, `summary`) and release notes for the desktop **1.4.3** ship.
> 
> The entry groups user-facing changes into **Sharing and safety** (opt-in publishing and access levels, sharing meeting summaries vs private notes, delete/sign-out confirmations), **Meetings and navigation** (sidebar filters, Automations history sidebar, searchable settings, post-meeting calendar UI and **Stop** when overtime, notification deduping), and **Design and reliability** (updated artwork, pre-meeting titles/prompts, bounded memory/queues for long sessions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dee4db925bc2da9029f2f459463e520a2935549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->