### PR TITLE
Use record action for unknown meeting links

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -170,8 +170,10 @@ function HeaderMeetingActionPill({
   );
   const remote = getRemoteMeeting(event?.meeting_link);
   const meetingLink = event?.meeting_link || null;
-  const canJoinFromHeader =
-    remote !== null || event?.tracking_id === WELCOME_NOTE_TRACKING_ID;
+  const canJoinFromHeader = Boolean(
+    meetingLink &&
+    (remote !== null || event?.tracking_id === WELCOME_NOTE_TRACKING_ID),
+  );
   const hasTranscript = useHasTranscript(sessionId);
   const { audioExists } = useAudioPlayer();
   const canResume = audioExists || hasTranscript;


### PR DESCRIPTION
Show the default record action for unrecognized meeting URLs while preserving join-and-record for supported platforms and the onboarding demo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single boolean guard in session header UI; low impact on recording or auth flows.
> 
> **Overview**
> **Join & record** in the session outer header now only appears when the event has a **meeting link** and the URL is a supported platform (via `getRemoteMeeting`) or the onboarding welcome-note demo.
> 
> Sessions with an unrecognized or unsupported meeting URL (link present but `remote === null`) keep the default **Record** / **Resume** action instead of offering join-and-record. The welcome-note path still uses **Join & record**, but only when a link is available to open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67154da3a4ca1a8d7bc6be02e94b7aba05e4192d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->