### PR TITLE
fix: use host Wayland libraries in AppImage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,5 +8,6 @@ jobs:
       - run: >-
           node --test
           scripts/desktop-release-provenance.test.mjs
+          scripts/repack-linux-appimage.test.mjs
           scripts/verify-linux-audio-qa-run.test.mjs
           scripts/verify-linux-audio-qa-evidence.test.mjs

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -417,6 +417,11 @@ jobs:
           VITE_API_URL: https://api.anarlog.so
           VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
           VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
+      - run: node scripts/repack-linux-appimage.mjs "apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage"
+        env:
+          ARCH: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64' || 'x86_64' }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
       - if: ${{ inputs.channel == 'stable' }}
         uses: ./.github/actions/sentry_cli
       - if: ${{ inputs.channel == 'stable' }}

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - .github/actions/install_desktop_deps/**
       - .github/workflows/desktop_ci.yaml
+      - scripts/repack-linux-appimage.mjs
+      - scripts/repack-linux-appimage.test.mjs
       - apps/cli/**
       - apps/desktop/**
       - plugins/**
@@ -17,6 +19,8 @@ on:
     paths:
       - .github/actions/install_desktop_deps/**
       - .github/workflows/desktop_ci.yaml
+      - scripts/repack-linux-appimage.mjs
+      - scripts/repack-linux-appimage.test.mjs
       - apps/cli/**
       - apps/desktop/**
       - plugins/**
@@ -450,6 +454,12 @@ jobs:
           VITE_APP_URL: https://anarlog.so
           VITE_API_URL: https://api.anarlog.so
           VITE_PRO_PRODUCT_ID: ${{ secrets.VITE_PRO_PRODUCT_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      - if: github.event_name == 'workflow_dispatch'
+        run: node scripts/repack-linux-appimage.mjs "apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage"
+        env:
+          ARCH: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64' || 'x86_64' }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
       - if: github.event_name == 'workflow_dispatch'

--- a/scripts/repack-linux-appimage.mjs
+++ b/scripts/repack-linux-appimage.mjs
@@ -1,0 +1,178 @@
+import { spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access, readdir, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Host Mesa and WebKitGTK must resolve against the host's matching Wayland ABI.
+const waylandLibraryPattern = /^libwayland-.*\.so(?:\..*)?$/;
+
+async function findSingleBundleEntry(bundleDirectory, suffix, isExpectedType) {
+  const entries = await readdir(bundleDirectory, { withFileTypes: true });
+  const matches = entries.filter(
+    (entry) => entry.name.endsWith(suffix) && isExpectedType(entry),
+  );
+
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one ${suffix} in ${bundleDirectory}, found ${matches.length}`,
+    );
+  }
+
+  return path.join(bundleDirectory, matches[0].name);
+}
+
+export async function findBundledWaylandLibraries(directory) {
+  const matches = [];
+
+  async function walk(currentDirectory) {
+    const entries = await readdir(currentDirectory, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(currentDirectory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+      } else if (waylandLibraryPattern.test(entry.name)) {
+        matches.push(entryPath);
+      }
+    }
+  }
+
+  await walk(directory);
+  return matches.sort();
+}
+
+function defaultPluginPath() {
+  const cacheDirectory =
+    process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache");
+  return path.join(
+    cacheDirectory,
+    "tauri",
+    "linuxdeploy-plugin-appimage.AppImage",
+  );
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: options.env ?? process.env,
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(
+        new Error(
+          `${command} exited with ${signal ? `signal ${signal}` : `code ${code}`}`,
+        ),
+      );
+    });
+  });
+}
+
+export async function repackLinuxAppImage({
+  bundleDirectory,
+  arch = process.env.ARCH,
+  pluginPath = process.env.TAURI_APPIMAGE_PLUGIN ?? defaultPluginPath(),
+  run = runCommand,
+}) {
+  const appDirectory = await findSingleBundleEntry(
+    bundleDirectory,
+    ".AppDir",
+    (entry) => entry.isDirectory(),
+  );
+  const appImage = await findSingleBundleEntry(
+    bundleDirectory,
+    ".AppImage",
+    (entry) => entry.isFile(),
+  );
+  const waylandLibraries = await findBundledWaylandLibraries(
+    path.join(appDirectory, "usr"),
+  );
+
+  if (waylandLibraries.length === 0) {
+    console.log(`AppImage already uses host Wayland libraries: ${appImage}`);
+    return { appDirectory, appImage, removedLibraries: [] };
+  }
+
+  if (!arch) {
+    throw new Error("AppImage architecture is required for repacking");
+  }
+
+  try {
+    await access(pluginPath, constants.X_OK);
+  } catch {
+    throw new Error(`AppImage output plugin is not executable: ${pluginPath}`);
+  }
+
+  await Promise.all(waylandLibraries.map((library) => rm(library)));
+
+  const remainingLibraries = await findBundledWaylandLibraries(
+    path.join(appDirectory, "usr"),
+  );
+  if (remainingLibraries.length > 0) {
+    throw new Error(
+      `Failed to remove bundled Wayland libraries: ${remainingLibraries.join(", ")}`,
+    );
+  }
+
+  console.log(
+    `Removed bundled Wayland libraries:\n${waylandLibraries.join("\n")}`,
+  );
+
+  await rm(appImage);
+  await run(
+    pluginPath,
+    ["--appimage-extract-and-run", "--appdir", appDirectory],
+    {
+      env: {
+        ...process.env,
+        APPIMAGE_EXTRACT_AND_RUN: "1",
+        ARCH: arch,
+        OUTPUT: appImage,
+      },
+    },
+  );
+
+  const appImageStat = await stat(appImage);
+  if (appImageStat.size === 0) {
+    throw new Error(`Repacked AppImage is empty: ${appImage}`);
+  }
+
+  const signature = `${appImage}.sig`;
+  await rm(signature, { force: true });
+  await run("pnpm", ["-F", "desktop", "tauri", "signer", "sign", appImage]);
+
+  const signatureStat = await stat(signature);
+  if (signatureStat.size === 0) {
+    throw new Error(`Regenerated AppImage signature is empty: ${signature}`);
+  }
+
+  console.log(`Repacked and re-signed AppImage: ${appImage}`);
+  return { appDirectory, appImage, removedLibraries: waylandLibraries };
+}
+
+async function main() {
+  const bundleDirectory = process.argv[2];
+  if (!bundleDirectory) {
+    throw new Error(
+      "Usage: node scripts/repack-linux-appimage.mjs <appimage-bundle-directory>",
+    );
+  }
+
+  await repackLinuxAppImage({
+    bundleDirectory: path.resolve(bundleDirectory),
+  });
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/repack-linux-appimage.test.mjs
+++ b/scripts/repack-linux-appimage.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { constants } from "node:fs";
+import {
+  access,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { repackLinuxAppImage } from "./repack-linux-appimage.mjs";
+
+async function createFixture(t, { withWaylandLibraries = true } = {}) {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "anarlog-appimage-repack-"),
+  );
+  t.after(() => rm(directory, { force: true, recursive: true }));
+
+  const appDirectory = path.join(directory, "Anarlog.AppDir");
+  const libraryDirectory = path.join(appDirectory, "usr", "lib");
+  const nestedLibraryDirectory = path.join(libraryDirectory, "gtk-3.0");
+  const appImage = path.join(directory, "Anarlog_1.4.5_amd64.AppImage");
+  const plugin = path.join(
+    directory,
+    "tools",
+    "linuxdeploy-plugin-appimage.AppImage",
+  );
+
+  await mkdir(nestedLibraryDirectory, { recursive: true });
+  await mkdir(path.dirname(plugin), { recursive: true });
+  await writeFile(path.join(libraryDirectory, "libgtk-3.so.0"), "gtk");
+  if (withWaylandLibraries) {
+    await writeFile(
+      path.join(libraryDirectory, "libwayland-client.so.0"),
+      "wayland-client",
+    );
+    await writeFile(
+      path.join(nestedLibraryDirectory, "libwayland-cursor.so.0.22.0"),
+      "wayland-cursor",
+    );
+  }
+  await writeFile(appImage, "original-appimage");
+  await writeFile(`${appImage}.sig`, "stale-signature");
+  await writeFile(plugin, "plugin");
+  await chmod(plugin, 0o755);
+
+  return { directory, appDirectory, appImage, plugin };
+}
+
+test("removes Wayland libraries, repacks, and regenerates the signature", async (t) => {
+  const fixture = await createFixture(t);
+  const commands = [];
+
+  const result = await repackLinuxAppImage({
+    arch: "x86_64",
+    bundleDirectory: fixture.directory,
+    pluginPath: fixture.plugin,
+    run: async (command, args, options) => {
+      commands.push({ command, args, options });
+      if (command === fixture.plugin) {
+        await assert.rejects(access(fixture.appImage, constants.F_OK));
+        await writeFile(fixture.appImage, "repacked-appimage");
+      } else {
+        await writeFile(`${fixture.appImage}.sig`, "fresh-signature");
+      }
+    },
+  });
+
+  assert.equal(result.removedLibraries.length, 2);
+  await assert.rejects(
+    access(
+      path.join(fixture.appDirectory, "usr", "lib", "libwayland-client.so.0"),
+      constants.F_OK,
+    ),
+  );
+  await assert.rejects(
+    access(
+      path.join(
+        fixture.appDirectory,
+        "usr",
+        "lib",
+        "gtk-3.0",
+        "libwayland-cursor.so.0.22.0",
+      ),
+      constants.F_OK,
+    ),
+  );
+  assert.equal(
+    await readFile(
+      path.join(fixture.appDirectory, "usr", "lib", "libgtk-3.so.0"),
+      "utf8",
+    ),
+    "gtk",
+  );
+  assert.equal(await readFile(fixture.appImage, "utf8"), "repacked-appimage");
+  assert.equal(
+    await readFile(`${fixture.appImage}.sig`, "utf8"),
+    "fresh-signature",
+  );
+
+  assert.deepEqual(commands[0].args, [
+    "--appimage-extract-and-run",
+    "--appdir",
+    fixture.appDirectory,
+  ]);
+  assert.equal(commands[0].options.env.APPIMAGE_EXTRACT_AND_RUN, "1");
+  assert.equal(commands[0].options.env.ARCH, "x86_64");
+  assert.equal(commands[0].options.env.OUTPUT, fixture.appImage);
+  assert.deepEqual(commands[1], {
+    command: "pnpm",
+    args: ["-F", "desktop", "tauri", "signer", "sign", fixture.appImage],
+    options: undefined,
+  });
+});
+
+test("keeps an already-clean AppImage and its signature unchanged", async (t) => {
+  const fixture = await createFixture(t, { withWaylandLibraries: false });
+
+  const result = await repackLinuxAppImage({
+    bundleDirectory: fixture.directory,
+    pluginPath: path.join(fixture.directory, "missing-plugin"),
+    run: async () => {
+      throw new Error("clean AppImages must not be repacked");
+    },
+  });
+
+  assert.deepEqual(result.removedLibraries, []);
+  assert.equal(await readFile(fixture.appImage, "utf8"), "original-appimage");
+  assert.equal(
+    await readFile(`${fixture.appImage}.sig`, "utf8"),
+    "stale-signature",
+  );
+});
+
+test("fails before mutation when the AppImage output plugin is unavailable", async (t) => {
+  const fixture = await createFixture(t);
+  const waylandLibrary = path.join(
+    fixture.appDirectory,
+    "usr",
+    "lib",
+    "libwayland-client.so.0",
+  );
+
+  await assert.rejects(
+    repackLinuxAppImage({
+      arch: "x86_64",
+      bundleDirectory: fixture.directory,
+      pluginPath: path.join(fixture.directory, "missing-plugin"),
+    }),
+    /AppImage output plugin is not executable/,
+  );
+
+  assert.equal(await readFile(waylandLibrary, "utf8"), "wayland-client");
+  assert.equal(
+    await readFile(`${fixture.appImage}.sig`, "utf8"),
+    "stale-signature",
+  );
+});
+
+test("refuses an ambiguous AppImage bundle before mutation", async (t) => {
+  const fixture = await createFixture(t);
+  await writeFile(
+    path.join(fixture.directory, "Anarlog_1.4.5_arm64.AppImage"),
+    "other-appimage",
+  );
+
+  await assert.rejects(
+    repackLinuxAppImage({
+      arch: "x86_64",
+      bundleDirectory: fixture.directory,
+      pluginPath: fixture.plugin,
+    }),
+    /Expected exactly one \.AppImage.*found 2/,
+  );
+
+  assert.equal(
+    await readFile(
+      path.join(fixture.appDirectory, "usr", "lib", "libwayland-client.so.0"),
+      "utf8",
+    ),
+    "wayland-client",
+  );
+});
+
+test("requires an architecture before mutating the AppDir", async (t) => {
+  const fixture = await createFixture(t);
+  const waylandLibrary = path.join(
+    fixture.appDirectory,
+    "usr",
+    "lib",
+    "libwayland-client.so.0",
+  );
+
+  await assert.rejects(
+    repackLinuxAppImage({
+      arch: "",
+      bundleDirectory: fixture.directory,
+      pluginPath: fixture.plugin,
+    }),
+    /AppImage architecture is required/,
+  );
+
+  assert.equal(await readFile(waylandLibrary, "utf8"), "wayland-client");
+});


### PR DESCRIPTION
Strip bundled Wayland ABI libraries, rebuild the AppImage, and regenerate updater signatures in Linux CI and release builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Linux release artifacts and updater signatures after build; mitigated by tests, no-op when already clean, and validation before mutating the bundle.
> 
> **Overview**
> Adds a **post-build Linux AppImage repack** so shipped bundles drop vendored `libwayland-*.so` libraries and rely on the host Wayland ABI (for Mesa/WebKitGTK compatibility on Wayland).
> 
> The new `scripts/repack-linux-appimage.mjs` walks the `.AppDir`, removes matching Wayland libs when present, rebuilds the `.AppImage` via the Tauri/linuxdeploy AppImage plugin, and **regenerates the `.sig`** with `pnpm -F desktop tauri signer sign`. If no bundled Wayland libraries are found, it exits without repacking or re-signing.
> 
> **CI/release wiring:** `desktop_cd` runs the script after every Linux `tauri build`; `desktop_ci` runs it on `workflow_dispatch` Linux builds (before existing bundle checks/smoke tests). Root `ci.yaml` includes `repack-linux-appimage.test.mjs` in `node --test`, and `desktop_ci` path filters include the new scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f53dba5389c5699c9c043fb89720b4acdd26629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->