### PR TITLE
Keep mockup traffic lights circular

### DIFF
--- a/apps/web/src/components/home-page/hero-section.tsx
+++ b/apps/web/src/components/home-page/hero-section.tsx
@@ -126,7 +126,7 @@ function HeroWorkflowDemo() {
         aria-hidden="true"
       />
       <div
-        className="relative z-10 mx-auto max-w-[420px] overflow-hidden rounded-xl border-x border-t border-neutral-200 bg-white shadow-[0_24px_70px_rgba(24,22,19,0.08)]"
+        className="relative z-10 mx-auto max-w-[420px] overflow-hidden rounded-xl border-x border-t border-neutral-200 bg-white shadow-[0_24px_70px_rgba(24,22,19,0.08)] [corner-shape:squircle]"
         style={{
           WebkitMaskImage:
             "linear-gradient(to bottom, black 0%, black calc(100% - 5rem), transparent 100%)",
@@ -135,7 +135,7 @@ function HeroWorkflowDemo() {
         }}
       >
         <div className="flex items-center gap-2 px-4 py-3">
-          <div className="flex gap-2">
+          <div className="flex gap-2 [&>*]:[corner-shape:round]">
             <div className="h-3 w-3 rounded-full bg-red-400"></div>
             <div className="h-3 w-3 rounded-full bg-yellow-400"></div>
             <div className="h-3 w-3 rounded-full bg-green-400"></div>

--- a/apps/web/src/components/home-page/social-proof-sections.tsx
+++ b/apps/web/src/components/home-page/social-proof-sections.tsx
@@ -158,7 +158,7 @@ function TestimonialTweetCard({
         onMoveToSide();
       }}
       className={cn([
-        "border-color-subtle absolute rounded-[3px] border bg-white p-5 text-left transition-[transform,box-shadow,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] select-none motion-reduce:transition-none sm:p-5",
+        "border-color-subtle absolute rounded-xl border bg-white p-5 text-left transition-[transform,box-shadow,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] select-none [corner-shape:squircle] motion-reduce:transition-none sm:p-5",
         className,
       ])}
       style={style}


### PR DESCRIPTION
Preserve the squircle window while rendering its traffic lights as semantic circles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Homepage-only CSS/Tailwind tweaks with no logic, data, or auth changes; squircle is a progressive enhancement in supporting browsers.
> 
> **Overview**
> Applies **`corner-shape: squircle`** to the hero workflow mockup window and testimonial tweet cards, and bumps testimonial corners from **`rounded-[3px]`** to **`rounded-xl`**.
> 
> On the mockup chrome, child traffic-light dots get **`corner-shape: round`** via **`[&>*]:[corner-shape:round]`** so they stay circular while the parent uses squircle corners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77e1f72ffe76140a7412122911bcd43bdc2fee8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->