### PR TITLE
Remove misleading auth step indicator

### DIFF
--- a/apps/desktop/src/instruction/index.tsx
+++ b/apps/desktop/src/instruction/index.tsx
@@ -87,12 +87,6 @@ function InstructionShell({
             </p>
           </div>
 
-          <div className="flex items-center gap-2.5 pt-1">
-            <div className="bg-muted-foreground/75 h-1.5 w-1.5 rounded-full" />
-            <div className="bg-muted h-1.5 w-1.5 rounded-full" />
-            <div className="bg-muted h-1.5 w-1.5 rounded-full" />
-          </div>
-
           {action ? <div className="w-full">{action}</div> : null}
           {children ? (
             <div className="flex w-full flex-col items-center gap-3">


### PR DESCRIPTION
Delete the static three-dot progress UI from the shared instruction screen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic layout change in the instruction UI with no auth, billing, or routing logic touched.
> 
> **Overview**
> Removes the **three-dot row** from the shared `InstructionShell` layout (sign-in, billing, and integration instruction flows).
> 
> Those dots were purely decorative and always showed the same state, so they read like a multi-step progress indicator even though the screen is not a wizard. The title, description, and actions are unchanged; only that misleading chrome is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35026931d1e969769847407ee0e3a87df2f622c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->