### PR TITLE
Stabilize Cloud API snapshot uploads

### DIFF
--- a/apps/desktop/src/cloud-api/client.test.ts
+++ b/apps/desktop/src/cloud-api/client.test.ts
@@ -39,6 +39,7 @@ import {
   backfillCloudApiSnapshots,
   CloudApiClientError,
   deleteCloudApiSnapshotBestEffort,
+  getCloudApiSettings,
   initializeCloudApiBackfill,
   scheduleCloudApiSnapshotSync,
   syncCloudApiSnapshot,
@@ -130,7 +131,141 @@ describe("cloud API client", () => {
 
     expect(mocks.getCloudSnapshot).toHaveBeenCalledWith("meeting-too-large");
     expect(mocks.getCloudSnapshot).toHaveBeenCalledWith("meeting-2");
-    expect(consoleError).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[cloud-api] background sync failed",
+      "CloudApiClientError [invalid_request]: Snapshot too large",
+    );
+  });
+
+  it("uploads snapshots one at a time across meetings", async () => {
+    mocks.getSession.mockResolvedValue(authSession("user-upload-queue"));
+    mocks.getCloudSnapshot.mockImplementation(async (sessionId: string) => ({
+      status: "ok",
+      data: { id: sessionId, transcripts: [] },
+    }));
+
+    await getCloudApiSettings();
+
+    const pendingUploads: Array<() => void> = [];
+    mocks.fetch.mockImplementation((input: string | URL | Request) => {
+      if (!String(input).includes("/v1/sync-snapshots/")) {
+        return Promise.resolve(new Response(null, { status: 200 }));
+      }
+      return new Promise<Response>((resolve) => {
+        pendingUploads.push(() => resolve(new Response(null, { status: 204 })));
+      });
+    });
+
+    const first = syncCloudApiSnapshot("meeting-1");
+    const second = syncCloudApiSnapshot("meeting-2");
+
+    await vi.waitFor(() => expect(pendingUploads).toHaveLength(1));
+    expect(
+      mocks.fetch.mock.calls.filter(([input]) =>
+        String(input).includes("/v1/sync-snapshots/"),
+      ),
+    ).toHaveLength(1);
+
+    pendingUploads[0]?.();
+    await vi.waitFor(() => expect(pendingUploads).toHaveLength(2));
+    pendingUploads[1]?.();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(
+      mocks.fetch.mock.calls
+        .filter(([input]) => String(input).includes("/v1/sync-snapshots/"))
+        .map(([input]) => String(input).split("/").pop()),
+    ).toEqual(["meeting-1", "meeting-2"]);
+  });
+
+  it("skips an upload deleted while waiting on the request queue", async () => {
+    mocks.getSession.mockResolvedValue(authSession("user-delete-queue"));
+    mocks.getCloudSnapshot.mockImplementation(async (sessionId: string) => ({
+      status: "ok",
+      data: { id: sessionId, transcripts: [] },
+    }));
+
+    await getCloudApiSettings();
+
+    let releaseBlockingUpload: (() => void) | undefined;
+    mocks.fetch.mockImplementation(
+      (input: string | URL | Request, init?: RequestInit) => {
+        if (
+          String(input).endsWith("/v1/sync-snapshots/meeting-blocking") &&
+          init?.method === "PUT"
+        ) {
+          return new Promise<Response>((resolve) => {
+            releaseBlockingUpload = () =>
+              resolve(new Response(null, { status: 204 }));
+          });
+        }
+        return Promise.resolve(new Response(null, { status: 204 }));
+      },
+    );
+
+    const blockingSync = syncCloudApiSnapshot("meeting-blocking");
+    await vi.waitFor(() => expect(releaseBlockingUpload).toBeDefined());
+
+    const deletedSync = syncCloudApiSnapshot("meeting-deleted-in-queue");
+    await vi.waitFor(() =>
+      expect(mocks.getCloudSnapshot).toHaveBeenCalledWith(
+        "meeting-deleted-in-queue",
+      ),
+    );
+    localStorage.setItem(
+      "anarlog.cloud-api-pending.v1.user-delete-queue",
+      JSON.stringify({
+        upserts: ["meeting-deleted-in-queue"],
+        deletes: [],
+      }),
+    );
+    let resolveDeleteSession:
+      | ((session: ReturnType<typeof authSession>) => void)
+      | undefined;
+    mocks.getSession.mockReturnValueOnce(
+      new Promise<ReturnType<typeof authSession>>((resolve) => {
+        resolveDeleteSession = resolve;
+      }),
+    );
+    const sessionCallsBeforeDelete = mocks.getSession.mock.calls.length;
+    deleteCloudApiSnapshotBestEffort("meeting-deleted-in-queue");
+    await vi.waitFor(() =>
+      expect(mocks.getSession.mock.calls.length).toBeGreaterThan(
+        sessionCallsBeforeDelete,
+      ),
+    );
+
+    releaseBlockingUpload?.();
+    await Promise.all([blockingSync, deletedSync]);
+    expect(
+      JSON.parse(
+        localStorage.getItem(
+          "anarlog.cloud-api-pending.v1.user-delete-queue",
+        ) ?? "{}",
+      ),
+    ).toEqual({
+      upserts: ["meeting-deleted-in-queue"],
+      deletes: [],
+    });
+
+    resolveDeleteSession?.(authSession("user-delete-queue"));
+    await vi.waitFor(() =>
+      expect(mocks.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/sync-snapshots/meeting-deleted-in-queue"),
+        expect.objectContaining({ method: "DELETE" }),
+      ),
+    );
+
+    expect(
+      mocks.fetch.mock.calls
+        .filter(([input]) =>
+          String(input).includes("/v1/sync-snapshots/meeting-deleted-in-queue"),
+        )
+        .map(([, init]) => (init as RequestInit).method),
+    ).toEqual(["DELETE"]);
   });
 
   it("queues transient local snapshot failures for retry", async () => {

--- a/apps/desktop/src/cloud-api/client.ts
+++ b/apps/desktop/src/cloud-api/client.ts
@@ -45,6 +45,7 @@ let backfillRetryTimer: ReturnType<typeof setTimeout> | null = null;
 type SnapshotIntent = { kind: "delete" | "upsert" };
 const snapshotIntents = new Map<string, SnapshotIntent>();
 const snapshotSyncs = new Map<string, Promise<void>>();
+let snapshotRequestQueue = Promise.resolve();
 
 function setSnapshotIntent(sessionId: string, kind: SnapshotIntent["kind"]) {
   const intent = { kind };
@@ -311,17 +312,25 @@ async function performCloudApiSnapshotSync(
   if (hasSnapshotIntent(sessionId, "delete")) {
     return;
   }
-  await request(
-    `/v1/sync-snapshots/${encodeURIComponent(sessionId)}`,
-    {
-      method: "PUT",
-      body: JSON.stringify(result.data),
-    },
-    true,
-    true,
-    userId,
-  );
-  removePendingChange(userId, sessionId, "upserts");
+  const uploaded = await enqueueSnapshotRequest(async () => {
+    if (hasSnapshotIntent(sessionId, "delete")) {
+      return false;
+    }
+    await request(
+      `/v1/sync-snapshots/${encodeURIComponent(sessionId)}`,
+      {
+        method: "PUT",
+        body: JSON.stringify(result.data),
+      },
+      true,
+      true,
+      userId,
+    );
+    return true;
+  });
+  if (uploaded) {
+    removePendingChange(userId, sessionId, "upserts");
+  }
 }
 
 export async function deleteCloudApiSnapshot(sessionId: string): Promise<void> {
@@ -348,12 +357,14 @@ async function deleteCloudApiSnapshotForUser(
     removePendingChange(userId, sessionId, "deletes");
     return;
   }
-  await request(
-    `/v1/sync-snapshots/${encodeURIComponent(sessionId)}`,
-    { method: "DELETE" },
-    true,
-    true,
-    userId,
+  await enqueueSnapshotRequest(() =>
+    request(
+      `/v1/sync-snapshots/${encodeURIComponent(sessionId)}`,
+      { method: "DELETE" },
+      true,
+      true,
+      userId,
+    ),
   );
   removePendingChange(userId, sessionId, "deletes");
 }
@@ -634,6 +645,15 @@ function shouldRetry(error: unknown) {
   );
 }
 
+function enqueueSnapshotRequest(operation: () => Promise<unknown>) {
+  const queuedRequest = snapshotRequestQueue.catch(() => {}).then(operation);
+  snapshotRequestQueue = queuedRequest.then(
+    () => undefined,
+    () => undefined,
+  );
+  return queuedRequest;
+}
+
 function getStoredValue(key: string) {
   try {
     return localStorage.getItem(key);
@@ -669,6 +689,10 @@ function reportBackgroundError(error: unknown) {
   }
   console.error(
     "[cloud-api] background sync failed",
-    error instanceof Error ? error.name : typeof error,
+    error instanceof CloudApiClientError
+      ? `${error.name} [${error.code}]: ${error.message}`
+      : error instanceof Error
+        ? `${error.name}: ${error.message}`
+        : typeof error,
   );
 }


### PR DESCRIPTION
Serialize snapshot mutations through the native HTTP transport and preserve actionable background error details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering and race handling for cloud snapshot sync over the network; behavior is well-tested but mistakes could cause missed uploads or stale cloud data.
> 
> **Overview**
> **Cloud API snapshot PUT/DELETE calls are now serialized** through a module-level `enqueueSnapshotRequest` queue so only one native HTTP sync request runs at a time, including across different meetings.
> 
> Uploads **re-check delete intent** right before the PUT and only clear pending upserts when an upload actually completes; deletes use the same queue. Background sync logging now includes **error code and message** (e.g. `CloudApiClientError [invalid_request]: …`) instead of logging only the error name.
> 
> Tests cover **strict one-at-a-time upload ordering**, the updated backfill error log shape, and **delete-wins** when a meeting is removed while its upload is still queued (expecting DELETE, not PUT).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d436a31201e084b7189f5e37f886d1d1cfbb751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->