### PR TITLE
Make Linux audio QA deterministic

### DIFF
--- a/e2e/blackbox/wdio.blackbox.conf.ts
+++ b/e2e/blackbox/wdio.blackbox.conf.ts
@@ -1,7 +1,8 @@
-import { waitTauriDriverReady } from "@crabnebula/tauri-driver";
 import { waitTestRunnerBackendReady } from "@crabnebula/test-runner-backend";
 import type { Frameworks } from "@wdio/types";
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { Socket } from "node:net";
+import os from "node:os";
 import path from "node:path";
 
 import { TestRecorder } from "./record.js";
@@ -98,10 +99,19 @@ export const config = {
   beforeSession: async () => {
     const env = { ...process.env, ONBOARDING: "0" };
     const useXvfb = process.platform === "linux" && !!process.env.CI;
+    const tauriDriverCommand =
+      process.platform === "linux"
+        ? path.join(
+            process.env.CARGO_HOME ?? path.join(os.homedir(), ".cargo"),
+            "bin",
+            "tauri-driver",
+          )
+        : "tauri-driver";
+    killedTauriDriver = false;
 
     if (useXvfb) {
       console.log("Starting tauri-driver with xvfb-run (ONBOARDING=0)...");
-      tauriDriver = spawn("xvfb-run", ["-a", "tauri-driver"], {
+      tauriDriver = spawn("xvfb-run", ["-a", tauriDriverCommand], {
         stdio: [null, process.stdout, process.stderr],
         env,
       });
@@ -109,7 +119,7 @@ export const config = {
       console.log(
         `Starting tauri-driver on ${process.platform} (ONBOARDING=0)...`,
       );
-      tauriDriver = spawn("tauri-driver", [], {
+      tauriDriver = spawn(tauriDriverCommand, [], {
         stdio: [null, process.stdout, process.stderr],
         env,
       });
@@ -129,8 +139,8 @@ export const config = {
     await waitTauriDriverReady();
   },
 
-  afterSession: () => {
-    closeTauriDriver();
+  afterSession: async () => {
+    await closeTauriDriver();
   },
 
   onComplete: () => {
@@ -139,7 +149,18 @@ export const config = {
   },
 };
 
-function closeTauriDriver() {
+async function closeTauriDriver() {
+  killedTauriDriver = true;
+  if (!tauriDriver || tauriDriver.exitCode !== null) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    tauriDriver.once("exit", () => resolve());
+    tauriDriver.kill();
+  });
+}
+
+function killTauriDriver() {
   killedTauriDriver = true;
   tauriDriver?.kill();
 }
@@ -160,8 +181,31 @@ function onShutdown(fn: () => void) {
   process.on("SIGBREAK", cleanup);
 }
 
-onShutdown(closeTauriDriver);
+onShutdown(killTauriDriver);
 
 async function sleep(ms: number) {
   return await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitTauriDriverReady() {
+  await new Promise<void>((resolve) => {
+    const tryPort = () => {
+      const socket = new Socket();
+      socket.setTimeout(1000);
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.once("timeout", () => {
+        socket.destroy();
+        setTimeout(tryPort, 200);
+      });
+      socket.once("error", () => {
+        socket.destroy();
+        setTimeout(tryPort, 200);
+      });
+      socket.connect(4444, "127.0.0.1");
+    };
+    tryPort();
+  });
 }

--- a/scripts/qa/linux_virtual_audio_smoke.sh
+++ b/scripts/qa/linux_virtual_audio_smoke.sh
@@ -231,7 +231,9 @@ export QA_SYSTEM_SINK=qa_system
 export RUST_LOG="info,sqlx=warn,hyper=warn"
 
 set +e
-pnpm -F e2e-blackbox e2e 2>&1 | tee "$artifact_dir/e2e.log"
+pnpm -F e2e-blackbox e2e \
+  --spec ./tests/linux-virtual-audio.spec.ts \
+  2>&1 | tee "$artifact_dir/e2e.log"
 e2e_status=${PIPESTATUS[0]}
 set -e
 


### PR DESCRIPTION
Use the Cargo-installed driver on Linux x64 and ARM64, wait for driver shutdown between specs, and limit the release gate to the virtual-audio scenario.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E/QA harness configuration and driver lifecycle; no production app, auth, or data paths are touched.
> 
> **Overview**
> **Linux blackbox E2E** now launches `tauri-driver` from `$CARGO_HOME/bin` (including under `xvfb-run`) instead of relying on PATH, so x64 and ARM64 CI use the same Cargo-installed binary.
> 
> **Driver readiness and teardown** drop the `@crabnebula/tauri-driver` helper in favor of polling `127.0.0.1:4444` until the WebDriver port accepts connections. `afterSession` awaits a clean driver exit after `kill()`, while process shutdown still uses a synchronous kill so hooks don’t block exit.
> 
> **Release gate** `linux_virtual_audio_smoke.sh` runs only `./tests/linux-virtual-audio.spec.ts` instead of the full blackbox suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e394034006972667adc41147b8c0846a13c93f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->