### PR TITLE
fix(desktop): remove duplicate back arrow over sidebar headers

### DIFF
--- a/apps/desktop/src/contacts/shared.tsx
+++ b/apps/desktop/src/contacts/shared.tsx
@@ -44,7 +44,12 @@ function SortDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button size="icon" variant="ghost" aria-label={t`Sort options`}>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="text-muted-foreground hover:text-foreground"
+          aria-label={t`Sort options`}
+        >
           <ArrowsDownUp size={16} />
         </Button>
       </DropdownMenuTrigger>
@@ -119,7 +124,13 @@ export function ColumnHeader({
               />
             </div>
           )}
-          <Button onClick={onAdd} size="icon" variant="ghost" title={t`Add`}>
+          <Button
+            onClick={onAdd}
+            size="icon"
+            variant="ghost"
+            className="text-muted-foreground hover:text-foreground"
+            title={t`Add`}
+          >
             <Plus size={16} />
           </Button>
         </div>

--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -398,28 +398,14 @@ describe("ClassicMainBody", () => {
   });
 
   it.each([
-    ["windows", "settings", { state: { tab: "app" } }],
-    ["windows", "calendar", {}],
-    ["windows", "contacts", { state: { selected: null } }],
-    ["windows", "automations", {}],
-    [
-      "windows",
-      "templates",
-      { state: { selectedMineId: null, selectedWebIndex: null } },
-    ],
-    ["linux", "settings", { state: { tab: "app" } }],
-    ["linux", "calendar", {}],
-    ["linux", "contacts", { state: { selected: null } }],
-    ["linux", "automations", {}],
-    [
-      "linux",
-      "templates",
-      { state: { selectedMineId: null, selectedWebIndex: null } },
-    ],
+    ["settings", { state: { tab: "app" } }],
+    ["calendar", {}],
+    ["contacts", { state: { selected: null } }],
+    ["automations", {}],
+    ["templates", { state: { selectedMineId: null, selectedWebIndex: null } }],
   ] as const)(
-    "uses the 8px %s fallback gutter for the %s back button",
-    (runtimePlatform, type, extraTabState) => {
-      mocks.runtimePlatform = runtimePlatform;
+    "leaves the %s chrome row back button to the sidebar header",
+    (type, extraTabState) => {
       mocks.currentTab = {
         active: true,
         pinned: false,
@@ -430,9 +416,7 @@ describe("ClassicMainBody", () => {
 
       render(<ClassicMainBody />);
 
-      const backButton = screen.getByRole("button", { name: "Go back" });
-      expect(backButton.parentElement?.className).toContain("pl-2");
-      expect(backButton.parentElement?.className).not.toContain("pl-[76px]");
+      expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
     },
   );
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -1,4 +1,3 @@
-import { ArrowLeft } from "@phosphor-icons/react";
 import {
   type CSSProperties,
   type WheelEvent as ReactWheelEvent,
@@ -29,10 +28,7 @@ import {
 } from "./left-sidebar-panel";
 import { useMainAreaTopWindowDrag } from "./main-area-window-drag";
 import { ClassicMainSidebar } from "./shell-sidebar";
-import {
-  LeftSurfaceChromeButton,
-  SidebarTimelineChromeWithUpcomingMeeting,
-} from "./sidebar-timeline-chrome";
+import { SidebarTimelineChromeWithUpcomingMeeting } from "./sidebar-timeline-chrome";
 import { ClassicMainTabContent } from "./tab-content";
 import { useClassicMainShortcuts } from "./useShortcuts";
 
@@ -62,7 +58,7 @@ type LeftSidebarSizeStyle = CSSProperties & {
 export function ClassicMainBody() {
   const { leftsidebar } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
-  const { runEscapeShortcut } = useClassicMainShortcuts();
+  useClassicMainShortcuts();
   const [leftSidebarPanelConstraints, setLeftSidebarPanelConstraints] =
     useState(createLeftSidebarPanelConstraints);
   const [leftSidebarPanelSize, setLeftSidebarPanelSize] = useState(
@@ -95,7 +91,6 @@ export function ClassicMainBody() {
     showSidebarTimelineChrome && !leftsidebar.expanded;
   const mountLeftSidebarPanel = !isOnboarding;
   const showLeftSidebarPanel = mountLeftSidebarPanel && leftsidebar.expanded;
-  const showLeftSurfaceChromeBack = hasLeftSurfaceCustomSidebar;
   const sidebarOwnsChromeRow = hasOwnSidebarHeaderTab(currentTab);
   const enableMainAreaTopDrag =
     showSidebarTimelineChrome || hasLeftSurfaceCustomSidebar;
@@ -476,34 +471,6 @@ export function ClassicMainBody() {
           />
         </div>
       )}
-      {showLeftSurfaceChromeBack ? (
-        <div
-          data-tauri-drag-region
-          data-left-sidebar-chrome
-          style={leftSidebarChromeStyle}
-          className={cn([
-            "absolute top-0 left-0 z-50 h-12",
-            // The sidebar header underneath carries the drag region and its
-            // own actions; only the back button here must stay interactive.
-            sidebarOwnsChromeRow && "pointer-events-none",
-          ])}
-        >
-          <div
-            data-tauri-drag-region
-            className={cn([
-              "flex h-full min-w-0 items-start pt-[9px]",
-              showWindowControlsGutter ? "pl-[76px]" : "pl-2",
-            ])}
-          >
-            <LeftSurfaceChromeButton
-              ariaLabel="Go back"
-              onClick={runEscapeShortcut}
-            >
-              <ArrowLeft size={16} />
-            </LeftSurfaceChromeButton>
-          </div>
-        </div>
-      ) : null}
       <ResizablePanelGroup
         autoSaveId={
           mountLeftSidebarPanel && canResizeLeftSidebarPanel

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -541,7 +541,7 @@ describe("ClassicMainBody", () => {
   });
 
   it.each(["calendar", "settings", "contacts", "templates"])(
-    "runs the escape shortcut from the %s left chrome back button",
+    "renders no chrome back button over the %s sidebar header",
     (type) => {
       mocks.currentTab = {
         active: true,
@@ -552,17 +552,9 @@ describe("ClassicMainBody", () => {
 
       render(<ClassicMainBody />);
 
-      const backButton = screen.getByRole("button", { name: "Go back" });
-      const topArea = backButton.parentElement?.parentElement;
-
-      fireEvent.click(backButton);
-
       expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
-      expect(backButton.hasAttribute("disabled")).toBe(false);
-      expect(topArea?.className).toContain("h-12");
-      expect(topArea?.className).toContain("absolute");
-      expect(mocks.goBack).not.toHaveBeenCalled();
-      expect(mocks.runEscapeShortcut).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
+      expect(mocks.runEscapeShortcut).not.toHaveBeenCalled();
     },
   );
 

--- a/apps/desktop/src/sidebar/automations.tsx
+++ b/apps/desktop/src/sidebar/automations.tsx
@@ -36,7 +36,7 @@ export function AutomationsNav() {
           type="button"
           size="icon"
           variant="ghost"
-          className="text-muted-foreground hover:text-foreground relative z-[60] size-6 rounded-full"
+          className="text-muted-foreground hover:text-foreground relative z-[60]"
           aria-label="New automation"
           onClick={() => startNewChat("automations")}
         >

--- a/apps/desktop/src/sidebar/custom-sidebar-header.tsx
+++ b/apps/desktop/src/sidebar/custom-sidebar-header.tsx
@@ -53,7 +53,7 @@ export function CustomSidebarHeader({ children }: { children?: ReactNode }) {
           title={t`Back`}
           onClick={handleBack}
         >
-          <ArrowLeft size={14} />
+          <ArrowLeft size={16} />
         </CustomSidebarHeaderButton>
       </div>
       {children ? (
@@ -89,7 +89,7 @@ function CustomSidebarHeaderButton({
       data-tauri-drag-region="false"
       disabled={disabled}
       className={cn([
-        "relative z-50 flex size-6 shrink-0 items-center justify-center rounded-full",
+        "relative z-50 flex size-7 shrink-0 items-center justify-center rounded-full",
         "text-muted-foreground hover:bg-accent hover:text-foreground transition-colors",
         "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
         "disabled:text-muted-foreground/70 disabled:hover:text-muted-foreground/70 disabled:hover:bg-transparent",

--- a/apps/desktop/src/sidebar/index.test.tsx
+++ b/apps/desktop/src/sidebar/index.test.tsx
@@ -114,23 +114,10 @@ describe("LeftSidebar", () => {
   });
 
   it.each([
-    ["contacts", "contacts-nav"],
-    ["templates", "templates-nav"],
-  ])("keeps %s below the window chrome", (type, testId) => {
-    mocks.currentTab = { type };
-
-    const { container } = render(<LeftSidebar />);
-    const classList = container.firstElementChild?.className.split(" ") ?? [];
-
-    expect(screen.getByTestId(testId)).toBeTruthy();
-    expect(classList).toContain("pt-11");
-    expect(classList).toContain("pr-1");
-    expect(classList).not.toContain("pt-0");
-  });
-
-  it.each([
     ["settings", "settings-nav"],
     ["calendar", "calendar-nav"],
+    ["contacts", "contacts-nav"],
+    ["templates", "templates-nav"],
     ["automations", "automations-nav"],
   ])(
     "lets the %s nav place its own header in the chrome row",

--- a/apps/desktop/src/sidebar/use-custom-sidebar.ts
+++ b/apps/desktop/src/sidebar/use-custom-sidebar.ts
@@ -22,6 +22,8 @@ const LEFT_SURFACE_CUSTOM_SIDEBAR_TYPES: Tab["type"][] = [
 const OWN_SIDEBAR_HEADER_TYPES: Tab["type"][] = [
   "calendar",
   "settings",
+  "contacts",
+  "templates",
   "automations",
 ];
 

--- a/apps/desktop/src/templates/template-sidebar.tsx
+++ b/apps/desktop/src/templates/template-sidebar.tsx
@@ -344,7 +344,7 @@ export function TemplatesSidebarContent({
                 <Button
                   size="icon"
                   variant="ghost"
-                  className="text-muted-foreground relative z-[60] hover:text-black"
+                  className="text-muted-foreground hover:text-foreground relative z-[60]"
                 >
                   <ArrowsDownUp size={16} />
                 </Button>
@@ -369,7 +369,7 @@ export function TemplatesSidebarContent({
           <Button
             size="icon"
             variant="ghost"
-            className="text-muted-foreground relative z-[60] hover:text-black"
+            className="text-muted-foreground hover:text-foreground relative z-[60]"
             onClick={createDefaultTemplate}
           >
             <Plus size={16} />


### PR DESCRIPTION
Special-mode sidebars rendered two back arrows: the chrome row drew its
own "Go back" button while each nav's CustomSidebarHeader drew another,
overlapping on settings/calendar/automations and stacking in a second
row on contacts/templates.

Drop the chrome-row back button from ClassicMainBody and let contacts
and templates own the chrome row like the other special navs, so the
header lays out as [traffic lights] [back] ... [actions]. Align the
header icons: back button matches the size-7/16px icon buttons, and all
header actions use text-muted-foreground with hover:text-foreground.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop shell and sidebar chrome only; navigation still goes through CustomSidebarHeader back handler, with tests updated for the removed overlay button.
> 
> **Overview**
> Fixes **duplicate back arrows** on special-mode sidebars by removing the overlay **Go back** control from `ClassicMainBody` and relying on each nav’s `CustomSidebarHeader` for navigation.
> 
> **Contacts** and **templates** are treated like calendar, settings, and automations: they register as owning the window chrome row (`OWN_SIDEBAR_HEADER_TYPES`), so layout is traffic lights → back → actions without a second header row or extra top padding (`pt-11`).
> 
> **Header polish:** back control is `size-7` with a **16px** arrow; sort/add/plus actions on contacts, templates, and automations use `text-muted-foreground` / `hover:text-foreground` consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d722161093625f25156b00b9a366532d09af779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->