### PR TITLE
Add YC founder perks page

### DIFF
--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -326,6 +326,7 @@ async function createCheckoutUrl({
           },
         ],
         mode: "subscription",
+        allow_promotion_codes: trial ? undefined : true,
         payment_method_collection: trial
           ? WEB_TRIAL_CHECKOUT_FIELDS.payment_method_collection
           : undefined,

--- a/apps/web/src/functions/yc-perk.ts
+++ b/apps/web/src/functions/yc-perk.ts
@@ -1,0 +1,103 @@
+import { createServerFn } from "@tanstack/react-start";
+import { createHash } from "node:crypto";
+
+import { env, requireEnv } from "@/env";
+import { getStripeClient } from "@/functions/stripe";
+import { getSupabaseAdminClient } from "@/functions/supabase";
+import { sendLoopsEvent, sendLoopsTransactional } from "@/lib/loops";
+import {
+  normalizeYcVerificationUrl,
+  verifyYcFounder,
+  ycPerkRequestSchema,
+} from "@/lib/yc-perk";
+import {
+  createYcPromotionCode,
+  getOrCreateYcPromotionCode,
+  getYcPerkClaimId,
+} from "@/lib/yc-perk-promotion";
+
+const YC_PERK_TRANSACTIONAL_ID = "cmshjqnof011b0jxiks475igx";
+
+async function getOrCreateYcPerkClaimCode(claimId: string) {
+  const supabase = getSupabaseAdminClient();
+  const candidateCode = createYcPromotionCode();
+  const { error: insertError } = await supabase
+    .from("yc_perk_claims")
+    .upsert(
+      { claim_id: claimId, promotion_code: candidateCode },
+      { onConflict: "claim_id", ignoreDuplicates: true },
+    );
+  if (insertError) {
+    throw insertError;
+  }
+
+  const { data: claim, error: claimError } = await supabase
+    .from("yc_perk_claims")
+    .select("promotion_code")
+    .eq("claim_id", claimId)
+    .single();
+  if (claimError) {
+    throw claimError;
+  }
+
+  return claim.promotion_code as string;
+}
+
+export const submitYcPerkRequest = createServerFn({ method: "POST" })
+  .inputValidator(ycPerkRequestSchema)
+  .handler(async ({ data }) => {
+    if (data.additionalComments) {
+      return { status: "submitted" as const };
+    }
+
+    const email = data.email.trim().toLowerCase();
+    const verificationUrl = normalizeYcVerificationUrl(data.verificationUrl);
+    const claimId = getYcPerkClaimId(email);
+    const requestId = createHash("sha256")
+      .update(`${email}\n${verificationUrl}`)
+      .digest("hex");
+
+    const verification = await verifyYcFounder({ email, verificationUrl });
+    if (verification.status === "invalid") {
+      return verification;
+    }
+
+    const promotionCode = await getOrCreateYcPerkClaimCode(claimId);
+    const promotion = await getOrCreateYcPromotionCode({
+      stripe: getStripeClient(),
+      claimId,
+      code: promotionCode,
+    });
+    if (promotion.status === "claimed") {
+      return { status: "already_claimed" as const };
+    }
+
+    const loopsKey = requireEnv(env.LOOPS_KEY, "LOOPS_KEY");
+    await sendLoopsTransactional({
+      apiKey: loopsKey,
+      transactionalId: YC_PERK_TRANSACTIONAL_ID,
+      email,
+      dataVariables: {
+        firstName: verification.firstName,
+        promotionCode: promotion.code,
+      },
+      idempotencyKey: `yc-perk-email:${requestId}`,
+    });
+    try {
+      await sendLoopsEvent({
+        apiKey: loopsKey,
+        email,
+        eventName: "anarlogYcPerkRequested",
+        firstName: verification.firstName,
+        eventProperties: {
+          source: "yc_perk_page",
+          verificationUrl,
+        },
+        idempotencyKey: `yc-perk-event:${requestId}`,
+      });
+    } catch (error) {
+      console.error("Failed to record YC perk request:", error);
+    }
+
+    return { status: "verified" as const };
+  });

--- a/apps/web/src/lib/loops.test.ts
+++ b/apps/web/src/lib/loops.test.ts
@@ -32,6 +32,34 @@ test("sends lifecycle events with contact data and idempotency", async () => {
   });
 });
 
