### PR TITLE
track: add user analytics to auth and OTP flows

### DIFF
--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -17,6 +17,7 @@ import {
 } from "@/functions/supabase";
 import { sanitizeInternalReturnPath } from "@/lib/auth-redirect";
 import { captureOperationalError } from "@/lib/error-reporting";
+import { identifyServerUserFromRequest } from "@/lib/server-analytics";
 
 const shared = z.object({
   flow: z.enum(["desktop", "web"]).default("desktop"),
@@ -99,7 +100,7 @@ async function resolveTokensForFlow({
   return tokenSuccess(desktopSession);
 }
 
-function toSuccessTokenResponse(result: FlowTokenResult) {
+function toSuccessTokenResponse(result: FlowTokenResult, userId?: string) {
   if (!result.ok) {
     return { success: false as const, error: result.error };
   }
@@ -107,10 +108,11 @@ function toSuccessTokenResponse(result: FlowTokenResult) {
     success: true as const,
     access_token: result.access_token,
     refresh_token: result.refresh_token,
+    userId,
   };
 }
 
-function toMutationTokenResponse(result: FlowTokenResult) {
+function toMutationTokenResponse(result: FlowTokenResult, userId?: string) {
   if (!result.ok) {
     return { error: true as const, message: result.error };
   }
@@ -118,6 +120,7 @@ function toMutationTokenResponse(result: FlowTokenResult) {
     success: true as const,
     access_token: result.access_token,
     refresh_token: result.refresh_token,
+    userId,
   };
 }
 
@@ -282,12 +285,16 @@ export const exchangeOAuthCode = createServerFn({ method: "POST" })
     }
 
     await upsertAdminGithubTokenIfNeeded(supabase, authData.session);
+    await identifyServerUserFromRequest(authData.session.user.id, {
+      method: "oauth",
+      flow: data.flow,
+    });
     const newAccount = isNewWebAccount(data.flow, authData.session, "oauth");
     const tokens = await resolveTokensForFlow({
       flow: data.flow,
       session: authData.session,
     });
-    const response = toSuccessTokenResponse(tokens);
+    const response = toSuccessTokenResponse(tokens, authData.session.user.id);
     return response.success ? { ...response, newAccount } : response;
   });
 
@@ -330,11 +337,18 @@ export const doPasswordSignUp = createServerFn({ method: "POST" })
         session: authData.session,
         email: data.email,
       });
-      const response = toMutationTokenResponse(tokens);
+      const response = toMutationTokenResponse(
+        tokens,
+        authData.session.user.id,
+      );
       return response.success ? { ...response, newAccount } : response;
     }
 
-    return { success: true, needsConfirmation: true };
+    return {
+      success: true,
+      needsConfirmation: true,
+      userId: authData.user?.id,
+    };
   });
 
 export const doPasswordSignIn = createServerFn({ method: "POST" })
@@ -365,7 +379,7 @@ export const doPasswordSignIn = createServerFn({ method: "POST" })
       session: authData.session,
       email: data.email,
     });
-    return toMutationTokenResponse(tokens);
+    return toMutationTokenResponse(tokens, authData.session.user.id);
   });
 
 export const exchangeOtpToken = createServerFn({ method: "POST" })
@@ -405,7 +419,7 @@ export const exchangeOtpToken = createServerFn({ method: "POST" })
       flow,
       session: authData.session,
     });
-    const response = toSuccessTokenResponse(tokens);
+    const response = toSuccessTokenResponse(tokens, authData.session.user.id);
     return response.success ? { ...response, newAccount } : response;
   });
 

--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -17,7 +17,10 @@ import {
 } from "@/functions/supabase";
 import { sanitizeInternalReturnPath } from "@/lib/auth-redirect";
 import { captureOperationalError } from "@/lib/error-reporting";
-import { identifyServerUserFromRequest } from "@/lib/server-analytics";
+import {
+  clearServerAnalyticsIdentity,
+  identifyServerUserFromRequest,
+} from "@/lib/server-analytics";
 
 const shared = z.object({
   flow: z.enum(["desktop", "web"]).default("desktop"),
@@ -264,6 +267,7 @@ export const signOutFn = createServerFn({ method: "POST" }).handler(
       return { success: false, message: error.message };
     }
 
+    clearServerAnalyticsIdentity();
     return { success: true };
   },
 );

--- a/apps/web/src/lib/private-route-analytics-identity.test.ts
+++ b/apps/web/src/lib/private-route-analytics-identity.test.ts
@@ -1,10 +1,23 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import type { AnalyticsIdentity } from "./private-route-analytics-identity.ts";
 import {
   createPrivateRouteIdentity,
+  parseAnalyticsIdentity,
   parsePostHogDistinctId,
+  serializeAnalyticsIdentity,
 } from "./private-route-analytics-identity.ts";
