### PR TITLE
fix(desktop): hide Sync settings menu when signed out

### DIFF
--- a/apps/desktop/src/sidebar/settings.test.tsx
+++ b/apps/desktop/src/sidebar/settings.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  session: { user: { id: "user-1" } } as { user: { id: string } } | null,
   currentTab: { type: "settings", state: { tab: "app" } } as {
     type: "settings";
     state: { tab?: string };
@@ -73,6 +74,10 @@ vi.mock("./custom-sidebar-header", () => ({
   CustomSidebarHeader: () => <div />,
 }));
 
+vi.mock("~/auth", () => ({
+  useAuth: () => ({ session: mocks.session }),
+}));
+
 vi.mock("~/store/zustand/tabs", () => {
   const getState = () => ({
     currentTab: mocks.currentTab,
@@ -99,6 +104,7 @@ describe("SettingsNav", () => {
   afterEach(cleanup);
 
   beforeEach(() => {
+    mocks.session = { user: { id: "user-1" } };
     mocks.currentTab = { type: "settings", state: { tab: "app" } };
     mocks.tabs = [];
     mocks.openNew.mockClear();
@@ -232,6 +238,15 @@ describe("SettingsNav", () => {
       mocks.currentTab,
       { tab: "sync" },
     );
+  });
+
+  it("hides Sync when the user is not signed in", () => {
+    mocks.session = null;
+
+    render(<SettingsNav />);
+
+    expect(screen.queryByText("Sync")).toBeNull();
+    expect(screen.getByText("Imports")).toBeTruthy();
   });
 
   it("opens Imports inside settings", () => {

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -26,6 +26,7 @@ import { cn } from "@anlg/utils";
 
 import { CustomSidebarHeader } from "./custom-sidebar-header";
 
+import { useAuth } from "~/auth";
 import { type SettingsTab, type TabInput, useTabs } from "~/store/zustand/tabs";
 
 type SettingsNavItem =
@@ -41,6 +42,7 @@ type SettingsNavGroup = { label: string; items: SettingsNavItem[] };
 
 export function SettingsNav() {
   const { t } = useLingui();
+  const signedIn = Boolean(useAuth().session);
   const [search, setSearch] = useState("");
   const currentTab = useTabs((state) => state.currentTab);
   const updateSettingsTabState = useTabs(
@@ -116,7 +118,9 @@ export function SettingsNav() {
     {
       label: t`Data`,
       items: [
-        { id: "sync", label: t`Sync`, icon: ArrowsClockwise },
+        ...(signedIn
+          ? [{ id: "sync" as const, label: t`Sync`, icon: ArrowsClockwise }]
+          : []),
         { id: "imports", label: t`Imports`, icon: DownloadSimple },
       ],
     },


### PR DESCRIPTION
Sync requires an account, so showing the nav item to signed-out users is a dead end. Omit the Sync item from the settings sidebar Data group unless an auth session exists, and cover the signed-out case in the SettingsNav tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI visibility change in settings navigation with no changes to auth or sync behavior.
> 
> **Overview**
> **Settings sidebar** no longer shows **Sync** under the Data group unless the user has an auth session, since sync requires an account.
> 
> `SettingsNav` reads `useAuth().session` and only spreads the Sync nav item when signed in; **Imports** stays visible either way. Tests mock `~/auth`, default to a signed-in session, and assert Sync is absent (and Imports still present) when `session` is `null`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec257bade9a5235724888c2b7602dc04098555ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->