### PR TITLE
Match note filter to app popover style

### DIFF
--- a/apps/desktop/src/sidebar/note-filter-menu.tsx
+++ b/apps/desktop/src/sidebar/note-filter-menu.tsx
@@ -2,6 +2,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { FunnelSimple } from "@phosphor-icons/react";
 
 import {
+  AppFloatingPanel,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuRadioGroup,
@@ -42,20 +43,22 @@ export function SidebarNoteFilterMenu({
           />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-52">
-        <DropdownMenuRadioGroup
-          value={value}
-          onValueChange={(nextValue) =>
-            onValueChange(nextValue as SidebarNoteFilter)
-          }
-        >
-          <DropdownMenuRadioItem value="mine">
-            <Trans>My notes</Trans>
-          </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="shared">
-            <Trans>Shared</Trans>
-          </DropdownMenuRadioItem>
-        </DropdownMenuRadioGroup>
+      <DropdownMenuContent variant="app" align="start" className="w-52">
+        <AppFloatingPanel className="overflow-hidden p-1">
+          <DropdownMenuRadioGroup
+            value={value}
+            onValueChange={(nextValue) =>
+              onValueChange(nextValue as SidebarNoteFilter)
+            }
+          >
+            <DropdownMenuRadioItem value="mine">
+              <Trans>My notes</Trans>
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="shared">
+              <Trans>Shared</Trans>
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </AppFloatingPanel>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
Use the shared app floating panel chrome for the sidebar note filter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change to the note filter menu; no logic or data handling.
> 
> **Overview**
> The sidebar **note filter** dropdown now uses the same floating-panel styling as other desktop popovers.
> 
> `DropdownMenuContent` gets **`variant="app"`**, and the radio group is wrapped in **`AppFloatingPanel`** (`overflow-hidden p-1`). Filter behavior and options are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f47ee133d5cff221cc0e410cd4c4ffdb02c558b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->