### PR TITLE
fix/share-modal-scroll

### DIFF
--- a/apps/desktop/src/session-sharing/attachment-controls.test.tsx
+++ b/apps/desktop/src/session-sharing/attachment-controls.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SessionAttachmentControls } from "./attachment-controls";
+import type { SessionShareAttachment } from "./attachments";
+
+const audio: SessionShareAttachment = {
+  id: "audio-1",
+  filename: "audio.mp3",
+  contentType: "audio/mpeg",
+  sizeBytes: 42,
+  sha256: "a".repeat(64),
+  sourceType: "session_audio",
+  sourceId: "session-1",
+  cloudSyncEnabled: false,
+  cloudObjectKey: "",
+  localAvailability: "present",
+  transferDirection: null,
+  transferPhase: null,
+  transferError: "",
+};
+
+afterEach(cleanup);
+
+describe("SessionAttachmentControls", () => {
+  it("stays hidden when the session has no audio recording", () => {
+    const attachment = {
+      ...audio,
+      id: "attachment-1",
+      sourceType: "note_upload",
+    };
+
+    render(
+      <SessionAttachmentControls
+        attachments={[attachment]}
+        sharedAttachmentIds={new Map()}
+        canShare
+        pendingAttachmentId={null}
+        onShareChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("switch", { name: "Share audio" })).toBeNull();
+  });
+
+  it("shares and unshares the session audio with one switch", () => {
+    const onShareChange = vi.fn();
+    const view = render(
+      <SessionAttachmentControls
+        attachments={[audio]}
+        sharedAttachmentIds={new Map()}
+        canShare
+        pendingAttachmentId={null}
+        onShareChange={onShareChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: "Share audio" }));
+    expect(onShareChange).toHaveBeenCalledWith(audio, true);
+
+    view.rerender(
+      <SessionAttachmentControls
+        attachments={[audio]}
+        sharedAttachmentIds={new Map([[audio.id, "shared-audio-1"]])}
+        canShare
+        pendingAttachmentId={null}
+        onShareChange={onShareChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: "Share audio" }));
+    expect(onShareChange).toHaveBeenLastCalledWith(audio, false);
+  });
+});

--- a/apps/desktop/src/session-sharing/attachment-controls.tsx
+++ b/apps/desktop/src/session-sharing/attachment-controls.tsx
@@ -1,236 +1,73 @@
-import {
-  ArrowsClockwise,
-  CircleNotch,
-  Cloud,
-  Paperclip,
-  WarningCircle,
-} from "@phosphor-icons/react";
-import { useMutation } from "@tanstack/react-query";
+import { CircleNotch, Waveform } from "@phosphor-icons/react";
 
-import { Button } from "@anlg/ui/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@anlg/ui/components/ui/select";
-import { sonnerToast } from "@anlg/ui/components/ui/toast";
+import { Switch } from "@anlg/ui/components/ui/switch";
 
 import {
   isAttachmentShareable,
   type SessionShareAttachment,
 } from "./attachments";
 
