### PR TITLE
Make toasts dismissible by default

### DIFF
--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -51,6 +51,7 @@ describe("sidebar toast registry", () => {
     expect(toast?.id).toBe("missing-llm");
     expect(toast?.description).toBe("Language model needed");
     expect(toast?.primaryAction?.label).toBe("Add");
+    expect(toast?.dismissible).toBe(false);
   });
 
   it("keeps the missing transcription provider message short", () => {
@@ -65,6 +66,7 @@ describe("sidebar toast registry", () => {
     expect(toast?.id).toBe("missing-stt");
     expect(toast?.description).toBe("Transcription provider needed");
     expect(toast?.primaryAction?.label).toBe("Add");
+    expect(toast?.dismissible).toBe(false);
   });
 
   it("suggests signing in before provider setup", () => {
@@ -268,6 +270,7 @@ describe("sidebar toast registry", () => {
     expect(languageModelToast.id).toBe("devtools-missing-llm");
     expect(languageModelToast.description).toBe("Language model needed");
     expect(languageModelToast.primaryAction?.label).toBe("Add");
+    expect(languageModelToast.dismissible).toBe(false);
     const transcriptionModelToast = createDevtoolsToastPreview({
       preview: "transcription-model",
       onSignIn: vi.fn(),
@@ -277,6 +280,7 @@ describe("sidebar toast registry", () => {
     expect(transcriptionModelToast.description).toBe(
       "Transcription provider needed",
     );
+    expect(transcriptionModelToast.dismissible).toBe(false);
     expect(downloadToast.id).toBe("devtools-downloading-model");
     expect(downloadToast.loading).toBe(true);
   });

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -54,6 +54,18 @@ describe("sidebar toast registry", () => {
     expect(toast?.dismissible).toBe(false);
   });
 
+  it("shows required setup even if it was dismissed previously", () => {
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        hasLLMConfigured: false,
+      }),
+      (id) => id === "missing-llm",
+    );
+
+    expect(toast?.id).toBe("missing-llm");
+  });
+
   it("keeps the missing transcription provider message short", () => {
     const toast = getToastToShow(
       createToastRegistry({

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -274,7 +274,10 @@ export function getToastToShow(
   isDismissed: (id: string) => boolean,
 ): ToastType | null {
   for (const entry of registry) {
-    if (entry.condition() && !isDismissed(entry.toast.id)) {
+    if (
+      entry.condition() &&
+      (!entry.toast.dismissible || !isDismissed(entry.toast.id))
+    ) {
       return entry.toast;
     }
   }

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -175,7 +175,7 @@ export function createToastRegistry({
           label: "Add",
           onClick: onOpenLLMSettings,
         },
-        dismissible: true,
+        dismissible: false,
       },
       condition: () =>
         hasUsableSttConfigured &&
@@ -296,7 +296,7 @@ export function createDevtoolsToastPreview({
           label: "Add",
           onClick: onOpenLLMSettings,
         },
-        dismissible: true,
+        dismissible: false,
       };
     case "transcription-model":
       return {

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
@@ -74,6 +74,7 @@ describe("UndoDeleteToast", () => {
       expect.objectContaining({
         id: "undo-delete:session-1",
         duration: Infinity,
+        closeButton: false,
         action: expect.objectContaining({ label: "Undo" }),
       }),
     );

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
@@ -158,6 +158,7 @@ function UndoDeleteSonnerToast({ group }: { group: ToastGroup }) {
     sonnerToast.message(label, {
       id: toastId,
       duration: Infinity,
+      closeButton: false,
       description: (
         <span
           aria-hidden="true"

--- a/packages/ui/src/components/ui/toast.tsx
+++ b/packages/ui/src/components/ui/toast.tsx
@@ -9,6 +9,7 @@ const Toaster = ({
   theme = "system",
   position = "bottom-right",
   richColors = true,
+  closeButton = true,
   style,
   ...props
 }: ToasterProps) => (
@@ -16,6 +17,7 @@ const Toaster = ({
     theme={theme}
     position={position}
     richColors={richColors}
+    closeButton={closeButton}
     className="toaster group"
     style={{ "--width": "300px", ...style } as CSSProperties}
     toastOptions={{


### PR DESCRIPTION
Enable the shared toast close button while preserving per-toast opt-outs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toast behavior changes with targeted tests; no auth, data, or API impact.
> 
> **Overview**
> Turns on Sonner’s **close button** on the shared `Toaster` (`closeButton` defaults to `true`), so dismissible sidebar toasts can be closed from the UI. Sidebar rendering already wires `toast.dismissible` to per-toast `closeButton`.
> 
> **Required setup** toasts (missing LLM/STT) are now **`dismissible: false`**, and `getToastToShow` **ignores prior dismissals** for non-dismissible entries so users can’t hide “Language model needed” / “Transcription provider needed” until setup is done. The undo-delete toast also sets **`closeButton: false`** so it stays action-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c264a3cc3adecc3d15718190a6483f2ced3faae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->