### PR TITLE
Honor Linux audio QA timeout

### DIFF
--- a/e2e/blackbox/tests/linux-virtual-audio.spec.ts
+++ b/e2e/blackbox/tests/linux-virtual-audio.spec.ts
@@ -8,9 +8,7 @@ const virtualAudioEnabled = process.env.E2E_VIRTUAL_AUDIO === "1";
 const describeVirtualAudio = virtualAudioEnabled ? describe : describe.skip;
 
 describeVirtualAudio("Linux virtual audio capture", () => {
-  it("persists separated microphone and system-audio tracks", async function () {
-    this.timeout(180_000);
-
+  it("persists separated microphone and system-audio tracks", async () => {
     if (process.platform !== "linux") {
       throw new Error("E2E_VIRTUAL_AUDIO is only supported on Linux");
     }

--- a/e2e/blackbox/wdio.blackbox.conf.ts
+++ b/e2e/blackbox/wdio.blackbox.conf.ts
@@ -41,7 +41,7 @@ export const config = {
   framework: "mocha",
   mochaOpts: {
     ui: "bdd",
-    timeout: 60000,
+    timeout: process.env.E2E_VIRTUAL_AUDIO === "1" ? 180_000 : 60_000,
   },
   autoCompileOpts: {
     autoCompile: true,


### PR DESCRIPTION
Apply the extended Mocha timeout in runner configuration so the x64 and ARM64 audio gates can complete all capture and persistence assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test configuration only; no production or runtime behavior changes.
> 
> **Overview**
> Linux virtual-audio blackbox runs can exceed the default **60s** Mocha limit while playing phased mic/system signals and waiting on recording UI. The PR applies a **180s** timeout at the WebdriverIO runner when `E2E_VIRTUAL_AUDIO=1`, and drops the per-test `this.timeout(180_000)` from the Linux virtual audio spec so timeout policy lives in one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fd737aabb5dac44285b39d03871e909eeb74939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->