### PR TITLE
Show ad hoc meeting controls

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -801,7 +801,24 @@ describe("OuterHeader", () => {
     expect(mocks.openUrl).not.toHaveBeenCalled();
   });
 
-  it("hides meeting controls for an inactive ad hoc session with a transcript", () => {
+  it("shows record for a new ad hoc meeting note", () => {
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Record" }));
+
+    expect(mocks.startListening).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("button", { name: "Open event metadata" }),
+    ).not.toBeNull();
+  });
+
+  it("shows only metadata for an inactive ad hoc session with a transcript", () => {
     mocks.hasTranscriptBySession = { "session-1": true };
 
     render(
@@ -815,12 +832,12 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
     expect(
-      screen.queryByRole("button", { name: "Open event metadata" }),
-    ).toBeNull();
+      screen.getByRole("button", { name: "Open event metadata" }),
+    ).not.toBeNull();
     expect(mocks.startListening).not.toHaveBeenCalled();
   });
 
-  it("hides meeting controls for an inactive ad hoc session with audio", () => {
+  it("shows only metadata for an inactive ad hoc session with audio", () => {
     mocks.audioExists = true;
 
     render(
@@ -834,8 +851,8 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
     expect(
-      screen.queryByRole("button", { name: "Open event metadata" }),
-    ).toBeNull();
+      screen.getByRole("button", { name: "Open event metadata" }),
+    ).not.toBeNull();
     expect(mocks.startListening).not.toHaveBeenCalled();
   });
 
@@ -852,6 +869,9 @@ describe("OuterHeader", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Stop" }));
 
+    expect(
+      screen.getByRole("button", { name: "Open event metadata" }),
+    ).not.toBeNull();
     expect(mocks.stopListening).toHaveBeenCalledTimes(1);
   });
 
@@ -960,6 +980,9 @@ describe("OuterHeader", () => {
     fireEvent.click(screen.getByRole("button", { name: "Write" }));
     expect(onTranscriptEditModeChange).toHaveBeenCalledWith(true);
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Open event metadata" }),
+    ).not.toBeNull();
 
     view.rerender(
       <OuterHeader

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -135,6 +135,7 @@ function HeaderMeetingControl({
 }) {
   const sessionEvent = useSessionEvent(sessionId);
   const hasTranscript = useHasTranscript(sessionId);
+  const { audioExists } = useAudioPlayer();
   const now = useNow();
   const endedAt = sessionEvent?.ended_at
     ? safeParseDate(sessionEvent.ended_at)
@@ -154,11 +155,9 @@ function HeaderMeetingControl({
           editMode={transcriptEditMode}
           onEditModeChange={onTranscriptEditModeChange}
         />
-        {sessionEvent ? (
-          <div className="mr-1 shrink-0">
-            <MetadataButton sessionId={sessionId} />
-          </div>
-        ) : null}
+        <div className="mr-1 shrink-0">
+          <MetadataButton sessionId={sessionId} />
+        </div>
       </>
     );
   }
@@ -167,7 +166,27 @@ function HeaderMeetingControl({
     sessionMode === "active" || sessionMode === "running_batch";
 
   if (!sessionEvent && !isRecording) {
-    return null;
+    if (hasTranscript || audioExists) {
+      return (
+        <div className="mr-1 shrink-0">
+          <MetadataButton sessionId={sessionId} />
+        </div>
+      );
+    }
+
+    if (sessionMode === "finalizing") {
+      return null;
+    }
+
+    return (
+      <HeaderMeetingActionPill
+        sessionId={sessionId}
+        event={null}
+        sessionMode={sessionMode}
+        hasTranscript={hasTranscript}
+        audioExists={audioExists}
+      />
+    );
   }
 
   if (ended && !isRecording) {
@@ -184,6 +203,7 @@ function HeaderMeetingControl({
       event={sessionEvent}
       sessionMode={sessionMode}
       hasTranscript={hasTranscript}
+      audioExists={audioExists}
     />
   );
 }
@@ -193,6 +213,7 @@ function HeaderMeetingActionPill({
   event,
   sessionMode,
   hasTranscript,
+  audioExists,
 }: {
   sessionId: string;
   event: {
@@ -201,6 +222,7 @@ function HeaderMeetingActionPill({
   } | null;
   sessionMode: string;
   hasTranscript: boolean;
+  audioExists: boolean;
 }) {
   const startListening = useStartListening(sessionId);
   const { canStartLiveSession, stop, stopTranscription } = useListener(
@@ -222,7 +244,6 @@ function HeaderMeetingActionPill({
     meetingLink &&
     (remote !== null || event?.tracking_id === WELCOME_NOTE_TRACKING_ID),
   );
-  const { audioExists } = useAudioPlayer();
   const canResume = audioExists || hasTranscript;
   const { t } = useLingui();
   const joiningMeetingRef = useRef(false);


### PR DESCRIPTION
Add a record action for new ad hoc notes and metadata-only controls after recorded meetings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop session header UI and test updates; no auth, data, or API changes.
> 
> **Overview**
> **Ad hoc session header controls** no longer disappear when there is no linked calendar event. New notes show a **Record** action via `HeaderMeetingActionPill` with `event={null}`; after transcript or audio exists (inactive), the header shows **Open event metadata** only—no Record/Resume. **Finalizing** still hides controls.
> 
> `useAudioPlayer`’s `audioExists` is read in `HeaderMeetingControl` and passed into the action pill so resume/record logic stays consistent. **Transcript edit** mode always shows the metadata button, not only when a `sessionEvent` exists.
> 
> Tests were updated to match: new case for record on a blank ad hoc note, renamed cases for metadata-only inactive ad hoc sessions, and assertions that metadata stays visible during stop, write, and related flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3d7fb12e049c64120a567993da203d260ebc8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->