### PR TITLE
Simplify the sharing panel

### DIFF
--- a/apps/desktop/src/session-sharing/draft-panel.tsx
+++ b/apps/desktop/src/session-sharing/draft-panel.tsx
@@ -62,7 +62,7 @@ export function SessionShareDraftContent({
       aria-describedby="session-share-description"
       className="w-[440px] max-w-[calc(100vw-16px)] overflow-hidden"
     >
-      <AppFloatingPanel className="flex max-h-[min(530px,calc(100vh-74px))] min-h-[330px] flex-col overflow-hidden">
+      <AppFloatingPanel className="flex max-h-[min(530px,calc(100vh-74px))] flex-col overflow-hidden">
         <h2 id="session-share-heading" className="sr-only">
           <Trans>Share</Trans>
         </h2>

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -606,8 +606,8 @@ describe("SessionShareButton", () => {
     expect(screen.getByRole("heading", { name: "Share" }).className).toContain(
       "sr-only",
     );
-    expect(screen.getByTestId("share-floating-panel").className).toContain(
-      "min-h-[330px]",
+    expect(screen.getByTestId("share-floating-panel").className).not.toContain(
+      "min-h-",
     );
     expect(screen.getByTestId("share-floating-panel").className).toContain(
       "max-h-[min(530px,calc(100vh-74px))]",
@@ -620,6 +620,9 @@ describe("SessionShareButton", () => {
     expect(screen.getByTestId("share-popover").className).toContain(
       "w-[440px]",
     );
+    expect(
+      screen.queryByRole("button", { name: "Update shared copy" }),
+    ).toBeNull();
 
     fireEvent.click(trigger);
 
@@ -881,7 +884,7 @@ describe("SessionShareButton", () => {
     expect(mocks.events.slice(0, 2)).toEqual(["management", "access"]);
   });
 
-  it("prunes a shared attachment whose local version was replaced", async () => {
+  it("prunes a replaced shared attachment before enabling link access", async () => {
     const remoteAttachment = {
       id: "88888888-8888-4888-8888-888888888888",
       filename: "diagram.png",
@@ -901,7 +904,7 @@ describe("SessionShareButton", () => {
     await openSharePopover();
     mocks.publishSessionShareSnapshot.mockClear();
 
-    fireEvent.click(screen.getByRole("button", { name: "Update shared copy" }));
+    fireEvent.click(screen.getByText("Anyone with the link"));
 
     await waitFor(() =>
       expect(mocks.publishSessionShareSnapshot).toHaveBeenCalledWith(
@@ -968,7 +971,7 @@ describe("SessionShareButton", () => {
     expect(mocks.toastSuccess).not.toHaveBeenCalled();
   });
 
-  it("blocks a manual publish before an editable snapshot is reconciled locally", async () => {
+  it("blocks link access before an editable snapshot is reconciled locally", async () => {
     mocks.createOrReuseSessionShare.mockResolvedValueOnce({
       shareId: SHARE_ID,
       generalScope: "restricted",
@@ -981,7 +984,7 @@ describe("SessionShareButton", () => {
     await openSharePopover();
     mocks.publishSessionShareSnapshot.mockClear();
 
-    fireEvent.click(screen.getByRole("button", { name: "Update shared copy" }));
+    fireEvent.click(screen.getByText("Anyone with the link"));
 
     await waitFor(() =>
       expect(mocks.loadSessionShareSyncState).toHaveBeenCalledWith(
@@ -992,11 +995,11 @@ describe("SessionShareButton", () => {
     );
     expect(mocks.publishSessionShareSnapshot).not.toHaveBeenCalled();
     expect(mocks.toastError).toHaveBeenCalledWith(
-      "Could not update the shared copy.",
+      "Could not update general access.",
     );
   });
 
-  it("blocks a manual publish for a legacy read-only snapshot without reconciliation state", async () => {
+  it("blocks link access for a legacy read-only snapshot without reconciliation state", async () => {
     mocks.durableNote.webEditable = false;
     mocks.createOrReuseSessionShare.mockResolvedValueOnce({
       shareId: SHARE_ID,
@@ -1010,7 +1013,7 @@ describe("SessionShareButton", () => {
     await openSharePopover();
     mocks.publishSessionShareSnapshot.mockClear();
 
-    fireEvent.click(screen.getByRole("button", { name: "Update shared copy" }));
+    fireEvent.click(screen.getByText("Anyone with the link"));
 
     await waitFor(() =>
       expect(mocks.loadSessionShareSyncState).toHaveBeenCalledWith(
@@ -1021,7 +1024,7 @@ describe("SessionShareButton", () => {
     );
     expect(mocks.publishSessionShareSnapshot).not.toHaveBeenCalled();
     expect(mocks.toastError).toHaveBeenCalledWith(
-      "Could not update the shared copy.",
+      "Could not update general access.",
     );
   });
 
@@ -1068,12 +1071,8 @@ describe("SessionShareButton", () => {
       }),
     ).not.toBeNull();
     expect(
-      (
-        screen.getByRole("button", {
-          name: "Update shared copy",
-        }) as HTMLButtonElement
-      ).disabled,
-    ).toBe(true);
+      screen.queryByRole("button", { name: "Update shared copy" }),
+    ).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Open web copy" }));
     await waitFor(() => expect(mocks.openUrl).toHaveBeenCalledOnce());

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -613,7 +613,7 @@ function SessionShareUpgradeContent({ onUpgrade }: { onUpgrade: () => void }) {
       aria-describedby="session-share-upgrade-description"
       className="w-[440px] max-w-[calc(100vw-16px)] overflow-hidden"
     >
-      <AppFloatingPanel className="flex max-h-[min(530px,calc(100vh-74px))] min-h-[330px] flex-col items-center overflow-y-auto px-6 py-7 text-center">
+      <AppFloatingPanel className="flex max-h-[min(530px,calc(100vh-74px))] flex-col items-center overflow-y-auto px-6 py-7 text-center">
         <div className="bg-accent flex size-10 items-center justify-center rounded-full">
           <Users className="size-4" aria-hidden="true" />
         </div>

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -144,22 +144,6 @@ export function SessionSharePopoverContent({
     onChanged,
   });
 
-  const refreshMutation = useMutation({
-    mutationFn: () =>
-      runOperation((signal) => {
-        if (!canExpand) throw new ShareManagementError();
-        return publishLatest(signal);
-      }),
-    onSuccess: () => {
-      sonnerToast.success("Shared copy updated.");
-    },
-    onError: (error) => {
-      if (error instanceof ShareOperationAbortedError) return;
-      sonnerToast.error("Could not update the shared copy.");
-    },
-    onSettled: onChanged,
-  });
-
   const keepDesktopMutation = useMutation({
     mutationFn: () =>
       runOperation((signal) =>
@@ -308,7 +292,6 @@ export function SessionSharePopoverContent({
 
   const anyPending =
     inviteMutation.isPending ||
-    refreshMutation.isPending ||
     scopeMutation.isPending ||
     entryMutation.isPending ||
     generalCopyMutation.isPending ||
@@ -350,7 +333,7 @@ export function SessionSharePopoverContent({
       aria-describedby="session-share-description"
       className="w-[440px] max-w-[calc(100vw-16px)] overflow-hidden"
     >
-      <AppFloatingPanel className="flex max-h-[min(530px,calc(100vh-74px))] min-h-[330px] flex-col overflow-hidden">
+      <AppFloatingPanel className="flex max-h-[min(530px,calc(100vh-74px))] flex-col overflow-hidden">
         <div ref={operationLifecycleRef} className="contents">
           <h2 id="session-share-heading" className="sr-only">
             <Trans>Share</Trans>
@@ -569,26 +552,7 @@ export function SessionSharePopoverContent({
             </div>
           </div>
 
-          <footer className="border-border/60 flex items-center justify-between border-t px-3 py-2">
-            <Button
-              type="button"
-              size="icon"
-              variant="ghost"
-              disabled={!canPublish || !management || refreshMutation.isPending}
-              onClick={() => refreshMutation.mutate()}
-              aria-label="Update shared copy"
-              title="Update shared copy"
-              className="size-7"
-            >
-              {refreshMutation.isPending ? (
-                <CircleNotch
-                  className="size-3.5 animate-spin"
-                  aria-hidden="true"
-                />
-              ) : (
-                <ArrowsClockwise className="size-3.5" aria-hidden="true" />
-              )}
-            </Button>
+          <footer className="border-border/60 flex items-center justify-end border-t px-3 py-2">
             <Button
               type="button"
               size="sm"


### PR DESCRIPTION
Remove the redundant manual refresh action and size all sharing states to their content while preserving viewport-capped scrolling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sharing panel changes with test updates; publish behavior remains on existing access and conflict flows, not a new data path.
> 
> **Overview**
> **Simplifies the desktop session sharing popover** by dropping the fixed minimum height and the separate manual “Update shared copy” control.
> 
> `AppFloatingPanel` in the draft, management, and upgrade flows no longer uses `min-h-[330px]`, so panels **size to their content** while keeping the existing viewport-capped max height and scrollable body. The management footer is **right-aligned** with only the copy-link action; snapshot refresh is no longer exposed as its own icon button (publishing still runs through scope changes such as **Anyone with the link**, invites, and conflict resolution via **Keep desktop edits**).
> 
> Tests were updated to expect **no** “Update shared copy” control, **no** `min-h-` on the floating panel, and to drive publish/reconciliation scenarios through general-access UI instead of the removed refresh action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9bcffca842b700489e285cc7b78a53204a0e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->