### PR TITLE
fix(desktop): drop redundant title from left sidebar header

### DIFF
--- a/apps/desktop/src/contacts/shared.tsx
+++ b/apps/desktop/src/contacts/shared.tsx
@@ -86,7 +86,6 @@ function SortDropdown({
 }
 
 export function ColumnHeader({
-  title,
   sortOption,
   setSortOption,
   onAdd,
@@ -94,7 +93,6 @@ export function ColumnHeader({
   onSearchChange,
   searchInputRef,
 }: {
-  title: React.ReactNode;
   sortOption?: SortOption;
   setSortOption?: (option: SortOption) => void;
   onAdd: () => void;
@@ -111,7 +109,7 @@ export function ColumnHeader({
 
   return (
     <div className="@container">
-      <CustomSidebarHeader title={title}>
+      <CustomSidebarHeader>
         <div className="flex shrink-0 items-center">
           {sortOption && setSortOption && (
             <div className="hidden @[220px]:block">

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -431,7 +431,6 @@ msgstr "Browser handoff not working? Paste the callback link instead"
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr "Calendar"
@@ -797,7 +796,6 @@ msgstr "Connect your integration"
 msgid "Connecting..."
 msgstr "Connecting..."
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr "Contacts"
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr "Setting up encrypted cloud sync."
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr "Settings"
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr "Template content with Jinja2: {{ variable }}, {% if condition %}"
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr "Templates"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -431,7 +431,6 @@ msgstr ""
 
 #: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
-#: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
@@ -797,7 +796,6 @@ msgstr ""
 msgid "Connecting..."
 msgstr ""
 
-#: src/sidebar/contacts.tsx
 #: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
@@ -2430,7 +2428,6 @@ msgid "Setting up encrypted cloud sync."
 msgstr ""
 
 #: src/main/empty.tsx
-#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
@@ -2857,7 +2854,6 @@ msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
 #: src/sidebar/settings.tsx
-#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 

--- a/apps/desktop/src/sidebar/automations.test.tsx
+++ b/apps/desktop/src/sidebar/automations.test.tsx
@@ -39,17 +39,8 @@ vi.mock("~/chat/state/chat-context", () => ({
 }));
 
 vi.mock("~/sidebar/custom-sidebar-header", () => ({
-  CustomSidebarHeader: ({
-    children,
-    title,
-  }: {
-    children?: React.ReactNode;
-    title: React.ReactNode;
-  }) => (
-    <header>
-      <span>{title}</span>
-      {children}
-    </header>
+  CustomSidebarHeader: ({ children }: { children?: React.ReactNode }) => (
+    <header>{children}</header>
   ),
 }));
 

--- a/apps/desktop/src/sidebar/automations.tsx
+++ b/apps/desktop/src/sidebar/automations.tsx
@@ -31,7 +31,7 @@ export function AutomationsNav() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden pb-2">
-      <CustomSidebarHeader title="Automations">
+      <CustomSidebarHeader>
         <Button
           type="button"
           size="icon"

--- a/apps/desktop/src/sidebar/calendar.tsx
+++ b/apps/desktop/src/sidebar/calendar.tsx
@@ -1,5 +1,3 @@
-import { Trans } from "@lingui/react/macro";
-
 import { CustomSidebarHeader } from "./custom-sidebar-header";
 
 import { CalendarSidebarContent } from "~/calendar/components/sidebar";
@@ -7,7 +5,7 @@ import { CalendarSidebarContent } from "~/calendar/components/sidebar";
 export function CalendarNav() {
   return (
     <div className="flex h-full flex-col overflow-hidden pb-2">
-      <CustomSidebarHeader title={<Trans>Calendar</Trans>} />
+      <CustomSidebarHeader />
       <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-3">
         <CalendarSidebarContent />
       </div>

--- a/apps/desktop/src/sidebar/contacts.tsx
+++ b/apps/desktop/src/sidebar/contacts.tsx
@@ -1,4 +1,3 @@
-import { Trans } from "@lingui/react/macro";
 import { Reorder } from "motion/react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -211,7 +210,6 @@ function ContactsList({
   return (
     <div className="flex h-full w-full flex-col">
       <ColumnHeader
-        title={<Trans>Contacts</Trans>}
         sortOption={sortOption}
         setSortOption={setSortOption}
         onAdd={handleAdd}

--- a/apps/desktop/src/sidebar/custom-sidebar-header.test.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.test.tsx
@@ -46,7 +46,7 @@ describe("CustomSidebarHeader", () => {
   });
 
   it("opens home from the back button", () => {
-    render(<CustomSidebarHeader title="Settings" />);
+    render(<CustomSidebarHeader />);
 
     fireEvent.click(screen.getByRole("button", { name: "Go home" }));
 
@@ -57,7 +57,7 @@ describe("CustomSidebarHeader", () => {
     const homeTab = { type: "empty" };
     mocks.tabs = [homeTab];
 
-    render(<CustomSidebarHeader title="Calendar" />);
+    render(<CustomSidebarHeader />);
 
     fireEvent.click(screen.getByRole("button", { name: "Go home" }));
 
@@ -68,7 +68,7 @@ describe("CustomSidebarHeader", () => {
   it("closes floating chat before opening home", () => {
     mocks.chatMode = "FloatingOpen";
 
-    render(<CustomSidebarHeader title="Contacts" />);
+    render(<CustomSidebarHeader />);
 
     fireEvent.click(screen.getByRole("button", { name: "Go home" }));
 
@@ -79,7 +79,7 @@ describe("CustomSidebarHeader", () => {
   it("closes right panel chat before opening home", () => {
     mocks.chatMode = "RightPanelOpen";
 
-    render(<CustomSidebarHeader title="Contacts" />);
+    render(<CustomSidebarHeader />);
 
     fireEvent.click(screen.getByRole("button", { name: "Go home" }));
 
@@ -91,7 +91,7 @@ describe("CustomSidebarHeader", () => {
     mocks.chatMode = "RightPanelOpen";
     mocks.currentTab = { type: "automations" };
 
-    render(<CustomSidebarHeader title="Automations" />);
+    render(<CustomSidebarHeader />);
 
     fireEvent.click(screen.getByRole("button", { name: "Go home" }));
 
@@ -100,7 +100,7 @@ describe("CustomSidebarHeader", () => {
   });
 
   it("does not render history controls", () => {
-    render(<CustomSidebarHeader title="Settings" />);
+    render(<CustomSidebarHeader />);
 
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();

--- a/apps/desktop/src/sidebar/custom-sidebar-header.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.tsx
@@ -8,13 +8,7 @@ import { useShell } from "~/contexts/shell";
 import { useWindowControlsGutter } from "~/shared/hooks/useWindowControlsGutter";
 import { useTabs } from "~/store/zustand/tabs";
 
-export function CustomSidebarHeader({
-  title,
-  children,
-}: {
-  title: ReactNode;
-  children?: ReactNode;
-}) {
+export function CustomSidebarHeader({ children }: { children?: ReactNode }) {
   const { t } = useLingui();
   const { chat } = useShell();
   const showWindowControlsGutter = useWindowControlsGutter();
@@ -61,9 +55,6 @@ export function CustomSidebarHeader({
         >
           <ArrowLeft size={14} />
         </CustomSidebarHeaderButton>
-        <h3 className="truncate font-sans text-sm font-medium select-none">
-          {title}
-        </h3>
       </div>
       {children ? (
         <div

--- a/apps/desktop/src/sidebar/settings.test.tsx
+++ b/apps/desktop/src/sidebar/settings.test.tsx
@@ -70,7 +70,7 @@ vi.mock("@lingui/react/macro", () => ({
 }));
 
 vi.mock("./custom-sidebar-header", () => ({
-  CustomSidebarHeader: ({ title }: { title: ReactNode }) => <div>{title}</div>,
+  CustomSidebarHeader: () => <div />,
 }));
 
 vi.mock("~/store/zustand/tabs", () => {

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -147,7 +147,7 @@ export function SettingsNav() {
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
-      <CustomSidebarHeader title={<Trans>Settings</Trans>} />
+      <CustomSidebarHeader />
       <div className="pb-2">
         <div
           className={cn([

--- a/apps/desktop/src/templates/template-sidebar.tsx
+++ b/apps/desktop/src/templates/template-sidebar.tsx
@@ -337,7 +337,7 @@ export function TemplatesSidebarContent({
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
       <div>
-        <CustomSidebarHeader title={<Trans>Templates</Trans>}>
+        <CustomSidebarHeader>
           {userTemplates.length > 1 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>


### PR DESCRIPTION
The CustomSidebarHeader title truncated awkwardly on the Contacts,
Templates, and Automations pages and duplicated context already visible
in the page itself. Remove the title from CustomSidebarHeader and all
callers (settings, calendar, contacts, templates, automations), leaving
only the back button and header actions, and regenerate lingui catalogs
for the removed messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only header simplification with no auth, data, or routing changes.
> 
> **Overview**
> Removes the section **title** from `CustomSidebarHeader` on Contacts, Templates, Automations, Calendar, and Settings sidebars so the header only shows the back control and action slots (sort, add, search, etc.). **Contacts** `ColumnHeader` no longer accepts or forwards a `title` prop.
> 
> Lingui catalogs are updated to drop obsolete `#:` references to removed sidebar title sources (`sidebar/calendar.tsx`, `sidebar/contacts.tsx`, `templates/template-sidebar.tsx`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 712e725eadcb85caa4d87985d4ac945d0a141919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->