### PR TITLE
Show active meeting titles in the menu bar

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -31,6 +31,7 @@ import { FloatingMeetingWindowHost } from "./meeting-float/host";
 import { routeTree } from "./routeTree.gen";
 import { EventListeners } from "./services/event-listeners";
 import { TaskManager } from "./services/task-manager";
+import { TrayRecordingSync } from "./services/tray-recording";
 import { TrayScheduleSync } from "./services/tray-schedule";
 import { useRemoteSessionDeletionUndoListener } from "./session/hooks/useDeleteSession";
 import { refreshLegacySettingsSnapshots } from "./settings/legacy-snapshots";
@@ -99,6 +100,7 @@ function AppRoot() {
         {isMainWindow ? <FloatingMeetingWindowHost /> : null}
         {isMainWindow ? <EventListeners /> : null}
         {isMainWindow ? <TrayScheduleSync /> : null}
+        {isMainWindow ? <TrayRecordingSync /> : null}
         <Toaster position="bottom-right" theme={theme} />
       </TinyTickProvider>
     </QueryClientProvider>

--- a/apps/desktop/src/services/tray-recording.test.ts
+++ b/apps/desktop/src/services/tray-recording.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  createTrayRecordingTitlePublisher,
+  getTrayRecordingSessionId,
+  getTrayRecordingTitle,
+} from "./tray-recording";
+
+import { resolveLiveSessionTitle } from "~/store/zustand/live-title";
+
+describe("createTrayRecordingTitlePublisher", () => {
+  test("publishes title changes in order", async () => {
+    let resolveFirst: (() => void) | undefined;
+    const published: Array<string | null> = [];
+    const publish = createTrayRecordingTitlePublisher(
+      (title) =>
+        new Promise<void>((resolve) => {
+          published.push(title);
+          if (title === "First") {
+            resolveFirst = resolve;
+          } else {
+            resolve();
+          }
+        }),
+    );
+
+    const first = publish("First");
+    const second = publish("Second");
+
+    await Promise.resolve();
+    expect(published).toEqual(["First"]);
+
+    resolveFirst?.();
+    await Promise.all([first, second]);
+
+    expect(published).toEqual(["First", "Second"]);
+  });
+});
+
+describe("getTrayRecordingSessionId", () => {
+  test.each(["active", "finalizing"] as const)(
+    "keeps the recording session while %s",
+    (status) => {
+      expect(getTrayRecordingSessionId(status, "session-1")).toBe("session-1");
+    },
+  );
+
+  test("clears the recording session when inactive", () => {
+    expect(getTrayRecordingSessionId("inactive", "session-1")).toBe("");
+  });
+});
+
+describe("getTrayRecordingTitle", () => {
+  test("returns a real session title", () => {
+    expect(getTrayRecordingTitle("  Customer call  ")).toBe("Customer call");
+  });
+
+  test.each([undefined, null, "", "  ", "Untitled", "Untitled event"])(
+    "hides an ad-hoc placeholder title: %s",
+    (title) => {
+      expect(getTrayRecordingTitle(title)).toBeNull();
+    },
+  );
+});
+
+describe("resolveLiveSessionTitle", () => {
+  test("keeps a persisted optimistic title until the live query catches up", () => {
+    expect(
+      resolveLiveSessionTitle(
+        {
+          value: "Customer call",
+          persisted: true,
+          persistedAt: Date.now(),
+          previousTitle: "Untitled",
+        },
+        "Untitled",
+      ),
+    ).toBe("Customer call");
+  });
+
+  test("uses a newer store title after the optimistic write is acknowledged", () => {
+    expect(
+      resolveLiveSessionTitle(
+        {
+          value: "Customer call",
+          persisted: true,
+          persistedAt: Date.now(),
+          previousTitle: "Untitled",
+        },
+        "Customer follow-up",
+      ),
+    ).toBe("Customer follow-up");
+  });
+
+  test("drops an unacknowledged optimistic title after the live-query window", () => {
+    expect(
+      resolveLiveSessionTitle(
+        {
+          value: "Customer call",
+          persisted: true,
+          persistedAt: 0,
+          previousTitle: "Untitled",
+        },
+        "Untitled",
+      ),
+    ).toBe("Untitled");
+  });
+});

