### PR TITLE
Add 1.4.5 desktop changelog

### DIFF
--- a/packages/changelog/content/1.4.5.md
+++ b/packages/changelog/content/1.4.5.md
@@ -1,0 +1,26 @@
+---
+date: "2026-08-06"
+summary: "Anarlog 1.4.5 adds flexible Dock icon appearance and improves calendar links, sharing, language defaults, and local transcription."
+---
+
+## Appearance
+
+- Choose whether the macOS Dock icon follows the system appearance or stays
+  light or dark
+- See the same flat Anarlog icon in the Dock, Finder, Spotlight, and app
+  launchers on macOS
+
+## Meetings and sharing
+
+- Join the correct meeting when a calendar event has its call link in the
+  location and an unrelated link in the description
+- Use a sharing panel that fits its content without a redundant manual update
+  control
+
+## Language and transcription
+
+- Use your device's primary language as the default without duplicating it in
+  additional languages
+- Keep long local recordings transcribing when speaker detection reaches its
+  memory-safe limit
+- Prevent a rare crash while returning local file transcription results


### PR DESCRIPTION
Summarize the user-facing desktop changes since 1.4.4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog entry with no application or infrastructure changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.5.md`**, the desktop release notes for **1.4.5**, covering macOS Dock icon appearance (system/light/dark and consistent flat icon), smarter calendar meeting links when location vs description differ, a tighter sharing panel, primary-language defaults without duplicate entries, and local transcription fixes (long recordings past speaker-detection limits and a rare results crash).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c0da80032cc858d3bea057c52896417b7c078f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->