### PR TITLE
fix(ci): upload Windows debug symbols to Sentry

### DIFF
--- a/.github/actions/sentry_cli/action.yaml
+++ b/.github/actions/sentry_cli/action.yaml
@@ -5,7 +5,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="${{ inputs.version }}" sh
+    - if: runner.os != 'Windows'
+      run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="${{ inputs.version }}" sh
       shell: bash
+    - if: runner.os == 'Windows'
+      run: |
+        $dir = Join-Path $env:RUNNER_TEMP "sentry-cli"
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+        Invoke-WebRequest `
+          "https://downloads.sentry-cdn.com/sentry-cli/${{ inputs.version }}/sentry-cli-Windows-x86_64.exe" `
+          -OutFile (Join-Path $dir "sentry-cli.exe")
+        Add-Content $env:GITHUB_PATH $dir
+      shell: pwsh
     - run: sentry-cli --version
       shell: bash

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -622,6 +622,7 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           VITE_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN_HYPRNOTE_2 }}
+          CARGO_PROFILE_RELEASE_DEBUG: line-tables-only
           APP_VERSION: ${{ needs.compute-version.outputs.version }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -631,6 +632,43 @@ jobs:
           VITE_API_URL: https://api.anarlog.so
           VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
           VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
+      - if: ${{ inputs.channel == 'stable' }}
+        uses: ./.github/actions/sentry_cli
+      - if: ${{ inputs.channel == 'stable' }}
+        name: Upload Windows debug symbols to Sentry
+        shell: bash
+        env:
+          INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
+          INFISICAL_TOKEN: ${{ secrets.INFISICAL_SENTRY_TOKEN }}
+        run: |
+          release_dir="apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release"
+          if [[ ! -f "$release_dir/anarlog.pdb" ]]; then
+            echo "::error::Missing anarlog.pdb next to the Windows binary"
+            exit 1
+          fi
+          sentry-cli debug-files check "$release_dir/anarlog.pdb"
+
+          response=$(
+            curl --fail --silent --show-error --get \
+              --header "Authorization: Bearer $INFISICAL_TOKEN" \
+              --data-urlencode "projectId=$INFISICAL_PROJECT_ID" \
+              --data-urlencode "environment=prod" \
+              --data-urlencode "secretPath=/anarlog/github" \
+              --data-urlencode "expandSecretReferences=false" \
+              "https://app.infisical.com/api/v4/secrets/SENTRY_AUTH_TOKEN"
+          )
+          if ! SENTRY_AUTH_TOKEN=$(jq -er '.secret.secretValue | select(length > 0)' <<< "$response"); then
+            echo "::error::Missing SENTRY_AUTH_TOKEN in Infisical prod:/anarlog/github"
+            exit 1
+          fi
+          export SENTRY_AUTH_TOKEN
+
+          sentry-cli debug-files upload \
+            --org fastrepl \
+            --project hyprnote2 \
+            --include-sources \
+            "$release_dir/anarlog.exe" \
+            "$release_dir/anarlog.pdb"
       - if: ${{ inputs.channel == 'stable' }}
         name: Sign in to Azure
         uses: azure/login@v3


### PR DESCRIPTION
Windows crash reports arrive unsymbolicated — the app frames in [HYPRNOTE2-2MRF](https://fastrepl.sentry.io/issues/7660082131/) (`STATUS_HEAP_CORRUPTION` in 1.4.5) show as `anarlog +0x… <unknown>`, and Sentry reports the debug file for `anarlog.exe` as missing. The Windows release build never emits a usable PDB and nothing uploads one, unlike the macOS and Linux jobs.

Changes:

- Set `CARGO_PROFILE_RELEASE_DEBUG: line-tables-only` on the Windows tauri build, matching macOS/Linux, so the MSVC linker emits a PDB with line tables.
- Add a stable-only step in `build-windows` that verifies the PDB exists, runs `sentry-cli debug-files check`, fetches `SENTRY_AUTH_TOKEN` from Infisical, and uploads `anarlog.exe` + `anarlog.pdb` to `fastrepl/hyprnote2` — mirroring the existing macOS/Linux upload steps.
- Teach the shared `sentry_cli` action to install on Windows runners by downloading the pinned Windows binary from the Sentry CDN (the `curl | sh` installer is Unix-only).

Forward-looking only: the existing 1.4.5 event cannot be retro-symbolicated since no PDB exists for that build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI and release observability; stable Windows builds may fail if PDB generation or Sentry upload breaks, but app runtime behavior is unchanged.
> 
> **Overview**
> **Stable Windows desktop builds** will emit and upload debug symbols so Sentry can symbolicate crash reports, matching what macOS and Linux already do.
> 
> The Windows `tauri build` job now sets **`CARGO_PROFILE_RELEASE_DEBUG: line-tables-only`** so MSVC produces a PDB with line tables. On **stable** only, CI installs `sentry-cli`, fails fast if `anarlog.pdb` is missing, runs `debug-files check`, loads **`SENTRY_AUTH_TOKEN`** from Infisical, and uploads **`anarlog.exe`** and **`anarlog.pdb`** to **`fastrepl/hyprnote2`** with `--include-sources`.
> 
> The shared **`sentry_cli`** composite action is split by OS: Unix runners still use the `curl | sh` installer; **Windows** downloads the pinned **`sentry-cli`** binary from the Sentry CDN and adds it to **`PATH`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f12816a0af49a0e39b4665c5ea3c8cc7150d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->