### PR TITLE
Fix CloudSync recovery performance

### DIFF
--- a/crates/db-app/src/e2ee.rs
+++ b/crates/db-app/src/e2ee.rs
@@ -183,6 +183,7 @@ pub use replica_apply::{
 #[cfg(test)]
 use replica_apply::{
     apply_e2ee_replica_changes_inner, apply_received_e2ee_replica_changes_with_witness_bounded,
+    load_changed_e2ee_record_metadata,
 };
 use replica_encrypt::check_e2ee_cancellation;
 pub use replica_encrypt::{

--- a/crates/db-app/src/e2ee/replica_apply.rs
+++ b/crates/db-app/src/e2ee/replica_apply.rs
@@ -139,7 +139,7 @@ async fn commit_e2ee_apply_transaction(
     check_e2ee_apply_cancellation(is_cancelled)
 }
 
-async fn load_changed_e2ee_record_metadata(
+pub(super) async fn load_changed_e2ee_record_metadata(
     pool: &SqlitePool,
     keys: &HashMap<String, WorkspaceKey>,
     cursor: Option<&(String, String)>,
@@ -151,6 +151,8 @@ async fn load_changed_e2ee_record_metadata(
            SELECT input.id, input.workspace_id
            FROM e2ee_records AS input
            INDEXED BY idx_e2ee_records_workspace
+           LEFT JOIN e2ee_local_state AS local
+             ON local.record_id = input.id
            WHERE input.workspace_id IN (",
     );
     {
@@ -159,7 +161,14 @@ async fn load_changed_e2ee_record_metadata(
             separated.push_bind(workspace_id);
         }
     }
-    query.push(")");
+    query.push(
+        ")
+           AND (
+             local.record_id IS NULL
+             OR local.workspace_id != input.workspace_id
+             OR local.payload != input.payload
+           )",
+    );
     if let Some((workspace_id, record_id)) = cursor {
         query
             .push(

--- a/crates/db-app/src/e2ee/tests/replica_apply.rs
+++ b/crates/db-app/src/e2ee/tests/replica_apply.rs
@@ -761,3 +761,58 @@ async fn failed_remote_apply_rolls_back_the_guard() {
     .unwrap();
     assert_eq!(dirty_count, 1);
 }
+
+#[tokio::test]
+async fn replica_apply_scan_selects_only_records_that_need_work() {
+    let workspace_keys = keys("workspace-a");
+    let target = test_db().await;
+    sqlx::query(
+        "WITH RECURSIVE counter(value) AS (
+           SELECT 0
+           UNION ALL
+           SELECT value + 1 FROM counter WHERE value < 255
+         )
+         INSERT INTO e2ee_witness_records (
+           workspace_id, record_id, revision, writer_id,
+           payload_hash, payload, sequence
+         )
+         SELECT
+           'workspace-a',
+           printf('record-%03d', value),
+           1,
+           'writer-a',
+           printf('hash-%03d', value),
+           printf('payload-%03d', value),
+           value + 1
+         FROM counter",
+    )
+    .execute(target.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO e2ee_records (id, workspace_id, payload)
+         SELECT record_id, workspace_id, payload FROM e2ee_witness_records",
+    )
+    .execute(target.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO e2ee_local_state (record_id, workspace_id, payload)
+         SELECT id, workspace_id, payload FROM e2ee_records",
+    )
+    .execute(target.pool())
+    .await
+    .unwrap();
+
+    sqlx::query("UPDATE e2ee_records SET payload = 'changed' WHERE id = 'record-255'")
+        .execute(target.pool())
+        .await
+        .unwrap();
+
+    let changed = load_changed_e2ee_record_metadata(target.pool(), &workspace_keys, None)
+        .await
+        .unwrap();
+    assert_eq!(changed.len(), 1);
+    assert_eq!(changed[0].id, "record-255");
+    assert!(changed[0].changed);
+}

--- a/crates/db-app/src/e2ee/witness.rs
+++ b/crates/db-app/src/e2ee/witness.rs
@@ -9,7 +9,6 @@ use super::{
 };
 
 const E2EE_WITNESS_REPAIR_SCAN_PAGE_LIMIT: i64 = 128;
-const E2EE_WITNESS_REPAIR_SCAN_BYTE_LIMIT: usize = 16 * 1024 * 1024;
 pub(super) const PENDING_E2EE_WITNESS_UPLOADS_SQL: &str = "
   SELECT
     pending.record_id,
@@ -538,7 +537,7 @@ async fn load_bounded_e2ee_witness_repairs(
         usize::try_from(max_records).map_err(|_| E2eeReplicaError::WitnessRepairTooLarge)?;
     let mut workspace_ids = keys.keys().collect::<Vec<_>>();
     workspace_ids.sort_unstable();
-    let mut selected = Vec::with_capacity(
+    let mut selected_keys = Vec::with_capacity(
         max_records.min(
             usize::try_from(E2EE_WITNESS_REPAIR_SCAN_PAGE_LIMIT)
                 .map_err(|_| E2eeReplicaError::InvalidRow)?,
@@ -549,15 +548,16 @@ async fn load_bounded_e2ee_witness_repairs(
     loop {
         check_e2ee_cancellation(is_cancelled)?;
         let mut metadata_query = QueryBuilder::<Sqlite>::new(
-            "SELECT
-               workspace_id,
-               record_id,
-               LENGTH(CAST(workspace_id AS BLOB))
-                 + LENGTH(CAST(record_id AS BLOB))
-                 + LENGTH(CAST(payload AS BLOB))
-                 + 256
-             FROM e2ee_witness_records
-             WHERE workspace_id IN (",
+            "WITH page AS MATERIALIZED (
+               SELECT
+                 witness.workspace_id,
+                 witness.record_id,
+                 LENGTH(CAST(witness.workspace_id AS BLOB))
+                   + LENGTH(CAST(witness.record_id AS BLOB))
+                   + LENGTH(CAST(witness.payload AS BLOB))
+                   + 256 AS record_bytes
+               FROM e2ee_witness_records AS witness
+               WHERE witness.workspace_id IN (",
         );
         {
             let mut separated = metadata_query.separated(", ");
@@ -568,140 +568,152 @@ async fn load_bounded_e2ee_witness_repairs(
         metadata_query.push(")");
         if let Some((after_workspace_id, after_record_id)) = &after {
             metadata_query
-                .push(" AND (workspace_id > ")
+                .push(" AND (witness.workspace_id > ")
                 .push_bind(after_workspace_id)
-                .push(" OR (workspace_id = ")
+                .push(" OR (witness.workspace_id = ")
                 .push_bind(after_workspace_id)
-                .push(" AND record_id > ")
+                .push(" AND witness.record_id > ")
                 .push_bind(after_record_id)
                 .push("))");
         }
         metadata_query
-            .push(" ORDER BY workspace_id, record_id LIMIT ")
-            .push_bind(E2EE_WITNESS_REPAIR_SCAN_PAGE_LIMIT);
-        let metadata: Vec<(String, String, i64)> =
+            .push(" ORDER BY witness.workspace_id, witness.record_id LIMIT ")
+            .push_bind(E2EE_WITNESS_REPAIR_SCAN_PAGE_LIMIT)
+            .push(
+                ")
+             SELECT
+               witness.workspace_id,
+               witness.record_id,
+               page.record_bytes,
+               (
+                 (replica.id IS NULL AND ",
+            )
+            .push_bind(include_missing)
+            .push(
+                ")
+                 OR (
+                   replica.id IS NOT NULL
+                   AND (
+                     replica.workspace_id != witness.workspace_id
+                     OR replica.payload != witness.payload
+                   )
+                 )
+               ) AS needs_repair
+             FROM page
+             INNER JOIN e2ee_witness_records AS witness
+               ON witness.workspace_id = page.workspace_id
+              AND witness.record_id = page.record_id
+             LEFT JOIN e2ee_records AS replica
+               ON replica.id = witness.record_id
+             ORDER BY witness.workspace_id, witness.record_id",
+            );
+        let metadata: Vec<(String, String, i64, bool)> =
             metadata_query.build_query_as().fetch_all(pool).await?;
         check_e2ee_cancellation(is_cancelled)?;
         if metadata.is_empty() {
-            return Ok((selected, false));
+            return finish_e2ee_witness_repair_selection(pool, &selected_keys, false, is_cancelled)
+                .await;
         }
         let page_is_full = metadata.len()
             == usize::try_from(E2EE_WITNESS_REPAIR_SCAN_PAGE_LIMIT)
                 .map_err(|_| E2eeReplicaError::InvalidRow)?;
         let page_after = metadata
             .last()
-            .map(|(workspace_id, record_id, _)| (workspace_id.clone(), record_id.clone()))
+            .map(|(workspace_id, record_id, _, _)| (workspace_id.clone(), record_id.clone()))
             .ok_or(E2eeReplicaError::InvalidRow)?;
 
-        let mut offset = 0;
-        while offset < metadata.len() {
-            check_e2ee_cancellation(is_cancelled)?;
-            let mut end = offset;
-            let mut scan_bytes = 0_usize;
-            while end < metadata.len() {
-                let record_bytes =
-                    usize::try_from(metadata[end].2).map_err(|_| E2eeReplicaError::InvalidRow)?;
-                if end > offset
-                    && scan_bytes.saturating_add(record_bytes) > E2EE_WITNESS_REPAIR_SCAN_BYTE_LIMIT
-                {
-                    break;
-                }
-                scan_bytes = scan_bytes.saturating_add(record_bytes);
-                end += 1;
-                if scan_bytes >= E2EE_WITNESS_REPAIR_SCAN_BYTE_LIMIT {
-                    break;
-                }
+        for (workspace_id, record_id, record_bytes, needs_repair) in metadata {
+            if !needs_repair {
+                continue;
             }
-
-            let chunk = &metadata[offset..end];
-            let mut records_query = QueryBuilder::<Sqlite>::new(
-                "SELECT workspace_id, record_id, revision, writer_id, payload_hash, payload,
-                        sequence
-                 FROM e2ee_witness_records
-                 WHERE ",
-            );
-            for (index, (workspace_id, record_id, _)) in chunk.iter().enumerate() {
-                if index > 0 {
-                    records_query.push(" OR ");
-                }
-                records_query
-                    .push("(workspace_id = ")
-                    .push_bind(workspace_id)
-                    .push(" AND record_id = ")
-                    .push_bind(record_id)
-                    .push(")");
+            if selected_keys.len() >= max_records {
+                return finish_e2ee_witness_repair_selection(
+                    pool,
+                    &selected_keys,
+                    true,
+                    is_cancelled,
+                )
+                .await;
             }
-            records_query.push(" ORDER BY workspace_id, record_id");
-            let records: Vec<WitnessRecord> =
-                records_query.build_query_as().fetch_all(pool).await?;
-            check_e2ee_cancellation(is_cancelled)?;
-            if records.len() != chunk.len()
-                || !records
-                    .iter()
-                    .zip(chunk)
-                    .all(|(record, (workspace_id, record_id, _))| {
-                        &record.workspace_id == workspace_id && &record.record_id == record_id
-                    })
-            {
-                return Err(E2eeReplicaError::InvalidRow);
+            let record_bytes =
+                usize::try_from(record_bytes).map_err(|_| E2eeReplicaError::InvalidRow)?;
+            if selected_bytes.saturating_add(record_bytes) > max_bytes {
+                if selected_keys.is_empty() {
+                    return Err(E2eeReplicaError::WitnessRepairTooLarge);
+                }
+                return finish_e2ee_witness_repair_selection(
+                    pool,
+                    &selected_keys,
+                    true,
+                    is_cancelled,
+                )
+                .await;
             }
-
-            let mut replica_query = QueryBuilder::<Sqlite>::new(
-                "SELECT id, workspace_id, payload FROM e2ee_records WHERE id IN (",
-            );
-            {
-                let mut separated = replica_query.separated(", ");
-                for record in &records {
-                    separated.push_bind(&record.record_id);
-                }
+            selected_bytes = selected_bytes.saturating_add(record_bytes);
+            selected_keys.push((workspace_id, record_id));
+            if selected_keys.len() >= max_records {
+                return finish_e2ee_witness_repair_selection(
+                    pool,
+                    &selected_keys,
+                    true,
+                    is_cancelled,
+                )
+                .await;
             }
-            replica_query.push(")");
-            let replicas: Vec<(String, String, String)> =
-                replica_query.build_query_as().fetch_all(pool).await?;
-            check_e2ee_cancellation(is_cancelled)?;
-            let replicas = replicas
-                .into_iter()
-                .map(|(record_id, workspace_id, payload)| (record_id, (workspace_id, payload)))
-                .collect::<HashMap<_, _>>();
-
-            for (record, (_, _, record_bytes)) in records.into_iter().zip(chunk) {
-                check_e2ee_cancellation(is_cancelled)?;
-                let needs_repair = match replicas.get(&record.record_id) {
-                    None => include_missing,
-                    Some((workspace_id, payload)) => {
-                        workspace_id != &record.workspace_id || payload != &record.payload
-                    }
-                };
-                if !needs_repair {
-                    continue;
-                }
-                if selected.len() >= max_records {
-                    return Ok((selected, true));
-                }
-                let record_bytes =
-                    usize::try_from(*record_bytes).map_err(|_| E2eeReplicaError::InvalidRow)?;
-                if selected_bytes.saturating_add(record_bytes) > max_bytes {
-                    if selected.is_empty() {
-                        return Err(E2eeReplicaError::WitnessRepairTooLarge);
-                    }
-                    return Ok((selected, true));
-                }
-                selected_bytes = selected_bytes.saturating_add(record_bytes);
-                selected.push(record);
-                if selected.len() >= max_records {
-                    return Ok((selected, true));
-                }
-            }
-            offset = end;
-            yield_once().await;
         }
 
         if !page_is_full {
-            return Ok((selected, false));
+            return finish_e2ee_witness_repair_selection(pool, &selected_keys, false, is_cancelled)
+                .await;
         }
         after = Some(page_after);
         yield_once().await;
     }
+}
+
+async fn finish_e2ee_witness_repair_selection(
+    pool: &SqlitePool,
+    selected_keys: &[(String, String)],
+    remaining: bool,
+    is_cancelled: &(impl Fn() -> bool + Sync),
+) -> E2eeReplicaResult<(Vec<WitnessRecord>, bool)> {
+    check_e2ee_cancellation(is_cancelled)?;
+    if selected_keys.is_empty() {
+        return Ok((Vec::new(), remaining));
+    }
+    let mut query = QueryBuilder::<Sqlite>::new("WITH wanted(workspace_id, record_id) AS (");
+    query.push_values(selected_keys, |mut row, key| {
+        row.push_bind(&key.0).push_bind(&key.1);
+    });
+    query.push(
+        ")
+         SELECT
+           witness.workspace_id,
+           witness.record_id,
+           witness.revision,
+           witness.writer_id,
+           witness.payload_hash,
+           witness.payload,
+           witness.sequence
+         FROM wanted
+         INNER JOIN e2ee_witness_records AS witness
+           ON witness.workspace_id = wanted.workspace_id
+          AND witness.record_id = wanted.record_id
+         ORDER BY witness.workspace_id, witness.record_id",
+    );
+    let records: Vec<WitnessRecord> = query.build_query_as().fetch_all(pool).await?;
+    check_e2ee_cancellation(is_cancelled)?;
+    if records.len() != selected_keys.len()
+        || !records
+            .iter()
+            .zip(selected_keys)
+            .all(|(record, (workspace_id, record_id))| {
+                &record.workspace_id == workspace_id && &record.record_id == record_id
+            })
+    {
+        return Err(E2eeReplicaError::InvalidRow);
+    }
+    Ok((records, remaining))
 }
 
 async fn persist_e2ee_witness_repairs(

--- a/crates/db-app/src/e2ee/witness/witness_cancellation_tests.rs
+++ b/crates/db-app/src/e2ee/witness/witness_cancellation_tests.rs
@@ -321,6 +321,69 @@ async fn cancelled_all_match_witness_scan_stays_bounded_and_releases_local_write
 }
 
 #[tokio::test]
+async fn witness_scan_selects_only_records_that_need_repair() {
+    let db = test_db().await;
+    let workspace_keys = HashMap::from([("workspace-a".to_string(), workspace_key())]);
+    sqlx::query(
+        "WITH RECURSIVE counter(value) AS (
+           SELECT 0
+           UNION ALL
+           SELECT value + 1 FROM counter WHERE value < 255
+         )
+         INSERT INTO e2ee_witness_records (
+           workspace_id, record_id, revision, writer_id,
+           payload_hash, payload, sequence
+         )
+         SELECT
+           'workspace-a',
+           printf('record-%03d', value),
+           1,
+           'writer-a',
+           printf('hash-%03d', value),
+           printf('payload-%03d', value),
+           value + 1
+         FROM counter",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO e2ee_records (id, workspace_id, payload)
+         SELECT record_id, workspace_id, payload FROM e2ee_witness_records",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let cancellation_checks = AtomicUsize::new(0);
+    let (repairs, remaining) =
+        load_bounded_e2ee_witness_repairs(db.pool(), &workspace_keys, true, 2, usize::MAX, &|| {
+            cancellation_checks.fetch_add(1, Ordering::SeqCst);
+            false
+        })
+        .await
+        .unwrap();
+    assert!(repairs.is_empty());
+    assert!(!remaining);
+    assert!(cancellation_checks.load(Ordering::SeqCst) <= 10);
+
+    sqlx::query("UPDATE e2ee_records SET payload = 'changed' WHERE id = 'record-255'")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    let (repairs, remaining) =
+        load_bounded_e2ee_witness_repairs(db.pool(), &workspace_keys, true, 2, usize::MAX, &|| {
+            false
+        })
+        .await
+        .unwrap();
+    assert_eq!(repairs.len(), 1);
+    assert_eq!(repairs[0].record_id, "record-255");
+    assert!(!remaining);
+}
+
+#[tokio::test]
 async fn cancelled_witness_upload_processing_releases_local_writes() {
     let db = test_db().await;
     let key = workspace_key();

--- a/plugins/db/src/runtime/recovery.rs
+++ b/plugins/db/src/runtime/recovery.rs
@@ -430,6 +430,20 @@ impl PluginDbRuntime {
                                 return Ok(CloudsyncRecoveryStep::Deferred);
                             }
                             let keys = e2ee_sync_hook.snapshot();
+                            let apply = anlg_db_app::apply_received_e2ee_replica_changes_with_witness_cancellable(
+                                db.pool(),
+                                &keys,
+                                false,
+                                || cloudsync_recovery_cancelled(&recovery_cancelled),
+                            )
+                            .await
+                            .map_err(|error| std::io::Error::other(error.to_string()))?;
+                            if cloudsync_recovery_cancelled(&recovery_cancelled) {
+                                return Ok(CloudsyncRecoveryStep::Deferred);
+                            }
+                            if apply.applied_fields > 0 {
+                                return Ok(CloudsyncRecoveryStep::Progressed);
+                            }
                             let repair =
                                 anlg_db_app::repair_e2ee_replica_from_witness_bounded_cancellable(
                                     db.pool(),
@@ -444,18 +458,7 @@ impl PluginDbRuntime {
                             if cloudsync_recovery_cancelled(&recovery_cancelled) {
                                 return Ok(CloudsyncRecoveryStep::Deferred);
                             }
-                            let apply = anlg_db_app::apply_received_e2ee_replica_changes_with_witness_cancellable(
-                                db.pool(),
-                                &keys,
-                                false,
-                                || cloudsync_recovery_cancelled(&recovery_cancelled),
-                            )
-                            .await
-                            .map_err(|error| std::io::Error::other(error.to_string()))?;
-                            if cloudsync_recovery_cancelled(&recovery_cancelled) {
-                                return Ok(CloudsyncRecoveryStep::Deferred);
-                            }
-                            if repair.repaired_records > 0 || apply.applied_fields > 0 {
+                            if repair.repaired_records > 0 {
                                 return Ok(CloudsyncRecoveryStep::Progressed);
                             }
                             if repair.remaining || apply.remaining_replica_changes {


### PR DESCRIPTION
## Summary
- filter unchanged encrypted replica rows in SQLite before paging
- compare witness metadata in bounded SQL pages and fetch payloads only for repairs
- apply already-witnessed replica changes before starting whole-replica witness repair
- add regression coverage for both optimized scan paths

## Root cause
Recovery repeatedly loaded and compared large batches of records in application code, including unchanged rows and full encrypted payloads. On large local databases this made each recovery cycle take seconds and left users looking at a long-running sync state.

## Impact
CloudSync recovery remains cancellation-safe and bounded while avoiding unnecessary record and payload scans. The measured 128-record page on the reported 1.8 GB database dropped from seconds to under 10 ms.

## Validation
- cargo test --locked -p db-app --lib (165 passed)
- cargo test --locked -p tauri-plugin-db --lib (133 passed)
- cargo check --locked -p db-app -p tauri-plugin-db
- cargo clippy --locked -p db-app --all-targets --no-deps -- -D warnings
- pnpm fmt:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bounded E2EE replica apply and witness repair logic used during CloudSync recovery; incorrect filtering could skip needed applies or repairs on large local DBs.
> 
> **Overview**
> **CloudSync recovery** was spending seconds per cycle scanning unchanged encrypted rows and full witness payloads in Rust. This PR pushes that work into **bounded SQLite queries** and tweaks recovery ordering.
> 
> **Replica apply preflight** (`load_changed_e2ee_record_metadata`) now pages only `e2ee_records` that differ from `e2ee_local_state` (missing row or mismatched workspace/payload), so unchanged replicas are not loaded for comparison.
> 
> **Witness repair selection** (`load_bounded_e2ee_witness_repairs`) compares witness vs replica metadata in SQL pages, marks `needs_repair`, and loads full witness rows only for selected keys via `finish_e2ee_witness_repair_selection`—replacing per-page Rust fetches and replica hash maps.
> 
> In **`NeedWitnessRepair`**, **`apply_received_e2ee_replica_changes_with_witness_cancellable`** runs **before** bounded witness repair so already-witnessed replica changes apply without a full repair scan first.
> 
> Regression tests cover both optimized scan paths (256 in-sync rows, single changed record).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e431a3868f29422a96579775e3acf959b445f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->