### PR TITLE
Polish memo template selection

### DIFF
--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -428,10 +428,16 @@ describe("RawEditor", () => {
     const buttons = screen.getAllByRole("button");
 
     expect(heading.className).toContain("h-8");
+    expect(heading.className).toContain("text-muted-foreground");
     expect(heading.className).not.toContain("px-2");
     expect(buttons.every((button) => button.className.includes("h-8"))).toBe(
       true,
     );
+    expect(
+      buttons.every((button) =>
+        button.className.includes("text-muted-foreground"),
+      ),
+    ).toBe(true);
     expect(buttons.every((button) => !button.className.includes("px-2"))).toBe(
       true,
     );

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   cleanup,
   createEvent,
   fireEvent,
@@ -65,6 +66,9 @@ vi.mock("@anlg/editor/note", async () => {
           replaceContent: (content: unknown) => {
             hoisted.replacementContent = content;
             hoisted.replaceContent(content);
+            (
+              props.onDocumentChange as ((content: unknown) => void) | undefined
+            )?.(content);
           },
         },
         flushPendingChanges: () => {
@@ -448,6 +452,53 @@ describe("RawEditor", () => {
       "New template",
     ]);
     expect(screen.queryByRole("button", { name: "Board Meeting" })).toBeNull();
+  });
+
+  it("toggles template suggestions from live memo changes", () => {
+    hoisted.userTemplates = [
+      {
+        id: "default-project-kickoff",
+        title: "Project Kickoff",
+        pinned: false,
+        icon: { type: "emoji", value: "🚀" },
+        sections: [{ title: "Goals", description: "" }],
+      },
+    ];
+
+    render(<RawEditor sessionId="session-1" />);
+
+    expect(
+      screen.getByRole("button", { name: "Project Kickoff" }),
+    ).not.toBeNull();
+    const onDocumentChange = hoisted.noteEditorProps[
+      hoisted.noteEditorProps.length - 1
+    ]?.onDocumentChange as (content: unknown) => void;
+
+    act(() => {
+      onDocumentChange({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Live memo" }],
+          },
+        ],
+      });
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Project Kickoff" }),
+    ).toBeNull();
+    expect(hoisted.persistChange).not.toHaveBeenCalled();
+
+    act(() => {
+      onDocumentChange({ type: "doc", content: [{ type: "paragraph" }] });
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Project Kickoff" }),
+    ).not.toBeNull();
+    expect(hoisted.persistChange).not.toHaveBeenCalled();
   });
 
   it("prioritizes event-aware template suggestions", () => {

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -22,6 +22,9 @@ const hoisted = vi.hoisted(() => ({
   meetingChatRecords: [] as unknown[],
   eventParticipants: [] as Array<Record<string, unknown>>,
   userTemplates: [] as Array<Record<string, unknown>>,
+  replacementContent: null as unknown,
+  replaceContent: vi.fn(),
+  flushPendingChanges: vi.fn(),
   createTemplate: vi.fn(() => Promise.resolve("new-template")),
   openTemplatesTab: vi.fn(),
   noteEditorProps: [] as Record<string, unknown>[],
@@ -49,14 +52,35 @@ vi.mock("@lingui/react/macro", () => ({
   }),
 }));
 
-vi.mock("@anlg/editor/note", () => ({
-  normalizePortableAttachmentUrls: (value: unknown) => value,
-  NoteEditor: (props: Record<string, unknown>) => {
-    hoisted.noteEditorProps.push(props);
+vi.mock("@anlg/editor/note", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
 
-    return <div>Note editor</div>;
-  },
-}));
+  return {
+    normalizePortableAttachmentUrls: (value: unknown) => value,
+    NoteEditor: React.forwardRef((props: Record<string, unknown>, ref) => {
+      hoisted.noteEditorProps.push(props);
+      React.useImperativeHandle(ref, () => ({
+        view: null,
+        commands: {
+          replaceContent: (content: unknown) => {
+            hoisted.replacementContent = content;
+            hoisted.replaceContent(content);
+          },
+        },
+        flushPendingChanges: () => {
+          hoisted.flushPendingChanges();
+          if (hoisted.replacementContent) {
+            (props.handleChange as (content: unknown) => void)(
+              hoisted.replacementContent,
+            );
+          }
+        },
+      }));
+
+      return <div>Note editor</div>;
+    }),
+  };
+});
 
 vi.mock("@anlg/plugin-analytics", () => ({
   commands: {
@@ -208,6 +232,9 @@ describe("RawEditor", () => {
     hoisted.meetingChatRecords = [];
     hoisted.eventParticipants = [];
     hoisted.userTemplates = [];
+    hoisted.replacementContent = null;
+    hoisted.replaceContent.mockReset();
+    hoisted.flushPendingChanges.mockReset();
     hoisted.createTemplate.mockReset();
     hoisted.createTemplate.mockResolvedValue("new-template");
     hoisted.openTemplatesTab.mockReset();
@@ -336,25 +363,29 @@ describe("RawEditor", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Standup" }));
 
+    const expectedContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Yesterday" }],
+        },
+        { type: "paragraph" },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Today" }],
+        },
+        { type: "paragraph" },
+      ],
+    };
+    expect(hoisted.replaceContent).toHaveBeenCalledWith(expectedContent);
+    expect(hoisted.flushPendingChanges).toHaveBeenCalledOnce();
+
     await waitFor(() =>
       expect(hoisted.persistChange).toHaveBeenCalledWith({
-        raw_md: JSON.stringify({
-          type: "doc",
-          content: [
-            {
-              type: "heading",
-              attrs: { level: 2 },
-              content: [{ type: "text", text: "Yesterday" }],
-            },
-            { type: "paragraph" },
-            {
-              type: "heading",
-              attrs: { level: 2 },
-              content: [{ type: "text", text: "Today" }],
-            },
-            { type: "paragraph" },
-          ],
-        }),
+        raw_md: JSON.stringify(expectedContent),
       }),
     );
   });

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -108,6 +108,18 @@ export const RawEditor = forwardRef<
       () => !hasStoredNoteContent(JSON.stringify(initialContent)),
       [initialContent],
     );
+    const editorRef = useRef<NoteEditorRef>(null);
+    const setEditorRef = useCallback(
+      (editor: NoteEditorRef | null) => {
+        editorRef.current = editor;
+        if (typeof ref === "function") {
+          ref(editor);
+        } else if (ref) {
+          ref.current = editor;
+        }
+      },
+      [ref],
+    );
 
     const persistChange = useCallback(
       (input: JSONContent) => {
@@ -150,34 +162,33 @@ export const RawEditor = forwardRef<
       [persistChange, hasNonEmptyText],
     );
 
-    const handleApplyTemplate = useCallback(
-      (template: UserTemplate) => {
-        const content = template.sections.flatMap((section) => {
-          const title = section.title.trim();
-          if (!title) {
-            return [];
-          }
-
-          return [
-            {
-              type: "heading",
-              attrs: { level: 2 },
-              content: [{ type: "text", text: title }],
-            },
-            { type: "paragraph" },
-          ];
-        });
-        if (content.length === 0) {
-          return;
+    const handleApplyTemplate = useCallback((template: UserTemplate) => {
+      const content = template.sections.flatMap((section) => {
+        const title = section.title.trim();
+        if (!title) {
+          return [];
         }
 
-        handleChange({ type: "doc", content });
-        trackAnalyticsEvent("template_applied", {
-          entry_point: "memo",
-        });
-      },
-      [handleChange],
-    );
+        return [
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: title }],
+          },
+          { type: "paragraph" },
+        ];
+      });
+      if (content.length === 0) {
+        return;
+      }
+
+      const nextContent = { type: "doc", content };
+      editorRef.current?.commands.replaceContent(nextContent);
+      editorRef.current?.flushPendingChanges();
+      trackAnalyticsEvent("template_applied", {
+        entry_point: "memo",
+      });
+    }, []);
 
     const mentionConfig = useMentionConfig();
     const commentAnchors = useSessionCommentAnchors(sessionId);
@@ -198,7 +209,7 @@ export const RawEditor = forwardRef<
         <>
           <div className="relative min-h-full">
             <NoteEditor
-              ref={ref}
+              ref={setEditorRef}
               className={cn(["session-note-editor", className])}
               key={`session-${sessionId}-raw`}
               initialContent={initialContent}

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -1,7 +1,7 @@
 import { useLingui } from "@lingui/react/macro";
 import { Plus } from "@phosphor-icons/react";
 import type { EditorView } from "prosemirror-view";
-import { forwardRef, useCallback, useMemo, useRef } from "react";
+import { forwardRef, useCallback, useMemo, useRef, useState } from "react";
 
 import { parseJsonContent } from "@anlg/editor/markdown";
 import {
@@ -104,10 +104,18 @@ export const RawEditor = forwardRef<
       () => removeDocumentTitle(parseJsonContent(rawMd), sessionTitle),
       [rawMd, sessionTitle],
     );
-    const isMemoEmpty = useMemo(
+    const persistedIsMemoEmpty = useMemo(
       () => !hasStoredNoteContent(JSON.stringify(initialContent)),
       [initialContent],
     );
+    const [liveMemoState, setLiveMemoState] = useState(() => ({
+      sessionId,
+      isEmpty: persistedIsMemoEmpty,
+    }));
+    const isMemoEmpty =
+      liveMemoState.sessionId === sessionId
+        ? liveMemoState.isEmpty
+        : persistedIsMemoEmpty;
     const editorRef = useRef<NoteEditorRef>(null);
     const setEditorRef = useCallback(
       (editor: NoteEditorRef | null) => {
@@ -160,6 +168,19 @@ export const RawEditor = forwardRef<
         }
       },
       [persistChange, hasNonEmptyText],
+    );
+
+    const handleDocumentChange = useCallback(
+      (input: JSONContent) => {
+        const isEmpty = !hasStoredNoteContent(JSON.stringify(input));
+        setLiveMemoState((current) => {
+          if (current.sessionId === sessionId && current.isEmpty === isEmpty) {
+            return current;
+          }
+          return { sessionId, isEmpty };
+        });
+      },
+      [sessionId],
     );
 
     const handleApplyTemplate = useCallback((template: UserTemplate) => {
@@ -215,6 +236,7 @@ export const RawEditor = forwardRef<
               initialContent={initialContent}
               resolveAttachment={resolveAttachment}
               handleChange={handleChange}
+              onDocumentChange={handleDocumentChange}
               placeholderComponent={placeholderComponent}
               mentionConfig={mentionConfig}
               sessionMentionDropConfig={sessionMentionDropConfig}

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -388,7 +388,7 @@ function TemplateEmptyState({
         onClick={handleCreateTemplate}
         className={cn([
           "hover:bg-accent focus-visible:bg-accent flex h-8 w-full items-center gap-2 rounded-md pr-2 text-left",
-          "text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-hidden",
+          "text-muted-foreground hover:text-foreground focus-visible:text-foreground transition-colors focus-visible:outline-hidden",
         ])}
       >
         <Plus aria-hidden className="size-4" />
@@ -424,7 +424,7 @@ function TemplateSection({
           onClick={() => onApply(template)}
           className={cn([
             "hover:bg-accent focus-visible:bg-accent flex h-8 w-full items-center gap-2 rounded-md pr-2 text-left",
-            "text-foreground transition-colors focus-visible:outline-hidden",
+            "text-muted-foreground hover:text-foreground focus-visible:text-foreground transition-colors focus-visible:outline-hidden",
           ])}
         >
           <TemplateIconGlyph icon={template.icon} className="size-4 text-sm" />

--- a/packages/editor/src/note/index.test.ts
+++ b/packages/editor/src/note/index.test.ts
@@ -248,6 +248,40 @@ describe("createReadOnlyPlugin", () => {
 });
 
 describe("browser-safe editor controls", () => {
+  it("reports document changes before debounced persistence", async () => {
+    const ref = createRef<NoteEditorRef>();
+    const handleChange = vi.fn();
+    const onDocumentChange = vi.fn();
+    render(
+      createElement(NoteEditor, {
+        ref,
+        initialContent: baseDoc,
+        handleChange,
+        onDocumentChange,
+        enforceTitleHeading: false,
+      }),
+    );
+
+    await waitFor(() => expect(ref.current?.view).not.toBeNull());
+
+    act(() => {
+      const view = ref.current?.view;
+      view?.dispatch(view.state.tr.insertText("!", 4));
+    });
+
+    expect(onDocumentChange).toHaveBeenCalledOnce();
+    expect(onDocumentChange.mock.calls[0]?.[0]).toMatchObject({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "old!" }],
+        },
+      ],
+    });
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
   it("flushes the current document through the change handler immediately", async () => {
     const ref = createRef<NoteEditorRef>();
     const handleChange = vi.fn();

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -175,6 +175,7 @@ type NodeViewComponents = NonNullable<
 export interface NoteEditorProps {
   className?: string;
   handleChange?: (content: JSONContent) => void;
+  onDocumentChange?: (content: JSONContent) => void;
   initialContent?: JSONContent;
   resolveAttachment?: AttachmentResolver;
   mentionConfig?: MentionConfig;
@@ -584,6 +585,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
   function NoteEditor(props, ref) {
     const {
       handleChange,
+      onDocumentChange,
       className,
       initialContent,
       resolveAttachment,
@@ -611,6 +613,8 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
 
     const commentAnchorsEventRef = useRef(onCommentAnchorsEvent);
     commentAnchorsEventRef.current = onCommentAnchorsEvent;
+    const onDocumentChangeRef = useRef(onDocumentChange);
+    onDocumentChangeRef.current = onDocumentChange;
 
     const taskStorage = useTaskStorageOptional();
     const normalizedInitialContent = useMemo(
@@ -692,6 +696,9 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
     );
     const onUpdateRef = useRef(onUpdate);
     onUpdateRef.current = onUpdate;
+    const notifyDocumentChange = useCallback((doc: PMNode) => {
+      onDocumentChangeRef.current?.(doc.toJSON() as JSONContent);
+    }, []);
 
     useImperativeHandle(
       ref,
@@ -723,7 +730,10 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         reactKeys(),
         createCompositionStatePlugin(setCompositionActive),
         ...(readOnly ? [createReadOnlyPlugin()] : []),
-        docChangeListenerPlugin((doc) => onUpdateRef.current(doc)),
+        docChangeListenerPlugin((doc) => {
+          notifyDocumentChange(doc);
+          onUpdateRef.current(doc);
+        }),
         buildInputRules(),
         ...(enforceTitleHeading ? [titleHeadingPlugin()] : []),
         taskIdentityPlugin(),
@@ -767,6 +777,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         readOnly,
         setCompositionActive,
         commentAnchorsEnabled,
+        notifyDocumentChange,
       ],
     );
     const nodeViews = useMemo(
@@ -847,6 +858,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
           });
           onUpdate.cancel();
           view.updateState(state);
+          notifyDocumentChange(view.state.doc);
           previousContentRef.current = reconciledInitialContent;
         } catch {
           // invalid content
@@ -865,6 +877,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       syncContentWhenFocused,
       enforceTitleHeading,
       onUpdate,
+      notifyDocumentChange,
     ]);
 
     const onViewReady = useCallback(


### PR DESCRIPTION
Prefill new memos from template headings, keep picker styling consistent, and update suggestions immediately as the editor changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and editor callback behavior in memo/template flows; persistence semantics for template apply are more explicit but scoped to empty-memo UX.
> 
> **Overview**
> Memo template UX now reacts to **live editor content**, not only what was last saved. `NoteEditor` adds an optional **`onDocumentChange`** callback that runs on every document update **before** the debounced `handleChange` persistence path.
> 
> The session **raw memo** editor uses that hook to track whether the memo is empty in real time, so the favorite/suggested template overlay **hides as soon as the user types** and can reappear when the doc is empty again—without triggering a save. Applying a template now **replaces document content via editor commands** and **`flushPendingChanges`** so the prefilled headings persist immediately.
> 
> Template picker actions use **muted default text** with hover/focus foreground for consistency with the section labels. Tests cover `onDocumentChange` timing, template apply via replace/flush, live toggle of suggestions, and styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7358414c5ef0e27bee13cdadc4c7bed35496037e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->