### PR TITLE
Keep stable builds on the production channel

### DIFF
--- a/apps/desktop/src-tauri/src/embedded_cli.rs
+++ b/apps/desktop/src-tauri/src/embedded_cli.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 
 const DEV_BUNDLE_ID: &str = "com.hyprnote.dev";
 const FLATPAK_BUNDLE_ID: &str = "so.anarlog.Anarlog";
+const LEGACY_STABLE_BUNDLE_ID: &str = "com.hyprnote.Hyprnote";
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 const MANAGED_CLI_DIR: &str = ".anarlog-cli";
 const STABLE_BUNDLE_ID: &str = "com.hyprnote.stable";
@@ -168,10 +169,10 @@ fn unavailable_status(command_name: &str, details: &str) -> EmbeddedCliStatus {
 
 fn command_name_from_identifier(identifier: &str) -> &'static str {
     match identifier {
-        STABLE_BUNDLE_ID | FLATPAK_BUNDLE_ID => "anarlog",
+        STABLE_BUNDLE_ID | LEGACY_STABLE_BUNDLE_ID | FLATPAK_BUNDLE_ID => "anarlog",
         STAGING_BUNDLE_ID => "anarlog-staging",
         DEV_BUNDLE_ID => "anarlog-dev",
-        _ => "anarlog-dev",
+        _ => "anarlog",
     }
 }
 

