### PR TITLE
Read the Sentry token from the exported secret file

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -259,13 +259,12 @@ jobs:
         uses: ./.github/actions/sentry_cli
       - if: ${{ inputs.channel == 'stable' }}
         name: Upload macOS debug symbols to Sentry
-        env:
-          SENTRY_AUTH_TOKEN: ${{ fromJSON(steps.sentry-secrets.outputs.secrets).SENTRY_AUTH_TOKEN }}
         run: |
-          if [[ -z "$SENTRY_AUTH_TOKEN" ]]; then
+          if ! SENTRY_AUTH_TOKEN=$(jq -er '.SENTRY_AUTH_TOKEN | select(length > 0)' "${{ steps.sentry-secrets.outputs.secrets_file }}"); then
             echo "::error::Missing SENTRY_AUTH_TOKEN in Infisical prod:/anarlog/github"
             exit 1
           fi
+          export SENTRY_AUTH_TOKEN
 
           sentry-cli debug-files upload \
             --org fastrepl \


### PR DESCRIPTION
Consume the same-job Infisical secret file instead of passing masked JSON through a GitHub Actions output. This fixes the empty token seen in stable dry-run 30940251239.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how the Sentry upload token is sourced; no app runtime or release signing behavior changes.
> 
> **Overview**
> Fixes stable macOS **Sentry debug-symbol upload** failing with an empty `SENTRY_AUTH_TOKEN` when the token was taken from the masked `infisical_export` `secrets` output.
> 
> The upload step now reads `SENTRY_AUTH_TOKEN` from `steps.sentry-secrets.outputs.secrets_file` with `jq`, fails fast if the value is missing or empty, then exports it for `sentry-cli`. The step-level `env` block that wired the token from `fromJSON(steps.sentry-secrets.outputs.secrets)` is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b522f0bc1d7ecbf73e0ae6512824ab227aa8dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->