### PR TITLE
Suppress Sentry telemetry from Linux package smoke tests

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -512,6 +512,7 @@ jobs:
             --volume "$PWD:/workspace:ro" \
             --env DEB_PATH="/workspace/$deb" \
             --env BINARY_PATH="/usr/bin/$binary_name" \
+            --env ANARLOG_DISABLE_SENTRY=1 \
             ubuntu:24.04 \
             bash -euxo pipefail -c '
               export DEBIAN_FRONTEND=noninteractive

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -81,7 +81,11 @@ pub async fn main() {
         };
 
     let sentry_client = {
-        let dsn = option_env!("SENTRY_DSN");
+        let dsn = if std::env::var_os("ANARLOG_DISABLE_SENTRY").is_some() {
+            None
+        } else {
+            option_env!("SENTRY_DSN")
+        };
 
         if let Some(dsn) = dsn {
             let release =


### PR DESCRIPTION
## Summary

- add a runtime switch that skips desktop Sentry initialization
- enable it only for the headless Linux package smoke test
- keep production desktop telemetry unchanged

## Validation

- `pnpm exec dprint fmt`
- `pnpm fmt:check`
- `cargo check -p desktop`
- `cargo test -p desktop` (29 passed)
- `pnpm -F desktop typecheck`
- `pnpm -F desktop test` (2,877 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in guard around Sentry init used only in CI smoke tests; production telemetry behavior is unchanged.
> 
> **Overview**
> Adds a runtime **`ANARLOG_DISABLE_SENTRY`** switch so desktop startup treats the Sentry DSN as absent and skips Sentry/minidump initialization when the variable is set, instead of always using the compile-time `SENTRY_DSN`.
> 
> The headless **Linux `.deb` smoke test** in `desktop_cd` now passes **`ANARLOG_DISABLE_SENTRY=1`** into the Docker run so CI package verification does not emit Sentry telemetry; normal user installs are unchanged unless that env is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22f4fdfea261432c668e2c177722532d8531e934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->