### PR TITLE
fix(desktop): skip tray icon when appindicator library is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18057,6 +18057,7 @@ version = "0.1.0"
 dependencies = [
  "host",
  "intercept",
+ "libloading 0.8.9",
  "open",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,6 +311,7 @@ isolang = "2.4"
 itertools = "0.14.0"
 jsonschema = "0.46.0"
 lazy_static = "1.5.0"
+libloading = "0.8"
 moka = { version = "0.12", features = ["future"] }
 open = "5"
 regex = "1.12"

--- a/plugins/tray/Cargo.toml
+++ b/plugins/tray/Cargo.toml
@@ -39,3 +39,6 @@ unicode-width = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 anlg-intercept = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libloading = { workspace = true }

--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -128,11 +128,32 @@ pub struct Tray<'a, R: tauri::Runtime, M: tauri::Manager<R>> {
     _runtime: std::marker::PhantomData<fn() -> R>,
 }
 
+// libappindicator-sys panics at first use when it cannot dlopen any
+// appindicator library, so probe the same candidates before tray-icon
+// reaches it.
+#[cfg(target_os = "linux")]
+fn linux_tray_backend_available() -> bool {
+    [
+        "libayatana-appindicator3.so.1",
+        "libappindicator3.so.1",
+        "libayatana-appindicator3.so",
+        "libappindicator3.so",
+    ]
+    .iter()
+    .any(|name| unsafe { libloading::Library::new(name) }.is_ok())
+}
+
 impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
     pub fn create_tray_menu(&self) -> Result<()> {
         let app = self.manager.app_handle();
 
         if app.tray_by_id(TRAY_ID).is_some() {
+            return Ok(());
+        }
+
+        #[cfg(target_os = "linux")]
+        if !linux_tray_backend_available() {
+            tracing::warn!("appindicator_library_missing_skipping_tray_icon");
             return Ok(());
         }
 


### PR DESCRIPTION
libappindicator-sys panics at dlopen time when neither
libayatana-appindicator3 nor libappindicator3 is installed, crashing
Linux startup inside setup despite create_tray_menu returning Result
(Sentry HYPRNOTE2-2MRE, CachyOS user on 1.4.5). Probe the same library
candidates with libloading before building the tray and degrade to a
warning when none load.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Linux-only guard around optional tray setup; no auth or data paths, and failure mode is intentional degradation with a log warning.
> 
> **Overview**
> On **Linux**, tray creation no longer assumes **libayatana-appindicator3** / **libappindicator3** are installed. Before building the tray icon, the plugin **dlopens** the same library names the underlying stack would use; if none load, it logs **`appindicator_library_missing_skipping_tray_icon`** and returns success **without** creating a tray.
> 
> **`libloading`** is wired in as a **Linux-only** dependency on the tray plugin (workspace-level pin). The rest of the app should keep starting; users simply lose the system tray until the distro packages are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a273090a1475dc69c2256bddfb9197d7d2cdb8eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->