### PR TITLE
fix/telemetry-data-quality

### DIFF
--- a/.github/workflows/web_cd.yaml
+++ b/.github/workflows/web_cd.yaml
@@ -37,10 +37,50 @@ jobs:
           : "${NETLIFY_SITE_ID:?Missing NETLIFY_SITE_ID repository secret}"
       - run: pnpm -F ui build
       - run: npm install -g netlify-cli@26.2.0
-      - name: Build and deploy web to Netlify
+      - name: Build web for Netlify
+        run: |
+          netlify build \
+            --context production \
+            --site "$NETLIFY_SITE_ID" \
+            --filter @anlg/web
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          SENTRY_BUILD_SOURCEMAPS: "1"
+          VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
+      - name: Upload web source maps to Sentry
+        run: |
+          response=$(
+            curl --fail --silent --show-error --get \
+              --header "Authorization: Bearer $INFISICAL_TOKEN" \
+              --data-urlencode "projectId=$INFISICAL_PROJECT_ID" \
+              --data-urlencode "environment=prod" \
+              --data-urlencode "secretPath=/anarlog/github" \
+              --data-urlencode "expandSecretReferences=false" \
+              "https://app.infisical.com/api/v4/secrets/SENTRY_AUTH_TOKEN"
+          )
+          if ! SENTRY_AUTH_TOKEN=$(jq -er '.secret.secretValue | select(length > 0)' <<< "$response"); then
+            echo "::error::Missing SENTRY_AUTH_TOKEN in Infisical prod:/anarlog/github"
+            exit 1
+          fi
+          export SENTRY_AUTH_TOKEN
+
+          pnpm -F @anlg/web exec sentry-cli sourcemaps inject dist
+          pnpm -F @anlg/web exec sentry-cli sourcemaps upload \
+            --org fastrepl \
+            --project hyprnote2 \
+            --release "$SENTRY_RELEASE" \
+            dist
+          find apps/web/dist -type f -name '*.map' -delete
+        env:
+          INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
+          INFISICAL_TOKEN: ${{ secrets.INFISICAL_SENTRY_TOKEN }}
+          SENTRY_RELEASE: anarlog-web@${{ needs.compute-version.outputs.version }}
+      - name: Deploy web to Netlify
         run: |
           netlify deploy \
             --prod \
+            --no-build \
             --context production \
             --site "$NETLIFY_SITE_ID" \
             --filter @anlg/web \
@@ -48,7 +88,6 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
 
   tag:
     needs: [compute-version, deploy]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18030,6 +18030,7 @@ dependencies = [
  "tauri-specta",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -93,6 +93,7 @@
     "@content-collections/mdx": "^0.2.2",
     "@content-collections/vite": "^0.3.0",
     "@dotenvx/dotenvx": "^1.61.0",
+    "@sentry/cli": "^3.6.1",
     "@anlg/plugin-auth": "workspace:*",
     "@anlg/plugin-deeplink2": "workspace:*",
     "@tailwindcss/typography": "^0.5.19",

--- a/apps/web/src/lib/error-reporting.test.ts
+++ b/apps/web/src/lib/error-reporting.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  createErrorEventFilter,
   operationalErrorMetadata,
   sanitizeErrorEvent,
 } from "./error-reporting.ts";
@@ -68,4 +69,54 @@ test("removes private error content while preserving exception diagnostics", () 
       mechanism: { type: "generic", handled: false },
     },
   ]);
+});
+
+test("reports one grouped signal for repeated stackless promise rejections", () => {
+  const filter = createErrorEventFilter();
+  const event = () => ({
+    type: undefined,
+    exception: {
+      values: [
+        {
+          type: "UnhandledRejection",
+          value: "private rejection value",
+          mechanism: {
+            type: "auto.browser.global_handlers.onunhandledrejection",
+            handled: false,
+          },
+        },
+      ],
+    },
+  });
+
+  const first = filter(event());
+  assert.deepEqual(first?.fingerprint, [
+    "web",
+    "stackless-unhandled-rejection",
+  ]);
+  assert.equal(first?.tags?.["error.type"], "stackless_unhandled_rejection");
+  assert.equal(filter(event()), null);
+});
+
+test("does not rate-limit promise rejections with stack traces", () => {
+  const filter = createErrorEventFilter();
+  const event = () => ({
+    type: undefined,
+    exception: {
+      values: [
+        {
+          type: "UnhandledRejection",
+          value: "private rejection value",
+          mechanism: {
+            type: "auto.browser.global_handlers.onunhandledrejection",
+            handled: false,
+          },
+          stacktrace: { frames: [{ filename: "app.ts" }] },
+        },
+      ],
+    },
+  });
+
+  assert.notEqual(filter(event()), null);
+  assert.notEqual(filter(event()), null);
 });

