### PR TITLE
fix/sidebar-header-chat-input

### DIFF
--- a/apps/desktop/src/chat/components/input/chat-input.css
+++ b/apps/desktop/src/chat/components/input/chat-input.css
@@ -49,6 +49,10 @@
   color: hsl(var(--muted-foreground)) !important;
 }
 
+[data-chat-input-surface="elevated"] .chat-input-editor.prosemirror-editor {
+  padding-bottom: 0;
+}
+
 .dark
   [data-chat-input-surface="elevated"]
   .chat-input-editor.prosemirror-editor,

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -50,6 +50,7 @@ import type { SidebarNoteFilter } from "~/sidebar/note-filter";
 import {
   hasCustomSidebarTab,
   hasLeftSurfaceCustomSidebarTab,
+  hasOwnSidebarHeaderTab,
 } from "~/sidebar/use-custom-sidebar";
 import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
 
@@ -95,6 +96,7 @@ export function ClassicMainBody() {
   const mountLeftSidebarPanel = !isOnboarding;
   const showLeftSidebarPanel = mountLeftSidebarPanel && leftsidebar.expanded;
   const showLeftSurfaceChromeBack = hasLeftSurfaceCustomSidebar;
+  const sidebarOwnsChromeRow = hasOwnSidebarHeaderTab(currentTab);
   const enableMainAreaTopDrag =
     showSidebarTimelineChrome || hasLeftSurfaceCustomSidebar;
   const mainAreaTopDrag = useMainAreaTopWindowDrag(enableMainAreaTopDrag);
@@ -458,7 +460,10 @@ export function ClassicMainBody() {
           data-tauri-drag-region
           data-left-sidebar-chrome
           style={leftSidebarChromeStyle}
-          className="absolute top-0 left-0 z-40 h-10"
+          className={cn([
+            "absolute top-0 left-0 z-40 h-10",
+            sidebarOwnsChromeRow && "pointer-events-none",
+          ])}
         />
       ) : (
         <div data-tauri-drag-region className="relative h-10 shrink-0">
@@ -476,7 +481,12 @@ export function ClassicMainBody() {
           data-tauri-drag-region
           data-left-sidebar-chrome
           style={leftSidebarChromeStyle}
-          className="absolute top-0 left-0 z-50 h-12"
+          className={cn([
+            "absolute top-0 left-0 z-50 h-12",
+            // The sidebar header underneath carries the drag region and its
+            // own actions; only the back button here must stay interactive.
+            sidebarOwnsChromeRow && "pointer-events-none",
+          ])}
         >
           <div
             data-tauri-drag-region

--- a/apps/desktop/src/sidebar/custom-sidebar-header.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.tsx
@@ -46,7 +46,7 @@ export function CustomSidebarHeader({
     <div
       data-tauri-drag-region
       className={cn([
-        "-mt-11 flex h-12 shrink-0 items-start py-0 pt-[9px] pr-1",
+        "flex h-12 shrink-0 items-start py-0 pt-[9px] pr-1",
         showWindowControlsGutter ? "pl-[76px]" : "pl-2",
       ])}
     >

--- a/apps/desktop/src/sidebar/index.test.tsx
+++ b/apps/desktop/src/sidebar/index.test.tsx
@@ -114,11 +114,8 @@ describe("LeftSidebar", () => {
   });
 
   it.each([
-    ["settings", "settings-nav"],
-    ["calendar", "calendar-nav"],
     ["contacts", "contacts-nav"],
     ["templates", "templates-nav"],
-    ["automations", "automations-nav"],
   ])("keeps %s below the window chrome", (type, testId) => {
     mocks.currentTab = { type };
 
@@ -130,4 +127,23 @@ describe("LeftSidebar", () => {
     expect(classList).toContain("pr-1");
     expect(classList).not.toContain("pt-0");
   });
+
+  it.each([
+    ["settings", "settings-nav"],
+    ["calendar", "calendar-nav"],
+    ["automations", "automations-nav"],
+  ])(
+    "lets the %s nav place its own header in the chrome row",
+    (type, testId) => {
+      mocks.currentTab = { type };
+
+      const { container } = render(<LeftSidebar />);
+      const classList = container.firstElementChild?.className.split(" ") ?? [];
+
+      expect(screen.getByTestId(testId)).toBeTruthy();
+      expect(classList).toContain("pt-0");
+      expect(classList).toContain("pr-1");
+      expect(classList).not.toContain("pt-11");
+    },
+  );
 });

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -10,6 +10,7 @@ import { SettingsNav } from "./settings";
 import { SharedNotesNav } from "./shared-notes";
 import { TemplatesNav } from "./templates";
 import { TimelineView } from "./timeline";
+import { hasOwnSidebarHeaderTab } from "./use-custom-sidebar";
 
 import { useTabs } from "~/store/zustand/tabs";
 
@@ -38,11 +39,16 @@ export function LeftSidebar({
     isTemplatesMode ||
     isAutomationsMode;
   const isTimelineSidebarLayout = !isSpecialMode;
+  // Navs with their own CustomSidebarHeader fill the chrome row themselves; a
+  // top padding here would push the header out of it (and overflow-hidden
+  // would clip a pulled-up header).
+  const needsChromeRowGutter =
+    isSpecialMode && !hasOwnSidebarHeaderTab(currentTab);
   return (
     <div
       className={cn([
         "flex h-full w-full shrink-0 flex-col gap-1 overflow-hidden",
-        isTimelineSidebarLayout ? "pt-0" : "pt-11",
+        needsChromeRowGutter ? "pt-11" : "pt-0",
         !isTimelineSidebarLayout && "pr-1",
       ])}
     >

--- a/apps/desktop/src/sidebar/use-custom-sidebar.ts
+++ b/apps/desktop/src/sidebar/use-custom-sidebar.ts
@@ -18,12 +18,23 @@ const LEFT_SURFACE_CUSTOM_SIDEBAR_TYPES: Tab["type"][] = [
   "automations",
 ];
 
+// Tabs whose sidebar nav renders CustomSidebarHeader in the window chrome row.
+const OWN_SIDEBAR_HEADER_TYPES: Tab["type"][] = [
+  "calendar",
+  "settings",
+  "automations",
+];
+
 export function hasCustomSidebarTab(tab: Tab | null): boolean {
   return tab !== null && CUSTOM_SIDEBAR_TYPES.includes(tab.type);
 }
 
 export function hasLeftSurfaceCustomSidebarTab(tab: Tab | null): boolean {
   return tab !== null && LEFT_SURFACE_CUSTOM_SIDEBAR_TYPES.includes(tab.type);
+}
+
+export function hasOwnSidebarHeaderTab(tab: Tab | null): boolean {
+  return tab !== null && OWN_SIDEBAR_HEADER_TYPES.includes(tab.type);
 }
 
 export function useCustomSidebarEffect(


### PR DESCRIPTION
Summary Fix clipping of CustomSidebarHeader in the chrome row so title and actions (e.g., automations "+" button) are visible and clickable.
- Make window-chrome pointer-transparent for tabs that their own headersettings, calendar, automations) preserving button interactivity- Remove extra bottom padding the elevated chat input (zero out inherited24px to match floating variant and even space under the.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop layout and CSS only; behavior is covered by updated LeftSidebar padding tests with no auth or data changes.
> 
> **Overview**
> Fixes **settings, calendar, and automations** sidebar navs so `CustomSidebarHeader` (title and actions like the automations “+” button) sits in the window chrome row without being clipped or blocked.
> 
> **Left sidebar** no longer applies `pt-11` on tabs that own their header; **contacts** and **templates** still get the chrome gutter. **`CustomSidebarHeader`** drops the `-mt-11` pull-up that fought `overflow-hidden`. **`ClassicMainBody`** sets `pointer-events-none` on the top chrome overlays when the sidebar owns the row so drag regions don’t steal clicks from the header (the back control stays usable).
> 
> **Elevated** chat input sets editor `padding-bottom: 0` so spacing matches the floating variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713a090fd9748e4d9212e6069c06740a7791f75c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->