+test("sends event properties without requiring account contact fields", async () => {
+  let request: { init?: RequestInit } | undefined;
+
+  await sendLoopsEvent({
+    apiKey: "loops-key",
+    email: "founder@example.com",
+    eventName: "anarlogYcPerkRequested",
+    eventProperties: {
+      source: "yc_perk_page",
+      verificationUrl: "https://www.ycombinator.com/verify/founder-token",
+    },
+    idempotencyKey: "yc-perk:request-123",
+    fetcher: async (_url, init) => {
+      request = { init };
+      return Response.json({ success: true });
+    },
+  });
+
+  assert.deepEqual(JSON.parse(String(request?.init?.body)), {
+    email: "founder@example.com",
+    eventName: "anarlogYcPerkRequested",
+    eventProperties: {
+      source: "yc_perk_page",
+      verificationUrl: "https://www.ycombinator.com/verify/founder-token",
+    },
+  });
+});
+
 test("sends transactionals without putting idempotency in the body", async () => {
   let request: { init?: RequestInit } | undefined;
 

--- a/apps/web/src/lib/loops.ts
+++ b/apps/web/src/lib/loops.ts
@@ -55,14 +55,16 @@ export function sendLoopsEvent({
   userId,
   eventName,
   firstName,
+  eventProperties,
   idempotencyKey,
   fetcher = fetch,
 }: {
   apiKey: string;
   email: string;
-  userId: string;
+  userId?: string;
   eventName: string;
-  firstName: string;
+  firstName?: string;
+  eventProperties?: Record<string, string | number | boolean>;
   idempotencyKey: string;
   fetcher?: typeof fetch;
 }) {
@@ -72,9 +74,10 @@ export function sendLoopsEvent({
     idempotencyKey,
     body: {
       email,
-      userId,
       eventName,
-      firstName,
+      ...(userId ? { userId } : {}),
+      ...(firstName ? { firstName } : {}),
+      ...(eventProperties ? { eventProperties } : {}),
     },
     fetcher,
   });

--- a/apps/web/src/lib/yc-perk-promotion.test.ts
+++ b/apps/web/src/lib/yc-perk-promotion.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type Stripe from "stripe";
+
+import {
+  createYcPromotionCode,
+  getOrCreateYcPromotionCode,
+  getYcPerkClaimId,
+  YC_FOUNDER_COUPON_ID,
+} from "./yc-perk-promotion.ts";
+
+const claimId = "0123456789abcdef0123456789abcdef";
+const code = "YC-0123456789ABCDEF01234567";
+
+test("uses the normalized founder email as the claim identity", () => {
+  assert.equal(
+    getYcPerkClaimId(" Founder@Example.com "),
+    getYcPerkClaimId("founder@example.com"),
+  );
+});
+
+test("creates an unpredictable customer-facing code", () => {
+  assert.match(createYcPromotionCode(), /^YC-[A-F0-9]{24}$/);
+});
+
+test("reuses an existing promotion code", async () => {
+  let creates = 0;
+  const stripe = {
+    promotionCodes: {
+      list: async () => ({
+        data: [
+          {
+            active: true,
+            code: "YC-EXISTING",
+            max_redemptions: 1,
+            metadata: { claim_id: claimId },
+            times_redeemed: 0,
+          },
+        ],
+      }),
+      create: async () => {
+        creates += 1;
+        return { code: "YC-NEW" };
+      },
+    },
+  } as unknown as Stripe;
+
+  assert.deepEqual(
+    await getOrCreateYcPromotionCode({ stripe, claimId, code }),
+    { status: "available", code: "YC-EXISTING" },
+  );
+  assert.equal(creates, 0);
+});
+
+test("reports an existing redeemed promotion code as claimed", async () => {
+  const stripe = {
+    promotionCodes: {
+      list: async () => ({
+        data: [
+          {
+            active: false,
+            code: "YC-CLAIMED",
+            max_redemptions: 1,
+            metadata: { claim_id: claimId },
+            times_redeemed: 1,
+          },
+        ],
+      }),
+    },
+  } as unknown as Stripe;
+
+  assert.deepEqual(
+    await getOrCreateYcPromotionCode({ stripe, claimId, code }),
+    { status: "claimed" },
+  );
+});
+
+test("creates a single-use promotion code for the YC coupon", async () => {
+  const calls: Array<{ params: unknown; options: unknown }> = [];
+  const stripe = {
+    promotionCodes: {
+      list: async () => ({ data: [] }),
+      create: async (params: unknown, options: unknown) => {
+        calls.push({ params, options });
+        return { code };
+      },
+    },
+  } as unknown as Stripe;
+
+  assert.deepEqual(
+    await getOrCreateYcPromotionCode({ stripe, claimId, code }),
+    { status: "available", code },
+  );
+  assert.deepEqual(calls, [
+    {
+      params: {
+        promotion: { type: "coupon", coupon: YC_FOUNDER_COUPON_ID },
+        code,
+        max_redemptions: 1,
+        metadata: { claim_id: claimId, source: "yc_perk_page" },
+      },
+      options: {
+        idempotencyKey: `yc-perk-promotion:${claimId}`,
+      },
+    },
+  ]);
+});

--- a/apps/web/src/lib/yc-perk-promotion.ts
+++ b/apps/web/src/lib/yc-perk-promotion.ts
@@ -1,0 +1,61 @@
+import { createHash, randomBytes } from "node:crypto";
+import type Stripe from "stripe";
+
+export const YC_FOUNDER_COUPON_ID = "yc-founders-3-months-free";
+
+export function getYcPerkClaimId(email: string) {
+  return createHash("sha256").update(email.trim().toLowerCase()).digest("hex");
+}
+
+export function createYcPromotionCode() {
+  return `YC-${randomBytes(12).toString("hex").toUpperCase()}`;
+}
+
+export async function getOrCreateYcPromotionCode({
+  stripe,
+  claimId,
+  code,
+}: {
+  stripe: Stripe;
+  claimId: string;
+  code: string;
+}) {
+  const findPromotionCode = async () =>
+    (await stripe.promotionCodes.list({ code, limit: 1 })).data[0];
+  const getExistingPromotion = (promotion: Stripe.PromotionCode) =>
+    !promotion.active ||
+    (promotion.max_redemptions !== null &&
+      promotion.times_redeemed >= promotion.max_redemptions)
+      ? ({ status: "claimed" } as const)
+      : ({ status: "available", code: promotion.code } as const);
+
+  const existingPromotion = await findPromotionCode();
+  if (existingPromotion) {
+    return getExistingPromotion(existingPromotion);
+  }
+
+  try {
+    const promotionCode = await stripe.promotionCodes.create(
+      {
+        promotion: {
+          type: "coupon",
+          coupon: YC_FOUNDER_COUPON_ID,
+        },
+        code,
+        max_redemptions: 1,
+        metadata: {
+          claim_id: claimId,
+          source: "yc_perk_page",
+        },
+      },
+      { idempotencyKey: `yc-perk-promotion:${claimId}` },
+    );
+    return { status: "available", code: promotionCode.code } as const;
+  } catch (error) {
+    const concurrentPromotion = await findPromotionCode();
+    if (concurrentPromotion) {
+      return getExistingPromotion(concurrentPromotion);
+    }
+    throw error;
+  }
+}

--- a/apps/web/src/lib/yc-perk.test.ts
+++ b/apps/web/src/lib/yc-perk.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getYcVerificationApiUrl,
+  isYcVerificationUrl,
+  normalizeYcVerificationUrl,
+  validateYcPerkEmail,
+  validateYcVerificationUrl,
+  verifyYcFounder,
+  ycPerkRequestSchema,
+} from "./yc-perk.ts";
+
+test("accepts YC founder verification links", () => {
+  assert.equal(
+    isYcVerificationUrl("https://www.ycombinator.com/verify/founder-token"),
+    true,
+  );
+  assert.equal(
+    isYcVerificationUrl("https://ycombinator.com/verify/founder_token/"),
+    true,
+  );
+});
+
+test("rejects lookalike and generic YC URLs", () => {
+  assert.equal(
+    isYcVerificationUrl(
+      "https://www.ycombinator.com.evil.example/verify/founder-token",
+    ),
+    false,
+  );
+  assert.equal(
+    isYcVerificationUrl("https://www.ycombinator.com/verify"),
+    false,
+  );
+  assert.equal(
+    isYcVerificationUrl("http://www.ycombinator.com/verify/founder-token"),
+    false,
+  );
+});
+
+test("validates complete YC perk requests", () => {
+  assert.equal(
+    ycPerkRequestSchema.safeParse({
+      email: "founder@example.com",
+      verificationUrl: "https://www.ycombinator.com/verify/founder-token",
+      additionalComments: "",
+    }).success,
+    true,
+  );
+  assert.equal(
+    ycPerkRequestSchema.safeParse({
+      email: "not-an-email",
+      verificationUrl: "https://www.ycombinator.com/verify/founder-token",
+      additionalComments: "",
+    }).success,
+    false,
+  );
+});
+
+test("normalizes founder verification links", () => {
+  assert.equal(
+    normalizeYcVerificationUrl(
+      " https://ycombinator.com/verify/founder-token/?source=deal#details ",
+    ),
+    "https://www.ycombinator.com/verify/founder-token",
+  );
+  assert.equal(
+    getYcVerificationApiUrl(
+      "https://www.ycombinator.com/verify/founder-token/",
+    ),
+    "https://www.ycombinator.com/verify/founder-token.json",
+  );
+});
+
+test("returns field-level validation messages", () => {
+  assert.equal(validateYcPerkEmail("founder@example.com"), undefined);
+  assert.equal(validateYcPerkEmail("not-an-email"), "Enter a valid email");
+  assert.equal(
+    validateYcVerificationUrl("https://example.com/verify/founder-token"),
+    "Use your ycombinator.com/verify link",
+  );
+});
+
+test("verifies founders when the YC email matches", async () => {
+  const requestedUrls: string[] = [];
+  const result = await verifyYcFounder({
+    email: "founder@example.com",
+    verificationUrl: "https://ycombinator.com/verify/founder-token/",
+    fetcher: (async (url) => {
+      requestedUrls.push(String(url));
+      return Response.json({
+        verified: true,
+        name: "Ada Lovelace",
+        email: "Founder@Example.com",
+        companies: [{ name: "Analytical Engines", batch: "S25" }],
+      });
+    }) as typeof fetch,
+  });
+
+  assert.deepEqual(result, { status: "verified", firstName: "Ada" });
+  assert.deepEqual(requestedUrls, [
+    "https://www.ycombinator.com/verify/founder-token.json",
+  ]);
+});
+
+test("rejects inactive verification links", async () => {
+  const result = await verifyYcFounder({
+    email: "founder@example.com",
+    verificationUrl: "https://www.ycombinator.com/verify/founder-token",
+    fetcher: (async () => Response.json({ verified: false })) as typeof fetch,
+  });
+
+  assert.deepEqual(result, { status: "invalid", reason: "not_verified" });
+});
+
+test("requires the YC verification email", async () => {
+  const result = await verifyYcFounder({
+    email: "founder@example.com",
+    verificationUrl: "https://www.ycombinator.com/verify/founder-token",
+    fetcher: (async () =>
+      Response.json({ verified: true, name: "Ada Lovelace" })) as typeof fetch,
+  });
+
+  assert.deepEqual(result, { status: "invalid", reason: "email_missing" });
+});
+
+test("requires the submitted email to match YC", async () => {
+  const result = await verifyYcFounder({
+    email: "other@example.com",
+    verificationUrl: "https://www.ycombinator.com/verify/founder-token",
+    fetcher: (async () =>
+      Response.json({
+        verified: true,
+        name: "Ada Lovelace",
+        email: "founder@example.com",
+      })) as typeof fetch,
+  });
+
+  assert.deepEqual(result, { status: "invalid", reason: "email_mismatch" });
+});
+
+test("fails closed on unexpected YC responses", async () => {
+  await assert.rejects(
+    verifyYcFounder({
+      email: "founder@example.com",
+      verificationUrl: "https://www.ycombinator.com/verify/founder-token",
+      fetcher: (async () => Response.json({ verified: "yes" })) as typeof fetch,
+    }),
+    /unexpected response/,
+  );
+});

--- a/apps/web/src/lib/yc-perk.ts
+++ b/apps/web/src/lib/yc-perk.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+
+const YC_VERIFICATION_HOSTS = new Set([
+  "www.ycombinator.com",
+  "ycombinator.com",
+]);
+
+const ycFounderVerificationSchema = z
+  .object({
+    verified: z.boolean(),
+    name: z.string().optional(),
+    email: z.string().email().optional(),
+    companies: z
+      .array(
+        z
+          .object({
+            name: z.string(),
+            batch: z.string().optional(),
+          })
+          .passthrough(),
+      )
+      .optional(),
+  })
+  .passthrough();
+
+export type YcFounderVerificationResult =
+  | {
+      status: "verified";
+      firstName: string;
+    }
+  | {
+      status: "invalid";
+      reason: "not_verified" | "email_missing" | "email_mismatch";
+    };
+
+export function isYcVerificationUrl(value: string) {
+  try {
+    const url = new URL(value.trim());
+    const segments = url.pathname.split("/").filter(Boolean);
+
+    return (
+      url.protocol === "https:" &&
+      YC_VERIFICATION_HOSTS.has(url.hostname.toLowerCase()) &&
+      !url.username &&
+      !url.password &&
+      segments.length === 2 &&
+      segments[0] === "verify" &&
+      segments[1].length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+export const ycPerkRequestSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .min(1, "Enter your work email")
+    .email("Enter a valid email")
+    .max(320),
+  verificationUrl: z
+    .string()
+    .trim()
+    .min(1, "Paste your YC verification link")
+    .max(2_048)
+    .refine(isYcVerificationUrl, "Use your ycombinator.com/verify link"),
+  additionalComments: z.string().max(200),
+});
+
+export function validateYcPerkEmail(value: string) {
+  const result = ycPerkRequestSchema.shape.email.safeParse(value);
+  return result.success ? undefined : result.error.issues[0]?.message;
+}
+
+export function validateYcVerificationUrl(value: string) {
+  const result = ycPerkRequestSchema.shape.verificationUrl.safeParse(value);
+  return result.success ? undefined : result.error.issues[0]?.message;
+}
+
+export function normalizeYcVerificationUrl(value: string) {
+  const url = new URL(value.trim());
+  url.hostname = "www.ycombinator.com";
+  url.hash = "";
+  url.search = "";
+  url.pathname = url.pathname.replace(/\/$/, "");
+  return url.toString();
+}
+
+export function getYcVerificationApiUrl(value: string) {
+  return `${normalizeYcVerificationUrl(value)}.json`;
+}
+
+export async function verifyYcFounder({
+  email,
+  verificationUrl,
+  fetcher = fetch,
+  signal = AbortSignal.timeout(5_000),
+}: {
+  email: string;
+  verificationUrl: string;
+  fetcher?: typeof fetch;
+  signal?: AbortSignal;
+}): Promise<YcFounderVerificationResult> {
+  const response = await fetcher(getYcVerificationApiUrl(verificationUrl), {
+    headers: { Accept: "application/json" },
+    redirect: "error",
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error("YC verification is temporarily unavailable");
+  }
+
+  const verification = ycFounderVerificationSchema.safeParse(
+    await response.json(),
+  );
+  if (!verification.success) {
+    throw new Error("YC verification returned an unexpected response");
+  }
+  if (!verification.data.verified) {
+    return { status: "invalid", reason: "not_verified" };
+  }
+  if (!verification.data.email) {
+    return { status: "invalid", reason: "email_missing" };
+  }
+  if (
+    verification.data.email.trim().toLowerCase() !== email.trim().toLowerCase()
+  ) {
+    return { status: "invalid", reason: "email_mismatch" };
+  }
+
+  return {
+    status: "verified",
+    firstName: verification.data.name?.trim().split(/\s+/)[0] || "there",
+  };
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as ConfirmAuthRouteImport } from './routes/confirm-auth'
 import { Route as AuthRouteImport } from './routes/auth'
 import { Route as ViewRouteRouteImport } from './routes/_view/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as YcIndexRouteImport } from './routes/yc/index'
 import { Route as ChangelogIndexRouteImport } from './routes/changelog/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as ShareShareIdRouteImport } from './routes/share/$shareId'
@@ -121,6 +122,11 @@ const ViewRouteRoute = ViewRouteRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const YcIndexRoute = YcIndexRouteImport.update({
+  id: '/yc/',
+  path: '/yc/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ChangelogIndexRoute = ChangelogIndexRouteImport.update({
@@ -450,6 +456,7 @@ export interface FileRoutesByFullPath {
   '/share/$shareId': typeof ShareShareIdRoute
   '/blog/': typeof BlogIndexRoute
   '/changelog/': typeof ChangelogIndexRoute
+  '/yc/': typeof YcIndexRoute
   '/app/account': typeof ViewAppAccountRoute
   '/app/checkout': typeof ViewAppCheckoutRoute
   '/app/integration': typeof ViewAppIntegrationRoute
@@ -519,6 +526,7 @@ export interface FileRoutesByTo {
   '/share/$shareId': typeof ShareShareIdRoute
   '/blog': typeof BlogIndexRoute
   '/changelog': typeof ChangelogIndexRoute
+  '/yc': typeof YcIndexRoute
   '/app/account': typeof ViewAppAccountRoute
   '/app/checkout': typeof ViewAppCheckoutRoute
   '/app/integration': typeof ViewAppIntegrationRoute
@@ -591,6 +599,7 @@ export interface FileRoutesById {
   '/share/$shareId': typeof ShareShareIdRoute
   '/blog/': typeof BlogIndexRoute
   '/changelog/': typeof ChangelogIndexRoute
+  '/yc/': typeof YcIndexRoute
   '/_view/app/account': typeof ViewAppAccountRoute
   '/_view/app/checkout': typeof ViewAppCheckoutRoute
   '/_view/app/integration': typeof ViewAppIntegrationRoute
@@ -663,6 +672,7 @@ export interface FileRouteTypes {
     | '/share/$shareId'
     | '/blog/'
     | '/changelog/'
+    | '/yc/'
     | '/app/account'
     | '/app/checkout'
     | '/app/integration'
@@ -732,6 +742,7 @@ export interface FileRouteTypes {
     | '/share/$shareId'
     | '/blog'
     | '/changelog'
+    | '/yc'
     | '/app/account'
     | '/app/checkout'
     | '/app/integration'
@@ -803,6 +814,7 @@ export interface FileRouteTypes {
     | '/share/$shareId'
     | '/blog/'
     | '/changelog/'
+    | '/yc/'
     | '/_view/app/account'
     | '/_view/app/checkout'
     | '/_view/app/integration'
@@ -874,6 +886,7 @@ export interface RootRouteChildren {
   ShareShareIdRoute: typeof ShareShareIdRoute
   BlogIndexRoute: typeof BlogIndexRoute
   ChangelogIndexRoute: typeof ChangelogIndexRoute
+  YcIndexRoute: typeof YcIndexRoute
   ApiAssetsSplatRoute: typeof ApiAssetsSplatRoute
   ApiTweetIdRoute: typeof ApiTweetIdRoute
   ApiWebhooksSlackInteractiveRoute: typeof ApiWebhooksSlackInteractiveRoute
@@ -977,6 +990,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/yc/': {
+      id: '/yc/'
+      path: '/yc'
+      fullPath: '/yc/'
+      preLoaderRoute: typeof YcIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/changelog/': {
@@ -1468,6 +1488,7 @@ const rootRouteChildren: RootRouteChildren = {
   ShareShareIdRoute: ShareShareIdRoute,
   BlogIndexRoute: BlogIndexRoute,
   ChangelogIndexRoute: ChangelogIndexRoute,
+  YcIndexRoute: YcIndexRoute,
   ApiAssetsSplatRoute: ApiAssetsSplatRoute,
   ApiTweetIdRoute: ApiTweetIdRoute,
   ApiWebhooksSlackInteractiveRoute: ApiWebhooksSlackInteractiveRoute,

--- a/apps/web/src/routes/yc/index.tsx
+++ b/apps/web/src/routes/yc/index.tsx
@@ -1,0 +1,380 @@
+import {
+  ArrowUpRight,
+  Check,
+  CircleNotch,
+  LockKey,
+} from "@phosphor-icons/react";
+import { useForm } from "@tanstack/react-form";
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { cn } from "@anlg/utils";
+
+import { AnarlogLogo } from "@/components/anarlog-logo";
+import { submitYcPerkRequest } from "@/functions/yc-perk";
+import { getCanonicalUrl } from "@/lib/seo";
+import {
+  validateYcPerkEmail,
+  validateYcVerificationUrl,
+  ycPerkRequestSchema,
+} from "@/lib/yc-perk";
+
+const title = "YC founder perk · Anarlog";
+const description =
+  "YC founders get three months of Anarlog Pro free for bot-free, local-first meeting notes.";
+
+const invalidVerificationMessages = {
+  not_verified: "This YC verification link is no longer active.",
+  email_missing:
+    "Update your YC verification link to include your email, then try again.",
+  email_mismatch:
+    "Use the same email shown on your YC verification link, then try again.",
+};
+
+export const Route = createFileRoute("/yc/")({
+  component: YcPerkPage,
+  head: () => ({
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:url", content: getCanonicalUrl("/yc") },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+      { name: "twitter:url", content: getCanonicalUrl("/yc") },
+    ],
+    links: [{ rel: "canonical", href: getCanonicalUrl("/yc") }],
+  }),
+});
+
+function YcPerkPage() {
+  const requestMutation = useMutation({
+    mutationFn: (data: {
+      email: string;
+      verificationUrl: string;
+      additionalComments: string;
+    }) => submitYcPerkRequest({ data }),
+  });
+  const form = useForm({
+    defaultValues: {
+      email: "",
+      verificationUrl: "",
+      additionalComments: "",
+    },
+    validators: { onSubmit: ycPerkRequestSchema },
+    onSubmit: ({ value }) => requestMutation.mutate(value),
+  });
+  const requestSucceeded =
+    requestMutation.data?.status === "verified" ||
+    requestMutation.data?.status === "submitted";
+  const invalidVerificationMessage =
+    requestMutation.data?.status === "invalid"
+      ? invalidVerificationMessages[requestMutation.data.reason]
+      : undefined;
+  const requestErrorMessage =
+    requestMutation.data?.status === "already_claimed"
+      ? "This YC perk has already been claimed for this email."
+      : invalidVerificationMessage;
+
+  return (
+    <main className="bg-page text-color min-h-screen">
+      <header className="mx-auto flex w-full max-w-6xl items-center justify-between px-5 py-5 sm:px-8 lg:px-10">
+        <Link to="/" aria-label="Anarlog home" className="inline-flex">
+          <AnarlogLogo className="h-8 w-auto" />
+        </Link>
+        <div className="flex items-center gap-3">
+          <span className="text-color-secondary hidden text-sm sm:inline">
+            Built by YC founders
+          </span>
+          <img
+            src="/icons/yc.svg"
+            alt="Y Combinator"
+            width={28}
+            height={28}
+            className="size-7 rounded"
+          />
+        </div>
+      </header>
+
+      <section className="mx-auto grid min-h-[calc(100vh-92px)] w-full max-w-6xl items-center gap-14 px-5 py-12 sm:px-8 md:py-16 lg:grid-cols-[minmax(0,0.92fr)_minmax(420px,1.08fr)] lg:gap-20 lg:px-10 lg:py-20">
+        <div className="max-w-xl">
+          <div className="brand-yellow border-color-subtle inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
+            <img
+              src="/icons/yc.svg"
+              alt=""
+              width={20}
+              height={20}
+              className="size-5 rounded-sm"
+            />
+            The YC founder offer
+          </div>
+
+          <h1 className="mt-8 text-5xl leading-[0.98]! font-medium tracking-[-0.045em] text-balance sm:text-6xl lg:text-7xl">
+            Build the company. Keep every decision.
+          </h1>
+          <p className="text-color-secondary mt-7 max-w-lg text-lg leading-8">
+            Get three months of Anarlog Pro free. Keep private, bot-free notes
+            from customer calls, investor conversations, and the meetings that
+            move your startup forward.
+          </p>
+
+          <div className="mt-9 max-w-lg">
+            {requestSucceeded ? (
+              <div
+                className="surface border-color-subtle rounded-2xl border p-6 shadow-sm"
+                role="status"
+              >
+                <div className="flex size-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-700">
+                  <Check size={20} weight="bold" aria-hidden="true" />
+                </div>
+                <h2 className="mt-5 text-xl font-semibold tracking-tight">
+                  You’re verified.
+                </h2>
+                <p className="text-color-secondary mt-2 text-base leading-7">
+                  Your three-month Pro code is on its way to{" "}
+                  {requestMutation.variables?.email}.
+                </p>
+              </div>
+            ) : (
+              <form
+                className="flex flex-col gap-3"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void form.handleSubmit();
+                }}
+              >
+                <form.Field
+                  name="email"
+                  validators={{
+                    onChange: ({ value }) => validateYcPerkEmail(value),
+                    onBlur: ({ value }) => validateYcPerkEmail(value),
+                    onSubmit: ({ value }) => validateYcPerkEmail(value),
+                  }}
+                >
+                  {(field) => (
+                    <div>
+                      <label htmlFor={field.name} className="sr-only">
+                        Work email
+                      </label>
+                      <input
+                        id={field.name}
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        required
+                        placeholder="Work email"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        className={cn([
+                          "surface text-color min-h-13 w-full rounded-xl border px-4 text-base shadow-sm transition outline-none",
+                          "placeholder:text-color-muted focus:border-stone-500 focus:ring-3 focus:ring-stone-300/40",
+                          field.state.meta.errors.length > 0
+                            ? "border-red-500"
+                            : "border-color-subtle",
+                        ])}
+                        aria-invalid={field.state.meta.errors.length > 0}
+                      />
+                      <FieldError errors={field.state.meta.errors} />
+                    </div>
+                  )}
+                </form.Field>
+
+                <form.Field
+                  name="verificationUrl"
+                  validators={{
+                    onChange: ({ value }) => validateYcVerificationUrl(value),
+                    onBlur: ({ value }) => validateYcVerificationUrl(value),
+                    onSubmit: ({ value }) => validateYcVerificationUrl(value),
+                  }}
+                >
+                  {(field) => (
+                    <div>
+                      <label htmlFor={field.name} className="sr-only">
+                        YC verification link
+                      </label>
+                      <input
+                        id={field.name}
+                        name={field.name}
+                        type="url"
+                        autoComplete="url"
+                        required
+                        placeholder="https://www.ycombinator.com/verify/..."
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        className={cn([
+                          "surface text-color min-h-13 w-full rounded-xl border px-4 text-base shadow-sm transition outline-none",
+                          "placeholder:text-color-muted focus:border-stone-500 focus:ring-3 focus:ring-stone-300/40",
+                          field.state.meta.errors.length > 0
+                            ? "border-red-500"
+                            : "border-color-subtle",
+                        ])}
+                        aria-invalid={field.state.meta.errors.length > 0}
+                      />
+                      <FieldError errors={field.state.meta.errors} />
+                    </div>
+                  )}
+                </form.Field>
+
+                <form.Field name="additionalComments">
+                  {(field) => (
+                    <div
+                      className="pointer-events-none absolute -left-[10000px]"
+                      aria-hidden="true"
+                    >
+                      <label htmlFor={field.name}>Additional comments</label>
+                      <input
+                        id={field.name}
+                        name={field.name}
+                        type="text"
+                        tabIndex={-1}
+                        autoComplete="off"
+                        value={field.state.value}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </div>
+                  )}
+                </form.Field>
+
+                {(requestMutation.isError || requestErrorMessage) && (
+                  <p className="text-sm text-red-700" role="alert">
+                    {requestErrorMessage ??
+                      "We couldn’t process your YC perk right now. Please try again."}
+                  </p>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={requestMutation.isPending}
+                  className="mt-1 inline-flex min-h-13 items-center justify-center gap-2 rounded-xl bg-linear-to-t from-stone-600 to-stone-500 px-5 text-base font-medium text-white shadow-md transition hover:-translate-y-0.5 hover:shadow-lg disabled:translate-y-0 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {requestMutation.isPending ? (
+                    <>
+                      <CircleNotch
+                        className="size-5 animate-spin"
+                        aria-hidden="true"
+                      />
+                      Submitting…
+                    </>
+                  ) : (
+                    "Claim your YC perk"
+                  )}
+                </button>
+
+                <a
+                  href="https://www.ycombinator.com/verify"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-color-secondary mt-1 inline-flex w-fit items-center gap-1 text-sm underline decoration-stone-400 underline-offset-4 transition hover:text-stone-900"
+                >
+                  Get your YC verification link
+                  <ArrowUpRight size={14} aria-hidden="true" />
+                </a>
+              </form>
+            )}
+          </div>
+
+          <div className="text-color-secondary mt-8 flex items-center gap-2 text-sm">
+            <LockKey size={16} aria-hidden="true" />
+            Verified directly with Y Combinator. Your link is only used to
+            confirm YC status.
+          </div>
+        </div>
+
+        <FounderMeetingVisual />
+      </section>
+    </main>
+  );
+}
+
+function FounderMeetingVisual() {
+  return (
+    <div
+      className="relative mx-auto flex aspect-square w-full max-w-[560px] items-center justify-center"
+      aria-hidden="true"
+    >
+      <div className="brand-yellow absolute inset-[8%] rounded-full blur-3xl" />
+      <div className="surface border-color-subtle absolute top-[10%] left-[14%] z-10 flex size-28 -rotate-8 flex-col justify-between rounded-3xl border p-4 shadow-[0_24px_55px_rgba(68,54,36,0.18)] sm:size-32">
+        <img
+          src="/icons/yc.svg"
+          alt=""
+          width={48}
+          height={48}
+          className="size-12 rounded-lg shadow-sm"
+        />
+        <span className="text-right text-sm font-semibold">S25</span>
+      </div>
+      <div className="surface border-color-subtle absolute top-[13%] right-[12%] size-28 rotate-9 rounded-3xl border p-4 shadow-[0_24px_55px_rgba(68,54,36,0.16)] sm:size-32">
+        <span className="text-color-secondary text-xs font-medium tracking-[0.14em] uppercase">
+          Today
+        </span>
+        <p className="mt-3 text-sm leading-5 font-semibold">
+          Customer interview
+        </p>
+      </div>
+
+      <div className="surface-dark relative z-20 mt-14 w-[82%] rotate-[-2deg] rounded-[2rem] p-6 text-white shadow-[0_36px_80px_rgba(68,54,36,0.28)] sm:p-8">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold text-white">Anarlog</span>
+          <div className="flex items-center gap-1.5">
+            {[8, 14, 20, 12, 17, 9].map((height, index) => (
+              <span
+                key={`${height}-${index}`}
+                className="w-1 rounded-full bg-stone-300"
+                style={{ height }}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="mt-10">
+          <p className="text-xs tracking-[0.15em] text-stone-400 uppercase">
+            Founder sync
+          </p>
+          <h2 className="mt-2 text-2xl leading-tight font-medium tracking-tight text-white sm:text-3xl">
+            Decisions, without another bot in the room.
+          </h2>
+        </div>
+        <div className="mt-8 space-y-3">
+          {[
+            "Ship onboarding this week",
+            "John owns customer follow-up",
+            "Review pricing on Friday",
+          ].map((item) => (
+            <div
+              key={item}
+              className="flex items-center gap-3 rounded-xl bg-white/8 px-4 py-3"
+            >
+              <span className="size-1.5 shrink-0 rounded-full bg-stone-300" />
+              <span className="text-sm text-stone-200">{item}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FieldError({ errors }: { errors: Array<unknown> }) {
+  const firstError = errors[0];
+  const message =
+    typeof firstError === "string"
+      ? firstError
+      : firstError && typeof firstError === "object" && "message" in firstError
+        ? String(firstError.message)
+        : undefined;
+
+  return message ? (
+    <p className="mt-1.5 px-1 text-sm text-red-700" role="alert">
+      {message}
+    </p>
+  ) : null;
+}

--- a/apps/web/src/utils/sitemap.ts
+++ b/apps/web/src/utils/sitemap.ts
@@ -42,6 +42,10 @@ export function getSitemap(): Sitemap<TRoutes> {
         priority: 0.9,
         changeFrequency: "weekly",
       },
+      "/yc/": {
+        priority: 0.7,
+        changeFrequency: "monthly",
+      },
       // Per-version release notes are noindex (see routes/changelog/$version),
       // so listing them here would contradict the directive.
       "/changelog/$version": [],

--- a/supabase/migrations/20260807100000_yc_perk_claims.sql
+++ b/supabase/migrations/20260807100000_yc_perk_claims.sql
@@ -1,0 +1,11 @@
+CREATE TABLE public.yc_perk_claims (
+  claim_id text PRIMARY KEY CHECK (claim_id ~ '^[a-f0-9]{64}$'),
+  promotion_code text NOT NULL UNIQUE
+    CHECK (promotion_code ~ '^YC-[A-F0-9]{24}$'),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.yc_perk_claims ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.yc_perk_claims FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.yc_perk_claims TO service_role;


### PR DESCRIPTION
Add a validated YC verification request flow backed by Loops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing (promotion codes), Stripe promotion creation, and a public unauthenticated flow that calls YC and creates redeemable discounts; mitigated by URL validation, email matching, one redemption per claim, and locked-down DB access.
> 
> **Overview**
> Adds a **public `/yc` landing page** where YC founders submit email and a `ycombinator.com/verify` link to claim three months of Pro.
> 
> **Verification and fulfillment:** A new server action validates the link against YC’s `.json` endpoint (HTTPS host/path checks, email must match), then issues a **single-use Stripe promotion code** tied to a hashed email claim id. Claim codes are persisted in a new **`yc_perk_claims`** table (service role only) and synced to Stripe with idempotency; redeemed codes return **already claimed**. Verified founders get the code via **Loops transactional** email and an **`anarlogYcPerkRequested`** event (Loops events now support optional contact fields and **`eventProperties`**). Honeypot **`additionalComments`** short-circuits to a fake success.
> 
> **Checkout:** Non-trial Stripe checkout sessions enable **`allow_promotion_codes`** so founders can apply the emailed code.
> 
> **Discovery:** `/yc/` is registered in the router and sitemap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c9e6046ba19b0607910a05d9e91bf9abb9c7f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->