### PR TITLE
Start trials automatically for eligible accounts

### DIFF
--- a/apps/desktop/src/auth/billing.test.tsx
+++ b/apps/desktop/src/auth/billing.test.tsx
@@ -2,7 +2,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { canStartTrial as canStartTrialApi } from "@anlg/api-client";
+import {
+  canStartTrial as canStartTrialApi,
+  startTrial as startTrialApi,
+} from "@anlg/api-client";
 import { commands as authCommands } from "@anlg/plugin-auth";
 
 import * as billingProviderModule from "./billing";
@@ -49,6 +52,7 @@ vi.mock("./auth-context", () => ({
 
 vi.mock("@anlg/api-client", () => ({
   canStartTrial: vi.fn(),
+  startTrial: vi.fn(),
 }));
 
 vi.mock("@anlg/api-client/client", () => ({
@@ -88,6 +92,11 @@ vi.mock("~/settings/queries", async (importOriginal) => {
     setSettingValues: settingsState.setSettingValues,
   };
 });
+
+vi.mock("~/shared/billing", () => ({
+  waitForBillingUpdate: async (refreshSession: () => Promise<unknown>) =>
+    refreshSession(),
+}));
 
 vi.mock("../billing/trial-ended-dialog", () => ({
   TrialEndedDialog: ({ open }: { open: boolean }) => (
@@ -236,6 +245,14 @@ describe("BillingProvider", () => {
       request: new Request("https://api.example.test/can-start-trial"),
       response: new Response(),
     });
+    vi.mocked(startTrialApi)
+      .mockReset()
+      .mockResolvedValue({
+        data: { started: true, reason: "started" as const },
+        error: undefined,
+        request: new Request("https://api.example.test/start-trial"),
+        response: new Response(),
+      });
   });
 
   afterEach(() => {
@@ -256,6 +273,26 @@ describe("BillingProvider", () => {
       expect(
         screen.getByTestId("trial-ended-dialog").getAttribute("data-open"),
       ).toBe("true");
+    });
+  });
+
+  it("automatically starts a trial for an eligible signed-in account", async () => {
+    vi.mocked(canStartTrialApi).mockResolvedValue({
+      data: { canStartTrial: true, reason: "eligible" as const },
+      error: undefined,
+      request: new Request("https://api.example.test/can-start-trial"),
+      response: new Response(),
+    });
+
+    renderBillingProvider();
+
+    await waitFor(() => {
+      expect(startTrialApi).toHaveBeenCalledWith(
+        expect.objectContaining({ query: { interval: "monthly" } }),
+      );
+    });
+    await waitFor(() => {
+      expect(refreshSession).toHaveBeenCalledOnce();
     });
   });
 

--- a/apps/desktop/src/auth/billing.tsx
+++ b/apps/desktop/src/auth/billing.tsx
@@ -26,6 +26,7 @@ import { TrialStartedDialog } from "../billing/trial-started-dialog";
 import { env } from "../env";
 import { waitForBillingUpdate } from "../shared/billing";
 import { configurePaidSettings } from "../shared/config/configure-paid-settings";
+import { startTrialOnce } from "../shared/trial-start";
 import { buildWebAppUrl } from "../shared/utils";
 import { useAuth } from "./auth-context";
 import { type BillingAccess, BillingContext } from "./billing-context";
@@ -142,25 +143,28 @@ export function BillingProvider({ children }: { children: ReactNode }) {
       canTrialQuery.data?.canStartTrial === true,
     queryKey: [auth?.session?.user.id ?? "", "startEligibleTrial"],
     queryFn: async () => {
+      const userId = auth?.session?.user.id;
       const headers = auth?.getHeaders();
-      if (!headers) {
+      if (!userId || !headers) {
         throw new Error("No authentication headers available");
       }
 
-      const client = createClient({ baseUrl: env.VITE_API_URL, headers });
-      const { data, error } = await startTrialApi({
-        client,
-        query: { interval: "monthly" },
-      });
-      if (error) {
-        throw error;
-      }
+      return startTrialOnce(userId, async () => {
+        const client = createClient({ baseUrl: env.VITE_API_URL, headers });
+        const { data, error } = await startTrialApi({
+          client,
+          query: { interval: "monthly" },
+        });
+        if (error) {
+          throw error;
+        }
 
-      await waitForBillingUpdate(
-        () => auth.refreshSession(),
-        data?.started ? 3000 : 1500,
-      );
-      return data;
+        await waitForBillingUpdate(
+          () => auth.refreshSession(),
+          data?.started ? 3000 : 1500,
+        );
+        return data;
+      });
     },
     retry: 1,
     refetchOnWindowFocus: false,
@@ -348,8 +352,7 @@ export function BillingProvider({ children }: { children: ReactNode }) {
     ) {
       if (trialEligibilityRefreshPendingRef.current !== userId) {
         trialEligibilityRefreshPendingRef.current = userId;
-        void auth
-          .refreshSession()
+        void waitForBillingUpdate(() => auth.refreshSession(), 3000)
           .catch(() => null)
           .finally(() => {
             setTrialEligibilityRefreshedUserId(userId);

--- a/apps/desktop/src/auth/billing.tsx
+++ b/apps/desktop/src/auth/billing.tsx
@@ -9,7 +9,10 @@ import {
   useState,
 } from "react";
 
-import { canStartTrial as canStartTrialApi } from "@anlg/api-client";
+import {
+  canStartTrial as canStartTrialApi,
+  startTrial as startTrialApi,
+} from "@anlg/api-client";
 import { createClient } from "@anlg/api-client/client";
 import { commands as analyticsCommands } from "@anlg/plugin-analytics";
 import { commands as authCommands } from "@anlg/plugin-auth";
@@ -21,6 +24,7 @@ import { TrialEndedDialog } from "../billing/trial-ended-dialog";
 import { TrialPaymentReminderDialog } from "../billing/trial-payment-reminder-dialog";
 import { TrialStartedDialog } from "../billing/trial-started-dialog";
 import { env } from "../env";
+import { waitForBillingUpdate } from "../shared/billing";
 import { configurePaidSettings } from "../shared/config/configure-paid-settings";
 import { buildWebAppUrl } from "../shared/utils";
 import { useAuth } from "./auth-context";
@@ -127,6 +131,40 @@ export function BillingProvider({ children }: { children: ReactNode }) {
       canTrialQuery.isPending,
     ],
   );
+
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- The user ID owns one automatic attempt; a refreshed token must not trigger another start.
+  useQuery({
+    enabled:
+      !!auth?.session &&
+      isReady &&
+      claimsAreCurrent &&
+      !billing.isPaid &&
+      canTrialQuery.data?.canStartTrial === true,
+    queryKey: [auth?.session?.user.id ?? "", "startEligibleTrial"],
+    queryFn: async () => {
+      const headers = auth?.getHeaders();
+      if (!headers) {
+        throw new Error("No authentication headers available");
+      }
+
+      const client = createClient({ baseUrl: env.VITE_API_URL, headers });
+      const { data, error } = await startTrialApi({
+        client,
+        query: { interval: "monthly" },
+      });
+      if (error) {
+        throw error;
+      }
+
+      await waitForBillingUpdate(
+        () => auth.refreshSession(),
+        data?.started ? 3000 : 1500,
+      );
+      return data;
+    },
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
 
   const [isUpgradingToPro, setIsUpgradingToPro] = useState(false);
   // State alone cannot gate re-entry: a second click can land before the

--- a/apps/desktop/src/onboarding/account/trial.tsx
+++ b/apps/desktop/src/onboarding/account/trial.tsx
@@ -12,6 +12,7 @@ import { useBillingAccess } from "~/auth/billing-context";
 import { env } from "~/env";
 import { waitForBillingUpdate } from "~/shared/billing";
 import { configurePaidSettings } from "~/shared/config/configure-paid-settings";
+import { startTrialOnce } from "~/shared/trial-start";
 
 export type TrialPhase =
   | "checking"
@@ -33,21 +34,25 @@ export function useTrialFlow(onContinue: () => void) {
     isSuccess,
   } = useMutation({
     mutationFn: async () => {
+      const userId = auth.session?.user.id;
       const headers = auth.getHeaders();
-      if (!headers) throw new Error("no headers");
-      const client = createClient({ baseUrl: env.VITE_API_URL, headers });
-      const { data, error } = await startTrial({
-        client,
-        query: { interval: "monthly" },
+      if (!userId || !headers) throw new Error("no headers");
+
+      return startTrialOnce(userId, async () => {
+        const client = createClient({ baseUrl: env.VITE_API_URL, headers });
+        const { data, error } = await startTrial({
+          client,
+          query: { interval: "monthly" },
+        });
+        if (error) throw error;
+        await waitForBillingUpdate(
+          () => auth.refreshSession(),
+          data?.started ? 3000 : 1500,
+        );
+        return data;
       });
-      if (error) throw error;
-      return data;
     },
-    onSuccess: async (data) => {
-      await waitForBillingUpdate(
-        () => auth.refreshSession(),
-        data?.started ? 3000 : 1500,
-      );
+    onSuccess: () => {
       onContinue();
     },
     onError: async (e) => {

--- a/apps/desktop/src/shared/trial-start.test.ts
+++ b/apps/desktop/src/shared/trial-start.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { startTrialOnce } from "./trial-start";
+
+describe("startTrialOnce", () => {
+  it("shares one successful trial start per user", async () => {
+    const start = vi.fn().mockResolvedValue({ started: true });
+
+    const [first, second] = await Promise.all([
+      startTrialOnce("deduplicated-user", start),
+      startTrialOnce("deduplicated-user", start),
+    ]);
+
+    expect(start).toHaveBeenCalledOnce();
+    expect(first).toEqual({ started: true });
+    expect(second).toEqual({ started: true });
+  });
+
+  it("allows a failed trial start to retry", async () => {
+    const start = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Unavailable"))
+      .mockResolvedValueOnce({ started: true });
+
+    await expect(startTrialOnce("retry-user", start)).rejects.toThrow(
+      "Unavailable",
+    );
+    await expect(startTrialOnce("retry-user", start)).resolves.toEqual({
+      started: true,
+    });
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/shared/trial-start.ts
+++ b/apps/desktop/src/shared/trial-start.ts
@@ -1,0 +1,18 @@
+const trialStarts = new Map<string, Promise<unknown>>();
+
+export function startTrialOnce<T>(
+  userId: string,
+  start: () => Promise<T>,
+): Promise<T> {
+  const existing = trialStarts.get(userId);
+  if (existing) {
+    return existing as Promise<T>;
+  }
+
+  const request = start().catch((error) => {
+    trialStarts.delete(userId);
+    throw error;
+  });
+  trialStarts.set(userId, request);
+  return request;
+}

--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -38,16 +38,17 @@ type FlowTokenResult =
 
 async function prepareNewAccountTrial(
   flow: Flow,
+  supabase: SupabaseClient,
   session: Session,
   method: NewAccountAuthMethod,
 ) {
   if (!isConfirmedNewAccount(session.user, method)) {
-    return false;
+    return { needsTrialCheckout: false, session };
   }
 
+  let result: Awaited<ReturnType<typeof ensureNewAccountTrial>>;
   try {
-    await ensureNewAccountTrial(session.access_token);
-    return false;
+    result = await ensureNewAccountTrial(session.access_token);
   } catch (error) {
     captureOperationalError(error, {
       operation: "new_account_trial_start",
@@ -57,12 +58,39 @@ async function prepareNewAccountTrial(
         user_id: session.user.id,
       },
     });
-    return shouldOfferNewAccountTrialCheckoutFallback({
-      flow,
-      method,
-      user: session.user,
-    });
+    return {
+      needsTrialCheckout: shouldOfferNewAccountTrialCheckoutFallback({
+        flow,
+        method,
+        user: session.user,
+      }),
+      session,
+    };
   }
+
+  if (flow !== "web" || result !== "started") {
+    return { needsTrialCheckout: false, session };
+  }
+
+  const { data, error } = await supabase.auth.refreshSession({
+    refresh_token: session.refresh_token,
+  });
+  if (error || !data.session) {
+    captureOperationalError(
+      error ?? new Error("New account trial session refresh failed"),
+      {
+        operation: "new_account_trial_session_refresh",
+        context: {
+          flow,
+          method,
+          user_id: session.user.id,
+        },
+      },
+    );
+    return { needsTrialCheckout: false, session };
+  }
+
+  return { needsTrialCheckout: false, session: data.session };
 }
 
 function buildAuthCallbackParams(data: {
@@ -312,18 +340,19 @@ export const exchangeOAuthCode = createServerFn({ method: "POST" })
       method: "oauth",
       flow: data.flow,
     });
-    const needsTrialCheckout = await prepareNewAccountTrial(
+    const trial = await prepareNewAccountTrial(
       data.flow,
+      supabase,
       authData.session,
       "oauth",
     );
     const tokens = await resolveTokensForFlow({
       flow: data.flow,
-      session: authData.session,
+      session: trial.session,
     });
     const response = toSuccessTokenResponse(tokens, authData.session.user.id);
     return response.success
-      ? { ...response, newAccount: needsTrialCheckout }
+      ? { ...response, newAccount: trial.needsTrialCheckout }
       : response;
   });
 
@@ -356,14 +385,15 @@ export const doPasswordSignUp = createServerFn({ method: "POST" })
     }
 
     if (authData.session) {
-      const needsTrialCheckout = await prepareNewAccountTrial(
+      const trial = await prepareNewAccountTrial(
         data.flow,
+        supabase,
         authData.session,
         "password-signup",
       );
       const tokens = await resolveTokensForFlow({
         flow: data.flow,
-        session: authData.session,
+        session: trial.session,
         email: data.email,
       });
       const response = toMutationTokenResponse(
@@ -371,7 +401,7 @@ export const doPasswordSignUp = createServerFn({ method: "POST" })
         authData.session.user.id,
       );
       return response.success
-        ? { ...response, newAccount: needsTrialCheckout }
+        ? { ...response, newAccount: trial.needsTrialCheckout }
         : response;
     }
 
@@ -439,8 +469,9 @@ export const exchangeOtpToken = createServerFn({ method: "POST" })
       return { success: false, error: error?.message || "Unknown error" };
     }
 
-    const needsTrialCheckout = await prepareNewAccountTrial(
+    const trial = await prepareNewAccountTrial(
       data.flow,
+      supabase,
       authData.session,
       data.type,
     );
@@ -452,11 +483,11 @@ export const exchangeOtpToken = createServerFn({ method: "POST" })
     const flow: Flow = shouldMintDesktopSession ? "desktop" : "web";
     const tokens = await resolveTokensForFlow({
       flow,
-      session: authData.session,
+      session: trial.session,
     });
     const response = toSuccessTokenResponse(tokens, authData.session.user.id);
     return response.success
-      ? { ...response, newAccount: needsTrialCheckout }
+      ? { ...response, newAccount: trial.needsTrialCheckout }
       : response;
   });
 

--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -6,9 +6,11 @@ import { isAdminEmail } from "@/functions/admin";
 import { getRequestAppOrigin } from "@/functions/app-origin";
 import { mintDesktopSessionForAuthenticatedUser } from "@/functions/auth-session";
 import { desktopSchemeSchema } from "@/functions/desktop-flow";
+import { ensureNewAccountTrial } from "@/functions/new-account-trial";
 import {
+  isConfirmedNewAccount,
   type NewAccountAuthMethod,
-  shouldOfferNewAccountTrialCheckout,
+  shouldOfferNewAccountTrialCheckoutFallback,
 } from "@/functions/new-account-trial-policy";
 import {
   getSupabaseAdminClient,
@@ -34,16 +36,33 @@ type FlowTokenResult =
   | { ok: true; access_token: string; refresh_token: string }
   | { ok: false; error: string };
 
-function isNewWebAccount(
+async function prepareNewAccountTrial(
   flow: Flow,
   session: Session,
   method: NewAccountAuthMethod,
 ) {
-  return shouldOfferNewAccountTrialCheckout({
-    flow,
-    method,
-    user: session.user,
-  });
+  if (!isConfirmedNewAccount(session.user, method)) {
+    return false;
+  }
+
+  try {
+    await ensureNewAccountTrial(session.access_token);
+    return false;
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "new_account_trial_start",
+      context: {
+        flow,
+        method,
+        user_id: session.user.id,
+      },
+    });
+    return shouldOfferNewAccountTrialCheckoutFallback({
+      flow,
+      method,
+      user: session.user,
+    });
+  }
 }
 
 function buildAuthCallbackParams(data: {
@@ -293,13 +312,19 @@ export const exchangeOAuthCode = createServerFn({ method: "POST" })
       method: "oauth",
       flow: data.flow,
     });
-    const newAccount = isNewWebAccount(data.flow, authData.session, "oauth");
+    const needsTrialCheckout = await prepareNewAccountTrial(
+      data.flow,
+      authData.session,
+      "oauth",
+    );
     const tokens = await resolveTokensForFlow({
       flow: data.flow,
       session: authData.session,
     });
     const response = toSuccessTokenResponse(tokens, authData.session.user.id);
-    return response.success ? { ...response, newAccount } : response;
+    return response.success
+      ? { ...response, newAccount: needsTrialCheckout }
+      : response;
   });
 
 export const doPasswordSignUp = createServerFn({ method: "POST" })
@@ -331,7 +356,7 @@ export const doPasswordSignUp = createServerFn({ method: "POST" })
     }
 
     if (authData.session) {
-      const newAccount = isNewWebAccount(
+      const needsTrialCheckout = await prepareNewAccountTrial(
         data.flow,
         authData.session,
         "password-signup",
@@ -345,7 +370,9 @@ export const doPasswordSignUp = createServerFn({ method: "POST" })
         tokens,
         authData.session.user.id,
       );
-      return response.success ? { ...response, newAccount } : response;
+      return response.success
+        ? { ...response, newAccount: needsTrialCheckout }
+        : response;
     }
 
     return {
@@ -412,7 +439,11 @@ export const exchangeOtpToken = createServerFn({ method: "POST" })
       return { success: false, error: error?.message || "Unknown error" };
     }
 
-    const newAccount = isNewWebAccount(data.flow, authData.session, data.type);
+    const needsTrialCheckout = await prepareNewAccountTrial(
+      data.flow,
+      authData.session,
+      data.type,
+    );
 
     const shouldMintDesktopSession =
       data.flow === "desktop" &&
@@ -424,7 +455,9 @@ export const exchangeOtpToken = createServerFn({ method: "POST" })
       session: authData.session,
     });
     const response = toSuccessTokenResponse(tokens, authData.session.user.id);
-    return response.success ? { ...response, newAccount } : response;
+    return response.success
+      ? { ...response, newAccount: needsTrialCheckout }
+      : response;
   });
 
 export const createDesktopSession = createServerFn({ method: "POST" }).handler(

--- a/apps/web/src/functions/new-account-trial-policy.test.ts
+++ b/apps/web/src/functions/new-account-trial-policy.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import {
   isConfirmedNewAccount,
   type NewAccountAuthMethod,
-  shouldOfferNewAccountTrialCheckout,
+  shouldOfferNewAccountTrialCheckoutFallback,
 } from "./new-account-trial-policy.ts";
 
 const confirmedAt = "2026-07-17T06:00:00.000Z";
@@ -41,7 +41,7 @@ for (const method of ["password-signup", "signup", "invite"] as const) {
 }
 
 for (const method of ["oauth", "email", "magiclink"] as const) {
-  test(`${method} qualifies for checkout on the initial confirmed session`, () => {
+  test(`${method} qualifies on the initial confirmed session`, () => {
     assert.equal(isConfirmedNewAccount(user(), method), true);
   });
 
@@ -67,7 +67,7 @@ test("a delayed first magic-link confirmation still qualifies", () => {
 });
 
 for (const method of ["recovery", "email_change"] as NewAccountAuthMethod[]) {
-  test(`${method} never offers a new-account trial`, () => {
+  test(`${method} never qualifies for a new-account trial`, () => {
     assert.equal(isConfirmedNewAccount(user(), method), false);
   });
 }
@@ -83,9 +83,9 @@ test("missing or invalid sign-in timestamps do not qualify", () => {
   );
 });
 
-test("only web auth offers the card-required trial checkout", () => {
+test("only web auth offers the card-required checkout fallback", () => {
   assert.equal(
-    shouldOfferNewAccountTrialCheckout({
+    shouldOfferNewAccountTrialCheckoutFallback({
       flow: "web",
       method: "oauth",
       user: user(),
@@ -93,7 +93,7 @@ test("only web auth offers the card-required trial checkout", () => {
     true,
   );
   assert.equal(
-    shouldOfferNewAccountTrialCheckout({
+    shouldOfferNewAccountTrialCheckoutFallback({
       flow: "desktop",
       method: "oauth",
       user: user(),

--- a/apps/web/src/functions/new-account-trial-policy.ts
+++ b/apps/web/src/functions/new-account-trial-policy.ts
@@ -21,7 +21,7 @@ type ConfirmedAccountUser = Pick<
   | "last_sign_in_at"
 >;
 
-export function shouldOfferNewAccountTrialCheckout({
+export function shouldOfferNewAccountTrialCheckoutFallback({
   flow,
   method,
   user,

--- a/apps/web/src/functions/new-account-trial.test.ts
+++ b/apps/web/src/functions/new-account-trial.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ensureNewAccountTrial } from "./new-account-trial.ts";
+
+test("accepts a newly started trial", async () => {
+  await assert.doesNotReject(() =>
+    ensureNewAccountTrial("access-token", async () => ({
+      data: { started: true, reason: "started" },
+    })),
+  );
+});
+
+test("accepts an account that is already ineligible", async () => {
+  await assert.doesNotReject(() =>
+    ensureNewAccountTrial("access-token", async () => ({
+      data: { started: false, reason: "not_eligible" },
+    })),
+  );
+});
+
+test("rejects API and malformed responses", async () => {
+  await assert.rejects(
+    ensureNewAccountTrial("access-token", async () => ({
+      error: new Error("API unavailable"),
+    })),
+    /API unavailable/,
+  );
+  await assert.rejects(
+    ensureNewAccountTrial("access-token", async () => ({
+      data: { started: false },
+    })),
+    /invalid response/,
+  );
+});

--- a/apps/web/src/functions/new-account-trial.test.ts
+++ b/apps/web/src/functions/new-account-trial.test.ts
@@ -4,18 +4,20 @@ import test from "node:test";
 import { ensureNewAccountTrial } from "./new-account-trial.ts";
 
 test("accepts a newly started trial", async () => {
-  await assert.doesNotReject(() =>
-    ensureNewAccountTrial("access-token", async () => ({
+  assert.equal(
+    await ensureNewAccountTrial("access-token", async () => ({
       data: { started: true, reason: "started" },
     })),
+    "started",
   );
 });
 
 test("accepts an account that is already ineligible", async () => {
-  await assert.doesNotReject(() =>
-    ensureNewAccountTrial("access-token", async () => ({
+  assert.equal(
+    await ensureNewAccountTrial("access-token", async () => ({
       data: { started: false, reason: "not_eligible" },
     })),
+    "not_eligible",
   );
 });
 

--- a/apps/web/src/functions/new-account-trial.ts
+++ b/apps/web/src/functions/new-account-trial.ts
@@ -33,8 +33,12 @@ export async function ensureNewAccountTrial(
     throw error;
   }
 
-  if (data?.started || data?.reason === "not_eligible") {
-    return;
+  if (data?.started) {
+    return "started" as const;
+  }
+
+  if (data?.reason === "not_eligible") {
+    return "not_eligible" as const;
   }
 
   throw new Error("New account trial returned an invalid response");

--- a/apps/web/src/functions/new-account-trial.ts
+++ b/apps/web/src/functions/new-account-trial.ts
@@ -1,0 +1,41 @@
+type TrialRequest = (accessToken: string) => Promise<{
+  data?: {
+    started: boolean;
+    reason?: "started" | "not_eligible" | null;
+  };
+  error?: unknown;
+}>;
+
+async function requestTrial(accessToken: string) {
+  const [{ startTrial }, { createClient }, { env }] = await Promise.all([
+    import("@anlg/api-client"),
+    import("@anlg/api-client/client"),
+    import("../env.ts"),
+  ]);
+  const client = createClient({
+    baseUrl: env.VITE_API_URL,
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  return startTrial({
+    client,
+    query: { interval: "monthly" },
+  });
+}
+
+export async function ensureNewAccountTrial(
+  accessToken: string,
+  request: TrialRequest = requestTrial,
+) {
+  const { data, error } = await request(accessToken);
+
+  if (error) {
+    throw error;
+  }
+
+  if (data?.started || data?.reason === "not_eligible") {
+    return;
+  }
+
+  throw new Error("New account trial returned an invalid response");
+}


### PR DESCRIPTION
Start cardless Pro trials during new-account auth and recover previously missed eligible users when they reopen the desktop app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trial provisioning across auth and billing paths; incorrect eligibility or session refresh timing could mis-route users between auto-trial and checkout fallback, though `startTrialOnce` limits duplicate API calls.
> 
> **Overview**
> Eligible users get a **cardless monthly Pro trial** started automatically instead of relying on manual onboarding or a default “new account → checkout” path.
> 
> On **web**, confirmed new-account flows (OAuth, password signup, OTP) call `ensureNewAccountTrial` during auth. A successful start refreshes the Supabase session before tokens are returned. The `newAccount` flag now means **needs card-required checkout fallback** (mainly when `startTrial` fails), not “this is a new user.”
> 
> On **desktop**, `BillingProvider` runs a one-per-user query when `canStartTrial` is true and the user is unpaid, calling `startTrial` and then `waitForBillingUpdate` + session refresh. Onboarding `useTrialFlow` uses the same pattern. Shared **`startTrialOnce`** deduplicates concurrent starts per user and allows retry after failure.
> 
> Trial-ineligibility refresh in billing also goes through `waitForBillingUpdate` instead of a bare `refreshSession`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17b9004ee159783aac79a9ee12d51bf18066967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->