### PR TITLE
fix(desktop): loosen template empty state and stop blocking editor clicks

### DIFF
--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -453,9 +453,16 @@ describe("RawEditor", () => {
         button.className.includes("text-muted-foreground"),
       ),
     ).toBe(true);
-    expect(buttons.every((button) => !button.className.includes("px-2"))).toBe(
-      true,
-    );
+    expect(
+      buttons.every(
+        (button) =>
+          button.className.includes("w-fit") &&
+          button.className.includes("pointer-events-auto") &&
+          // px-2 offset by -ml-2 keeps content aligned with the editor column
+          button.className.includes("-ml-2") &&
+          button.className.includes("px-2"),
+      ),
+    ).toBe(true);
     expect(buttons.map((button) => button.textContent)).toEqual([
       "Template iconProject Kickoff",
       "Template iconDaily Standup",

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -408,7 +408,7 @@ function TemplateEmptyState({
   }, [createTemplate, openTemplatesTab]);
 
   return (
-    <div className="absolute inset-x-0 top-8 z-10 flex flex-col">
+    <div className="pointer-events-none absolute inset-x-0 top-16 z-10 flex flex-col">
       <TemplateSection
         label={t`Start with a favorite template`}
         templates={favoriteTemplates}
@@ -423,7 +423,7 @@ function TemplateEmptyState({
         type="button"
         onClick={handleCreateTemplate}
         className={cn([
-          "hover:bg-accent focus-visible:bg-accent flex h-8 w-full items-center gap-2 rounded-md pr-2 text-left",
+          "hover:bg-accent focus-visible:bg-accent pointer-events-auto -ml-2 flex h-8 w-fit max-w-full items-center gap-2 rounded-md px-2 text-left",
           "text-muted-foreground hover:text-foreground focus-visible:text-foreground transition-colors focus-visible:outline-hidden",
         ])}
       >
@@ -459,7 +459,7 @@ function TemplateSection({
           type="button"
           onClick={() => onApply(template)}
           className={cn([
-            "hover:bg-accent focus-visible:bg-accent flex h-8 w-full items-center gap-2 rounded-md pr-2 text-left",
+            "hover:bg-accent focus-visible:bg-accent pointer-events-auto -ml-2 flex h-8 w-fit max-w-full items-center gap-2 rounded-md px-2 text-left",
             "text-muted-foreground hover:text-foreground focus-visible:text-foreground transition-colors focus-visible:outline-hidden",
           ])}
         >


### PR DESCRIPTION
The template suggestions overlay sat right under the Start writing
placeholder and its full-width buttons swallowed clicks anywhere in the
editor, making it unclear where to click to start typing.

- Push the overlay down (top-8 -> top-16) for clearer separation from
  the placeholder line
- Make the overlay click-through (pointer-events-none) so clicking
  empty space focuses the editor; only the buttons stay interactive
- Shrink template buttons to fit their content (w-fit) with a -ml-2/px-2
  hover pill that keeps icon and text aligned with the editor column

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session note empty-state UI and class assertions only; no persistence, auth, or data-path changes.
> 
> **Overview**
> Fixes the empty-memo **template suggestions** overlay so it no longer blocks focusing the editor.
> 
> The overlay moves down (`top-8` → `top-16`) and uses **`pointer-events-none`**, with **`pointer-events-auto`** only on template and “New template” buttons. Buttons switch from full-width (`w-full`) to content-sized (`w-fit`) with **`-ml-2` / `px-2`** so hover pills stay aligned with the editor column. Tests now assert the new button classes instead of expecting no horizontal padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7221f68daf72573e8e44ab4d07e233d65cffc085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->