### PR TITLE
Respect pre-meeting summary templates

### DIFF
--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -74,6 +74,7 @@ function createSnapshot({
     event: null,
     eventId: null,
     rawNoteId: "session-1",
+    rawTemplateId: "",
     rawContent: "",
     rawContentFormat: "prosemirror_json",
     rawMarkdown: "",
@@ -258,6 +259,33 @@ describe("EnhancerService", () => {
     );
   });
 
+  it("prefers the meeting memo template over the global default", async () => {
+    snapshot = {
+      ...createSnapshot(),
+      rawTemplateId: "memo-template",
+    };
+    const ai = createMockAITaskStore();
+    const service = new EnhancerService(
+      createDeps({
+        aiTaskStore: ai.store,
+        getSelectedTemplateId: () => "global-template",
+      }),
+    );
+
+    await service.enhance("session-1");
+
+    expect(mocks.ensureSummaryDocument).toHaveBeenCalledWith(
+      "session-1",
+      "memo-template",
+    );
+    expect(ai.generate).toHaveBeenCalledWith(
+      "note-1-enhance",
+      expect.objectContaining({
+        args: expect.objectContaining({ templateId: "memo-template" }),
+      }),
+    );
+  });
+
   it("returns already_active while the note task is generating", async () => {
     snapshot = createSnapshot({ notes: [createNote()] });
     const ai = createMockAITaskStore(() => ({ status: "generating" }));
@@ -322,8 +350,11 @@ describe("EnhancerService", () => {
     );
   });
 
-  it("lets an explicit null template override the selected default", async () => {
-    snapshot = createSnapshot({ notes: [createNote({ templateId: "old" })] });
+  it("lets explicit Auto override the memo and global templates", async () => {
+    snapshot = {
+      ...createSnapshot({ notes: [createNote({ templateId: "old" })] }),
+      rawTemplateId: "memo-template",
+    };
     const service = new EnhancerService(
       createDeps({ getSelectedTemplateId: () => "default-template" }),
     );

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -172,6 +172,7 @@ function shouldHydrateTemplateTitle(
 function resolveTemplateId(
   opts: EnhanceOpts | undefined,
   getSelectedTemplateId: () => string | undefined,
+  memoTemplateId?: string,
 ) {
   if (opts?.templateId === null) {
     return undefined;
@@ -181,7 +182,7 @@ function resolveTemplateId(
     return opts.templateId || undefined;
   }
 
-  return getSelectedTemplateId();
+  return memoTemplateId || getSelectedTemplateId();
 }
 
 let instance: EnhancerService | null = null;
@@ -265,7 +266,11 @@ export class EnhancerService {
   ): Promise<QueueEmptySummaryResult> {
     return retryDatabaseLock(async () => {
       const snapshot = await this.loadSession(sessionId);
-      const templateId = this.deps.getSelectedTemplateId();
+      const templateId = resolveTemplateId(
+        undefined,
+        this.deps.getSelectedTemplateId,
+        snapshot.rawTemplateId,
+      );
       const existingNote = getAutoEnhancedNote(snapshot, templateId);
 
       if (
@@ -298,7 +303,11 @@ export class EnhancerService {
     if (mode === "regenerate") {
       const pendingAutoEnhance = await retryDatabaseLock(async () => {
         const snapshot = await this.loadSession(sessionId);
-        const selectedTemplateId = this.deps.getSelectedTemplateId();
+        const selectedTemplateId = resolveTemplateId(
+          undefined,
+          this.deps.getSelectedTemplateId,
+          snapshot.rawTemplateId,
+        );
         const existingNote = getAutoEnhancedNote(snapshot, selectedTemplateId);
         return ensurePendingAutoEnhanceDocument(
           sessionId,
@@ -452,7 +461,11 @@ export class EnhancerService {
     if (!model) return { type: "no_model" };
 
     const snapshot = await this.loadSession(sessionId);
-    let templateId = resolveTemplateId(opts, getSelectedTemplateId);
+    let templateId = resolveTemplateId(
+      opts,
+      getSelectedTemplateId,
+      snapshot.rawTemplateId,
+    );
     const pendingAutoEnhanceNote = opts?.pendingAutoEnhance
       ? getSessionEnhancedNote(snapshot, opts.pendingAutoEnhance.noteId)
       : undefined;

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -50,6 +50,7 @@ function createSnapshot(channel = 1): SessionContentSnapshot {
     event: null,
     eventId: null,
     rawNoteId: "session-1",
+    rawTemplateId: "",
     rawContent: "",
     rawContentFormat: "prosemirror_json",
     rawMarkdown: "",

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -29,6 +29,7 @@ const hoisted = vi.hoisted(() => ({
   createTemplate: vi.fn(() => Promise.resolve("new-template")),
   openTemplatesTab: vi.fn(),
   noteEditorProps: [] as Record<string, unknown>[],
+  canShowTranscript: false,
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -96,6 +97,13 @@ vi.mock("@anlg/plugin-opener2", () => ({
   commands: { openUrl: vi.fn() },
 }));
 
+vi.mock("~/audio-player", () => ({
+  useAudioPlayer: () => ({
+    audioExists: false,
+    audioExistsResolved: true,
+  }),
+}));
+
 vi.mock("~/editor-bridge/app-link-view", () => ({
   AppLinkView: () => null,
 }));
@@ -128,6 +136,7 @@ vi.mock("~/session-sharing/comment-anchors", () => ({
 }));
 
 vi.mock("~/session/components/shared", () => ({
+  useCanShowTranscript: () => hoisted.canShowTranscript,
   hasStoredNoteContent: (value: unknown) => {
     if (typeof value !== "string" || !value.trim()) {
       return false;
@@ -236,6 +245,7 @@ describe("RawEditor", () => {
     hoisted.meetingChatRecords = [];
     hoisted.eventParticipants = [];
     hoisted.userTemplates = [];
+    hoisted.canShowTranscript = false;
     hoisted.replacementContent = null;
     hoisted.replaceContent.mockReset();
     hoisted.flushPendingChanges.mockReset();
@@ -390,6 +400,7 @@ describe("RawEditor", () => {
     await waitFor(() =>
       expect(hoisted.persistChange).toHaveBeenCalledWith({
         raw_md: JSON.stringify(expectedContent),
+        raw_template_id: "template-standup",
       }),
     );
   });
@@ -452,6 +463,25 @@ describe("RawEditor", () => {
       "New template",
     ]);
     expect(screen.queryByRole("button", { name: "Board Meeting" })).toBeNull();
+  });
+
+  it("hides template suggestions after the meeting", () => {
+    hoisted.canShowTranscript = true;
+    hoisted.userTemplates = [
+      {
+        id: "default-daily-standup",
+        title: "Daily Standup",
+        pinned: false,
+        icon: { type: "emoji", value: "☀️" },
+        sections: [{ title: "Today", description: "" }],
+      },
+    ];
+
+    render(<RawEditor sessionId="session-1" />);
+
+    expect(screen.queryByText("Suggested templates")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Daily Standup" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "New template" })).toBeNull();
   });
 
   it("toggles template suggestions from live memo changes", () => {

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -18,6 +18,7 @@ import { useNoteFileHandlerConfig } from "./file-handler";
 import { MeetingChatHighlights } from "./meeting-chat-highlights";
 
 import { trackAnalyticsEvent } from "~/analytics";
+import { useAudioPlayer } from "~/audio-player";
 import { useSessionEventParticipants } from "~/calendar/queries";
 import { AppLinkView } from "~/editor-bridge/app-link-view";
 import { useMentionConfig } from "~/editor-bridge/mention-config";
@@ -25,7 +26,10 @@ import { openEditorLink } from "~/editor-bridge/open-editor-link";
 import { sessionMentionDropConfig } from "~/editor-bridge/session-mention-drop";
 import { SessionNodeView } from "~/editor-bridge/session-view";
 import { useSessionCommentAnchors } from "~/session-sharing/comment-anchors";
-import { hasStoredNoteContent } from "~/session/components/shared";
+import {
+  hasStoredNoteContent,
+  useCanShowTranscript,
+} from "~/session/components/shared";
 import { useAttachmentResolver } from "~/session/hooks/useAttachmentResolver";
 import { useUpdateSession } from "~/session/queries";
 import { removeDocumentTitle } from "~/session/title-content";
@@ -97,6 +101,8 @@ export const RawEditor = forwardRef<
   ) => {
     const { t } = useLingui();
     const updateSession = useUpdateSession(sessionId);
+    const { audioExists, audioExistsResolved } = useAudioPlayer();
+    const canShowTranscript = useCanShowTranscript(sessionId, { audioExists });
     const resolveAttachment = useAttachmentResolver(sessionId);
     const { audioDropTargetProps, fileHandlerConfig, isAudioDragActive } =
       useNoteFileHandlerConfig(sessionId);
@@ -130,15 +136,17 @@ export const RawEditor = forwardRef<
     );
 
     const persistChange = useCallback(
-      (input: JSONContent) => {
+      (input: JSONContent, templateId?: string) => {
         const portableInput = normalizePortableAttachmentUrls(input);
         return updateSession({
           raw_md: JSON.stringify(portableInput),
+          ...(templateId ? { raw_template_id: templateId } : {}),
         });
       },
       [updateSession],
     );
 
+    const pendingTemplateIdRef = useRef<string | undefined>(undefined);
     const hasTrackedWriteRef = useRef(false);
     const trackedSessionIdRef = useRef(sessionId);
     if (trackedSessionIdRef.current !== sessionId) {
@@ -155,7 +163,9 @@ export const RawEditor = forwardRef<
 
     const handleChange = useCallback(
       (input: JSONContent) => {
-        void persistChange(input).catch((error) => {
+        const templateId = pendingTemplateIdRef.current;
+        pendingTemplateIdRef.current = undefined;
+        void persistChange(input, templateId).catch((error) => {
           console.error("[raw-editor] failed to persist note", error);
         });
 
@@ -203,9 +213,13 @@ export const RawEditor = forwardRef<
         return;
       }
 
+      const editor = editorRef.current;
+      if (!editor) return;
+
       const nextContent = { type: "doc", content };
-      editorRef.current?.commands.replaceContent(nextContent);
-      editorRef.current?.flushPendingChanges();
+      pendingTemplateIdRef.current = template.id;
+      editor.commands.replaceContent(nextContent);
+      editor.flushPendingChanges();
       trackAnalyticsEvent("template_applied", {
         entry_point: "memo",
       });
@@ -257,7 +271,7 @@ export const RawEditor = forwardRef<
                 onViewDisposed?.(view);
               }}
             />
-            {isMemoEmpty ? (
+            {isMemoEmpty && audioExistsResolved && !canShowTranscript ? (
               <TemplateEmptyState
                 sessionId={sessionId}
                 eventTitle={eventTitle ?? sessionTitle}

--- a/apps/desktop/src/session/content-queries.test.ts
+++ b/apps/desktop/src/session/content-queries.test.ts
@@ -26,6 +26,7 @@ describe("session content SQLite snapshots", () => {
         event_json: JSON.stringify({ title: "Weekly planning" }),
         event_id: "event-1",
         raw_note_id: "session-1",
+        raw_template_id: "template-1",
         raw_body: JSON.stringify({
           type: "doc",
           content: [
@@ -92,6 +93,7 @@ describe("session content SQLite snapshots", () => {
       event: { title: "Weekly planning" },
       eventId: "event-1",
       rawNoteId: "session-1",
+      rawTemplateId: "template-1",
       rawContentFormat: "prosemirror_json",
       enhancedNotes: [
         { id: "summary-1", markdown: "First summary", position: 1 },

--- a/apps/desktop/src/session/content-queries.ts
+++ b/apps/desktop/src/session/content-queries.ts
@@ -11,6 +11,7 @@ type SessionContentSqlRow = {
   event_json: string;
   event_id: string;
   raw_note_id: string;
+  raw_template_id: string;
   raw_body: string;
   raw_body_format: string;
   enhanced_notes_json: string;
@@ -50,6 +51,7 @@ export type SessionContentSnapshot = {
   event: unknown;
   eventId: string | null;
   rawNoteId: string | null;
+  rawTemplateId: string;
   rawContent: string;
   rawContentFormat: string;
   rawMarkdown: string;
@@ -88,6 +90,7 @@ const SESSION_CONTENT_SQL = `
     session.event_json,
     COALESCE(NULLIF(session.event_id, ''), NULLIF(session.external_event_id, ''), '') AS event_id,
     COALESCE(note.id, '') AS raw_note_id,
+    COALESCE(note.template_id, '') AS raw_template_id,
     COALESCE(note.body, '') AS raw_body,
     COALESCE(note.body_format, 'prosemirror_json') AS raw_body_format,
     COALESCE((
@@ -241,6 +244,7 @@ function mapSessionContentRow(
     event: parseJson(row.event_json),
     eventId: row.event_id || null,
     rawNoteId: row.raw_note_id || null,
+    rawTemplateId: row.raw_template_id,
     rawContent: row.raw_body,
     rawContentFormat: row.raw_body_format,
     rawMarkdown: bodyToMarkdown(row.raw_body, row.raw_body_format),

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
@@ -10,6 +10,7 @@ const hoisted = vi.hoisted(() => ({
   enhancedNoteIds: [] as string[],
   selectedTemplateId: "template-1" as string | undefined,
   memoTemplateId: "" as string | undefined,
+  sessionLoaded: true,
   llmStatus: {
     status: "success",
     providerId: "anarlog",
@@ -39,7 +40,8 @@ vi.mock("~/services/enhancer", () => ({
 
 vi.mock("~/session/queries", () => ({
   useEnhancedNoteRecords: () => hoisted.enhancedNoteIds.map((id) => ({ id })),
-  useSession: () => ({ raw_template_id: hoisted.memoTemplateId }),
+  useSession: () =>
+    hoisted.sessionLoaded ? { raw_template_id: hoisted.memoTemplateId } : null,
 }));
 
 vi.mock("~/shared/config", () => ({
@@ -72,6 +74,7 @@ describe("useEnsureDefaultSummary", () => {
     hoisted.enhancedNoteIds = [];
     hoisted.selectedTemplateId = "template-1";
     hoisted.memoTemplateId = "";
+    hoisted.sessionLoaded = true;
     hoisted.llmStatus = {
       status: "success",
       providerId: "anarlog",
@@ -99,6 +102,27 @@ describe("useEnsureDefaultSummary", () => {
     hoisted.memoTemplateId = "memo-template";
 
     renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).toHaveBeenCalledWith(
+        "session-1",
+        "memo-template",
+      );
+    });
+  });
+
+  it("waits for session hydration before choosing a template", async () => {
+    hoisted.sessionLoaded = false;
+    hoisted.memoTemplateId = "memo-template";
+
+    const { rerender } = renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).not.toHaveBeenCalled();
+    });
+
+    hoisted.sessionLoaded = true;
+    rerender();
 
     await waitFor(() => {
       expect(hoisted.service.ensureNote).toHaveBeenCalledWith(

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.test.tsx
@@ -9,6 +9,7 @@ const hoisted = vi.hoisted(() => ({
   batchError: null as string | null,
   enhancedNoteIds: [] as string[],
   selectedTemplateId: "template-1" as string | undefined,
+  memoTemplateId: "" as string | undefined,
   llmStatus: {
     status: "success",
     providerId: "anarlog",
@@ -38,6 +39,7 @@ vi.mock("~/services/enhancer", () => ({
 
 vi.mock("~/session/queries", () => ({
   useEnhancedNoteRecords: () => hoisted.enhancedNoteIds.map((id) => ({ id })),
+  useSession: () => ({ raw_template_id: hoisted.memoTemplateId }),
 }));
 
 vi.mock("~/shared/config", () => ({
@@ -69,6 +71,7 @@ describe("useEnsureDefaultSummary", () => {
     hoisted.batchError = null;
     hoisted.enhancedNoteIds = [];
     hoisted.selectedTemplateId = "template-1";
+    hoisted.memoTemplateId = "";
     hoisted.llmStatus = {
       status: "success",
       providerId: "anarlog",
@@ -90,6 +93,19 @@ describe("useEnsureDefaultSummary", () => {
     expect(
       hoisted.service.queueAutoEnhanceIfSummaryEmpty,
     ).not.toHaveBeenCalled();
+  });
+
+  it("uses the meeting memo template before the global default", async () => {
+    hoisted.memoTemplateId = "memo-template";
+
+    renderHook(() => useEnsureDefaultSummary("session-1"));
+
+    await waitFor(() => {
+      expect(hoisted.service.ensureNote).toHaveBeenCalledWith(
+        "session-1",
+        "memo-template",
+      );
+    });
   });
 
   it("does not create the summary row before transcript exists", async () => {

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.ts
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.ts
@@ -6,6 +6,7 @@ import { useHasTranscript } from "~/session/components/shared";
 import {
   useEnhancedNote as useSqliteEnhancedNote,
   useEnhancedNoteRecords,
+  useSession,
 } from "~/session/queries";
 import { useConfigValue } from "~/shared/config";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
@@ -33,12 +34,14 @@ export function useEnsureDefaultSummary(sessionId: string) {
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const batchError = useListener((state) => state.batch[sessionId]?.error);
   const enhancedNoteIds = useEnhancedNotes(sessionId);
+  const memoTemplateId = useSession(sessionId)?.raw_template_id;
   useEnsureDefaultSummaryFromState({
     batchError: Boolean(batchError),
     enhancedNoteCount: enhancedNoteIds.length,
     hasTranscript,
     sessionId,
     sessionMode,
+    memoTemplateId,
   });
 }
 
@@ -47,6 +50,7 @@ export function useEnsureDefaultSummaryFromState({
   enabled = true,
   enhancedNoteCount,
   hasTranscript,
+  memoTemplateId,
   sessionId,
   sessionMode,
 }: {
@@ -54,11 +58,12 @@ export function useEnsureDefaultSummaryFromState({
   enabled?: boolean;
   enhancedNoteCount: number;
   hasTranscript: boolean;
+  memoTemplateId?: string;
   sessionId: string;
   sessionMode: SessionMode;
 }) {
   const selectedTemplateId = useConfigValue("selected_template_id");
-  const templateId = selectedTemplateId || undefined;
+  const templateId = memoTemplateId || selectedTemplateId || undefined;
 
   useEffect(() => {
     if (!enabled) {

--- a/apps/desktop/src/session/hooks/useEnhancedNotes.ts
+++ b/apps/desktop/src/session/hooks/useEnhancedNotes.ts
@@ -34,14 +34,15 @@ export function useEnsureDefaultSummary(sessionId: string) {
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const batchError = useListener((state) => state.batch[sessionId]?.error);
   const enhancedNoteIds = useEnhancedNotes(sessionId);
-  const memoTemplateId = useSession(sessionId)?.raw_template_id;
+  const session = useSession(sessionId);
   useEnsureDefaultSummaryFromState({
     batchError: Boolean(batchError),
+    enabled: session !== null,
     enhancedNoteCount: enhancedNoteIds.length,
     hasTranscript,
     sessionId,
     sessionMode,
-    memoTemplateId,
+    memoTemplateId: session?.raw_template_id,
   });
 }
 

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -188,6 +188,7 @@ function TabContentNoteInner({
     enabled: contentHydrated,
     enhancedNoteCount: enhancedNoteIds.length,
     hasTranscript,
+    memoTemplateId: session?.raw_template_id,
     sessionId,
     sessionMode,
   });

--- a/apps/desktop/src/session/queries.test.ts
+++ b/apps/desktop/src/session/queries.test.ts
@@ -114,6 +114,27 @@ describe("session SQLite operations", () => {
     expect(statements[1].params).toContain('{"type":"doc"}');
   });
 
+  it("stores a memo template without clearing it on later edits", async () => {
+    await updateSession("session-1", {
+      raw_md: '{"type":"doc"}',
+      raw_template_id: "template-1",
+    });
+
+    const templateStatement = mocks.executeTransaction.mock.calls[0][0][0];
+    expect(templateStatement.sql).toContain(
+      "template_id = excluded.template_id",
+    );
+    expect(templateStatement.params).toContain("template-1");
+
+    mocks.executeTransaction.mockClear();
+    await updateSession("session-1", { raw_md: '{"type":"doc"}' });
+
+    const editStatement = mocks.executeTransaction.mock.calls[0][0][0];
+    expect(editStatement.sql).not.toContain(
+      "template_id = excluded.template_id",
+    );
+  });
+
   it("creates a session with its initial event and note content atomically", async () => {
     await createSession("Welcome", "user-1", {
       event_json: '{"tracking_id":"welcome"}',

--- a/apps/desktop/src/session/queries/sessions.ts
+++ b/apps/desktop/src/session/queries/sessions.ts
@@ -21,6 +21,7 @@ type SessionSqlRow = {
   title: string;
   raw_body: string;
   raw_body_format: string;
+  raw_template_id: string;
 };
 
 type SessionSummarySqlRow = {
@@ -46,7 +47,8 @@ const SESSION_SELECT_SQL = `
     sessions.event_json,
     sessions.title,
     COALESCE(note.body, '') AS raw_body,
-    COALESCE(note.body_format, 'prosemirror_json') AS raw_body_format
+    COALESCE(note.body_format, 'prosemirror_json') AS raw_body_format,
+    COALESCE(note.template_id, '') AS raw_template_id
   FROM sessions
   LEFT JOIN session_documents AS note
     ON note.id = sessions.id
@@ -196,24 +198,33 @@ export function updateSession(
     }
 
     if (changes.raw_md !== undefined) {
+      const hasTemplateChange = changes.raw_template_id !== undefined;
       statements.push({
         sql: `
           INSERT INTO session_documents (
-            id, workspace_id, session_id, kind, body_format, body, created_by,
-            updated_by, created_at, updated_at, deleted_at
+            id, workspace_id, session_id, kind, template_id, body_format, body,
+            created_by, updated_by, created_at, updated_at, deleted_at
           )
-          SELECT ?, workspace_id, id, 'note', 'prosemirror_json', ?,
+          SELECT ?, workspace_id, id, 'note', ?, 'prosemirror_json', ?,
             owner_user_id, owner_user_id, ?, ?, NULL
           FROM sessions
           WHERE id = ? AND deleted_at IS NULL
           ON CONFLICT(id) DO UPDATE SET
+            ${hasTemplateChange ? "template_id = excluded.template_id," : ""}
             body_format = excluded.body_format,
             body = excluded.body,
             updated_by = excluded.updated_by,
             updated_at = excluded.updated_at,
             deleted_at = NULL
         `,
-        params: [sessionId, changes.raw_md, now, now, sessionId],
+        params: [
+          sessionId,
+          changes.raw_template_id ?? "",
+          changes.raw_md,
+          now,
+          now,
+          sessionId,
+        ],
       });
     }
 
@@ -239,5 +250,6 @@ function mapSessionRow(row: SessionSqlRow): SessionRecord {
     event_json: row.event_json,
     title: row.title,
     raw_md: rawMd,
+    raw_template_id: row.raw_template_id,
   };
 }

--- a/apps/desktop/src/session/queries/types.ts
+++ b/apps/desktop/src/session/queries/types.ts
@@ -6,12 +6,18 @@ export type SessionRecord = {
   event_json: string;
   title: string;
   raw_md: string;
+  raw_template_id: string;
 };
 
 export type SessionChanges = Partial<
   Pick<
     SessionRecord,
-    "created_at" | "event_json" | "folder_id" | "raw_md" | "title"
+    | "created_at"
+    | "event_json"
+    | "folder_id"
+    | "raw_md"
+    | "raw_template_id"
+    | "title"
   >
 >;
 

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
@@ -58,6 +58,7 @@ function createSnapshot(title = "") {
     event: null,
     eventId: null,
     rawNoteId: "session-1",
+    rawTemplateId: "",
     rawContent: "",
     rawContentFormat: "prosemirror_json",
     rawMarkdown: "",
@@ -385,6 +386,43 @@ describe("enhanceSuccess.onSuccess", () => {
     expect(
       Array.from(markdown.replace(/\s+/gu, " ")).length,
     ).toBeLessThanOrEqual(MIN_SUMMARY_CHARACTERS);
+  });
+
+  it("keeps every selected template section for a short transcript", async () => {
+    mocks.loadSessionContentSnapshot.mockResolvedValue(
+      createSnapshot("Meeting title"),
+    );
+    const transformedArgs = createTransformedArgs();
+    transformedArgs.template = {
+      title: "1:1 Meeting",
+      description: null,
+      sections: [
+        { title: "Updates", description: null },
+        { title: "Feedback", description: null },
+        { title: "Next Steps", description: null },
+      ],
+    };
+    transformedArgs.transcripts = [
+      {
+        startedAt: null,
+        endedAt: null,
+        segments: [{ speaker: "John", text: "x".repeat(160) }],
+      },
+    ];
+
+    await enhanceSuccess.onSuccess?.(
+      createParams({
+        text: "# Updates\n\n- One\n\n# Feedback\n\n- Two\n\n# Next Steps\n\n- Three",
+        transformedArgs,
+      }),
+    );
+
+    const content =
+      mocks.persistGeneratedEnhancedNote.mock.calls[0][0].note.nextContent;
+    const markdown = json2md(JSON.parse(content));
+    expect(markdown).toContain("# Updates");
+    expect(markdown).toContain("# Feedback");
+    expect(markdown).toContain("# Next Steps");
   });
 
   it("does not claim success when the guarded SQLite write fails", async () => {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
@@ -47,7 +47,9 @@ export const runEnhanceSuccess = async ({
   signal,
   onPersisted,
 }: EnhanceSuccessParams) => {
-  const lengthPolicy = getSummaryLengthPolicy(transformedArgs.transcripts);
+  const lengthPolicy = transformedArgs.template?.sections.length
+    ? null
+    : getSummaryLengthPolicy(transformedArgs.transcripts);
   const constrainedText = constrainSummaryLength(text, lengthPolicy);
   if (!constrainedText) {
     return;

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.test.ts
@@ -172,6 +172,45 @@ describe("enhanceTransform.transformArgs", () => {
     });
   });
 
+  it("keeps the applied template when the memo has no section headings", async () => {
+    mocks.loadSessionContentSnapshot.mockResolvedValue({
+      ...createSnapshot(),
+      rawTemplateId: "template-1",
+      rawContent: JSON.stringify({
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      }),
+      rawContentFormat: "prosemirror_json",
+      rawMarkdown: "Notes without headings",
+    });
+    mocks.getTemplateById.mockResolvedValue({
+      title: "1:1 Meeting",
+      description: "Weekly conversation",
+      sections: [
+        { title: "Updates", description: "Recent changes" },
+        { title: "Action Items", description: "Follow-ups" },
+      ],
+    });
+
+    const result = await enhanceTransform.transformArgs(
+      {
+        sessionId: "session-1",
+        enhancedNoteId: "note-1",
+        templateId: "template-1",
+      },
+      settingsValues,
+    );
+
+    expect(result.template).toEqual({
+      title: "1:1 Meeting",
+      description: "Weekly conversation",
+      sections: [
+        { title: "Updates", description: "Recent changes" },
+        { title: "Action Items", description: "Follow-ups" },
+      ],
+    });
+  });
+
   it("uses the saved prompt override for Auto summaries", async () => {
     const result = await enhanceTransform.transformArgs(
       { sessionId: "session-1", enhancedNoteId: "note-1" },

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.test.ts
@@ -52,6 +52,7 @@ function createSnapshot() {
     event: null,
     eventId: null,
     rawNoteId: "session-1",
+    rawTemplateId: "",
     rawContent: "![post](asset://localhost/post.png)",
     rawContentFormat: "markdown",
     rawMarkdown: "![post](asset://localhost/post.png)",
@@ -118,6 +119,57 @@ describe("enhanceTransform.transformArgs", () => {
     expect(result.participants).toEqual([
       { name: "Alice", jobTitle: "Engineer" },
     ]);
+  });
+
+  it("uses the edited memo headings for its applied template", async () => {
+    mocks.loadSessionContentSnapshot.mockResolvedValue({
+      ...createSnapshot(),
+      rawTemplateId: "template-1",
+      rawContent: JSON.stringify({
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: "Updates" }],
+          },
+          { type: "paragraph" },
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: "Next Steps" }],
+          },
+        ],
+      }),
+      rawContentFormat: "prosemirror_json",
+      rawMarkdown: "## Updates\n\n## Next Steps",
+    });
+    mocks.getTemplateById.mockResolvedValue({
+      title: "1:1 Meeting",
+      description: "Weekly conversation",
+      sections: [
+        { title: "Updates", description: "Recent changes" },
+        { title: "Action Items", description: "Follow-ups" },
+      ],
+    });
+
+    const result = await enhanceTransform.transformArgs(
+      {
+        sessionId: "session-1",
+        enhancedNoteId: "note-1",
+        templateId: "template-1",
+      },
+      settingsValues,
+    );
+
+    expect(result.template).toEqual({
+      title: "1:1 Meeting",
+      description: "Weekly conversation",
+      sections: [
+        { title: "Updates", description: "Recent changes" },
+        { title: "Next Steps", description: "Follow-ups" },
+      ],
+    });
   });
 
   it("uses the saved prompt override for Auto summaries", async () => {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.ts
@@ -1,7 +1,13 @@
+import {
+  md2json,
+  parseJsonContent,
+  type JSONContent,
+} from "@anlg/editor/markdown";
 import type {
   Participant,
   Segment,
   Session,
+  TemplateSection,
   Transcript,
 } from "@anlg/plugin-template";
 import { sessionEventSchema } from "@anlg/store";
@@ -62,13 +68,26 @@ async function transformArgs(
   );
   const sessionContext = getSessionContext(snapshot, meetingChatContext);
   const templateRecord = await loadTemplate(templateId);
-  const template = templateRecord
+  const memoTemplateSections =
+    templateId === snapshot.rawTemplateId
+      ? getMemoTemplateSections(snapshot, templateRecord?.sections ?? [])
+      : null;
+  let template: TaskArgsMapTransformed["enhance"]["template"] = templateRecord
     ? {
         title: templateRecord.title,
         description: templateRecord.description ?? null,
         sections: templateRecord.sections,
       }
     : null;
+  if (memoTemplateSections !== null) {
+    template = memoTemplateSections.length
+      ? {
+          title: templateRecord?.title ?? "Meeting memo",
+          description: templateRecord?.description ?? null,
+          sections: memoTemplateSections,
+        }
+      : null;
+  }
   const language = getLanguage(settingsValues);
   const promptOverride = getPromptOverride(settingsValues, templateId);
   const segments = await getTranscriptSegments(snapshot);
@@ -93,6 +112,42 @@ async function transformArgs(
     transcripts: formatTranscripts(segments, sessionContext.transcriptsMeta),
     imageContext,
   };
+}
+
+function getMemoTemplateSections(
+  snapshot: SessionContentSnapshot,
+  originalSections: TemplateSection[],
+): TemplateSection[] {
+  const document =
+    snapshot.rawContentFormat === "markdown"
+      ? md2json(snapshot.rawContent)
+      : parseJsonContent(snapshot.rawContent);
+  const originalByTitle = new Map(
+    originalSections.map((section) => [section.title.trim(), section]),
+  );
+  const headings = (document.content ?? []).flatMap((node) => {
+    if (node.type !== "heading" || node.attrs?.level !== 2) return [];
+    const title = getNodeText(node).trim();
+    return title ? [title] : [];
+  });
+  const preservePositionDescriptions =
+    headings.length === originalSections.length;
+
+  return headings.map((title, index) => ({
+    title,
+    description:
+      originalByTitle.get(title)?.description ??
+      (preservePositionDescriptions
+        ? originalSections[index]?.description
+        : null) ??
+      null,
+  }));
+}
+
+function getNodeText(node: JSONContent): string {
+  return (
+    node.text ?? node.content?.map((child) => getNodeText(child)).join("") ?? ""
+  );
 }
 
 async function loadTemplate(templateId: string | undefined) {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.ts
@@ -79,14 +79,12 @@ async function transformArgs(
         sections: templateRecord.sections,
       }
     : null;
-  if (memoTemplateSections !== null) {
-    template = memoTemplateSections.length
-      ? {
-          title: templateRecord?.title ?? "Meeting memo",
-          description: templateRecord?.description ?? null,
-          sections: memoTemplateSections,
-        }
-      : null;
+  if (memoTemplateSections?.length) {
+    template = {
+      title: templateRecord?.title ?? "Meeting memo",
+      description: templateRecord?.description ?? null,
+      sections: memoTemplateSections,
+    };
   }
   const language = getLanguage(settingsValues);
   const promptOverride = getPromptOverride(settingsValues, templateId);

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
@@ -48,6 +48,7 @@ async function* executeWorkflow(params: {
   const prompt = withLengthGuidance(
     withImageContextNote(await getUserPrompt(args), args.imageContext.length),
     args.transcripts,
+    Boolean(args.template?.sections.length),
   );
 
   yield* generateSummary({
@@ -201,7 +202,10 @@ ${IMAGE_CONTEXT_NOTE}`;
 function withLengthGuidance(
   prompt: string,
   transcripts: TaskArgsMapTransformed["enhance"]["transcripts"],
+  hasTemplateSections: boolean,
 ): string {
+  if (hasTemplateSections) return prompt;
+
   const guidance = formatSummaryLengthGuidance(
     getSummaryLengthPolicy(transcripts),
   );

--- a/crates/template-app/assets/_macros.jinja
+++ b/crates/template-app/assets/_macros.jinja
@@ -116,7 +116,8 @@ Description: {{ desc }}
 Sections:
 {% for section in tpl.sections -%}
 {{ loop.index }}. {{ section.title }}{% if section.description.is_some() %} - {{ section.description.as_ref().unwrap() }}{% endif %}
-{% endfor -%}
+{% endfor %}
+Use every section in order with its exact title. Keep sections without relevant content brief instead of inventing details.
 {%- when None %}
 
 # Instructions

--- a/crates/template-app/src/enhance.rs
+++ b/crates/template-app/src/enhance.rs
@@ -239,6 +239,8 @@ mod tests {
     Sections:
     1. Section 1 - Section 1 description
     2. Section 2 - Section 2 description
+
+    Use every section in order with its exact title. Keep sections without relevant content brief instead of inventing details.
     ");
 
     tpl_snapshot!(

--- a/crates/template-app/src/types.rs
+++ b/crates/template-app/src/types.rs
@@ -231,6 +231,8 @@ mod tests {
     Sections:
     1. Summary - Brief overview
     2. Action Items
+
+    Use every section in order with its exact title. Keep sections without relevant content brief instead of inventing details.
     "
     );
 


### PR DESCRIPTION
Persist the meeting template and honor edited section headings through generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes template resolution and AI summary shaping across enhancer, SQLite updates, and prompt generation; behavior is heavily tested but affects core post-meeting output quality.
> 
> **Overview**
> Pre-meeting template choice is now **stored on the session note** (`raw_template_id`) when a user applies a template from the empty memo; later memo edits no longer clear it. **Default summary and enhance flows** pick the memo template ahead of the global `selected_template_id`, with explicit Auto (`templateId: null`) still overriding both; default-summary creation waits until the session is hydrated.
> 
> **Enhancement** builds the prompt template from the memo’s level-2 headings when they match the stored template (preserving section descriptions where possible), **skips transcript-based length caps** when a structured template is used, and the Rust/Jinja prompts tell the model to use every section in order.
> 
> The **raw memo empty state** hides suggested templates once the meeting is over (transcript/audio path), and tests cover persistence, resolution order, and section behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18a961e595da1380ecb3af216f9526b3179b7f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->