### PR TITLE
Clarify the Pro trial call to action

### DIFF
--- a/apps/web/src/components/home-page/pricing-section.tsx
+++ b/apps/web/src/components/home-page/pricing-section.tsx
@@ -2,7 +2,6 @@ import { Link } from "@tanstack/react-router";
 
 import {
   MARKETING_PLAN_TIERS,
-  PRO_TRIAL_DAYS,
   type MarketingPlanData,
   PlanFeatureList,
 } from "@anlg/pricing";
@@ -91,9 +90,7 @@ function PricingCard({ plan }: { plan: MarketingPlanData }) {
               : "bg-[#f4efe6] text-[#181613] hover:bg-[#eadfce]",
           ])}
         >
-          {plan.price
-            ? `Download and start your ${PRO_TRIAL_DAYS}-day Pro trial`
-            : "Download for free"}
+          {plan.price ? "Start your three-week Pro trial" : "Download for free"}
         </Link>
       </div>
     </article>


### PR DESCRIPTION
Use concise three-week trial copy on the landing-page pricing card.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy only on the home pricing card; no billing, auth, or trial logic changes.
> 
> **Overview**
> Updates the paid-plan button on the landing **pricing** section from dynamic “Download and start your {N}-day Pro trial” copy to **“Start your three-week Pro trial”**, dropping the `PRO_TRIAL_DAYS` import on that component.
> 
> Free-tier **“Download for free”** text is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b40df205bcfbc585889237619697f81f5a6538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->