### PR TITLE
chore(changelog): cover post-draft fixes in 1.4.6 notes

### DIFF
--- a/packages/changelog/content/1.4.6.md
+++ b/packages/changelog/content/1.4.6.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-08-08"
+date: "2026-08-09"
 summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30 other assistants, and automations that deliver each meeting summary to Slack, Linear, Notion, or a Markdown folder."
 ---
 
@@ -87,6 +87,13 @@ summary: "Anarlog 1.4.6 adds transcript editing, meeting history imports from 30
 - See summary bullets spaced the same while streaming as in the finished note
 - Use the header buttons in Settings, Calendar, and Automations views that the
   window controls previously covered
+- Keep update notices out of live meetings, and have them come back after
+  being dismissed until the update is actually installed; automatic updates
+  also wait until your meeting ends
+- Skip summary generation when a transcript is too short, whether it runs
+  automatically, from regenerate, or from applying a template, with a single
+  notice instead of repeated ones
+- See Sync settings only while signed in
 - Keep app sounds from crashing the app on Linux
 - Start the app on Linux systems that are missing the tray icon library or
   desktop protocol-handler tools instead of crashing at launch


### PR DESCRIPTION
Add the update-toast resurfacing, too-short transcript summary skip, and signed-out Sync menu fixes to the 1.4.6 changelog, and bump the release date to 2026-08-09.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changelog edits with no application or runtime impact.
> 
> **Overview**
> Updates **`packages/changelog/content/1.4.6.md`** so the 1.4.6 release notes match fixes landed after the first draft.
> 
> The frontmatter **release date** moves from **2026-08-08** to **2026-08-09**. Under **Fixes**, three bullets are added: update toasts stay hidden during live meetings, reappear after dismiss until install, and auto-updates defer until the meeting ends; summary generation is skipped for transcripts that are too short (auto, regenerate, and template paths) with one notice instead of repeats; and **Sync** settings appear only when signed in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a22270d3241306904e9a8be8fcb6c778db6e637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->