### PR TITLE
fix(web): make trailing-slash and legacy-page redirects permanent

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -123,6 +123,31 @@ to = "https://anarlog.so/:splat"
 status = 301
 force = true
 
+# Char-era marketing pages that no longer exist; 301 to keep backlink equity
+[[redirects]]
+from = "/pricing"
+to = "/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/faq"
+to = "/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/about"
+to = "/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/enterprise"
+to = "/"
+status = 301
+force = true
+
 [[redirects]]
 from = "/roadmap"
 to = "/changelog/"

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -24,13 +24,9 @@ Allow: /api/og/
 Allow: /blog
 Allow: /docs
 Allow: /changelog
-Allow: /pricing
-Allow: /enterprise
 Allow: /privacy
 Allow: /terms
 Allow: /download
-Allow: /faq
-Allow: /about
 
 # Disallow private or intentionally non-indexed routes
 Disallow: /product/

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -2,7 +2,7 @@ export const ANARLOG_SITE_URL = "https://anarlog.so";
 export const DEFAULT_OG_IMAGE_URL = `${ANARLOG_SITE_URL}/og.jpg`;
 
 /**
- * The site serves every page at a trailing-slash URL and 307-redirects the
+ * The site serves every page at a trailing-slash URL and 308-redirects the
  * bare form, so canonical tags, og:url, and sitemap entries must all carry the
  * slash or they point at a redirect.
  */

--- a/apps/web/src/middleware/trailing-slash.ts
+++ b/apps/web/src/middleware/trailing-slash.ts
@@ -1,0 +1,32 @@
+import { createMiddleware } from "@tanstack/react-start";
+
+// The router normalizes bare paths with a 307, which search engines treat as
+// temporary and keep the bare URL as a canonical candidate (GSC flagged
+// "Duplicate, Google chose different canonical than user"). Redirect
+// permanently here before the router runs. API routes serve at bare paths
+// today, so they must stay untouched.
+export const trailingSlashMiddleware = createMiddleware({
+  type: "request",
+}).server(({ next, request, pathname, serverFnMeta }) => {
+  const lastSegment = pathname.slice(pathname.lastIndexOf("/") + 1);
+  const isBarePagePath =
+    (request.method === "GET" || request.method === "HEAD") &&
+    !serverFnMeta &&
+    pathname !== "/" &&
+    !pathname.endsWith("/") &&
+    pathname !== "/api" &&
+    !pathname.startsWith("/api/") &&
+    !pathname.startsWith("/_") &&
+    !lastSegment.includes(".");
+
+  if (isBarePagePath) {
+    const url = new URL(request.url);
+    url.pathname = `${pathname}/`;
+    return new Response(null, {
+      status: 308,
+      headers: { Location: url.toString() },
+    });
+  }
+
+  return next();
+});

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -1,11 +1,14 @@
 import { createStart } from "@tanstack/react-start";
 
 import { prepareShareRoutePrivacy } from "./lib/share-route-privacy";
+import { trailingSlashMiddleware } from "./middleware/trailing-slash";
 import { bootstrapBrowserTelemetry } from "./telemetry";
 
 prepareShareRoutePrivacy();
 bootstrapBrowserTelemetry();
 
 export const startInstance = createStart(() => {
-  return {};
+  return {
+    requestMiddleware: [trailingSlashMiddleware],
+  };
 });


### PR DESCRIPTION
GSC flagged "Duplicate, Google chose different canonical than user"
because bare paths 307-redirect to their trailing-slash form, so Google
treated the bare URL as a canonical candidate. Add a request middleware
that 308-redirects bare page paths before the router issues its 307,
leaving /api, server functions, and file paths untouched. 301 the dead
char-era marketing pages (/pricing, /faq, /about, /enterprise) to the
homepage in netlify.toml and drop their stale robots.txt Allow entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SEO and routing-only changes with explicit exclusions for API and asset paths; no auth or data handling impact.
> 
> **Overview**
> Addresses Google Search Console **"Duplicate, Google chose different canonical than user"** by making bare-path → trailing-slash normalization permanent instead of the router’s temporary **307**.
> 
> A new **request middleware** runs before routing and returns **308** for GET/HEAD bare page paths (skipping `/api`, server functions, `/_` routes, and paths with file extensions). **`start.ts`** registers it; **`seo.ts`** documents the **308** behavior for canonical URLs.
> 
> **Netlify** adds **301** redirects from retired Char-era paths (`/pricing`, `/faq`, `/about`, `/enterprise`) to `/`. **`robots.txt`** drops **Allow** rules for those URLs so crawlers aren’t steered toward dead pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e4b50fbb614baf6baa2cd230291ebb9e9b3a7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->