### PR TITLE
fix(desktop): connect Apple Calendar via header plus button

### DIFF
--- a/apps/desktop/src/calendar/components/sidebar.tsx
+++ b/apps/desktop/src/calendar/components/sidebar.tsx
@@ -14,7 +14,7 @@ import {
 import { cn } from "@anlg/utils";
 
 import { AppleCalendarSelection } from "./apple/calendar-selection";
-import { AccessPermissionRow, TroubleShootingLink } from "./apple/permission";
+import { TroubleShootingLink } from "./apple/permission";
 import { OAuthProviderContent } from "./oauth/provider-content";
 import { type CalendarProvider, PROVIDERS } from "./shared";
 
@@ -171,6 +171,8 @@ function ProviderAccordionItem({
     ) ?? [];
 
   const requiresPro = !!provider.nangoIntegrationId && !isPro;
+  const appleNeedsPermission =
+    provider.id === "apple" && calendar.status !== "authorized";
 
   const canAddAccount =
     !!provider.nangoIntegrationId &&
@@ -181,10 +183,23 @@ function ProviderAccordionItem({
   const shouldConnectOnClick =
     canAddAccount && providerConnections.length === 0;
 
+  const handleAppleConnect = useCallback(() => {
+    if (calendar.isPending) return;
+    if (calendar.status === "denied") {
+      void calendar.open();
+    } else {
+      calendar.request();
+    }
+  }, [calendar]);
   const handleTriggerClick = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
       if (requiresPro) {
         event.preventDefault();
+        return;
+      }
+      if (appleNeedsPermission) {
+        event.preventDefault();
+        handleAppleConnect();
         return;
       }
       if (!shouldConnectOnClick) return;
@@ -196,6 +211,8 @@ function ProviderAccordionItem({
       });
     },
     [
+      appleNeedsPermission,
+      handleAppleConnect,
       openIntegration,
       provider.nangoIntegrationId,
       requiresPro,
@@ -308,6 +325,20 @@ function ProviderAccordionItem({
             )}
             {t`Upgrade to Pro`}
           </button>
+        ) : appleNeedsPermission ? (
+          <button
+            type="button"
+            onClick={handleAppleConnect}
+            disabled={calendar.isPending}
+            className="text-muted-foreground hover:bg-accent hover:text-foreground shrink-0 rounded-full p-1 transition-colors disabled:opacity-50"
+            aria-label={t`Connect ${provider.displayName}`}
+          >
+            {calendar.isPending ? (
+              <CircleNotch className="size-4 animate-spin" />
+            ) : (
+              <Plus className="size-4" />
+            )}
+          </button>
         ) : hasAddAccountButton ? (
           <button
             type="button"
@@ -324,7 +355,7 @@ function ProviderAccordionItem({
           </button>
         ) : null}
 
-        {!requiresPro && (
+        {!requiresPro && !appleNeedsPermission && (
           <CaretRight
             className={cn([
               "text-muted-foreground size-4 shrink-0 transition-transform duration-200",
@@ -333,31 +364,20 @@ function ProviderAccordionItem({
           />
         )}
       </div>
-      {!requiresPro && (
+      {!requiresPro && !appleNeedsPermission && (
         <AccordionContent className="pb-3">
           {provider.id === "apple" && (
             <div className="flex flex-col gap-3">
-              {calendar.status !== "authorized" ? (
-                <AccessPermissionRow
-                  title={t`Calendar`}
-                  status={calendar.status}
-                  isPending={calendar.isPending}
-                  onOpen={calendar.open}
-                  onRequest={calendar.request}
-                  onReset={calendar.reset}
-                />
-              ) : (
-                <AppleCalendarSelection
-                  leftAction={
-                    <TroubleShootingLink
-                      isPending={calendar.isPending}
-                      onOpen={calendar.open}
-                      onRequest={calendar.request}
-                      onReset={calendar.reset}
-                    />
-                  }
-                />
-              )}
+              <AppleCalendarSelection
+                leftAction={
+                  <TroubleShootingLink
+                    isPending={calendar.isPending}
+                    onOpen={calendar.open}
+                    onRequest={calendar.request}
+                    onReset={calendar.reset}
+                  />
+                }
+              />
             </div>
           )}
           {provider.nangoIntegrationId && (

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -429,7 +429,6 @@ msgstr "Bring your meeting history"
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr "Browser handoff not working? Paste the callback link instead"
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr "Confirm"
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -429,7 +429,6 @@ msgstr ""
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx
 #: src/settings/general/permissions.tsx
 #: src/sidebar/calendar.tsx
 #: src/sidebar/settings.tsx
@@ -749,6 +748,8 @@ msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
+#. placeholder {0}: provider.displayName
+#: src/calendar/components/sidebar.tsx
 #: src/instruction/index.tsx
 #: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"


### PR DESCRIPTION
Apple Calendar only ever has one account, so the pre-connect accordion
(chevron plus the red "Calendar" permission row with "Having trouble?"
and an arrow button) was noise. The provider row now shows only a plus
button before access is granted; clicking it (or the row) requests
calendar permission, or opens the permission panel when denied. The
chevron and cascading calendar list appear once access is authorized.
Drops the AccessPermissionRow usage from the calendar sidebar and
regenerates lingui catalogs for the new "Connect {name}" label.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized calendar sidebar UX and permission entry points only; no backend or auth logic changes.
> 
> **Overview**
> **Apple Calendar** in the calendar sidebar no longer expands into a permission accordion before macOS calendar access is granted. When permission is missing, the row shows only a **plus** control (and hides the chevron); tapping the row or the button runs **`handleAppleConnect`**—request permission, or open system settings when status is **denied**—with a loading spinner while pending.
> 
> After authorization, the accordion behaves as before: chevron, expanded **`AppleCalendarSelection`**, and **Having trouble?** via **`TroubleShootingLink`**. The in-panel **`AccessPermissionRow`** (“Calendar” permission row) is removed from this flow. Lingui catalogs pick up **`Connect {provider}`** for the new connect button aria-label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b790cb40050e70d2402a01536df249e86f0f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->