### PR TITLE
feat(sharing): seed share invites with session participants

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -1236,8 +1236,7 @@ msgstr "Insert below"
 msgid "Intelligence"
 msgstr "Intelligence"
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr "Invite"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -1236,8 +1236,7 @@ msgstr ""
 msgid "Intelligence"
 msgstr ""
 
-#: src/session-sharing/draft-panel.tsx
-#: src/session-sharing/management-panel.tsx
+#: src/session-sharing/invite-recipients.tsx
 msgid "Invite"
 msgstr ""
 

--- a/apps/desktop/src/session-sharing/draft-panel.tsx
+++ b/apps/desktop/src/session-sharing/draft-panel.tsx
@@ -1,9 +1,7 @@
 import { Trans } from "@lingui/react/macro";
 import { CircleNotch, Copy } from "@phosphor-icons/react";
-import { useForm } from "@tanstack/react-form";
 
 import { Button } from "@anlg/ui/components/ui/button";
-import { Input } from "@anlg/ui/components/ui/input";
 import {
   AppFloatingPanel,
   PopoverContent,
@@ -13,37 +11,31 @@ import {
   GeneralAccessSelector,
   type GeneralAccessTarget,
 } from "./general-access";
-import { isInviteEmail } from "./invitation-management";
+import { ShareInviteForm, useShareInvite } from "./invite-recipients";
 import type { AvailableShareWorkspace } from "./source";
 
 import { useAuth } from "~/auth";
-import { useHumans } from "~/contacts/queries";
 import { ContactFacehash } from "~/contacts/shared";
 
 export type DraftShareAction =
-  | { type: "invite"; email: string }
+  | { type: "invite"; emails: string[] }
   | { type: "copy-link" }
   | { type: "scope"; target: GeneralAccessTarget };
 
 export function SessionShareDraftContent({
+  sessionId,
   disabled,
   pendingAction,
   workspaces,
   onAction,
 }: {
+  sessionId: string;
   disabled: boolean;
   pendingAction: DraftShareAction | null;
   workspaces: AvailableShareWorkspace[];
   onAction: (action: DraftShareAction) => void;
 }) {
   const auth = useAuth();
-  const humans = useHumans();
-  const form = useForm({
-    defaultValues: { email: "" },
-    onSubmit: ({ value }) => {
-      onAction({ type: "invite", email: value.email.trim() });
-    },
-  });
   const ownerEmail = auth.session?.user.email ?? "";
   const ownerMetadata = auth.session?.user.user_metadata;
   const ownerName =
@@ -52,18 +44,7 @@ export function SessionShareDraftContent({
       : typeof ownerMetadata?.name === "string" && ownerMetadata.name
         ? ownerMetadata.name
         : ownerEmail || "You";
-  const suggestedContacts = (query: string) => {
-    const normalized = query.trim().toLowerCase();
-    if (!normalized || isInviteEmail(normalized)) return [];
-    return humans
-      .filter(
-        (human) =>
-          human.email &&
-          human.email.toLowerCase() !== ownerEmail.toLowerCase() &&
-          `${human.name}\n${human.email}`.toLowerCase().includes(normalized),
-      )
-      .slice(0, 4);
-  };
+  const invite = useShareInvite({ sessionId, ownerEmail, invitedEmails: [] });
   const actionPending = pendingAction !== null;
   const generalAccessValue =
     pendingAction?.type === "scope" ? pendingAction.target : "restricted";
@@ -96,88 +77,12 @@ export function SessionShareDraftContent({
               <h3 id="invite-people-heading" className="sr-only">
                 <Trans>People with access</Trans>
               </h3>
-              <form
-                className="flex items-center gap-2"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  void form.handleSubmit();
-                }}
-              >
-                <form.Field name="email">
-                  {(field) => (
-                    <Input
-                      type="text"
-                      aria-label="Invitee email"
-                      autoComplete="email"
-                      required
-                      value={field.state.value}
-                      disabled={disabled || actionPending}
-                      onBlur={field.handleBlur}
-                      onChange={(event) =>
-                        field.handleChange(event.target.value)
-                      }
-                      placeholder="Email or name"
-                      className="h-8 min-w-0 flex-1 rounded-md text-xs"
-                    />
-                  )}
-                </form.Field>
-                <form.Subscribe selector={(state) => state.values.email}>
-                  {(email) => (
-                    <Button
-                      type="submit"
-                      size="sm"
-                      disabled={
-                        disabled || actionPending || !isInviteEmail(email)
-                      }
-                      className="h-8 shrink-0 rounded-md px-3"
-                    >
-                      {pendingAction?.type === "invite" ? (
-                        <CircleNotch
-                          className="size-3.5 animate-spin"
-                          aria-hidden="true"
-                        />
-                      ) : null}
-                      <Trans>Invite</Trans>
-                    </Button>
-                  )}
-                </form.Subscribe>
-              </form>
-
-              <form.Subscribe selector={(state) => state.values.email}>
-                {(query) => {
-                  const suggestions = suggestedContacts(query);
-                  return suggestions.length ? (
-                    <div className="mt-1 space-y-0.5 rounded-lg border p-1">
-                      {suggestions.map((contact) => (
-                        <button
-                          key={contact.id}
-                          type="button"
-                          className="hover:bg-accent flex w-full items-center gap-2 rounded-md px-2 py-1 text-left"
-                          onClick={() =>
-                            form.setFieldValue("email", contact.email)
-                          }
-                        >
-                          <ContactFacehash
-                            name={contact.name || contact.email}
-                            size={22}
-                          />
-                          <span className="min-w-0 flex-1">
-                            <span className="block truncate text-xs font-medium">
-                              {contact.name || contact.email}
-                            </span>
-                            {contact.name ? (
-                              <span className="text-muted-foreground block truncate text-[10px]">
-                                {contact.email}
-                              </span>
-                            ) : null}
-                          </span>
-                        </button>
-                      ))}
-                    </div>
-                  ) : null;
-                }}
-              </form.Subscribe>
+              <ShareInviteForm
+                invite={invite}
+                disabled={disabled || actionPending}
+                pending={pendingAction?.type === "invite"}
+                onSubmit={(emails) => onAction({ type: "invite", emails })}
+              />
 
               <div className="mt-2 flex min-h-9 items-center gap-2 rounded-lg px-1.5 py-1">
                 <ContactFacehash name={ownerName} size={24} />

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1529,6 +1529,31 @@ describe("SessionShareButton", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Invitation sent.");
   });
 
+  it("keeps failed invitation recipients in the draft", async () => {
+    mocks.managedNote = null;
+    mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);
+    mocks.createSessionAccessInvitation.mockRejectedValueOnce(
+      new Error("unavailable"),
+    );
+    renderShareButton();
+    await openSharePopover();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Invitee email" }), {
+      target: { value: "person@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Could not create this invitation.",
+      ),
+    );
+    expect(mocks.markSessionShareActivated).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Remove person@example.com" }),
+    ).not.toBeNull();
+  });
+
   it("invites every session participant seeded into the field", async () => {
     mocks.managedNote = null;
     mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1638,6 +1638,32 @@ describe("SessionShareButton", () => {
     );
   });
 
+  it("does not overwrite clipboard fallback links for multiple invitations", async () => {
+    mocks.participants = [
+      { id: "p1", source: "auto", name: "Sungbin Jo", email: "sungbin@e.com" },
+      { id: "p2", source: "auto", name: "Yujong Lee", email: "yujong@e.com" },
+    ];
+    mocks.sendSessionAccessInvitationEmail.mockRejectedValue(
+      new Error("mail unavailable"),
+    );
+    mocks.revokeSessionAccessInvitation.mockResolvedValue({
+      invitationId: INVITATION_ID,
+      revokedAt: "2026-08-04T00:00:00Z",
+    });
+    renderShareButton();
+    await openSharePopover();
+
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Could not create these invitations.",
+      ),
+    );
+    expect(mocks.clipboardWriteText).not.toHaveBeenCalled();
+    expect(mocks.revokeSessionAccessInvitation).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps an emailed invitation when the popover closes", async () => {
     let resolveEmail: (() => void) | undefined;
     mocks.sendSessionAccessInvitationEmail.mockReturnValueOnce(

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1565,6 +1565,26 @@ describe("SessionShareButton", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Invitations sent.");
   });
 
+  it("clears successfully invited participants from the field", async () => {
+    mocks.participants = [
+      { id: "p1", source: "auto", name: "Sungbin Jo", email: "sungbin@e.com" },
+    ];
+    renderShareButton();
+    await openSharePopover();
+
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Remove Sungbin Jo" }),
+      ).toBeNull(),
+    );
+    expect(
+      (screen.getByRole("button", { name: "Invite" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
   it("drops a removed participant from the invitation", async () => {
     mocks.managedNote = null;
     mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1569,6 +1569,26 @@ describe("SessionShareButton", () => {
     mocks.participants = [
       { id: "p1", source: "auto", name: "Sungbin Jo", email: "sungbin@e.com" },
     ];
+    mocks.createSessionAccessInvitation.mockImplementationOnce(async () => {
+      mocks.access = [
+        {
+          entryType: "invitation",
+          entryId: INVITATION_ID,
+          userId: null,
+          userEmail: "sungbin@e.com",
+          capability: "viewer",
+          status: "pending",
+          createdAt: "2026-08-04T00:00:00Z",
+          expiresAt: "2026-08-17T00:00:00Z",
+        },
+      ];
+      return {
+        invitationId: INVITATION_ID,
+        inviteToken: TOKEN,
+        invitationExpiresAt: "2026-08-17T00:00:00Z",
+        wasCreated: true,
+      };
+    });
     renderShareButton();
     await openSharePopover();
 
@@ -1583,6 +1603,50 @@ describe("SessionShareButton", () => {
       (screen.getByRole("button", { name: "Invite" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
+  });
+
+  it("re-seeds an invited participant after access is revoked", async () => {
+    mocks.participants = [
+      { id: "p1", source: "auto", name: "Sungbin Jo", email: "sungbin@e.com" },
+    ];
+    mocks.createSessionAccessInvitation.mockImplementationOnce(async () => {
+      mocks.access = [
+        {
+          entryType: "invitation",
+          entryId: INVITATION_ID,
+          userId: null,
+          userEmail: "sungbin@e.com",
+          capability: "viewer",
+          status: "pending",
+          createdAt: "2026-08-04T00:00:00Z",
+          expiresAt: "2026-08-17T00:00:00Z",
+        },
+      ];
+      return {
+        invitationId: INVITATION_ID,
+        inviteToken: TOKEN,
+        invitationExpiresAt: "2026-08-17T00:00:00Z",
+        wasCreated: true,
+      };
+    });
+    mocks.revokeSessionAccessInvitation.mockImplementationOnce(async () => {
+      mocks.access = [];
+      return {
+        invitationId: INVITATION_ID,
+        revokedAt: "2026-08-04T00:00:00Z",
+      };
+    });
+    renderShareButton();
+    await openSharePopover();
+
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+    await screen.findByText("Invitation pending");
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Remove Sungbin Jo" }),
+    ).not.toBeNull();
   });
 
   it("drops a removed participant from the invitation", async () => {

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -64,6 +64,7 @@ const mocks = vi.hoisted(() => ({
   toastError: vi.fn(),
   clipboardWriteText: vi.fn().mockResolvedValue(undefined),
   contacts: [] as any[],
+  participants: [] as any[],
   workspaces: [] as { id: string; name: string }[],
 }));
 
@@ -81,6 +82,10 @@ vi.mock("~/contacts/queries", () => ({
 
 vi.mock("~/contacts/shared", () => ({
   ContactFacehash: ({ name }: { name: string }) => <span>{name[0]}</span>,
+}));
+
+vi.mock("~/session/queries", () => ({
+  useSessionParticipants: () => mocks.participants,
 }));
 
 vi.mock("@anlg/plugin-opener2", () => ({
@@ -367,6 +372,7 @@ describe("SessionShareButton", () => {
     mocks.events = [];
     mocks.access = [];
     mocks.contacts = [];
+    mocks.participants = [];
     mocks.workspaces = [];
     mocks.auth.session = createSession();
     mocks.auth.supabase = {};
@@ -1521,6 +1527,115 @@ describe("SessionShareButton", () => {
       "session-1",
     );
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Invitation sent.");
+  });
+
+  it("invites every session participant seeded into the field", async () => {
+    mocks.managedNote = null;
+    mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);
+    mocks.participants = [
+      { id: "p1", source: "auto", name: "Sungbin Jo", email: "sungbin@e.com" },
+      { id: "p2", source: "auto", name: "", email: "yujong@e.com" },
+      { id: "p3", source: "auto", name: "Artem", email: "" },
+      { id: "p4", source: "excluded", name: "Dropped", email: "drop@e.com" },
+      { id: "p5", source: "auto", name: "Me", email: "owner@example.com" },
+    ];
+    mocks.auth.session = {
+      ...createSession(),
+      user: { id: USER_ID, is_anonymous: false, email: "owner@example.com" },
+    };
+    renderShareButton();
+    await openSharePopover();
+    mocks.sendSessionAccessInvitationEmail.mockClear();
+
+    expect(screen.getByText("Sungbin Jo")).not.toBeNull();
+    expect(screen.getByText("yujong@e.com")).not.toBeNull();
+    expect(screen.queryByText("Artem")).toBeNull();
+    expect(screen.queryByText("Dropped")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() =>
+      expect(mocks.sendSessionAccessInvitationEmail).toHaveBeenCalledTimes(2),
+    );
+    expect(
+      mocks.createSessionAccessInvitation.mock.calls.map(
+        (call) => call[1].inviteeEmail,
+      ),
+    ).toEqual(["sungbin@e.com", "yujong@e.com"]);
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Invitations sent.");
+  });
+
+  it("drops a removed participant from the invitation", async () => {
+    mocks.managedNote = null;
+    mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);
+    mocks.participants = [
+      { id: "p1", source: "auto", name: "Sungbin Jo", email: "sungbin@e.com" },
+      { id: "p2", source: "auto", name: "Yujong Lee", email: "yujong@e.com" },
+    ];
+    renderShareButton();
+    await openSharePopover();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove Yujong Lee" }));
+    expect(screen.queryByText("Yujong Lee")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() =>
+      expect(mocks.createSessionAccessInvitation).toHaveBeenCalledOnce(),
+    );
+    expect(
+      mocks.createSessionAccessInvitation.mock.calls[0]![1].inviteeEmail,
+    ).toBe("sungbin@e.com");
+  });
+
+  it("skips participants that already have access", async () => {
+    mocks.participants = [
+      { id: "p1", source: "auto", name: "Sungbin Jo", email: "sungbin@e.com" },
+      { id: "p2", source: "auto", name: "Yujong Lee", email: "yujong@e.com" },
+    ];
+    mocks.access = [
+      {
+        entryType: "invitation",
+        entryId: INVITATION_ID,
+        userId: null,
+        userEmail: "Sungbin@e.com",
+        capability: "viewer",
+        status: "pending",
+        createdAt: "2026-07-17T00:00:00Z",
+        expiresAt: "2026-08-17T00:00:00Z",
+      },
+    ];
+    renderShareButton();
+    await openSharePopover();
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Remove Yujong Lee" }),
+      ).not.toBeNull(),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Remove Sungbin Jo" }),
+    ).toBeNull();
+  });
+
+  it("reports invitations that could not be created", async () => {
+    mocks.participants = [
+      { id: "p1", source: "auto", name: "Sungbin Jo", email: "sungbin@e.com" },
+      { id: "p2", source: "auto", name: "Yujong Lee", email: "yujong@e.com" },
+    ];
+    mocks.createSessionAccessInvitation.mockImplementationOnce(async () => {
+      throw new Error("nope");
+    });
+    renderShareButton();
+    await openSharePopover();
+
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Invited 1. Could not invite 1. Try again.",
+      ),
+    );
   });
 
   it("keeps an emailed invitation when the popover closes", async () => {

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1594,26 +1594,6 @@ describe("SessionShareButton", () => {
     mocks.participants = [
       { id: "p1", source: "auto", name: "Sungbin Jo", email: "sungbin@e.com" },
     ];
-    mocks.createSessionAccessInvitation.mockImplementationOnce(async () => {
-      mocks.access = [
-        {
-          entryType: "invitation",
-          entryId: INVITATION_ID,
-          userId: null,
-          userEmail: "sungbin@e.com",
-          capability: "viewer",
-          status: "pending",
-          createdAt: "2026-08-04T00:00:00Z",
-          expiresAt: "2026-08-17T00:00:00Z",
-        },
-      ];
-      return {
-        invitationId: INVITATION_ID,
-        inviteToken: TOKEN,
-        invitationExpiresAt: "2026-08-17T00:00:00Z",
-        wasCreated: true,
-      };
-    });
     renderShareButton();
     await openSharePopover();
 

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -23,7 +23,11 @@ import {
 import { type DraftShareAction, SessionShareDraftContent } from "./draft-panel";
 import { flushCanonicalSessionEditorChanges } from "./editor-activity";
 import { generalAccessWorkspaceId } from "./general-access";
-import { deliverSessionShareInvitation } from "./invitation-management";
+import {
+  deliverSessionShareInvitations,
+  reportSessionShareInvitations,
+  type SessionShareInvitationDelivery,
+} from "./invitation-management";
 import {
   copySessionShareUrl,
   enableAndCopySessionShareLink,
@@ -263,25 +267,23 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
           context = requireActivePrepareContext(identity, signal);
         }
         let actionResult:
-          | { type: "invite"; deliveredBy: "email" | "clipboard" }
+          | { type: "invite"; deliveries: SessionShareInvitationDelivery[] }
           | { type: "copy-link" }
           | { type: "scope"; copied: boolean };
         if (action.type === "invite") {
           actionResult = {
             type: "invite",
-            deliveredBy: (
-              await deliverSessionShareInvitation({
-                context,
-                shareId: share.shareId,
-                email: action.email,
-                capability: "viewer",
-                noteTitle: source.title,
-                signal,
-                requireActive: () => {
-                  requireActivePrepareContext(identity, signal);
-                },
-              })
-            ).deliveredBy,
+            deliveries: await deliverSessionShareInvitations({
+              context,
+              shareId: share.shareId,
+              emails: action.emails,
+              capability: "viewer",
+              noteTitle: source.title,
+              signal,
+              requireActive: () => {
+                requireActivePrepareContext(identity, signal);
+              },
+            }),
           };
         } else if (action.type === "copy-link") {
           await copySessionShareUrl(share.shareId, () =>
@@ -356,15 +358,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
         queryKey: ["durable-shared-note-cache", identity.ownerUserId],
       });
       if (actionResult.type === "invite") {
-        trackAnalyticsEvent("share_invitation_sent", {
-          delivery_method: actionResult.deliveredBy,
-          capability: "viewer",
-        });
-        sonnerToast.success(
-          actionResult.deliveredBy === "email"
-            ? "Invitation sent."
-            : "Email unavailable. Invite link copied instead.",
-        );
+        reportSessionShareInvitations(actionResult.deliveries, "viewer");
       } else if (actionResult.type === "copy-link") {
         trackAnalyticsEvent("share_link_copied", {
           entry_point: "share_panel",
@@ -396,7 +390,9 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
       console.error("[session-sharing] could not activate share", error);
       sonnerToast.error(
         variables.action.type === "invite"
-          ? "Could not create this invitation."
+          ? variables.action.emails.length > 1
+            ? "Could not create these invitations."
+            : "Could not create this invitation."
           : variables.action.type === "scope"
             ? "Could not update general access."
             : "Could not copy the share link.",
@@ -579,6 +575,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
         />
       ) : activeSharePreparationIdentity ? (
         <SessionShareDraftContent
+          sessionId={activeSharePreparationIdentity.sessionId}
           disabled={
             managedNoteQuery.isLoading || !billing.isReady || !billing.isPaid
           }

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -271,19 +271,23 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
           | { type: "copy-link" }
           | { type: "scope"; copied: boolean };
         if (action.type === "invite") {
+          const deliveries = await deliverSessionShareInvitations({
+            context,
+            shareId: share.shareId,
+            emails: action.emails,
+            capability: "viewer",
+            noteTitle: source.title,
+            signal,
+            requireActive: () => {
+              requireActivePrepareContext(identity, signal);
+            },
+          });
+          if (!deliveries.some((delivery) => delivery.deliveredBy)) {
+            throw new ShareManagementError();
+          }
           actionResult = {
             type: "invite",
-            deliveries: await deliverSessionShareInvitations({
-              context,
-              shareId: share.shareId,
-              emails: action.emails,
-              capability: "viewer",
-              noteTitle: source.title,
-              signal,
-              requireActive: () => {
-                requireActivePrepareContext(identity, signal);
-              },
-            }),
+            deliveries,
           };
         } else if (action.type === "copy-link") {
           await copySessionShareUrl(share.shareId, () =>

--- a/apps/desktop/src/session-sharing/invitation-management.ts
+++ b/apps/desktop/src/session-sharing/invitation-management.ts
@@ -1,4 +1,3 @@
-import { useForm } from "@tanstack/react-form";
 import { useMutation } from "@tanstack/react-query";
 
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
@@ -93,6 +92,76 @@ export async function deliverSessionShareInvitation({
   return { deliveredBy: "email" as const };
 }
 
+export type SessionShareInvitationDelivery = {
+  email: string;
+  deliveredBy: "email" | "clipboard" | null;
+};
+
+export async function deliverSessionShareInvitations({
+  emails,
+  ...invitation
+}: {
+  context: ShareManagementContext;
+  shareId: string;
+  emails: string[];
+  capability: SessionAccessCapability;
+  noteTitle: string;
+  signal: AbortSignal;
+  requireActive: () => void;
+}): Promise<SessionShareInvitationDelivery[]> {
+  const deliveries: SessionShareInvitationDelivery[] = [];
+  for (const email of emails) {
+    invitation.requireActive();
+    try {
+      const { deliveredBy } = await deliverSessionShareInvitation({
+        ...invitation,
+        email,
+      });
+      deliveries.push({ email, deliveredBy });
+    } catch (error) {
+      if (invitation.signal.aborted) throw error;
+      console.error("[session-sharing] could not invite", email, error);
+      deliveries.push({ email, deliveredBy: null });
+    }
+  }
+  return deliveries;
+}
+
+export function reportSessionShareInvitations(
+  deliveries: SessionShareInvitationDelivery[],
+  capability: SessionAccessCapability,
+) {
+  const sent = deliveries.filter((delivery) => delivery.deliveredBy);
+  for (const delivery of sent) {
+    trackAnalyticsEvent("share_invitation_sent", {
+      delivery_method: delivery.deliveredBy,
+      capability,
+    });
+  }
+  const failed = deliveries.length - sent.length;
+  if (!sent.length) {
+    sonnerToast.error(
+      deliveries.length > 1
+        ? "Could not create these invitations."
+        : "Could not create this invitation.",
+    );
+    return;
+  }
+  if (failed) {
+    sonnerToast.error(
+      `Invited ${sent.length}. Could not invite ${failed}. Try again.`,
+    );
+    return;
+  }
+  sonnerToast.success(
+    sent.some((delivery) => delivery.deliveredBy === "clipboard")
+      ? "Email unavailable. Invite link copied instead."
+      : sent.length > 1
+        ? "Invitations sent."
+        : "Invitation sent.",
+  );
+}
+
 export function useSessionInvitationManagement({
   identity,
   managementAvailable,
@@ -112,22 +181,9 @@ export function useSessionInvitationManagement({
   onActivated: () => Promise<unknown>;
   onChanged: () => Promise<unknown>;
 }) {
-  const inviteForm = useForm({
-    defaultValues: {
-      email: "",
-      capability: "viewer" as SessionAccessCapability,
-    },
-    onSubmit: ({ value }) => {
-      inviteMutation.mutate({
-        email: value.email,
-        capability: value.capability,
-      });
-    },
-  });
-
   const inviteMutation = useMutation({
     mutationFn: (input: {
-      email: string;
+      emails: string[];
       capability: SessionAccessCapability;
     }) =>
       runOperation(async (signal) => {
@@ -136,10 +192,10 @@ export function useSessionInvitationManagement({
         }
         const published = await publishLatest(signal);
         const context = requireActiveContext(signal);
-        const delivery = await deliverSessionShareInvitation({
+        const deliveries = await deliverSessionShareInvitations({
           context,
           shareId: identity.shareId,
-          email: input.email,
+          emails: input.emails,
           capability: input.capability,
           noteTitle: published.title,
           signal,
@@ -148,26 +204,21 @@ export function useSessionInvitationManagement({
           },
         });
         await onActivated();
-        return delivery;
+        return deliveries;
       }),
-    onSuccess: ({ deliveredBy }, input) => {
-      trackAnalyticsEvent("share_invitation_sent", {
-        delivery_method: deliveredBy,
-        capability: input.capability,
-      });
-      inviteForm.reset();
-      sonnerToast.success(
-        deliveredBy === "email"
-          ? "Invitation sent."
-          : "Email unavailable. Invite link copied instead.",
-      );
+    onSuccess: (deliveries, input) => {
+      reportSessionShareInvitations(deliveries, input.capability);
     },
-    onError: (error) => {
+    onError: (error, input) => {
       if (error instanceof ShareOperationAbortedError) return;
-      sonnerToast.error("Could not create this invitation.");
+      sonnerToast.error(
+        input.emails.length > 1
+          ? "Could not create these invitations."
+          : "Could not create this invitation.",
+      );
     },
     onSettled: onChanged,
   });
 
-  return { inviteForm, inviteMutation };
+  return { inviteMutation };
 }

--- a/apps/desktop/src/session-sharing/invitation-management.ts
+++ b/apps/desktop/src/session-sharing/invitation-management.ts
@@ -5,6 +5,7 @@ import { sonnerToast } from "@anlg/ui/components/ui/toast";
 import {
   createSessionAccessInvitation,
   resendSessionAccessInvitation,
+  revokeSessionAccessInvitation,
   sendSessionAccessInvitationEmail,
   type SessionAccessCapability,
   type ShareManagementContext,
@@ -42,6 +43,7 @@ export async function deliverSessionShareInvitation({
   noteTitle,
   signal,
   requireActive,
+  allowClipboardFallback,
 }: {
   context: ShareManagementContext;
   shareId: string;
@@ -50,6 +52,7 @@ export async function deliverSessionShareInvitation({
   noteTitle: string;
   signal: AbortSignal;
   requireActive: () => void;
+  allowClipboardFallback: boolean;
 }) {
   let invitation = await createSessionAccessInvitation(context, {
     shareId,
@@ -77,6 +80,14 @@ export async function deliverSessionShareInvitation({
       signal,
     });
   } catch {
+    requireActive();
+    if (!allowClipboardFallback) {
+      await revokeSessionAccessInvitation(
+        withoutSignal(context),
+        invitation.invitationId,
+      ).catch(() => undefined);
+      throw new ShareManagementError();
+    }
     await copyInvitationOrRevoke(
       withoutSignal(context),
       {
@@ -110,12 +121,14 @@ export async function deliverSessionShareInvitations({
   requireActive: () => void;
 }): Promise<SessionShareInvitationDelivery[]> {
   const deliveries: SessionShareInvitationDelivery[] = [];
+  const allowClipboardFallback = emails.length === 1;
   for (const email of emails) {
     invitation.requireActive();
     try {
       const { deliveredBy } = await deliverSessionShareInvitation({
         ...invitation,
         email,
+        allowClipboardFallback,
       });
       deliveries.push({ email, deliveredBy });
     } catch (error) {

--- a/apps/desktop/src/session-sharing/invite-recipients.tsx
+++ b/apps/desktop/src/session-sharing/invite-recipients.tsx
@@ -104,10 +104,10 @@ export function useShareInvite({
         current.includes(key) ? current : [...current, key],
       );
     },
-    clear: (email: string) => {
+    restore: (email: string) => {
       const key = email.trim().toLowerCase();
-      setAdded((current) =>
-        current.filter((entry) => entry.email.toLowerCase() !== key),
+      setDismissed((current) =>
+        current.filter((dismissedEmail) => dismissedEmail !== key),
       );
     },
   };

--- a/apps/desktop/src/session-sharing/invite-recipients.tsx
+++ b/apps/desktop/src/session-sharing/invite-recipients.tsx
@@ -1,0 +1,237 @@
+import { Trans } from "@lingui/react/macro";
+import { CircleNotch, X } from "@phosphor-icons/react";
+import { useState } from "react";
+
+import { Button } from "@anlg/ui/components/ui/button";
+import { cn } from "@anlg/utils";
+
+import { isInviteEmail } from "./invitation-management";
+
+import { useHumans } from "~/contacts/queries";
+import { ContactFacehash } from "~/contacts/shared";
+import { useSessionParticipants } from "~/session/queries";
+
+export function useShareInvite({
+  sessionId,
+  ownerEmail,
+  invitedEmails,
+}: {
+  sessionId: string;
+  ownerEmail: string;
+  invitedEmails: string[];
+}) {
+  const participants = useSessionParticipants(sessionId);
+  const [query, setQuery] = useState("");
+  const [added, setAdded] = useState<{ email: string; name: string }[]>([]);
+  const [removed, setRemoved] = useState<string[]>([]);
+
+  const excluded = new Set(
+    [ownerEmail, ...invitedEmails]
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  // Recipients are derived on every render so participants that arrive from the
+  // live query after the panel opened still seed the field, while a chip the
+  // user removed stays removed.
+  const taken = new Set(removed);
+  const recipients: { email: string; name: string }[] = [];
+  for (const candidate of [
+    ...participants
+      .filter((participant) => participant.source !== "excluded")
+      .map((participant) => ({
+        email: participant.email.trim(),
+        name: participant.name.trim(),
+      })),
+    ...added,
+  ]) {
+    const key = candidate.email.toLowerCase();
+    if (
+      !isInviteEmail(candidate.email) ||
+      excluded.has(key) ||
+      taken.has(key)
+    ) {
+      continue;
+    }
+    taken.add(key);
+    recipients.push(candidate);
+  }
+
+  const typed = query.trim();
+  const isSelectable = (email: string) => {
+    const key = email.trim().toLowerCase();
+    return (
+      isInviteEmail(email) &&
+      !excluded.has(key) &&
+      !recipients.some((recipient) => recipient.email.toLowerCase() === key)
+    );
+  };
+  const add = (recipient: { email: string; name: string }) => {
+    const key = recipient.email.trim().toLowerCase();
+    setRemoved((current) => current.filter((email) => email !== key));
+    setAdded((current) =>
+      current.some((entry) => entry.email.toLowerCase() === key)
+        ? current
+        : [
+            ...current,
+            { email: recipient.email.trim(), name: recipient.name.trim() },
+          ],
+    );
+    setQuery("");
+  };
+  const emails = isSelectable(typed)
+    ? [...recipients.map((recipient) => recipient.email), typed]
+    : recipients.map((recipient) => recipient.email);
+
+  return {
+    query,
+    setQuery,
+    recipients,
+    emails,
+    canSubmit: emails.length > 0 && (!typed || isInviteEmail(typed)),
+    isSelectable,
+    add,
+    commitQuery: () => {
+      if (!isInviteEmail(typed)) return;
+      if (isSelectable(typed)) add({ email: typed, name: "" });
+      else setQuery("");
+    },
+    remove: (email: string) => {
+      const key = email.trim().toLowerCase();
+      setAdded((current) =>
+        current.filter((entry) => entry.email.toLowerCase() !== key),
+      );
+      setRemoved((current) =>
+        current.includes(key) ? current : [...current, key],
+      );
+    },
+  };
+}
+
+export function ShareInviteForm({
+  invite,
+  disabled,
+  pending,
+  onSubmit,
+}: {
+  invite: ReturnType<typeof useShareInvite>;
+  disabled: boolean;
+  pending: boolean;
+  onSubmit: (emails: string[]) => void;
+}) {
+  const humans = useHumans();
+  const normalized = invite.query.trim().toLowerCase();
+  const suggestions =
+    !normalized || isInviteEmail(normalized)
+      ? []
+      : humans
+          .filter(
+            (human) =>
+              human.email &&
+              invite.isSelectable(human.email) &&
+              `${human.name}\n${human.email}`
+                .toLowerCase()
+                .includes(normalized),
+          )
+          .slice(0, 4);
+
+  return (
+    <>
+      <form
+        className="flex items-start gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const emails = invite.emails;
+          invite.commitQuery();
+          onSubmit(emails);
+        }}
+      >
+        <div
+          className={cn([
+            "border-input focus-within:ring-ring flex min-h-8 min-w-0 flex-1 flex-wrap items-center gap-1 rounded-md border bg-transparent px-1.5 py-1 shadow-xs focus-within:ring-1",
+            disabled && "opacity-50",
+          ])}
+        >
+          {invite.recipients.map((recipient) => (
+            <span
+              key={recipient.email.toLowerCase()}
+              className="bg-accent flex max-w-full items-center gap-1 rounded px-1.5 py-0.5 text-[11px]"
+            >
+              <span className="truncate">
+                {recipient.name || recipient.email}
+              </span>
+              <button
+                type="button"
+                aria-label={`Remove ${recipient.name || recipient.email}`}
+                disabled={disabled}
+                onClick={() => invite.remove(recipient.email)}
+                className="text-muted-foreground hover:text-foreground shrink-0 disabled:cursor-not-allowed"
+              >
+                <X className="size-2.5" aria-hidden="true" />
+              </button>
+            </span>
+          ))}
+          <input
+            type="text"
+            aria-label="Invitee email"
+            autoComplete="email"
+            value={invite.query}
+            disabled={disabled}
+            onChange={(event) => invite.setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && isInviteEmail(invite.query)) {
+                event.preventDefault();
+                invite.commitQuery();
+                return;
+              }
+              if (event.key === "Backspace" && !invite.query) {
+                const last = invite.recipients[invite.recipients.length - 1];
+                if (last) invite.remove(last.email);
+              }
+            }}
+            placeholder={invite.recipients.length ? "" : "Email or name"}
+            className="placeholder:text-muted-foreground min-w-[120px] flex-1 bg-transparent text-xs outline-hidden disabled:cursor-not-allowed"
+          />
+        </div>
+        <Button
+          type="submit"
+          size="sm"
+          disabled={disabled || !invite.canSubmit}
+          className="h-8 shrink-0 rounded-md px-3"
+        >
+          {pending ? (
+            <CircleNotch className="size-3.5 animate-spin" aria-hidden="true" />
+          ) : null}
+          <Trans>Invite</Trans>
+        </Button>
+      </form>
+
+      {suggestions.length ? (
+        <div className="mt-1 space-y-0.5 rounded-lg border p-1">
+          {suggestions.map((contact) => (
+            <button
+              key={contact.id}
+              type="button"
+              className="hover:bg-accent flex w-full items-center gap-2 rounded-md px-2 py-1 text-left"
+              onClick={() =>
+                invite.add({ email: contact.email, name: contact.name })
+              }
+            >
+              <ContactFacehash name={contact.name || contact.email} size={22} />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-xs font-medium">
+                  {contact.name || contact.email}
+                </span>
+                {contact.name ? (
+                  <span className="text-muted-foreground block truncate text-[10px]">
+                    {contact.email}
+                  </span>
+                ) : null}
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/desktop/src/session-sharing/invite-recipients.tsx
+++ b/apps/desktop/src/session-sharing/invite-recipients.tsx
@@ -23,7 +23,7 @@ export function useShareInvite({
   const participants = useSessionParticipants(sessionId);
   const [query, setQuery] = useState("");
   const [added, setAdded] = useState<{ email: string; name: string }[]>([]);
-  const [removed, setRemoved] = useState<string[]>([]);
+  const [dismissed, setDismissed] = useState<string[]>([]);
 
   const excluded = new Set(
     [ownerEmail, ...invitedEmails]
@@ -33,7 +33,7 @@ export function useShareInvite({
   // Recipients are derived on every render so participants that arrive from the
   // live query after the panel opened still seed the field, while a chip the
   // user removed stays removed.
-  const taken = new Set(removed);
+  const taken = new Set(dismissed);
   const recipients: { email: string; name: string }[] = [];
   for (const candidate of [
     ...participants
@@ -67,7 +67,7 @@ export function useShareInvite({
   };
   const add = (recipient: { email: string; name: string }) => {
     const key = recipient.email.trim().toLowerCase();
-    setRemoved((current) => current.filter((email) => email !== key));
+    setDismissed((current) => current.filter((email) => email !== key));
     setAdded((current) =>
       current.some((entry) => entry.email.toLowerCase() === key)
         ? current
@@ -100,8 +100,14 @@ export function useShareInvite({
       setAdded((current) =>
         current.filter((entry) => entry.email.toLowerCase() !== key),
       );
-      setRemoved((current) =>
+      setDismissed((current) =>
         current.includes(key) ? current : [...current, key],
+      );
+    },
+    clear: (email: string) => {
+      const key = email.trim().toLowerCase();
+      setAdded((current) =>
+        current.filter((entry) => entry.email.toLowerCase() !== key),
       );
     },
   };

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -453,7 +453,7 @@ export function SessionSharePopoverContent({
                         onSuccess: (deliveries) => {
                           for (const delivery of deliveries) {
                             if (delivery.deliveredBy) {
-                              invite.clear(delivery.email);
+                              invite.remove(delivery.email);
                             }
                           }
                         },
@@ -499,7 +499,19 @@ export function SessionSharePopoverContent({
                                 entry.userEmail?.toLowerCase(),
                             )?.name
                           }
-                          onMutate={entryMutation.mutate}
+                          onMutate={(mutation) => {
+                            entryMutation.mutate(mutation, {
+                              onSuccess: () => {
+                                if (
+                                  (mutation.type === "grant-revoke" ||
+                                    mutation.type === "invitation-revoke") &&
+                                  mutation.entry.userEmail
+                                ) {
+                                  invite.restore(mutation.entry.userEmail);
+                                }
+                              },
+                            });
+                          }}
                         />
                       ))
                     : null}

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -11,7 +11,6 @@ import { type MutableRefObject, useState } from "react";
 
 import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { Button } from "@anlg/ui/components/ui/button";
-import { Input } from "@anlg/ui/components/ui/input";
 import {
   AppFloatingPanel,
   PopoverContent,
@@ -35,10 +34,8 @@ import {
   type GeneralAccessTarget,
   type GeneralAccessValue,
 } from "./general-access";
-import {
-  isInviteEmail,
-  useSessionInvitationManagement,
-} from "./invitation-management";
+import { useSessionInvitationManagement } from "./invitation-management";
+import { ShareInviteForm, useShareInvite } from "./invite-recipients";
 import {
   copyPublicSessionShareUrl,
   copySessionShareUrl,
@@ -133,7 +130,7 @@ export function SessionSharePopoverContent({
     requireActiveContext,
     onChanged,
   });
-  const { inviteForm, inviteMutation } = useSessionInvitationManagement({
+  const { inviteMutation } = useSessionInvitationManagement({
     identity,
     managementAvailable: Boolean(management),
     canExpand,
@@ -332,24 +329,14 @@ export function SessionSharePopoverContent({
       : typeof ownerMetadata?.name === "string" && ownerMetadata.name
         ? ownerMetadata.name
         : ownerEmail || "You";
-  const existingEmails = new Set(
-    data?.access
-      .map((entry) => entry.userEmail?.toLowerCase())
-      .filter((email): email is string => Boolean(email)) ?? [],
-  );
-  const suggestedContacts = (query: string) => {
-    const normalized = query.trim().toLowerCase();
-    if (!normalized || isInviteEmail(normalized)) return [];
-    return humans
-      .filter(
-        (human) =>
-          human.email &&
-          !existingEmails.has(human.email.toLowerCase()) &&
-          human.email.toLowerCase() !== ownerEmail.toLowerCase() &&
-          `${human.name}\n${human.email}`.toLowerCase().includes(normalized),
-      )
-      .slice(0, 4);
-  };
+  const invite = useShareInvite({
+    sessionId,
+    ownerEmail,
+    invitedEmails:
+      data?.access
+        .map((entry) => entry.userEmail ?? "")
+        .filter((email) => Boolean(email)) ?? [],
+  });
 
   return (
     <PopoverContent
@@ -455,94 +442,14 @@ export function SessionSharePopoverContent({
                 <h3 id="invite-people-heading" className="sr-only">
                   <Trans>People with access</Trans>
                 </h3>
-                <form
-                  className="flex items-center gap-2"
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    void inviteForm.handleSubmit();
-                  }}
-                >
-                  <inviteForm.Field name="email">
-                    {(field) => (
-                      <Input
-                        type="text"
-                        aria-label="Invitee email"
-                        autoComplete="email"
-                        required
-                        value={field.state.value}
-                        disabled={!canPublish || inviteMutation.isPending}
-                        onBlur={field.handleBlur}
-                        onChange={(event) =>
-                          field.handleChange(event.target.value)
-                        }
-                        placeholder="Email or name"
-                        className="h-8 min-w-0 flex-1 rounded-md text-xs"
-                      />
-                    )}
-                  </inviteForm.Field>
-                  <inviteForm.Subscribe
-                    selector={(state) => state.values.email}
-                  >
-                    {(email) => (
-                      <Button
-                        type="submit"
-                        size="sm"
-                        disabled={
-                          !canPublish ||
-                          !isInviteEmail(email) ||
-                          inviteMutation.isPending
-                        }
-                        className="h-8 shrink-0 rounded-md px-3"
-                      >
-                        {inviteMutation.isPending ? (
-                          <CircleNotch
-                            className="size-3.5 animate-spin"
-                            aria-hidden="true"
-                          />
-                        ) : null}
-                        <Trans>Invite</Trans>
-                      </Button>
-                    )}
-                  </inviteForm.Subscribe>
-                </form>
-
-                <inviteForm.Subscribe selector={(state) => state.values.email}>
-                  {(query) => {
-                    const suggestions = suggestedContacts(query);
-                    return suggestions.length ? (
-                      <div className="mt-1 space-y-0.5 rounded-lg border p-1">
-                        {suggestions.map((contact) => {
-                          return (
-                            <button
-                              key={contact.id}
-                              type="button"
-                              className="hover:bg-accent flex w-full items-center gap-2 rounded-md px-2 py-1 text-left"
-                              onClick={() =>
-                                inviteForm.setFieldValue("email", contact.email)
-                              }
-                            >
-                              <ContactFacehash
-                                name={contact.name || contact.email}
-                                size={22}
-                              />
-                              <span className="min-w-0 flex-1">
-                                <span className="block truncate text-xs font-medium">
-                                  {contact.name || contact.email}
-                                </span>
-                                {contact.name ? (
-                                  <span className="text-muted-foreground block truncate text-[10px]">
-                                    {contact.email}
-                                  </span>
-                                ) : null}
-                              </span>
-                            </button>
-                          );
-                        })}
-                      </div>
-                    ) : null;
-                  }}
-                </inviteForm.Subscribe>
+                <ShareInviteForm
+                  invite={invite}
+                  disabled={!canPublish || inviteMutation.isPending}
+                  pending={inviteMutation.isPending}
+                  onSubmit={(emails) =>
+                    inviteMutation.mutate({ emails, capability: "viewer" })
+                  }
+                />
 
                 <div className="mt-2 space-y-0.5">
                   <div className="flex min-h-9 items-center gap-2 rounded-lg px-1.5 py-1">

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -446,9 +446,20 @@ export function SessionSharePopoverContent({
                   invite={invite}
                   disabled={!canPublish || inviteMutation.isPending}
                   pending={inviteMutation.isPending}
-                  onSubmit={(emails) =>
-                    inviteMutation.mutate({ emails, capability: "viewer" })
-                  }
+                  onSubmit={(emails) => {
+                    inviteMutation.mutate(
+                      { emails, capability: "viewer" },
+                      {
+                        onSuccess: (deliveries) => {
+                          for (const delivery of deliveries) {
+                            if (delivery.deliveredBy) {
+                              invite.remove(delivery.email);
+                            }
+                          }
+                        },
+                      },
+                    );
+                  }}
                 />
 
                 <div className="mt-2 space-y-0.5">

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -453,7 +453,7 @@ export function SessionSharePopoverContent({
                         onSuccess: (deliveries) => {
                           for (const delivery of deliveries) {
                             if (delivery.deliveredBy) {
-                              invite.remove(delivery.email);
+                              invite.clear(delivery.email);
                             }
                           }
                         },


### PR DESCRIPTION
Sharing a meeting note meant retyping every attendee one email at a time,
even though the session already knows who was in the meeting.

The invite field is now a chip editor seeded from the session participants
(skipping the owner, excluded participants, and anyone who already has
access), so inviting the whole meeting is a single click. Chips are derived
per render so participants arriving from the live query still seed the
field, and a removed chip stays removed. Invitations are delivered for every
recipient, with a summary toast reporting partial failures.

Extracts the duplicated invite form out of the draft and management panels
into session-sharing/invite-recipients.tsx.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session-sharing invitation creation, email/clipboard fallbacks, and access revocation on failure—user-visible sharing behavior with partial-failure edge cases, though covered by new tests.
> 
> **Overview**
> Replaces the single-email invite field in draft and management share panels with a **chip-based invite editor** in `invite-recipients.tsx`, shared by both flows.
> 
> The field **auto-seeds from session participants** (with email, not excluded, not the owner, and not already on the access list). Users can add contacts, remove chips, and invite **many recipients in one action**; successful invites clear chips, and revoking access **re-seeds** that person.
> 
> Invitation delivery is now **batch-oriented**: `deliverSessionShareInvitations` loops recipients, aggregates per-email outcomes, and `reportSessionShareInvitations` drives analytics and toasts (including partial failures). **Clipboard fallback when email fails applies only to a single invite**; multi-invite failures revoke created invitations instead of copying one link over others.
> 
> Locale catalogs update the **Invite** string source to `invite-recipients.tsx`. Tests cover seeding, removal, partial failure, and clipboard behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b2030f03753bd878e391b9820ef44070753a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->