### PR TITLE
chore(changelog): cover contacts, chrome polish, and Linux startup fixes

### DIFF
--- a/packages/changelog/content/1.4.6.md
+++ b/packages/changelog/content/1.4.6.md
@@ -11,6 +11,9 @@ summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30
   Notion page
 - Set each automation up in settings with pickers for the destination, an
   enable/disable switch, and a status line showing the last run
+- Browse automations from a sidebar list and open each one's detail view,
+  with its own chat thread kept per automation and a plus button that starts
+  a fresh draft
 
 ## Transcripts
 
@@ -34,6 +37,7 @@ summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30
   your favorites on top, plus a shortcut to create a new template
 - Keep the template you chose before a meeting when the summary is generated,
   including your edited section headings
+- Rename a template and change its icon right from the details toolbar
 
 ## Importing
 
@@ -41,6 +45,14 @@ summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30
   Granola, Otter, Fireflies, Fathom, Notion AI Meeting Notes, and Zoom
 - See only the apps actually installed on your machine, with their icons and
   per-app import instructions
+
+## Contacts
+
+- Put a real photo on a person or organization by clicking their avatar;
+  uploads are compressed automatically and shown across contact lists and
+  pages, with a menu action to remove the photo
+- Scroll each contact page as one piece, with pin and delete actions in a
+  compact header menu
 
 ## Sharing
 
@@ -59,6 +71,12 @@ summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30
 - Follow system light and dark appearance reliably, with the Dock icon now
   matching your theme choice automatically instead of a separate toggle
 - Read documents with a heading scale that no longer competes with the title
+- Connect Apple Calendar with a single click from the calendar list instead
+  of an expandable permission row
+- See one back button and evenly aligned header icons in Settings, Calendar,
+  Contacts, Templates, and Automations, without a redundant sidebar title
+- Get a tidier chat panel: tighter input padding, header icons aligned with
+  the sidebar, and a placeholder that fits narrow widths
 
 ## Fixes
 
@@ -70,3 +88,5 @@ summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30
 - Use the header buttons in Settings, Calendar, and Automations views that the
   window controls previously covered
 - Keep app sounds from crashing the app on Linux
+- Start the app on Linux systems that are missing the tray icon library or
+  desktop protocol-handler tools instead of crashing at launch


### PR DESCRIPTION
The 1.4.6 entry predates today's merged sweep. Add a Contacts section
for avatar uploads and the unified contact page scroll, extend
Automations with the sidebar detail views, and note template toolbar
renaming, the one-click Apple Calendar connect, the sidebar and chat
chrome cleanups, and the Linux tray and deep-link startup crash fixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or security impact.
> 
> **Overview**
> Expands **`packages/changelog/content/1.4.6.md`** so the 1.4.6 release notes match recently shipped work that was missing from the entry.
> 
> **Automations** now documents browsing automations from a sidebar, opening per-automation detail views, dedicated chat threads, and a plus control for new drafts. **Memos and templates** adds rename-and-icon editing from the details toolbar. A new **Contacts** section covers avatar upload (with compression and remove-photo), plus unified scrolling and a compact header menu for pin/delete.
> 
> **Settings and appearance** gains one-click Apple Calendar connect, consistent back buttons and header alignment across workspace views (without a redundant sidebar title), and chat panel spacing/placeholder tweaks. **Fixes** adds Linux launch resilience when tray or protocol-handler dependencies are absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0685d9c975a163eaf7bffda2077a5c264965804c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->