+
+function createStore(initial: AnalyticsIdentity = {}) {
+  let raw = serializeAnalyticsIdentity(initial);
+  return {
+    read: () => parseAnalyticsIdentity(raw),
+    write: (identity: AnalyticsIdentity) => {
+      raw = serializeAnalyticsIdentity(identity);
+    },
+  };
+}
 
 test("parses raw PostHog localStorage JSON without decoding its contents", () => {
   const raw = JSON.stringify({
@@ -15,73 +28,106 @@ test("parses raw PostHog localStorage JSON without decoding its contents", () =>
   assert.equal(parsePostHogDistinctId(raw), "anonymous-id");
 });
 
+test("ignores malformed or non-string identity cookie values", () => {
+  assert.deepEqual(parseAnalyticsIdentity(null), {});
+  assert.deepEqual(parseAnalyticsIdentity("not json"), {});
+  assert.deepEqual(parseAnalyticsIdentity("[]"), {});
+  assert.deepEqual(
+    parseAnalyticsIdentity(JSON.stringify({ userId: 7, anonymousId: "a" })),
+    { anonymousId: "a" },
+  );
+});
+
 test("never reuses an identified user as the next anonymous id", () => {
-  const storage = new Map<string, string>();
-  Object.defineProperty(globalThis, "window", {
-    configurable: true,
-    value: {
-      sessionStorage: {
-        getItem: (key: string) => storage.get(key) ?? null,
-        removeItem: (key: string) => storage.delete(key),
-        setItem: (key: string, value: string) => storage.set(key, value),
-      },
-    },
-  });
+  const identity = createPrivateRouteIdentity(
+    createStore(),
+    () => "fresh-anonymous-id",
+  );
 
-  try {
-    const identity = createPrivateRouteIdentity(() => "fresh-anonymous-id");
+  assert.equal(
+    identity.distinctIdForEvent("original-anonymous-id"),
+    "original-anonymous-id",
+  );
+  assert.equal(
+    identity.anonymousIdForIdentify("first-user", "original-anonymous-id"),
+    "original-anonymous-id",
+  );
+  assert.equal(
+    identity.distinctIdForEvent("original-anonymous-id"),
+    "first-user",
+  );
+  assert.equal(
+    identity.anonymousIdForIdentify("second-user", "original-anonymous-id"),
+    "fresh-anonymous-id",
+  );
+  assert.equal(
+    identity.distinctIdForEvent("original-anonymous-id"),
+    "second-user",
+  );
+});
 
-    assert.equal(
-      identity.distinctIdForEvent("original-anonymous-id"),
-      "original-anonymous-id",
-    );
-    assert.equal(
-      identity.anonymousIdForIdentify("first-user", "original-anonymous-id"),
-      "original-anonymous-id",
-    );
-    assert.equal(
-      identity.distinctIdForEvent("original-anonymous-id"),
-      "first-user",
-    );
-    assert.equal(
-      identity.anonymousIdForIdentify("second-user", "original-anonymous-id"),
-      "fresh-anonymous-id",
-    );
-    assert.equal(
-      identity.distinctIdForEvent("original-anonymous-id"),
-      "second-user",
-    );
-  } finally {
-    Reflect.deleteProperty(globalThis, "window");
-  }
+test("keeps the claim when the browsing context restarts", () => {
+  const store = createStore();
+  createPrivateRouteIdentity(store).anonymousIdForIdentify(
+    "first-user",
+    "original-anonymous-id",
+  );
+
+  const laterVisit = createPrivateRouteIdentity(
+    store,
+    () => "fresh-anonymous-id",
+  );
+
+  assert.equal(
+    laterVisit.anonymousIdForIdentify("second-user", "original-anonymous-id"),
+    "fresh-anonymous-id",
+  );
 });
 
 test("adopts a new anonymous id after PostHog resets", () => {
-  const storage = new Map<string, string>();
-  Object.defineProperty(globalThis, "window", {
-    configurable: true,
-    value: {
-      sessionStorage: {
-        getItem: (key: string) => storage.get(key) ?? null,
-        removeItem: (key: string) => storage.delete(key),
-        setItem: (key: string, value: string) => storage.set(key, value),
-      },
-    },
-  });
+  const store = createStore();
+  const identity = createPrivateRouteIdentity(store);
+  identity.anonymousIdForIdentify("first-user", "original-anonymous-id");
 
-  try {
-    const identity = createPrivateRouteIdentity();
-    identity.anonymousIdForIdentify("first-user", "original-anonymous-id");
+  assert.equal(
+    identity.distinctIdForEvent("reset-anonymous-id"),
+    "reset-anonymous-id",
+  );
+  assert.equal(
+    identity.anonymousIdForIdentify("second-user", "reset-anonymous-id"),
+    "reset-anonymous-id",
+  );
+});
 
-    assert.equal(
-      identity.distinctIdForEvent("reset-anonymous-id"),
-      "reset-anonymous-id",
-    );
-    assert.equal(
-      identity.anonymousIdForIdentify("second-user", "reset-anonymous-id"),
-      "reset-anonymous-id",
-    );
-  } finally {
-    Reflect.deleteProperty(globalThis, "window");
-  }
+test("clearing the identity lets the next user merge the fresh PostHog id", () => {
+  const store = createStore();
+  const identity = createPrivateRouteIdentity(store);
+  identity.anonymousIdForIdentify("first-user", "original-anonymous-id");
+
+  identity.reset();
+
+  assert.equal(
+    identity.anonymousIdForIdentify("second-user", "signed-out-anonymous-id"),
+    "signed-out-anonymous-id",
+  );
+});
+
+test("skips the merge when nothing anonymous was ever captured", () => {
+  const identity = createPrivateRouteIdentity(createStore());
+
+  assert.equal(identity.anonymousIdForIdentify("first-user", null), null);
+  assert.equal(identity.distinctIdForEvent(null), "first-user");
+});
+
+test("does not re-identify the same user twice", () => {
+  const identity = createPrivateRouteIdentity(createStore());
+
+  assert.equal(
+    identity.anonymousIdForIdentify("first-user", "original-anonymous-id"),
+    "original-anonymous-id",
+  );
+  assert.equal(
+    identity.anonymousIdForIdentify("first-user", "original-anonymous-id"),
+    null,
+  );
 });

--- a/apps/web/src/lib/private-route-analytics-identity.test.ts
+++ b/apps/web/src/lib/private-route-analytics-identity.test.ts
@@ -136,6 +136,23 @@ test("reports nothing to remember when sign-out finds no claimed id", () => {
   assert.equal(createPrivateRouteIdentity(createStore()).signOut(null), false);
 });
 
+test("does not claim a PostHog id before a user is identified", () => {
+  const store = createStore({
+    anonymousId: "original-anonymous-id",
+    postHogId: "original-anonymous-id",
+  });
+  const identity = createPrivateRouteIdentity(
+    store,
+    () => "fresh-anonymous-id",
+  );
+
+  assert.equal(identity.signOut("original-anonymous-id"), false);
+  assert.equal(
+    identity.anonymousIdForIdentify("first-user", "original-anonymous-id"),
+    "original-anonymous-id",
+  );
+});
+
 test("skips the merge when nothing anonymous was ever captured", () => {
   const identity = createPrivateRouteIdentity(createStore());
 

--- a/apps/web/src/lib/private-route-analytics-identity.test.ts
+++ b/apps/web/src/lib/private-route-analytics-identity.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createPrivateRouteIdentity,
+  parsePostHogDistinctId,
+} from "./private-route-analytics-identity.ts";
+
+test("parses raw PostHog localStorage JSON without decoding its contents", () => {
+  const raw = JSON.stringify({
+    distinct_id: "anonymous-id",
+    $initial_referrer: "https://example.com/%E0%A4%A",
+  });
+
+  assert.equal(parsePostHogDistinctId(raw), "anonymous-id");
+});
+
+test("never reuses an identified user as the next anonymous id", () => {
+  const storage = new Map<string, string>();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      sessionStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        removeItem: (key: string) => storage.delete(key),
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+    },
+  });
+
+  try {
+    const identity = createPrivateRouteIdentity(() => "fresh-anonymous-id");
+
+    assert.equal(
+      identity.distinctIdForEvent("original-anonymous-id"),
+      "original-anonymous-id",
+    );
+    assert.equal(
+      identity.anonymousIdForIdentify("first-user", "original-anonymous-id"),
+      "original-anonymous-id",
+    );
+    assert.equal(
+      identity.distinctIdForEvent("original-anonymous-id"),
+      "first-user",
+    );
+    assert.equal(
+      identity.anonymousIdForIdentify("second-user", "original-anonymous-id"),
+      "fresh-anonymous-id",
+    );
+    assert.equal(
+      identity.distinctIdForEvent("original-anonymous-id"),
+      "second-user",
+    );
+  } finally {
+    Reflect.deleteProperty(globalThis, "window");
+  }
+});
+
+test("adopts a new anonymous id after PostHog resets", () => {
+  const storage = new Map<string, string>();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      sessionStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        removeItem: (key: string) => storage.delete(key),
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+    },
+  });
+
+  try {
+    const identity = createPrivateRouteIdentity();
+    identity.anonymousIdForIdentify("first-user", "original-anonymous-id");
+
+    assert.equal(
+      identity.distinctIdForEvent("reset-anonymous-id"),
+      "reset-anonymous-id",
+    );
+    assert.equal(
+      identity.anonymousIdForIdentify("second-user", "reset-anonymous-id"),
+      "reset-anonymous-id",
+    );
+  } finally {
+    Reflect.deleteProperty(globalThis, "window");
+  }
+});

