### PR TITLE
Keep additional languages empty by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4950,6 +4950,7 @@ dependencies = [
  "regex",
  "serde",
  "specta",
+ "sys-locale",
  "sysinfo",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -437,4 +437,5 @@ xcap = "0.9.3"
 rmcp = "1.4"
 rustls = { version = "0.23", default-features = false }
 sqlx = { version = "=0.9.0-alpha.1", default-features = false }
+sys-locale = "0.3.2"
 sysinfo = "0.38"

--- a/apps/desktop/src/settings/queries.test.tsx
+++ b/apps/desktop/src/settings/queries.test.tsx
@@ -218,7 +218,7 @@ describe("SQLite settings", () => {
     ]);
   });
 
-  it("persists OS language defaults only when no stored values exist", async () => {
+  it("uses the primary OS language without adding spoken languages", async () => {
     let rows: Array<{ id: string; value_json: string }> = [];
     mocks.execute.mockImplementation(async () => rows);
     mocks.executeTransaction.mockImplementation(async (statements) => {
@@ -237,11 +237,47 @@ describe("SQLite settings", () => {
 
     const statements = mocks.executeTransaction.mock.calls[0][0];
     expect(statements.map((statement) => statement.params.slice(0, 2))).toEqual(
-      [
-        ["ai_language", JSON.stringify("ko")],
-        ["spoken_languages", JSON.stringify(JSON.stringify(["ko", "en"]))],
-      ],
+      [["ai_language", JSON.stringify("ko")]],
     );
+  });
+
+  it("clears spoken languages previously populated from the OS", async () => {
+    mocks.execute.mockResolvedValue([
+      { id: "ai_language", value_json: JSON.stringify("ko") },
+      {
+        id: "spoken_languages",
+        value_json: JSON.stringify(JSON.stringify(["ko", "en"])),
+      },
+    ]);
+    mocks.getPreferredLanguages.mockResolvedValue({
+      status: "ok",
+      data: ["ko", "en"],
+    });
+
+    await initializeApplicationSettings();
+
+    const statements = mocks.executeTransaction.mock.calls[0][0];
+    expect(statements.map((statement) => statement.params.slice(0, 2))).toEqual(
+      [["spoken_languages", JSON.stringify("[]")]],
+    );
+  });
+
+  it("preserves explicitly selected spoken languages", async () => {
+    mocks.execute.mockResolvedValue([
+      { id: "ai_language", value_json: JSON.stringify("ko") },
+      {
+        id: "spoken_languages",
+        value_json: JSON.stringify(JSON.stringify(["en"])),
+      },
+    ]);
+    mocks.getPreferredLanguages.mockResolvedValue({
+      status: "ok",
+      data: ["ko", "en"],
+    });
+
+    await initializeApplicationSettings();
+
+    expect(mocks.executeTransaction).not.toHaveBeenCalled();
   });
 
   it("repairs a selected external transcription provider with no model", async () => {

--- a/apps/desktop/src/settings/queries.test.tsx
+++ b/apps/desktop/src/settings/queries.test.tsx
@@ -218,7 +218,7 @@ describe("SQLite settings", () => {
     ]);
   });
 
-  it("uses the primary OS language without adding spoken languages", async () => {
+  it("initializes languages from OS preferences", async () => {
     let rows: Array<{ id: string; value_json: string }> = [];
     mocks.execute.mockImplementation(async () => rows);
     mocks.executeTransaction.mockImplementation(async (statements) => {
@@ -237,11 +237,14 @@ describe("SQLite settings", () => {
 
     const statements = mocks.executeTransaction.mock.calls[0][0];
     expect(statements.map((statement) => statement.params.slice(0, 2))).toEqual(
-      [["ai_language", JSON.stringify("ko")]],
+      [
+        ["ai_language", JSON.stringify("ko")],
+        ["spoken_languages", JSON.stringify(JSON.stringify(["en"]))],
+      ],
     );
   });
 
-  it("clears spoken languages previously populated from the OS", async () => {
+  it("normalizes spoken languages previously populated from the OS", async () => {
     mocks.execute.mockResolvedValue([
       { id: "ai_language", value_json: JSON.stringify("ko") },
       {
@@ -258,16 +261,16 @@ describe("SQLite settings", () => {
 
     const statements = mocks.executeTransaction.mock.calls[0][0];
     expect(statements.map((statement) => statement.params.slice(0, 2))).toEqual(
-      [["spoken_languages", JSON.stringify("[]")]],
+      [["spoken_languages", JSON.stringify(JSON.stringify(["en"]))]],
     );
   });
 
-  it("preserves explicitly selected spoken languages", async () => {
+  it("preserves an explicitly empty spoken language list", async () => {
     mocks.execute.mockResolvedValue([
       { id: "ai_language", value_json: JSON.stringify("ko") },
       {
         id: "spoken_languages",
-        value_json: JSON.stringify(JSON.stringify(["en"])),
+        value_json: JSON.stringify(JSON.stringify([])),
       },
     ]);
     mocks.getPreferredLanguages.mockResolvedValue({

--- a/apps/desktop/src/settings/queries.ts
+++ b/apps/desktop/src/settings/queries.ts
@@ -121,14 +121,14 @@ export async function initializeApplicationSettings(): Promise<void> {
     const storedSpokenLanguages = parseStringArray(
       stored.values.spoken_languages ?? "[]",
     );
-    if (
+    const isSystemDefault =
       stored.values.ai_language === languageResult.data[0] &&
       storedSpokenLanguages.length === languageResult.data.length &&
       storedSpokenLanguages.every(
         (language, index) => language === languageResult.data[index],
-      )
-    ) {
-      updates.spoken_languages = "[]";
+      );
+    if (!stored.hasValues.has("spoken_languages") || isSystemDefault) {
+      updates.spoken_languages = JSON.stringify(languageResult.data.slice(1));
     }
   }
 

--- a/apps/desktop/src/settings/queries.ts
+++ b/apps/desktop/src/settings/queries.ts
@@ -117,8 +117,18 @@ export async function initializeApplicationSettings(): Promise<void> {
     if (!stored.hasValues.has("ai_language")) {
       updates.ai_language = languageResult.data[0];
     }
-    if (!stored.hasValues.has("spoken_languages")) {
-      updates.spoken_languages = JSON.stringify(languageResult.data);
+
+    const storedSpokenLanguages = parseStringArray(
+      stored.values.spoken_languages ?? "[]",
+    );
+    if (
+      stored.values.ai_language === languageResult.data[0] &&
+      storedSpokenLanguages.length === languageResult.data.length &&
+      storedSpokenLanguages.every(
+        (language, index) => language === languageResult.data[index],
+      )
+    ) {
+      updates.spoken_languages = "[]";
     }
   }
 

--- a/crates/detect/Cargo.toml
+++ b/crates/detect/Cargo.toml
@@ -25,16 +25,18 @@ tracing = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }
 specta = { workspace = true, features = ["derive"] }
+sys-locale = { workspace = true }
+
+anlg-language = { workspace = true }
 
 [target."cfg(target_os = \"macos\")".dependencies]
 anlg-bundle = { workspace = true }
-anlg-language = { workspace = true }
 
 plist = "1.7"
 cidre = { workspace = true, features = ["ax"] }
 block2 = { workspace = true }
 
-objc2-foundation = { workspace = true, features = ["NSLocale", "NSArray", "NSString"] }
+objc2-foundation = { workspace = true, features = ["NSArray", "NSString"] }
 objc2-app-kit = { workspace = true, features = ["NSWorkspace", "NSRunningApplication", "libc"] }
 objc2 = { workspace = true }
 objc2-core-foundation = { workspace = true }

--- a/crates/detect/src/language.rs
+++ b/crates/detect/src/language.rs
@@ -1,10 +1,6 @@
 pub fn get_preferred_languages() -> Vec<anlg_language::Language> {
-    use objc2_foundation::NSLocale;
-
-    let languages = NSLocale::preferredLanguages();
-    languages
-        .iter()
-        .filter_map(|s| locale_to_language(&s.to_string()))
+    sys_locale::get_locales()
+        .filter_map(|locale| locale_to_language(&locale))
         .collect()
 }
 
@@ -13,10 +9,7 @@ fn locale_to_language(locale: &str) -> Option<anlg_language::Language> {
 }
 
 pub fn get_current_locale_identifier() -> String {
-    use objc2_foundation::NSLocale;
-
-    let locale = NSLocale::currentLocale();
-    locale.localeIdentifier().to_string()
+    sys_locale::get_locale().unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -52,15 +45,18 @@ mod tests {
 
     #[test]
     fn test_get_preferred_languages() {
-        let languages = get_preferred_languages();
-        println!("Preferred languages: {:?}", languages);
-        assert!(!languages.is_empty());
+        let expected = sys_locale::get_locales()
+            .filter_map(|locale| locale_to_language(&locale))
+            .collect::<Vec<_>>();
+
+        assert_eq!(get_preferred_languages(), expected);
     }
 
     #[test]
     fn test_get_current_locale_identifier() {
-        let locale = get_current_locale_identifier();
-        println!("Current locale: {}", locale);
-        assert!(!locale.is_empty());
+        assert_eq!(
+            get_current_locale_identifier(),
+            sys_locale::get_locale().unwrap_or_default()
+        );
     }
 }

--- a/crates/detect/src/lib.rs
+++ b/crates/detect/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "app")]
 mod app;
 mod error;
-#[cfg(all(target_os = "macos", feature = "language"))]
+#[cfg(feature = "language")]
 mod language;
 #[cfg(feature = "list")]
 mod list;
@@ -27,7 +27,7 @@ mod zoom;
 
 #[cfg(feature = "app")]
 pub use app::*;
-#[cfg(all(target_os = "macos", feature = "language"))]
+#[cfg(feature = "language")]
 pub use language::*;
 #[cfg(feature = "list")]
 pub use list::*;

--- a/packages/store/src/zod.ts
+++ b/packages/store/src/zod.ts
@@ -300,7 +300,7 @@ export const generalSchema = z.object({
   respect_dnd: z.boolean().default(false),
   quit_intercept: z.boolean().default(false),
   ai_language: z.string().default("en"),
-  spoken_languages: jsonObject(z.array(z.string()).default(["en"])),
+  spoken_languages: jsonObject(z.array(z.string()).default([])),
   personalization_dictionary_terms: jsonObject(z.array(z.string()).default([])),
   ignored_platforms: jsonObject(z.array(z.string()).default([])),
   included_platforms: jsonObject(z.array(z.string()).default([])),

--- a/plugins/detect/src/commands.rs
+++ b/plugins/detect/src/commands.rs
@@ -140,7 +140,6 @@ pub(crate) async fn set_mic_active_threshold<R: tauri::Runtime>(
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
 #[tauri::command]
 #[specta::specta]
 pub(crate) async fn get_preferred_languages<R: tauri::Runtime>(
@@ -152,31 +151,12 @@ pub(crate) async fn get_preferred_languages<R: tauri::Runtime>(
         .collect())
 }
 
-#[cfg(not(target_os = "macos"))]
-#[tauri::command]
-#[specta::specta]
-pub(crate) async fn get_preferred_languages<R: tauri::Runtime>(
-    _app: tauri::AppHandle<R>,
-) -> Result<Vec<String>, String> {
-    Ok(Vec::new())
-}
-
-#[cfg(target_os = "macos")]
 #[tauri::command]
 #[specta::specta]
 pub(crate) async fn get_current_locale_identifier<R: tauri::Runtime>(
     _app: tauri::AppHandle<R>,
 ) -> Result<String, String> {
     Ok(anlg_detect::get_current_locale_identifier())
-}
-
-#[cfg(not(target_os = "macos"))]
-#[tauri::command]
-#[specta::specta]
-pub(crate) async fn get_current_locale_identifier<R: tauri::Runtime>(
-    _app: tauri::AppHandle<R>,
-) -> Result<String, String> {
-    Ok(String::new())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Seed only the main language from macOS and clear matching auto-populated defaults while preserving explicit selections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings initialization and locale detection behavior changes are localized; risk is mainly one-time migration of spoken-language defaults for existing users.
> 
> **Overview**
> **Additional spoken languages** now default to empty instead of mirroring the full OS language preference list. On first-run init, only the primary OS language seeds `ai_language`; `spoken_languages` gets OS locales **after** the first entry (`slice(1)`). Existing installs that still have the old “full OS list” pattern are **normalized** on startup to that slimmer list, while an **explicitly empty** `spoken_languages` value is left unchanged.
> 
> Locale detection moves from macOS-only `NSLocale` to **`sys-locale`** in the detect crate, with the language feature and Tauri `get_preferred_languages` / `get_current_locale_identifier` commands available on all platforms (non-macOS stubs that returned empty results are removed). The store Zod default for `spoken_languages` changes from `["en"]` to `[]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca69d3f3c09e7ec279d677f1acac4f08ea1b2e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->