### PR TITLE
Prevent Soniqo file payload crashes

### DIFF
--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -316,12 +316,6 @@ private struct ModelDownloadPayload: Codable {
   var error: String?
 }
 
-private struct FileTranscriptionPayload: Codable {
-  var text: String
-  var durationSeconds: Double
-  var error: String?
-}
-
 private struct StatusPayload: Codable {
   var running: Bool
   var sessionToken: String?
@@ -352,6 +346,23 @@ private func encodeJSONObject(_ value: Any) -> String {
   }
 
   return string
+}
+
+private func encodeFileTranscriptionJSON(
+  text: String,
+  durationSeconds: Double,
+  error: String? = nil
+) -> String {
+  var payload: [String: Any] = [
+    "text": text,
+    "durationSeconds": durationSeconds,
+  ]
+  if let error {
+    payload["error"] = error
+  } else {
+    payload["error"] = NSNull()
+  }
+  return encodeJSONObject(payload)
 }
 
 private func encodeLiveAppendJSON(
@@ -795,20 +806,15 @@ private actor SoniqoBridge {
         language: trimmedLanguage.isEmpty ? nil : trimmedLanguage
       )
 
-      return encodeJSON(
-        FileTranscriptionPayload(
-          text: text,
-          durationSeconds: Double(audio.count) / Double(soniqoFileTranscriptionSampleRate),
-          error: nil
-        )
+      return encodeFileTranscriptionJSON(
+        text: text,
+        durationSeconds: Double(audio.count) / Double(soniqoFileTranscriptionSampleRate)
       )
     } catch {
-      return encodeJSON(
-        FileTranscriptionPayload(
-          text: "",
-          durationSeconds: 0,
-          error: error.localizedDescription
-        )
+      return encodeFileTranscriptionJSON(
+        text: "",
+        durationSeconds: 0,
+        error: error.localizedDescription
       )
     }
   }


### PR DESCRIPTION
Encode file transcription results through JSONSerialization to avoid the optimized Swift Codable cleanup fault.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized encoding change with the same JSON shape for Rust; no transcription or auth logic touched.
> 
> **Overview**
> Fixes crashes when returning file transcription results from the Soniqo Swift bridge by **stopping use of `JSONEncoder` + a `Codable` payload** for that response.
> 
> File transcription success and error paths now build JSON through **`encodeFileTranscriptionJSON`**, which uses **`JSONSerialization`** (via the existing `encodeJSONObject` helper)—the same approach already used for live partials and diarization. The removed `FileTranscriptionPayload` struct is unused on the Swift side; the Rust bridge still deserializes `text`, `durationSeconds`, and optional `error` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa61984e28da2d1291476bd35431a394df74dc5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->