### PR TITLE
Recover macOS microphone listener transitions

### DIFF
--- a/crates/detect/src/mic/macos/app.rs
+++ b/crates/detect/src/mic/macos/app.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
-use std::sync::atomic::Ordering;
 
 use crate::{DetectEvent, InstalledApp};
 
+use super::device::is_mic_running;
 use super::state::SharedContext;
 
 fn diff_apps(
@@ -28,13 +28,20 @@ fn diff_apps(
 }
 
 pub(super) fn poll_apps(ctx: &SharedContext) {
-    if !ctx.polling_active.load(Ordering::SeqCst) {
+    if !ctx.app_polling_active() {
         return;
     }
 
     let Ok(current_apps) = crate::list_mic_using_apps() else {
         return;
     };
+    if ctx.polling_fallback_active()
+        && let Ok(device) = cidre::core_audio::System::default_input_device()
+        && let Some(mic_in_use) = is_mic_running(&device)
+        && ctx.sync_polling_fallback_state(mic_in_use, current_apps.clone())
+    {
+        return;
+    }
     let Ok(mut state_guard) = ctx.state.lock() else {
         return;
     };

--- a/crates/detect/src/mic/macos/device.rs
+++ b/crates/detect/src/mic/macos/device.rs
@@ -15,8 +15,12 @@ pub(super) fn is_mic_running(device: &ca::Device) -> Option<bool> {
         .ok()
 }
 
+fn is_current_default_device_callback(obj_id: ca::Obj, device: &ca::Device) -> bool {
+    device.0 == obj_id
+}
+
 pub(super) extern "C-unwind" fn device_listener(
-    _obj_id: ca::Obj,
+    obj_id: ca::Obj,
     number_addresses: u32,
     addresses: *const ca::PropAddr,
     client_data: *mut (),
@@ -32,13 +36,34 @@ pub(super) extern "C-unwind" fn device_listener(
             continue;
         }
         if let Ok(device) = ca::System::default_input_device()
+            && is_current_default_device_callback(obj_id, &device)
             && let Some(running) = is_mic_running(&device)
         {
+            data.ctx.disable_polling_fallback();
             data.ctx.handle_mic_change(running);
         }
     }
 
     os::Status::NO_ERR
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_device_callbacks_do_not_match_the_current_default_device() {
+        let current_device = ca::Device(ca::Obj(2));
+
+        assert!(is_current_default_device_callback(
+            ca::Obj(2),
+            &current_device,
+        ));
+        assert!(!is_current_default_device_callback(
+            ca::Obj(1),
+            &current_device,
+        ));
+    }
 }
 
 pub(super) extern "C-unwind" fn system_listener(
@@ -62,39 +87,80 @@ pub(super) extern "C-unwind" fn system_listener(
             continue;
         };
 
-        if let Some(old_device) = device_guard.take()
-            && let Err(error) = old_device.remove_prop_listener(
-                &DEVICE_IS_RUNNING_SOMEWHERE,
-                device_listener,
-                data.device_listener_ptr,
-            )
+        let new_device = ca::System::default_input_device();
+
+        if let Ok(new_device) = new_device.as_ref()
+            && device_guard.as_ref() == Some(new_device)
         {
-            tracing::error!(?error, "removing_previous_device_listener_failed");
-            *device_guard = Some(old_device);
+            let mic_in_use = is_mic_running(new_device);
+            drop(device_guard);
+            if let Some(running) = mic_in_use {
+                data.ctx.disable_polling_fallback();
+                data.ctx.handle_mic_change(running);
+            }
             continue;
         }
 
-        let Ok(new_device) = ca::System::default_input_device() else {
+        let previous_device = device_guard.take();
+        let previous_removal_error = previous_device.as_ref().and_then(|device| {
+            device
+                .remove_prop_listener(
+                    &DEVICE_IS_RUNNING_SOMEWHERE,
+                    device_listener,
+                    data.device_listener_ptr,
+                )
+                .err()
+        });
+        if let Some(error) = previous_removal_error {
+            tracing::error!(
+                ?error,
+                tags.error.code = error.status().0,
+                "removing_previous_device_listener_failed"
+            );
+        }
+
+        let Ok(new_device) = new_device else {
+            if previous_removal_error.is_some() {
+                *device_guard = previous_device;
+            }
+            drop(device_guard);
+            data.ctx.enable_polling_fallback();
+            tracing::warn!("no_default_input_device_found");
             continue;
         };
 
-        if new_device
-            .add_prop_listener(
-                &DEVICE_IS_RUNNING_SOMEWHERE,
-                device_listener,
-                data.device_listener_ptr,
-            )
-            .is_ok()
-        {
-            let mic_in_use = is_mic_running(&new_device);
-            *device_guard = Some(new_device);
-            drop(device_guard);
+        match new_device.add_prop_listener(
+            &DEVICE_IS_RUNNING_SOMEWHERE,
+            device_listener,
+            data.device_listener_ptr,
+        ) {
+            Ok(()) => {
+                if previous_removal_error.is_some() {
+                    data.ctx.require_device_listener_context_retention();
+                }
+                let mic_in_use = is_mic_running(&new_device);
+                *device_guard = Some(new_device);
+                drop(device_guard);
 
-            if let Some(running) = mic_in_use {
-                data.ctx.handle_mic_change(running);
+                if let Some(running) = mic_in_use {
+                    data.ctx.disable_polling_fallback();
+                    data.ctx.handle_mic_change(running);
+                } else {
+                    data.ctx.enable_polling_fallback();
+                }
             }
-        } else {
-            tracing::error!("adding_replacement_device_listener_failed");
+            Err(error) => {
+                if previous_removal_error.is_some() {
+                    *device_guard = previous_device;
+                }
+                drop(device_guard);
+                data.ctx.enable_polling_fallback();
+                tracing::error!(
+                    ?error,
+                    tags.error.code = error.status().0,
+                    "adding_replacement_device_listener_failed"
+                );
+            }
         }
     }
 

--- a/crates/detect/src/mic/macos/mod.rs
+++ b/crates/detect/src/mic/macos/mod.rs
@@ -88,10 +88,13 @@ struct ListenerRetention {
 fn listener_retention(
     system_unregister_failed: bool,
     device_unregister_failed: bool,
+    device_context_retention_required: bool,
 ) -> ListenerRetention {
     ListenerRetention {
         system: system_unregister_failed,
-        device: system_unregister_failed || device_unregister_failed,
+        device: system_unregister_failed
+            || device_unregister_failed
+            || device_context_retention_required,
     }
 }
 
@@ -159,6 +162,7 @@ impl CoreAudioListeners {
         if self.system_listener_registered {
             tracing::info!("adding_system_listener_success");
         } else {
+            self.ctx.require_polling_fallback();
             tracing::error!("adding_system_listener_failed");
         }
 
@@ -166,28 +170,35 @@ impl CoreAudioListeners {
             Ok(device) => {
                 let mic_in_use = device::is_mic_running(&device);
                 let device_listener_ptr = self.device_listener_ptr();
-                if device
-                    .add_prop_listener(
-                        &DEVICE_IS_RUNNING_SOMEWHERE,
-                        device_listener,
-                        device_listener_ptr,
-                    )
-                    .is_ok()
-                {
-                    tracing::info!("adding_device_listener_success");
+                match device.add_prop_listener(
+                    &DEVICE_IS_RUNNING_SOMEWHERE,
+                    device_listener,
+                    device_listener_ptr,
+                ) {
+                    Ok(()) => {
+                        tracing::info!("adding_device_listener_success");
 
-                    let mut device_guard = self
-                        .ctx
-                        .current_device
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    *device_guard = Some(device);
-                    drop(device_guard);
-                    if let Some(mic_in_use) = mic_in_use {
-                        self.ctx.seed_running_state(mic_in_use);
+                        let mut device_guard = self
+                            .ctx
+                            .current_device
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        *device_guard = Some(device);
+                        drop(device_guard);
+                        if let Some(mic_in_use) = mic_in_use {
+                            self.ctx.seed_running_state(mic_in_use);
+                        } else {
+                            self.ctx.enable_polling_fallback();
+                        }
                     }
-                } else {
-                    tracing::error!("adding_device_listener_failed");
+                    Err(error) => {
+                        self.ctx.enable_polling_fallback();
+                        tracing::error!(
+                            ?error,
+                            tags.error.code = error.status().0,
+                            "adding_device_listener_failed"
+                        );
+                    }
                 }
             }
             Err(_) => tracing::warn!("no_default_input_device_found"),
@@ -239,7 +250,11 @@ impl Drop for CoreAudioListeners {
             false
         };
 
-        let retention = listener_retention(system_unregister_failed, device_unregister_failed);
+        let retention = listener_retention(
+            system_unregister_failed,
+            device_unregister_failed,
+            self.ctx.device_listener_context_retention_required(),
+        );
         if retention.system {
             retain_callback_context(&mut self.system_listener_data);
         }
@@ -362,7 +377,7 @@ mod tests {
     #[test]
     fn retains_only_device_context_when_device_unregister_fails() {
         assert_eq!(
-            listener_retention(false, true),
+            listener_retention(false, true, false),
             ListenerRetention {
                 system: false,
                 device: true,
@@ -373,7 +388,7 @@ mod tests {
     #[test]
     fn system_unregister_failure_retains_both_reachable_contexts() {
         assert_eq!(
-            listener_retention(true, false),
+            listener_retention(true, false, false),
             ListenerRetention {
                 system: true,
                 device: true,
@@ -384,10 +399,21 @@ mod tests {
     #[test]
     fn successful_unregisters_release_both_contexts() {
         assert_eq!(
-            listener_retention(false, false),
+            listener_retention(false, false, false),
             ListenerRetention {
                 system: false,
                 device: false,
+            }
+        );
+    }
+
+    #[test]
+    fn orphaned_device_listener_retains_device_context() {
+        assert_eq!(
+            listener_retention(false, false, true),
+            ListenerRetention {
+                system: false,
+                device: true,
             }
         );
     }

--- a/crates/detect/src/mic/macos/state.rs
+++ b/crates/detect/src/mic/macos/state.rs
@@ -92,6 +92,9 @@ pub(super) struct SharedContext {
     pub(super) current_device: Arc<Mutex<Option<cidre::core_audio::Device>>>,
     pub(super) state: Arc<Mutex<DetectorState>>,
     pub(super) polling_active: Arc<AtomicBool>,
+    polling_fallback_active: Arc<AtomicBool>,
+    polling_fallback_required: Arc<AtomicBool>,
+    device_listener_context_retention_required: Arc<AtomicBool>,
     listener_callbacks_active: Arc<AtomicBool>,
 }
 
@@ -102,6 +105,9 @@ impl SharedContext {
             current_device: Arc::new(Mutex::new(None)),
             state: Arc::new(Mutex::new(DetectorState::new())),
             polling_active: Arc::new(AtomicBool::new(false)),
+            polling_fallback_active: Arc::new(AtomicBool::new(false)),
+            polling_fallback_required: Arc::new(AtomicBool::new(false)),
+            device_listener_context_retention_required: Arc::new(AtomicBool::new(false)),
             listener_callbacks_active: Arc::new(AtomicBool::new(true)),
         }
     }
@@ -112,6 +118,11 @@ impl SharedContext {
             current_device: self.current_device.clone(),
             state: self.state.clone(),
             polling_active: self.polling_active.clone(),
+            polling_fallback_active: self.polling_fallback_active.clone(),
+            polling_fallback_required: self.polling_fallback_required.clone(),
+            device_listener_context_retention_required: self
+                .device_listener_context_retention_required
+                .clone(),
             listener_callbacks_active: self.listener_callbacks_active.clone(),
         }
     }
@@ -120,10 +131,47 @@ impl SharedContext {
         self.listener_callbacks_active
             .store(false, Ordering::SeqCst);
         self.polling_active.store(false, Ordering::SeqCst);
+        self.polling_fallback_active.store(false, Ordering::SeqCst);
+        self.polling_fallback_required
+            .store(false, Ordering::SeqCst);
     }
 
     pub(super) fn listener_callbacks_active(&self) -> bool {
         self.listener_callbacks_active.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn enable_polling_fallback(&self) {
+        self.polling_fallback_active.store(true, Ordering::SeqCst);
+    }
+
+    pub(super) fn require_polling_fallback(&self) {
+        self.polling_fallback_required.store(true, Ordering::SeqCst);
+        self.enable_polling_fallback();
+    }
+
+    pub(super) fn disable_polling_fallback(&self) {
+        if !self.polling_fallback_required.load(Ordering::SeqCst) {
+            self.polling_fallback_active.store(false, Ordering::SeqCst);
+        }
+    }
+
+    pub(super) fn polling_fallback_active(&self) -> bool {
+        self.polling_fallback_active.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn app_polling_active(&self) -> bool {
+        self.polling_active.load(Ordering::SeqCst)
+            || self.polling_fallback_active.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn require_device_listener_context_retention(&self) {
+        self.device_listener_context_retention_required
+            .store(true, Ordering::SeqCst);
+    }
+
+    pub(super) fn device_listener_context_retention_required(&self) -> bool {
+        self.device_listener_context_retention_required
+            .load(Ordering::SeqCst)
     }
 
     pub(super) fn emit(&self, event: DetectEvent) {
@@ -144,6 +192,21 @@ impl SharedContext {
             Ok(Vec::new())
         };
         self.handle_mic_change_with_snapshot(mic_in_use, app_snapshot);
+    }
+
+    pub(super) fn sync_polling_fallback_state(
+        &self,
+        mic_in_use: bool,
+        current_apps: Vec<InstalledApp>,
+    ) -> bool {
+        let should_sync = self
+            .state
+            .lock()
+            .is_ok_and(|state| state.last_state != mic_in_use);
+        if should_sync {
+            self.handle_mic_change_with_snapshot(mic_in_use, Ok(current_apps));
+        }
+        should_sync
     }
 
     pub(super) fn flush_pending_mic_change(&self) {
@@ -426,10 +489,71 @@ mod tests {
     fn deactivated_listener_context_ignores_late_callbacks() {
         let (ctx, events) = test_context();
 
+        ctx.enable_polling_fallback();
         ctx.deactivate_listener_callbacks();
         ctx.handle_mic_change(true);
 
+        assert!(!ctx.app_polling_active());
         assert!(!ctx.state.lock().unwrap().last_state);
         assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn polling_fallback_keeps_app_polling_active_without_a_running_mic() {
+        let (ctx, _) = test_context();
+
+        assert!(!ctx.app_polling_active());
+        ctx.enable_polling_fallback();
+        assert!(ctx.app_polling_active());
+        ctx.disable_polling_fallback();
+        assert!(!ctx.app_polling_active());
+    }
+
+    #[test]
+    fn required_polling_fallback_survives_healthy_device_callbacks() {
+        let (ctx, _) = test_context();
+
+        ctx.require_polling_fallback();
+        ctx.disable_polling_fallback();
+
+        assert!(ctx.polling_fallback_active());
+    }
+
+    #[test]
+    fn polling_fallback_updates_coreaudio_state_without_duplicate_recovery_edge() {
+        let (ctx, events) = test_context();
+
+        ctx.enable_polling_fallback();
+        assert!(ctx.sync_polling_fallback_state(true, vec![app("recorder")]));
+        ctx.disable_polling_fallback();
+        ctx.handle_mic_change_with_snapshot(true, Ok(vec![app("recorder")]));
+
+        let state = ctx.state.lock().unwrap();
+        assert!(state.last_state);
+        assert_eq!(state.active_apps.len(), 1);
+        assert_eq!(state.active_apps[0].id, "recorder");
+        drop(state);
+        assert_eq!(events.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn polling_fallback_preserves_running_state_while_apps_are_not_visible() {
+        let (ctx, events) = test_context();
+
+        ctx.handle_mic_change_with_snapshot(true, Ok(Vec::new()));
+
+        assert!(!ctx.sync_polling_fallback_state(true, Vec::new()));
+        assert!(ctx.state.lock().unwrap().last_state);
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn device_listener_context_retention_is_shared() {
+        let (ctx, _) = test_context();
+        let cloned_ctx = ctx.clone_shared();
+
+        cloned_ctx.require_device_listener_context_retention();
+
+        assert!(ctx.device_listener_context_retention_required());
     }
 }


### PR DESCRIPTION
Keep monitoring new default devices after CoreAudio cleanup failures, fall back to app polling when listener registration fails, and preserve safe CoreAudio error codes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CoreAudio callback lifecycle, device switching, and mic state emission paths; mistakes could cause missed events, duplicate edges, or unsafe use-after-free if retention logic is wrong, though coverage is heavily unit-tested.
> 
> **Overview**
> Improves **macOS microphone detection** when CoreAudio property listeners are missing, stale, or fail during device transitions.
> 
> Adds a **polling fallback** path: if system/device listener registration fails, `is_mic_running` is unreadable, or there is no default input device, the detector keeps periodic app polling and can reconcile mic on/off via `sync_polling_fallback_state` instead of relying solely on callbacks. Healthy device callbacks turn fallback off unless fallback was **required** (e.g. system listener never registered).
> 
> **Default input device handling** is reworked: stale `DEVICE_IS_RUNNING_SOMEWHERE` callbacks are ignored unless they match the current default device; duplicate default-device notifications refresh state without re-registering; failed removal of the previous device listener can leave the old registration in place and **retain listener context** so late callbacks stay safe. CoreAudio errors are logged with status codes.
> 
> `poll_apps` gates on `app_polling_active()` (normal mic-on polling or fallback), with an early path during fallback that syncs CoreAudio running state before app diff events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985517878ee625843bfabd9c48ee835f48aac8ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->