### PR TITLE
Add 1.4.4 desktop changelog

### DIFF
--- a/packages/changelog/content/1.4.4.md
+++ b/packages/changelog/content/1.4.4.md
@@ -1,0 +1,15 @@
+---
+date: "2026-08-05"
+summary: "Anarlog 1.4.4 makes sharing smoother with clearer invitees and simpler recording audio controls."
+---
+
+## Sharing
+
+- Keep every sharing control accessible in a panel that scrolls within smaller
+  windows
+- Review meeting participants and pending invitees as clear person rows before
+  sending invitations
+- Include a locally available meeting recording with one **Share audio** switch,
+  without requiring a private cloud backup
+- Hide audio sharing controls when the recording is no longer on the device,
+  while keeping the option to remove audio that is already shared


### PR DESCRIPTION
Document the user-facing Share improvements for the next stable release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no application or release-pipeline code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.4.md`** for the 1.4.4 desktop stable release (dated 2026-08-05), following the existing frontmatter + sectioned bullet format.
> 
> The entry documents **Sharing** improvements only: a scrollable sharing panel on small windows, person-row review of participants and pending invitees before invites go out, optional **Share audio** for local recordings without private cloud backup, and hiding audio controls when the file is gone while still allowing removal of already-shared audio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c58baed9129c89980dcd58a1a5bb2db150dbd0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->