### PR TITLE
Use window icon for standalone notes

### DIFF
--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui/react/macro";
 import {
+  AppWindow,
   ArrowsClockwise,
-  ArrowSquareOut,
   DotsThree,
   FileArrowDown,
   FileText,
@@ -193,7 +193,7 @@ export function OverflowButton({
                 onClick={handleOpenStandaloneWindow}
                 className="cursor-pointer"
               >
-                <ArrowSquareOut />
+                <AppWindow />
                 <span>
                   <Trans>Open in New Window</Trans>
                 </span>


### PR DESCRIPTION
Replace the external-link glyph with an application-window icon in note actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Icon-only UI change with no behavior or data impact.
> 
> **Overview**
> The session overflow menu **Open in New Window** action now uses Phosphor’s `AppWindow` icon instead of `ArrowSquareOut`, so the glyph matches opening another app window rather than an external link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05538c668fb760acf922b57000fd05cf9850f09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->