### PR TITLE
Store recordings as centered mono

### DIFF
--- a/crates/listener-core/src/actors/recorder/disk.rs
+++ b/crates/listener-core/src/actors/recorder/disk.rs
@@ -31,12 +31,6 @@ pub(super) fn create_disk_sink(session_dir: &Path) -> Result<DiskSink, ActorProc
     let encoded_path = session_dir.join(FINAL_AUDIO_FILE);
     let is_stereo = prepare_existing_audio_state(&encoded_path, &ogg_path, &wav_path)?;
 
-    let stereo_spec = hound::WavSpec {
-        channels: 2,
-        sample_rate: super::super::SAMPLE_RATE,
-        bits_per_sample: 32,
-        sample_format: hound::SampleFormat::Float,
-    };
     let mono_spec = hound::WavSpec {
         channels: 1,
         sample_rate: super::super::SAMPLE_RATE,
@@ -46,8 +40,6 @@ pub(super) fn create_disk_sink(session_dir: &Path) -> Result<DiskSink, ActorProc
 
     let writer = if wav_path.exists() {
         hound::WavWriter::append(&wav_path)?
-    } else if is_stereo {
-        hound::WavWriter::create(&wav_path, stereo_spec)?
     } else {
         hound::WavWriter::create(&wav_path, mono_spec)?
     };
@@ -173,7 +165,7 @@ fn prepare_existing_audio_state(
         return Ok(wav_is_stereo(wav_path)?);
     }
 
-    Ok(true)
+    Ok(false)
 }
 
 fn decode_mp3_to_wav(encoded_path: &Path, wav_path: &Path) -> Result<(), ActorProcessingErr> {
@@ -311,6 +303,27 @@ mod tests {
 
         assert!(session_dir.join(WAV_FILE).exists());
         assert!(!session_dir.join(FINAL_AUDIO_FILE).exists());
+    }
+
+    #[test]
+    fn create_disk_sink_mixes_new_recordings_to_mono() {
+        let dir = tempdir().unwrap();
+        let session_dir = dir.path().join("session");
+        std::fs::create_dir_all(&session_dir).unwrap();
+
+        let mut sink = create_disk_sink(&session_dir).unwrap();
+        write_dual(&mut sink, &[0.25, -0.25], &[0.5, 0.5]).unwrap();
+        finalize_writer(&mut sink.writer, Some(&sink.wav_path)).unwrap();
+
+        let mut reader = hound::WavReader::open(session_dir.join(WAV_FILE)).unwrap();
+        assert_eq!(reader.spec().channels, 1);
+        assert_eq!(
+            reader
+                .samples::<f32>()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![0.75, 0.25]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Mix microphone and system audio into one channel so saved recordings play equally through left and right speakers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk audio format for new sessions and playback balance; legacy stereo append paths remain but any code assuming new files are stereo could break.
> 
> **Overview**
> **New sessions** no longer create stereo `audio.wav` files. `create_disk_sink` always uses a mono spec for new files and treats a clean session directory as mono (`prepare_existing_audio_state` now returns `false` instead of defaulting to stereo).
> 
> **Dual-input capture** for those sessions goes through the existing mono path: mic and speaker buffers are summed with `mix_audio_f32` into one channel before write. **Legacy behavior is preserved** when resuming—decoded MP3/OGG or an on-disk WAV still sets `is_stereo` from channel count, so older stereo sessions keep interleaved L/R appends.
> 
> A unit test asserts that `write_dual` on a fresh sink produces a 1-channel WAV with mixed sample values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a5d2d19acf78e83cbc557aee905501f9ed0629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->