### PR TITLE
Make session titles editable

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -39,6 +39,7 @@ const hoisted = vi.hoisted(() => ({
   sessionMode: "inactive",
   isMainWebviewWindow: true,
   isDeletingRecording: false,
+  updateSession: vi.fn(() => Promise.resolve()),
   transcriptExportRequest: {},
   transcriptRenderDataCalls: 0,
   transcriptSegments: [{ speaker: "Speaker 1", text: "Hello transcript" }],
@@ -152,6 +153,7 @@ vi.mock("~/ai/hooks", () => ({
   }),
   useLanguageModel: () => "model",
   useLLMConnectionStatus: () => "connected",
+  useTitleGenerating: () => false,
 }));
 
 vi.mock("~/session/enhance-config", () => ({
@@ -191,6 +193,7 @@ vi.mock("~/session/queries", () => ({
   }),
   useEnhancedNoteRecords: () => [{ id: "note-1" }],
   useSession: () => ({ raw_md: "", title: hoisted.sessionTitle }),
+  useUpdateSession: () => hoisted.updateSession,
 }));
 
 vi.mock("~/session/components/note-input/transcript/actions", () => ({
@@ -464,7 +467,10 @@ describe("Header", () => {
       screen.queryByRole("group", { name: "Session note views" }),
     ).toBeNull();
     expect(screen.queryByRole("button")).toBeNull();
-    expect(screen.getByText("Weekly planning").className).toContain("truncate");
+    const title = screen.getByRole("textbox", { name: "Session title" });
+    expect((title as HTMLInputElement).value).toBe("Weekly planning");
+    expect(title.className).toContain("border-none");
+    expect(title.parentElement?.parentElement?.className).toContain("pl-2");
   });
 
   it("shows Untitled for an ad hoc memo with no title", () => {
@@ -479,8 +485,31 @@ describe("Header", () => {
       />,
     );
 
-    expect(screen.getByText("Untitled")).not.toBeNull();
+    const title = screen.getByPlaceholderText("Untitled");
+    expect((title as HTMLInputElement).value).toBe("");
     expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("persists edits to the session title", async () => {
+    render(
+      <Header
+        sessionId="session-1"
+        editorTabs={[{ type: "raw" }]}
+        currentTab={{ type: "raw" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    const title = screen.getByRole("textbox", { name: "Session title" });
+    fireEvent.focus(title);
+    fireEvent.change(title, { target: { value: "Customer follow-up" } });
+    fireEvent.blur(title);
+
+    await waitFor(() => {
+      expect(hoisted.updateSession).toHaveBeenCalledWith({
+        title: "Customer follow-up",
+      });
+    });
   });
 
   it("can switch from transcript back to memo or summary tabs", () => {

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -7,12 +7,9 @@ import { HeaderViewRaw } from "./header-raw";
 import { HeaderViewTranscript } from "./header-transcript";
 
 import { useCanShowTranscript } from "~/session/components/shared";
+import { EditableSessionTitle } from "~/session/components/title-input";
 import { useEnsureDefaultSummary } from "~/session/hooks/useEnhancedNotes";
-import {
-  deleteEnhancedNote,
-  useEnhancedNoteRecords,
-  useSession,
-} from "~/session/queries";
+import { deleteEnhancedNote, useEnhancedNoteRecords } from "~/session/queries";
 import { type EditorView } from "~/store/zustand/tabs/schema";
 
 export function Header({
@@ -29,7 +26,6 @@ export function Header({
   isTranscribing?: boolean;
 }) {
   const { t } = useLingui();
-  const sessionTitle = useSession(sessionId)?.title.trim();
   const primaryEnhancedTabId = editorTabs.find(
     (view): view is Extract<EditorView, { type: "enhanced" }> =>
       view.type === "enhanced",
@@ -40,9 +36,9 @@ export function Header({
     return (
       <div
         data-tauri-drag-region
-        className="text-foreground min-w-0 truncate pl-3 text-sm font-medium"
+        className="text-foreground min-w-0 pl-2 text-sm font-medium"
       >
-        {sessionTitle || t`Untitled`}
+        <EditableSessionTitle sessionId={sessionId} placeholder={t`Untitled`} />
       </div>
     );
   }

--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -150,8 +150,9 @@ describe("TitleInput", () => {
     renderTitleInput();
 
     const input = screen.getByPlaceholderText("Untitled");
-    fireEvent.focus(input);
+    input.focus();
     fireEvent.change(input, { target: { value: "Customer call" } });
+    (input as HTMLInputElement).setSelectionRange(3, 3);
     fireEvent.keyDown(input, { key: "Enter" });
 
     expect(hoisted.setStoreTitle).toHaveBeenCalledWith("Customer call");
@@ -190,10 +191,10 @@ describe("TitleInput", () => {
     renderTitleInput();
 
     const input = screen.getByPlaceholderText("Untitled");
-    fireEvent.focus(input);
+    input.focus();
     fireEvent.change(input, { target: { value: "Customer call" } });
-    fireEvent.blur(input);
-    fireEvent.focus(input);
+    input.blur();
+    input.focus();
     fireEvent.keyDown(input, { key: "Enter" });
 
     await act(async () => {

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -138,6 +138,7 @@ const TitleInputInner = memo(
     {
       sessionId: string;
       editorId: string;
+      placeholder?: string;
       onTransferContentToEditor?: (content: string) => void;
       onFocusEditorAtStart?: () => void;
       onFocusEditorAtPixelWidth?: (pixelWidth: number) => void;
@@ -148,6 +149,7 @@ const TitleInputInner = memo(
       {
         sessionId,
         editorId,
+        placeholder,
         onTransferContentToEditor,
         onFocusEditorAtStart,
         onFocusEditorAtPixelWidth,
@@ -156,6 +158,7 @@ const TitleInputInner = memo(
       ref,
     ) => {
       const { t } = useLingui();
+      const untitled = placeholder ?? t`Untitled`;
       const storeTitle = useSession(sessionId)?.title;
       const updateSession = useUpdateSession(sessionId);
       const [draftTitle, setDraftTitle] = useState<string | null>(null);
@@ -230,9 +233,7 @@ const TitleInputInner = memo(
         isOverflowing && !isTitleFocused && title.length > 0;
       const titleHoverScrollStyle = showHoverReveal
         ? ({
-            "--title-hover-scroll-distance": `-${Math.ceil(
-              overflowDistance,
-            )}px`,
+            "--title-hover-scroll-distance": `-${Math.ceil(overflowDistance)}px`,
             "--title-hover-scroll-duration": `${Math.min(
               Math.max(overflowDistance / 48, 2.5),
               8,
@@ -240,8 +241,8 @@ const TitleInputInner = memo(
           } as CSSProperties)
         : undefined;
       const visibleTitleLength = Math.max(
-        title.length || t`Untitled`.length,
-        t`Untitled`.length,
+        title.length || untitled.length,
+        untitled.length,
       );
       const titleShellStyle = {
         ...titleFadeStyle,
@@ -338,6 +339,12 @@ const TitleInputInner = memo(
 
         if (e.key === "Enter") {
           e.preventDefault();
+          if (!onTransferContentToEditor && !onFocusEditorAtStart) {
+            editRevisionRef.current += 1;
+            e.currentTarget.blur();
+            return;
+          }
+
           const input = internalRef.current;
           if (!input) return;
 
@@ -355,10 +362,10 @@ const TitleInputInner = memo(
           } else {
             setTimeout(() => onFocusEditorAtStart?.(), 0);
           }
-        } else if (e.key === "Tab") {
+        } else if (e.key === "Tab" && onFocusEditorAtStart) {
           e.preventDefault();
           setTimeout(() => onFocusEditorAtStart?.(), 0);
-        } else if (e.key === "ArrowRight") {
+        } else if (e.key === "ArrowRight" && onFocusEditorAtStart) {
           const input = internalRef.current;
           if (!input) return;
           const cursorPos = input.selectionStart ?? 0;
@@ -369,7 +376,7 @@ const TitleInputInner = memo(
             e.preventDefault();
             setTimeout(() => onFocusEditorAtStart?.(), 0);
           }
-        } else if (e.key === "ArrowDown") {
+        } else if (e.key === "ArrowDown" && onFocusEditorAtPixelWidth) {
           e.preventDefault();
           const input = internalRef.current;
           if (!input) return;
@@ -405,7 +412,7 @@ const TitleInputInner = memo(
             aria-label={t`Session title`}
             ref={setInputRef}
             id={`title-input-${sessionId}-${editorId}`}
-            placeholder={t`Untitled`}
+            placeholder={untitled}
             type="text"
             onChange={(e) => {
               const value = e.target.value;
@@ -468,6 +475,23 @@ const TitleInputInner = memo(
     },
   ),
 );
+
+export function EditableSessionTitle({
+  sessionId,
+  placeholder,
+}: {
+  sessionId: string;
+  placeholder: string;
+}) {
+  return (
+    <TitleInputInner
+      sessionId={sessionId}
+      editorId="header"
+      placeholder={placeholder}
+      variant="breadcrumb"
+    />
+  );
+}
 
 function isComposingKeyEvent(event: React.KeyboardEvent<HTMLInputElement>) {
   return (


### PR DESCRIPTION
Reuse the transparent title editor in the memo header and align it with the note body.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI change to session title editing in the memo header; persistence uses existing update-session flow with added test coverage.
> 
> **Overview**
> When a session only shows the memo view (no tab switcher), the static header title is replaced with an **editable** field that reuses the breadcrumb-style `EditableSessionTitle` / `TitleInputInner` stack, so users can rename the session inline and persist via `useUpdateSession` on blur.
> 
> `TitleInputInner` gains an optional **placeholder** prop and a dedicated **`EditableSessionTitle`** export for header use without tab/editor handoff callbacks. **Enter** in that mode blurs instead of splitting title into the note body; **Tab**, **ArrowRight**, and **ArrowDown** editor-navigation shortcuts only run when the corresponding focus/transfer callbacks are provided.
> 
> Tests in `header.test.tsx` and `title-input.test.tsx` are updated for the textbox UI and persistence behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66dccd3ed8bd167baa7cb8c025454c78ac66abdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->