### PR TITLE
chore(changelog): add 1.4.6 desktop release notes

### DIFF
--- a/packages/changelog/content/1.4.6.md
+++ b/packages/changelog/content/1.4.6.md
@@ -1,0 +1,58 @@
+---
+date: "2026-08-07"
+summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30 other assistants, smarter memo templates, and email and Slack recap sharing."
+---
+
+## Transcripts
+
+- Edit transcript text directly, and switch between reading and editing modes
+- Reassign a speaker by selecting the words that belong to them
+- Create a new speaker while reassigning instead of picking from existing ones
+  only
+
+## Meetings
+
+- Start recording from a new ad hoc note without creating a calendar event first
+- Keep scheduled event details visible after a meeting ends, and see resume
+  listening in the transcript menu instead of stale recording controls
+- Rename a note straight from its header
+- Hear saved recordings evenly through both speakers instead of one side
+
+## Memos and templates
+
+- Pick a template in an empty memo and get its section headings right away
+- See template suggestions ranked from the meeting and its participants, with
+  your favorites on top, plus a shortcut to create a new template
+- Keep the template you chose before a meeting when the summary is generated,
+  including your edited section headings
+
+## Importing
+
+- Bring your meeting history over from 30 other meeting assistants, including
+  Granola, Otter, Fireflies, Fathom, Notion AI Meeting Notes, and Zoom
+- See only the apps actually installed on your machine, with their icons and
+  per-app import instructions
+
+## Sharing
+
+- Send a meeting recap by email or Slack from the same share flow
+- Get a note-specific preview when a shared link is posted to social apps and
+  chat
+- Add comments from the selection toolbar in the editor
+
+## Settings and appearance
+
+- Find Calendar, Contacts, Templates, and Automations under a new Workspace
+  group in settings, with audio controls folded into Meetings
+- Add dictionary entries from a compact control, with guidance while the
+  dictionary is still empty
+- Stay in the automation workspace without the chat panel detaching
+- Follow system light and dark appearance reliably, including live Dock icon
+  updates on macOS
+- Read documents with a heading scale that no longer competes with the title
+
+## Fixes
+
+- Start your Pro trial automatically when you sign up with an eligible account,
+  and recover trials that were missed earlier
+- Keep app sounds from crashing the app on Linux


### PR DESCRIPTION
The 1.4.6 stable release needs its changelog on main before the release
workflow will accept the version.

Adds packages/changelog/content/1.4.6.md covering the desktop user-facing
changes since desktop_v1.4.5: transcript editing and selection-based speaker
reassignment, meeting history imports from 30 detected assistants, memo
template prefill and personalized suggestions, email and Slack recap sharing,
shared-note link previews, the Workspace settings group, reliable system
appearance following, and automatic Pro trial start.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or application code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.6.md`** so the stable **1.4.6** desktop release can ship through the release workflow (changelog on `main` is required for the version).
> 
> The new entry documents user-facing changes since **1.4.5**: transcript editing and selection-based speaker reassignment, ad hoc recording and post-meeting UI tweaks, memo template prefill/suggestions/persistence, imports from ~30 detected meeting assistants, email/Slack recap sharing and richer link previews, a **Workspace** settings grouping, appearance/dictionary/automation polish, and fixes (auto Pro trial, Linux app sounds).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8da8524501a99720c37cbf3a5d16cbcd211e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->