### PR TITLE
Load Sentry symbol upload token from Infisical

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -246,12 +246,27 @@ jobs:
           echo "Verified dSYM UUID $dsym_uuid"
           echo "path=$dsym" >> "$GITHUB_OUTPUT"
       - if: ${{ inputs.channel == 'stable' }}
+        id: sentry-secrets
+        name: Load Sentry upload token
+        uses: ./.github/actions/infisical_export
+        with:
+          project-id: ${{ secrets.INFISICAL_PROJECT_ID }}
+          folder: /anarlog/github
+          env: prod
+        env:
+          INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
+      - if: ${{ inputs.channel == 'stable' }}
         uses: ./.github/actions/sentry_cli
       - if: ${{ inputs.channel == 'stable' }}
         name: Upload macOS debug symbols to Sentry
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ fromJSON(steps.sentry-secrets.outputs.secrets).SENTRY_AUTH_TOKEN }}
         run: |
+          if [[ -z "$SENTRY_AUTH_TOKEN" ]]; then
+            echo "::error::Missing SENTRY_AUTH_TOKEN in Infisical prod:/anarlog/github"
+            exit 1
+          fi
+
           sentry-cli debug-files upload \
             --org fastrepl \
             --project hyprnote2 \


### PR DESCRIPTION
## Summary
- load the macOS symbol upload token from Infisical `prod:/anarlog/github`
- fail fast when the credential is missing
- use the organization-scoped `org:ci` token created for desktop release symbols

## Validation
- `pnpm exec dprint fmt`
- `pnpm fmt:check`
- parsed `.github/workflows/desktop_cd.yaml` with `yq`
- verified the token against Sentry debug-files API (HTTP 200)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only secret sourcing for Sentry symbol upload; stable releases fail if Infisical or the token is misconfigured, with no app runtime impact.
> 
> **Overview**
> For **stable** macOS desktop CD, the Sentry debug-symbol upload step no longer uses the GitHub `SENTRY_AUTH_TOKEN` secret. It now runs **`infisical_export`** against `prod:/anarlog/github` and passes `SENTRY_AUTH_TOKEN` from that export into `sentry-cli`.
> 
> The upload step **fails fast** if the token is missing after export, with an explicit error pointing at the Infisical path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86cc8bc65f5d762a19b33c0b1f9e7f428aedfc3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->