### PR TITLE
Hide completed meeting resume controls

### DIFF
--- a/apps/desktop/src/session/components/note-input/header-transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/header-transcript.tsx
@@ -21,6 +21,11 @@ import {
   useNativeContextMenu,
 } from "~/shared/hooks/useNativeContextMenu";
 import { useListener } from "~/stt/contexts";
+import { useStartListening } from "~/stt/useStartListening";
+import {
+  isMainWebviewWindow,
+  requestMainListenerControl,
+} from "~/stt/window-control";
 
 export function HeaderViewTranscript({
   isActive,
@@ -186,6 +191,7 @@ function HeaderViewTranscriptActive({
   };
 }) {
   const regenerate = useRegenerateTranscript(sessionId);
+  const startListening = useStartListening(sessionId);
   const { request: transcriptExportRequest } =
     useSessionTranscriptRenderData(sessionId);
   const {
@@ -222,6 +228,14 @@ function HeaderViewTranscriptActive({
   const handleDeleteRecording = useCallback(() => {
     void deleteRecording();
   }, [deleteRecording]);
+  const handleResumeListening = useCallback(() => {
+    if (!isMainWebviewWindow()) {
+      void requestMainListenerControl("start", sessionId);
+      return;
+    }
+
+    void startListening();
+  }, [sessionId, startListening]);
   const contextMenu = useMemo<MenuItemDef[]>(() => {
     const items: MenuItemDef[] = [
       {
@@ -233,6 +247,14 @@ function HeaderViewTranscriptActive({
         disabled: !canCopyTranscript,
       },
     ];
+
+    if (sessionMode === "inactive") {
+      items.push({
+        id: `resume-listening-${sessionId}`,
+        text: "Resume listening",
+        action: handleResumeListening,
+      });
+    }
 
     if (audioExistsResolved && sessionMode === "inactive" && audioExists) {
       items.push({
@@ -260,6 +282,7 @@ function HeaderViewTranscriptActive({
     canCopyTranscript,
     handleCopyTranscript,
     handleDeleteRecording,
+    handleResumeListening,
     isDeletingRecording,
     regenerate,
     sessionMode,

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -534,7 +534,12 @@ describe("Header", () => {
 
     expect(
       menu.map((item) => ("text" in item ? item.text : "separator")),
-    ).toEqual(["Copy", "Re-transcribe", "Delete recording"]);
+    ).toEqual([
+      "Copy",
+      "Resume listening",
+      "Re-transcribe",
+      "Delete recording",
+    ]);
     expect(menu.find(isMenuItem)?.disabled).toBe(false);
     expect(
       menu.find(
@@ -542,6 +547,43 @@ describe("Header", () => {
           "id" in item && item.id === "delete-recording-session-1",
       )?.disabled,
     ).toBe(false);
+    menu
+      .find(
+        (item): item is Extract<CapturedMenuItem, { id: string }> =>
+          "id" in item && item.id === "resume-listening-session-1",
+      )
+      ?.action();
+    expect(hoisted.startListening).toHaveBeenCalledTimes(1);
+  });
+
+  it("delegates transcript resume listening from standalone windows", () => {
+    hoisted.isMainWebviewWindow = false;
+
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={[
+          { type: "enhanced", id: "note-1" },
+          { type: "raw" },
+          { type: "transcript" },
+        ]}
+        currentTab={{ type: "transcript" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    findContextMenu("resume-listening-session-1")
+      .find(
+        (item): item is Extract<CapturedMenuItem, { id: string }> =>
+          "id" in item && item.id === "resume-listening-session-1",
+      )
+      ?.action();
+
+    expect(hoisted.requestMainListenerControl).toHaveBeenCalledWith(
+      "start",
+      "session-1",
+    );
+    expect(hoisted.startListening).not.toHaveBeenCalled();
   });
 
   it("does not prepare transcript export data while the transcript tab is inactive", () => {
@@ -595,7 +637,7 @@ describe("Header", () => {
 
     expect(
       menu.map((item) => ("text" in item ? item.text : "separator")),
-    ).toEqual(["Copy"]);
+    ).toEqual(["Copy", "Resume listening"]);
   });
 
   it.each(["active", "finalizing", "running_batch"])(
@@ -646,7 +688,7 @@ describe("Header", () => {
       findContextMenu("copy-transcript-session-1").map((item) =>
         "text" in item ? item.text : "separator",
       ),
-    ).toEqual(["Copy", "Delete recording"]);
+    ).toEqual(["Copy", "Resume listening", "Delete recording"]);
   });
 
   it("replaces the current enhanced note when changing templates", async () => {

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -801,7 +801,7 @@ describe("OuterHeader", () => {
     expect(mocks.openUrl).not.toHaveBeenCalled();
   });
 
-  it("shows resume when an inactive session already has a transcript", () => {
+  it("hides meeting controls for an inactive ad hoc session with a transcript", () => {
     mocks.hasTranscriptBySession = { "session-1": true };
 
     render(
@@ -812,17 +812,15 @@ describe("OuterHeader", () => {
       />,
     );
 
-    const resumeButton = screen.getByRole("button", { name: "Resume" });
-
-    fireEvent.click(resumeButton);
-
-    expect(resumeButton.title).toBe("Resume listening");
+    expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
-    expect(screen.getByTestId("recording-icon")).not.toBeNull();
-    expect(mocks.startListening).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("button", { name: "Open event metadata" }),
+    ).toBeNull();
+    expect(mocks.startListening).not.toHaveBeenCalled();
   });
 
-  it("shows resume when an inactive session has audio without a transcript", () => {
+  it("hides meeting controls for an inactive ad hoc session with audio", () => {
     mocks.audioExists = true;
 
     render(
@@ -833,13 +831,28 @@ describe("OuterHeader", () => {
       />,
     );
 
-    const resumeButton = screen.getByRole("button", { name: "Resume" });
-
-    fireEvent.click(resumeButton);
-
-    expect(resumeButton.title).toBe("Resume listening");
+    expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
-    expect(mocks.startListening).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("button", { name: "Open event metadata" }),
+    ).toBeNull();
+    expect(mocks.startListening).not.toHaveBeenCalled();
+  });
+
+  it("keeps stop available for an active ad hoc session", () => {
+    mocks.sessionModes = { "session-1": "active" };
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    expect(mocks.stopListening).toHaveBeenCalledTimes(1);
   });
 
   it("shows stop while the meeting is in progress", () => {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -125,6 +125,10 @@ function HeaderMeetingControl({
   const isRecording =
     sessionMode === "active" || sessionMode === "running_batch";
 
+  if (!sessionEvent && !isRecording) {
+    return null;
+  }
+
   if (ended && !isRecording) {
     return (
       <div className="mr-1 shrink-0">


### PR DESCRIPTION
Keep scheduled calendar metadata visible, hide inactive ad hoc controls, and add resume listening to the transcript menu.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when users can start/resume STT from the header vs transcript menu and cross-window listener control; behavior is covered by tests but affects a core recording UX path.
> 
> **Overview**
> **Outer header** no longer shows Record/Resume/metadata for **inactive ad hoc sessions** (no linked calendar event). The meeting pill still appears for scheduled events and while **active** or **running_batch** listening (e.g. Stop).
> 
> **Transcript tab** context menu gains **Resume listening** when the session is **inactive**. In the main window it calls `useStartListening`; in standalone windows it delegates via `requestMainListenerControl("start", sessionId)`.
> 
> Tests were updated to expect the new menu item and delegation behavior, and to assert that ad hoc inactive sessions hide outer-header meeting controls while active ad hoc sessions still expose Stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb2dd3baafe3a57c6952d88534f04241975af69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->