### PR TITLE
Expose Windows and Linux downloads

### DIFF
--- a/apps/web/src/components/home-page/hero-section.tsx
+++ b/apps/web/src/components/home-page/hero-section.tsx
@@ -313,10 +313,8 @@ function DownloadButton() {
   const orderedSections = getOrderedDesktopDownloadSections(preferredPlatform);
   const preferredSection = orderedSections[0];
   const preferredDownload = preferredSection.downloads[0];
-  const preferredPlatformComingSoon = preferredPlatform !== "macos";
-  const preferredLabel = preferredPlatformComingSoon
-    ? `${preferredPlatform === "linux" ? "Linux" : "Windows"} — Coming soon`
-    : preferredSection.platform === "macos"
+  const preferredLabel =
+    preferredSection.platform === "macos"
       ? `Download for ${preferredDownload.name}`
       : `Download for ${preferredSection.name}`;
 
@@ -351,26 +349,18 @@ function DownloadButton() {
       className="relative inline-flex text-sm font-medium"
     >
       <a
-        href={
-          preferredPlatformComingSoon ? "/download/" : preferredDownload.url
+        href={preferredDownload.url}
+        onClick={() =>
+          track("download_clicked", {
+            platform: preferredSection.platform,
+            spec: preferredDownload.name,
+            source: "homepage",
+          })
         }
-        onClick={() => {
-          if (!preferredPlatformComingSoon) {
-            track("download_clicked", {
-              platform: preferredSection.platform,
-              spec: preferredDownload.name,
-              source: "homepage",
-            });
-          }
-        }}
         className="inline-flex items-center gap-1.5 rounded-l-full bg-[#181613] py-3 pr-2 pl-4 text-[13px] text-white sm:pl-5 sm:text-sm"
       >
         <Icon
-          icon={getPlatformIcon(
-            preferredPlatformComingSoon
-              ? preferredPlatform
-              : preferredSection.platform,
-          )}
+          icon={getPlatformIcon(preferredSection.platform)}
           width={16}
           height={16}
           className="shrink-0"
@@ -396,10 +386,7 @@ function DownloadButton() {
           {orderedSections.map((section) =>
             section.downloads.map((download) => {
               if (!download.showInMenu) return null;
-              if (
-                !preferredPlatformComingSoon &&
-                download.url === preferredDownload.url
-              ) {
+              if (download.url === preferredDownload.url) {
                 return null;
               }
 

--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -8,12 +8,32 @@ import {
   getOrderedDesktopDownloadSections,
 } from "./download.ts";
 
-test("offers macOS downloads while Linux and Windows are coming soon", () => {
+test("offers macOS, Windows, and Linux downloads", () => {
   assert.deepEqual(
     desktopDownloadSections.map((section) => section.platform),
-    ["macos"],
+    ["macos", "windows", "linux"],
   );
-  assert.deepEqual(comingSoonPlatforms.slice(0, 2), ["Linux", "Windows"]);
+  assert.deepEqual(comingSoonPlatforms, [
+    "iOS",
+    "Android",
+    "Apple Watch",
+    "Galaxy Watch",
+  ]);
+
+  const windowsDownloads = desktopDownloadSections.find(
+    (section) => section.platform === "windows",
+  )!.downloads;
+  const linuxDownloads = desktopDownloadSections.find(
+    (section) => section.platform === "linux",
+  )!.downloads;
+
+  assert.match(windowsDownloads[0].url, /\/nsis-x86_64\?/);
+  assert.deepEqual(
+    linuxDownloads.map((download) =>
+      new URL(download.url).pathname.split("/").at(-1),
+    ),
+    ["appimage-x86_64", "debian-x86_64", "appimage-aarch64", "debian-aarch64"],
+  );
 });
 
 test("detects supported desktop platforms from browser user agents", () => {
@@ -50,7 +70,7 @@ test("orders the detected platform first", () => {
     getOrderedDesktopDownloadSections("windows").map(
       (section) => section.platform,
     ),
-    ["macos"],
+    ["windows", "macos", "linux"],
   );
   assert.equal(
     getOrderedDesktopDownloadSections("macos")[0].downloads[0].name,

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -11,8 +11,6 @@ export const appleSiliconDownloadUrl = getStableDownloadUrl("dmg-aarch64");
 export const appleIntelDownloadUrl = getStableDownloadUrl("dmg-x86_64");
 
 export const comingSoonPlatforms = [
-  "Linux",
-  "Windows",
   "iOS",
   "Android",
   "Apple Watch",
@@ -37,6 +35,52 @@ export const desktopDownloadSections = [
         detail: "Intel-based Mac · DMG",
         url: appleIntelDownloadUrl,
         showInMenu: true,
+      },
+    ],
+  },
+  {
+    platform: "windows",
+    name: "Windows",
+    status: "Beta",
+    description: "Beta installer for 64-bit Windows PCs.",
+    downloads: [
+      {
+        name: "Windows x64",
+        detail: "NSIS installer · EXE",
+        url: getStableDownloadUrl("nsis-x86_64"),
+        showInMenu: true,
+      },
+    ],
+  },
+  {
+    platform: "linux",
+    name: "Linux",
+    status: "Beta",
+    description: "AppImage and Debian packages for x64 and ARM64.",
+    downloads: [
+      {
+        name: "AppImage x64",
+        detail: "Intel or AMD 64-bit · AppImage",
+        url: getStableDownloadUrl("appimage-x86_64"),
+        showInMenu: true,
+      },
+      {
+        name: "Debian x64",
+        detail: "Debian or Ubuntu · DEB",
+        url: getStableDownloadUrl("debian-x86_64"),
+        showInMenu: true,
+      },
+      {
+        name: "AppImage ARM64",
+        detail: "64-bit ARM · AppImage",
+        url: getStableDownloadUrl("appimage-aarch64"),
+        showInMenu: false,
+      },
+      {
+        name: "Debian ARM64",
+        detail: "Debian or Ubuntu on 64-bit ARM · DEB",
+        url: getStableDownloadUrl("debian-aarch64"),
+        showInMenu: false,
       },
     ],
   },

--- a/apps/web/src/lib/seo.test.ts
+++ b/apps/web/src/lib/seo.test.ts
@@ -24,10 +24,11 @@ test("tolerates paths without a leading slash", () => {
   assert.equal(getCanonicalUrl("download"), "https://anarlog.so/download/");
 });
 
-test("points downloadUrl at the canonical download page", () => {
+test("describes downloads for every supported desktop platform", () => {
   const jsonLd = getSoftwareApplicationJsonLd({ description: "Anarlog" });
 
   assert.equal(jsonLd.downloadUrl, "https://anarlog.so/download/");
+  assert.deepEqual(jsonLd.operatingSystem, ["macOS", "Windows", "Linux"]);
 });
 
 test("emits offers when pricing is supplied", () => {

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -64,7 +64,7 @@ export function getSoftwareApplicationJsonLd({
     url,
     description,
     applicationCategory: "ProductivityApplication",
-    operatingSystem: ["macOS"],
+    operatingSystem: ["macOS", "Windows", "Linux"],
     downloadUrl: getCanonicalUrl("/download"),
     publisher: getOrganizationJsonLd(),
     ...(featureList ? { featureList } : {}),

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/_view/download/")({
       {
         name: "description",
         content:
-          "Download Anarlog for macOS. Linux and Windows are coming soon.",
+          "Download Anarlog for macOS, Windows, or Linux. Every desktop build uses the same release version.",
       },
       { property: "og:title", content: "Download Anarlog" },
       { property: "og:url", content: getCanonicalUrl("/download") },


### PR DESCRIPTION
List current stable desktop installers and route detected platforms to them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing and download-link configuration only; no auth, data, or backend behavior changes.
> 
> **Overview**
> **Ships stable Windows and Linux installers** on the marketing site alongside macOS, using the same CrabNebula stable CDN URLs (Windows NSIS x64; Linux AppImage and Debian for x64 and ARM64).
> 
> **Homepage hero download CTA** no longer treats Windows/Linux as “coming soon”: detected platform gets a real download link, normal labels/icons, and `download_clicked` analytics on every primary click. Platform ordering still puts the detected OS first.
> 
> **Copy and SEO** now say all three desktop OSes are supported (`download` meta description and `SoftwareApplication` JSON-LD `operatingSystem`). **Coming soon** is limited to mobile/watch platforms. Tests assert the new sections, URLs, and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d8daa432dcfb7e0e6353b2f3f508aee021ceab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->