### PR TITLE
Move comments into the selection bubble

### DIFF
--- a/apps/desktop/src/session-sharing/comments.test.tsx
+++ b/apps/desktop/src/session-sharing/comments.test.tsx
@@ -131,6 +131,11 @@ function Harness({ canCompose }: { canCompose: boolean }) {
       >
         Reposition comments
       </button>
+      {controller.selection && (
+        <button type="button" onClick={controller.startDraft}>
+          Comment
+        </button>
+      )}
       <SessionCommentsLayer controller={controller} />
     </div>
   );
@@ -173,6 +178,11 @@ function OwnedSummaryHarness() {
       >
         Select owner text
       </button>
+      {controller.selection && (
+        <button type="button" onClick={controller.startDraft}>
+          Comment
+        </button>
+      )}
       <SessionCommentsLayer controller={controller} />
     </div>
   );

--- a/apps/desktop/src/session-sharing/comments.tsx
+++ b/apps/desktop/src/session-sharing/comments.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import { ChatCenteredDots, CircleNotch, Trash } from "@phosphor-icons/react";
+import { CircleNotch, Trash } from "@phosphor-icons/react";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { EditorView } from "prosemirror-view";
@@ -403,22 +403,6 @@ export function SessionCommentsLayer({
   return (
     <>
       <span ref={controller.anchorSyncRef} className="hidden" />
-      {controller.selection && !controller.draft && (
-        <Button
-          type="button"
-          size="sm"
-          className="absolute z-30 -translate-x-full -translate-y-[calc(100%+6px)] shadow-md"
-          style={{
-            left: controller.selection.left,
-            top: controller.selection.top,
-          }}
-          onMouseDown={(event) => event.preventDefault()}
-          onClick={controller.startDraft}
-        >
-          <ChatCenteredDots className="size-3.5" aria-hidden="true" />
-          <Trans>Comment</Trans>
-        </Button>
-      )}
       {controller.draft && (
         <Popover
           open

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -18,6 +18,8 @@ const hoisted = vi.hoisted(() => ({
   showWindow: vi.fn(),
   unminimizeWindow: vi.fn(),
   focusWindow: vi.fn(),
+  startCommentDraft: vi.fn(),
+  commentDraft: null as Record<string, unknown> | null,
   noteEditorProps: [] as Record<string, unknown>[],
 }));
 
@@ -94,6 +96,9 @@ vi.mock("~/session-sharing/comments", () => ({
     onCommentAnchorsEvent: vi.fn(),
     onViewReady: vi.fn(),
     onViewDisposed: vi.fn(),
+    draft: hoisted.commentDraft,
+    selection: {},
+    startDraft: hoisted.startCommentDraft,
   }),
 }));
 
@@ -125,6 +130,7 @@ describe("EnhancedEditor", () => {
     hoisted.persistContent = vi.fn(() => Promise.resolve());
     hoisted.fileUpload = vi.fn();
     hoisted.processAudioFile = vi.fn();
+    hoisted.commentDraft = null;
     hoisted.showWindow.mockReset();
     hoisted.unminimizeWindow.mockReset();
     hoisted.focusWindow.mockReset();
@@ -158,6 +164,7 @@ describe("EnhancedEditor", () => {
     expect(props?.className).toContain("session-note-editor");
     expect(props?.className).toContain("enhanced-summary-editor");
     expect(props?.onCommentAnchorsEvent).toEqual(expect.any(Function));
+    expect(props?.onCommentSelection).toBe(hoisted.startCommentDraft);
     expect(screen.getByTestId("summary-comments-layer")).toBeTruthy();
     expect(props?.placeholderComponent).toEqual(expect.any(Function));
     expect(props?.syncContentWhenFocused).toBe(false);
@@ -178,6 +185,21 @@ describe("EnhancedEditor", () => {
         },
       ],
     });
+  });
+
+  it("hides the selection comment action while a draft is open", () => {
+    hoisted.commentDraft = {};
+
+    render(
+      <EnhancedEditor
+        sessionId="session-1"
+        enhancedNoteId="note-1"
+        content={hoisted.content}
+      />,
+    );
+
+    const props = hoisted.noteEditorProps[hoisted.noteEditorProps.length - 1];
+    expect(props?.onCommentSelection).toBeUndefined();
   });
 
   it("does not rerender the editor when its props are unchanged", () => {

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -165,6 +165,11 @@ const EnhancedEditorInner = forwardRef<
             extraNodeViews={extraNodeViews}
             commentAnchorsEnabled
             onCommentAnchorsEvent={comments.onCommentAnchorsEvent}
+            onCommentSelection={
+              comments.selection && !comments.draft
+                ? comments.startDraft
+                : undefined
+            }
             onViewReady={(view) => {
               comments.onViewReady(view);
               onViewReady?.(view);

--- a/apps/desktop/src/shared-notes/index.test.tsx
+++ b/apps/desktop/src/shared-notes/index.test.tsx
@@ -18,6 +18,8 @@ const mocks = vi.hoisted(() => ({
   },
   preview: { status: "unavailable" } as any,
   signIn: vi.fn(),
+  startCommentDraft: vi.fn(),
+  commentDraft: null as Record<string, unknown> | null,
   commentInputs: [] as Array<Record<string, unknown>>,
 }));
 
@@ -46,6 +48,9 @@ vi.mock("~/session-sharing/comments", () => ({
       onCommentAnchorsEvent: vi.fn(),
       onViewDisposed: vi.fn(),
       onViewReady: vi.fn(),
+      draft: input.canCompose ? mocks.commentDraft : null,
+      selection: input.canCompose ? {} : null,
+      startDraft: mocks.startCommentDraft,
     };
   },
 }));
@@ -74,15 +79,18 @@ vi.mock("@anlg/editor/note", () => ({
     readOnly,
     showFormatToolbar,
     initialContent,
+    onCommentSelection,
   }: {
     readOnly?: boolean;
     showFormatToolbar?: boolean;
     initialContent?: unknown;
+    onCommentSelection?: () => void;
   }) => (
     <div
       data-content={JSON.stringify(initialContent)}
       data-read-only={String(readOnly)}
       data-show-format-toolbar={String(showFormatToolbar)}
+      data-comment-action={String(Boolean(onCommentSelection))}
       data-testid="shared-note-editor"
     />
   ),
@@ -120,6 +128,7 @@ describe("TabContentSharedNote", () => {
     mocks.query = { data: null, isLoading: false, error: null };
     mocks.preview = { status: "unavailable" };
     mocks.signIn.mockResolvedValue(undefined);
+    mocks.commentDraft = null;
     mocks.commentInputs = [];
   });
 
@@ -193,6 +202,9 @@ describe("TabContentSharedNote", () => {
       manageAccess: false,
       shareId: "share-1",
     });
+    expect(screen.getByTestId("shared-note-editor").dataset.commentAction).toBe(
+      "false",
+    );
   });
 
   it("allows commenters to compose without making the shared note editable", () => {
@@ -223,6 +235,33 @@ describe("TabContentSharedNote", () => {
       manageAccess: false,
       shareId: "share-1",
     });
+    expect(screen.getByTestId("shared-note-editor").dataset.commentAction).toBe(
+      "true",
+    );
+  });
+
+  it("hides the selection comment action while a draft is open", () => {
+    mocks.commentDraft = {};
+    mocks.query.data = {
+      shareId: "share-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      schemaVersion: 1,
+      contentRevision: 2,
+      title: "Shared plan",
+      body: { type: "doc", content: [{ type: "paragraph" }] },
+      attachments: [],
+      capability: "commenter",
+      manageAccess: false,
+      accessVersion: 3,
+      publishedAt: "2026-07-16T17:30:00.000Z",
+    };
+
+    renderSharedNote();
+
+    expect(screen.getByTestId("shared-note-editor").dataset.commentAction).toBe(
+      "false",
+    );
   });
 
   it("removes content when access is no longer cached", () => {

--- a/apps/desktop/src/shared-notes/index.tsx
+++ b/apps/desktop/src/shared-notes/index.tsx
@@ -278,6 +278,11 @@ function SharedNoteDocument({
             onCommentAnchorsEvent={
               comments ? commentController.onCommentAnchorsEvent : undefined
             }
+            onCommentSelection={
+              commentController.selection && !commentController.draft
+                ? commentController.startDraft
+                : undefined
+            }
             onLinkOpen={openEditorLink}
             onViewDisposed={
               comments ? commentController.onViewDisposed : undefined

--- a/packages/editor/src/note/index.test.ts
+++ b/packages/editor/src/note/index.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { EditorState, TextSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { createElement, createRef } from "react";
@@ -154,6 +161,52 @@ describe("createReadOnlyPlugin", () => {
 
     expect(view?.state.doc.textContent).toBe("shared");
     expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it("shows a comment-only selection toolbar in read-only documents", async () => {
+    let view: EditorView | null = null;
+    const onCommentSelection = vi.fn();
+    render(
+      createElement(NoteEditor, {
+        initialContent: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "shared" }],
+            },
+          ],
+        },
+        onCommentSelection,
+        onViewReady: (nextView) => {
+          view = nextView;
+        },
+        readOnly: true,
+      }),
+    );
+
+    await waitFor(() => expect(view).not.toBeNull());
+    vi.spyOn(view!, "coordsAtPos").mockReturnValue({
+      bottom: 20,
+      left: 0,
+      right: 40,
+      top: 0,
+    });
+    act(() => {
+      view?.dispatch(
+        view.state.tr.setSelection(TextSelection.create(view.state.doc, 1, 4)),
+      );
+    });
+
+    const commentButton = await screen.findByRole("button", {
+      name: "Comment",
+    });
+    expect(screen.getByRole("toolbar").querySelectorAll("button")).toHaveLength(
+      1,
+    );
+    fireEvent.click(commentButton);
+
+    expect(onCommentSelection).toHaveBeenCalledOnce();
   });
 
   it("hides attachment mutation controls in read-only documents", async () => {

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -197,6 +197,7 @@ export interface NoteEditorProps {
   /** Fixed at mount: plugins are not reconfigurable afterwards. */
   commentAnchorsEnabled?: boolean;
   onCommentAnchorsEvent?: (event: CommentAnchorsEvent) => void;
+  onCommentSelection?: () => void;
 }
 
 const baseNodeViews = {
@@ -605,6 +606,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       enforceTitleHeading = true,
       commentAnchorsEnabled = false,
       onCommentAnchorsEvent,
+      onCommentSelection,
     } = props;
 
     const commentAnchorsEventRef = useRef(onCommentAnchorsEvent);
@@ -923,7 +925,12 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
                     onViewDisposed={handleViewDisposed}
                   />
                   <EditorCommandsBridge commandsRef={commandsRef} />
-                  {showFormatToolbar && !readOnly && <FormatToolbar />}
+                  {((showFormatToolbar && !readOnly) || onCommentSelection) && (
+                    <FormatToolbar
+                      onComment={onCommentSelection}
+                      showFormatting={showFormatToolbar && !readOnly}
+                    />
+                  )}
                   {showSlashCommand && !readOnly && <SlashCommandMenu />}
                   {mentionConfig && !readOnly && (
                     <MentionSuggestion config={mentionConfig} />

--- a/packages/editor/src/widgets/format-toolbar.tsx
+++ b/packages/editor/src/widgets/format-toolbar.tsx
@@ -12,6 +12,7 @@ import {
   useEditorState,
 } from "@handlewithcare/react-prosemirror";
 import {
+  ChatCenteredDots,
   Code,
   Highlighter,
   TextB,
@@ -68,13 +69,23 @@ const TOOLBAR_BUTTONS: {
   { id: "highlight", icon: Highlighter, markType: schema.marks.highlight },
 ];
 
-export function FormatToolbar() {
+export function FormatToolbar({
+  onComment,
+  showFormatting = true,
+}: {
+  onComment?: () => void;
+  showFormatting?: boolean;
+}) {
   const toolbarRef = useRef<HTMLDivElement>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
 
   const editorState = useEditorState();
+  const canFormatSelection = editorState
+    ? showFormatting && !selectionTouchesTitleHeading(editorState)
+    : false;
   const shouldShowToolbar = editorState
-    ? !editorState.selection.empty && !selectionTouchesTitleHeading(editorState)
+    ? !editorState.selection.empty &&
+      (canFormatSelection || onComment !== undefined)
     : false;
 
   const toggle = useEditorEventCallback((view, markType: MarkType) => {
@@ -139,25 +150,42 @@ export function FormatToolbar() {
       style={{ top: 0, left: 0, zIndex: 40 }}
       onMouseDown={(e) => e.preventDefault()}
     >
-      {TOOLBAR_BUTTONS.map((button) => {
-        const active = isMarkActive(editorState, button.markType);
-        return (
-          <button
-            key={button.id}
-            aria-pressed={active}
-            className={cn([
-              "flex size-7 items-center justify-center rounded-md",
-              "cursor-pointer border-none transition-colors",
-              active
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-accent hover:text-accent-foreground bg-transparent",
-            ])}
-            onClick={() => toggle(button.markType)}
-          >
-            <button.icon className="size-4" />
-          </button>
-        );
-      })}
+      {canFormatSelection &&
+        TOOLBAR_BUTTONS.map((button) => {
+          const active = isMarkActive(editorState, button.markType);
+          return (
+            <button
+              key={button.id}
+              aria-pressed={active}
+              className={cn([
+                "flex size-7 items-center justify-center rounded-md",
+                "cursor-pointer border-none transition-colors",
+                active
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground bg-transparent",
+              ])}
+              onClick={() => toggle(button.markType)}
+            >
+              <button.icon className="size-4" />
+            </button>
+          );
+        })}
+      {canFormatSelection && onComment && (
+        <span className="bg-border mx-0.5 h-4 w-px" aria-hidden="true" />
+      )}
+      {onComment && (
+        <button
+          type="button"
+          aria-label="Comment"
+          className={cn([
+            "text-muted-foreground flex size-7 items-center justify-center rounded-md",
+            "hover:bg-accent hover:text-accent-foreground cursor-pointer border-none bg-transparent transition-colors",
+          ])}
+          onClick={onComment}
+        >
+          <ChatCenteredDots className="size-4" />
+        </button>
+      )}
     </div>,
     document.body,
   );


### PR DESCRIPTION
Add a conditional comment action to the editor toolbar and keep comment-only selection controls for read-only collaborators.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Collaboration UX refactor with existing draft/anchor logic unchanged; main risk is selection-toolbar visibility or double-trigger edge cases, covered by new tests.
> 
> **Overview**
> **Comment on selection** now lives in the editor’s floating selection toolbar instead of a separate absolute “Comment” button on `SessionCommentsLayer`.
> 
> `NoteEditor` gains **`onCommentSelection`**, which mounts `FormatToolbar` even when the doc is read-only or formatting is off. The toolbar can show **format controls only**, **Comment only**, or both (with a divider). Title-heading selections still suppress formatting but can still offer Comment when a handler is passed.
> 
> Enhanced summaries and shared notes wire **`startDraft`** through `onCommentSelection` when there is a commentable selection and **no open draft**; the handler is cleared while a draft is open so users don’t get duplicate entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38c71b0e046876b882f16a9fd1a887c64b3d11be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->