### PR TITLE
Verify macOS CloudSync release builds

### DIFF
--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -52,10 +52,28 @@ jobs:
       - uses: ./.github/actions/rust_install
         with:
           platform: ${{ matrix.platform }}
+      - if: github.event_name == 'workflow_dispatch'
+        run: crates/cloudsync/scripts/rebuild-macos.sh
+      - if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudsync-macos-aarch64-${{ github.sha }}
+          path: crates/cloudsync/vendor/cloudsync/macos/aarch64/cloudsync.dylib
+          if-no-files-found: error
+          retention-days: 7
+      - if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudsync-macos-x86_64-${{ github.sha }}
+          path: crates/cloudsync/vendor/cloudsync/macos/x86_64/cloudsync.dylib
+          if-no-files-found: error
+          retention-days: 7
       - if: matrix.platform == 'macos'
         run: echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
       - run: cargo check -p desktop
       - run: cargo test -p desktop
+      - run: cargo test --locked -p cloudsync
+      - run: "cargo test --locked -p db-core 'cloudsync::' -- --test-threads=1"
       - run: |
           cargo test --workspace \
             --exclude desktop \


### PR DESCRIPTION
Rebuild and cancellation-test the patched macOS CloudSync vendor bundle during manual desktop CI, and upload both architecture artifacts for release evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow steps; no application runtime or sync logic is modified.
> 
> **Overview**
> **Manual macOS desktop CI** now rebuilds the patched CloudSync vendor bundle and keeps release evidence for both architectures.
> 
> On `workflow_dispatch`, the macOS job runs `rebuild-macos.sh`, then uploads **aarch64** and **x86_64** `cloudsync.dylib` artifacts (7-day retention, fail if missing). That mirrors the existing Windows/Linux CloudSync rebuild-and-artifact steps.
> 
> The macOS job also always runs **`cargo test --locked -p cloudsync`** and **`db-core` tests filtered to `cloudsync::`** with **`--test-threads=1`**, so CloudSync and cancellation-related coverage runs on every macOS CI pass, not only on manual runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8bbbfebeb160ba2281ef0511685e92f2def5451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->