### PR TITLE
Prevent desktop startup and log-rotation panics

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -204,6 +204,7 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           VITE_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN_HYPRNOTE_2 }}
+          CARGO_PROFILE_RELEASE_DEBUG: line-tables-only
           APP_VERSION: ${{ needs.compute-version.outputs.version }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
@@ -219,6 +220,43 @@ jobs:
           VITE_API_URL: "https://api.anarlog.so"
           VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
           VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
+      - if: ${{ inputs.channel == 'stable' }}
+        id: macos-symbols
+        name: Generate and verify macOS debug symbols
+        run: |
+          shopt -s nullglob
+          app_dir="apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/macos"
+          apps=("$app_dir"/*.app)
+          if [[ ${#apps[@]} -ne 1 ]]; then
+            echo "::error::Expected one macOS app for ${{ matrix.target }}, found ${#apps[@]}"
+            exit 1
+          fi
+
+          binary="${apps[0]}/Contents/MacOS/anarlog"
+          dsym="apps/desktop/src-tauri/target/${{ matrix.target }}/release/anarlog.dSYM"
+          dsymutil "$binary" -o "$dsym"
+
+          binary_uuid=$(dwarfdump --uuid "$binary" | awk '{print $2}')
+          dsym_uuid=$(dwarfdump --uuid "$dsym" | awk '{print $2}')
+          if [[ -z "$binary_uuid" || "$binary_uuid" != "$dsym_uuid" ]]; then
+            echo "::error::dSYM UUID does not match the packaged binary"
+            exit 1
+          fi
+
+          echo "Verified dSYM UUID $dsym_uuid"
+          echo "path=$dsym" >> "$GITHUB_OUTPUT"
+      - if: ${{ inputs.channel == 'stable' }}
+        uses: ./.github/actions/sentry_cli
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Upload macOS debug symbols to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          sentry-cli debug-files upload \
+            --org fastrepl \
+            --project hyprnote2 \
+            --include-sources \
+            "${{ steps.macos-symbols.outputs.path }}"
       - if: ${{ inputs.channel == 'stable' }}
         name: Verify macOS updater signature
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5912,16 +5912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "file-rotate"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8e2fa049328a1f3295991407a88585805d126dfaadf74b9fe8c194c730aafc"
-dependencies = [
- "chrono",
- "flate2",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19174,7 +19164,6 @@ name = "tauri-plugin-tracing"
 version = "0.1.0"
 dependencies = [
  "dirs 6.0.0",
- "file-rotate",
  "regex",
  "rquickjs 0.10.0",
  "sentry",

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -5,17 +5,18 @@ use anlg_db_core::Db;
 const DB_FILENAME: &str = "app.db";
 const DEFAULT_CLOUDSYNC_INTERVAL_MS: u64 = 30_000;
 
-pub async fn open_desktop_db(identifier: &str) -> Arc<Db> {
-    let db_path = desktop_db_dir(identifier).map(|dir| {
-        std::fs::create_dir_all(&dir).expect("failed to create app data dir");
-        dir.join(DB_FILENAME)
-    });
+pub async fn open_desktop_db(identifier: &str) -> Result<Arc<Db>, String> {
+    let dir = desktop_db_dir(identifier)
+        .ok_or_else(|| "application data directory is unavailable".to_string())?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|error| format!("failed to create application data directory: {error}"))?;
 
-    let db = tauri_plugin_db::open_app_db(db_path.as_deref())
+    let db_path = dir.join(DB_FILENAME);
+    let db = tauri_plugin_db::open_app_db(Some(&db_path))
         .await
-        .expect("failed to open app database");
+        .map_err(|error| format!("failed to open application database: {error}"))?;
 
-    Arc::new(db)
+    Ok(Arc::new(db))
 }
 
 pub fn cloudsync_runtime_config_from_env()
@@ -100,9 +101,8 @@ fn parse_env_flag(value: String) -> Result<bool, String> {
 }
 
 fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
-    let data_dir = dirs::data_dir().expect("data_dir must be available");
-    let default_dir =
-        anlg_storage::global::compute_default_base(identifier).expect("data_dir must be available");
+    let data_dir = dirs::data_dir()?;
+    let default_dir = anlg_storage::global::compute_default_base(identifier)?;
     let identifier_dir = data_dir.join(identifier);
 
     if identifier_dir.join(DB_FILENAME).is_file() && !default_dir.join(DB_FILENAME).is_file() {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -123,7 +123,10 @@ pub async fn main() {
     let audio: std::sync::Arc<dyn anlg_audio_actual::AudioProvider> =
         create_audio_provider(&context.config().identifier);
 
-    let db = open_desktop_db(&context.config().identifier).await;
+    let db = match open_desktop_db(&context.config().identifier).await {
+        Ok(db) => db,
+        Err(error) => exit_after_startup_failure(&error),
+    };
     let cloudsync_config = match cloudsync_runtime_config_from_env() {
         Ok(config) => config,
         Err(error) => {
@@ -276,13 +279,17 @@ pub async fn main() {
                 let appearance_settings =
                     appearance::load_app_appearance_settings::<tauri::Wry, _>(&app_handle);
 
-                app_handle
+                if let Err(error) = app_handle
                     .windows()
                     .set_show_app_in_dock(appearance_settings.show_app_in_dock)
-                    .unwrap();
+                {
+                    tracing::warn!(%error, "failed to apply dock visibility during startup");
+                }
 
                 if appearance_settings.show_tray_icon {
-                    app_handle.tray().create_tray_menu().unwrap();
+                    if let Err(error) = app_handle.tray().create_tray_menu() {
+                        tracing::warn!(%error, "failed to create tray menu during startup");
+                    }
                 }
             }
 
@@ -330,7 +337,11 @@ pub async fn main() {
 
     match get_onboarding_flag() {
         None => {}
-        Some(false) => app.set_onboarding_needed(false).unwrap(),
+        Some(false) => {
+            if let Err(error) = app.set_onboarding_needed(false) {
+                tracing::warn!(%error, "failed to persist onboarding state during startup");
+            }
+        }
         Some(true) => {
             use tauri_plugin_auth::AuthPluginExt;
             use tauri_plugin_settings::SettingsPluginExt;
@@ -356,7 +367,9 @@ pub async fn main() {
 
     {
         let app_handle = app.handle().clone();
-        AppWindow::Main.show(&app_handle).unwrap();
+        if let Err(error) = AppWindow::Main.show(&app_handle) {
+            exit_after_startup_failure(&error);
+        }
     }
 
     #[cfg(target_os = "macos")]
@@ -366,7 +379,9 @@ pub async fn main() {
     app.run(move |app, event| match event {
         #[cfg(target_os = "macos")]
         tauri::RunEvent::Reopen { .. } => {
-            AppWindow::Main.show(app).unwrap();
+            if let Err(error) = AppWindow::Main.show(app) {
+                tracing::error!(%error, "failed to reopen main window");
+            }
         }
         tauri::RunEvent::ExitRequested { api, .. } => {
             if let Some(ref ctx) = root_supervisor_ctx_for_run {

--- a/plugins/tracing/Cargo.toml
+++ b/plugins/tracing/Cargo.toml
@@ -32,7 +32,6 @@ serde_json = { workspace = true }
 specta = { workspace = true, features = ["derive", "serde_json"] }
 thiserror = { workspace = true }
 
-file-rotate = "0.8"
 regex = "1"
 tracing = { workspace = true }
 tracing-appender = { version = "0.2" }

--- a/plugins/tracing/src/lib.rs
+++ b/plugins/tracing/src/lib.rs
@@ -6,7 +6,7 @@ mod utils;
 
 pub use errors::*;
 pub use ext::*;
-pub use utils::cleanup_old_daily_logs;
+pub use utils::{cleanup_old_daily_logs, make_file_writer};
 
 use sentry::integrations::tracing::EventFilter;
 use tauri::Manager;
@@ -14,7 +14,7 @@ use tracing_subscriber::{
     EnvFilter, fmt, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt,
 };
 
-use utils::{cleanup_legacy_logs, make_file_writer_if_enabled};
+use utils::cleanup_legacy_logs;
 
 const PLUGIN_NAME: &str = "tracing";
 const WEBVIEW_CONSOLE_TARGET: &str = "anarlog.webview.console";
@@ -93,20 +93,24 @@ impl Builder {
                         return Ok(());
                     }
                 };
-                if let Some((file_writer, guard)) = make_file_writer_if_enabled(true, &logs_dir) {
-                    tracing_subscriber::Registry::default()
-                        .with(env_filter)
-                        .with(sentry_layer)
-                        .with(fmt::layer())
-                        .with(fmt::layer().with_ansi(false).with_writer(file_writer))
-                        .init();
-                    assert!(app.manage(guard));
-                } else {
-                    tracing_subscriber::Registry::default()
-                        .with(env_filter)
-                        .with(sentry_layer)
-                        .with(fmt::layer())
-                        .init();
+                match make_file_writer(&logs_dir) {
+                    Ok((file_writer, guard)) => {
+                        tracing_subscriber::Registry::default()
+                            .with(env_filter)
+                            .with(sentry_layer)
+                            .with(fmt::layer())
+                            .with(fmt::layer().with_ansi(false).with_writer(file_writer))
+                            .init();
+                        app.manage(guard);
+                    }
+                    Err(error) => {
+                        eprintln!("Failed to create log file: {error}");
+                        tracing_subscriber::Registry::default()
+                            .with(env_filter)
+                            .with(sentry_layer)
+                            .with(fmt::layer())
+                            .init();
+                    }
                 }
 
                 Ok(())

--- a/plugins/tracing/src/utils.rs
+++ b/plugins/tracing/src/utils.rs
@@ -1,9 +1,12 @@
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-use file_rotate::{ContentLimit, FileRotate, compression::Compression, suffix::AppendCount};
 use tauri::Manager;
 use tracing_appender::non_blocking::WorkerGuard;
+
+const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
+const MAX_LOG_FILES: usize = 5;
 
 pub(crate) fn cleanup_legacy_logs<M: Manager<tauri::Wry>>(app: &M) {
     let Ok(data_dir) = app.path().data_dir() else {
@@ -50,29 +53,138 @@ pub fn cleanup_old_daily_logs(logs_dir: &PathBuf) -> io::Result<()> {
     Ok(())
 }
 
-pub(crate) fn make_file_writer_if_enabled(
-    enabled: bool,
-    logs_dir: &PathBuf,
-) -> Option<(tracing_appender::non_blocking::NonBlocking, WorkerGuard)> {
-    if !enabled {
-        return None;
+struct SizeRollingWriter {
+    base_path: PathBuf,
+    file: Option<fs::File>,
+    max_bytes: u64,
+    max_files: usize,
+    written: u64,
+}
+
+impl SizeRollingWriter {
+    fn new(base_path: PathBuf, max_bytes: u64, max_files: usize) -> io::Result<Self> {
+        if max_bytes == 0 || max_files == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "log rotation limits must be greater than zero",
+            ));
+        }
+
+        if let Some(parent) = base_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut writer = Self {
+            base_path,
+            file: None,
+            max_bytes,
+            max_files,
+            written: 0,
+        };
+        writer.open_current_file()?;
+        Ok(writer)
     }
 
+    fn suffixed_path(&self, suffix: usize) -> PathBuf {
+        PathBuf::from(format!("{}.{}", self.base_path.display(), suffix))
+    }
+
+    fn remove_if_exists(path: &Path) -> io::Result<()> {
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn move_if_exists(source: &Path, destination: &Path) -> io::Result<()> {
+        Self::remove_if_exists(destination)?;
+        match fs::rename(source, destination) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn open_current_file(&mut self) -> io::Result<()> {
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.base_path)?;
+        self.written = file.metadata()?.len();
+        self.file = Some(file);
+        Ok(())
+    }
+
+    fn rotate(&mut self) -> io::Result<()> {
+        let flush_result = self
+            .file
+            .take()
+            .map(|mut file| file.flush())
+            .unwrap_or(Ok(()));
+        let rotation_result = flush_result.and_then(|_| {
+            Self::remove_if_exists(&self.suffixed_path(self.max_files))?;
+            for suffix in (1..self.max_files).rev() {
+                Self::move_if_exists(&self.suffixed_path(suffix), &self.suffixed_path(suffix + 1))?;
+            }
+            Self::move_if_exists(&self.base_path, &self.suffixed_path(1))
+        });
+        let open_result = self.open_current_file();
+
+        rotation_result.and(open_result)
+    }
+
+    fn current_file(&mut self) -> io::Result<&mut fs::File> {
+        self.file
+            .as_mut()
+            .ok_or_else(|| io::Error::other("log file is not open"))
+    }
+}
+
+impl Write for SizeRollingWriter {
+    fn write(&mut self, mut buffer: &[u8]) -> io::Result<usize> {
+        let total = buffer.len();
+
+        while !buffer.is_empty() {
+            if self.written >= self.max_bytes {
+                self.rotate()?;
+            }
+
+            let remaining = usize::try_from(self.max_bytes - self.written)
+                .unwrap_or(usize::MAX)
+                .min(buffer.len());
+            let written = self.current_file()?.write(&buffer[..remaining])?;
+            if written == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write application log",
+                ));
+            }
+
+            self.written += written as u64;
+            buffer = &buffer[written..];
+        }
+
+        Ok(total)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.current_file()?.flush()
+    }
+}
+
+pub fn make_file_writer(
+    logs_dir: &PathBuf,
+) -> io::Result<(tracing_appender::non_blocking::NonBlocking, WorkerGuard)> {
     let _ = cleanup_old_daily_logs(logs_dir);
 
     let log_path = logs_dir.join("app.log");
-    let file_appender = FileRotate::new(
-        log_path,
-        AppendCount::new(5),
-        ContentLimit::Bytes(5 * 1024 * 1024),
-        Compression::None,
-        None,
-    );
+    let file_appender = SizeRollingWriter::new(log_path, MAX_LOG_BYTES, MAX_LOG_FILES)?;
 
     let redacting_appender = crate::redaction::RedactingWriter::new(file_appender);
 
     let (non_blocking, guard) = tracing_appender::non_blocking(redacting_appender);
-    Some((non_blocking, guard))
+    Ok((non_blocking, guard))
 }
 
 #[cfg(test)]
@@ -143,5 +255,41 @@ mod tests {
 
         assert!(logs_dir.join("log.txt").exists());
         assert!(logs_dir.join("log.backup").exists());
+    }
+
+    #[test]
+    fn size_rolling_writer_rotates_without_panicking_on_existing_suffixes() {
+        let temp = tempdir().unwrap();
+        let log_path = temp.path().join("app.log");
+        fs::write(&log_path, "0123456789").unwrap();
+        fs::write(temp.path().join("app.log.1"), "previous").unwrap();
+
+        let mut writer = SizeRollingWriter::new(log_path, 10, 2).unwrap();
+        writer.write_all(b"abcdefghijk").unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(fs::read(temp.path().join("app.log")).unwrap(), b"k");
+        assert_eq!(
+            fs::read(temp.path().join("app.log.1")).unwrap(),
+            b"abcdefghij"
+        );
+        assert_eq!(
+            fs::read(temp.path().join("app.log.2")).unwrap(),
+            b"0123456789"
+        );
+    }
+
+    #[test]
+    fn size_rolling_writer_recovers_when_the_active_log_disappears() {
+        let temp = tempdir().unwrap();
+        let log_path = temp.path().join("app.log");
+        fs::write(&log_path, "0123456789").unwrap();
+
+        let mut writer = SizeRollingWriter::new(log_path.clone(), 10, 2).unwrap();
+        fs::remove_file(&log_path).unwrap();
+        writer.write_all(b"new log").unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(fs::read(log_path).unwrap(), b"new log");
     }
 }

--- a/plugins/tracing/tests/integration.rs
+++ b/plugins/tracing/tests/integration.rs
@@ -2,27 +2,16 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use tauri_plugin_tracing::redaction::RedactingWriter;
+use tauri_plugin_tracing::{make_file_writer, redaction::RedactingWriter};
 use tempfile::tempdir;
 
-use file_rotate::{ContentLimit, FileRotate, compression::Compression, suffix::AppendCount};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{fmt, prelude::*};
 
 fn create_test_file_writer(
     logs_dir: &PathBuf,
 ) -> (tracing_appender::non_blocking::NonBlocking, WorkerGuard) {
-    let log_path = logs_dir.join("app.log");
-    let file_appender = FileRotate::new(
-        log_path,
-        AppendCount::new(5),
-        ContentLimit::Bytes(5 * 1024 * 1024),
-        Compression::None,
-        None,
-    );
-
-    let redacting_appender = RedactingWriter::new(file_appender);
-    tracing_appender::non_blocking(redacting_appender)
+    make_file_writer(logs_dir).unwrap()
 }
 
 mod e2e {
@@ -126,17 +115,7 @@ mod e2e {
         let logs_dir = temp.path().to_path_buf();
         fs::create_dir_all(&logs_dir).unwrap();
 
-        let log_path = logs_dir.join("app.log");
-        let file_appender = FileRotate::new(
-            log_path,
-            AppendCount::new(5),
-            ContentLimit::Bytes(1024 * 1024),
-            Compression::None,
-            None,
-        );
-
-        let redacting_appender = RedactingWriter::new(file_appender);
-        let (file_writer, guard) = tracing_appender::non_blocking(redacting_appender);
+        let (file_writer, guard) = create_test_file_writer(&logs_dir);
 
         let subscriber = tracing_subscriber::registry()
             .with(fmt::layer().with_ansi(false).with_writer(file_writer));
@@ -209,7 +188,7 @@ mod e2e {
     }
 
     #[test]
-    fn test_redacting_writer_with_file_rotate_direct() {
+    fn test_redacting_writer_with_file_direct() {
         use std::io::Write;
 
         let temp = tempdir().unwrap();
@@ -217,13 +196,11 @@ mod e2e {
         fs::create_dir_all(&logs_dir).unwrap();
 
         let log_path = logs_dir.join("app.log");
-        let file_appender = FileRotate::new(
-            log_path,
-            AppendCount::new(5),
-            ContentLimit::Bytes(100),
-            Compression::None,
-            None,
-        );
+        let file_appender = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .unwrap();
 
         let mut redacting_writer = RedactingWriter::new(file_appender);
 


### PR DESCRIPTION
## Summary
- handle database, dock, tray, onboarding, and window startup failures without panicking
- replace assertion-based `file-rotate` behavior with tolerant size-based rotation
- generate UUID-verified macOS dSYMs and upload stable-release symbols to Sentry

## Verification
- `pnpm fmt:check`
- `cargo check --locked -p desktop`
- `cargo test -p desktop`
- `cargo test --locked -p tauri-plugin-tracing`
- `cargo clippy --locked -p tauri-plugin-tracing --all-targets -- -D warnings`
- local `dsymutil` and `dwarfdump` UUID match

## Sentry
Targets HYPRNOTE2-2MH7, HYPRNOTE2-2MJD, and HYPRNOTE2-20QF. Stable release CI requires `SENTRY_AUTH_TOKEN` to be available as a repository or organization secret.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core startup and logging paths; failures are handled more gracefully but behavior on DB/window errors shifts from crash to controlled exit with user messaging.
> 
> **Overview**
> Replaces **panic-prone desktop startup** with explicit error handling: database open and showing the main window now fail through `exit_after_startup_failure` (Sentry + macOS alert), while dock, tray, onboarding persistence, and reopen-window errors are logged instead of aborting.
> 
> The **tracing plugin** drops the `file-rotate` dependency in favor of an in-house **size-based rotator** (5 MB × 5 files) that tolerates pre-existing rotated files and a deleted active log; file logging init degrades to console-only on failure instead of asserting.
> 
> **Stable macOS CI** builds with `CARGO_PROFILE_RELEASE_DEBUG=line-tables-only`, generates and UUID-checks dSYMs, then uploads debug symbols (with sources) to Sentry for `hyprnote2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77658efce59003c9bd438d7204415072c28930f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->