### PR TITLE
chore(changelog): cover automations and post-draft fixes in 1.4.6

### DIFF
--- a/packages/changelog/content/1.4.6.md
+++ b/packages/changelog/content/1.4.6.md
@@ -1,7 +1,16 @@
 ---
-date: "2026-08-07"
-summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30 other assistants, smarter memo templates, and email and Slack recap sharing."
+date: "2026-08-08"
+summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30 other assistants, and automations that deliver each meeting summary to Slack, Linear, Notion, or a Markdown folder."
 ---
+
+## Automations
+
+- Let automations run after each meeting once the AI summary is ready: export
+  the note as Markdown to a folder you choose, post the summary to a Slack
+  channel, file open action items as Linear issues, or append the summary to a
+  Notion page
+- Set each automation up in settings with pickers for the destination, an
+  enable/disable switch, and a status line showing the last run
 
 ## Transcripts
 
@@ -47,12 +56,17 @@ summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30
 - Add dictionary entries from a compact control, with guidance while the
   dictionary is still empty
 - Stay in the automation workspace without the chat panel detaching
-- Follow system light and dark appearance reliably, including live Dock icon
-  updates on macOS
+- Follow system light and dark appearance reliably, with the Dock icon now
+  matching your theme choice automatically instead of a separate toggle
 - Read documents with a heading scale that no longer competes with the title
 
 ## Fixes
 
 - Start your Pro trial automatically when you sign up with an eligible account,
   and recover trials that were missed earlier
+- Click anywhere in an empty note to start typing; template suggestions no
+  longer block the editor
+- See summary bullets spaced the same while streaming as in the finished note
+- Use the header buttons in Settings, Calendar, and Automations views that the
+  window controls previously covered
 - Keep app sounds from crashing the app on Linux


### PR DESCRIPTION
The 1.4.6 changelog entry was written before the automation engine landed. Add an Automations section covering the Markdown export, Slack, Linear, and Notion runners with their settings controls, fold the theme-driven Dock icon change into the appearance bullet, and add the template overlay click-through, streaming bullet spacing, and header clipping fixes. Refresh the date and index summary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or product code changes.
> 
> **Overview**
> Updates the **1.4.6** release notes to match what shipped after the first draft: bumps the release **date** to 2026-08-08 and rewrites the front-matter **summary** to highlight post-meeting **automations** (Markdown export, Slack, Linear, Notion) instead of email/Slack recap sharing alone.
> 
> Adds a new **Automations** section describing runners that fire after the AI summary is ready and the settings UX (destination pickers, enable switch, last-run status). Tweaks **Settings and appearance** so the Dock icon bullet reflects automatic theme matching rather than a separate toggle.
> 
> Adds **Fixes** bullets for empty-note click-through past template suggestions, consistent streaming vs final summary bullet spacing, and header buttons no longer hidden under window controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274eeeb9230b3bff33001a56c279e2c4777e9f4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->