### PR TITLE
Hide unavailable audio sharing controls

### DIFF
--- a/apps/desktop/src/session-sharing/attachment-controls.test.tsx
+++ b/apps/desktop/src/session-sharing/attachment-controls.test.tsx
@@ -43,6 +43,20 @@ describe("SessionAttachmentControls", () => {
     expect(screen.queryByRole("switch", { name: "Share audio" })).toBeNull();
   });
 
+  it("stays hidden when only deleted audio metadata remains", () => {
+    render(
+      <SessionAttachmentControls
+        attachments={[{ ...audio, localAvailability: "absent" }]}
+        sharedAttachmentIds={new Map()}
+        canShare
+        pendingAttachmentId={null}
+        onShareChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("switch", { name: "Share audio" })).toBeNull();
+  });
+
   it("shares and unshares the session audio with one switch", () => {
     const onShareChange = vi.fn();
     const view = render(
@@ -58,9 +72,10 @@ describe("SessionAttachmentControls", () => {
     fireEvent.click(screen.getByRole("switch", { name: "Share audio" }));
     expect(onShareChange).toHaveBeenCalledWith(audio, true);
 
+    const unavailableAudio = { ...audio, localAvailability: "absent" as const };
     view.rerender(
       <SessionAttachmentControls
-        attachments={[audio]}
+        attachments={[unavailableAudio]}
         sharedAttachmentIds={new Map([[audio.id, "shared-audio-1"]])}
         canShare
         pendingAttachmentId={null}
@@ -69,6 +84,6 @@ describe("SessionAttachmentControls", () => {
     );
 
     fireEvent.click(screen.getByRole("switch", { name: "Share audio" }));
-    expect(onShareChange).toHaveBeenLastCalledWith(audio, false);
+    expect(onShareChange).toHaveBeenLastCalledWith(unavailableAudio, false);
   });
 });

--- a/apps/desktop/src/session-sharing/attachment-controls.tsx
+++ b/apps/desktop/src/session-sharing/attachment-controls.tsx
@@ -29,6 +29,8 @@ export function SessionAttachmentControls({
   if (!audio) return null;
 
   const included = sharedAttachmentIds.has(audio.id);
+  if (!included && audio.localAvailability !== "present") return null;
+
   const pending = pendingAttachmentId === audio.id;
   const available = isAttachmentShareable(audio);
 


### PR DESCRIPTION
Show the audio toggle only for local recordings or existing shared copies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI guard in session-sharing attachment controls with no changes to auth, APIs, or persistence.
> 
> **Overview**
> **Session audio sharing** no longer shows the “Share audio” control when the recording isn’t on the device and isn’t already part of the share—e.g. only leftover metadata after local deletion.
> 
> If audio is **already shared**, the toggle still appears so users can turn sharing off. Tests cover the hidden-when-absent case and unshare with `localAvailability: "absent"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b307dc44ce937470338ca5dc6113b16ebc0fda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->