### PR TITLE
fix(desktop): resurface dismissed update toast until installed

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -33,6 +33,7 @@ import { EventListeners } from "./services/event-listeners";
 import { TaskManager } from "./services/task-manager";
 import { TrayRecordingSync } from "./services/tray-recording";
 import { TrayScheduleSync } from "./services/tray-schedule";
+import { UpdaterMeetingSync } from "./services/updater-meeting";
 import { useRemoteSessionDeletionUndoListener } from "./session/hooks/useDeleteSession";
 import { refreshLegacySettingsSnapshots } from "./settings/legacy-snapshots";
 import { migratePlaintextAiProviderApiKeys } from "./settings/providers";
@@ -101,6 +102,7 @@ function AppRoot() {
         {isMainWindow ? <EventListeners /> : null}
         {isMainWindow ? <TrayScheduleSync /> : null}
         {isMainWindow ? <TrayRecordingSync /> : null}
+        {isMainWindow ? <UpdaterMeetingSync /> : null}
         <Toaster position="bottom-right" theme={theme} />
       </TinyTickProvider>
     </QueryClientProvider>

--- a/apps/desktop/src/services/updater-meeting.tsx
+++ b/apps/desktop/src/services/updater-meeting.tsx
@@ -1,0 +1,44 @@
+import { useStore } from "zustand";
+
+import { commands as updaterCommands } from "@anlg/plugin-updater2";
+
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+import { listenerStore } from "~/store/zustand/listener/instance";
+
+// Serialized so rapid start/stop transitions publish in order.
+const publishMeetingActive = (() => {
+  let queue = Promise.resolve();
+  return (active: boolean) => {
+    const publication = queue.then(async () => {
+      await updaterCommands.setMeetingActive(active);
+    });
+    queue = publication.catch(() => undefined);
+    return publication;
+  };
+})();
+
+// Mirrors live-meeting state into the updater2 plugin so the Rust side never
+// auto-installs (restarting the app) or auto-downloads during a recording.
+export function UpdaterMeetingSync() {
+  const meetingActive = useStore(
+    listenerStore,
+    (state) => state.live.status === "active",
+  );
+
+  return (
+    <UpdaterMeetingPublisher
+      key={String(meetingActive)}
+      active={meetingActive}
+    />
+  );
+}
+
+function UpdaterMeetingPublisher({ active }: { active: boolean }) {
+  useMountEffect(() => {
+    void publishMeetingActive(active).catch((error) => {
+      console.error("[updater] failed to publish meeting state", error);
+    });
+  });
+
+  return null;
+}

--- a/apps/desktop/src/services/updater-meeting.tsx
+++ b/apps/desktop/src/services/updater-meeting.tsx
@@ -22,7 +22,8 @@ const publishMeetingActive = (() => {
 export function UpdaterMeetingSync() {
   const meetingActive = useStore(
     listenerStore,
-    (state) => state.live.status === "active",
+    (state) =>
+      state.live.status === "active" || state.live.status === "finalizing",
   );
 
   return (

--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -380,7 +380,7 @@ describe("ToastNotifications", () => {
     );
   });
 
-  it("resurfaces the update notice when the main window is shown again", () => {
+  it("resurfaces the update notice only after the main window is hidden and shown again", () => {
     mocks.update.status = "available";
     mocks.update.version = "1.0.34";
 
@@ -391,10 +391,22 @@ describe("ToastNotifications", () => {
     act(() => firstOptions.onDismiss());
     mocks.message.mockClear();
 
+    // A show without a prior hide (e.g. dock Reopen while visible) keeps the snooze.
     act(() => {
       mocks.visibilityHandlers.forEach((handler) =>
         handler({ payload: { window: { type: "main" }, visible: true } }),
       );
+    });
+    expect(mocks.message).not.toHaveBeenCalledWith(
+      "Anarlog 1.0.34 is available",
+      expect.anything(),
+    );
+
+    act(() => {
+      mocks.visibilityHandlers.forEach((handler) => {
+        handler({ payload: { window: { type: "main" }, visible: false } });
+        handler({ payload: { window: { type: "main" }, visible: true } });
+      });
     });
 
     expect(mocks.message).toHaveBeenCalledWith(

--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -15,6 +15,13 @@ const mocks = vi.hoisted(() => ({
   dismiss: vi.fn(),
   dismissedToastIds: new Set<string>(),
   sessionMode: "inactive",
+  live: {
+    status: "inactive" as "inactive" | "active" | "finalizing",
+    sessionId: null as string | null,
+  },
+  visibilityHandlers: [] as Array<
+    (event: { payload: { window: { type: string }; visible: boolean } }) => void
+  >,
   currentTab: {
     type: "empty",
   } as {
@@ -48,6 +55,26 @@ const mocks = vi.hoisted(() => ({
     installing: false,
     downloadUpdate: vi.fn(),
     installUpdate: vi.fn(),
+  },
+}));
+
+vi.mock("@anlg/plugin-windows", () => ({
+  events: {
+    visibilityEvent: {
+      listen: (
+        handler: (event: {
+          payload: { window: { type: string }; visible: boolean };
+        }) => void,
+      ) => {
+        mocks.visibilityHandlers.push(handler);
+        return Promise.resolve(() => {
+          const index = mocks.visibilityHandlers.indexOf(handler);
+          if (index !== -1) {
+            mocks.visibilityHandlers.splice(index, 1);
+          }
+        });
+      },
+    },
   },
 }));
 
@@ -119,8 +146,11 @@ vi.mock("~/stt/capabilities", () => ({
 
 vi.mock("~/stt/contexts", () => ({
   useListener: (
-    selector: (state: { getSessionMode: () => string }) => unknown,
-  ) => selector({ getSessionMode: () => mocks.sessionMode }),
+    selector: (state: {
+      getSessionMode: () => string;
+      live: typeof mocks.live;
+    }) => unknown,
+  ) => selector({ getSessionMode: () => mocks.sessionMode, live: mocks.live }),
 }));
 
 vi.mock("./useDismissedToasts", () => ({
@@ -143,6 +173,8 @@ describe("ToastNotifications", () => {
     mocks.loading.mockClear();
     mocks.dismiss.mockClear();
     mocks.dismissedToastIds.clear();
+    mocks.live = { status: "inactive", sessionId: null };
+    mocks.visibilityHandlers.length = 0;
     mocks.openNew.mockClear();
     mocks.updateSettingsTabState.mockClear();
     mocks.currentTab = { type: "empty" };
@@ -247,11 +279,11 @@ describe("ToastNotifications", () => {
     expect(mocks.openNew).not.toHaveBeenCalled();
   });
 
-  it("dismisses update notices only for the current launch", () => {
+  it("snoozes dismissed update notices without persisting them", () => {
     mocks.update.status = "available";
     mocks.update.version = "1.0.34";
 
-    const firstLaunch = render(<ToastNotifications />);
+    const view = render(<ToastNotifications />);
     act(() => vi.advanceTimersByTime(500));
 
     const firstOptions = mocks.message.mock.calls[0][1];
@@ -266,10 +298,104 @@ describe("ToastNotifications", () => {
     act(() => firstOptions.onDismiss());
     expect(mocks.dismissToast).not.toHaveBeenCalled();
 
+    mocks.message.mockClear();
+    view.rerender(<ToastNotifications />);
+    expect(mocks.message).not.toHaveBeenCalledWith(
+      "Anarlog 1.0.34 is available",
+      expect.anything(),
+    );
+  });
+
+  it("resurfaces the update notice on relaunch", () => {
+    mocks.update.status = "available";
+    mocks.update.version = "1.0.34";
+
+    const firstLaunch = render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+
+    const firstOptions = mocks.message.mock.calls[0][1];
+    act(() => firstOptions.onDismiss());
+
     firstLaunch.unmount();
     mocks.message.mockClear();
     render(<ToastNotifications />);
     act(() => vi.advanceTimersByTime(500));
+
+    expect(mocks.message).toHaveBeenCalledWith(
+      "Anarlog 1.0.34 is available",
+      expect.objectContaining({ id: "desktop-update:1.0.34" }),
+    );
+  });
+
+  it("hides the update notice while a meeting is recording and resurfaces it after", () => {
+    mocks.update.status = "available";
+    mocks.update.version = "1.0.34";
+
+    const view = render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+
+    expect(mocks.message).toHaveBeenCalledWith(
+      "Anarlog 1.0.34 is available",
+      expect.objectContaining({ id: "desktop-update:1.0.34" }),
+    );
+
+    mocks.live = { status: "active", sessionId: "meeting-1" };
+    view.rerender(<ToastNotifications />);
+    expect(mocks.dismiss).toHaveBeenCalledWith("desktop-update:1.0.34");
+
+    mocks.message.mockClear();
+    mocks.live = { status: "inactive", sessionId: null };
+    view.rerender(<ToastNotifications />);
+
+    expect(mocks.message).toHaveBeenCalledWith(
+      "Anarlog 1.0.34 is available",
+      expect.objectContaining({ id: "desktop-update:1.0.34" }),
+    );
+  });
+
+  it("resurfaces a dismissed update notice after a meeting ends", () => {
+    mocks.update.status = "available";
+    mocks.update.version = "1.0.34";
+
+    const view = render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+
+    const firstOptions = mocks.message.mock.calls[0][1];
+    act(() => firstOptions.onDismiss());
+
+    mocks.message.mockClear();
+    mocks.live = { status: "active", sessionId: "meeting-1" };
+    view.rerender(<ToastNotifications />);
+    expect(mocks.message).not.toHaveBeenCalledWith(
+      "Anarlog 1.0.34 is available",
+      expect.anything(),
+    );
+
+    mocks.live = { status: "inactive", sessionId: null };
+    view.rerender(<ToastNotifications />);
+
+    expect(mocks.message).toHaveBeenCalledWith(
+      "Anarlog 1.0.34 is available",
+      expect.objectContaining({ id: "desktop-update:1.0.34" }),
+    );
+  });
+
+  it("resurfaces the update notice when the main window is shown again", () => {
+    mocks.update.status = "available";
+    mocks.update.version = "1.0.34";
+
+    render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+
+    const firstOptions = mocks.message.mock.calls[0][1];
+    act(() => firstOptions.onDismiss());
+    mocks.message.mockClear();
+
+    act(() => {
+      mocks.visibilityHandlers.forEach((handler) =>
+        handler({ payload: { window: { type: "main" }, visible: true } }),
+      );
+    });
 
     expect(mocks.message).toHaveBeenCalledWith(
       "Anarlog 1.0.34 is available",

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 
+import { events as windowsEvents } from "@anlg/plugin-windows";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 
 import {
@@ -31,9 +32,12 @@ export function ToastNotifications() {
   const auth = useAuth();
   const cloudsyncProgress = useCloudsyncInitialSyncProgress();
   const { dismissToast, isDismissed } = useDismissedToasts();
-  const [dismissedForLaunch, setDismissedForLaunch] = useState<Set<string>>(
-    () => new Set(),
-  );
+  // Update-toast dismissals are only a snooze: they expire when a meeting
+  // ends, when the main window is shown again, or on relaunch — so the toast
+  // keeps resurfacing until the update is installed.
+  const [snoozedUpdateToastId, setSnoozedUpdateToastId] = useState<
+    string | null
+  >(null);
   const shouldShowToast = useShouldShowToast();
   const {
     hasActiveDownload,
@@ -88,6 +92,43 @@ export function ToastNotifications() {
       ? state.getSessionMode(activeTranscriptSessionId) === "running_batch"
       : false,
   );
+  const activeLiveSessionId = useListener((state) =>
+    state.live.status === "active" ? state.live.sessionId : null,
+  );
+  const isLiveMeetingActive = activeLiveSessionId !== null;
+
+  const [lastLiveSessionId, setLastLiveSessionId] =
+    useState(activeLiveSessionId);
+  if (lastLiveSessionId !== activeLiveSessionId) {
+    setLastLiveSessionId(activeLiveSessionId);
+    if (lastLiveSessionId !== null) {
+      setSnoozedUpdateToastId(null);
+    }
+  }
+
+  useMountEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    void windowsEvents.visibilityEvent
+      .listen(({ payload }) => {
+        if (payload.window.type === "main" && payload.visible) {
+          setSnoozedUpdateToastId(null);
+        }
+      })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  });
 
   const openNew = useTabs((state) => state.openNew);
   const updateSettingsTabState = useTabs(
@@ -131,6 +172,7 @@ export function ToastNotifications() {
         isAiTranscriptionTabActive,
         isAiIntelligenceTabActive,
         isBatchTranscribingInActiveTranscriptTab,
+        isLiveMeetingActive,
         cloudsyncInitialSyncToastId:
           cloudsyncProgress.state === "syncing"
             ? cloudsyncProgress.toastId
@@ -155,6 +197,7 @@ export function ToastNotifications() {
       isAiTranscriptionTabActive,
       isAiIntelligenceTabActive,
       isBatchTranscribingInActiveTranscriptTab,
+      isLiveMeetingActive,
       cloudsyncProgress,
       hasActiveDownload,
       downloadingModel,
@@ -172,10 +215,10 @@ export function ToastNotifications() {
     () =>
       getToastToShow(registry, (id) =>
         isDesktopUpdateToastId(id)
-          ? dismissedForLaunch.has(id)
+          ? snoozedUpdateToastId === id
           : isDismissed(id),
       ),
-    [dismissedForLaunch, registry, isDismissed],
+    [snoozedUpdateToastId, registry, isDismissed],
   );
   const devtoolsToast = useMemo(
     () =>
@@ -207,11 +250,7 @@ export function ToastNotifications() {
 
     if (currentToast) {
       if (isDesktopUpdateToastId(currentToast.id)) {
-        setDismissedForLaunch((dismissed) => {
-          const nextDismissed = new Set(dismissed);
-          nextDismissed.add(currentToast.id);
-          return nextDismissed;
-        });
+        setSnoozedUpdateToastId(currentToast.id);
         return;
       }
       dismissToast(currentToast.id);

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -93,7 +93,9 @@ export function ToastNotifications() {
       : false,
   );
   const activeLiveSessionId = useListener((state) =>
-    state.live.status === "active" ? state.live.sessionId : null,
+    state.live.status === "active" || state.live.status === "finalizing"
+      ? state.live.sessionId
+      : null,
   );
   const isLiveMeetingActive = activeLiveSessionId !== null;
 
@@ -109,10 +111,19 @@ export function ToastNotifications() {
   useMountEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | undefined;
+    // Main.show() emits visible:true even when the window is already visible
+    // (e.g. dock Reopen), so only a show that follows a hide clears the snooze.
+    let mainWindowWasHidden = false;
 
     void windowsEvents.visibilityEvent
       .listen(({ payload }) => {
-        if (payload.window.type === "main" && payload.visible) {
+        if (payload.window.type !== "main") {
+          return;
+        }
+        if (!payload.visible) {
+          mainWindowWasHidden = true;
+        } else if (mainWindowWasHidden) {
+          mainWindowWasHidden = false;
           setSnoozedUpdateToastId(null);
         }
       })

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -16,6 +16,7 @@ const baseParams = {
   isAiTranscriptionTabActive: false,
   isAiIntelligenceTabActive: false,
   isBatchTranscribingInActiveTranscriptTab: false,
+  isLiveMeetingActive: false,
   cloudsyncInitialSyncToastId: null,
   hasActiveDownload: false,
   downloadingModel: null,
@@ -208,6 +209,23 @@ describe("sidebar toast registry", () => {
 
     toast?.primaryAction?.onClick();
     expect(downloadUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("hides the desktop update toast while a meeting is recording", () => {
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        isLiveMeetingActive: true,
+        update: {
+          ...baseParams.update,
+          status: "available",
+          version: "1.0.34",
+        },
+      }),
+      () => false,
+    );
+
+    expect(toast).toBeNull();
   });
 
   it("keeps desktop update progress in the toast", () => {

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -23,6 +23,7 @@ type ToastRegistryParams = {
   isAiTranscriptionTabActive: boolean;
   isAiIntelligenceTabActive: boolean;
   isBatchTranscribingInActiveTranscriptTab: boolean;
+  isLiveMeetingActive: boolean;
   cloudsyncInitialSyncToastId: string | null;
   hasActiveDownload: boolean;
   downloadingModel: string | null;
@@ -52,6 +53,7 @@ export function createToastRegistry({
   isAiTranscriptionTabActive,
   isAiIntelligenceTabActive,
   isBatchTranscribingInActiveTranscriptTab,
+  isLiveMeetingActive,
   cloudsyncInitialSyncToastId,
   hasActiveDownload,
   downloadingModel,
@@ -99,7 +101,8 @@ export function createToastRegistry({
       ? [
           {
             toast: updateToast,
-            condition: () => true,
+            // Never show update prompts mid-meeting; they resurface after.
+            condition: () => !isLiveMeetingActive,
           },
         ]
       : []),

--- a/plugins/updater2/build.rs
+++ b/plugins/updater2/build.rs
@@ -6,6 +6,7 @@ const COMMANDS: &[&str] = &[
     "maybe_emit_updated",
     "postinstall",
     "set_automatic_updates_enabled",
+    "set_meeting_active",
 ];
 
 fn main() {

--- a/plugins/updater2/js/bindings.gen.ts
+++ b/plugins/updater2/js/bindings.gen.ts
@@ -54,6 +54,9 @@ async setAutomaticUpdatesEnabled(enabled: boolean) : Promise<Result<null, string
     else return { status: "error", error: e  as any };
 }
 },
+async setMeetingActive(active: boolean) : Promise<void> {
+    await TAURI_INVOKE("plugin:updater2|set_meeting_active", { active });
+},
 async maybeEmitUpdated() : Promise<void> {
     await TAURI_INVOKE("plugin:updater2|maybe_emit_updated");
 }

--- a/plugins/updater2/permissions/autogenerated/commands/set_meeting_active.toml
+++ b/plugins/updater2/permissions/autogenerated/commands/set_meeting_active.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-set-meeting-active"
+description = "Enables the set_meeting_active command without any pre-configured scope."
+commands.allow = ["set_meeting_active"]
+
+[[permission]]
+identifier = "deny-set-meeting-active"
+description = "Denies the set_meeting_active command without any pre-configured scope."
+commands.deny = ["set_meeting_active"]

--- a/plugins/updater2/permissions/autogenerated/reference.md
+++ b/plugins/updater2/permissions/autogenerated/reference.md
@@ -11,6 +11,7 @@ Default permissions for the plugin
 - `allow-postinstall`
 - `allow-maybe-emit-updated`
 - `allow-set-automatic-updates-enabled`
+- `allow-set-meeting-active`
 
 ## Permission Table
 
@@ -199,6 +200,32 @@ Enables the set_automatic_updates_enabled command without any pre-configured sco
 <td>
 
 Denies the set_automatic_updates_enabled command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`updater2:allow-set-meeting-active`
+
+</td>
+<td>
+
+Enables the set_meeting_active command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`updater2:deny-set-meeting-active`
+
+</td>
+<td>
+
+Denies the set_meeting_active command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/updater2/permissions/default.toml
+++ b/plugins/updater2/permissions/default.toml
@@ -1,3 +1,3 @@
 [default]
 description = "Default permissions for the plugin"
-permissions = ["allow-check", "allow-download", "allow-install", "allow-is-downloaded", "allow-postinstall", "allow-maybe-emit-updated", "allow-set-automatic-updates-enabled"]
+permissions = ["allow-check", "allow-download", "allow-install", "allow-is-downloaded", "allow-postinstall", "allow-maybe-emit-updated", "allow-set-automatic-updates-enabled", "allow-set-meeting-active"]

--- a/plugins/updater2/permissions/schemas/schema.json
+++ b/plugins/updater2/permissions/schemas/schema.json
@@ -379,10 +379,22 @@
           "markdownDescription": "Denies the set_automatic_updates_enabled command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-is-downloaded`\n- `allow-postinstall`\n- `allow-maybe-emit-updated`\n- `allow-set-automatic-updates-enabled`",
+          "description": "Enables the set_meeting_active command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-set-meeting-active",
+          "markdownDescription": "Enables the set_meeting_active command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_meeting_active command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-set-meeting-active",
+          "markdownDescription": "Denies the set_meeting_active command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-is-downloaded`\n- `allow-postinstall`\n- `allow-maybe-emit-updated`\n- `allow-set-automatic-updates-enabled`\n- `allow-set-meeting-active`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-is-downloaded`\n- `allow-postinstall`\n- `allow-maybe-emit-updated`\n- `allow-set-automatic-updates-enabled`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-is-downloaded`\n- `allow-postinstall`\n- `allow-maybe-emit-updated`\n- `allow-set-automatic-updates-enabled`\n- `allow-set-meeting-active`"
         }
       ]
     }

--- a/plugins/updater2/src/commands.rs
+++ b/plugins/updater2/src/commands.rs
@@ -66,6 +66,12 @@ pub(crate) fn set_automatic_updates_enabled<R: tauri::Runtime>(
 
 #[tauri::command]
 #[specta::specta]
+pub(crate) fn set_meeting_active<R: tauri::Runtime>(app: tauri::AppHandle<R>, active: bool) {
+    app.updater2().set_meeting_active(active);
+}
+
+#[tauri::command]
+#[specta::specta]
 pub(crate) fn maybe_emit_updated<R: tauri::Runtime>(app: tauri::AppHandle<R>) {
     app.updater2().maybe_emit_updated();
 }

--- a/plugins/updater2/src/ext.rs
+++ b/plugins/updater2/src/ext.rs
@@ -13,6 +13,8 @@ use crate::events::{
 static DOWNLOAD_MUTEX: LazyLock<tokio::sync::Mutex<()>> =
     LazyLock::new(|| tokio::sync::Mutex::new(()));
 
+static MEETING_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum InstallResult {
@@ -37,6 +39,14 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Updater2<'a, R, M> {
         let store = self.manager.store2().scoped_store(crate::PLUGIN_NAME)?;
         store.set(crate::StoreKey::AutomaticUpdatesEnabled, enabled)?;
         Ok(())
+    }
+
+    pub fn meeting_active(&self) -> bool {
+        MEETING_ACTIVE.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn set_meeting_active(&self, active: bool) {
+        MEETING_ACTIVE.store(active, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub fn get_last_seen_version(&self) -> Result<Option<String>, crate::Error> {

--- a/plugins/updater2/src/lib.rs
+++ b/plugins/updater2/src/lib.rs
@@ -23,6 +23,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::is_downloaded::<tauri::Wry>,
             commands::postinstall::<tauri::Wry>,
             commands::set_automatic_updates_enabled::<tauri::Wry>,
+            commands::set_meeting_active::<tauri::Wry>,
             commands::maybe_emit_updated::<tauri::Wry>,
         ])
         .events(tauri_specta::collect_events![
@@ -83,6 +84,13 @@ async fn check_and_download<R: tauri::Runtime>(
             tracing::error!("automatic_update_policy_read_failed: {}", e);
             return;
         }
+    }
+
+    // Never install (which restarts the app) or download while a meeting is
+    // being recorded; the next 30-minute tick retries after the meeting.
+    if updater2.meeting_active() {
+        tracing::info!("automatic_update_deferred_meeting_active");
+        return;
     }
 
     let version = match updater2.check().await {

--- a/plugins/updater2/src/lib.rs
+++ b/plugins/updater2/src/lib.rs
@@ -56,8 +56,10 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
             tauri::async_runtime::spawn(async move {
                 let mut install_cached_update = true;
                 loop {
-                    check_and_download(&handle, install_cached_update).await;
-                    install_cached_update = false;
+                    let deferred = check_and_download(&handle, install_cached_update).await;
+                    if !deferred {
+                        install_cached_update = false;
+                    }
                     tokio::time::sleep(std::time::Duration::from_secs(30 * 60)).await;
                 }
             });
@@ -67,22 +69,24 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
         .build()
 }
 
+// Returns true when deferred because a meeting is active, so the caller keeps
+// the cached-install intent for the next tick.
 async fn check_and_download<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     install_cached_update: bool,
-) {
+) -> bool {
     if cfg!(debug_assertions) {
-        return;
+        return false;
     }
 
     let updater2 = app.updater2();
 
     match updater2.automatic_updates_enabled() {
         Ok(true) => {}
-        Ok(false) => return,
+        Ok(false) => return false,
         Err(e) => {
             tracing::error!("automatic_update_policy_read_failed: {}", e);
-            return;
+            return false;
         }
     }
 
@@ -90,22 +94,22 @@ async fn check_and_download<R: tauri::Runtime>(
     // being recorded; the next 30-minute tick retries after the meeting.
     if updater2.meeting_active() {
         tracing::info!("automatic_update_deferred_meeting_active");
-        return;
+        return true;
     }
 
     let version = match updater2.check().await {
         Ok(Some(v)) => v,
-        Ok(None) => return,
+        Ok(None) => return false,
         Err(e) => {
             tracing::error!("update_check_failed: {}", e);
-            return;
+            return false;
         }
     };
 
     // A meeting may have started while the check was in flight.
     if updater2.meeting_active() {
         tracing::info!("automatic_update_deferred_meeting_active");
-        return;
+        return true;
     }
 
     if install_cached_update && updater2.has_cached_update(&version) {
@@ -113,19 +117,20 @@ async fn check_and_download<R: tauri::Runtime>(
             Ok(result) => result,
             Err(e) => {
                 tracing::error!("cached_update_install_failed: {}", e);
-                return;
+                return false;
             }
         };
 
         if let Err(e) = updater2.postinstall(result).await {
             tracing::error!("cached_update_relaunch_failed: {}", e);
         }
-        return;
+        return false;
     }
 
     if let Err(e) = updater2.download(&version).await {
         tracing::error!("update_download_failed: {}", e);
     }
+    false
 }
 
 #[cfg(test)]

--- a/plugins/updater2/src/lib.rs
+++ b/plugins/updater2/src/lib.rs
@@ -102,6 +102,12 @@ async fn check_and_download<R: tauri::Runtime>(
         }
     };
 
+    // A meeting may have started while the check was in flight.
+    if updater2.meeting_active() {
+        tracing::info!("automatic_update_deferred_meeting_active");
+        return;
+    }
+
     if install_cached_update && updater2.has_cached_update(&version) {
         let result = match updater2.install(&version).await {
             Ok(result) => result,


### PR DESCRIPTION
Dismissing the desktop-update toast used to hide it for the whole app
launch, so users who dismissed it mid-meeting rarely came back to it.
Dismissal is now only a snooze: it expires when the meeting that was
active at dismissal ends, when the main window is shown again after
Cmd+W/dock reopen (via the windows plugin visibilityEvent), and on
relaunch, so the toast keeps resurfacing until the update is installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automatic update install/relaunch timing and meeting-gated behavior in Rust; UI-only snooze logic is lower risk but affects when users see update prompts.
> 
> **Overview**
> **Update toast dismissals are now a snooze**, not a per-launch hide: closing the desktop-update toast no longer writes to persistent dismiss storage. The snooze clears when a live meeting ends, when the main window is shown again after a hide (`visibilityEvent`, ignoring dock “Reopen” while already visible), or on relaunch—so the notice can keep coming back until the update is installed.
> 
> **During active or finalizing recordings**, update toasts are suppressed in the registry and dismissed in the UI; snoozed notices can return when the meeting ends. **`UpdaterMeetingSync`** publishes live-meeting state to **updater2** (`setMeetingActive`, serialized on rapid transitions).
> 
> **Automatic background updates** in updater2 now skip check, download, and install (including cached relaunch) while a meeting is marked active, retrying on the next 30-minute tick and preserving cached-install intent when deferred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b90ffb52d8d9c325d687fedd0c7fb61dddd5aeb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->