--- a/apps/web/src/lib/private-route-analytics-identity.test.ts
+++ b/apps/web/src/lib/private-route-analytics-identity.test.ts
@@ -112,6 +112,30 @@ test("clearing the identity lets the next user merge the fresh PostHog id", () =
   );
 });
 
+test("keeps the claim on sign-out so the next user is not merged in", () => {
+  const store = createStore();
+  const identity = createPrivateRouteIdentity(
+    store,
+    () => "fresh-anonymous-id",
+  );
+  identity.anonymousIdForIdentify("first-user", "original-anonymous-id");
+
+  assert.equal(identity.signOut("original-anonymous-id"), true);
+
+  assert.equal(
+    identity.distinctIdForEvent("original-anonymous-id"),
+    "fresh-anonymous-id",
+  );
+  assert.equal(
+    identity.anonymousIdForIdentify("second-user", "original-anonymous-id"),
+    "fresh-anonymous-id",
+  );
+});
+
+test("reports nothing to remember when sign-out finds no claimed id", () => {
+  assert.equal(createPrivateRouteIdentity(createStore()).signOut(null), false);
+});
+
 test("skips the merge when nothing anonymous was ever captured", () => {
   const identity = createPrivateRouteIdentity(createStore());
 

--- a/apps/web/src/lib/private-route-analytics-identity.ts
+++ b/apps/web/src/lib/private-route-analytics-identity.ts
@@ -1,6 +1,11 @@
-const ANONYMOUS_ID_KEY = "anarlog.private-analytics-anonymous-id";
-const POSTHOG_ID_KEY = "anarlog.private-analytics-posthog-id";
-const USER_ID_KEY = "anarlog.private-analytics-user-id";
+export const ANALYTICS_IDENTITY_COOKIE = "anlg_analytics_identity";
+export const ANALYTICS_IDENTITY_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+export type AnalyticsIdentity = {
+  anonymousId?: string;
+  postHogId?: string;
+  userId?: string;
+};
 
 export function parsePostHogDistinctId(raw: string) {
   try {
@@ -19,105 +24,105 @@ export function parsePostHogDistinctId(raw: string) {
   return null;
 }
 
+export function parseAnalyticsIdentity(raw: string | null | undefined) {
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) {
+      return {};
+    }
+
+    const identity: AnalyticsIdentity = {};
+    for (const key of ["anonymousId", "postHogId", "userId"] as const) {
+      const value = (parsed as Record<string, unknown>)[key];
+      if (typeof value === "string" && value) {
+        identity[key] = value;
+      }
+    }
+    return identity;
+  } catch {
+    return {};
+  }
+}
+
+export function serializeAnalyticsIdentity(identity: AnalyticsIdentity) {
+  return JSON.stringify(identity);
+}
+
+/**
+ * Tracks which person the persisted posthog-js `distinct_id` already belongs to.
+ *
+ * posthog-js mints one anonymous id per browser and keeps it until `reset()`,
+ * so on a shared browser the same id outlives the first sign-in. Merging it into
+ * a second user would fold two people together, and keying pre-login events on it
+ * would file them under the previous user. The record lives in a cookie so it
+ * survives tab closes and stays visible to the server-side OAuth identify.
+ */
 export function createPrivateRouteIdentity(
+  store: {
+    read: () => AnalyticsIdentity;
+    write: (identity: AnalyticsIdentity) => void;
+  },
   createId: () => string = () => crypto.randomUUID(),
 ) {
-  let fallbackAnonymousId: string | null = null;
-  let fallbackPostHogId: string | null = null;
-  let fallbackUserId: string | null = null;
-
-  const read = (key: string) => {
-    try {
-      return window.sessionStorage.getItem(key);
-    } catch {
-      return null;
-    }
-  };
-
-  const write = (key: string, value: string) => {
-    try {
-      window.sessionStorage.setItem(key, value);
-    } catch {}
-  };
-
-  const clear = (key: string) => {
-    try {
-      window.sessionStorage.removeItem(key);
-    } catch {}
-  };
-
-  const getAnonymousId = (postHogDistinctId: string | null) => {
-    const existing = read(ANONYMOUS_ID_KEY) ?? fallbackAnonymousId;
-    if (existing) {
-      return existing;
+  const sync = (postHogDistinctId: string | null): AnalyticsIdentity => {
+    const identity = store.read();
+    if (!postHogDistinctId || postHogDistinctId === identity.postHogId) {
+      return identity;
     }
 
-    const resolved = postHogDistinctId ?? createId();
-    fallbackAnonymousId = resolved;
-    write(ANONYMOUS_ID_KEY, resolved);
-    return resolved;
-  };
-
-  const setAnonymousId = (anonymousId: string) => {
-    fallbackAnonymousId = anonymousId;
-    write(ANONYMOUS_ID_KEY, anonymousId);
-  };
-
-  const getPostHogId = () => read(POSTHOG_ID_KEY) ?? fallbackPostHogId;
-
-  const setPostHogId = (postHogId: string) => {
-    fallbackPostHogId = postHogId;
-    write(POSTHOG_ID_KEY, postHogId);
-  };
-
-  const getUserId = () => read(USER_ID_KEY) ?? fallbackUserId;
-
-  const setUserId = (userId: string) => {
-    fallbackUserId = userId;
-    write(USER_ID_KEY, userId);
-  };
-
-  const clearUserId = () => {
-    fallbackUserId = null;
-    clear(USER_ID_KEY);
-  };
-
-  const syncPostHogId = (postHogDistinctId: string | null) => {
-    if (!postHogDistinctId || postHogDistinctId === getPostHogId()) {
-      return;
+    if (postHogDistinctId === identity.userId) {
+      const next = { ...identity, postHogId: postHogDistinctId };
+      store.write(next);
+      return next;
     }
 
-    setPostHogId(postHogDistinctId);
-    const userId = getUserId();
-    if (postHogDistinctId === userId) {
-      return;
-    }
-
-    setAnonymousId(postHogDistinctId);
-    if (userId) {
-      clearUserId();
-    }
+    const next = {
+      anonymousId: postHogDistinctId,
+      postHogId: postHogDistinctId,
+    };
+    store.write(next);
+    return next;
   };
 
   return {
     distinctIdForEvent(postHogDistinctId: string | null) {
-      syncPostHogId(postHogDistinctId);
-      return getUserId() ?? getAnonymousId(postHogDistinctId);
+      const identity = sync(postHogDistinctId);
+      if (identity.userId) {
+        return identity.userId;
+      }
+      if (identity.anonymousId) {
+        return identity.anonymousId;
+      }
+
+      const anonymousId = postHogDistinctId ?? createId();
+      store.write({ ...identity, anonymousId });
+      return anonymousId;
     },
 
     anonymousIdForIdentify(userId: string, postHogDistinctId: string | null) {
-      syncPostHogId(postHogDistinctId);
-      const previousUserId = getUserId();
-      if (previousUserId === userId) {
+      const identity = sync(postHogDistinctId);
+      if (identity.userId === userId) {
         return null;
       }
 
-      const previousAnonymousId = getAnonymousId(postHogDistinctId);
-      const anonymousId = previousUserId ? createId() : previousAnonymousId;
+      const anonymousId = identity.userId
+        ? createId()
+        : (identity.anonymousId ?? postHogDistinctId);
 
-      setAnonymousId(anonymousId);
-      setUserId(userId);
-      return anonymousId === userId ? null : anonymousId;
+      store.write({
+        ...identity,
+        ...(anonymousId ? { anonymousId } : {}),
+        userId,
+      });
+      return anonymousId && anonymousId !== userId ? anonymousId : null;
+    },
+
+    reset() {
+      store.write({});
     },
   };
 }

--- a/apps/web/src/lib/private-route-analytics-identity.ts
+++ b/apps/web/src/lib/private-route-analytics-identity.ts
@@ -121,6 +121,26 @@ export function createPrivateRouteIdentity(
       return anonymousId && anonymousId !== userId ? anonymousId : null;
     },
 
+    /**
+     * Releases the signed-in user while keeping the posthog-js id recorded as
+     * claimed, so the next sign-in on this browser mints a fresh anonymous id
+     * instead of merging the previous user's id into a second person.
+     *
+     * Returns false when nothing was ever claimed and the record can be dropped.
+     */
+    signOut(postHogDistinctId: string | null) {
+      const claimedPostHogId = postHogDistinctId ?? store.read().postHogId;
+      if (!claimedPostHogId) {
+        return false;
+      }
+
+      store.write({
+        anonymousId: createId(),
+        postHogId: claimedPostHogId,
+      });
+      return true;
+    },
+
     reset() {
       store.write({});
     },

--- a/apps/web/src/lib/private-route-analytics-identity.ts
+++ b/apps/web/src/lib/private-route-analytics-identity.ts
@@ -129,7 +129,12 @@ export function createPrivateRouteIdentity(
      * Returns false when nothing was ever claimed and the record can be dropped.
      */
     signOut(postHogDistinctId: string | null) {
-      const claimedPostHogId = postHogDistinctId ?? store.read().postHogId;
+      const identity = store.read();
+      if (!identity.userId) {
+        return false;
+      }
+
+      const claimedPostHogId = postHogDistinctId ?? identity.postHogId;
       if (!claimedPostHogId) {
         return false;
       }

--- a/apps/web/src/lib/private-route-analytics-identity.ts
+++ b/apps/web/src/lib/private-route-analytics-identity.ts
@@ -1,0 +1,123 @@
+const ANONYMOUS_ID_KEY = "anarlog.private-analytics-anonymous-id";
+const POSTHOG_ID_KEY = "anarlog.private-analytics-posthog-id";
+const USER_ID_KEY = "anarlog.private-analytics-user-id";
+
+export function parsePostHogDistinctId(raw: string) {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "distinct_id" in parsed &&
+      typeof parsed.distinct_id === "string" &&
+      parsed.distinct_id
+    ) {
+      return parsed.distinct_id;
+    }
+  } catch {}
+
+  return null;
+}
+
+export function createPrivateRouteIdentity(
+  createId: () => string = () => crypto.randomUUID(),
+) {
+  let fallbackAnonymousId: string | null = null;
+  let fallbackPostHogId: string | null = null;
+  let fallbackUserId: string | null = null;
+
+  const read = (key: string) => {
+    try {
+      return window.sessionStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  };
+
+  const write = (key: string, value: string) => {
+    try {
+      window.sessionStorage.setItem(key, value);
+    } catch {}
+  };
+
+  const clear = (key: string) => {
+    try {
+      window.sessionStorage.removeItem(key);
+    } catch {}
+  };
+
+  const getAnonymousId = (postHogDistinctId: string | null) => {
+    const existing = read(ANONYMOUS_ID_KEY) ?? fallbackAnonymousId;
+    if (existing) {
+      return existing;
+    }
+
+    const resolved = postHogDistinctId ?? createId();
+    fallbackAnonymousId = resolved;
+    write(ANONYMOUS_ID_KEY, resolved);
+    return resolved;
+  };
+
+  const setAnonymousId = (anonymousId: string) => {
+    fallbackAnonymousId = anonymousId;
+    write(ANONYMOUS_ID_KEY, anonymousId);
+  };
+
+  const getPostHogId = () => read(POSTHOG_ID_KEY) ?? fallbackPostHogId;
+
+  const setPostHogId = (postHogId: string) => {
+    fallbackPostHogId = postHogId;
+    write(POSTHOG_ID_KEY, postHogId);
+  };
+
+  const getUserId = () => read(USER_ID_KEY) ?? fallbackUserId;
+
+  const setUserId = (userId: string) => {
+    fallbackUserId = userId;
+    write(USER_ID_KEY, userId);
+  };
+
+  const clearUserId = () => {
+    fallbackUserId = null;
+    clear(USER_ID_KEY);
+  };
+
+  const syncPostHogId = (postHogDistinctId: string | null) => {
+    if (!postHogDistinctId || postHogDistinctId === getPostHogId()) {
+      return;
+    }
+
+    setPostHogId(postHogDistinctId);
+    const userId = getUserId();
+    if (postHogDistinctId === userId) {
+      return;
+    }
+
+    setAnonymousId(postHogDistinctId);
+    if (userId) {
+      clearUserId();
+    }
+  };
+
+  return {
+    distinctIdForEvent(postHogDistinctId: string | null) {
+      syncPostHogId(postHogDistinctId);
+      return getUserId() ?? getAnonymousId(postHogDistinctId);
+    },
+
+    anonymousIdForIdentify(userId: string, postHogDistinctId: string | null) {
+      syncPostHogId(postHogDistinctId);
+      const previousUserId = getUserId();
+      if (previousUserId === userId) {
+        return null;
+      }
+
+      const previousAnonymousId = getAnonymousId(postHogDistinctId);
+      const anonymousId = previousUserId ? createId() : previousAnonymousId;
+
+      setAnonymousId(anonymousId);
+      setUserId(userId);
+      return anonymousId === userId ? null : anonymousId;
+    },
+  };
+}

--- a/apps/web/src/lib/private-route-analytics.ts
+++ b/apps/web/src/lib/private-route-analytics.ts
@@ -1,12 +1,17 @@
+import posthog from "posthog-js";
+
 import { env } from "@/env";
 import { hasGlobalPrivacyControl } from "@/lib/global-privacy-control";
 
+import type { AnalyticsIdentity } from "./private-route-analytics-identity";
 import {
+  ANALYTICS_IDENTITY_COOKIE,
+  ANALYTICS_IDENTITY_MAX_AGE_SECONDS,
   createPrivateRouteIdentity,
+  parseAnalyticsIdentity,
   parsePostHogDistinctId,
+  serializeAnalyticsIdentity,
 } from "./private-route-analytics-identity";
-
-const privateRouteIdentity = createPrivateRouteIdentity();
 
 function readCookie(name: string) {
   const prefix = `${name}=`;
@@ -16,6 +21,24 @@ function readCookie(name: string) {
     .find((part) => part.startsWith(prefix));
   return match ? match.slice(prefix.length) : null;
 }
+
+const privateRouteIdentity = createPrivateRouteIdentity({
+  read: () => {
+    try {
+      const raw = readCookie(ANALYTICS_IDENTITY_COOKIE);
+      return parseAnalyticsIdentity(raw ? decodeURIComponent(raw) : null);
+    } catch {
+      return {};
+    }
+  },
+  write: (identity: AnalyticsIdentity) => {
+    try {
+      const value = encodeURIComponent(serializeAnalyticsIdentity(identity));
+      const secure = window.location.protocol === "https:" ? "; secure" : "";
+      document.cookie = `${ANALYTICS_IDENTITY_COOKIE}=${value}; path=/; max-age=${ANALYTICS_IDENTITY_MAX_AGE_SECONDS}; samesite=lax${secure}`;
+    } catch {}
+  },
+});
 
 /**
  * posthog-js persists its anonymous distinct_id under `ph_<token>_posthog`
@@ -87,6 +110,25 @@ export function capturePrivateRouteEvent(
         },
       }),
     }).catch(() => undefined);
+  } catch {}
+}
+
+/**
+ * Drops the analytics identity so the next person on this browser starts fresh.
+ *
+ * Without the posthog-js reset its anonymous `distinct_id` outlives the session,
+ * and every later visitor's pageviews keep landing on the person we just signed
+ * out. Runs regardless of Global Privacy Control or dev mode: clearing identity
+ * state is never the thing we want to suppress.
+ */
+export function resetPrivateRouteAnalyticsIdentity() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  privateRouteIdentity.reset();
+  try {
+    posthog.reset();
   } catch {}
 }
 

--- a/apps/web/src/lib/private-route-analytics.ts
+++ b/apps/web/src/lib/private-route-analytics.ts
@@ -4,30 +4,79 @@ import { hasGlobalPrivacyControl } from "@/lib/global-privacy-control";
 const PRIVATE_ANALYTICS_ID_KEY = "anarlog.private-analytics-id";
 let fallbackDistinctId: string | null = null;
 
+function readCookie(name: string) {
+  const prefix = `${name}=`;
+  const match = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+  return match ? match.slice(prefix.length) : null;
+}
+
+/**
+ * posthog-js persists its anonymous distinct_id under `ph_<token>_posthog`
+ * (localStorage, mirrored to a cookie). Telemetry is disabled on auth routes,
+ * so posthog-js is never initialized here and cannot hand us the id directly.
+ * Reading the persisted value keeps events fired from auth routes attached to
+ * the same person as the marketing-site pageviews that preceded them.
+ */
+function readPostHogAnonId() {
+  if (!env.VITE_POSTHOG_API_KEY) {
+    return null;
+  }
+
+  try {
+    const key = `ph_${env.VITE_POSTHOG_API_KEY}_posthog`;
+    const raw = window.localStorage.getItem(key) ?? readCookie(key);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(decodeURIComponent(raw)) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "distinct_id" in parsed &&
+      typeof parsed.distinct_id === "string" &&
+      parsed.distinct_id
+    ) {
+      return parsed.distinct_id;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
 function getDistinctId() {
   try {
     const existing = window.sessionStorage.getItem(PRIVATE_ANALYTICS_ID_KEY);
     if (existing) return existing;
 
-    const created = crypto.randomUUID();
-    window.sessionStorage.setItem(PRIVATE_ANALYTICS_ID_KEY, created);
-    return created;
+    const resolved = readPostHogAnonId() ?? crypto.randomUUID();
+    window.sessionStorage.setItem(PRIVATE_ANALYTICS_ID_KEY, resolved);
+    return resolved;
   } catch {
-    fallbackDistinctId ??= crypto.randomUUID();
+    fallbackDistinctId ??= readPostHogAnonId() ?? crypto.randomUUID();
     return fallbackDistinctId;
   }
+}
+
+function analyticsSuppressed() {
+  return (
+    typeof window === "undefined" ||
+    import.meta.env.DEV ||
+    !env.VITE_POSTHOG_API_KEY ||
+    hasGlobalPrivacyControl()
+  );
 }
 
 export function capturePrivateRouteEvent(
   event: string,
   properties: Record<string, unknown> = {},
 ) {
-  if (
-    typeof window === "undefined" ||
-    import.meta.env.DEV ||
-    !env.VITE_POSTHOG_API_KEY ||
-    hasGlobalPrivacyControl()
-  ) {
+  if (analyticsSuppressed()) {
     return;
   }
 
@@ -51,5 +100,53 @@ export function capturePrivateRouteEvent(
         },
       }),
     }).catch(() => undefined);
+  } catch {}
+}
+
+/**
+ * Merges the anonymous browsing identity into the Supabase user id.
+ *
+ * `account_created` / `account_confirmed` are delivered server-side (Supabase
+ * trigger -> outbox -> scheduled Netlify function) keyed on the Supabase user
+ * uuid, while everything captured in the browser is keyed on the posthog-js
+ * anonymous id. Without this $identify the two never resolve to the same
+ * person and any funnel crossing signup silently under-reports.
+ */
+export function identifyPrivateRouteUser(
+  userId: string | undefined | null,
+  properties: Record<string, unknown> = {},
+) {
+  if (!userId || analyticsSuppressed()) {
+    return;
+  }
+
+  try {
+    const anonDistinctId = getDistinctId();
+    if (anonDistinctId === userId) {
+      return;
+    }
+
+    const host = env.VITE_POSTHOG_HOST.replace(/\/+$/, "");
+    void fetch(`${host}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      keepalive: true,
+      body: JSON.stringify({
+        api_key: env.VITE_POSTHOG_API_KEY,
+        event: "$identify",
+        properties: {
+          ...properties,
+          distinct_id: userId,
+          $anon_distinct_id: anonDistinctId,
+          surface: "web",
+          analytics_schema_version: 1,
+          app_version: env.VITE_APP_VERSION ?? "unknown",
+        },
+      }),
+    }).catch(() => undefined);
+
+    // Subsequent events in this tab should ride the identified id so they land
+    // on the merged person even before PostHog processes the merge.
+    window.sessionStorage.setItem(PRIVATE_ANALYTICS_ID_KEY, userId);
   } catch {}
 }

--- a/apps/web/src/lib/private-route-analytics.ts
+++ b/apps/web/src/lib/private-route-analytics.ts
@@ -1,8 +1,12 @@
 import { env } from "@/env";
 import { hasGlobalPrivacyControl } from "@/lib/global-privacy-control";
 
-const PRIVATE_ANALYTICS_ID_KEY = "anarlog.private-analytics-id";
-let fallbackDistinctId: string | null = null;
+import {
+  createPrivateRouteIdentity,
+  parsePostHogDistinctId,
+} from "./private-route-analytics-identity";
+
+const privateRouteIdentity = createPrivateRouteIdentity();
 
 function readCookie(name: string) {
   const prefix = `${name}=`;
@@ -20,46 +24,27 @@ function readCookie(name: string) {
  * Reading the persisted value keeps events fired from auth routes attached to
  * the same person as the marketing-site pageviews that preceded them.
  */
-function readPostHogAnonId() {
+function readPostHogDistinctId() {
   if (!env.VITE_POSTHOG_API_KEY) {
     return null;
   }
 
   try {
     const key = `ph_${env.VITE_POSTHOG_API_KEY}_posthog`;
-    const raw = window.localStorage.getItem(key) ?? readCookie(key);
-    if (!raw) {
-      return null;
+    const localValue = window.localStorage.getItem(key);
+    if (localValue) {
+      const localDistinctId = parsePostHogDistinctId(localValue);
+      if (localDistinctId) {
+        return localDistinctId;
+      }
     }
 
-    const parsed = JSON.parse(decodeURIComponent(raw)) as unknown;
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      "distinct_id" in parsed &&
-      typeof parsed.distinct_id === "string" &&
-      parsed.distinct_id
-    ) {
-      return parsed.distinct_id;
-    }
+    const cookieValue = readCookie(key);
+    return cookieValue
+      ? parsePostHogDistinctId(decodeURIComponent(cookieValue))
+      : null;
   } catch {
     return null;
-  }
-
-  return null;
-}
-
-function getDistinctId() {
-  try {
-    const existing = window.sessionStorage.getItem(PRIVATE_ANALYTICS_ID_KEY);
-    if (existing) return existing;
-
-    const resolved = readPostHogAnonId() ?? crypto.randomUUID();
-    window.sessionStorage.setItem(PRIVATE_ANALYTICS_ID_KEY, resolved);
-    return resolved;
-  } catch {
-    fallbackDistinctId ??= readPostHogAnonId() ?? crypto.randomUUID();
-    return fallbackDistinctId;
   }
 }
 
@@ -82,7 +67,9 @@ export function capturePrivateRouteEvent(
 
   try {
     const host = env.VITE_POSTHOG_HOST.replace(/\/+$/, "");
-    const distinctId = getDistinctId();
+    const distinctId = privateRouteIdentity.distinctIdForEvent(
+      readPostHogDistinctId(),
+    );
     void fetch(`${host}/capture/`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -121,8 +108,11 @@ export function identifyPrivateRouteUser(
   }
 
   try {
-    const anonDistinctId = getDistinctId();
-    if (anonDistinctId === userId) {
+    const anonDistinctId = privateRouteIdentity.anonymousIdForIdentify(
+      userId,
+      readPostHogDistinctId(),
+    );
+    if (!anonDistinctId) {
       return;
     }
 
@@ -144,9 +134,5 @@ export function identifyPrivateRouteUser(
         },
       }),
     }).catch(() => undefined);
-
-    // Subsequent events in this tab should ride the identified id so they land
-    // on the merged person even before PostHog processes the merge.
-    window.sessionStorage.setItem(PRIVATE_ANALYTICS_ID_KEY, userId);
   } catch {}
 }

--- a/apps/web/src/lib/server-analytics.ts
+++ b/apps/web/src/lib/server-analytics.ts
@@ -1,6 +1,21 @@
-import { getRequestHeaders } from "@tanstack/react-start/server";
+import {
+  deleteCookie,
+  getCookie,
+  getRequestHeaders,
+  setCookie,
+} from "@tanstack/react-start/server";
 
 import { env } from "@/env";
+import { getRequestAppOrigin } from "@/functions/app-origin";
+
+import type { AnalyticsIdentity } from "./private-route-analytics-identity";
+import {
+  ANALYTICS_IDENTITY_COOKIE,
+  ANALYTICS_IDENTITY_MAX_AGE_SECONDS,
+  createPrivateRouteIdentity,
+  parseAnalyticsIdentity,
+  serializeAnalyticsIdentity,
+} from "./private-route-analytics-identity";
 
 export async function captureServerAnalytics({
   event,
@@ -83,6 +98,39 @@ function readPostHogAnonIdFromRequest() {
   return null;
 }
 
+function identityCookieOptions() {
+  return {
+    httpOnly: false,
+    maxAge: ANALYTICS_IDENTITY_MAX_AGE_SECONDS,
+    path: "/",
+    sameSite: "lax" as const,
+    secure: getRequestAppOrigin().startsWith("https://"),
+  };
+}
+
+function createRequestIdentityStore() {
+  return {
+    read: () => parseAnalyticsIdentity(getCookie(ANALYTICS_IDENTITY_COOKIE)),
+    write: (identity: AnalyticsIdentity) => {
+      setCookie(
+        ANALYTICS_IDENTITY_COOKIE,
+        serializeAnalyticsIdentity(identity),
+        identityCookieOptions(),
+      );
+    },
+  };
+}
+
+/**
+ * Forgets which person owns this browser's posthog-js anonymous id.
+ *
+ * The browser clears the same record on sign-out, but a hard navigation to
+ * `/callback/signout` never runs that code, so the server drops it too.
+ */
+export function clearServerAnalyticsIdentity() {
+  deleteCookie(ANALYTICS_IDENTITY_COOKIE, { path: "/" });
+}
+
 /**
  * Server-side counterpart to `identifyPrivateRouteUser`.
  *
@@ -98,8 +146,17 @@ export async function identifyServerUserFromRequest(
     return;
   }
 
-  const anonDistinctId = readPostHogAnonIdFromRequest();
-  if (!anonDistinctId || anonDistinctId === userId) {
+  // No posthog-js cookie means nothing was ever captured anonymously here, so
+  // there is no merge to make and no identity worth recording (GPC, opt-out).
+  const postHogDistinctId = readPostHogAnonIdFromRequest();
+  if (!postHogDistinctId) {
+    return;
+  }
+
+  const anonDistinctId = createPrivateRouteIdentity(
+    createRequestIdentityStore(),
+  ).anonymousIdForIdentify(userId, postHogDistinctId);
+  if (!anonDistinctId) {
     return;
   }
 

--- a/apps/web/src/lib/server-analytics.ts
+++ b/apps/web/src/lib/server-analytics.ts
@@ -122,13 +122,22 @@ function createRequestIdentityStore() {
 }
 
 /**
- * Forgets which person owns this browser's posthog-js anonymous id.
+ * Ends the signed-in analytics identity for this browser.
  *
- * The browser clears the same record on sign-out, but a hard navigation to
- * `/callback/signout` never runs that code, so the server drops it too.
+ * A hard navigation to `/callback/signout` redirects from the server, so
+ * `posthog.reset()` never runs and the posthog-js anonymous id outlives the
+ * session still tied to the user who just left. Dropping the record entirely
+ * would let the next sign-in merge that id into a second person, so the claim
+ * is kept and a fresh anonymous id takes over for later events.
  */
 export function clearServerAnalyticsIdentity() {
-  deleteCookie(ANALYTICS_IDENTITY_COOKIE, { path: "/" });
+  const claimed = createPrivateRouteIdentity(
+    createRequestIdentityStore(),
+  ).signOut(readPostHogAnonIdFromRequest());
+
+  if (!claimed) {
+    deleteCookie(ANALYTICS_IDENTITY_COOKIE, { path: "/" });
+  }
 }
 
 /**
@@ -146,15 +155,19 @@ export async function identifyServerUserFromRequest(
     return;
   }
 
-  // No posthog-js cookie means nothing was ever captured anonymously here, so
-  // there is no merge to make and no identity worth recording (GPC, opt-out).
+  // A direct `/auth` visit mints its own anonymous id when posthog-js never ran
+  // before it, so the funnel identity can live in our cookie alone. Nothing
+  // recorded in either place means no analytics happened here (GPC, opt-out),
+  // leaving no merge to make and no identity worth recording.
+  const identityStore = createRequestIdentityStore();
   const postHogDistinctId = readPostHogAnonIdFromRequest();
-  if (!postHogDistinctId) {
+  const identity = identityStore.read();
+  if (!postHogDistinctId && !identity.anonymousId && !identity.userId) {
     return;
   }
 
   const anonDistinctId = createPrivateRouteIdentity(
-    createRequestIdentityStore(),
+    identityStore,
   ).anonymousIdForIdentify(userId, postHogDistinctId);
   if (!anonDistinctId) {
     return;

--- a/apps/web/src/lib/server-analytics.ts
+++ b/apps/web/src/lib/server-analytics.ts
@@ -1,3 +1,5 @@
+import { getRequestHeaders } from "@tanstack/react-start/server";
+
 import { env } from "@/env";
 
 export async function captureServerAnalytics({
@@ -39,5 +41,87 @@ export async function captureServerAnalytics({
 
   if (!response.ok) {
     throw new Error(`PostHog capture failed with ${response.status}`);
+  }
+}
+
+function readPostHogAnonIdFromRequest() {
+  if (!env.VITE_POSTHOG_API_KEY) {
+    return null;
+  }
+
+  try {
+    const cookieHeader: string | null = getRequestHeaders().get("cookie");
+    if (!cookieHeader) {
+      return null;
+    }
+
+    const name = `ph_${env.VITE_POSTHOG_API_KEY}_posthog`;
+    const prefix = `${name}=`;
+    const raw = cookieHeader
+      .split(";")
+      .map((part: string) => part.trim())
+      .find((part: string) => part.startsWith(prefix))
+      ?.slice(prefix.length);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(decodeURIComponent(raw)) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "distinct_id" in parsed &&
+      typeof parsed.distinct_id === "string" &&
+      parsed.distinct_id
+    ) {
+      return parsed.distinct_id;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Server-side counterpart to `identifyPrivateRouteUser`.
+ *
+ * Used by flows that complete during `beforeLoad` (OAuth code exchange), where
+ * no browser code runs before the redirect. The posthog-js anonymous id rides
+ * along on the request cookie, so the merge can be emitted from here.
+ */
+export async function identifyServerUserFromRequest(
+  userId: string,
+  properties: Record<string, unknown> = {},
+) {
+  if (!env.VITE_POSTHOG_API_KEY || process.env.NODE_ENV !== "production") {
+    return;
+  }
+
+  const anonDistinctId = readPostHogAnonIdFromRequest();
+  if (!anonDistinctId || anonDistinctId === userId) {
+    return;
+  }
+
+  try {
+    await fetch(`${env.VITE_POSTHOG_HOST.replace(/\/+$/, "")}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: AbortSignal.timeout(1_000),
+      body: JSON.stringify({
+        api_key: env.VITE_POSTHOG_API_KEY,
+        event: "$identify",
+        properties: {
+          ...properties,
+          distinct_id: userId,
+          $anon_distinct_id: anonDistinctId,
+          surface: "api",
+          analytics_schema_version: 1,
+          app_version: env.VITE_APP_VERSION ?? "unknown",
+        },
+      }),
+    });
+  } catch {
+    // identity stitching is best-effort and must never block auth
   }
 }

--- a/apps/web/src/routes/_view/app/-account-access.tsx
+++ b/apps/web/src/routes/_view/app/-account-access.tsx
@@ -12,6 +12,7 @@ import {
 import { signOutFn } from "@/functions/auth";
 import { deleteAccount } from "@/functions/billing";
 import { captureOperationalError } from "@/lib/error-reporting";
+import { resetPrivateRouteAnalyticsIdentity } from "@/lib/private-route-analytics";
 
 export function AccountAccessSection() {
   const navigate = useNavigate();
@@ -27,6 +28,7 @@ export function AccountAccessSection() {
       throw new Error(res.message);
     },
     onSuccess: () => {
+      resetPrivateRouteAnalyticsIdentity();
       navigate({ to: "/" });
     },
     onError: (error) => {

--- a/apps/web/src/routes/_view/callback/signout.tsx
+++ b/apps/web/src/routes/_view/callback/signout.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { signOutFn } from "@/functions/auth";
+import { resetPrivateRouteAnalyticsIdentity } from "@/lib/private-route-analytics";
 
 const validateSearch = z.object({
   redirect: z.string().optional(),
@@ -14,6 +15,7 @@ export const Route = createFileRoute("/_view/callback/signout")({
   }),
   beforeLoad: async ({ search }) => {
     await signOutFn();
+    resetPrivateRouteAnalyticsIdentity();
     throw redirect({ to: search.redirect || "/" });
   },
 });

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -32,7 +32,10 @@ import {
   buildPostAuthDestination,
   sanitizeInternalReturnPath,
 } from "@/lib/auth-redirect";
-import { capturePrivateRouteEvent } from "@/lib/private-route-analytics";
+import {
+  capturePrivateRouteEvent,
+  identifyPrivateRouteUser,
+} from "@/lib/private-route-analytics";
 
 const commonSearch = {
   redirect: z.string().optional(),
@@ -375,6 +378,12 @@ function PasswordForm({
         result.success &&
         "access_token" in result
       ) {
+        identifyPrivateRouteUser(
+          "userId" in result
+            ? (result.userId as string | undefined)
+            : undefined,
+          { method: "password", action: "sign_in", flow },
+        );
         handlePasswordSuccess(
           result.access_token as string,
           result.refresh_token as string,
@@ -420,6 +429,12 @@ function PasswordForm({
         return;
       }
       if (result && "success" in result && result.success) {
+        identifyPrivateRouteUser(
+          "userId" in result
+            ? (result.userId as string | undefined)
+            : undefined,
+          { method: "password", action: "sign_up", flow },
+        );
         if ("needsConfirmation" in result && result.needsConfirmation) {
           setSubmitted(true);
           return;

--- a/apps/web/src/routes/confirm-auth.tsx
+++ b/apps/web/src/routes/confirm-auth.tsx
@@ -19,6 +19,7 @@ import {
   toAuthFlowSearch,
 } from "@/lib/auth-flow-context";
 import { buildPostAuthDestination } from "@/lib/auth-redirect";
+import { identifyPrivateRouteUser } from "@/lib/private-route-analytics";
 
 const validateSearch = z.object({
   token_hash: z.string().min(1),
@@ -69,6 +70,12 @@ function Component() {
         setErrorMessage(result.error);
         return;
       }
+
+      identifyPrivateRouteUser(result.userId, {
+        method: "otp",
+        action: search.type,
+        flow: context.flow,
+      });
 
       if (search.type === "recovery") {
         navigate({


### PR DESCRIPTION
Identify the signed-in user during OAuth token exchange and
include the userId in auth token responses for consistent
analytics. Track OTP-based confirmation flows by calling
identifyPrivateRouteUser once the userId is available.

Add server-side analytics helpers to read PostHog anonymous
distinct_id from request cookies using server request headers. This
enables server-driven PostHog identification in auth flows where
client code does not run first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth response shapes and cookie-based identity on sign-in/out; mis-stitching could affect analytics attribution but auth is designed not to block on identify failures.
> 
> **Overview**
> Adds **PostHog identity stitching** for signup/login so pre-auth events and server-side `account_*` events resolve to the same person, while avoiding **cross-user merges on shared browsers**.
> 
> A new **`anlg_analytics_identity` cookie** and `createPrivateRouteIdentity` logic track which PostHog `distinct_id` is already claimed; a second user on the same browser gets a fresh anonymous id instead of inheriting the previous user’s id. Private-route capture now reads PostHog’s persisted id (localStorage/cookie) instead of a session-only UUID, and emits **`$identify`** merges via `identifyPrivateRouteUser` on password, OTP, and related client flows.
> 
> **Server-side:** OAuth code exchange calls `identifyServerUserFromRequest` before redirect; `signOutFn` runs `clearServerAnalyticsIdentity` (claim retained, fresh anonymous id). Auth responses include **`userId`** where tokens are returned (including email confirmation pending). Sign-out paths also call `resetPrivateRouteAnalyticsIdentity` / `posthog.reset()` when the client runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa9494b319d59ea849d21a29cf06dea650b7b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->