### PR TITLE
fix(desktop): never generate summaries for too-short transcripts

### DIFF
--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -890,6 +890,51 @@ describe("EnhancerService", () => {
     });
   });
 
+  it("retires a durable job when the transcript stays too short", async () => {
+    vi.useFakeTimers();
+    snapshot = createSnapshot({ wordCount: 1 });
+    const service = new EnhancerService(createDeps());
+    const pendingJob = createPendingJob();
+
+    service.queueAutoEnhance("session-1", pendingJob);
+    await vi.advanceTimersByTimeAsync(10_500);
+
+    expect(mocks.discardPendingAutoEnhanceJob).toHaveBeenCalledWith(pendingJob);
+  });
+
+  it("refuses manual enhancement when the transcript is too short", async () => {
+    snapshot = createSnapshot({ wordCount: 5 });
+    const ai = createMockAITaskStore();
+    const service = new EnhancerService(createDeps({ aiTaskStore: ai.store }));
+    const event = vi.fn();
+    service.on(event);
+
+    await expect(service.enhance("session-1")).resolves.toEqual({
+      type: "too_short",
+    });
+
+    expect(ai.generate).not.toHaveBeenCalled();
+    expect(mocks.ensureSummaryDocument).not.toHaveBeenCalled();
+    expect(mocks.replaceSummaryDocumentTemplate).not.toHaveBeenCalled();
+    expect(event).toHaveBeenCalledWith({
+      type: "auto-enhance-skipped",
+      sessionId: "session-1",
+      reason: "Transcript too short to summarize (24/160 characters minimum)",
+      reasonCode: "transcript_too_short",
+    });
+  });
+
+  it("still enhances sessions without any transcript", async () => {
+    snapshot = createSnapshot({ notes: [createNote()] });
+    const ai = createMockAITaskStore();
+    const service = new EnhancerService(createDeps({ aiTaskStore: ai.store }));
+
+    await expect(service.enhance("session-1")).resolves.toEqual({
+      type: "started",
+      noteId: "note-1",
+    });
+  });
+
   it("cancels a pending retry when the session becomes active", async () => {
     vi.useFakeTimers();
     snapshot = createSnapshot({ wordCount: 1 });

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -29,7 +29,8 @@ import { getTemplateById } from "~/templates/queries";
 type EnhanceResult =
   | { type: "started"; noteId: string }
   | { type: "already_active"; noteId: string }
-  | { type: "no_model" };
+  | { type: "no_model" }
+  | { type: "too_short" };
 
 type QueueEmptySummaryResult =
   | { type: "queued" }
@@ -387,7 +388,11 @@ export class EnhancerService {
         return;
       }
 
+      const pendingJob = this.activeAutoEnhance.get(sessionId);
       this.activeAutoEnhance.delete(sessionId);
+      if (pendingJob) {
+        await discardPendingAutoEnhanceJob(pendingJob);
+      }
       this.emit({
         type: "auto-enhance-skipped",
         sessionId,
@@ -403,6 +408,14 @@ export class EnhancerService {
       pendingAutoEnhance,
     });
     if (!this.activeAutoEnhance.has(sessionId)) return;
+
+    if (result.type === "too_short") {
+      this.activeAutoEnhance.delete(sessionId);
+      if (pendingAutoEnhance) {
+        await discardPendingAutoEnhanceJob(pendingAutoEnhance);
+      }
+      return;
+    }
 
     if (result.type === "no_model") {
       this.activeAutoEnhance.delete(sessionId);
@@ -461,6 +474,17 @@ export class EnhancerService {
     if (!model) return { type: "no_model" };
 
     const snapshot = await this.loadSession(sessionId);
+    const eligibility = getEligibility(snapshot.transcripts);
+    if (!eligibility.eligible && eligibility.code === "transcript_too_short") {
+      this.emit({
+        type: "auto-enhance-skipped",
+        sessionId,
+        reason: eligibility.reason,
+        reasonCode: eligibility.code,
+      });
+      return { type: "too_short" };
+    }
+
     let templateId = resolveTemplateId(
       opts,
       getSelectedTemplateId,

--- a/apps/desktop/src/session/components/note-input/enhanced-actions.test.ts
+++ b/apps/desktop/src/session/components/note-input/enhanced-actions.test.ts
@@ -5,6 +5,10 @@ const mocks = vi.hoisted(() => ({
   model: null as unknown,
   start: vi.fn(),
   toastError: vi.fn(),
+  toastWarning: vi.fn(),
+  isMainWindow: true,
+  requestMainEnhance: vi.fn(),
+  snapshot: null as unknown,
 }));
 
 vi.mock("@anlg/plugin-analytics", () => ({
@@ -12,7 +16,7 @@ vi.mock("@anlg/plugin-analytics", () => ({
 }));
 
 vi.mock("@anlg/ui/components/ui/toast", () => ({
-  sonnerToast: { error: mocks.toastError },
+  sonnerToast: { error: mocks.toastError, warning: mocks.toastWarning },
 }));
 
 vi.mock("~/ai/hooks", () => ({
@@ -27,9 +31,13 @@ vi.mock("~/ai/hooks", () => ({
 }));
 
 vi.mock("~/ai/task-window-sync", () => ({
-  isMainAITaskHostWindow: () => true,
+  isMainAITaskHostWindow: () => mocks.isMainWindow,
   requestMainAITaskCancel: vi.fn(),
-  requestMainEnhance: vi.fn(),
+  requestMainEnhance: mocks.requestMainEnhance,
+}));
+
+vi.mock("~/session/content-queries", () => ({
+  loadSessionContentSnapshot: () => Promise.resolve(mocks.snapshot),
 }));
 
 vi.mock("~/session/queries", () => ({
@@ -38,20 +46,28 @@ vi.mock("~/session/queries", () => ({
 
 import { useEnhancedNoteActions } from "./enhanced-actions";
 
+function renderActions() {
+  return renderHook(() =>
+    useEnhancedNoteActions({
+      enhancedNoteId: "summary-1",
+      sessionId: "session-1",
+    }),
+  );
+}
+
 describe("useEnhancedNoteActions", () => {
   beforeEach(() => {
     mocks.model = null;
+    mocks.isMainWindow = true;
+    mocks.snapshot = null;
     mocks.start.mockReset();
     mocks.toastError.mockReset();
+    mocks.toastWarning.mockReset();
+    mocks.requestMainEnhance.mockReset();
   });
 
   it("shows a toast without entering an error state when Intelligence is not configured", async () => {
-    const { result } = renderHook(() =>
-      useEnhancedNoteActions({
-        enhancedNoteId: "summary-1",
-        sessionId: "session-1",
-      }),
-    );
+    const { result } = renderActions();
 
     await act(() => result.current.onRegenerate(null));
 
@@ -61,5 +77,49 @@ describe("useEnhancedNoteActions", () => {
     expect(mocks.start).not.toHaveBeenCalled();
     expect(result.current.isError).toBe(false);
     expect(result.current.error).toBeNull();
+  });
+
+  it("shows the too-short toast instead of forwarding to main from a standalone window", async () => {
+    mocks.model = { id: "model-1" };
+    mocks.isMainWindow = false;
+    mocks.snapshot = {
+      transcripts: [{ words: [{ text: "hi" }, { text: "there" }] }],
+    };
+
+    const { result } = renderActions();
+
+    await act(() => result.current.onRegenerate(null));
+
+    expect(mocks.toastWarning).toHaveBeenCalledWith(
+      "Summary wasn't generated",
+      expect.objectContaining({ id: "auto-summary-too-short-session-1" }),
+    );
+    expect(mocks.requestMainEnhance).not.toHaveBeenCalled();
+    expect(mocks.start).not.toHaveBeenCalled();
+  });
+
+  it("forwards eligible sessions to the main window", async () => {
+    mocks.model = { id: "model-1" };
+    mocks.isMainWindow = false;
+    mocks.snapshot = {
+      transcripts: [
+        {
+          words: Array.from({ length: 40 }, (_, index) => ({
+            text: `word-${index}`,
+          })),
+        },
+      ],
+    };
+
+    const { result } = renderActions();
+
+    await act(() => result.current.onRegenerate(null));
+
+    expect(mocks.toastWarning).not.toHaveBeenCalled();
+    expect(mocks.requestMainEnhance).toHaveBeenCalledWith("session-1", {
+      templateId: "template-1",
+      targetNoteId: "summary-1",
+    });
+    expect(mocks.start).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/session/components/note-input/enhanced-actions.ts
+++ b/apps/desktop/src/session/components/note-input/enhanced-actions.ts
@@ -10,7 +10,8 @@ import {
   requestMainAITaskCancel,
   requestMainEnhance,
 } from "~/ai/task-window-sync";
-import { getEnhancerService } from "~/services/enhancer";
+import { getEligibility } from "~/services/enhancer/eligibility";
+import { loadSessionContentSnapshot } from "~/session/content-queries";
 import { useEnhancedNote } from "~/session/queries";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 
@@ -44,9 +45,9 @@ export function useEnhancedNoteActions({
         return;
       }
 
-      const service = getEnhancerService();
-      if (service) {
-        const eligibility = await service.checkEligibility(sessionId);
+      const snapshot = await loadSessionContentSnapshot(sessionId);
+      if (snapshot) {
+        const eligibility = getEligibility(snapshot.transcripts);
         if (
           !eligibility.eligible &&
           eligibility.code === "transcript_too_short"

--- a/apps/desktop/src/session/components/note-input/enhanced-actions.ts
+++ b/apps/desktop/src/session/components/note-input/enhanced-actions.ts
@@ -10,6 +10,7 @@ import {
   requestMainAITaskCancel,
   requestMainEnhance,
 } from "~/ai/task-window-sync";
+import { getEnhancerService } from "~/services/enhancer";
 import { useEnhancedNote } from "~/session/queries";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 
@@ -41,6 +42,21 @@ export function useEnhancedNoteActions({
           "Set up Intelligence in Settings before regenerating this summary.",
         );
         return;
+      }
+
+      const service = getEnhancerService();
+      if (service) {
+        const eligibility = await service.checkEligibility(sessionId);
+        if (
+          !eligibility.eligible &&
+          eligibility.code === "transcript_too_short"
+        ) {
+          sonnerToast.warning("Summary wasn't generated", {
+            id: `auto-summary-too-short-${sessionId}`,
+            description: eligibility.reason,
+          });
+          return;
+        }
       }
 
       if (!isMainAITaskHostWindow()) {


### PR DESCRIPTION
The 160-character eligibility gate only guarded the auto-enhance path,
so manual regenerate, template apply, and upload flows could still
produce a summary while the auto path toasted "Summary wasn't
generated" for the same session — and an undischarged pending
auto-enhance job kept re-firing that toast every resume cycle.

- Gate EnhancerService.enhance() on transcript_too_short before any
  note writes, emitting the skip event and returning a too_short result
  (sessions without any transcript still enhance from notes)
- Precheck eligibility in onRegenerate before starting the task directly
- Discard the pending auto-enhance job when eligibility gives up, so the
  resume loop stops re-queueing and re-toasting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core enhancement entry points and durable job lifecycle; behavior is well-covered by new tests but affects all manual and auto summary flows.
> 
> **Overview**
> Applies the **transcript length eligibility gate** to **manual** summary generation, not only auto-enhance, so regenerate and other `enhance()` callers cannot start AI work or touch summary documents when the transcript is below the word/character minimums.
> 
> `EnhancerService.enhance()` now checks `getEligibility` early and returns **`too_short`** (with **`auto-enhance-skipped`**) for **`transcript_too_short`** only; sessions with **no transcript** still proceed from notes. Auto-enhance **discards durable pending jobs** when retries exhaust or `enhance` returns `too_short`, stopping resume-loop re-toasts.
> 
> **Regenerate** in standalone windows loads the session snapshot and shows the same **“Summary wasn’t generated”** warning instead of forwarding to the main window when ineligible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb36e6a539e1d2fa701e9c6cca58c4744c2e7c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->