--- a/apps/web/src/lib/error-reporting.ts
+++ b/apps/web/src/lib/error-reporting.ts
@@ -123,6 +123,33 @@ export function sanitizeErrorEvent(event: ErrorEvent): ErrorEvent {
   return event;
 }
 
+function isStacklessUnhandledRejection(event: ErrorEvent) {
+  return event.exception?.values?.some((exception) => {
+    const isUnhandledRejection =
+      exception.type === "UnhandledRejection" ||
+      exception.mechanism?.type.endsWith("onunhandledrejection");
+    return isUnhandledRejection && !exception.stacktrace?.frames?.length;
+  });
+}
+
+export function createErrorEventFilter() {
+  let reportedStacklessUnhandledRejection = false;
+
+  return (event: ErrorEvent): ErrorEvent | null => {
+    const sanitized = sanitizeErrorEvent(event);
+    if (!isStacklessUnhandledRejection(sanitized)) return sanitized;
+    if (reportedStacklessUnhandledRejection) return null;
+
+    reportedStacklessUnhandledRejection = true;
+    sanitized.fingerprint = ["web", "stackless-unhandled-rejection"];
+    sanitized.tags = {
+      ...sanitized.tags,
+      "error.type": "stackless_unhandled_rejection",
+    };
+    return sanitized;
+  };
+}
+
 export function captureOperationalError(
   error: unknown,
   {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -6,7 +6,7 @@ import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query
 import { ErrorPage } from "./components/error-page";
 import { env } from "./env";
 import { isTelemetryPrivateLocation } from "./lib/auth-route-privacy";
-import { sanitizeErrorEvent } from "./lib/error-reporting";
+import { createErrorEventFilter } from "./lib/error-reporting";
 import { prepareShareRoutePrivacy } from "./lib/share-route-privacy";
 import { routeTree } from "./routeTree.gen";
 
@@ -25,6 +25,8 @@ export function getRouter() {
   prepareShareRoutePrivacy();
 
   if (!router.isServer && env.VITE_SENTRY_DSN) {
+    const filterErrorEvent = createErrorEventFilter();
+
     Sentry.init({
       dsn: env.VITE_SENTRY_DSN,
       release: env.VITE_APP_VERSION
@@ -38,7 +40,7 @@ export function getRouter() {
           window.location.search,
         )
           ? null
-          : sanitizeErrorEvent(event),
+          : filterErrorEvent(event),
       beforeSendTransaction: (event) =>
         isTelemetryPrivateLocation(
           window.location.pathname,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,49 +8,61 @@ import { defineConfig } from "vite";
 
 import { getSitemap } from "./src/utils/sitemap";
 
-const config = defineConfig(() => ({
-  plugins: [
-    contentCollections(),
-    tailwindcss(),
-    tanstackStart({
-      sitemap: {
-        host: "https://anarlog.so",
-      },
-      prerender: {
-        enabled: true,
-        concurrency: 3,
-        crawlLinks: true,
-        autoStaticPathsDiscovery: true,
-        filter: ({ path }) => {
-          return [
-            "/",
-            "/download",
-            "/download/",
-            "/blog",
-            "/blog/",
-            "/blog/char-is-now-anarlog",
-            "/blog/char-is-now-anarlog/",
-          ].includes(path);
+const config = defineConfig(() => {
+  const generateSourceMaps = Boolean(
+    process.env.SENTRY_BUILD_SOURCEMAPS === "1" && process.env.VITE_APP_VERSION,
+  );
+
+  return {
+    build: {
+      sourcemap: generateSourceMaps ? ("hidden" as const) : false,
+    },
+    plugins: [
+      contentCollections(),
+      tailwindcss(),
+      tanstackStart({
+        sitemap: {
+          host: "https://anarlog.so",
         },
-      },
-    }),
-    viteReact(),
-    generateSitemap(getSitemap()),
-    process.env.SKIP_NETLIFY === "1"
-      ? null
-      : netlify({
-          dev: { images: { enabled: true }, edgeFunctions: { enabled: false } },
-        }),
-  ],
-  ssr: {
-    noExternal: ["posthog-js", "@posthog/react", "react-tweet"],
-  },
-  resolve: {
-    tsconfigPaths: true,
-  },
-  preview: {
-    host: "127.0.0.1",
-  },
-}));
+        prerender: {
+          enabled: true,
+          concurrency: 3,
+          crawlLinks: true,
+          autoStaticPathsDiscovery: true,
+          filter: ({ path }) => {
+            return [
+              "/",
+              "/download",
+              "/download/",
+              "/blog",
+              "/blog/",
+              "/blog/char-is-now-anarlog",
+              "/blog/char-is-now-anarlog/",
+            ].includes(path);
+          },
+        },
+      }),
+      viteReact(),
+      generateSitemap(getSitemap()),
+      process.env.SKIP_NETLIFY === "1"
+        ? null
+        : netlify({
+            dev: {
+              images: { enabled: true },
+              edgeFunctions: { enabled: false },
+            },
+          }),
+    ],
+    ssr: {
+      noExternal: ["posthog-js", "@posthog/react", "react-tweet"],
+    },
+    resolve: {
+      tsconfigPaths: true,
+    },
+    preview: {
+      host: "127.0.0.1",
+    },
+  };
+});
 
 export default config;

--- a/crates/api-subscription/src/trial.rs
+++ b/crates/api-subscription/src/trial.rs
@@ -96,7 +96,7 @@ impl ToAnalyticsPayload for TrialOutcome {
                     Interval::Monthly => "pro_monthly",
                     Interval::Yearly => "pro_yearly",
                 };
-                AnalyticsPayload::builder("trial_started")
+                AnalyticsPayload::builder("trial_created")
                     .with("plan", plan)
                     .build()
             }
@@ -145,7 +145,7 @@ mod tests {
         let event = outcome.to_analytics_payload();
         let properties = outcome.to_analytics_properties().unwrap();
 
-        assert_eq!(event.event, "trial_started");
+        assert_eq!(event.event, "trial_created");
         assert_eq!(event.props.get("plan"), Some(&json!("pro_monthly")));
         assert_eq!(properties.set.get("plan"), Some(&json!("trial")));
         assert_eq!(

--- a/plugins/analytics/Cargo.toml
+++ b/plugins/analytics/Cargo.toml
@@ -32,4 +32,5 @@ strum = { workspace = true, features = ["derive"] }
 
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
 uuid = { workspace = true, features = ["v7"] }

--- a/plugins/analytics/src/ext.rs
+++ b/plugins/analytics/src/ext.rs
@@ -1,7 +1,17 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::SystemTime;
 
 use tauri_plugin_misc::MiscPluginExt;
 use tauri_plugin_store2::Store2PluginExt;
+
+static REPORTED_QUEUE_FULL: AtomicBool = AtomicBool::new(false);
+static REPORTED_DELIVERY_FAILURE: AtomicBool = AtomicBool::new(false);
+
+fn report_delivery_problem_once(reported: &AtomicBool, event: &'static str) {
+    if !reported.swap(true, Ordering::Relaxed) {
+        tracing::event!(tracing::Level::ERROR, message = event);
+    }
+}
 
 pub struct Analytics<'a, R: tauri::Runtime, M: tauri::Manager<R>> {
     manager: &'a M,
@@ -37,6 +47,8 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
 
         let state = self.manager.state::<crate::ManagedState>();
         let Ok(permit) = state.fire_and_forget_slots.clone().try_acquire_owned() else {
+            report_delivery_problem_once(&REPORTED_QUEUE_FULL, "analytics_event_queue_full");
+            tracing::warn!(event = %payload.event, "analytics event dropped because the queue is full");
             return;
         };
 
@@ -44,10 +56,17 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Analytics<'a, R, M> {
 
         let machine_id = anlg_host::fingerprint();
         let client = state.client.clone();
+        let event = payload.event.clone();
 
         tauri::async_runtime::spawn(async move {
             let _permit = permit;
-            let _ = client.event(machine_id, payload).await;
+            if let Err(error) = client.event(machine_id, payload).await {
+                report_delivery_problem_once(
+                    &REPORTED_DELIVERY_FAILURE,
+                    "analytics_event_delivery_failed",
+                );
+                tracing::warn!(%error, %event, "analytics event delivery failed");
+            }
         });
     }
 

--- a/plugins/tracing/src/redaction.rs
+++ b/plugins/tracing/src/redaction.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 use std::sync::LazyLock;
 
 use regex::Regex;
-use sentry::protocol::{Context, Event, Stacktrace, User};
+use sentry::protocol::{Context, Event, Stacktrace, User, Value};
 
 static EMAIL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}").expect("Invalid regex")
@@ -10,6 +10,48 @@ static EMAIL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 
 static IP_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\b(?:\d{1,3}\.){3}\d{1,3}\b").expect("Invalid regex"));
+
+const SAFE_TAGS: &[&str] = &[
+    "anarlog.error.stage",
+    "anarlog.operation",
+    "anarlog.session.type",
+    "anarlog.surface",
+    "enduser.pseudo.id",
+    "error.code",
+    "error.type",
+    "http.response.status_code",
+    "service.name",
+    "service.namespace",
+];
+
+fn safe_identifier(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= 128
+        && !looks_like_absolute_path(value)
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "_.:/-".contains(character)))
+    .then_some(value)
+}
+
+fn looks_like_absolute_path(value: &str) -> bool {
+    value.starts_with('/')
+        || value.starts_with('\\')
+        || matches!(value.as_bytes(), [drive, b':', b'/' | b'\\', ..] if drive.is_ascii_alphabetic())
+}
+
+fn tracing_location_key(event: &Event<'_>) -> Option<String> {
+    let Context::Other(location) = event.contexts.get("Rust Tracing Location")? else {
+        return None;
+    };
+    let module_path = location
+        .get("module_path")?
+        .as_str()
+        .and_then(safe_identifier)?;
+    let line = location.get("line")?.as_u64()?;
+    Some(format!("{module_path}:{line}"))
+}
 
 fn redact_sensitive_text(value: &str, home_dir: Option<&str>) -> String {
     let mut redacted = value.to_string();
@@ -41,7 +83,7 @@ fn sanitize_stacktrace(stacktrace: &mut Stacktrace, home_dir: Option<&str>) {
     }
 }
 
-fn sanitize_context(context: &mut Context) -> bool {
+fn sanitize_context(key: &str, context: &mut Context, home_dir: Option<&str>) -> bool {
     match context {
         Context::Device(device) => {
             device.name = None;
@@ -59,6 +101,30 @@ fn sanitize_context(context: &mut Context) -> bool {
             trace.data.clear();
         }
         Context::Gpu(gpu) => gpu.other.clear(),
+        Context::Other(values) if key == "Rust Tracing Location" => {
+            values.retain(|field, value| match field.as_str() {
+                "module_path" | "file" => {
+                    let Value::String(text) = value else {
+                        return false;
+                    };
+                    *text = redact_sensitive_text(text, home_dir);
+                    true
+                }
+                "line" => matches!(value, Value::Number(_)),
+                _ => false,
+            });
+            return !values.is_empty();
+        }
+        Context::Other(values) if key == "anarlog.session" => {
+            values.retain(|field, value| match field.as_str() {
+                "anarlog.session.onboarding" => matches!(value, Value::Bool(_)),
+                "anarlog.session.transcription_mode" => {
+                    value.as_str().and_then(safe_identifier).is_some()
+                }
+                _ => false,
+            });
+            return !values.is_empty();
+        }
         _ => return false,
     }
     true
@@ -68,7 +134,21 @@ fn sanitize_sentry_event_with_home(
     mut event: Event<'static>,
     home_dir: Option<&str>,
 ) -> Event<'static> {
-    event.fingerprint = Event::default().fingerprint;
+    let default_fingerprint = Event::default().fingerprint;
+    let operation = event
+        .message
+        .as_deref()
+        .and_then(safe_identifier)
+        .map(str::to_owned);
+    let location = tracing_location_key(&event);
+    if event.fingerprint != default_fingerprint
+        && !event
+            .fingerprint
+            .iter()
+            .all(|part| safe_identifier(part).is_some())
+    {
+        event.fingerprint = default_fingerprint.clone();
+    }
     event.culprit = None;
     event.transaction = None;
     event.message = None;
@@ -128,13 +208,30 @@ fn sanitize_sentry_event_with_home(
     }
     event
         .contexts
-        .retain(|_, context| sanitize_context(context));
-    event.tags.retain(|key, _| {
-        matches!(
-            key.as_str(),
-            "service.name" | "service.namespace" | "enduser.pseudo.id"
-        )
-    });
+        .retain(|key, context| sanitize_context(key, context, home_dir));
+    event
+        .tags
+        .retain(|key, _| SAFE_TAGS.contains(&key.as_str()));
+
+    if event.exception.is_empty() && event.stacktrace.is_none() {
+        let logger = event
+            .logger
+            .as_deref()
+            .and_then(safe_identifier)
+            .map(str::to_owned);
+        let grouping_key = operation
+            .clone()
+            .or(location)
+            .or(logger)
+            .unwrap_or_else(|| "native_error".to_string());
+        event.message = Some(operation.unwrap_or_else(|| format!("native_error:{grouping_key}")));
+        event
+            .tags
+            .insert("anarlog.operation".to_string(), grouping_key.clone());
+        if event.fingerprint == default_fingerprint {
+            event.fingerprint = vec!["native_error".into(), grouping_key.into()].into();
+        }
+    }
 
     event
 }
@@ -374,6 +471,7 @@ mod tests {
             .into(),
             tags: [
                 ("service.name".to_string(), "desktop".to_string()),
+                ("error.type".to_string(), "file_read_failed".to_string()),
                 ("private-note".to_string(), "meeting plans".to_string()),
             ]
             .into_iter()
@@ -431,14 +529,125 @@ mod tests {
         assert!(frame.vars.is_empty());
         assert_eq!(
             event.tags,
-            [("service.name".to_string(), "desktop".to_string())]
-                .into_iter()
-                .collect()
+            [
+                ("error.type".to_string(), "file_read_failed".to_string()),
+                ("service.name".to_string(), "desktop".to_string()),
+            ]
+            .into_iter()
+            .collect()
         );
         assert_eq!(event.contexts.len(), 1);
         let Context::Os(os) = &event.contexts["os"] else {
             panic!("expected os context");
         };
         assert!(os.other.is_empty());
+    }
+
+    #[test]
+    fn sentry_event_preserves_safe_native_grouping_data() {
+        let event = Event {
+            message: Some("model_download_error".to_string()),
+            logger: Some("model_downloader".to_string()),
+            fingerprint: vec!["native_error".into(), "model_download".into()].into(),
+            contexts: [(
+                "Rust Tracing Location".to_string(),
+                Context::Other(
+                    [
+                        (
+                            "module_path".to_string(),
+                            Value::String("model_downloader::download_task".to_string()),
+                        ),
+                        (
+                            "file".to_string(),
+                            Value::String("/Users/alice/src/download_task.rs".to_string()),
+                        ),
+                        ("line".to_string(), Value::Number(51.into())),
+                        (
+                            "private".to_string(),
+                            Value::String("meeting plans".to_string()),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+
+        let event = sanitize_sentry_event_with_home(event, Some("/Users/alice"));
+
+        assert_eq!(event.message.as_deref(), Some("model_download_error"));
+        assert_eq!(
+            event.fingerprint.as_ref(),
+            ["native_error", "model_download"]
+        );
+        assert_eq!(
+            event.tags.get("anarlog.operation").map(String::as_str),
+            Some("model_download_error")
+        );
+        let Context::Other(location) = &event.contexts["Rust Tracing Location"] else {
+            panic!("expected tracing location context");
+        };
+        assert_eq!(
+            location.get("file"),
+            Some(&Value::String("[HOME]/src/download_task.rs".to_string()))
+        );
+        assert!(!location.contains_key("private"));
+    }
+
+    #[test]
+    fn sentry_event_does_not_group_by_absolute_paths() {
+        for message in ["/Users/alice/private.wav", "C:/Users/alice/private.wav"] {
+            let event = Event {
+                message: Some(message.to_string()),
+                logger: Some("file_reader".to_string()),
+                ..Default::default()
+            };
+
+            let event = sanitize_sentry_event_with_home(event, Some("/Users/alice"));
+
+            assert_eq!(event.message.as_deref(), Some("native_error:file_reader"));
+            assert_eq!(event.fingerprint.as_ref(), ["native_error", "file_reader"]);
+            assert!(!event.tags["anarlog.operation"].contains("alice"));
+        }
+    }
+
+    #[test]
+    fn sentry_event_groups_redacted_messages_by_source_location() {
+        let event = Event {
+            message: Some("failed for alice@example.com".to_string()),
+            logger: Some("model_downloader".to_string()),
+            contexts: [(
+                "Rust Tracing Location".to_string(),
+                Context::Other(
+                    [
+                        (
+                            "module_path".to_string(),
+                            Value::String("model_downloader::download_task".to_string()),
+                        ),
+                        ("line".to_string(), Value::Number(51.into())),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+
+        let event = sanitize_sentry_event_with_home(event, None);
+
+        assert_eq!(
+            event.message.as_deref(),
+            Some("native_error:model_downloader::download_task:51")
+        );
+        assert_eq!(
+            event.fingerprint.as_ref(),
+            ["native_error", "model_downloader::download_task:51"]
+        );
+        assert!(!event.message.as_deref().unwrap().contains("alice"));
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -838,6 +838,9 @@ importers:
       '@dotenvx/dotenvx':
         specifier: ^1.61.0
         version: 1.61.0
+      '@sentry/cli':
+        specifier: ^3.6.1
+        version: 3.6.1
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.2)


### PR DESCRIPTION
- Preserve actionable error diagnostics by grouping stackless web promise failures with privacy-safe native grouping metadata to avoid Sentry flooding  
- Improve production debugging by generating hidden web source maps, injecting debug IDs, uploading them to Sentry, and deploying the prebuilt Netlify output  
- Separate trial creation from activation analytics: emit `trial_created` from the API while keeping Stripe authoritative for `trial_started`  
- Enhance analytics reliability by reporting desktop analytics delivery failures (queue saturation + PostHog delivery) once per process while retaining local warning details

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deploy (secrets, build artifacts) and error/analytics pipelines; behavior is mostly observability-only but misconfigured Sentry upload or deploy steps could affect releases.
> 
> **Overview**
> Improves **telemetry quality** across web, desktop, and subscription analytics without changing product behavior for users.
> 
> **Web Sentry & deploy:** Production Netlify CD now **builds once**, optionally emits **hidden source maps** when `SENTRY_BUILD_SOURCEMAPS` and `VITE_APP_VERSION` are set, **uploads** them to Sentry (`sentry-cli` inject + upload, token from Infisical), **strips** `.map` files from `dist`, then deploys with **`--no-build`**. `createErrorEventFilter` replaces bare `sanitizeErrorEvent` in `beforeSend` so **stackless unhandled promise rejections** are sanitized, **fingerprinted**, and **deduped** to a single grouped event per session (rejections with stacks are unchanged).
> 
> **Desktop Sentry:** `sanitize_sentry_event` keeps more **privacy-safe grouping metadata** (whitelisted tags, redacted tracing location / session contexts, safe fingerprints) and assigns **native_error** fingerprints from operation, module:line, or logger—**not** absolute paths or redacted message text.
> 
> **Analytics:** API trial success event renamed **`trial_started` → `trial_created`** (Stripe remains source of truth for activation). Desktop fire-and-forget analytics now **logs once per process** on queue saturation and PostHog delivery failure (`tracing` ERROR + warn details).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1584e87acbe93f3a8ab3e6cb3e780990ea926978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->