### PR TITLE
fix(stt): restore cloud endpoint for blank URL

### DIFF
--- a/apps/desktop/src/stt/useSTTConnection.test.ts
+++ b/apps/desktop/src/stt/useSTTConnection.test.ts
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@anlg/plugin-local-stt", () => ({
+  commands: {
+    getServerForModel: vi.fn(),
+    isModelDownloaded: vi.fn(),
+  },
+}));
+
+vi.mock("~/auth", () => ({
+  useAuth: () => ({ session: { access_token: "access-token" } }),
+}));
+
+vi.mock("~/auth/billing-context", () => ({
+  useBillingAccess: () => ({ isPaid: true }),
+}));
+
+vi.mock("~/env", () => ({
+  env: { VITE_API_URL: "https://api.anarlog.so" },
+}));
+
+vi.mock("~/settings/providers", () => ({
+  useAiProvider: () => ({
+    type: "stt",
+    base_url: "   ",
+    api_key: "",
+  }),
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValues: () => ({
+    current_stt_provider: "anarlog",
+    current_stt_model: "cloud",
+  }),
+}));
+
+vi.mock("~/stt/capabilities", () => ({
+  isAnarlogCloudSttModel: () => true,
+  isOnDeviceSttModel: () => false,
+}));
+
+import { useSTTConnection } from "./useSTTConnection";
+
+describe("useSTTConnection", () => {
+  it("uses the hosted STT URL when the stored Anarlog URL is blank", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(() => useSTTConnection(), { wrapper });
+
+    expect(result.current.conn).toEqual({
+      provider: "anarlog",
+      model: "cloud",
+      baseUrl: "https://api.anarlog.so/stt",
+      apiKey: "access-token",
+    });
+  });
+});

--- a/apps/desktop/src/stt/useSTTConnection.ts
+++ b/apps/desktop/src/stt/useSTTConnection.ts
@@ -98,7 +98,7 @@ export const useSTTConnection = () => {
       return {
         provider: current_stt_provider,
         model: current_stt_model,
-        baseUrl: baseUrl ?? new URL("/stt", env.VITE_API_URL).toString(),
+        baseUrl: baseUrl || new URL("/stt", env.VITE_API_URL).toString(),
         apiKey: auth.session.access_token,
       };
     }


### PR DESCRIPTION
Treat blank persisted Anarlog STT URLs as missing and cover the fallback with a hook regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change in STT URL resolution plus a unit test; no auth or data-model changes.
> 
> **Overview**
> Fixes cloud Anarlog STT when a persisted provider **base URL** is empty or whitespace-only after trim. **`useSTTConnection`** now picks the hosted endpoint with **`baseUrl || …`** instead of **`??`**, so an empty string no longer blocks the default `VITE_API_URL/stt` path.
> 
> Adds a **`useSTTConnection`** hook test that mocks a blank stored URL and asserts the connection uses **`https://api.anarlog.so/stt`** with the session access token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 024748347abbc3070df8ce58f7d030c575cb6003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->