### PR TITLE
fix(stt): keep long local transcriptions working

### DIFF
--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -14,10 +14,10 @@ use local::{
     FixedSoniqoFileChunkIterator, LOCAL_BATCH_CANCELLED, MAX_LOCAL_BATCH_CHANNELS,
     SONIQO_DIARIZATION_MAX_SAMPLES, SONIQO_DIRECT_MIC_MIN_RMS, SONIQO_PARAKEET_MAX_CHUNK_SAMPLES,
     SONIQO_PROGRESS_MAX, SONIQO_PROGRESS_PLANNED, SoniqoChunkStrategy, audio_rms,
-    collect_soniqo_channel_transcripts, ensure_soniqo_diarization_plan_within_limit,
-    ensure_soniqo_diarization_within_limit, resample_audio_to_channel_files,
-    resample_audio_to_channel_files_until, soniqo_batch_progress, soniqo_chunk_strategy,
-    soniqo_diarization_speaker_count, soniqo_language_hint,
+    collect_soniqo_channel_transcripts, ensure_soniqo_diarization_within_limit,
+    resample_audio_to_channel_files, resample_audio_to_channel_files_until, soniqo_batch_progress,
+    soniqo_chunk_strategy, soniqo_diarization_plan_within_limit, soniqo_diarization_speaker_count,
+    soniqo_language_hint,
 };
 
 #[cfg(test)]

--- a/crates/listener2-core/src/batch/simple/local.rs
+++ b/crates/listener2-core/src/batch/simple/local.rs
@@ -431,7 +431,25 @@ fn transcribe_soniqo_file(
         .iter()
         .map(|channel| channel.sample_count)
         .collect::<Vec<_>>();
-    ensure_soniqo_diarization_plan_within_limit(&channel_sample_counts, num_speakers)?;
+    let diarization_within_limit =
+        soniqo_diarization_plan_within_limit(&channel_sample_counts, num_speakers);
+    let diarization_num_speakers = if diarization_within_limit {
+        num_speakers
+    } else {
+        None
+    };
+    if !diarization_within_limit {
+        tracing::warn!(
+            anarlog.stt.provider.name = "soniqo",
+            anarlog.stt.model = %model,
+            audio.duration_seconds = channel_sample_counts.iter().copied().max().unwrap_or_default()
+                as f64
+                / TARGET_SAMPLE_RATE as f64,
+            diarization.max_duration_seconds =
+                SONIQO_DIARIZATION_MAX_SAMPLES / TARGET_SAMPLE_RATE as usize,
+            "soniqo_diarization_skipped_for_long_recording"
+        );
+    }
     if let Some(progress) = progress {
         progress.emit(soniqo_batch_progress(0, transcribed_channel_count));
     }
@@ -441,7 +459,7 @@ fn transcribe_soniqo_file(
     for (channel_index, channel) in channel_files.into_iter().enumerate() {
         ensure_local_batch_running(progress)?;
         let speaker_segments = match soniqo_diarization_speaker_count(
-            num_speakers,
+            diarization_num_speakers,
             transcribed_channel_count,
             channel_index,
         ) {
@@ -816,22 +834,23 @@ pub(super) fn ensure_soniqo_diarization_within_limit(
     )
 }
 
-pub(super) fn ensure_soniqo_diarization_plan_within_limit(
+pub(super) fn soniqo_diarization_plan_within_limit(
     channel_sample_counts: &[usize],
     num_speakers: Option<u32>,
-) -> std::result::Result<(), String> {
-    for (channel_index, sample_count) in channel_sample_counts.iter().enumerate() {
-        if soniqo_diarization_speaker_count(
-            num_speakers,
-            channel_sample_counts.len(),
-            channel_index,
-        )
-        .is_some()
-        {
-            ensure_soniqo_diarization_within_limit(*sample_count)?;
-        }
-    }
-    Ok(())
+) -> bool {
+    channel_sample_counts
+        .iter()
+        .enumerate()
+        .all(|(channel_index, sample_count)| {
+            match soniqo_diarization_speaker_count(
+                num_speakers,
+                channel_sample_counts.len(),
+                channel_index,
+            ) {
+                Some(_) => *sample_count <= SONIQO_DIARIZATION_MAX_SAMPLES,
+                None => true,
+            }
+        })
 }
 
 fn diarize_soniqo_channel(

--- a/crates/listener2-core/src/batch/simple/tests.rs
+++ b/crates/listener2-core/src/batch/simple/tests.rs
@@ -274,7 +274,7 @@ fn channel_spooling_stops_cooperatively_when_cancelled() {
 }
 
 #[test]
-fn long_exact_speaker_diarization_fails_before_loading_samples() {
+fn long_exact_speaker_diarization_is_omitted_from_the_plan() {
     assert!(ensure_soniqo_diarization_within_limit(SONIQO_DIARIZATION_MAX_SAMPLES).is_ok());
     let error =
         ensure_soniqo_diarization_within_limit(SONIQO_DIARIZATION_MAX_SAMPLES + 1).unwrap_err();
@@ -282,15 +282,23 @@ fn long_exact_speaker_diarization_fails_before_loading_samples() {
     assert!(error.contains("10 minutes"));
     assert!(error.contains("without an exact speaker count"));
 
+    let maximum_channel = [SONIQO_DIARIZATION_MAX_SAMPLES];
+    assert!(soniqo_diarization_plan_within_limit(
+        &maximum_channel,
+        Some(2)
+    ));
     let long_channel = [SONIQO_DIARIZATION_MAX_SAMPLES + 1];
-    assert!(ensure_soniqo_diarization_plan_within_limit(&long_channel, None).is_ok());
-    assert!(ensure_soniqo_diarization_plan_within_limit(&long_channel, Some(2)).is_err());
+    assert!(soniqo_diarization_plan_within_limit(&long_channel, None));
+    assert!(!soniqo_diarization_plan_within_limit(
+        &long_channel,
+        Some(2)
+    ));
     let long_stereo = [
         SONIQO_DIARIZATION_MAX_SAMPLES + 1,
         SONIQO_DIARIZATION_MAX_SAMPLES + 1,
     ];
-    assert!(ensure_soniqo_diarization_plan_within_limit(&long_stereo, Some(2)).is_ok());
-    assert!(ensure_soniqo_diarization_plan_within_limit(&long_stereo, Some(3)).is_err());
+    assert!(soniqo_diarization_plan_within_limit(&long_stereo, Some(2)));
+    assert!(!soniqo_diarization_plan_within_limit(&long_stereo, Some(3)));
 }
 
 #[test]


### PR DESCRIPTION
Skip Soniqo diarization beyond its memory-safe duration while continuing Parakeet batch transcription.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible STT output for long recordings with exact speaker counts (transcript without diarization instead of a hard error); scope is limited to local Soniqo batch planning.
> 
> **Overview**
> **Long local Soniqo batches no longer abort** when an exact speaker count would run diarization past the ~10 minute memory limit. The batch now checks `soniqo_diarization_plan_within_limit` (boolean helper, renamed from `ensure_soniqo_diarization_plan_within_limit`) and, if the plan is out of bounds, **drops diarization** by passing `None` as the effective speaker count while **Parakeet/chunk transcription continues**.
> 
> When diarization is skipped, a **`soniqo_diarization_skipped_for_long_recording`** warning is emitted with duration and limit metadata. Per-channel `ensure_soniqo_diarization_within_limit` is unchanged for paths that still diarize.
> 
> Tests were updated to assert the plan helper’s boolean semantics (e.g. long stereo with two speakers can still “fit” the plan because only the system channel diarizes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d74a9030a5eadd704db4685db3941846085ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->