### PR TITLE
fix(desktop): keep startup alive when deep link registration fails

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -264,8 +264,12 @@ pub async fn main() {
             #[cfg(any(windows, target_os = "linux"))]
             {
                 // https://v2.tauri.app/ko/plugin/deep-linking/#desktop-1
+                // Registration shells out to update-desktop-database/xdg-mime on Linux,
+                // which are missing on NixOS; failing setup here panics the app.
                 use tauri_plugin_deep_link::DeepLinkExt;
-                app.deep_link().register_all()?;
+                if let Err(error) = app.deep_link().register_all() {
+                    tracing::warn!(%error, "failed to register deep link handlers");
+                }
             }
 
             {


### PR DESCRIPTION
On Linux, tauri-plugin-deep-link registration shells out to
update-desktop-database and xdg-mime, which are missing on NixOS. The
resulting error propagated out of the setup hook, and tauri panics with
"Failed to setup app" inside the run event loop (Sentry HYPRNOTE2-2MRD).
Log a warning and continue instead, since protocol handler registration
is non-essential.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow startup-path change; deep links may be unregistered on failure, but the app no longer crashes at launch.
> 
> **Overview**
> **Prevents desktop startup from aborting** when OS-level deep link registration fails on Windows/Linux.
> 
> During Tauri `setup`, `register_all()` no longer uses `?` to bubble errors. Failures are logged with `tracing::warn` and startup continues, since custom URL protocol registration is optional for core app behavior.
> 
> Comments document that on Linux the plugin shells out to `update-desktop-database` / `xdg-mime`, which are often absent on NixOS and previously caused a setup panic (“Failed to setup app”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bea169c46c2fe7df86f94b2c0e0b20d9a67e0b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->