### PR TITLE
Complete Linux audio QA startup

### DIFF
--- a/e2e/blackbox/tests/linux-virtual-audio.spec.ts
+++ b/e2e/blackbox/tests/linux-virtual-audio.spec.ts
@@ -1,4 +1,4 @@
-import { $ } from "@wdio/globals";
+import { $, browser } from "@wdio/globals";
 import { spawn } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -39,6 +39,26 @@ describeVirtualAudio("Linux virtual audio capture", () => {
     await startRecording.waitForDisplayed({ timeout: 30_000 });
     await startRecording.waitForEnabled({ timeout: 30_000 });
     await startRecording.click();
+
+    await browser.waitUntil(
+      async () => {
+        const stopListening = await $('button[title="Stop listening"]');
+        const record = await $('button[title="Record"]');
+        return (
+          (await stopListening.isDisplayed()) || (await record.isDisplayed())
+        );
+      },
+      {
+        timeout: 30_000,
+        timeoutMsg: "session recording controls did not appear",
+      },
+    );
+
+    const record = await $('button[title="Record"]');
+    if (await record.isDisplayed()) {
+      await record.waitForEnabled({ timeout: 30_000 });
+      await record.click();
+    }
 
     const stopListening = await $('button[title="Stop listening"]');
     await stopListening.waitForDisplayed({ timeout: 30_000 });

--- a/e2e/blackbox/wdio.blackbox.conf.ts
+++ b/e2e/blackbox/wdio.blackbox.conf.ts
@@ -1,4 +1,3 @@
-import { waitTestRunnerBackendReady } from "@crabnebula/test-runner-backend";
 import type { Frameworks } from "@wdio/types";
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { Socket } from "node:net";
@@ -65,6 +64,8 @@ export const config = {
         process.exit(1);
       }
 
+      const { waitTestRunnerBackendReady } =
+        await import("@crabnebula/test-runner-backend");
       testRunnerBackend = spawn("pnpm", ["exec", "test-runner-backend"], {
         stdio: "inherit",
         shell: true,


### PR DESCRIPTION
Load the macOS runner helper only on macOS and explicitly start recording when a fresh Linux profile has no STT connection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to E2E startup and Webdriver config; no production app or auth/data paths affected.
> 
> **Overview**
> Linux virtual-audio blackbox QA now waits for session controls after **Start Recording**, and clicks **Record** when that button is shown instead of going straight to **Stop listening**—covering fresh profiles where STT is not already connected.
> 
> The Webdriver config **dynamically imports** `@crabnebula/test-runner-backend` only inside the macOS `onPrepare` branch, so Linux CI no longer loads the CrabNebula helper at config startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88b3397ce7a54883ade8de991cf7e782d034670b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->