--- a/apps/desktop/src-tauri/src/embedded_cli/tests.rs
+++ b/apps/desktop/src-tauri/src/embedded_cli/tests.rs
@@ -5,13 +5,17 @@ use std::os::unix::fs::PermissionsExt;
 #[test]
 fn maps_bundle_id_to_command_name() {
     assert_eq!(command_name_from_identifier(STABLE_BUNDLE_ID), "anarlog");
+    assert_eq!(
+        command_name_from_identifier(LEGACY_STABLE_BUNDLE_ID),
+        "anarlog"
+    );
     assert_eq!(command_name_from_identifier(FLATPAK_BUNDLE_ID), "anarlog");
     assert_eq!(
         command_name_from_identifier(STAGING_BUNDLE_ID),
         "anarlog-staging"
     );
     assert_eq!(command_name_from_identifier(DEV_BUNDLE_ID), "anarlog-dev");
-    assert_eq!(command_name_from_identifier("unknown"), "anarlog-dev");
+    assert_eq!(command_name_from_identifier("unknown"), "anarlog");
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/apps/desktop/src/settings/appearance/app-icon.test.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.test.tsx
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   applyAppIconPreference: vi.fn(),
   appIcon: "default",
   appearance: "auto",
-  appIdentifier: "com.hyprnote.stable",
+  appIdentifier: "com.hyprnote.stable" as string | undefined,
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -95,6 +95,15 @@ describe("AppIconSelector", () => {
         .getByRole("radio", { name: "Default" })
         .querySelector('source[media="(prefers-color-scheme: dark)"]'),
     ).not.toBeNull();
+  });
+
+  it("uses the stable icon while the app identifier is loading", () => {
+    mocks.appIdentifier = undefined;
+
+    render(<AppIconSelector />);
+
+    expect(screen.queryByRole("radio", { name: "Production" })).toBeNull();
+    expect(screen.getByRole("radio", { name: "Blueprint" })).toBeDefined();
   });
 
   it("applies and stores an explicit icon appearance", () => {

--- a/apps/desktop/src/settings/appearance/app-icon.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.tsx
@@ -42,7 +42,7 @@ export function AppIconSelector() {
   );
   const setAppIcon = useSetSettingValue("app_icon");
   const setAppearance = useSetSettingValue("app_icon_appearance");
-  const { data: appIdentifier = "com.hyprnote.dev" } = useQuery({
+  const { data: appIdentifier = "com.hyprnote.stable" } = useQuery({
     queryKey: ["tauri", "app-identifier"],
     queryFn: getIdentifier,
     staleTime: Infinity,

--- a/apps/desktop/src/shared/theme/provider.test.tsx
+++ b/apps/desktop/src/shared/theme/provider.test.tsx
@@ -147,6 +147,19 @@ describe("AppThemeProvider", () => {
     await waitFor(() => expect(setDockIcon).toHaveBeenCalledWith("staging"));
   });
 
+  it("uses the stable Dock icon when the app identifier is unavailable", async () => {
+    getIdentifier.mockRejectedValue(new Error("unavailable"));
+    themeState.settingsReady = true;
+
+    render(
+      <AppThemeProvider>
+        <div>child</div>
+      </AppThemeProvider>,
+    );
+
+    await waitFor(() => expect(setDockIcon).toHaveBeenCalledWith("stable"));
+  });
+
   it("applies the selected icon variant for the system appearance", async () => {
     themeState.settingsReady = true;
     themeState.theme = "dark";

--- a/apps/desktop/src/shared/theme/provider.tsx
+++ b/apps/desktop/src/shared/theme/provider.tsx
@@ -117,7 +117,9 @@ async function applyDockIcon(
   appearance: AppIconAppearance,
   systemIsDark: boolean,
 ) {
-  const appIdentifier = await getIdentifier().catch(() => "com.hyprnote.dev");
+  const appIdentifier = await getIdentifier().catch(
+    () => "com.hyprnote.stable",
+  );
 
   try {
     const result = await iconCommands.setDockIcon(

--- a/apps/desktop/src/shared/utils.test.ts
+++ b/apps/desktop/src/shared/utils.test.ts
@@ -17,9 +17,11 @@ describe("getScheme", () => {
 
   it.each([
     ["com.hyprnote.stable", "anarlog"],
+    ["com.hyprnote.Hyprnote", "anarlog"],
     ["com.hyprnote.staging", "anarlog-staging"],
     ["com.hyprnote.dev", "anarlog-dev"],
     ["so.anarlog.Anarlog", "anarlog"],
+    ["unknown", "anarlog"],
   ])("maps %s to %s", async (identifier, scheme) => {
     mocks.getIdentifier.mockResolvedValue(identifier);
 

--- a/apps/desktop/src/shared/utils.ts
+++ b/apps/desktop/src/shared/utils.ts
@@ -14,6 +14,7 @@ export const getScheme = async (): Promise<DesktopScheme> => {
   const id = await getIdentifier();
   const schemes: Record<string, DesktopScheme> = {
     "com.hyprnote.stable": "anarlog",
+    "com.hyprnote.Hyprnote": "anarlog",
     "com.hyprnote.staging": "anarlog-staging",
     "com.hyprnote.dev": "anarlog-dev",
     "so.anarlog.Anarlog": "anarlog",
@@ -21,7 +22,7 @@ export const getScheme = async (): Promise<DesktopScheme> => {
     "com.anarlog.staging": "anarlog-staging",
     "com.anarlog.dev": "anarlog-dev",
   };
-  return schemes[id] ?? "anarlog-dev";
+  return schemes[id] ?? "anarlog";
 };
 
 type DesktopFlowPath =


### PR DESCRIPTION
Treat legacy and unknown release identifiers as stable for web handoffs, CLI installation, and app icon selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral default changes are consistent across Rust and TypeScript with targeted tests; no auth or data-path changes.
> 
> **Overview**
> **Stable/production channel** is now the default when the app bundle ID is legacy, unknown, or not yet loaded—instead of assuming dev/blueprint.
> 
> Rust **embedded CLI** maps `com.hyprnote.Hyprnote` to the `anarlog` command and uses `anarlog` (not `anarlog-dev`) for unrecognized identifiers. **`getScheme`** adds the legacy Hyprnote ID and falls back to `anarlog` for unknown IDs, so web handoffs via `buildWebAppUrl` use the production scheme.
> 
> **App icon** settings and theme provider default the identifier to `com.hyprnote.stable` while loading or when `getIdentifier` fails, so Dock/icon UI matches production rather than dev. Tests cover legacy mapping, unknown schemes, loading state, and identifier errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8bbe75c9e9d607fd206b3bf108691348b2da7a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->