### PR TITLE
Prefer calendar location for meeting links

### DIFF
--- a/apps/desktop/src/services/calendar/fetch/incoming.test.ts
+++ b/apps/desktop/src/services/calendar/fetch/incoming.test.ts
@@ -51,4 +51,33 @@ describe("fetchIncomingEvents", () => {
     expect(result.participants.has("event-1")).toBe(true);
     expect(result.participants.get("event-1")).toEqual([]);
   });
+
+  test("prefers the location meeting link over links in the description", async () => {
+    const meetingLink = "https://meet.google.com/abc-defg-hij";
+    calendarCommands.parseMeetingLink.mockImplementation(async (text) => text);
+    calendarCommands.listEvents.mockResolvedValue({
+      status: "success",
+      data: [
+        {
+          id: "event-1",
+          calendar_id: "primary",
+          title: "Customer call",
+          description: "https://cal.com/customer-call/reschedule",
+          location: meetingLink,
+          started_at: "2026-06-01T10:00:00.000Z",
+          ended_at: "2026-06-01T11:00:00.000Z",
+          attendees: [],
+          organizer: null,
+          has_recurrence_rules: false,
+          is_all_day: false,
+        },
+      ],
+    });
+
+    const result = await fetchIncomingEvents(ctx);
+
+    expect(result.events[0]?.meeting_link).toBe(meetingLink);
+    expect(calendarCommands.parseMeetingLink).toHaveBeenCalledOnce();
+    expect(calendarCommands.parseMeetingLink).toHaveBeenCalledWith(meetingLink);
+  });
 });

--- a/apps/desktop/src/services/calendar/fetch/incoming.ts
+++ b/apps/desktop/src/services/calendar/fetch/incoming.ts
@@ -75,8 +75,8 @@ async function normalizeCalendarEvent(calendarEvent: CalendarEvent): Promise<{
   const meetingLink =
     calendarEvent.meeting_link ??
     (await extractMeetingLink(
-      calendarEvent.description,
       calendarEvent.location,
+      calendarEvent.description,
     ));
 
   const eventParticipants: EventParticipant[] = [];


### PR DESCRIPTION
Check event locations before descriptions when deriving join URLs and cover the precedence with a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small precedence change in calendar normalization with targeted test coverage; no auth or data-model impact.
> 
> **Overview**
> Incoming calendar sync now derives **join URLs** by scanning the event **location** before the **description**, so reschedule or marketing links in the body no longer override the real meeting link in the location field.
> 
> A regression test in `incoming.test.ts` asserts that when both fields contain URLs, `meeting_link` comes from location and `parseMeetingLink` runs only on that value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ffea41860284850649c25f8c2515d373658e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->