### PR TITLE
Allow Linux audio stop to settle

### DIFF
--- a/e2e/blackbox/tests/linux-virtual-audio.spec.ts
+++ b/e2e/blackbox/tests/linux-virtual-audio.spec.ts
@@ -97,7 +97,7 @@ describeVirtualAudio("Linux virtual audio capture", () => {
     await stopListening.click();
     const recordingStopSeconds = (performance.now() - anchor) / 1000;
     await stopListening.waitForDisplayed({
-      timeout: 30_000,
+      timeout: 60_000,
       reverse: true,
     });
     const settledControl = await $(


### PR DESCRIPTION
Wait through the post-stop transcript recovery window before asserting that recording controls have settled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout change with no production or security impact.
> 
> **Overview**
> **Linux virtual audio E2E** was flaky after **Stop listening** because the UI needs longer to finish the post-stop transcript recovery before controls disappear.
> 
> The spec now waits up to **60s** (was **30s**) for the stop-listening control to hide (`waitForDisplayed` with `reverse: true`) before asserting that resume/record/stop controls have settled—the settled-control wait was already 60s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360875c22381a9a1f69ca26c77b20718831306d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->