### PR TITLE
fix(ci): glob for the renamed Windows PDB in Sentry upload

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -642,11 +642,19 @@ jobs:
           INFISICAL_TOKEN: ${{ secrets.INFISICAL_SENTRY_TOKEN }}
         run: |
           release_dir="apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release"
-          if [[ ! -f "$release_dir/anarlog.pdb" ]]; then
-            echo "::error::Missing anarlog.pdb next to the Windows binary"
+          # Tauri renames the exe to mainBinaryName (anarlog.exe) but the PDB
+          # keeps the cargo target name (desktop.pdb), so glob instead of
+          # hardcoding a name that never exists.
+          shopt -s nullglob
+          pdbs=("$release_dir"/*.pdb)
+          if [[ ${#pdbs[@]} -eq 0 ]]; then
+            echo "::error::No PDB found next to the Windows binary"
             exit 1
           fi
-          sentry-cli debug-files check "$release_dir/anarlog.pdb"
+          echo "Found PDBs: ${pdbs[*]}"
+          for pdb in "${pdbs[@]}"; do
+            sentry-cli debug-files check "$pdb"
+          done
 
           response=$(
             curl --fail --silent --show-error --get \
@@ -668,7 +676,7 @@ jobs:
             --project hyprnote2 \
             --include-sources \
             "$release_dir/anarlog.exe" \
-            "$release_dir/anarlog.pdb"
+            "${pdbs[@]}"
       - if: ${{ inputs.channel == 'stable' }}
         name: Sign in to Azure
         uses: azure/login@v3


### PR DESCRIPTION
The stable dry-run for 1.4.6 failed because the symbols step looked for anarlog.pdb, but tauri only renames the exe to mainBinaryName; the PDB keeps the cargo target name desktop.pdb. Glob *.pdb next to the binary, check each file, and upload the set alongside anarlog.exe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the stable Windows Sentry symbol upload step; no runtime app or signing behavior is modified.
> 
> **Overview**
> Fixes stable Windows CD failing on the **Upload Windows debug symbols to Sentry** step when it expected `anarlog.pdb` while the build actually emits a PDB named after the Cargo target (e.g. `desktop.pdb`) even though Tauri packages `anarlog.exe` via `mainBinaryName`.
> 
> The workflow now globs `*.pdb` in the release directory, fails if none are found, runs `sentry-cli debug-files check` on each PDB, and uploads `anarlog.exe` together with all matched PDBs instead of a single hardcoded path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ca40389d0fd46dd9c835ce542cd3fdb2fff591b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->