### PR TITLE
Scale editor headings below title

### DIFF
--- a/packages/editor/src/styles/prosemirror/note-typography.css
+++ b/packages/editor/src/styles/prosemirror/note-typography.css
@@ -26,8 +26,7 @@
 
 /* The inset is `rem`, not `em`: it has to cancel against the scroll
  * container's fixed `px-3`, so it must not scale with the block's own font
- * size. With `em`, an h1 (1.5em) bled 18px into 12px of padding and the extra
- * 6px scrolled the whole note sideways. */
+ * size. */
 .note-typography.prosemirror-editor > * {
   transition: background-color 120ms ease;
   margin-inline: -0.75rem;
@@ -46,17 +45,17 @@
 /* Document hierarchy is proportional to the base size. */
 .note-typography h1 {
   font-weight: 700;
-  font-size: 1.5em;
-  line-height: 1.3333;
+  font-size: 1.25em;
+  line-height: 1.4;
 }
 .note-typography h2 {
   font-weight: 600;
-  font-size: 1.25em;
-  line-height: 1.6;
+  font-size: 1.125em;
+  line-height: 1.4444;
 }
 .note-typography h3 {
   font-weight: 600;
-  font-size: 1.125em;
+  font-size: 1em;
   line-height: 1.5;
 }
 .note-typography :where(h4, h5, h6) {


### PR DESCRIPTION
Reduce the shared H1-H3 typography scale while preserving the 24px document title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only typography tuning in shared note styles; no logic or data-path changes.
> 
> **Overview**
> **Tightens the shared `.note-typography` heading scale** for body content so H1–H3 read smaller relative to paragraph text, with matching line-height tweaks (H1 **1.5em → 1.25em**, H2 **1.25em → 1.125em**, H3 **1.125em → 1em**).
> 
> The **first-line session title** (`.note-title-editor > h1:first-child` at **1.5rem**) is untouched, so the document title stays at 24px while in-note headings step down. A long comment about `em`-sized hover-row insets causing horizontal scroll on large headings was removed from the ProseMirror editor block rule; behavior of that rule is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d3165d24f4eebaa2862108f7cde87b5aa7f4903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->