### PR TITLE
Prevent Linux SFX stderr panics

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -404,6 +404,7 @@ jobs:
           fi
           pnpm -F desktop tauri build "${BUILD_ARGS[@]}"
         env:
+          CARGO_PROFILE_RELEASE_DEBUG: line-tables-only
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           VITE_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN_HYPRNOTE_2 }}
@@ -416,6 +417,37 @@ jobs:
           VITE_API_URL: https://api.anarlog.so
           VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
           VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
+      - if: ${{ inputs.channel == 'stable' }}
+        uses: ./.github/actions/sentry_cli
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Upload Linux debug symbols to Sentry
+        env:
+          INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
+          INFISICAL_TOKEN: ${{ secrets.INFISICAL_SENTRY_TOKEN }}
+        run: |
+          binary="apps/desktop/src-tauri/target/${{ matrix.target }}/release/anarlog"
+          sentry-cli debug-files check "$binary"
+
+          response=$(
+            curl --fail --silent --show-error --get \
+              --header "Authorization: Bearer $INFISICAL_TOKEN" \
+              --data-urlencode "projectId=$INFISICAL_PROJECT_ID" \
+              --data-urlencode "environment=prod" \
+              --data-urlencode "secretPath=/anarlog/github" \
+              --data-urlencode "expandSecretReferences=false" \
+              "https://app.infisical.com/api/v4/secrets/SENTRY_AUTH_TOKEN"
+          )
+          if ! SENTRY_AUTH_TOKEN=$(jq -er '.secret.secretValue | select(length > 0)' <<< "$response"); then
+            echo "::error::Missing SENTRY_AUTH_TOKEN in Infisical prod:/anarlog/github"
+            exit 1
+          fi
+          export SENTRY_AUTH_TOKEN
+
+          sentry-cli debug-files upload \
+            --org fastrepl \
+            --project hyprnote2 \
+            --include-sources \
+            "$binary"
       - run: |
           shopt -s nullglob
           appimage_dir="apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage"

--- a/plugins/sfx/src/ext.rs
+++ b/plugins/sfx/src/ext.rs
@@ -28,9 +28,10 @@ pub(crate) fn to_speaker(
     let (tx, rx) = std::sync::mpsc::channel();
 
     std::thread::spawn(move || {
-        let Ok(stream) = DeviceSinkBuilder::open_default_sink() else {
+        let Ok(mut stream) = DeviceSinkBuilder::open_default_sink() else {
             return;
         };
+        stream.log_on_drop(false);
 
         let file = std::io::Cursor::new(bytes);
         let Ok(source) = Decoder::try_from(file) else {


### PR DESCRIPTION
Disable Rodio drop logging for app sounds and upload Linux ELF symbols to Sentry during stable builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized audio teardown change plus CI-only stable release symbol upload; no auth or runtime behavior changes for end users beyond better crash symbolication.
> 
> **Overview**
> **Rodio SFX on Linux** no longer logs when the default audio sink is dropped: the playback thread calls `log_on_drop(false)` on the opened stream so teardown does not emit stderr panics during app sounds.
> 
> **Stable Linux desktop CI** now builds release binaries with `CARGO_PROFILE_RELEASE_DEBUG: line-tables-only`, then (stable only) installs `sentry-cli`, validates the `anarlog` ELF, fetches `SENTRY_AUTH_TOKEN` from Infisical, and uploads debug files with sources to Sentry (`fastrepl` / `hyprnote2`)—aligning Linux symbol upload with the existing macOS stable pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04f1672d8b5cab5aca0afadff653540215f62be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->