### PR TITLE
Fetch only the Sentry upload secret

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -246,21 +246,23 @@ jobs:
           echo "Verified dSYM UUID $dsym_uuid"
           echo "path=$dsym" >> "$GITHUB_OUTPUT"
       - if: ${{ inputs.channel == 'stable' }}
-        id: sentry-secrets
-        name: Load Sentry upload token
-        uses: ./.github/actions/infisical_export
-        with:
-          project-id: ${{ secrets.INFISICAL_PROJECT_ID }}
-          folder: /anarlog/github
-          env: prod
-        env:
-          INFISICAL_TOKEN: ${{ secrets.INFISICAL_SENTRY_TOKEN }}
-      - if: ${{ inputs.channel == 'stable' }}
         uses: ./.github/actions/sentry_cli
       - if: ${{ inputs.channel == 'stable' }}
         name: Upload macOS debug symbols to Sentry
+        env:
+          INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
+          INFISICAL_TOKEN: ${{ secrets.INFISICAL_SENTRY_TOKEN }}
         run: |
-          if ! SENTRY_AUTH_TOKEN=$(jq -er '.SENTRY_AUTH_TOKEN | select(length > 0)' "${{ steps.sentry-secrets.outputs.secrets_file }}"); then
+          response=$(
+            curl --fail --silent --show-error --get \
+              --header "Authorization: Bearer $INFISICAL_TOKEN" \
+              --data-urlencode "projectId=$INFISICAL_PROJECT_ID" \
+              --data-urlencode "environment=prod" \
+              --data-urlencode "secretPath=/anarlog/github" \
+              --data-urlencode "expandSecretReferences=false" \
+              "https://app.infisical.com/api/v4/secrets/SENTRY_AUTH_TOKEN"
+          )
+          if ! SENTRY_AUTH_TOKEN=$(jq -er '.secret.secretValue | select(length > 0)' <<< "$response"); then
             echo "::error::Missing SENTRY_AUTH_TOKEN in Infisical prod:/anarlog/github"
             exit 1
           fi


### PR DESCRIPTION
Use Infisical's single-secret API without reference expansion so the least-privilege release credential can upload macOS dSYMs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how one secret is retrieved; upload logic and failure handling stay the same, with slightly different blast radius if the API response shape differs from the old export format.
> 
> **Overview**
> **Stable macOS dSYM upload** no longer uses the `infisical_export` composite action to load all secrets from `prod:/anarlog/github`. The upload step now calls Infisical’s **v4 single-secret** endpoint for `SENTRY_AUTH_TOKEN` with **`expandSecretReferences=false`**, so the release credential only needs access to that one secret instead of a full folder export.
> 
> Parsing switches from a bulk secrets JSON file to `jq` on `.secret.secretValue`; `sentry-cli debug-files upload` behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9510f7160d67eda1b308efe99a3945ebe9c036d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->