### PR TITLE
Simplify CLI and MCP settings

### DIFF
--- a/apps/desktop/src/settings/developers/cli.tsx
+++ b/apps/desktop/src/settings/developers/cli.tsx
@@ -4,7 +4,6 @@ import {
   CircleNotch,
   Code,
   Copy,
-  Plug,
   Terminal,
 } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -26,6 +25,21 @@ async function loadStatus() {
     throw new Error(result.error);
   }
   return result.data;
+}
+
+async function copyText(
+  text: string,
+  successMessage: string,
+  fallbackErrorMessage: string,
+) {
+  try {
+    await navigator.clipboard.writeText(text);
+    sonnerToast.success(successMessage);
+  } catch (error) {
+    sonnerToast.error(
+      error instanceof Error ? error.message : fallbackErrorMessage,
+    );
+  }
 }
 
 export function buildMcpConfiguration(command: string) {
@@ -86,16 +100,13 @@ export function CliSettingsSections() {
   const status = statusQuery.data;
 
   return (
-    <>
-      <CliSection
-        status={status}
-        isLoading={statusQuery.isPending}
-        error={statusQuery.error}
-        isInstalling={installMutation.isPending}
-        onInstall={() => installMutation.mutate()}
-      />
-      <McpSection status={status} />
-    </>
+    <CliSection
+      status={status}
+      isLoading={statusQuery.isPending}
+      error={statusQuery.error}
+      isInstalling={installMutation.isPending}
+      onInstall={() => installMutation.mutate()}
+    />
   );
 }
 
@@ -121,18 +132,18 @@ function CliSection({
 
   return (
     <section className="flex flex-col gap-3">
-      <h2 className="text-muted-foreground text-sm font-medium">CLI</h2>
-      <div className="border-border bg-card overflow-hidden rounded-2xl border">
-        <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between">
+      <h2 className="text-muted-foreground text-sm font-medium">CLI & MCP</h2>
+      <div className="border-border bg-card divide-border divide-y overflow-hidden rounded-2xl border">
+        <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 gap-3">
             <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-xl">
               <Terminal className="size-5" />
             </div>
             <div className="min-w-0">
               <h3 className="font-medium">Anarlog CLI</h3>
-              <p className="text-muted-foreground mt-1 text-sm leading-5">
-                Use Anarlog meetings from scripts and coding agents.
-              </p>
+              <CopyableCommand
+                command={`${commandName} --json meetings list`}
+              />
               <CliStatus status={status} isLoading={isLoading} error={error} />
             </div>
           </div>
@@ -162,19 +173,7 @@ function CliSection({
             </Button>
           </div>
         </div>
-
-        <div className="border-border divide-border divide-y border-t">
-          <CommandExample
-            icon={<Terminal className="size-4" />}
-            command={`${commandName} --json meetings list`}
-            description="List recent meetings for scripts and coding agents."
-          />
-          <CommandExample
-            icon={<Plug className="size-4" />}
-            command={`${commandName} mcp`}
-            description="Connect local Anarlog meeting context over MCP."
-          />
-        </div>
+        <McpRow status={status} />
       </div>
     </section>
   );
@@ -191,16 +190,16 @@ function CliStatus({
 }) {
   if (isLoading) {
     return (
-      <span className="text-muted-foreground mt-2 flex items-center gap-1.5 text-xs">
+      <span className="text-muted-foreground mt-1 flex items-center gap-1.5 text-xs">
         <CircleNotch className="size-3 animate-spin" />
-        Checking installation…
+        Checking…
       </span>
     );
   }
 
   if (error) {
     return (
-      <p className="text-destructive mt-2 text-xs">
+      <p className="text-destructive mt-1 text-xs">
         Could not check the CLI: {error.message}
       </p>
     );
@@ -210,9 +209,14 @@ function CliStatus({
     return null;
   }
 
+  const isInstalled = status.state === "installed";
+  const showDetails = ["conflict", "unsupported", "resource_missing"].includes(
+    status.state,
+  );
+
   return (
-    <div className="mt-2 flex items-start gap-1.5 text-xs">
-      {status.state === "installed" ? (
+    <div className="mt-1 flex items-start gap-1.5 text-xs">
+      {isInstalled ? (
         <CheckCircle className="mt-0.5 size-3.5 shrink-0 text-emerald-600" />
       ) : (
         <span
@@ -224,103 +228,84 @@ function CliStatus({
           ])}
         />
       )}
-      <span className="text-muted-foreground break-all">{status.details}</span>
+      <span className="text-muted-foreground break-all">
+        {isInstalled
+          ? "Installed"
+          : showDetails
+            ? (status.details ?? "Unavailable")
+            : "Not installed"}
+      </span>
     </div>
   );
 }
 
-function CommandExample({
-  icon,
-  command,
-  description,
-}: {
-  icon: React.ReactNode;
-  command: string;
-  description: string;
-}) {
+function CopyableCommand({ command }: { command: string }) {
   return (
-    <div className="flex items-start gap-3 px-4 py-3">
-      <span className="text-muted-foreground mt-0.5 shrink-0">{icon}</span>
-      <div className="min-w-0">
-        <code className="bg-muted rounded-md px-1.5 py-0.5 text-xs font-medium">
-          {command}
-        </code>
-        <p className="text-muted-foreground mt-1 text-xs">{description}</p>
-      </div>
+    <div className="mt-1 flex min-w-0 items-center gap-1">
+      <code className="bg-muted scrollbar-hide min-w-0 overflow-x-auto rounded-md px-1.5 py-0.5 text-xs font-medium">
+        {command}
+      </code>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-6 shrink-0"
+        aria-label={`Copy ${command}`}
+        onClick={() =>
+          void copyText(command, "Command copied", "Could not copy the command")
+        }
+      >
+        <Copy className="size-3.5" />
+      </Button>
     </div>
   );
 }
 
-function McpSection({ status }: { status: EmbeddedCliStatus | undefined }) {
+function McpRow({ status }: { status: EmbeddedCliStatus | undefined }) {
   const isInstalled = status?.state === "installed";
-  const command = isInstalled
-    ? status.installPath
-    : (status?.commandName ?? "anarlog");
-  const configuration = buildMcpConfiguration(command);
-
-  const copyConfiguration = async () => {
-    try {
-      await navigator.clipboard.writeText(configuration);
-      sonnerToast.success("MCP configuration copied");
-    } catch (error) {
-      sonnerToast.error(
-        error instanceof Error
-          ? error.message
-          : "Could not copy the MCP configuration",
-      );
-    }
-  };
+  const commandName = status?.commandName ?? "anarlog";
+  const configuration = buildMcpConfiguration(
+    isInstalled ? status.installPath : commandName,
+  );
 
   return (
-    <section className="flex flex-col gap-3">
-      <h2 className="text-muted-foreground text-sm font-medium">MCP</h2>
-      <div className="border-border bg-card overflow-hidden rounded-2xl border">
-        <div className="flex items-start justify-between gap-4 p-4">
-          <div className="flex min-w-0 gap-3">
-            <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-xl">
-              <Code className="size-5" />
-            </div>
-            <div>
-              <h3 className="font-medium">Anarlog MCP server</h3>
-              <p className="text-muted-foreground mt-1 text-sm leading-5">
-                Add read-only local meeting context to agents that support MCP.
-              </p>
-            </div>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="shrink-0"
-            onClick={() => void openerCommands.openUrl(MCP_GUIDE_URL, null)}
-          >
-            Guide
-            <ArrowSquareOut className="size-3.5" />
-          </Button>
+    <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex min-w-0 gap-3">
+        <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-xl">
+          <Code className="size-5" />
         </div>
-
-        <div className="border-border bg-muted/30 border-t p-3">
-          <div className="mb-2 flex items-center justify-between gap-3">
-            <span className="text-muted-foreground text-xs font-medium">
-              mcp.json
-            </span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-7"
-              disabled={!isInstalled}
-              onClick={() => void copyConfiguration()}
-            >
-              <Copy className="size-3.5" />
-              Copy
-            </Button>
-          </div>
-          <pre className="scrollbar-hide overflow-x-auto text-xs leading-5">
-            <code>{configuration}</code>
-          </pre>
+        <div className="min-w-0">
+          <h3 className="font-medium">MCP server</h3>
+          <CopyableCommand command={`${commandName} mcp`} />
         </div>
       </div>
-    </section>
+      <div className="flex shrink-0 gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => void openerCommands.openUrl(MCP_GUIDE_URL, null)}
+        >
+          Guide
+          <ArrowSquareOut className="size-3.5" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!isInstalled}
+          onClick={() =>
+            void copyText(
+              configuration,
+              "MCP configuration copied",
+              "Could not copy the MCP configuration",
+            )
+          }
+        >
+          <Copy className="size-3.5" />
+          Copy config
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/apps/desktop/src/settings/developers/index.test.tsx
+++ b/apps/desktop/src/settings/developers/index.test.tsx
@@ -144,7 +144,12 @@ describe("SettingsDevelopers", () => {
     cleanup();
   });
 
-  it("shows the installed CLI and uses its absolute path for MCP", async () => {
+  it("uses the installed CLI path when copying the MCP configuration", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
     mocks.checkEmbeddedCli.mockResolvedValue({
       status: "ok",
       data: {
@@ -168,8 +173,64 @@ describe("SettingsDevelopers", () => {
 
     expect(await screen.findByText("Reinstall")).toBeTruthy();
     expect(
-      screen.getAllByText(/\/Users\/test\/\.local\/bin\/anarlog/).length,
-    ).toBeGreaterThan(0);
+      screen.queryByText(/\/Users\/test\/\.local\/bin\/anarlog/),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy config" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    expect(JSON.parse(writeText.mock.calls[0][0])).toEqual({
+      mcpServers: {
+        anarlog: {
+          command: "/Users/test/.local/bin/anarlog",
+          args: ["mcp"],
+        },
+      },
+    });
+  });
+
+  it("copies each CLI command", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    mocks.checkEmbeddedCli.mockResolvedValue({
+      status: "ok",
+      data: {
+        supported: true,
+        commandName: "anarlog",
+        installPath: "/Users/test/.local/bin/anarlog",
+        state: "installed",
+        details: "Installed.",
+      },
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SettingsDevelopers />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Copy anarlog --json meetings list",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Copy anarlog mcp" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenNthCalledWith(
+        1,
+        "anarlog --json meetings list",
+      );
+      expect(writeText).toHaveBeenNthCalledWith(2, "anarlog mcp");
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(2);
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Command copied");
   });
 
   it("does not expose a nonexistent MCP path when the CLI is unsupported", async () => {
@@ -193,7 +254,9 @@ describe("SettingsDevelopers", () => {
       </QueryClientProvider>,
     );
 
-    const copyButton = await screen.findByRole("button", { name: "Copy" });
+    const copyButton = await screen.findByRole("button", {
+      name: "Copy config",
+    });
     expect(copyButton.hasAttribute("disabled")).toBe(true);
     expect(
       screen.queryByText(/\/Users\/test\/\.local\/bin\/anarlog-dev/),


### PR DESCRIPTION
Group local developer tools into compact rows while keeping install, guide, command copy, and MCP configuration actions available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop settings UI and tests only; install/MCP logic is unchanged aside from presentation and copy affordances.
> 
> **Overview**
> **Developers settings** now presents **CLI and MCP in a single “CLI & MCP” card** instead of two separate sections. Each area is a compact row with a **copyable command** (`anarlog --json meetings list` and `anarlog mcp`) plus existing Guide / Install / Copy config actions.
> 
> The **inline `mcp.json` preview is removed**; MCP setup is copied via **Copy config**, still using the **installed absolute CLI path** when available. A shared **`copyText` helper** drives clipboard + toasts for commands and config.
> 
> **CLI status copy is simplified** (e.g. “Installed” / “Not installed”, with details only for conflict, unsupported, or missing resource). Tests were updated to assert clipboard payloads and that install paths are not shown in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0254daac20d40da4beec78a7fc7202d37691134e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->