### PR TITLE
Expand user and developer documentation

### DIFF
--- a/apps/desktop/src/settings/imports/index.test.tsx
+++ b/apps/desktop/src/settings/imports/index.test.tsx
@@ -23,6 +23,9 @@ describe("SettingsImports", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Documentation" }));
 
-    expect(mocks.openUrl).toHaveBeenCalledWith("https://docs.anarlog.so", null);
+    expect(mocks.openUrl).toHaveBeenCalledWith(
+      "https://docs.anarlog.so/imports",
+      null,
+    );
   });
 });

--- a/apps/desktop/src/settings/imports/index.tsx
+++ b/apps/desktop/src/settings/imports/index.tsx
@@ -7,7 +7,7 @@ import { Button } from "@anlg/ui/components/ui/button";
 import { MeetingImportScreen } from "~/imports/screen";
 import { SettingsPageTitle } from "~/settings/page-title";
 
-const IMPORTS_DOCUMENTATION_URL = "https://docs.anarlog.so";
+const IMPORTS_DOCUMENTATION_URL = "https://docs.anarlog.so/imports";
 
 export function SettingsImports() {
   return (

--- a/docs/automations.mdx
+++ b/docs/automations.mdx
@@ -1,0 +1,44 @@
+---
+title: "Automate meeting follow-up"
+description: "Send recaps, create issues, update project notes, or export every meeting."
+---
+
+Automations run repeatable work when a meeting ends. They are part of Anarlog Pro.
+
+## Use a starter
+
+Open **Automations** and choose a starter from the sidebar:
+
+| Starter | What it does | Configuration |
+| --- | --- | --- |
+| Share a meeting recap in Slack | Posts the meeting title and AI summary. | Connect Slack and choose a channel. |
+| Update project notes in Notion | Appends a dated meeting update to a page. | Connect Notion and choose a page. |
+| Turn action items into Linear issues | Creates issue drafts from assigned follow-ups. | Connect Linear and choose a team. |
+| Export every meeting as Markdown | Writes the memo, summary, and transcript to a local file. | Choose an export folder. |
+
+1. Select the starter.
+2. Connect the service or choose the local folder it needs.
+3. Review the trigger, source content, and result preview.
+4. Click **Save & enable**.
+
+An enabled starter runs after a meeting ends and the content it needs is ready. Disable it when you want to keep the setup without running it.
+
+## Check whether it ran
+
+The automation detail shows whether it is enabled and the result of its last run. A failed run includes a short error. Check the selected destination and reconnect the service when authorization has expired.
+
+For Markdown exports, confirm that the chosen folder still exists and is writable. The local export does not need Slack, Notion, or Linear access.
+
+## Draft a custom automation in Chat
+
+You can describe a workflow in Chat, including what should happen and when. The draft and its conversation appear with your automations so you can return to them.
+
+Examples:
+
+- “After customer calls, draft Linear issues for action items assigned to our team.”
+- “Save completed interviews as Markdown in my research folder.”
+- “Post the summary of weekly planning meetings to the product Slack channel.”
+
+A Chat-created automation remains a draft and does not run automatically. Continue its Chat conversation to refine the workflow. Use one of the guided starters for an automation you can enable today.
+
+Automations send meeting content to the destination you configure. Use only workspaces, channels, pages, teams, and folders that should receive that content.

--- a/docs/chat.mdx
+++ b/docs/chat.mdx
@@ -1,0 +1,45 @@
+---
+title: "Chat with your meetings"
+description: "Ask questions, find related context, and review proposed note changes."
+---
+
+Anarlog Chat can answer questions about the open meeting, search your other meetings, and help turn a conversation into follow-up work. Chat uses the Intelligence model selected under **Settings → Intelligence**.
+
+## Ask about the open meeting
+
+1. Open a meeting note.
+2. Open **Chat**.
+3. Check the context chips above the input. The open meeting is added automatically when its content is available.
+4. Ask a question or choose a suggested prompt.
+
+Useful requests include:
+
+- “What are my action items from this meeting?”
+- “Draft a follow-up email to the participants.”
+- “What decisions did we make?”
+- “Compare this meeting with the previous project review.”
+- “Find meetings where we discussed the launch date.”
+
+Chat can search meeting titles and content, recurring meeting history, contacts, and connected calendar events when the request needs them.
+
+## Control the context
+
+Context chips show the meetings, people, and other records Chat can use for the next message.
+
+- Click a meeting or contact chip to open it.
+- Hover over a removable chip and click its remove button to exclude it.
+- Start a new chat when you want a clean conversation without the earlier message history.
+
+Check these chips before asking about sensitive or similarly named meetings. A clear request such as “Use only this meeting” also helps keep the answer scoped.
+
+## Review proposed changes
+
+Chat can propose a summary edit or transcript correction. Review the proposed change before you apply it. A proposal does not silently replace your note.
+
+For direct transcript editing, speaker reassignment, and re-transcription, see [Notes, summaries, and transcripts](/notes#correct-a-transcript).
+
+## Privacy and external search
+
+Chat sends the prompt and required context to your selected Intelligence provider. A local provider keeps that model request on your computer. A hosted provider receives the text needed to answer.
+
+Chat can also search the public web when a request needs current external information. The search query leaves your device. See [Data, privacy, and retention](/data-and-privacy) before using sensitive context with hosted models or web search.

--- a/docs/customize-summaries.mdx
+++ b/docs/customize-summaries.mdx
@@ -19,6 +19,10 @@ Changing the selected template does not rewrite an existing summary automaticall
 
 For example:
 
+```text
+Start with decisions. Then list action items with an owner and due date. Keep background context to three bullets.
+```
+
 The editor shows the complete system prompt used by Auto. Use the **Current date** and **Language** chips wherever those values should appear.
 
 Meeting notes, transcript, session details, and participants are always sent separately. Editing the Auto prompt cannot remove that source material.

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -18,7 +18,9 @@ The destination depends on the feature you choose:
 - A hosted **Transcription** provider receives the audio needed to create a transcript.
 - A hosted **Intelligence** provider receives the text and instructions needed to create a summary or chat response.
 - Connected calendars send the calendar and event details needed to show upcoming events and associate them with your notes.
-- [Sync](/sync) and sharing features send the content you choose to make available on another device or through a link.
+- [Sync](/sync) sends end-to-end encrypted content to keep your devices up to date. Anarlog cannot read the recovery key.
+- [Sharing](/sharing) uploads the generated summary and any audio you explicitly include. Your private memo is not part of the shared note.
+- [Chat](/chat) sends the prompt and required context to your selected Intelligence provider. Public web search also sends the search query to the search service.
 - [Cloud API & Connectors](/reference/api-cloud), when you explicitly enable it, uploads a separate server-readable copy of meeting titles, notes, summaries, participants, action items, and transcripts so remote agents can work while your desktop is offline. Turning it off deletes those copies.
 
 Anarlog Cloud, your own API-key providers, and local providers are separate choices. Review the provider's own retention and training policies before sending sensitive content.

--- a/docs/desktop-installation.mdx
+++ b/docs/desktop-installation.mdx
@@ -1,0 +1,56 @@
+---
+title: "Install the desktop app"
+description: "Choose the right Anarlog build for macOS, Windows, or Linux."
+---
+
+[Download Anarlog](https://anarlog.so/download) to get the latest stable desktop release. The download page offers every supported platform from the same release.
+
+## Choose the right build
+
+| Platform | Build | Notes |
+| --- | --- | --- |
+| macOS | Apple Silicon DMG | For Macs with an M-series chip. Requires macOS 15 or later. |
+| macOS | Intel DMG | For Intel-based Macs. Requires macOS 15 or later. |
+| Windows | Windows x64 EXE | For 64-bit Windows PCs. Windows support is in beta. |
+| Linux | x64 or ARM64 AppImage | Portable build. Linux support is in beta. |
+| Linux | x64 or ARM64 DEB | For Debian, Ubuntu, and compatible distributions. Linux support is in beta. |
+
+On a Mac, open **Apple menu → About This Mac** if you do not know whether it uses an Apple or Intel chip.
+
+## macOS
+
+1. Download the DMG that matches your Mac.
+2. Open the DMG and move Anarlog to **Applications**.
+3. Open Anarlog and follow the setup screen.
+4. Allow microphone, system audio, and calendar access when you want to use those features.
+
+## Windows
+
+1. Download the **Windows x64** installer.
+2. Run the EXE and follow the installer.
+3. Open Anarlog and complete setup.
+4. Allow microphone and system-audio access when prompted.
+
+## Linux
+
+For Debian or Ubuntu, install the downloaded package:
+
+```bash
+sudo apt install ./anarlog-*.deb
+```
+
+For an AppImage, make it executable and open it:
+
+```bash
+chmod +x ./anarlog-*.AppImage
+./anarlog-*.AppImage
+```
+
+## Platform differences
+
+- Apple Calendar integration is available on macOS. Google Calendar works through your Anarlog account on every supported platform.
+- Built-in on-device transcription is currently available only on Apple Silicon. On other platforms, choose Anarlog Cloud or configure a supported transcription provider.
+- Windows and Linux support are in beta. Include your operating system and Anarlog version when you report a platform-specific problem.
+- Anarlog does not currently offer a mobile app.
+
+When installation is complete, continue to [Your first meeting](/quickstart). If the app does not open or cannot capture audio, see [Troubleshooting](/troubleshooting).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -17,7 +17,7 @@
     "pages": [
       {
         "group": "Getting started",
-        "pages": ["index", "quickstart"]
+        "pages": ["index", "desktop-installation", "quickstart"]
       },
       {
         "group": "Using Anarlog",
@@ -25,10 +25,14 @@
           "meetings",
           "automatic-capture",
           "import-recordings",
+          "imports",
           "notes",
+          "sharing",
+          "chat",
           "customize-summaries",
           "calendar",
           "sync",
+          "automations",
           "languages"
         ]
       },

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -1,33 +1,74 @@
 ---
-title: "Common questions"
-description: "Find the right guide for the questions people ask most often about Anarlog."
+title: "Frequently asked questions"
+description: "Answers about recording, AI, privacy, sharing, sync, and developer tools."
 ---
 
-<CardGroup cols={2}>
-  <Card title="Does Anarlog join the call?" icon="video-slash" href="/meetings">
-    No. Anarlog captures microphone and computer audio on your Mac without adding a meeting bot.
-  </Card>
-  <Card title="Can I use it offline?" icon="wifi-slash" href="/offline">
-    Yes. Prepare local transcription and Intelligence models before disconnecting.
-  </Card>
-  <Card title="Where is my data stored?" icon="hard-drive" href="/data-and-privacy">
-    App data is stored locally. Hosted and connected features receive only the data needed for the feature.
-  </Card>
-  <Card title="Can I import an old recording?" icon="file-arrow-up" href="/import-recordings">
-    Import common audio formats, or start from an SRT or VTT transcript.
-  </Card>
-  <Card title="Can recording start automatically?" icon="clock" href="/automatic-capture">
-    Start calendar-backed meetings on schedule and get prompts for unscheduled calls.
-  </Card>
-  <Card title="How do I improve summaries?" icon="wand-magic-sparkles" href="/customize-summaries">
-    Choose a template, set standing instructions, and add specialized terms.
-  </Card>
-  <Card title="Can a meeting use multiple languages?" icon="language" href="/languages">
-    Choose the output language and add every language you expect people to speak.
-  </Card>
-  <Card title="How do I export my notes?" icon="file-export" href="/notes#export-a-meeting">
-    Export any combination of the memo, summary, and transcript.
-  </Card>
-</CardGroup>
+## Recording and notes
+
+### Does Anarlog join the call?
+
+No. Anarlog captures your microphone and computer audio from the desktop without adding a meeting bot. See [Record meetings](/meetings).
+
+### Can recording start automatically?
+
+Yes. Anarlog can start calendar-backed meetings on schedule and prompt you when it detects an unscheduled call. You control both behaviors under **Settings → App → Automatic recording**. See [Automatic capture](/automatic-capture).
+
+### Can I edit a transcript or fix a speaker?
+
+Yes. Use **Write** to edit transcript text. Select text or a speaker label to assign the correct person, create a speaker, or apply the change to every matching segment. See [Correct a transcript](/notes#correct-a-transcript).
+
+### Can I add more audio to an existing note?
+
+Yes. Right-click **Transcript** and choose **Resume listening**. The new recording stays in the same meeting note.
+
+### Can I import older meetings?
+
+Yes. Upload one audio, SRT, or VTT file to an empty note, or use **Settings → Imports** for meeting-history exports from another assistant. See [Import audio or a transcript](/import-recordings) and [Import meeting history](/imports).
+
+## AI, offline use, and privacy
+
+### Can I use Anarlog offline?
+
+Yes, if you prepare local models before disconnecting. Built-in on-device transcription is currently available only on Apple Silicon. LM Studio and Ollama can provide local Intelligence models on supported platforms. See [Use Anarlog offline](/offline).
+
+### Where is my data stored?
+
+Anarlog stores app data locally by default. Hosted AI, calendars, sync, sharing, and the optional Cloud API receive the content needed for the feature you enable. See [Data, privacy, and retention](/data-and-privacy).
+
+### Does Anarlog train on my meetings?
+
+The answer depends on the provider you choose. Local providers keep the model request on your computer. For Anarlog Cloud or a bring-your-own-key provider, review that provider's retention and training policy before sending sensitive content.
+
+### Can a meeting use multiple languages?
+
+Yes. Choose the summary language and add every spoken language you expect. The selected Transcription model must support them. See [Languages](/languages).
+
+## Sharing, sync, and automation
+
+### What gets shared with another person?
+
+Anarlog shares the generated summary, not your private memo. Retained audio is optional and must be included separately. Sharing is a Pro feature. See [Share meetings](/sharing).
+
+### Can Anarlog recover my sync recovery key?
+
+No. The key is shown only during setup and Anarlog cannot read or recover it. Save it in a password manager before closing the setup window. See [Cloud sync](/sync#save-the-recovery-key).
+
+### Can I automate follow-up work?
+
+Yes, with Anarlog Pro. Built-in starters can post a Slack recap, update a Notion page, create Linear issues, or export each meeting as Markdown. See [Automate meeting follow-up](/automations).
+
+## Platforms and developer tools
+
+### Which desktop platforms are supported?
+
+Anarlog supports macOS 15 or later. Windows x64 and Linux x64 or ARM64 builds are available in beta. See [Install the desktop app](/desktop-installation).
+
+### Is there a mobile app?
+
+Not yet. Anarlog currently ships as a desktop app.
+
+### Does the local API work while Anarlog is closed?
+
+No. The local API listens only on `127.0.0.1` while the desktop app is open. The CLI and local MCP server can read the local database while the app is closed. For hosted access, explicitly enable [Cloud API & Connectors](/reference/api-cloud).
 
 If something is not working, go to [Troubleshooting](/troubleshooting). For a question not covered here, email [founders@anarlog.so](mailto:founders@anarlog.so) or [join Discord](https://anarlog.so/discord).

--- a/docs/import-recordings.mdx
+++ b/docs/import-recordings.mdx
@@ -5,6 +5,8 @@ description: "Turn an existing recording or subtitle file into an Anarlog meetin
 
 You can use Anarlog with a conversation that was recorded elsewhere. Import audio to create a new transcript, or import an existing transcript to create a summary.
 
+To move many existing meetings from another meeting assistant, use [Import meeting history](/imports) instead.
+
 ## Import audio
 
 1. Create a **New Note** or open an empty note.

--- a/docs/imports.mdx
+++ b/docs/imports.mdx
@@ -1,0 +1,45 @@
+---
+title: "Import meeting history"
+description: "Bring notes and transcripts from another meeting assistant into Anarlog."
+---
+
+Meeting-history import turns official exports from another meeting assistant into Anarlog notes. It is designed for moving a library of past meetings, not for uploading one recording.
+
+<Note>
+  To import one audio, SRT, or VTT file, use [Import audio or a transcript](/import-recordings).
+</Note>
+
+## Import exported meetings
+
+1. Export your meetings from the original assistant.
+2. Open **Settings → Imports** in Anarlog.
+3. Find the detected assistant and click **Import**.
+4. Select one or more JSON, CSV, Markdown, text, VTT, or SRT export files.
+5. Review the result shown when the import finishes.
+
+Anarlog detects supported meeting-assistant apps installed on your computer. Supported sources include Granola, Circleback, Fireflies.ai, Fathom, Krisp, Otter.ai, Notion AI Meeting Notes, Zoom, Microsoft Teams, Google Meet, Webex, ChatGPT Record, Slack Huddles, and others.
+
+The exact content depends on the source export. Anarlog keeps supported titles, dates, notes, summaries, transcripts, speakers, and participants when those fields are available.
+
+## Understand the result
+
+The result separates meetings into four groups:
+
+- **Imported** meetings were added as new notes.
+- **Matched** meetings were already present and were left unchanged.
+- **Conflicts** need review because Anarlog could not safely choose between versions.
+- **Errors** could not be read or converted.
+
+You can select the same export again. Meetings that still match are not duplicated.
+
+## What is not imported
+
+Meeting-history import reads text-based exports. It does not copy the original audio or video.
+
+If you only have an audio recording, [upload the audio to an empty note](/import-recordings#import-audio) and let your selected Transcription model process it.
+
+## If your assistant is missing
+
+Anarlog lists assistants it detects on your computer. Open or reinstall the source app, restart Anarlog, and check **Settings → Imports** again. You can also export to SRT or VTT and [import the transcript directly](/import-recordings#import-a-transcript).
+
+See [Troubleshooting](/troubleshooting#meeting-history-import-shows-no-apps) if no supported app appears or an export fails.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -9,6 +9,9 @@ Anarlog records your microphone and computer audio without joining the call as a
   <Card title="Try your first meeting" icon="play" href="/quickstart">
     Use the private demo in Anarlog, then record a real meeting.
   </Card>
+  <Card title="Install the desktop app" icon="download" href="/desktop-installation">
+    Choose the right build for macOS, Windows, or Linux.
+  </Card>
   <Card title="Record a meeting" icon="microphone" href="/meetings">
     Start from your calendar or from a new note.
   </Card>
@@ -35,6 +38,12 @@ Anarlog records your microphone and computer audio without joining the call as a
   <Card title="How do I improve summaries?" icon="wand-magic-sparkles" href="/customize-summaries">
     Use templates, instructions, languages, and your dictionary.
   </Card>
+  <Card title="Can I share a meeting?" icon="share-nodes" href="/sharing">
+    Invite people, send a recap, or share a view-only link.
+  </Card>
+  <Card title="Can I import my meeting history?" icon="clock-rotate-left" href="/imports">
+    Bring supported exports from another meeting assistant.
+  </Card>
 </CardGroup>
 
 [Browse all common questions →](/help)
@@ -46,7 +55,7 @@ Anarlog records your microphone and computer audio without joining the call as a
 3. Take rough notes in **Memos** while Anarlog listens.
 4. Stop listening, then review **Summary** and **Transcript**.
 
-Your app data is stored locally. If you choose a hosted transcription or language-model provider, the content needed for that feature is sent to that provider.
+Your app data is stored locally by default. Hosted AI, sync, sharing, connected calendars, and the optional Cloud API send the content needed for the feature you choose. See [Data, privacy, and retention](/data-and-privacy) for the exact boundaries.
 
 <Note>
   New to Anarlog? Open the **Welcome to Anarlog** note and click **Join & record**. It uses a private, prerecorded demo meeting.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Installation"
+title: "CLI installation"
 description: "Install the current Anarlog CLI and point it at local meeting data."
 ---
 

--- a/docs/notes.mdx
+++ b/docs/notes.mdx
@@ -11,11 +11,32 @@ Every meeting note has up to three views:
 
 You can edit memos and summaries like regular notes. In a transcript, select a speaker label to assign a participant and use **Apply to all** when the same speaker appears again.
 
+## Correct a transcript
+
+- Click **Write** above the transcript to edit its text. Click **Done writing** when you finish.
+- Select words or a transcript segment and choose **Change speaker** to fix only that selection.
+- Select a speaker label to choose an existing participant or **Create new speaker**. Use **Apply to all** to update every matching speaker segment.
+- Right-click **Transcript** to copy the transcript, resume listening, re-transcribe retained audio, or delete the recording.
+
+Re-transcribing replaces the current transcript with output from your selected Transcription model. Edit or export anything you need before you start it.
+
+Deleting the recording does not delete the memo, summary, or transcript. It only removes the retained audio file.
+
 ## Shape the summary
 
 Use the template picker beside **Summary** to change its structure. You can also set standing instructions, add names and specialized terms, and control how templates interact with your preferences.
 
 See [Customize meeting summaries](/customize-summaries) for the complete setup.
+
+## Continue an existing note
+
+Right-click **Transcript** and choose **Resume listening** to add another recording to the same meeting note. This is useful when a call resumes after a break or when you want several related conversations in one place.
+
+## Share a meeting
+
+Use **Share** in the meeting header to invite people, send a recap, or copy a link. Anarlog shares the generated summary, not your private memo. You can include retained audio separately.
+
+See [Share meetings](/sharing) for access levels, comments, and link controls.
 
 ## Export a meeting
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,7 +5,7 @@ description: "Set up Anarlog and try a private demo before your next call."
 
 <Steps>
   <Step title="Install Anarlog">
-    [Download Anarlog](https://anarlog.so/download), open it, and follow the setup screen.
+    [Download Anarlog](https://anarlog.so/download), open it, and follow the setup screen. See [Install the desktop app](/desktop-installation) to choose the right macOS, Windows, or Linux build.
   </Step>
   <Step title="Allow audio access">
     Allow **Microphone** so Anarlog can hear you. Allow **System Audio** so it can hear everyone else on the call.
@@ -20,6 +20,15 @@ description: "Set up Anarlog and try a private demo before your next call."
     When the video ends, return to Anarlog and stop listening. Open **Memos**, **Summary**, and **Transcript** to see what Anarlog captured.
   </Step>
 </Steps>
+
+## Find your way around
+
+- The sidebar keeps upcoming meetings and recent notes within reach.
+- The center of the app shows the open memo, summary, or transcript.
+- **Chat** works with the open meeting and any context shown above its input.
+- **Settings** controls audio, AI providers, storage, sync, imports, integrations, and developer tools.
+
+You can rename a note from its title and keep several notes open in tabs. A meeting note stays useful before, during, and after the call.
 
 ## Record a real meeting
 

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -129,4 +129,4 @@ Verify the raw body before parsing it. For replay protection, reject stale signe
 
 ## Limits
 
-The server binds to `127.0.0.1` only and runs while the desktop app is open. There are no request rate limits. List endpoints cap `limit` at 200 and transcript pages at 500 words.
+The server binds to `127.0.0.1` only and runs while the desktop app is open. There are no request rate limits. List endpoints cap `limit` at 200, transcript pages at 500 words, and one installation can configure at most 64 webhook endpoints.

--- a/docs/sharing.mdx
+++ b/docs/sharing.mdx
@@ -1,0 +1,48 @@
+---
+title: "Share meetings"
+description: "Invite people, send a recap, or share a meeting summary by link."
+---
+
+Sharing publishes a meeting's generated summary so other people can review it without receiving your private memo. Sharing requires Anarlog Pro, an account, and an internet connection.
+
+## Share a note
+
+1. Open a meeting with a generated summary.
+2. Click **Share** in the meeting header.
+3. Choose how you want to share it:
+   - **Invite** people by email and give them viewing or commenting access.
+   - **Email** the meeting summary as a recap.
+   - **Slack** posts the meeting summary to a channel you can access.
+4. Review **General access** before you copy or send the link.
+
+The first share creates an online copy of the summary. Later summary edits sync to the shared note while sharing remains active.
+
+## Choose who can open it
+
+**General access** controls the broadest audience:
+
+- **Only people invited** requires an invitation to the note.
+- **Everyone in your workspace** makes the note available to members of the selected Anarlog workspace.
+- **Anyone with the link** allows anyone who has the bearer link to view it.
+
+Invited people can have **Can view** or **Can comment** access. The note owner keeps full access and can change or revoke each person's access.
+
+<Warning>
+  Treat an **Anyone with the link** URL like sensitive data. Replace the link if it was sent to the wrong place, or switch General access back to invited-only.
+</Warning>
+
+## Include audio
+
+If the meeting still has a retained recording, turn on **Share audio** to add it to the shared note. Audio is separate from the summary and can be removed from the share without deleting your local recording.
+
+Check [Audio file retention](/data-and-privacy#choose-how-long-audio-is-kept) if the option is missing. Anarlog cannot share audio that has already been removed from local storage.
+
+## Comments
+
+People with commenting access can select summary text and add an anchored comment. Viewers can read existing comments but cannot add new ones. The owner can manage access and delete comments on the shared note.
+
+## Stop or restrict sharing
+
+Open **Share** again to remove a person, change General access, stop sharing audio, or replace a link. Restricting a link prevents that link from granting access, but invited people keep the access you gave them.
+
+See [Data, privacy, and retention](/data-and-privacy) for what sharing sends to Anarlog's hosted service.

--- a/docs/sync.mdx
+++ b/docs/sync.mdx
@@ -12,7 +12,34 @@ Cloud sync keeps your notes up to date across your signed-in devices. It is part
 
 Sync runs automatically in the background. Use **Sync now** to send and receive the latest changes immediately. Your notes always remain available locally, even while sync is paused or you are offline.
 
-Your recovery key encrypts synced notes before they leave your device, so Anarlog cannot read them. See [Data, privacy, and retention](/data-and-privacy) for what stays on your computer.
+Pause sync when you want changes to remain only on the current device for a while. Resume it to send pending changes and receive updates from your other devices.
+
+## Save the recovery key
+
+Your recovery key encrypts synced notes before they leave your device, so Anarlog cannot read or recover it.
+
+When you create the key:
+
+1. Copy it into a password manager or download the text file.
+2. Confirm that you can find the saved copy before closing the setup window.
+3. Keep it separate from the computer you are syncing.
+
+The key is shown only during setup. Clipboard copies clear after 60 seconds when the operating system supports it.
+
+<Warning>
+  If you lose the recovery key, your existing local notes remain on their devices, but you cannot use that key to add another device. Anarlog support cannot recover it for you.
+</Warning>
+
+## Add another device
+
+1. Install Anarlog and sign in with the same account.
+2. Open **Settings → Sync** and turn on Cloud sync.
+3. Choose the option to enter an existing recovery key.
+4. Paste the key from your password manager, then wait for the first sync to finish.
+
+One account can sync up to five devices. If you reach the limit, remove an unused device before enabling sync on another one.
+
+See [Data, privacy, and retention](/data-and-privacy) for what stays on your computer.
 
 Cloud API & Connectors is a separate, optional feature. If you enable it under **Settings → Developers**, Anarlog uploads a server-readable copy for remote agents; it does not decrypt or weaken your end-to-end encrypted sync data. See [Cloud API and connectors](/reference/api-cloud).
 
@@ -27,3 +54,13 @@ Keep your Anarlog storage location out of folders managed by a file-syncing serv
 This includes Obsidian vaults stored in iCloud Drive. If you selected one as your storage location, choose a local folder instead.
 
 Anarlog shows a warning in **Settings → Sync** when your storage location is inside a known cloud-storage folder. Backup tools that snapshot files without continuously syncing them back are fine.
+
+## Fix a blocked sync
+
+- **Setup required:** Create a recovery key or enter the key from an existing device.
+- **Sign in again:** Sign out and sign back in, then resume sync.
+- **Identity mismatch:** Sign in again with the account that owns the synced notes. Check Sync settings before changing local files.
+- **Device limit reached:** Remove an unused device, then try again.
+- **macOS Keychain error:** Open **Settings → Sync**, click **Repair Keychain Access**, and resume sync.
+
+If sync is paused during recording or an import, let that activity finish. Anarlog resumes background sync when it is safe to do so.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -10,7 +10,9 @@ Open **Settings → Permissions** and confirm:
 - **Microphone** is allowed so Anarlog can hear you.
 - **System Audio** is allowed so Anarlog can hear the other people on the call.
 
-If a permission is denied, use **Open** to change it in macOS Settings, then restart Anarlog.
+If a permission is denied, use **Open** to change it in your operating system's settings, then restart Anarlog.
+
+On Linux, confirm that your desktop audio service can see the microphone and the output-monitor source. On Windows or Linux, include the app and operating-system versions if audio works in other apps but not in Anarlog.
 
 ## The transcript is not live
 
@@ -42,8 +44,60 @@ Audio imports accept WAV, MP3, OGG, MP4, M4A, FLAC, WebM, and AAC. Transcript im
 
 For audio, confirm that a Transcription model is selected and that a local provider is running. See [Import audio or a transcript](/import-recordings).
 
+## Meeting-history import shows no apps
+
+Anarlog lists supported meeting assistants it detects on your computer. Open the source app, restart Anarlog, and return to **Settings → Imports**.
+
+If you already removed the source app, reinstall it long enough to complete the import or export the transcript as SRT or VTT and [import it into an empty note](/import-recordings#import-a-transcript).
+
+## Chat has no meeting context
+
+Open the meeting before opening Chat and wait for its transcript or summary to finish. Check the context chips above the input. If no Intelligence model is configured, open **Settings → Intelligence**.
+
+See [Chat with your meetings](/chat) for context controls and example requests.
+
+## Sharing does not work
+
+Sharing requires Anarlog Pro, a signed-in account, an internet connection, and a generated summary. If a recipient cannot open the note, check their invitation and **General access** under **Share**.
+
+For an **Anyone with the link** share, copy the current link again. Replacing a link invalidates the earlier URL. See [Share meetings](/sharing).
+
+## An automation did not run
+
+Open **Automations**, select the automation, and check whether it is enabled and what its last run reports. Confirm that:
+
+- The destination channel, page, team, or folder is selected.
+- Slack, Notion, or Linear is still connected.
+- The meeting finished and produced the summary or action items the automation needs.
+- A local Markdown folder still exists and is writable.
+
+See [Automate meeting follow-up](/automations).
+
+## Cloud sync is blocked
+
+Open **Settings → Sync** and use the message shown there:
+
+- **Setup required:** Create a recovery key or enter the existing key.
+- **Sign in again** or **Identity mismatch:** Sign out and sign back in with the account that owns the synced notes.
+- **Device limit reached:** Remove an unused device before adding another one. An account can sync up to five devices.
+- **macOS Keychain error:** Click **Repair Keychain Access**, then resume sync.
+
+Do not move or delete local data while an identity problem is unresolved. See [Cloud sync](/sync#fix-a-blocked-sync).
+
+## The app does not open after installation
+
+Confirm that you downloaded the build for your operating system and CPU. On Linux, make an AppImage executable before opening it:
+
+```bash
+chmod +x ./anarlog-*.AppImage
+```
+
+For Debian or Ubuntu, install the DEB with `sudo apt install ./anarlog-*.deb` so the package manager can resolve dependencies. See [Install the desktop app](/desktop-installation).
+
 ## Get more help
 
 Email [founders@anarlog.so](mailto:founders@anarlog.so), [join Discord](https://anarlog.so/discord), or [open a GitHub issue](https://github.com/fastrepl/anarlog/issues).
+
+Include your operating system, Anarlog version, the exact error, what you expected, and the shortest steps that reproduce the problem. For AI failures, include the selected provider and model, but never include API keys, recovery keys, meeting content, or private share links.
 
 For CLI and MCP errors, use the [error reference](/reference/errors).


### PR DESCRIPTION
Add desktop setup, workflow guides, FAQ and troubleshooting coverage, sync recovery details, and local API limits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a documentation URL constant change only; no runtime product logic beyond the imports docs link.
> 
> **Overview**
> **Expands the Mintlify docs** with new guides for desktop installation, meeting-history imports, sharing, Chat, and Pro automations, and wires them into `docs.json` navigation plus the docs home page.
> 
> **Refreshes existing pages** with deeper coverage: structured FAQ (`help.mdx`), sync recovery/device limits/troubleshooting, transcript editing and sharing pointers in `notes`, privacy boundaries for sync/sharing/Chat in `data-and-privacy`, and broader troubleshooting (imports, Chat, sharing, automations, sync, post-install). **CLI install** is renamed to “CLI installation” to distinguish it from the new desktop install guide.
> 
> **Small product alignment:** **Settings → Imports** “Documentation” now opens `https://docs.anarlog.so/imports` (test updated). **Local API** docs note a **64 webhook endpoints** cap per installation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88dce4363a7b21b919d40e45b274c0db1d7828c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->