### PR TITLE
refactor(desktop): remove dead sidebar timeline update button

### DIFF
--- a/apps/desktop/src/main/update-banner.test.tsx
+++ b/apps/desktop/src/main/update-banner.test.tsx
@@ -95,16 +95,13 @@ vi.mock("@anlg/plugin-updater2", () => ({
   },
 }));
 
-import {
-  SidebarTimelineUpdateButton,
-  useDesktopUpdateControl,
-} from "./update-banner";
+import { useDesktopUpdateControl } from "./update-banner";
 
 import { useDevtoolsOtaPreview } from "~/store/zustand/devtools-ota-preview";
 
 const queryClients: QueryClient[] = [];
 
-describe("SidebarTimelineUpdateButton", () => {
+describe("useDesktopUpdateControl", () => {
   beforeEach(() => {
     checkMock.mockReset();
     downloadMock.mockReset();
@@ -169,30 +166,22 @@ describe("SidebarTimelineUpdateButton", () => {
     useDevtoolsOtaPreview.getState().clearPreview();
   });
 
-  it("downloads from the sidebar update button", async () => {
+  it("downloads the update reported by the update check", async () => {
     checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
 
-    renderSidebarUpdateButton();
+    renderUpdateControl();
 
-    const button = await screen.findByRole("button", {
-      name: "Download update",
-    });
-
-    expect(button.className.split(" ")).toEqual(
-      expect.arrayContaining(["h-7", "w-7", "min-h-7", "min-w-7", "p-0"]),
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("available"),
     );
-    expect(button.className.split(" ")).toEqual(
-      expect.arrayContaining(["bg-blue-500", "hover:bg-blue-600"]),
-    );
-    expect(button.className.split(" ")).not.toContain("bg-primary");
 
-    fireEvent.click(button);
+    fireEvent.click(screen.getByRole("button", { name: "download" }));
 
     await waitFor(() => expect(downloadMock).toHaveBeenCalledWith("1.0.34"));
   });
 
-  it("shows download when an external update check reports an available version", async () => {
-    renderSidebarUpdateButton();
+  it("reports available when an external update check emits an event", async () => {
+    renderUpdateControl();
 
     await waitFor(() =>
       expect(eventHandlers.updateAvailable).toBeTypeOf("function"),
@@ -202,13 +191,15 @@ describe("SidebarTimelineUpdateButton", () => {
       eventHandlers.updateAvailable?.({ payload: { version: "1.0.34" } });
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Download update" }));
+    expect(screen.getByTestId("status").textContent).toBe("available");
+
+    fireEvent.click(screen.getByRole("button", { name: "download" }));
 
     await waitFor(() => expect(downloadMock).toHaveBeenCalledWith("1.0.34"));
   });
 
   it("clears stale available state after a successful check finds no update", async () => {
-    renderSidebarUpdateButton();
+    renderUpdateControl();
 
     await waitFor(() =>
       expect(eventHandlers.updateAvailable).toBeTypeOf("function"),
@@ -218,9 +209,7 @@ describe("SidebarTimelineUpdateButton", () => {
       eventHandlers.updateAvailable?.({ payload: { version: "1.0.34" } });
     });
 
-    expect(
-      screen.getByRole("button", { name: "Download update" }),
-    ).toBeTruthy();
+    expect(screen.getByTestId("status").textContent).toBe("available");
 
     await act(async () => {
       await queryClients[queryClients.length - 1]?.refetchQueries({
@@ -229,14 +218,12 @@ describe("SidebarTimelineUpdateButton", () => {
     });
 
     await waitFor(() =>
-      expect(
-        screen.queryByRole("button", { name: "Download update" }),
-      ).toBeNull(),
+      expect(screen.getByTestId("status").textContent).toBe("none"),
     );
   });
 
-  it("keeps retry visible when a failed update is rechecked", async () => {
-    renderSidebarUpdateButton();
+  it("keeps failed state when a failed update is rechecked", async () => {
+    renderUpdateControl();
 
     await waitFor(() =>
       expect(eventHandlers.updateDownloadFailed).toBeTypeOf("function"),
@@ -248,56 +235,45 @@ describe("SidebarTimelineUpdateButton", () => {
       });
     });
 
-    expect(screen.getByRole("button", { name: "Retry update" })).toBeTruthy();
+    expect(screen.getByTestId("status").textContent).toBe("failed");
 
     act(() => {
       eventHandlers.updateAvailable?.({ payload: { version: "1.0.34" } });
     });
 
-    expect(screen.getByRole("button", { name: "Retry update" })).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: "Download update" }),
-    ).toBeNull();
+    expect(screen.getByTestId("status").textContent).toBe("failed");
   });
 
-  it("shows restart when the checked update is already downloaded", async () => {
+  it("reports ready when the checked update is already downloaded", async () => {
     checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
     isDownloadedMock.mockResolvedValue({ status: "ok", data: true });
 
-    renderSidebarUpdateButton();
+    renderUpdateControl();
 
-    expect(
-      await screen.findByRole("button", { name: "Restart to update" }),
-    ).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: "Download update" }),
-    ).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("ready"),
+    );
   });
 
-  it("keeps restart visible when an already-downloaded update also emits available", async () => {
+  it("keeps ready state when an already-downloaded update also emits available", async () => {
     checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
     isDownloadedMock.mockResolvedValue({ status: "ok", data: true });
 
-    renderSidebarUpdateButton();
+    renderUpdateControl();
 
-    expect(
-      await screen.findByRole("button", { name: "Restart to update" }),
-    ).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("ready"),
+    );
 
     act(() => {
       eventHandlers.updateAvailable?.({ payload: { version: "1.0.34" } });
     });
 
-    expect(
-      screen.getByRole("button", { name: "Restart to update" }),
-    ).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: "Download update" }),
-    ).toBeNull();
+    expect(screen.getByTestId("status").textContent).toBe("ready");
   });
 
-  it("shows sidebar circular progress while downloading", async () => {
-    renderSidebarUpdateButton();
+  it("tracks download progress from updater events", async () => {
+    renderUpdateControl();
 
     await waitFor(() =>
       expect(eventHandlers.updateDownloadProgress).toBeTypeOf("function"),
@@ -314,18 +290,12 @@ describe("SidebarTimelineUpdateButton", () => {
       });
     });
 
-    const button = screen.getByRole("button", {
-      name: "Downloading update, 50% complete",
-    });
-
-    expect(button.hasAttribute("disabled")).toBe(true);
-    expect(
-      button.querySelector("[data-testid='update-download-icon']"),
-    ).toBeNull();
+    expect(screen.getByTestId("status").textContent).toBe("downloading");
+    expect(screen.getByTestId("progress").textContent).toBe("0.5");
   });
 
-  it("restarts from the sidebar update button when ready", async () => {
-    renderSidebarUpdateButton();
+  it("installs the update when ready", async () => {
+    renderUpdateControl();
 
     await waitFor(() =>
       expect(eventHandlers.updateReady).toBeTypeOf("function"),
@@ -335,7 +305,9 @@ describe("SidebarTimelineUpdateButton", () => {
       eventHandlers.updateReady?.({ payload: { version: "1.0.34" } });
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Restart to update" }));
+    expect(screen.getByTestId("status").textContent).toBe("ready");
+
+    fireEvent.click(screen.getByRole("button", { name: "install" }));
 
     await waitFor(() => {
       expect(installMock).toHaveBeenCalledWith("1.0.34");
@@ -345,14 +317,14 @@ describe("SidebarTimelineUpdateButton", () => {
     });
   });
 
-  it("clears the button after the app reports it has updated", async () => {
+  it("clears the update after the app reports it has updated", async () => {
     checkMock.mockResolvedValue({ status: "ok", data: "1.0.34" });
 
-    renderSidebarUpdateButton();
+    renderUpdateControl();
 
-    expect(
-      await screen.findByRole("button", { name: "Download update" }),
-    ).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("available"),
+    );
 
     await waitFor(() => expect(eventHandlers.updated).toBeTypeOf("function"));
 
@@ -363,38 +335,49 @@ describe("SidebarTimelineUpdateButton", () => {
     });
 
     await waitFor(() =>
-      expect(
-        screen.queryByRole("button", { name: "Download update" }),
-      ).toBeNull(),
+      expect(screen.getByTestId("status").textContent).toBe("none"),
     );
   });
 
   it("shows the devtools OTA preview state without a real updater result", async () => {
     useDevtoolsOtaPreview.getState().showPreview("available");
 
-    renderSidebarUpdateButton();
+    renderUpdateControl();
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Download update" }),
+    expect(screen.getByTestId("status").textContent).toBe("available");
+
+    fireEvent.click(screen.getByRole("button", { name: "download" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("downloading"),
     );
-
-    expect(
-      await screen.findByRole("button", {
-        name: "Downloading update, 58% complete",
-      }),
-    ).toBeTruthy();
+    expect(screen.getByTestId("progress").textContent).toBe("0.58");
     expect(downloadMock).not.toHaveBeenCalled();
   });
 });
 
-function renderSidebarUpdateButton() {
-  return renderWithQueryClient(<SidebarUpdateButtonHarness />);
+function renderUpdateControl() {
+  return renderWithQueryClient(<UpdateControlProbe />);
 }
 
-function SidebarUpdateButtonHarness() {
+function UpdateControlProbe() {
   const update = useDesktopUpdateControl();
 
-  return <SidebarTimelineUpdateButton update={update} />;
+  return (
+    <div>
+      <span data-testid="status">{update.status ?? "none"}</span>
+      <span data-testid="version">{update.version ?? "none"}</span>
+      <span data-testid="progress">
+        {update.progress === null ? "none" : String(update.progress)}
+      </span>
+      <button type="button" onClick={update.downloadUpdate}>
+        download
+      </button>
+      <button type="button" onClick={update.installUpdate}>
+        install
+      </button>
+    </div>
+  );
 }
 
 function renderWithQueryClient(ui: ReactNode) {

--- a/apps/desktop/src/main/update-banner.tsx
+++ b/apps/desktop/src/main/update-banner.tsx
@@ -1,13 +1,11 @@
-import { ArrowClockwise, DownloadSimple } from "@phosphor-icons/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import {
   commands as updaterCommands,
   events as updaterEvents,
   type Result,
 } from "@anlg/plugin-updater2";
-import { cn } from "@anlg/utils";
 
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { useDevtoolsOtaPreview } from "~/store/zustand/devtools-ota-preview";
@@ -328,118 +326,6 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
     downloadUpdate: handleDownload,
     installUpdate: handleInstall,
   };
-}
-
-export function SidebarTimelineUpdateButton({
-  update,
-}: {
-  update: DesktopUpdateControl;
-}) {
-  if (!update.status || !update.version) {
-    return null;
-  }
-
-  const isDownloading = update.status === "downloading";
-  const isReady = update.status === "ready";
-  const label = sidebarUpdateLabel(update.status, update.progress);
-
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      data-tauri-drag-region="false"
-      disabled={isDownloading || update.downloadStarting || update.installing}
-      className={cn([
-        "relative ml-2 flex h-7 min-h-7 w-7 min-w-7 shrink-0 items-center justify-center rounded-full p-0",
-        "bg-blue-500 text-white shadow-sm transition-colors hover:bg-blue-600",
-        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
-        "disabled:cursor-default disabled:bg-blue-500 disabled:text-white disabled:opacity-70 disabled:hover:bg-blue-500",
-      ])}
-      onClick={isReady ? update.installUpdate : update.downloadUpdate}
-    >
-      {isDownloading ? (
-        <SidebarCircularProgress progress={update.progress} />
-      ) : (
-        <span className="relative z-10 flex items-center justify-center">
-          {sidebarActionIcon(update.status)}
-        </span>
-      )}
-    </button>
-  );
-}
-
-function SidebarCircularProgress({ progress }: { progress: number | null }) {
-  const pct = Math.max(0, Math.min(1, progress ?? 0));
-  const radius = 7.5;
-  const circumference = 2 * Math.PI * radius;
-
-  return (
-    <svg
-      aria-hidden="true"
-      className="pointer-events-none absolute top-1/2 left-1/2 size-[18px] -translate-x-1/2 -translate-y-1/2 -rotate-90"
-      viewBox="0 0 18 18"
-    >
-      <circle
-        cx="9"
-        cy="9"
-        r={radius}
-        fill="none"
-        stroke="currentColor"
-        strokeOpacity="0.14"
-        strokeWidth="1.5"
-      />
-      <circle
-        cx="9"
-        cy="9"
-        r={radius}
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeWidth="1.5"
-        strokeDasharray={circumference}
-        strokeDashoffset={circumference * (1 - pct)}
-        className="transition-[stroke-dashoffset] duration-200 ease-out"
-      />
-    </svg>
-  );
-}
-
-function sidebarUpdateLabel(
-  status: UpdateBannerStatus,
-  progress: number | null,
-): string {
-  if (status === "ready") {
-    return "Restart to update";
-  }
-
-  if (status === "downloading") {
-    if (progress === null) {
-      return "Downloading update";
-    }
-
-    return `Downloading update, ${Math.round(progress * 100)}% complete`;
-  }
-
-  if (status === "failed") {
-    return "Retry update";
-  }
-
-  return "Download update";
-}
-
-function sidebarActionIcon(status: UpdateBannerStatus): ReactNode {
-  if (status === "ready") {
-    return <ArrowClockwise size={14} aria-hidden="true" />;
-  }
-
-  return (
-    <DownloadSimple
-      size={14}
-      aria-hidden="true"
-      data-testid="update-download-icon"
-    />
-  );
 }
 
 function unwrapResult<T>(result: Result<T, string>): T {


### PR DESCRIPTION
SidebarTimelineUpdateButton and its helpers (sidebarUpdateLabel,
sidebarActionIcon, SidebarCircularProgress) were only referenced by
their own tests; the live desktop update UI is the sidebar toast.
Drop the component and rewrite update-banner tests to exercise
useDesktopUpdateControl directly through a state probe harness,
keeping all hook behavior coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead UI removal and test-only harness changes; `useDesktopUpdateControl` logic is unchanged.
> 
> **Overview**
> Removes the unused **`SidebarTimelineUpdateButton`** UI and its helpers (circular progress, labels, icons) from `update-banner.tsx`, since the live desktop update flow uses the sidebar toast and **`useDesktopUpdateControl`** only.
> 
> **`update-banner.test.tsx`** is refocused on the hook: the suite is renamed to **`useDesktopUpdateControl`**, assertions use a small **`UpdateControlProbe`** (`status` / `progress` test IDs and download/install buttons) instead of sidebar button labels and styling, while keeping the same updater event and mutation behavior coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee8206c6981d9be120d8e9e99302aad10bb347e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->