### PR TITLE
fix(desktop): match streaming bullet spacing to editor rhythm

### DIFF
--- a/apps/desktop/src/session/components/streamdown.tsx
+++ b/apps/desktop/src/session/components/streamdown.tsx
@@ -5,6 +5,25 @@ import { cn } from "@anlg/utils";
 // packages/editor styles) so the streaming view matches the editor exactly;
 // only structural concerns live here.
 export const streamdownComponents = {
+  // Streamdown's built-in li carries `py-1` (4px/side); the editor's rhythm is
+  // 0.125em/side on `li > p`. Padding the li itself (with `[&>p]:inline` so
+  // loose lists don't double-pad) keeps the flat streaming gap identical.
+  // A nested list breaks that equivalence: the li's padding wraps the whole
+  // li (text + sublist), while the editor pads only the text row. Shifting
+  // the li's share onto the sublist via margins (mt adds the missing half
+  // above, -mb cancels the li's bottom pad below) restores the 0.25em rhythm
+  // without stretching the sublist's guide rail. `!` because note-typography's
+  // `ul { margin-block: 0 }` reset is unlayered and outranks plain utilities.
+  li: ({ className, ...props }: React.LiHTMLAttributes<HTMLLIElement>) => (
+    <li
+      {...props}
+      className={cn([
+        "py-[0.125em] [&>p]:inline",
+        "[&>:is(ul,ol)]:mt-[0.125em]! [&>:is(ul,ol)]:-mb-[0.125em]!",
+        className,
+      ])}
+    />
+  ),
   img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
     const { editorWidth, title } = parseImageMetadata(props.title);
 


### PR DESCRIPTION
Streamdown's built-in li component ships `py-1` (4px/side), while the
editor's list rhythm comes from `li > p` padding of 0.125em (2px/side),
so bullets sat ~8px apart during summary streaming and snapped to ~4px
once the persisted note rendered in ProseMirror.

Override `li` in streamdownComponents with `py-[0.125em]`, keeping
`[&>p]:inline` so loose markdown lists do not double-pad, making the
streaming gap identical to the editor in both tight and loose lists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in the desktop streaming markdown renderer; no auth, data, or business logic.
> 
> **Overview**
> **Fixes a visible jump** when streamed summaries finish rendering: list bullets were ~8px apart during streaming and ~4px apart in the persisted note.
> 
> Adds a custom **`li`** override in `streamdownComponents` that replaces Streamdown’s default `py-1` with **`py-[0.125em]`** and **`[&>p]:inline`** so spacing matches the editor’s `li > p` rhythm for tight and loose lists.
> 
> For **nested lists**, applies margin tweaks on child **`ul`/`ol`** (`mt` / `-mb` with `!`) so padding on the parent `li` doesn’t stretch the gap around sublists, consistent with how ProseMirror only pads the text row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72abd53b6a4f3bbc32278d517c99b84262e904de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->