--- a/apps/desktop/src/services/tray-recording.tsx
+++ b/apps/desktop/src/services/tray-recording.tsx
@@ -1,0 +1,88 @@
+import { useStore } from "zustand";
+
+import { commands as trayCommands } from "@anlg/plugin-tray";
+
+import { useSession } from "~/session/queries";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+import { type LiveSessionStatus } from "~/store/zustand/listener/general-shared";
+import { listenerStore } from "~/store/zustand/listener/instance";
+import {
+  resolveLiveSessionTitle,
+  useLiveTitle,
+} from "~/store/zustand/live-title";
+
+const UNTITLED_SESSION_TITLES = new Set([
+  "untitled",
+  "untitled event",
+  "untitled meeting",
+  "untitled note",
+]);
+
+const publishTrayRecordingTitle = createTrayRecordingTitlePublisher(
+  async (title) => {
+    const result = await trayCommands.setTrayRecordingTitle(title);
+    if (result.status === "error") {
+      console.error("[tray] failed to publish recording title", result.error);
+    }
+  },
+);
+
+export function TrayRecordingSync() {
+  const activeSessionId = useStore(listenerStore, (state) =>
+    getTrayRecordingSessionId(state.live.status, state.live.sessionId),
+  );
+  const session = useSession(activeSessionId);
+  const liveTitle = useLiveTitle((state) => state.titles[activeSessionId]);
+  const title = getTrayRecordingTitle(
+    resolveLiveSessionTitle(liveTitle, session?.title),
+  );
+
+  return (
+    <TrayRecordingPublisher
+      key={`${activeSessionId}:${title ?? ""}`}
+      title={title}
+    />
+  );
+}
+
+export function getTrayRecordingSessionId(
+  status: LiveSessionStatus,
+  sessionId: string | null,
+): string {
+  return status === "active" || status === "finalizing"
+    ? (sessionId ?? "")
+    : "";
+}
+
+export function getTrayRecordingTitle(
+  title: string | null | undefined,
+): string | null {
+  const normalized = title?.trim();
+  if (!normalized || UNTITLED_SESSION_TITLES.has(normalized.toLowerCase())) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function createTrayRecordingTitlePublisher(
+  publish: (title: string | null) => Promise<void>,
+) {
+  let queue = Promise.resolve();
+
+  return (title: string | null) => {
+    const publication = queue.then(() => publish(title));
+    queue = publication.catch(() => undefined);
+    return publication;
+  };
+}
+
+function TrayRecordingPublisher({ title }: { title: string | null }) {
+  useMountEffect(() => {
+    void publishTrayRecordingTitle(title).catch((error) => {
+      console.error("[tray] failed to publish recording title", error);
+    });
+  });
+
+  return null;
+}

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -1,4 +1,11 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { type ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -8,6 +15,7 @@ import { TitleInput } from "./title-input";
 
 const hoisted = vi.hoisted(() => ({
   clearLiveTitle: vi.fn(),
+  markLiveTitlePersisted: vi.fn(),
   setStoreTitle: vi.fn((_title?: string) => Promise.resolve()),
   setLiveTitle: vi.fn(),
   storeTitle: "Untitled" as string | undefined,
@@ -31,11 +39,13 @@ vi.mock("~/store/zustand/live-title", () => ({
   useLiveTitle: (
     selector: (state: {
       clearTitle: typeof hoisted.clearLiveTitle;
+      markTitlePersisted: typeof hoisted.markLiveTitlePersisted;
       setTitle: typeof hoisted.setLiveTitle;
     }) => unknown,
   ) =>
     selector({
       clearTitle: hoisted.clearLiveTitle,
+      markTitlePersisted: hoisted.markLiveTitlePersisted,
       setTitle: hoisted.setLiveTitle,
     }),
 }));
@@ -99,6 +109,136 @@ describe("TitleInput", () => {
     expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
     expect(onTransferContentToEditor).not.toHaveBeenCalled();
     expect(onFocusEditorAtStart).not.toHaveBeenCalled();
+  });
+
+  it("keeps the live title until the persisted title settles", async () => {
+    let resolveUpdate: (() => void) | undefined;
+    hoisted.setStoreTitle.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+    renderTitleInput();
+
+    const input = screen.getByPlaceholderText("Untitled");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "Customer call" } });
+    fireEvent.blur(input);
+
+    expect(hoisted.setStoreTitle).toHaveBeenCalledWith("Customer call");
+    expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
+
+    resolveUpdate?.();
+
+    await waitFor(() => {
+      expect(hoisted.markLiveTitlePersisted).toHaveBeenCalledWith(
+        "session-1",
+        "Customer call",
+        "Untitled",
+      );
+    });
+    expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
+  });
+
+  it("keeps the live title when Enter persists the title", async () => {
+    let resolveUpdate: (() => void) | undefined;
+    hoisted.setStoreTitle.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+    renderTitleInput();
+
+    const input = screen.getByPlaceholderText("Untitled");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "Customer call" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(hoisted.setStoreTitle).toHaveBeenCalledWith("Customer call");
+    expect(hoisted.setLiveTitle).toHaveBeenLastCalledWith(
+      "session-1",
+      "Customer call",
+    );
+    expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
+
+    resolveUpdate?.();
+
+    await waitFor(() => {
+      expect(hoisted.markLiveTitlePersisted).toHaveBeenCalledWith(
+        "session-1",
+        "Customer call",
+        "Untitled",
+      );
+    });
+    expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
+  });
+
+  it("does not let an earlier blur clear a later Enter title", async () => {
+    let resolveBlurUpdate: (() => void) | undefined;
+    let resolveEnterUpdate: (() => void) | undefined;
+    hoisted.setStoreTitle
+      .mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          resolveBlurUpdate = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          resolveEnterUpdate = resolve;
+        }),
+      );
+    renderTitleInput();
+
+    const input = screen.getByPlaceholderText("Untitled");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "Customer call" } });
+    fireEvent.blur(input);
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await act(async () => {
+      resolveBlurUpdate?.();
+      await Promise.resolve();
+    });
+
+    expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
+    expect(hoisted.markLiveTitlePersisted).not.toHaveBeenCalled();
+
+    resolveEnterUpdate?.();
+
+    await waitFor(() => {
+      expect(hoisted.markLiveTitlePersisted).toHaveBeenCalledWith(
+        "session-1",
+        "Customer call",
+        "Untitled",
+      );
+    });
+    expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
+  });
+
+  it("does not clear a newer live title when an earlier update settles", async () => {
+    let resolveUpdate: (() => void) | undefined;
+    hoisted.setStoreTitle.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+    renderTitleInput();
+
+    const input = screen.getByPlaceholderText("Untitled");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "Customer call" } });
+    fireEvent.blur(input);
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "Customer follow-up" } });
+
+    await act(async () => {
+      resolveUpdate?.();
+      await Promise.resolve();
+    });
+
+    expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
+    expect(hoisted.markLiveTitlePersisted).not.toHaveBeenCalled();
   });
 
   it("left-aligns the empty title field without a generate button", () => {

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -165,7 +165,9 @@ const TitleInputInner = memo(
       const [showEndFade, setShowEndFade] = useState(false);
       const [isTitleFocused, setIsTitleFocused] = useState(false);
       const internalRef = useRef<HTMLInputElement>(null);
+      const editRevisionRef = useRef(0);
       const setLiveTitle = useLiveTitle((s) => s.setTitle);
+      const markLiveTitlePersisted = useLiveTitle((s) => s.markTitlePersisted);
       const clearLiveTitle = useLiveTitle((s) => s.clearTitle);
       const title = draftTitle ?? storeTitle ?? "";
 
@@ -292,11 +294,36 @@ const TitleInputInner = memo(
       }, [title, updateOverflowState]);
 
       const setStoreTitle = useCallback(
-        (title: string) =>
-          updateSession({ title }).catch((error) => {
-            console.error("[title-input] failed to persist title", error);
-          }),
+        (title: string) => updateSession({ title }),
         [updateSession],
+      );
+
+      const persistTitle = useCallback(
+        (value: string) => {
+          const editRevision = editRevisionRef.current;
+          const previousTitle = storeTitle;
+          return setStoreTitle(value)
+            .then(() => {
+              if (editRevisionRef.current !== editRevision) return;
+              markLiveTitlePersisted(sessionId, value, previousTitle);
+            })
+            .catch((error) => {
+              console.error("[title-input] failed to persist title", error);
+              if (editRevisionRef.current !== editRevision) return;
+              clearLiveTitle(sessionId);
+            })
+            .finally(() => {
+              if (editRevisionRef.current !== editRevision) return;
+              setDraftTitle(null);
+            });
+        },
+        [
+          clearLiveTitle,
+          markLiveTitlePersisted,
+          sessionId,
+          setStoreTitle,
+          storeTitle,
+        ],
       );
 
       const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -318,9 +345,10 @@ const TitleInputInner = memo(
           const beforeCursor = input.value.slice(0, cursorPos);
           const afterCursor = input.value.slice(cursorPos);
 
+          editRevisionRef.current += 1;
           setDraftTitle(beforeCursor);
-          void setStoreTitle(beforeCursor);
-          clearLiveTitle(sessionId);
+          setLiveTitle(sessionId, beforeCursor);
+          void persistTitle(beforeCursor);
 
           if (afterCursor) {
             setTimeout(() => onTransferContentToEditor?.(afterCursor), 0);
@@ -381,6 +409,7 @@ const TitleInputInner = memo(
             type="text"
             onChange={(e) => {
               const value = e.target.value;
+              editRevisionRef.current += 1;
               setDraftTitle(value);
               setLiveTitle(sessionId, value);
               updateOverflowState(e.target);
@@ -395,10 +424,7 @@ const TitleInputInner = memo(
             }}
             onBlur={(e) => {
               setIsTitleFocused(false);
-              void setStoreTitle(e.target.value).finally(() => {
-                setDraftTitle(null);
-              });
-              clearLiveTitle(sessionId);
+              void persistTitle(e.target.value);
               updateOverflowState(e.target);
             }}
             onScroll={(e) => updateOverflowState(e.currentTarget)}

--- a/apps/desktop/src/store/zustand/live-title.ts
+++ b/apps/desktop/src/store/zustand/live-title.ts
@@ -1,15 +1,57 @@
 import { create } from "zustand";
 
+const LIVE_TITLE_ACK_WINDOW_MS = 10_000;
+
 interface LiveTitleState {
-  titles: Record<string, string>;
+  titles: Record<
+    string,
+    {
+      value: string;
+      persisted: boolean;
+      persistedAt: number | null;
+      previousTitle: string | undefined;
+    }
+  >;
   setTitle: (sessionId: string, title: string) => void;
+  markTitlePersisted: (
+    sessionId: string,
+    title: string,
+    previousTitle: string | undefined,
+  ) => void;
   clearTitle: (sessionId: string) => void;
 }
 
 export const useLiveTitle = create<LiveTitleState>((set) => ({
   titles: {},
   setTitle: (sessionId, title) =>
-    set((state) => ({ titles: { ...state.titles, [sessionId]: title } })),
+    set((state) => ({
+      titles: {
+        ...state.titles,
+        [sessionId]: {
+          value: title,
+          persisted: false,
+          persistedAt: null,
+          previousTitle: undefined,
+        },
+      },
+    })),
+  markTitlePersisted: (sessionId, title, previousTitle) =>
+    set((state) => {
+      const current = state.titles[sessionId];
+      if (current?.value !== title) return state;
+
+      return {
+        titles: {
+          ...state.titles,
+          [sessionId]: {
+            value: title,
+            persisted: true,
+            persistedAt: Date.now(),
+            previousTitle,
+          },
+        },
+      };
+    }),
   clearTitle: (sessionId) =>
     set((state) => {
       const { [sessionId]: _, ...rest } = state.titles;
@@ -18,10 +60,31 @@ export const useLiveTitle = create<LiveTitleState>((set) => ({
 }));
 
 export function hasLiveSessionTitleDraft(sessionId: string): boolean {
-  return Object.prototype.hasOwnProperty.call(
-    useLiveTitle.getState().titles,
-    sessionId,
-  );
+  const title = useLiveTitle.getState().titles[sessionId];
+  return Boolean(title && !title.persisted);
+}
+
+export function resolveLiveSessionTitle(
+  liveTitle:
+    | {
+        value: string;
+        persisted: boolean;
+        persistedAt: number | null;
+        previousTitle: string | undefined;
+      }
+    | undefined,
+  storeTitle: string | undefined,
+): string {
+  if (!liveTitle) return storeTitle ?? "Untitled";
+  if (!liveTitle.persisted) return liveTitle.value;
+  if (
+    storeTitle === liveTitle.previousTitle &&
+    liveTitle.persistedAt !== null &&
+    Date.now() - liveTitle.persistedAt <= LIVE_TITLE_ACK_WINDOW_MS
+  ) {
+    return liveTitle.value;
+  }
+  return storeTitle ?? liveTitle.value;
 }
 
 export function useSessionTitle(
@@ -29,5 +92,5 @@ export function useSessionTitle(
   storeTitle: string | undefined,
 ): string {
   const liveTitle = useLiveTitle((s) => s.titles[sessionId]);
-  return liveTitle ?? (storeTitle as string) ?? "Untitled";
+  return resolveLiveSessionTitle(liveTitle, storeTitle);
 }

--- a/plugins/tray/build.rs
+++ b/plugins/tray/build.rs
@@ -1,4 +1,8 @@
-const COMMANDS: &[&str] = &["set_tray_icon_visible", "set_tray_schedule"];
+const COMMANDS: &[&str] = &[
+    "set_tray_icon_visible",
+    "set_tray_schedule",
+    "set_tray_recording_title",
+];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).build();

--- a/plugins/tray/js/bindings.gen.ts
+++ b/plugins/tray/js/bindings.gen.ts
@@ -21,6 +21,14 @@ async setTraySchedule(events: TrayScheduleEvent[]) : Promise<Result<null, string
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async setTrayRecordingTitle(title: string | null) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:anlg-tray|set_tray_recording_title", { title }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/plugins/tray/permissions/autogenerated/commands/set_tray_recording_title.toml
+++ b/plugins/tray/permissions/autogenerated/commands/set_tray_recording_title.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-set-tray-recording-title"
+description = "Enables the set_tray_recording_title command without any pre-configured scope."
+commands.allow = ["set_tray_recording_title"]
+
+[[permission]]
+identifier = "deny-set-tray-recording-title"
+description = "Denies the set_tray_recording_title command without any pre-configured scope."
+commands.deny = ["set_tray_recording_title"]

--- a/plugins/tray/permissions/autogenerated/reference.md
+++ b/plugins/tray/permissions/autogenerated/reference.md
@@ -5,6 +5,7 @@ Default permissions for the plugin
 #### This default permission set includes the following:
 
 - `allow-set-tray-icon-visible`
+- `allow-set-tray-recording-title`
 - `allow-set-tray-schedule`
 
 ## Permission Table
@@ -38,6 +39,32 @@ Enables the set_tray_icon_visible command without any pre-configured scope.
 <td>
 
 Denies the set_tray_icon_visible command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`anlg-tray:allow-set-tray-recording-title`
+
+</td>
+<td>
+
+Enables the set_tray_recording_title command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`anlg-tray:deny-set-tray-recording-title`
+
+</td>
+<td>
+
+Denies the set_tray_recording_title command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/tray/permissions/default.toml
+++ b/plugins/tray/permissions/default.toml
@@ -2,5 +2,6 @@
 description = "Default permissions for the plugin"
 permissions = [
     "allow-set-tray-icon-visible",
+    "allow-set-tray-recording-title",
     "allow-set-tray-schedule",
 ]

--- a/plugins/tray/permissions/schemas/schema.json
+++ b/plugins/tray/permissions/schemas/schema.json
@@ -307,6 +307,18 @@
           "markdownDescription": "Denies the set_tray_icon_visible command without any pre-configured scope."
         },
         {
+          "description": "Enables the set_tray_recording_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-set-tray-recording-title",
+          "markdownDescription": "Enables the set_tray_recording_title command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_tray_recording_title command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-set-tray-recording-title",
+          "markdownDescription": "Denies the set_tray_recording_title command without any pre-configured scope."
+        },
+        {
           "description": "Enables the set_tray_schedule command without any pre-configured scope.",
           "type": "string",
           "const": "allow-set-tray-schedule",
@@ -319,10 +331,10 @@
           "markdownDescription": "Denies the set_tray_schedule command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-set-tray-icon-visible`\n- `allow-set-tray-schedule`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-set-tray-icon-visible`\n- `allow-set-tray-recording-title`\n- `allow-set-tray-schedule`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-set-tray-icon-visible`\n- `allow-set-tray-schedule`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-set-tray-icon-visible`\n- `allow-set-tray-recording-title`\n- `allow-set-tray-schedule`"
         }
       ]
     }

--- a/plugins/tray/src/commands.rs
+++ b/plugins/tray/src/commands.rs
@@ -20,3 +20,14 @@ pub async fn set_tray_schedule(
         .set_schedule(events)
         .map_err(|error| error.to_string())
 }
+
+#[tauri::command]
+#[specta::specta]
+pub async fn set_tray_recording_title(
+    app: tauri::AppHandle<tauri::Wry>,
+    title: Option<String>,
+) -> Result<(), String> {
+    app.tray()
+        .set_recording_title(title)
+        .map_err(|error| error.to_string())
+}

--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -34,7 +34,8 @@ static START_DISABLED: AtomicBool = AtomicBool::new(false);
 static ANIMATION_TASK: Mutex<Option<JoinHandle<()>>> = Mutex::new(None);
 static SCHEDULE: Mutex<Vec<TrayScheduleEvent>> = Mutex::new(Vec::new());
 static SCHEDULE_TASK: Mutex<Option<JoinHandle<()>>> = Mutex::new(None);
-static SCHEDULE_TITLE: Mutex<Option<String>> = Mutex::new(None);
+static MENU_BAR_TITLE: Mutex<Option<String>> = Mutex::new(None);
+static RECORDING_TITLE: Mutex<Option<String>> = Mutex::new(None);
 static AGENDA_SECTIONS: Mutex<Vec<TrayAgendaSection>> = Mutex::new(Vec::new());
 
 #[cfg(target_os = "macos")]
@@ -148,7 +149,7 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
             .show_menu_on_left_click(true)
             .build(app)?;
 
-        Self::refresh_schedule_title(app)?;
+        Self::refresh_menu_bar_title(app)?;
 
         Ok(())
     }
@@ -196,7 +197,7 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
         *SCHEDULE.lock().unwrap() = events;
 
         let app = self.manager.app_handle();
-        Self::refresh_schedule_title(app)?;
+        Self::refresh_menu_bar_title(app)?;
         Self::refresh_menu_if_agenda_changed(app)?;
 
         let mut task = SCHEDULE_TASK.lock().unwrap();
@@ -206,8 +207,8 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
                 loop {
                     interval.tick().await;
-                    if let Err(error) = Self::refresh_schedule_title(&app) {
-                        tracing::warn!(%error, "failed to refresh tray schedule title");
+                    if let Err(error) = Self::refresh_menu_bar_title(&app) {
+                        tracing::warn!(%error, "failed to refresh menu bar title");
                     }
                     if let Err(error) = Self::refresh_menu_if_agenda_changed(&app) {
                         tracing::warn!(%error, "failed to refresh tray agenda");
@@ -228,7 +229,7 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
 
         let app = self.manager.app_handle();
         Self::persist_show_events(app, show);
-        Self::refresh_schedule_title(app)?;
+        Self::refresh_menu_bar_title(app)?;
         Self::rebuild_menu(app)
     }
 
@@ -258,7 +259,7 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
         }
     }
 
-    fn refresh_schedule_title(app: &AppHandle<tauri::Wry>) -> Result<()> {
+    fn refresh_menu_bar_title(app: &AppHandle<tauri::Wry>) -> Result<()> {
         let Some(tray) = app.tray_by_id(TRAY_ID) else {
             return Ok(());
         };
@@ -267,12 +268,15 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as f64;
+        let recording_title = RECORDING_TITLE.lock().unwrap().clone();
         let title = menu_bar_title(
             &SCHEDULE.lock().unwrap(),
             now_ms,
             SHOW_EVENTS.load(Ordering::SeqCst),
+            IS_RECORDING.load(Ordering::SeqCst),
+            recording_title.as_deref(),
         );
-        let mut current_title = SCHEDULE_TITLE.lock().unwrap();
+        let mut current_title = MENU_BAR_TITLE.lock().unwrap();
 
         if *current_title != title {
             // tray-icon currently treats None as a no-op on macOS.
@@ -363,7 +367,21 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
 
     pub fn set_recording(&self, recording: bool) -> Result<()> {
         IS_RECORDING.store(recording, Ordering::SeqCst);
-        Self::refresh_icon(self.manager.app_handle())
+        if !recording {
+            *RECORDING_TITLE.lock().unwrap() = None;
+        }
+
+        let app = self.manager.app_handle();
+        Self::refresh_menu_bar_title(app)?;
+        Self::refresh_icon(app)
+    }
+
+    pub fn set_recording_title(&self, title: Option<String>) -> Result<()> {
+        *RECORDING_TITLE.lock().unwrap() = title.and_then(|title| {
+            let title = title.trim();
+            (!title.is_empty()).then(|| title.to_string())
+        });
+        Self::refresh_menu_bar_title(self.manager.app_handle())
     }
 
     pub fn set_degraded(&self, degraded: bool) -> Result<()> {

--- a/plugins/tray/src/lib.rs
+++ b/plugins/tray/src/lib.rs
@@ -64,6 +64,7 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
         .commands(tauri_specta::collect_commands![
             commands::set_tray_icon_visible,
             commands::set_tray_schedule,
+            commands::set_tray_recording_title,
         ])
         .error_handling(tauri_specta::ErrorHandlingMode::Result)
 }

--- a/plugins/tray/src/schedule.rs
+++ b/plugins/tray/src/schedule.rs
@@ -84,7 +84,18 @@ pub fn menu_bar_title(
     events: &[TrayScheduleEvent],
     now_ms: f64,
     show_events: bool,
+    is_recording: bool,
+    recording_title: Option<&str>,
 ) -> Option<String> {
+    if is_recording {
+        let title = recording_title?.trim();
+        if title.is_empty() {
+            return None;
+        }
+
+        return Some(compact_title(title, MAX_MENU_BAR_LABEL_WIDTH));
+    }
+
     if !show_events {
         return None;
     }
@@ -225,7 +236,7 @@ mod tests {
         ];
 
         assert_eq!(
-            menu_bar_title(&events, now, true),
+            menu_bar_title(&events, now, true, false, None),
             Some("Standup • in 5m".to_string())
         );
     }
@@ -243,7 +254,7 @@ mod tests {
         ];
 
         assert_eq!(
-            menu_bar_title(&events, now, true),
+            menu_bar_title(&events, now, true, false, None),
             Some("Active meeting • 10m left".to_string())
         );
     }
@@ -258,11 +269,14 @@ mod tests {
         )];
 
         assert_eq!(
-            menu_bar_title(&events, now, true),
+            menu_bar_title(&events, now, true, false, None),
             Some("Sprint retrospec… • in 17h 20m".to_string())
         );
         assert_eq!(
-            menu_bar_title(&events, now, true).unwrap().chars().count(),
+            menu_bar_title(&events, now, true, false, None)
+                .unwrap()
+                .chars()
+                .count(),
             MAX_MENU_BAR_LABEL_WIDTH
         );
     }
@@ -276,10 +290,34 @@ mod tests {
             None,
         )];
 
-        let title = menu_bar_title(&events, now, true).unwrap();
+        let title = menu_bar_title(&events, now, true, false, None).unwrap();
 
         assert_eq!(title, "[실뻘한] char 정치현… • in 29m");
         assert_eq!(title.width(), MAX_MENU_BAR_LABEL_WIDTH);
+    }
+
+    #[test]
+    fn shows_the_recording_title_instead_of_the_calendar_schedule() {
+        let now = 1_000_000.0;
+        let events = vec![event("Unrelated event", now + 60_000.0, None)];
+
+        assert_eq!(
+            menu_bar_title(&events, now, true, true, Some("Customer call")),
+            Some("Customer call".to_string())
+        );
+        assert_eq!(
+            menu_bar_title(&events, now, false, true, Some("Customer call")),
+            Some("Customer call".to_string())
+        );
+    }
+
+    #[test]
+    fn hides_the_schedule_during_an_untitled_recording() {
+        let now = 1_000_000.0;
+        let events = vec![event("Unrelated event", now + 60_000.0, None)];
+
+        assert_eq!(menu_bar_title(&events, now, true, true, None), None);
+        assert_eq!(menu_bar_title(&events, now, true, true, Some("  ")), None);
     }
 
     #[test]
@@ -287,7 +325,7 @@ mod tests {
         let now = 1_000_000.0;
         let events = vec![event("Finished", now - 60_000.0, Some(now - 1.0))];
 
-        assert_eq!(menu_bar_title(&events, now, true), None);
+        assert_eq!(menu_bar_title(&events, now, true, false, None), None);
     }
 
     #[test]
@@ -295,7 +333,7 @@ mod tests {
         let now = 1_000_000.0;
         let events = vec![event("Standup", now + 5.0 * 60.0 * 1000.0, None)];
 
-        assert_eq!(menu_bar_title(&events, now, false), None);
+        assert_eq!(menu_bar_title(&events, now, false, false, None), None);
     }
 
     #[test]


### PR DESCRIPTION
Use the active session title while recording, hide labels for untitled ad-hoc sessions, and restore upcoming calendar labels afterward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Menu bar and title UX changes with solid unit test coverage; no auth, security, or data-model changes.
> 
> **Overview**
> While a session is **active** or **finalizing**, the macOS menu bar shows the current meeting title instead of the calendar schedule. **Untitled** and similar placeholder titles are suppressed so ad-hoc recordings do not show a label; when recording stops, the usual upcoming-event text returns.
> 
> A new **`TrayRecordingSync`** service on the main window follows the live session, resolves the title from the session store plus live-title state, and pushes updates to the tray plugin through **`set_tray_recording_title`** (serialized so out-of-order IPC does not flash stale text). The tray plugin stores a separate recording title and **`menu_bar_title`** prefers it whenever recording is on.
> 
> **Live title** handling was extended so titles stay visible until persistence settles: **`markTitlePersisted`**, a short ack window in **`resolveLiveSessionTitle`**, and **`TitleInput`** no longer clears the live title on blur/Enter immediately—revision guards avoid races when blur and Enter overlap or edits change mid-save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1129fdfd901a435b310b56a8759860caf7eea56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->