### PR TITLE
Use numeral in Pro trial CTA

### DIFF
--- a/apps/web/src/components/home-page/pricing-section.tsx
+++ b/apps/web/src/components/home-page/pricing-section.tsx
@@ -90,7 +90,7 @@ function PricingCard({ plan }: { plan: MarketingPlanData }) {
               : "bg-[#f4efe6] text-[#181613] hover:bg-[#eadfce]",
           ])}
         >
-          {plan.price ? "Start your three-week Pro trial" : "Download for free"}
+          {plan.price ? "Start your 3-week Pro trial" : "Download for free"}
         </Link>
       </div>
     </article>


### PR DESCRIPTION
Change the pricing CTA from three-week to 3-week.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single marketing string change with no logic, routing, or billing impact.
> 
> **Overview**
> Updates the paid-plan pricing card button copy from **"Start your three-week Pro trial"** to **"Start your 3-week Pro trial"** in `pricing-section.tsx`. The free-tier **"Download for free"** label is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57993b6924bea0bc25b2d45e4b441841cd9cf5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->