### PR TITLE
Refresh desktop 1.4.3 changelog

### DIFF
--- a/packages/changelog/content/1.4.3.md
+++ b/packages/changelog/content/1.4.3.md
@@ -1,6 +1,6 @@
 ---
-date: "2026-08-04"
-summary: "Anarlog 1.4.3 makes sharing faster and safer, simplifies navigation, improves meeting and trial workflows, and strengthens reliability."
+date: "2026-08-05"
+summary: "Anarlog 1.4.3 makes notes and recording simpler, improves sharing and navigation, and strengthens reliability."
 ---
 
 ## Sharing and safety
@@ -17,6 +17,12 @@ summary: "Anarlog 1.4.3 makes sharing faster and safer, simplifies navigation, i
 
 ## Meetings and navigation
 
+- Write memos in a cleaner editor without a duplicate title field, with a
+  focused prompt when you start a new note
+- Start recording directly from scheduled notes with unsupported meeting links
+  while keeping **Join & record** for supported calls
+- See the current recording title in the menu bar, with upcoming calendar
+  titles restored automatically after recording stops
 - Keep notes you own in **My notes**, find notes others shared with you in a
   focused **Shared** view, and spot shared notes by their people icon
 - Browse and search your full automation conversation history from a dedicated


### PR DESCRIPTION
Add the final memo, recording, and menu bar improvements to the stable release notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no application or infrastructure changes.
> 
> **Overview**
> Updates the **1.4.3** desktop changelog so the public release notes match the final memo, recording, and menu bar work.
> 
> Front matter moves the release date to **2026-08-05** and revises the one-line summary to highlight simpler notes/recording alongside sharing, navigation, and reliability. Under **Meetings and navigation**, three new bullets document the cleaner memo editor (no duplicate title, focused new-note prompt), recording from scheduled notes when the meeting link is unsupported (with **Join & record** unchanged for supported calls), and menu bar recording title plus calendar title restoration after stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce4b7269c0bf6dfe4eafed4c1b2483c1858453a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->