### PR TITLE
Install Infisical on macOS release runners

### DIFF
--- a/.github/actions/infisical_install/action.yaml
+++ b/.github/actions/infisical_install/action.yaml
@@ -1,7 +1,11 @@
 runs:
   using: "composite"
   steps:
-    - shell: bash
+    - if: runner.os == 'Linux'
+      shell: bash
       run: |
         curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
         sudo apt-get install -y infisical
+    - if: runner.os == 'macOS'
+      shell: bash
+      run: brew install infisical/get-cli/infisical


### PR DESCRIPTION
Use the documented Homebrew installer on macOS while retaining the Debian installer for Linux. This unblocks stable dSYM upload after dry-run 30937169690 failed before Sentry authentication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only composite action change with no application or security logic; adds a platform-specific install path alongside the existing Linux installer.
> 
> **Overview**
> The **`infisical_install`** composite action no longer runs the Debian installer on every runner. **Linux** still uses the existing `setup.deb.sh` + `apt-get` flow, gated with `runner.os == 'Linux'`.
> 
> **macOS** runners now install the CLI with `brew install infisical/get-cli/infisical`, matching Infisical’s documented macOS setup so release jobs on macOS can fetch secrets (e.g. for Sentry dSYM upload) instead of failing before authentication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a4bcca28f45948904c0259c34a323dd9498e123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->