### PR TITLE
Update 1.4.4 stability notes

### DIFF
--- a/packages/changelog/content/1.4.4.md
+++ b/packages/changelog/content/1.4.4.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-08-05"
-summary: "Anarlog 1.4.4 makes sharing smoother with clearer invitees and simpler recording audio controls."
+summary: "Anarlog 1.4.4 makes sharing smoother and improves live session stability."
 ---
 
 ## Sharing
@@ -13,3 +13,8 @@ summary: "Anarlog 1.4.4 makes sharing smoother with clearer invitees and simpler
   without requiring a private cloud backup
 - Hide audio sharing controls when the recording is no longer on the device,
   while keeping the option to remove audio that is already shared
+
+## Stability
+
+- Prevent a rare crash while processing a live session when background recorder
+  work pauses


### PR DESCRIPTION
Document the listener span panic fix in the stable release changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no runtime or deployment impact.
> 
> **Overview**
> Updates the **1.4.4** release notes to call out stability alongside sharing improvements in the top-level summary.
> 
> Adds a **Stability** section documenting a fix for a rare crash while processing a live session when background recorder work pauses (listener span panic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16b52d47d07fecc27f9384957d4208dd522091b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->