### PR TITLE
Use scoped Infisical token for Sentry uploads

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -254,7 +254,7 @@ jobs:
           folder: /anarlog/github
           env: prod
         env:
-          INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
+          INFISICAL_TOKEN: ${{ secrets.INFISICAL_SENTRY_TOKEN }}
       - if: ${{ inputs.channel == 'stable' }}
         uses: ./.github/actions/sentry_cli
       - if: ${{ inputs.channel == 'stable' }}


### PR DESCRIPTION
Read the Sentry upload secret with a dedicated, read-only Infisical service token scoped to Production /anarlog/github.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single secret reference swap in CI with no change to upload logic; requires the new GitHub secret to be configured.
> 
> **Overview**
> Stable **macOS** desktop CD now authenticates the **Load Sentry upload token** Infisical export with **`INFISICAL_SENTRY_TOKEN`** instead of the shared **`INFISICAL_TOKEN`**.
> 
> The Sentry upload path is unchanged: it still exports **prod** **`/anarlog/github`** and reads **`SENTRY_AUTH_TOKEN`** for **`sentry-cli debug-files upload`**. Only the CI credential used for that export is narrowed to a dedicated, read-only service token scoped to that folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 339dd82989c2f3e0f1410049ea9074c16145523c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->