### PR TITLE
Remove sync icon backgrounds

### DIFF
--- a/apps/desktop/src/settings/sync/index.tsx
+++ b/apps/desktop/src/settings/sync/index.tsx
@@ -440,7 +440,7 @@ export function SettingsSync() {
       <section className="flex flex-col gap-4">
         <div className="flex items-start justify-between gap-4">
           <div className="flex min-w-0 gap-3">
-            <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-full">
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-full">
               {statusIcon}
             </div>
             <div className="min-w-0">
@@ -538,7 +538,7 @@ export function SettingsSync() {
           <Trans>Security</Trans>
         </h2>
         <div className="flex items-start gap-3">
-          <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-full">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-full">
             {e2eeIdentityQuery.data?.configured ? (
               <ShieldCheck className="size-4 text-emerald-500" />
             ) : (


### PR DESCRIPTION
Keep the status and encryption icons lightweight without changing their layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Tailwind class removal on two decorative wrappers; no logic or behavior changes.
> 
> **Overview**
> **Sync settings** icon rows are visually lighter: the **status** and **End-to-end encryption** icon wrappers no longer use the `bg-muted` circular background. Sizing, rounding, and layout (`size-9`, `rounded-full`, flex alignment) are unchanged so only the fill behind the glyphs goes away.
> 
> The non-Pro upsell row and the cloud-storage warning callout are untouched (those still use tinted/icon backgrounds where applicable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21aa5066a749e8b9ebadd45d5bc7b3f5c41ae7a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->