-import { retryAttachmentTransfersForAttachment } from "~/attachment-sync/store";
-import { useConfigValue } from "~/shared/config";
-
 export function SessionAttachmentControls({
   attachments,
   sharedAttachmentIds,
-  canUseCloud,
-  canInclude,
-  cloudPendingAttachmentId,
-  sharePendingAttachmentId,
-  onCloudChange,
+  canShare,
+  pendingAttachmentId,
   onShareChange,
 }: {
   attachments: SessionShareAttachment[];
   sharedAttachmentIds: Map<string, string>;
-  canUseCloud: boolean;
-  canInclude: boolean;
-  cloudPendingAttachmentId: string | null;
-  sharePendingAttachmentId: string | null;
-  onCloudChange: (attachment: SessionShareAttachment, enabled: boolean) => void;
+  canShare: boolean;
+  pendingAttachmentId: string | null;
   onShareChange: (
     attachment: SessionShareAttachment,
     included: boolean,
   ) => void;
 }) {
-  const cloudSyncEnabled = useConfigValue("cloud_sync_enabled");
-  const retryMutation = useMutation({
-    mutationFn: retryAttachmentTransfersForAttachment,
-    onError: () => {
-      sonnerToast.error("Could not retry this attachment transfer.");
-    },
-  });
+  const audio = attachments.find(
+    (attachment) => attachment.sourceType === "session_audio",
+  );
+  if (!audio) return null;
 
-  if (attachments.length === 0) return null;
+  const included = sharedAttachmentIds.has(audio.id);
+  const pending = pendingAttachmentId === audio.id;
+  const available = isAttachmentShareable(audio);
 
   return (
-    <section
-      aria-labelledby="share-attachments-heading"
-      className="border-border/60 border-t pt-5"
-    >
-      <div className="mb-3">
-        <h3 id="share-attachments-heading" className="text-sm font-medium">
-          Attachments
-        </h3>
-        <p className="text-muted-foreground mt-0.5 text-xs">
-          Back up a file to Private cloud first, then choose whether to include
-          it in this shared note.
-        </p>
-      </div>
-      <div className="space-y-2">
-        {attachments.map((attachment) => {
-          const operationPending = Boolean(
-            cloudPendingAttachmentId || sharePendingAttachmentId,
-          );
-          const cloudPending = cloudPendingAttachmentId === attachment.id;
-          const sharePending = sharePendingAttachmentId === attachment.id;
-          const failed = attachment.transferPhase === "failed";
-          const included = sharedAttachmentIds.has(attachment.id);
-          return (
-            <div
-              key={attachment.id}
-              className="border-border/60 rounded-xl border px-3 py-3"
+    <section className="border-border/60 border-t py-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <div className="bg-muted flex size-7 shrink-0 items-center justify-center rounded-lg">
+            <Waveform className="size-3.5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <label
+              htmlFor={`share-audio-${audio.id}`}
+              className="text-xs font-medium"
             >
-              <div className="flex items-start gap-2.5">
-                <div className="bg-muted mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg">
-                  {attachment.sourceType === "session_audio" ? (
-                    <Cloud className="size-3.5" aria-hidden="true" />
-                  ) : (
-                    <Paperclip className="size-3.5" aria-hidden="true" />
-                  )}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-xs font-medium">
-                    {attachment.filename}
-                  </p>
-                  <p className="text-muted-foreground mt-0.5 text-[11px]">
-                    {formatBytes(attachment.sizeBytes)} ·{" "}
-                    {transferStatus(attachment)}
-                  </p>
-                  {failed && attachment.transferError ? (
-                    <p className="text-destructive mt-1 line-clamp-2 text-[11px]">
-                      {attachment.transferError}
-                    </p>
-                  ) : null}
-                </div>
-                {failed ? (
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    aria-label={`Retry ${attachment.filename}`}
-                    disabled={retryMutation.isPending}
-                    onClick={() => retryMutation.mutate(attachment.id)}
-                    className="size-7 shrink-0"
-                  >
-                    {retryMutation.isPending &&
-                    retryMutation.variables === attachment.id ? (
-                      <CircleNotch className="size-3.5 animate-spin" />
-                    ) : (
-                      <ArrowsClockwise className="size-3.5" />
-                    )}
-                  </Button>
-                ) : null}
-              </div>
-              <div className="mt-2.5 grid grid-cols-2 gap-2">
-                <Select
-                  value={attachment.cloudSyncEnabled ? "cloud" : "local"}
-                  disabled={
-                    operationPending ||
-                    (!attachment.cloudSyncEnabled &&
-                      (!canUseCloud || !cloudSyncEnabled))
-                  }
-                  onValueChange={(value) =>
-                    onCloudChange(attachment, value === "cloud")
-                  }
-                >
-                  <SelectTrigger
-                    aria-label={`Storage for ${attachment.filename}`}
-                    className="h-8 rounded-full text-xs"
-                  >
-                    {cloudPending ? (
-                      <CircleNotch className="size-3 animate-spin" />
-                    ) : null}
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="local">Only on this device</SelectItem>
-                    <SelectItem
-                      value="cloud"
-                      disabled={!canUseCloud || !cloudSyncEnabled}
-                    >
-                      Private cloud
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <Select
-                  value={included ? "included" : "private"}
-                  disabled={
-                    operationPending ||
-                    (!included &&
-                      (!canInclude || !isAttachmentShareable(attachment)))
-                  }
-                  onValueChange={(value) =>
-                    onShareChange(attachment, value === "included")
-                  }
-                >
-                  <SelectTrigger
-                    aria-label={`Sharing for ${attachment.filename}`}
-                    className="h-8 rounded-full text-xs"
-                  >
-                    {sharePending ? (
-                      <CircleNotch className="size-3 animate-spin" />
-                    ) : null}
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="private">Not shared</SelectItem>
-                    <SelectItem value="included">
-                      Include in shared note
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              {!cloudSyncEnabled ? (
-                <p className="text-muted-foreground mt-2 text-[11px]">
-                  Turn on Cloud Sync in Settings to use private cloud storage.
-                </p>
-              ) : attachment.localAvailability !== "present" ? (
-                <p className="text-muted-foreground mt-2 flex items-center gap-1 text-[11px]">
-                  <WarningCircle className="size-3" aria-hidden="true" />
-                  This file is not available on this device yet.
-                </p>
-              ) : attachment.cloudSyncEnabled && !attachment.cloudObjectKey ? (
-                <p className="text-muted-foreground mt-2 flex items-center gap-1 text-[11px]">
-                  <CircleNotch
-                    className="size-3 animate-spin"
-                    aria-hidden="true"
-                  />
-                  Wait for the private backup before sharing this file.
-                </p>
-              ) : null}
-            </div>
-          );
-        })}
+              Share audio
+            </label>
+            <p className="text-muted-foreground text-[11px]">
+              {available || included
+                ? "Let people with access play the recording."
+                : "Audio is not available on this device."}
+            </p>
+          </div>
+        </div>
+        {pending ? (
+          <CircleNotch
+            aria-label="Updating audio sharing"
+            className="text-muted-foreground size-4 animate-spin"
+          />
+        ) : (
+          <Switch
+            id={`share-audio-${audio.id}`}
+            size="sm"
+            checked={included}
+            disabled={!canShare || (!included && !available)}
+            onCheckedChange={(checked) => onShareChange(audio, checked)}
+          />
+        )}
       </div>
     </section>
   );
-}
-
-function transferStatus(attachment: SessionShareAttachment) {
-  if (attachment.transferPhase === "failed") return "Needs attention";
-  if (attachment.transferPhase === "retry_wait") return "Retry scheduled";
-  if (
-    attachment.transferPhase &&
-    !["completed", "queued"].includes(attachment.transferPhase)
-  ) {
-    if (attachment.transferDirection === "download") return "Downloading…";
-    if (attachment.transferDirection === "delete")
-      return "Removing from cloud…";
-    return "Uploading…";
-  }
-  if (attachment.transferPhase === "queued") return "Waiting to transfer";
-  return attachment.cloudObjectKey
-    ? "Available in private cloud"
-    : "Local only";
-}
-
-function formatBytes(value: number) {
-  if (value < 1024) return `${value} B`;
-  if (value < 1024 * 1024) return `${Math.round(value / 1024)} KB`;
-  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/apps/desktop/src/session-sharing/attachment-management.ts
+++ b/apps/desktop/src/session-sharing/attachment-management.ts
@@ -18,23 +18,14 @@ import {
 } from "./management-operation";
 
 import { env } from "~/env";
-import { setAttachmentCloudSyncEnabled } from "~/session/attachments";
 import type { SharedNoteAttachment } from "~/shared-notes/cache";
 
-type AttachmentMutation =
-  | {
-      type: "cloud";
-      attachment: SessionShareAttachment;
-      enabled: boolean;
-    }
-  | {
-      type: "share";
-      attachment: SessionShareAttachment;
-      included: boolean;
-    };
+type AttachmentMutation = {
+  attachment: SessionShareAttachment;
+  included: boolean;
+};
 
 export function useSessionAttachmentManagement({
-  sessionId,
   identity,
   managementAvailable,
   canExpand,
@@ -45,7 +36,6 @@ export function useSessionAttachmentManagement({
   requireActiveContext,
   onChanged,
 }: {
-  sessionId: string;
   identity: SharePanelIdentity;
   managementAvailable: boolean;
   canExpand: boolean;
@@ -62,26 +52,6 @@ export function useSessionAttachmentManagement({
         if (!managementAvailable) throw new ShareManagementError();
         const { attachment } = input;
         const currentId = sharedAttachmentIds.get(attachment.id);
-        if (input.type === "cloud") {
-          if (!input.enabled && currentId) {
-            if (!canExpand) throw new ShareManagementError();
-            await publishLatest(
-              signal,
-              sharedAttachments.filter((item) => item.id !== currentId),
-            );
-          } else if (input.enabled && !canExpand) {
-            throw new ShareManagementError();
-          }
-          requireActiveContext(signal);
-          await setAttachmentCloudSyncEnabled(
-            sessionId,
-            attachment.id,
-            input.enabled,
-          );
-          requireActiveContext(signal);
-          return;
-        }
-
         if (!canExpand) throw new ShareManagementError();
         let requested = [...sharedAttachments];
         if (!input.included) {

--- a/apps/desktop/src/session-sharing/attachments.test.ts
+++ b/apps/desktop/src/session-sharing/attachments.test.ts
@@ -84,6 +84,50 @@ describe("shared attachment selection", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
+  it("allows local session audio without a private backup", async () => {
+    const localAudio = {
+      ...attachment,
+      filename: "audio.mp3",
+      contentType: "audio/mpeg",
+      sourceType: "session_audio",
+      sourceId: "session-1",
+      cloudSyncEnabled: false,
+      cloudObjectKey: "",
+    };
+    const sharedAttachmentId = "33333333-3333-4333-8333-333333333333";
+    const fetcher = vi.fn().mockResolvedValue(
+      Response.json({
+        attachmentId: sharedAttachmentId,
+        objectKey: `11111111-1111-4111-8111-111111111111/22222222-2222-4222-8222-222222222222/${sharedAttachmentId}.sna1`,
+        objectState: "ready",
+        filename: localAudio.filename,
+        contentType: localAudio.contentType,
+        sizeBytes: localAudio.sizeBytes,
+        sha256: localAudio.sha256,
+      }),
+    );
+
+    expect(isAttachmentShareable(localAudio)).toBe(true);
+    await expect(
+      prepareSessionShareAttachment({
+        apiBaseUrl: "https://api.example.com",
+        supabaseUrl: "https://project.supabase.co",
+        session: {
+          access_token: "token",
+          user: { id: "11111111-1111-4111-8111-111111111111" },
+        } as any,
+        shareId: "22222222-2222-4222-8222-222222222222",
+        attachment: localAudio,
+        fetcher,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: sharedAttachmentId,
+        filename: "audio.mp3",
+      }),
+    );
+  });
+
   it("uploads every range from one verified native snapshot", async () => {
     const sharedAttachmentId = "33333333-3333-4333-8333-333333333333";
     const objectKey = `11111111-1111-4111-8111-111111111111/22222222-2222-4222-8222-222222222222/${sharedAttachmentId}.sna1`;

--- a/apps/desktop/src/session-sharing/attachments.ts
+++ b/apps/desktop/src/session-sharing/attachments.ts
@@ -137,8 +137,7 @@ export async function prepareSessionShareAttachment(input: {
   const attachment = input.attachment;
   if (
     attachment.localAvailability !== "present" ||
-    !attachment.cloudSyncEnabled ||
-    !attachment.cloudObjectKey ||
+    !meetsAttachmentBackupRequirement(attachment) ||
     attachment.sizeBytes <= 0 ||
     !SHA256_PATTERN.test(attachment.sha256)
   ) {
@@ -383,11 +382,17 @@ export function restoreLocalAttachmentIds(
 export function isAttachmentShareable(attachment: SessionShareAttachment) {
   return (
     attachment.localAvailability === "present" &&
-    attachment.cloudSyncEnabled &&
-    attachment.cloudObjectKey.length > 0 &&
+    meetsAttachmentBackupRequirement(attachment) &&
     attachment.sizeBytes > 0 &&
     attachment.sizeBytes <= 512 * 1024 * 1024 &&
     SHA256_PATTERN.test(attachment.sha256)
+  );
+}
+
+function meetsAttachmentBackupRequirement(attachment: SessionShareAttachment) {
+  return (
+    attachment.sourceType === "session_audio" ||
+    (attachment.cloudSyncEnabled && attachment.cloudObjectKey.length > 0)
   );
 }
 

--- a/apps/desktop/src/session-sharing/draft-panel.tsx
+++ b/apps/desktop/src/session-sharing/draft-panel.tsx
@@ -56,20 +56,15 @@ export function SessionShareDraftContent({
       sideOffset={8}
       aria-labelledby="session-share-heading"
       aria-describedby="session-share-description"
-      className="grid max-h-[min(540px,calc(100vh-64px))] min-h-[340px] w-[440px] max-w-[calc(100vw-16px)] overflow-hidden"
+      className="w-[440px] max-w-[calc(100vw-16px)] overflow-hidden"
     >
-      <AppFloatingPanel className="flex min-h-0 flex-col overflow-hidden">
-        <header className="border-border/60 border-b px-3 py-2 text-left">
-          <h2
-            id="session-share-heading"
-            className="text-sm leading-5 font-semibold tracking-normal"
-          >
-            <Trans>Share</Trans>
-          </h2>
-          <p id="session-share-description" className="sr-only">
-            <Trans>Invite people to this note.</Trans>
-          </p>
-        </header>
+      <AppFloatingPanel className="flex max-h-[min(530px,calc(100vh-74px))] min-h-[330px] flex-col overflow-hidden">
+        <h2 id="session-share-heading" className="sr-only">
+          <Trans>Share</Trans>
+        </h2>
+        <p id="session-share-description" className="sr-only">
+          <Trans>Invite people to this note.</Trans>
+        </p>
 
         <div className="scrollbar-soft min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-2">
           <div className="space-y-2">

--- a/apps/desktop/src/session-sharing/draft-panel.tsx
+++ b/apps/desktop/src/session-sharing/draft-panel.tsx
@@ -11,7 +11,11 @@ import {
   GeneralAccessSelector,
   type GeneralAccessTarget,
 } from "./general-access";
-import { ShareInviteForm, useShareInvite } from "./invite-recipients";
+import {
+  ShareInviteForm,
+  ShareInviteRecipientRows,
+  useShareInvite,
+} from "./invite-recipients";
 import type { AvailableShareWorkspace } from "./source";
 
 import { useAuth } from "~/auth";
@@ -79,22 +83,29 @@ export function SessionShareDraftContent({
                 onSubmit={(emails) => onAction({ type: "invite", emails })}
               />
 
-              <div className="mt-2 flex min-h-9 items-center gap-2 rounded-lg px-1.5 py-1">
-                <ContactFacehash name={ownerName} size={24} />
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-xs font-medium">
-                    {ownerName}{" "}
-                    <span className="text-muted-foreground">(You)</span>
-                  </p>
-                  {ownerEmail ? (
-                    <p className="text-muted-foreground truncate text-[10px]">
-                      {ownerEmail}
+              <div className="mt-2 space-y-0.5">
+                <div className="flex min-h-9 items-center gap-2 rounded-lg px-1.5 py-1">
+                  <ContactFacehash name={ownerName} size={24} />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-xs font-medium">
+                      {ownerName}{" "}
+                      <span className="text-muted-foreground">(You)</span>
                     </p>
-                  ) : null}
+                    {ownerEmail ? (
+                      <p className="text-muted-foreground truncate text-[10px]">
+                        {ownerEmail}
+                      </p>
+                    ) : null}
+                  </div>
+                  <span className="text-muted-foreground shrink-0 text-[11px]">
+                    <Trans>Full access</Trans>
+                  </span>
                 </div>
-                <span className="text-muted-foreground shrink-0 text-[11px]">
-                  <Trans>Full access</Trans>
-                </span>
+
+                <ShareInviteRecipientRows
+                  invite={invite}
+                  disabled={disabled || actionPending}
+                />
               </div>
             </section>
 

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -180,8 +180,16 @@ vi.mock("./client", async (importOriginal) => {
 });
 
 vi.mock("@anlg/ui/components/ui/popover", () => ({
-  AppFloatingPanel: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
+  AppFloatingPanel: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="share-floating-panel" className={className}>
+      {children}
+    </div>
   ),
   Popover: ({
     children,
@@ -605,12 +613,20 @@ describe("SessionShareButton", () => {
     await openSharePopover();
 
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByTestId("share-popover").className).toContain(
-      "min-h-[340px]",
+    expect(screen.getByRole("heading", { name: "Share" }).className).toContain(
+      "sr-only",
     );
-    expect(screen.getByTestId("share-popover").className).toContain(
-      "max-h-[min(540px,calc(100vh-64px))]",
+    expect(screen.getByTestId("share-floating-panel").className).toContain(
+      "min-h-[330px]",
     );
+    expect(screen.getByTestId("share-floating-panel").className).toContain(
+      "max-h-[min(530px,calc(100vh-74px))]",
+    );
+    expect(
+      screen
+        .getByTestId("share-floating-panel")
+        .querySelector('[class*="overflow-y-auto"]'),
+    ).not.toBeNull();
     expect(screen.getByTestId("share-popover").className).toContain(
       "w-[440px]",
     );

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -55,7 +55,6 @@ const mocks = vi.hoisted(() => ({
   ),
   loadSessionShareAttachments: vi.fn(),
   prepareSessionShareAttachment: vi.fn(),
-  setAttachmentCloudSyncEnabled: vi.fn(),
   loadSessionShareSyncState: vi.fn(),
   syncStatus: "clean" as "clean" | "conflict" | null,
   recordPublishedSessionShareState: vi.fn().mockResolvedValue(undefined),
@@ -130,10 +129,6 @@ vi.mock("./attachment-controls", () => ({
     mocks.attachmentControlProps = props;
     return null;
   },
-}));
-
-vi.mock("~/session/attachments", () => ({
-  setAttachmentCloudSyncEnabled: mocks.setAttachmentCloudSyncEnabled,
 }));
 
 vi.mock("./source", () => ({
@@ -397,11 +392,6 @@ describe("SessionShareButton", () => {
     mocks.sharedAttachmentMap = new Map();
     mocks.attachmentControlProps = null;
     mocks.loadSessionShareAttachments.mockResolvedValue([]);
-    mocks.setAttachmentCloudSyncEnabled.mockImplementation(
-      async (_sessionId: string, _attachmentId: string, enabled: boolean) => {
-        mocks.events.push(enabled ? "cloud-on" : "cloud-off");
-      },
-    );
     mocks.durableNote = {
       shareId: SHARE_ID,
       workspaceId: WORKSPACE_ID,
@@ -1164,17 +1154,17 @@ describe("SessionShareButton", () => {
     expect(mocks.upsertDurableSharedNoteCache).not.toHaveBeenCalled();
   });
 
-  it("revokes a shared copy before making its private backup local-only", async () => {
+  it("stops sharing audio without changing the local recording", async () => {
     const localAttachment = {
       id: "local-attachment",
-      filename: "diagram.png",
-      contentType: "image/png",
+      filename: "audio.mp3",
+      contentType: "audio/mpeg",
       sizeBytes: 42,
       sha256: "a".repeat(64),
-      sourceType: "note_upload",
-      sourceId: "diagram.png",
-      cloudSyncEnabled: true,
-      cloudObjectKey: "private/object.anb1",
+      sourceType: "session_audio",
+      sourceId: "session-1",
+      cloudSyncEnabled: false,
+      cloudObjectKey: "",
       localAvailability: "present",
       transferDirection: null,
       transferPhase: "completed",
@@ -1205,20 +1195,16 @@ describe("SessionShareButton", () => {
     mocks.events = [];
 
     act(() => {
-      mocks.attachmentControlProps.onCloudChange(localAttachment, false);
+      mocks.attachmentControlProps.onShareChange(localAttachment, false);
     });
 
     await waitFor(() =>
-      expect(mocks.setAttachmentCloudSyncEnabled).toHaveBeenCalledWith(
-        "session-1",
-        localAttachment.id,
-        false,
+      expect(mocks.publishSessionShareSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({ attachmentIds: [] }),
       ),
     );
-    expect(mocks.publishSessionShareSnapshot).toHaveBeenCalledWith(
-      expect.objectContaining({ attachmentIds: [] }),
-    );
-    expect(mocks.events.slice(0, 3)).toEqual(["load", "publish", "cloud-off"]);
+    expect(mocks.prepareSessionShareAttachment).not.toHaveBeenCalled();
+    expect(mocks.events.slice(0, 2)).toEqual(["load", "publish"]);
   });
 
   it("abandons an open draft when the account changes", async () => {

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1570,7 +1570,7 @@ describe("SessionShareButton", () => {
     ).not.toBeNull();
   });
 
-  it("invites every session participant seeded into the field", async () => {
+  it("lists meeting participants as people and invites them together", async () => {
     mocks.managedNote = null;
     mocks.loadManagedSharedNoteForSession.mockResolvedValue(null);
     mocks.participants = [
@@ -1588,7 +1588,11 @@ describe("SessionShareButton", () => {
     await openSharePopover();
     mocks.sendSessionAccessInvitationEmail.mockClear();
 
-    expect(screen.getByText("Sungbin Jo")).not.toBeNull();
+    const participantName = screen.getByText("Sungbin Jo");
+    expect(participantName.parentElement?.parentElement?.className).toContain(
+      "min-h-9",
+    );
+    expect(screen.getByText("sungbin@e.com")).not.toBeNull();
     expect(screen.getByText("yujong@e.com")).not.toBeNull();
     expect(screen.queryByText("Artem")).toBeNull();
     expect(screen.queryByText("Dropped")).toBeNull();

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -611,9 +611,9 @@ function SessionShareUpgradeContent({ onUpgrade }: { onUpgrade: () => void }) {
       sideOffset={8}
       aria-labelledby="session-share-upgrade-heading"
       aria-describedby="session-share-upgrade-description"
-      className="grid max-h-[min(540px,calc(100vh-64px))] min-h-[340px] w-[440px] max-w-[calc(100vw-16px)] overflow-hidden"
+      className="w-[440px] max-w-[calc(100vw-16px)] overflow-hidden"
     >
-      <AppFloatingPanel className="flex min-h-0 flex-col items-center overflow-y-auto px-6 py-7 text-center">
+      <AppFloatingPanel className="flex max-h-[min(530px,calc(100vh-74px))] min-h-[330px] flex-col items-center overflow-y-auto px-6 py-7 text-center">
         <div className="bg-accent flex size-10 items-center justify-center rounded-full">
           <Users className="size-4" aria-hidden="true" />
         </div>

--- a/apps/desktop/src/session-sharing/invite-recipients.tsx
+++ b/apps/desktop/src/session-sharing/invite-recipients.tsx
@@ -31,8 +31,8 @@ export function useShareInvite({
       .filter(Boolean),
   );
   // Recipients are derived on every render so participants that arrive from the
-  // live query after the panel opened still seed the field, while a chip the
-  // user removed stays removed.
+  // live query after the panel opened still appear, while a person the user
+  // removed stays removed.
   const taken = new Set(dismissed);
   const recipients: { email: string; name: string }[] = [];
   for (const candidate of [
@@ -154,29 +154,10 @@ export function ShareInviteForm({
       >
         <div
           className={cn([
-            "border-input focus-within:ring-ring flex min-h-8 min-w-0 flex-1 flex-wrap items-center gap-1 rounded-md border bg-transparent px-1.5 py-1 shadow-xs focus-within:ring-1",
+            "border-input focus-within:ring-ring flex h-8 min-w-0 flex-1 items-center rounded-md border bg-transparent px-2 shadow-xs focus-within:ring-1",
             disabled && "opacity-50",
           ])}
         >
-          {invite.recipients.map((recipient) => (
-            <span
-              key={recipient.email.toLowerCase()}
-              className="bg-accent flex max-w-full items-center gap-1 rounded px-1.5 py-0.5 text-[11px]"
-            >
-              <span className="truncate">
-                {recipient.name || recipient.email}
-              </span>
-              <button
-                type="button"
-                aria-label={`Remove ${recipient.name || recipient.email}`}
-                disabled={disabled}
-                onClick={() => invite.remove(recipient.email)}
-                className="text-muted-foreground hover:text-foreground shrink-0 disabled:cursor-not-allowed"
-              >
-                <X className="size-2.5" aria-hidden="true" />
-              </button>
-            </span>
-          ))}
           <input
             type="text"
             aria-label="Invitee email"
@@ -188,15 +169,10 @@ export function ShareInviteForm({
               if (event.key === "Enter" && isInviteEmail(invite.query)) {
                 event.preventDefault();
                 invite.commitQuery();
-                return;
-              }
-              if (event.key === "Backspace" && !invite.query) {
-                const last = invite.recipients[invite.recipients.length - 1];
-                if (last) invite.remove(last.email);
               }
             }}
-            placeholder={invite.recipients.length ? "" : "Email or name"}
-            className="placeholder:text-muted-foreground min-w-[120px] flex-1 bg-transparent text-xs outline-hidden disabled:cursor-not-allowed"
+            placeholder="Email or name"
+            className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-xs outline-hidden disabled:cursor-not-allowed"
           />
         </div>
         <Button
@@ -240,4 +216,41 @@ export function ShareInviteForm({
       ) : null}
     </>
   );
+}
+
+export function ShareInviteRecipientRows({
+  invite,
+  disabled,
+}: {
+  invite: ReturnType<typeof useShareInvite>;
+  disabled: boolean;
+}) {
+  return invite.recipients.map((recipient) => {
+    const label = recipient.name || recipient.email;
+    return (
+      <div
+        key={recipient.email.toLowerCase()}
+        className="hover:bg-accent/50 flex min-h-9 items-center gap-2 rounded-lg px-1.5 py-1"
+      >
+        <ContactFacehash name={label} size={24} />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-xs font-medium">{label}</p>
+          {recipient.name ? (
+            <p className="text-muted-foreground truncate text-[10px]">
+              {recipient.email}
+            </p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          aria-label={`Remove ${label}`}
+          disabled={disabled}
+          onClick={() => invite.remove(recipient.email)}
+          className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-7 shrink-0 items-center justify-center rounded-md disabled:cursor-not-allowed"
+        >
+          <X className="size-3.5" aria-hidden="true" />
+        </button>
+      </div>
+    );
+  });
 }

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -35,7 +35,11 @@ import {
   type GeneralAccessValue,
 } from "./general-access";
 import { useSessionInvitationManagement } from "./invitation-management";
-import { ShareInviteForm, useShareInvite } from "./invite-recipients";
+import {
+  ShareInviteForm,
+  ShareInviteRecipientRows,
+  useShareInvite,
+} from "./invite-recipients";
 import {
   copyPublicSessionShareUrl,
   copySessionShareUrl,
@@ -475,6 +479,11 @@ export function SessionSharePopoverContent({
                       <Trans>Full access</Trans>
                     </span>
                   </div>
+
+                  <ShareInviteRecipientRows
+                    invite={invite}
+                    disabled={!canPublish || inviteMutation.isPending}
+                  />
 
                   {data?.access.length
                     ? data.access.map((entry) => (

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -345,21 +345,16 @@ export function SessionSharePopoverContent({
       sideOffset={8}
       aria-labelledby="session-share-heading"
       aria-describedby="session-share-description"
-      className="grid max-h-[min(540px,calc(100vh-64px))] min-h-[340px] w-[440px] max-w-[calc(100vw-16px)] overflow-hidden"
+      className="w-[440px] max-w-[calc(100vw-16px)] overflow-hidden"
     >
-      <AppFloatingPanel className="flex min-h-0 flex-col overflow-hidden">
+      <AppFloatingPanel className="flex max-h-[min(530px,calc(100vh-74px))] min-h-[330px] flex-col overflow-hidden">
         <div ref={operationLifecycleRef} className="contents">
-          <header className="border-border/60 border-b px-3 py-2 text-left">
-            <h2
-              id="session-share-heading"
-              className="text-sm leading-5 font-semibold tracking-normal"
-            >
-              <Trans>Share</Trans>
-            </h2>
-            <p id="session-share-description" className="sr-only">
-              <Trans>Invite people to this note.</Trans>
-            </p>
-          </header>
+          <h2 id="session-share-heading" className="sr-only">
+            <Trans>Share</Trans>
+          </h2>
+          <p id="session-share-description" className="sr-only">
+            <Trans>Invite people to this note.</Trans>
+          </p>
 
           <div className="scrollbar-soft min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-2">
             <div className="space-y-2">

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -123,7 +123,6 @@ export function SessionSharePopoverContent({
   });
 
   const attachmentMutation = useSessionAttachmentManagement({
-    sessionId,
     identity,
     managementAvailable: Boolean(management),
     canExpand,
@@ -526,34 +525,18 @@ export function SessionSharePopoverContent({
                 <SessionAttachmentControls
                   attachments={sessionAttachments}
                   sharedAttachmentIds={sharedAttachmentIds}
-                  canUseCloud={canPublish}
-                  canInclude={
+                  canShare={
                     canPublish &&
                     sharedAttachmentsReady &&
                     Boolean(env.VITE_SUPABASE_URL)
                   }
-                  cloudPendingAttachmentId={
-                    attachmentMutation.isPending &&
-                    attachmentMutation.variables?.type === "cloud"
-                      ? (attachmentMutation.variables.attachment.id ?? null)
-                      : null
-                  }
-                  sharePendingAttachmentId={
-                    attachmentMutation.isPending &&
-                    attachmentMutation.variables?.type === "share"
+                  pendingAttachmentId={
+                    attachmentMutation.isPending
                       ? (attachmentMutation.variables?.attachment.id ?? null)
                       : null
                   }
-                  onCloudChange={(attachment, enabled) =>
-                    attachmentMutation.mutate({
-                      type: "cloud",
-                      attachment,
-                      enabled,
-                    })
-                  }
                   onShareChange={(attachment, included) =>
                     attachmentMutation.mutate({
-                      type: "share",
                       attachment,
                       included,
                     })

--- a/plugins/attachment-sync/src/runtime.rs
+++ b/plugins/attachment-sync/src/runtime.rs
@@ -1108,6 +1108,7 @@ fn validate_shared_upload_version(
     expected_content_type: &str,
     expected_cloud_object_key: &str,
 ) -> Result<()> {
+    let requires_private_backup = attachment.source_type != "session_audio";
     if !valid_sha256(expected_sha256)
         || expected_size_bytes == 0
         || expected_size_bytes > MAX_PLAINTEXT_BYTES
@@ -1115,8 +1116,8 @@ fn validate_shared_upload_version(
         || u64::try_from(attachment.size_bytes).ok() != Some(expected_size_bytes)
         || attachment.filename != expected_filename
         || attachment.content_type != expected_content_type
-        || attachment.cloud_sync_enabled != 1
-        || expected_cloud_object_key.is_empty()
+        || (requires_private_backup
+            && (attachment.cloud_sync_enabled != 1 || expected_cloud_object_key.is_empty()))
         || attachment.cloud_object_key != expected_cloud_object_key
     {
         return Err(Error::InvalidTransferState);

--- a/plugins/attachment-sync/src/runtime/tests/mod.rs
+++ b/plugins/attachment-sync/src/runtime/tests/mod.rs
@@ -3,3 +3,53 @@ use super::*;
 mod delete_guard;
 mod download;
 mod transfer;
+
+fn shared_upload_attachment(source_type: &str) -> SharedUploadAttachment {
+    SharedUploadAttachment {
+        attachment_id: "attachment-1".to_string(),
+        session_id: "session-1".to_string(),
+        workspace_id: "workspace-1".to_string(),
+        relative_path: "audio.mp3".to_string(),
+        source_type: source_type.to_string(),
+        sha256: "a".repeat(64),
+        size_bytes: 42,
+        filename: "audio.mp3".to_string(),
+        content_type: "audio/mpeg".to_string(),
+        cloud_sync_enabled: 0,
+        cloud_object_key: String::new(),
+    }
+}
+
+#[test]
+fn allows_local_session_audio_for_shared_uploads() {
+    let attachment = shared_upload_attachment("session_audio");
+
+    assert!(
+        validate_shared_upload_version(
+            &attachment,
+            &attachment.sha256,
+            42,
+            &attachment.filename,
+            &attachment.content_type,
+            "",
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn still_requires_private_backup_for_other_shared_uploads() {
+    let attachment = shared_upload_attachment("note_upload");
+
+    assert!(
+        validate_shared_upload_version(
+            &attachment,
+            &attachment.sha256,
+            42,
+            &attachment.filename,
+            &attachment.content_type,
+            "",
+        )
+        .is_err()
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes shared-note attachment upload rules and share-panel publish paths for session audio; incorrect validation could block sharing or allow wrong attachment types, but scope is limited to session sharing UI and attachment-sync validation with solid test coverage.
> 
> **Overview**
> **Share modal layout** — Popover sizing moves max-height/min-height onto `AppFloatingPanel` with a scrollable inner region; the visible “Share” header is screen-reader only. Draft and management panels match this pattern.
> 
> **Invites** — Meeting participants and pending invitees render as rows under the owner (not chips in the email field). The invite input is a single-line field; `ShareInviteRecipientRows` handles removal.
> 
> **Attachments** — The multi-attachment cloud/backup UI is replaced by a **Share audio** switch when `session_audio` exists. Cloud-sync toggles and retry flows are removed from the share panel; attachment mutations only include/exclude from the shared note.
> 
> **Sharing rules** — `session_audio` can be shared from local disk without a private cloud backup (`meetsAttachmentBackupRequirement`); other attachments still require cloud backup. The Rust `attachment-sync` validator aligns so shared uploads allow empty `cloud_object_key` for session audio only.
> 
> **Tests** — New `attachment-controls` tests; updated integration tests for scroll classes, participant rows, and unsharing audio without touching local files or cloud settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f803ccbdce85c69900683f5e7d3824d1147acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->