### PR TITLE
Scope Linux audio QA to persistence

### DIFF
--- a/e2e/blackbox/tests/linux-virtual-audio.spec.ts
+++ b/e2e/blackbox/tests/linux-virtual-audio.spec.ts
@@ -96,14 +96,6 @@ describeVirtualAudio("Linux virtual audio capture", () => {
     await pause(2_500);
     await stopListening.click();
     const recordingStopSeconds = (performance.now() - anchor) / 1000;
-    await stopListening.waitForDisplayed({
-      timeout: 60_000,
-      reverse: true,
-    });
-    const settledControl = await $(
-      'button[title="Resume listening"]:not([disabled]), button[title="Record"]:not([disabled]), button[title="Stop transcription"]:not([disabled])',
-    );
-    await settledControl.waitForDisplayed({ timeout: 60_000 });
     await persistPhases(phasesPath, phases, recordingStopSeconds);
     await pause(1_000);
   });


### PR DESCRIPTION
Remove the unrelated post-stop transcription UI assertion and leave persistence validation to the artifact verifier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test-only change that narrows assertions; no production or security impact.
> 
> **Overview**
> The Linux virtual-audio blackbox test no longer waits for transcription/recording UI to settle after **Stop listening**. It still clicks stop, records `recording_stop_seconds`, writes the phases JSON, and pauses briefly.
> 
> **Removed** waits for the stop-listening control to disappear and for a settled **Resume listening** / **Record** / **Stop transcription** button. Post-stop correctness is left to the external artifact verifier that consumes `QA_PHASES_PATH`, matching the test’s persistence-only scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d432c5c672d22a785b88a0edfe47d741b29eac4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->