### PR TITLE
fix/update-toast-spinner

### DIFF
--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -67,7 +67,7 @@ vi.mock("@tauri-apps/plugin-os", () => ({
 }));
 
 vi.mock("@anlg/ui/components/ui/toast", () => ({
-  sonnerToast: { error: vi.fn() },
+  sonnerToast: { error: vi.fn(), dismiss: vi.fn() },
 }));
 
 const NOW = new Date("2026-07-13T00:00:00Z");

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -987,7 +987,7 @@ async function activateCloudsync(
       if (credentialErrorCode === DEVICE_LIMIT_ERROR_CODE) {
         sonnerToast.error(
           t`Cloud sync is limited to 5 devices. Remove another device to sync here.`,
-          { id: DEVICE_LIMIT_TOAST_ID },
+          { id: DEVICE_LIMIT_TOAST_ID, duration: Infinity },
         );
         console.warn(
           "[cloudsync] device limit reached; sync remains disabled on this device",
@@ -1072,6 +1072,7 @@ async function activateCloudsync(
   }
 
   setCredentialBlock(null);
+  sonnerToast.dismiss(DEVICE_LIMIT_TOAST_ID);
 
   try {
     const configured = await enqueuePluginOperation(async () => {

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1149,6 +1149,7 @@ describe("SessionShareButton", () => {
     await waitFor(() =>
       expect(mocks.toastError).toHaveBeenCalledWith(
         "Could not publish the desktop edits. Check the latest web copy and try again.",
+        { id: "desktop-edits-publish-failed", duration: Infinity },
       ),
     );
     expect(mocks.recordPublishedSessionShareState).not.toHaveBeenCalled();

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -177,6 +177,7 @@ export function SessionSharePopoverContent({
       if (error instanceof ShareOperationAbortedError) return;
       sonnerToast.error(
         "Could not publish the desktop edits. Check the latest web copy and try again.",
+        { id: "desktop-edits-publish-failed", duration: Infinity },
       );
     },
     onSettled: onChanged,

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -69,6 +69,7 @@ async function revokeManagedShare(sessionId: string) {
       console.error("[delete-session] failed to look up managed share", error);
       sonnerToast.warning(
         "Note deleted, but its shared link could not be verified as removed.",
+        { id: "shared-link-removal-unverified", duration: Infinity },
       );
       return null;
     });
@@ -93,6 +94,7 @@ async function revokeManagedShare(sessionId: string) {
     );
     sonnerToast.warning(
       "Note deleted, but its shared link could not be removed.",
+      { id: "shared-link-removal-failed", duration: Infinity },
     );
     return;
   }

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -353,6 +353,7 @@ export function SelectProviderAndModel() {
         id="llm-settings-alert"
         description={alertDescription}
         variant={hasError ? "error" : "warning"}
+        lifecycle="condition-bound"
       />
 
       <h3 className="text-md font-sans font-semibold">

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -298,7 +298,7 @@ export function NonAnarlogProviderCard({
           hasUnresolvedKeychainError ? keychainToastDescription : undefined
         }
         variant="error"
-        dismissible={false}
+        lifecycle="condition-bound"
         action={
           isKeychainRecoveryInProgress
             ? undefined

--- a/apps/desktop/src/settings/ai/shared/provider-selection-prompt.test.ts
+++ b/apps/desktop/src/settings/ai/shared/provider-selection-prompt.test.ts
@@ -49,6 +49,7 @@ describe("useProviderSelectionPrompt", () => {
 
     expect(mocks.toastSuccess).toHaveBeenCalledWith("API key saved", {
       id: "provider-selection:llm:openai",
+      duration: Infinity,
       description: "Set OpenAI as the current provider?",
       action: {
         label: "Set as current",

--- a/apps/desktop/src/settings/ai/shared/provider-selection-prompt.ts
+++ b/apps/desktop/src/settings/ai/shared/provider-selection-prompt.ts
@@ -41,6 +41,7 @@ export function useProviderSelectionPrompt({
 
     sonnerToast.success(t`API key saved`, {
       id: `provider-selection:${providerType}:${providerId}`,
+      duration: Infinity,
       description: t`Set ${providerName} as the current provider?`,
       action: {
         label: t`Set as current`,

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -233,6 +233,7 @@ export function SelectProviderAndModel() {
         id="stt-settings-alert"
         description={alertDescription}
         variant={hasError ? "error" : "warning"}
+        lifecycle="condition-bound"
       />
       {!alertDescription && <TranscriptionLanguageWarningToast />}
 
@@ -358,22 +359,41 @@ export function SelectProviderAndModel() {
 const TRANSCRIPTION_LANGUAGE_WARNING_TOAST_ID =
   "transcription-language-warning";
 const MAX_DISMISSED_TRANSCRIPTION_LANGUAGE_WARNINGS = 128;
-const dismissedTranscriptionLanguageWarningKeys = new Set<string>();
+const DISMISSED_TRANSCRIPTION_LANGUAGE_WARNINGS_KEY =
+  "anarlog:dismissed-transcription-language-warnings";
 
 function rememberDismissedTranscriptionLanguageWarning(warningKey: string) {
-  dismissedTranscriptionLanguageWarningKeys.delete(warningKey);
-  dismissedTranscriptionLanguageWarningKeys.add(warningKey);
-  while (
-    dismissedTranscriptionLanguageWarningKeys.size >
-    MAX_DISMISSED_TRANSCRIPTION_LANGUAGE_WARNINGS
-  ) {
-    const oldestWarningKey = dismissedTranscriptionLanguageWarningKeys
-      .values()
-      .next().value;
-    if (oldestWarningKey === undefined) {
-      break;
-    }
-    dismissedTranscriptionLanguageWarningKeys.delete(oldestWarningKey);
+  try {
+    const warnings = readDismissedTranscriptionLanguageWarnings().filter(
+      (key) => key !== warningKey,
+    );
+    warnings.push(warningKey);
+    localStorage.setItem(
+      DISMISSED_TRANSCRIPTION_LANGUAGE_WARNINGS_KEY,
+      JSON.stringify(
+        warnings.slice(-MAX_DISMISSED_TRANSCRIPTION_LANGUAGE_WARNINGS),
+      ),
+    );
+  } catch {
+    return;
+  }
+}
+
+function isTranscriptionLanguageWarningDismissed(warningKey: string) {
+  return readDismissedTranscriptionLanguageWarnings().includes(warningKey);
+}
+
+function readDismissedTranscriptionLanguageWarnings(): string[] {
+  try {
+    const stored = JSON.parse(
+      localStorage.getItem(DISMISSED_TRANSCRIPTION_LANGUAGE_WARNINGS_KEY) ??
+        "[]",
+    );
+    return Array.isArray(stored)
+      ? stored.filter((key): key is string => typeof key === "string")
+      : [];
+  } catch {
+    return [];
   }
 }
 
@@ -381,7 +401,7 @@ function TranscriptionLanguageWarningToast() {
   const { i18n, t } = useLingui();
   const warning = useTranscriptionLanguageWarning();
 
-  if (!warning || dismissedTranscriptionLanguageWarningKeys.has(warning.key)) {
+  if (!warning || isTranscriptionLanguageWarningDismissed(warning.key)) {
     return null;
   }
 
@@ -425,6 +445,7 @@ function TranscriptionLanguageWarningToastLifecycle({
   actionLabel: string;
 }) {
   useMountEffect(() => {
+    let shouldRememberDismissal = true;
     sonnerToast.warning(description, {
       id: TRANSCRIPTION_LANGUAGE_WARNING_TOAST_ID,
       duration: Infinity,
@@ -432,13 +453,22 @@ function TranscriptionLanguageWarningToastLifecycle({
       action: {
         label: actionLabel,
         onClick: () => {
+          shouldRememberDismissal = false;
           rememberDismissedTranscriptionLanguageWarning(warningKey);
           clearTranscriptionLanguageWarningToast();
         },
       },
+      onDismiss: () => {
+        if (shouldRememberDismissal) {
+          rememberDismissedTranscriptionLanguageWarning(warningKey);
+        }
+      },
     });
 
-    return clearTranscriptionLanguageWarningToast;
+    return () => {
+      shouldRememberDismissal = false;
+      clearTranscriptionLanguageWarningToast();
+    };
   });
 
   return null;

--- a/apps/desktop/src/shared/ui/settings-alert.test.tsx
+++ b/apps/desktop/src/shared/ui/settings-alert.test.tsx
@@ -37,12 +37,15 @@ describe("SettingsAlertToast", () => {
         id="settings-alert"
         description="Provider not configured."
         variant="error"
+        lifecycle="persistent"
       />,
     );
 
     expect(mocks.error).toHaveBeenCalledWith("Provider not configured.", {
       id: "settings-alert",
       duration: Infinity,
+      dismissible: true,
+      closeButton: true,
     });
   });
 
@@ -51,6 +54,7 @@ describe("SettingsAlertToast", () => {
       <SettingsAlertToast
         id="settings-alert"
         description="Provider not configured."
+        lifecycle="condition-bound"
       />,
     );
 
@@ -67,7 +71,7 @@ describe("SettingsAlertToast", () => {
         id="keychain-alert"
         description="Repair Keychain access."
         variant="error"
-        dismissible={false}
+        lifecycle="condition-bound"
         action={{ label: "Repair", onClick }}
       />,
     );

--- a/apps/desktop/src/shared/ui/settings-alert.tsx
+++ b/apps/desktop/src/shared/ui/settings-alert.tsx
@@ -8,13 +8,13 @@ export function SettingsAlertToast({
   id,
   description,
   variant = "default",
-  dismissible,
+  lifecycle,
   action,
 }: {
   id: string;
   description?: string;
   variant?: "default" | "error" | "warning";
-  dismissible?: boolean;
+  lifecycle: "condition-bound" | "persistent";
   action?: {
     label: string;
     onClick: () => void | Promise<void>;
@@ -26,11 +26,11 @@ export function SettingsAlertToast({
 
   return (
     <SettingsAlertToastLifecycle
-      key={`${id}:${description}:${dismissible ?? "default"}:${action?.label ?? ""}`}
+      key={`${id}:${description}:${lifecycle}:${action?.label ?? ""}`}
       id={id}
       description={description}
       variant={variant}
-      dismissible={dismissible}
+      lifecycle={lifecycle}
       action={action}
     />
   );
@@ -40,28 +40,25 @@ function SettingsAlertToastLifecycle({
   id,
   description,
   variant,
-  dismissible,
+  lifecycle,
   action,
 }: {
   id: string;
   description: string;
   variant: "default" | "error" | "warning";
-  dismissible?: boolean;
+  lifecycle: "condition-bound" | "persistent";
   action?: {
     label: string;
     onClick: () => void | Promise<void>;
   };
 }) {
   useMountEffect(() => {
+    const dismissible = lifecycle === "persistent";
     const options = {
       id,
       duration: Infinity,
-      ...(dismissible === undefined
-        ? {}
-        : {
-            dismissible,
-            ...(dismissible ? {} : { closeButton: false }),
-          }),
+      dismissible,
+      closeButton: dismissible,
       ...(action
         ? {
             action: {

--- a/apps/desktop/src/shared/ui/toast-duration.test.ts
+++ b/apps/desktop/src/shared/ui/toast-duration.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  message: vi.fn(),
+  loading: vi.fn(),
+  custom: vi.fn(),
+  promise: vi.fn(),
+  dismiss: vi.fn(),
+  getHistory: vi.fn(),
+  getToasts: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  Toaster: () => null,
+  toast: Object.assign(mocks.base, {
+    success: mocks.success,
+    info: mocks.info,
+    warning: mocks.warning,
+    error: mocks.error,
+    message: mocks.message,
+    loading: mocks.loading,
+    custom: mocks.custom,
+    promise: mocks.promise,
+    dismiss: mocks.dismiss,
+    getHistory: mocks.getHistory,
+    getToasts: mocks.getToasts,
+  }),
+}));
+
+import { sonnerToast, TOAST_DURATIONS } from "@anlg/ui/components/ui/toast";
+
+describe("toast durations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies the default duration for each timed toast category", () => {
+    sonnerToast.success("Saved");
+    sonnerToast.info("Heads up");
+    sonnerToast.warning("Check this");
+    sonnerToast.error("Try again");
+    sonnerToast.message("Updated");
+
+    expect(mocks.success).toHaveBeenCalledWith("Saved", {
+      duration: TOAST_DURATIONS.success,
+    });
+    expect(mocks.info).toHaveBeenCalledWith("Heads up", {
+      duration: TOAST_DURATIONS.info,
+    });
+    expect(mocks.warning).toHaveBeenCalledWith("Check this", {
+      duration: TOAST_DURATIONS.warning,
+    });
+    expect(mocks.error).toHaveBeenCalledWith("Try again", {
+      duration: TOAST_DURATIONS.error,
+    });
+    expect(mocks.message).toHaveBeenCalledWith("Updated", {
+      duration: TOAST_DURATIONS.info,
+    });
+  });
+
+  it("preserves explicit durations and leaves loading toasts condition-bound", () => {
+    sonnerToast.warning("Keep this", { duration: Infinity, id: "warning" });
+    sonnerToast.loading("Working", { id: "loading" });
+
+    expect(mocks.warning).toHaveBeenCalledWith("Keep this", {
+      duration: Infinity,
+      id: "warning",
+    });
+    expect(mocks.loading).toHaveBeenCalledWith("Working", { id: "loading" });
+  });
+});

--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -19,9 +19,6 @@ const mocks = vi.hoisted(() => ({
     status: "inactive" as "inactive" | "active" | "finalizing",
     sessionId: null as string | null,
   },
-  visibilityHandlers: [] as Array<
-    (event: { payload: { window: { type: string }; visible: boolean } }) => void
-  >,
   currentTab: {
     type: "empty",
   } as {
@@ -55,26 +52,6 @@ const mocks = vi.hoisted(() => ({
     installing: false,
     downloadUpdate: vi.fn(),
     installUpdate: vi.fn(),
-  },
-}));
-
-vi.mock("@anlg/plugin-windows", () => ({
-  events: {
-    visibilityEvent: {
-      listen: (
-        handler: (event: {
-          payload: { window: { type: string }; visible: boolean };
-        }) => void,
-      ) => {
-        mocks.visibilityHandlers.push(handler);
-        return Promise.resolve(() => {
-          const index = mocks.visibilityHandlers.indexOf(handler);
-          if (index !== -1) {
-            mocks.visibilityHandlers.splice(index, 1);
-          }
-        });
-      },
-    },
   },
 }));
 
@@ -162,9 +139,18 @@ vi.mock("./useDismissedToasts", () => ({
 
 import { ToastNotifications } from "./index";
 
+const storedValues = new Map<string, string>();
+const localStorageMock = {
+  getItem: (key: string) => storedValues.get(key) ?? null,
+  setItem: (key: string, value: string) => storedValues.set(key, value),
+  removeItem: (key: string) => storedValues.delete(key),
+  clear: () => storedValues.clear(),
+};
+
 describe("ToastNotifications", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.stubGlobal("localStorage", localStorageMock);
     mocks.signIn.mockClear();
     mocks.dismissToast.mockClear();
     mocks.message.mockClear();
@@ -173,8 +159,8 @@ describe("ToastNotifications", () => {
     mocks.loading.mockClear();
     mocks.dismiss.mockClear();
     mocks.dismissedToastIds.clear();
+    localStorage.clear();
     mocks.live = { status: "inactive", sessionId: null };
-    mocks.visibilityHandlers.length = 0;
     mocks.openNew.mockClear();
     mocks.updateSettingsTabState.mockClear();
     mocks.currentTab = { type: "empty" };
@@ -199,6 +185,7 @@ describe("ToastNotifications", () => {
 
   afterEach(() => {
     cleanup();
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -232,7 +219,7 @@ describe("ToastNotifications", () => {
 
     const options = mocks.message.mock.calls[0][1];
     options.onDismiss();
-    expect(mocks.dismissToast).toHaveBeenCalledWith("sign-in-benefits");
+    expect(mocks.dismissToast).toHaveBeenCalledWith("auth-promotion");
   });
 
   it("uses a Sonner loading toast for model downloads", () => {
@@ -257,7 +244,7 @@ describe("ToastNotifications", () => {
   });
 
   it("uses the latest registry action while a toast remains visible", () => {
-    mocks.dismissedToastIds.add("sign-in-benefits");
+    mocks.dismissedToastIds.add("auth-promotion");
     mocks.config.current_llm_provider = null;
     mocks.config.current_llm_model = null;
 
@@ -279,7 +266,7 @@ describe("ToastNotifications", () => {
     expect(mocks.openNew).not.toHaveBeenCalled();
   });
 
-  it("snoozes dismissed update notices without persisting them", () => {
+  it("snoozes dismissed available updates for one day", () => {
     mocks.update.status = "available";
     mocks.update.version = "1.0.34";
 
@@ -290,7 +277,7 @@ describe("ToastNotifications", () => {
     expect(mocks.message).toHaveBeenCalledWith(
       "Anarlog 1.0.34 is available",
       expect.objectContaining({
-        id: "desktop-update:1.0.34",
+        id: "desktop-update:1.0.34:available",
         closeButton: true,
       }),
     );
@@ -306,7 +293,7 @@ describe("ToastNotifications", () => {
     );
   });
 
-  it("resurfaces the update notice on relaunch", () => {
+  it("keeps an available update snoozed across relaunches", () => {
     mocks.update.status = "available";
     mocks.update.version = "1.0.34";
 
@@ -321,9 +308,69 @@ describe("ToastNotifications", () => {
     render(<ToastNotifications />);
     act(() => vi.advanceTimersByTime(500));
 
+    expect(mocks.message).not.toHaveBeenCalledWith(
+      "Anarlog 1.0.34 is available",
+      expect.anything(),
+    );
+  });
+
+  it("resurfaces an available update after its one-day snooze expires", () => {
+    vi.setSystemTime(new Date("2026-08-09T00:00:00Z"));
+    mocks.update.status = "available";
+    mocks.update.version = "1.0.34";
+
+    const firstLaunch = render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+    act(() => mocks.message.mock.calls[0][1].onDismiss());
+    firstLaunch.unmount();
+
+    vi.setSystemTime(new Date("2026-08-10T00:00:00.001Z"));
+    mocks.message.mockClear();
+    render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+
     expect(mocks.message).toHaveBeenCalledWith(
       "Anarlog 1.0.34 is available",
-      expect.objectContaining({ id: "desktop-update:1.0.34" }),
+      expect.objectContaining({ id: "desktop-update:1.0.34:available" }),
+    );
+  });
+
+  it("resurfaces a dismissed ready update after relaunch", () => {
+    mocks.update.status = "ready";
+    mocks.update.version = "1.0.34";
+
+    const firstLaunch = render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+    act(() => mocks.message.mock.calls[0][1].onDismiss());
+    firstLaunch.unmount();
+
+    mocks.message.mockClear();
+    render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+
+    expect(mocks.message).toHaveBeenCalledWith(
+      "Anarlog 1.0.34 is ready to install",
+      expect.objectContaining({ id: "desktop-update:1.0.34:ready" }),
+    );
+  });
+
+  it("resurfaces a dismissed failed update after another download attempt", () => {
+    mocks.update.status = "failed";
+    mocks.update.version = "1.0.34";
+
+    const view = render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+    act(() => mocks.error.mock.calls[0][1].onDismiss());
+
+    mocks.update.status = "downloading";
+    view.rerender(<ToastNotifications />);
+    mocks.update.status = "failed";
+    mocks.error.mockClear();
+    view.rerender(<ToastNotifications />);
+
+    expect(mocks.error).toHaveBeenCalledWith(
+      "The update download failed",
+      expect.objectContaining({ id: "desktop-update:1.0.34:failed" }),
     );
   });
 
@@ -336,12 +383,14 @@ describe("ToastNotifications", () => {
 
     expect(mocks.message).toHaveBeenCalledWith(
       "Anarlog 1.0.34 is available",
-      expect.objectContaining({ id: "desktop-update:1.0.34" }),
+      expect.objectContaining({ id: "desktop-update:1.0.34:available" }),
     );
 
     mocks.live = { status: "active", sessionId: "meeting-1" };
     view.rerender(<ToastNotifications />);
-    expect(mocks.dismiss).toHaveBeenCalledWith("desktop-update:1.0.34");
+    expect(mocks.dismiss).toHaveBeenCalledWith(
+      "desktop-update:1.0.34:available",
+    );
 
     mocks.message.mockClear();
     mocks.live = { status: "inactive", sessionId: null };
@@ -349,11 +398,11 @@ describe("ToastNotifications", () => {
 
     expect(mocks.message).toHaveBeenCalledWith(
       "Anarlog 1.0.34 is available",
-      expect.objectContaining({ id: "desktop-update:1.0.34" }),
+      expect.objectContaining({ id: "desktop-update:1.0.34:available" }),
     );
   });
 
-  it("resurfaces a dismissed update notice after a meeting ends", () => {
+  it("keeps a dismissed available update snoozed after a meeting ends", () => {
     mocks.update.status = "available";
     mocks.update.version = "1.0.34";
 
@@ -374,44 +423,9 @@ describe("ToastNotifications", () => {
     mocks.live = { status: "inactive", sessionId: null };
     view.rerender(<ToastNotifications />);
 
-    expect(mocks.message).toHaveBeenCalledWith(
-      "Anarlog 1.0.34 is available",
-      expect.objectContaining({ id: "desktop-update:1.0.34" }),
-    );
-  });
-
-  it("resurfaces the update notice only after the main window is hidden and shown again", () => {
-    mocks.update.status = "available";
-    mocks.update.version = "1.0.34";
-
-    render(<ToastNotifications />);
-    act(() => vi.advanceTimersByTime(500));
-
-    const firstOptions = mocks.message.mock.calls[0][1];
-    act(() => firstOptions.onDismiss());
-    mocks.message.mockClear();
-
-    // A show without a prior hide (e.g. dock Reopen while visible) keeps the snooze.
-    act(() => {
-      mocks.visibilityHandlers.forEach((handler) =>
-        handler({ payload: { window: { type: "main" }, visible: true } }),
-      );
-    });
     expect(mocks.message).not.toHaveBeenCalledWith(
       "Anarlog 1.0.34 is available",
       expect.anything(),
-    );
-
-    act(() => {
-      mocks.visibilityHandlers.forEach((handler) => {
-        handler({ payload: { window: { type: "main" }, visible: false } });
-        handler({ payload: { window: { type: "main" }, visible: true } });
-      });
-    });
-
-    expect(mocks.message).toHaveBeenCalledWith(
-      "Anarlog 1.0.34 is available",
-      expect.objectContaining({ id: "desktop-update:1.0.34" }),
     );
   });
 });

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -1,13 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
 
-import { events as windowsEvents } from "@anlg/plugin-windows";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 
 import {
   createDevtoolsToastPreview,
   createToastRegistry,
   getToastToShow,
-  isDesktopUpdateToastId,
 } from "./registry";
 import type { ToastType } from "./types";
 import { useDismissedToasts } from "./useDismissedToasts";
@@ -32,12 +30,9 @@ export function ToastNotifications() {
   const auth = useAuth();
   const cloudsyncProgress = useCloudsyncInitialSyncProgress();
   const { dismissToast, isDismissed } = useDismissedToasts();
-  // Update-toast dismissals are only a snooze: they expire when a meeting
-  // ends, when the main window is shown again, or on relaunch — so the toast
-  // keeps resurfacing until the update is installed.
-  const [snoozedUpdateToastId, setSnoozedUpdateToastId] = useState<
-    string | null
-  >(null);
+  const [sessionDismissedToastIds, setSessionDismissedToastIds] = useState(
+    () => new Set<string>(),
+  );
   const shouldShowToast = useShouldShowToast();
   const {
     hasActiveDownload,
@@ -47,6 +42,18 @@ export function ToastNotifications() {
     isLocalSttModel,
   } = useNotifications();
   const update = useDesktopUpdateControl();
+  const [observedUpdateStatus, setObservedUpdateStatus] = useState(
+    update.status,
+  );
+  if (observedUpdateStatus !== update.status) {
+    setObservedUpdateStatus(update.status);
+    if (observedUpdateStatus === "failed") {
+      setSessionDismissedToastIds(
+        (current) =>
+          new Set([...current].filter((id) => !id.endsWith(":failed"))),
+      );
+    }
+  }
 
   const isAuthenticated = !!auth?.session;
   const isAuthLoading = auth.session === undefined;
@@ -98,48 +105,6 @@ export function ToastNotifications() {
       : null,
   );
   const isLiveMeetingActive = activeLiveSessionId !== null;
-
-  const [lastLiveSessionId, setLastLiveSessionId] =
-    useState(activeLiveSessionId);
-  if (lastLiveSessionId !== activeLiveSessionId) {
-    setLastLiveSessionId(activeLiveSessionId);
-    if (lastLiveSessionId !== null) {
-      setSnoozedUpdateToastId(null);
-    }
-  }
-
-  useMountEffect(() => {
-    let cancelled = false;
-    let unlisten: (() => void) | undefined;
-    // Main.show() emits visible:true even when the window is already visible
-    // (e.g. dock Reopen), so only a show that follows a hide clears the snooze.
-    let mainWindowWasHidden = false;
-
-    void windowsEvents.visibilityEvent
-      .listen(({ payload }) => {
-        if (payload.window.type !== "main") {
-          return;
-        }
-        if (!payload.visible) {
-          mainWindowWasHidden = true;
-        } else if (mainWindowWasHidden) {
-          mainWindowWasHidden = false;
-          setSnoozedUpdateToastId(null);
-        }
-      })
-      .then((fn) => {
-        if (cancelled) {
-          fn();
-        } else {
-          unlisten = fn;
-        }
-      });
-
-    return () => {
-      cancelled = true;
-      unlisten?.();
-    };
-  });
 
   const openNew = useTabs((state) => state.openNew);
   const updateSettingsTabState = useTabs(
@@ -222,14 +187,30 @@ export function ToastNotifications() {
     ],
   );
 
+  const isToastDismissed = useCallback(
+    (toast: ToastType) => {
+      if (toast.lifecycle.type === "condition-bound") {
+        return false;
+      }
+
+      const dismissalId = toast.lifecycle.dismissalId ?? toast.id;
+      if (toast.lifecycle.dismissal === "permanent") {
+        return isDismissed(dismissalId);
+      }
+      if (sessionDismissedToastIds.has(dismissalId)) {
+        return true;
+      }
+      return (
+        toast.lifecycle.dismissal === "day" &&
+        hasActiveDayToastSnooze(dismissalId)
+      );
+    },
+    [isDismissed, sessionDismissedToastIds],
+  );
+
   const currentToast = useMemo(
-    () =>
-      getToastToShow(registry, (id) =>
-        isDesktopUpdateToastId(id)
-          ? snoozedUpdateToastId === id
-          : isDismissed(id),
-      ),
-    [snoozedUpdateToastId, registry, isDismissed],
+    () => getToastToShow(registry, isToastDismissed),
+    [registry, isToastDismissed],
   );
   const devtoolsToast = useMemo(
     () =>
@@ -260,11 +241,22 @@ export function ToastNotifications() {
     }
 
     if (currentToast) {
-      if (isDesktopUpdateToastId(currentToast.id)) {
-        setSnoozedUpdateToastId(currentToast.id);
+      if (currentToast.lifecycle.type === "condition-bound") {
         return;
       }
-      dismissToast(currentToast.id);
+
+      const dismissalId = currentToast.lifecycle.dismissalId ?? currentToast.id;
+      if (currentToast.lifecycle.dismissal === "permanent") {
+        dismissToast(dismissalId);
+        return;
+      }
+      if (currentToast.lifecycle.dismissal === "day") {
+        saveDayToastSnooze(dismissalId);
+        return;
+      }
+      setSessionDismissedToastIds((current) =>
+        new Set(current).add(dismissalId),
+      );
     }
   }, [clearDevtoolsPreview, currentToast, devtoolsToast, dismissToast]);
 
@@ -285,7 +277,9 @@ export function ToastNotifications() {
     <SonnerNotification
       key={previewKey}
       toast={displayToast}
-      onDismiss={displayToast.dismissible ? handleDismiss : undefined}
+      onDismiss={
+        displayToast.lifecycle.type === "persistent" ? handleDismiss : undefined
+      }
     />
   );
 }
@@ -302,10 +296,12 @@ function SonnerNotification({
 
   useMountEffect(() => {
     let shouldPersistDismissal = true;
+    const dismissible = toast.lifecycle.type === "persistent";
     const options = {
       id: toast.id,
       duration: Infinity,
-      closeButton: toast.dismissible,
+      closeButton: dismissible,
+      dismissible,
       icon: toast.icon,
       action: toast.primaryAction
         ? {
@@ -340,6 +336,34 @@ function SonnerNotification({
   });
 
   return null;
+}
+
+const DAY_TOAST_SNOOZE_MS = 24 * 60 * 60 * 1_000;
+const DAY_TOAST_SNOOZE_KEY_PREFIX = "anarlog:toast:snoozed-until:";
+
+function hasActiveDayToastSnooze(id: string): boolean {
+  try {
+    const storageKey = `${DAY_TOAST_SNOOZE_KEY_PREFIX}${id}`;
+    const snoozedUntil = Number(localStorage.getItem(storageKey));
+    if (Number.isFinite(snoozedUntil) && snoozedUntil > Date.now()) {
+      return true;
+    }
+    localStorage.removeItem(storageKey);
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function saveDayToastSnooze(id: string) {
+  try {
+    localStorage.setItem(
+      `${DAY_TOAST_SNOOZE_KEY_PREFIX}${id}`,
+      String(Date.now() + DAY_TOAST_SNOOZE_MS),
+    );
+  } catch {
+    return;
+  }
 }
 
 function useShouldShowToast() {

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -265,6 +265,28 @@ describe("sidebar toast registry", () => {
     expect(toast?.primaryAction).toBeUndefined();
   });
 
+  it("offers a ready desktop update without a spinner", () => {
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        update: {
+          ...baseParams.update,
+          status: "ready",
+          version: "1.0.34",
+        },
+      }),
+      () => false,
+    );
+
+    expect(toast).toMatchObject({
+      id: "desktop-update:1.0.34:ready",
+      description: "Anarlog 1.0.34 is ready to install",
+      dismissible: true,
+      primaryAction: { label: "Restart" },
+    });
+    expect(toast?.loading).toBeUndefined();
+  });
+
   it("creates devtools previews with app toast content", () => {
     const languageModelToast = createDevtoolsToastPreview({
       preview: "language-model",

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -51,7 +51,7 @@ describe("sidebar toast registry", () => {
     expect(toast?.id).toBe("missing-llm");
     expect(toast?.description).toBe("Language model needed");
     expect(toast?.primaryAction?.label).toBe("Add");
-    expect(toast?.dismissible).toBe(false);
+    expect(toast?.lifecycle).toEqual({ type: "condition-bound" });
   });
 
   it("shows required setup even if it was dismissed previously", () => {
@@ -60,7 +60,7 @@ describe("sidebar toast registry", () => {
         ...baseParams,
         hasLLMConfigured: false,
       }),
-      (id) => id === "missing-llm",
+      (toast) => toast.id === "missing-llm",
     );
 
     expect(toast?.id).toBe("missing-llm");
@@ -78,7 +78,7 @@ describe("sidebar toast registry", () => {
     expect(toast?.id).toBe("missing-stt");
     expect(toast?.description).toBe("Transcription provider needed");
     expect(toast?.primaryAction?.label).toBe("Add");
-    expect(toast?.dismissible).toBe(false);
+    expect(toast?.lifecycle).toEqual({ type: "condition-bound" });
   });
 
   it("suggests signing in before provider setup", () => {
@@ -104,7 +104,7 @@ describe("sidebar toast registry", () => {
         isAuthenticated: false,
         hasProSttConfigured: true,
       }),
-      (id) => id === "sign-in-benefits",
+      (toast) => toast.id === "sign-in-benefits",
     );
 
     expect(toast?.id).toBe("missing-stt");
@@ -163,7 +163,7 @@ describe("sidebar toast registry", () => {
     expect(toast?.description).toBe("Starting transcription...");
   });
 
-  it("shows a dismissible loading toast during initial cloud sync", () => {
+  it("keeps initial cloud sync condition-bound", () => {
     const toast = getToastToShow(
       createToastRegistry({
         ...baseParams,
@@ -174,7 +174,7 @@ describe("sidebar toast registry", () => {
 
     expect(toast?.id).toBe("cloudsync-initial-sync-user-1");
     expect(toast?.description).toBe("Syncing your data in the background...");
-    expect(toast?.dismissible).toBe(true);
+    expect(toast?.lifecycle).toEqual({ type: "condition-bound" });
     expect(toast?.loading).toBe(true);
   });
 
@@ -184,7 +184,7 @@ describe("sidebar toast registry", () => {
         ...baseParams,
         isAuthenticated: false,
       }),
-      (id) => id === "sign-in-benefits",
+      (toast) => toast.id === "sign-in-benefits",
     );
     const previewToast = createDevtoolsToastPreview({
       preview: "pro",
@@ -199,7 +199,21 @@ describe("sidebar toast registry", () => {
     expect(previewToast.icon).toBeUndefined();
   });
 
-  it("offers an available desktop update as a dismissible toast", () => {
+  it("uses one permanent dismissal for sign-in and Pro promotions", () => {
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        isAuthenticated: false,
+      }),
+      (candidate) =>
+        candidate.lifecycle.type === "persistent" &&
+        candidate.lifecycle.dismissalId === "auth-promotion",
+    );
+
+    expect(toast).toBeNull();
+  });
+
+  it("offers an available desktop update with a one-day snooze", () => {
     const downloadUpdate = vi.fn();
     const toast = getToastToShow(
       createToastRegistry({
@@ -215,9 +229,9 @@ describe("sidebar toast registry", () => {
     );
 
     expect(toast).toMatchObject({
-      id: "desktop-update:1.0.34",
+      id: "desktop-update:1.0.34:available",
       description: "Anarlog 1.0.34 is available",
-      dismissible: true,
+      lifecycle: { type: "persistent", dismissal: "day" },
       primaryAction: { label: "Download" },
     });
 
@@ -257,9 +271,9 @@ describe("sidebar toast registry", () => {
     );
 
     expect(toast).toMatchObject({
-      id: "desktop-update:1.0.34",
+      id: "desktop-update:1.0.34:downloading",
       description: "Downloading Anarlog 1.0.34 (58%)",
-      dismissible: true,
+      lifecycle: { type: "condition-bound" },
       loading: true,
     });
     expect(toast?.primaryAction).toBeUndefined();
@@ -281,7 +295,7 @@ describe("sidebar toast registry", () => {
     expect(toast).toMatchObject({
       id: "desktop-update:1.0.34:ready",
       description: "Anarlog 1.0.34 is ready to install",
-      dismissible: true,
+      lifecycle: { type: "persistent", dismissal: "session" },
       primaryAction: { label: "Restart" },
     });
     expect(toast?.loading).toBeUndefined();
@@ -304,7 +318,7 @@ describe("sidebar toast registry", () => {
     expect(languageModelToast.id).toBe("devtools-missing-llm");
     expect(languageModelToast.description).toBe("Language model needed");
     expect(languageModelToast.primaryAction?.label).toBe("Add");
-    expect(languageModelToast.dismissible).toBe(false);
+    expect(languageModelToast.lifecycle).toEqual({ type: "condition-bound" });
     const transcriptionModelToast = createDevtoolsToastPreview({
       preview: "transcription-model",
       onSignIn: vi.fn(),
@@ -314,7 +328,9 @@ describe("sidebar toast registry", () => {
     expect(transcriptionModelToast.description).toBe(
       "Transcription provider needed",
     );
-    expect(transcriptionModelToast.dismissible).toBe(false);
+    expect(transcriptionModelToast.lifecycle).toEqual({
+      type: "condition-bound",
+    });
     expect(downloadToast.id).toBe("devtools-downloading-model");
     expect(downloadToast.loading).toBe(true);
   });

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -223,13 +223,14 @@ export function createDesktopUpdateToast(
 
   if (update.status === "ready") {
     return {
-      id,
+      // A new ID prevents Sonner from retaining the loading state used while
+      // this update was downloading.
+      id: `${id}:ready`,
       description: `Anarlog ${update.version} is ready to install`,
       primaryAction: busy
         ? undefined
         : { label: "Restart", onClick: update.installUpdate },
       dismissible: true,
-      loading: update.installing,
     };
   }
 

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -83,7 +83,7 @@ export function createToastRegistry({
       toast: {
         id: "downloading-model",
         description: downloadTitle,
-        dismissible: false,
+        lifecycle: { type: "condition-bound" },
         loading: true,
       },
       condition: () => hasActiveDownload,
@@ -92,7 +92,7 @@ export function createToastRegistry({
       toast: {
         id: cloudsyncInitialSyncToastId ?? "cloudsync-initial-sync",
         description: "Syncing your data in the background...",
-        dismissible: true,
+        lifecycle: { type: "condition-bound" },
         loading: true,
       },
       condition: () => cloudsyncInitialSyncToastId !== null,
@@ -110,7 +110,7 @@ export function createToastRegistry({
       toast: {
         id: "local-stt-loading",
         description: "Starting transcription...",
-        dismissible: false,
+        lifecycle: { type: "condition-bound" },
         loading: true,
       },
       condition: () =>
@@ -127,7 +127,7 @@ export function createToastRegistry({
           label: "Settings",
           onClick: onOpenSTTSettings,
         },
-        dismissible: true,
+        lifecycle: { type: "condition-bound" },
         variant: "error",
       },
       condition: () =>
@@ -151,7 +151,11 @@ export function createToastRegistry({
           label: "Sign in",
           onClick: onSignIn,
         },
-        dismissible: true,
+        lifecycle: {
+          type: "persistent",
+          dismissal: "permanent",
+          dismissalId: "auth-promotion",
+        },
       },
       condition: () => !isAuthLoading && !isAuthenticated,
     },
@@ -163,7 +167,7 @@ export function createToastRegistry({
           label: "Add",
           onClick: onOpenSTTSettings,
         },
-        dismissible: false,
+        lifecycle: { type: "condition-bound" },
       },
       condition: () => !hasUsableSttConfigured && !isAiTranscriptionTabActive,
     },
@@ -175,7 +179,7 @@ export function createToastRegistry({
           label: "Add",
           onClick: onOpenLLMSettings,
         },
-        dismissible: false,
+        lifecycle: { type: "condition-bound" },
       },
       condition: () =>
         hasUsableSttConfigured &&
@@ -190,7 +194,11 @@ export function createToastRegistry({
           label: "Upgrade",
           onClick: onSignIn,
         },
-        dismissible: true,
+        lifecycle: {
+          type: "persistent",
+          dismissal: "permanent",
+          dismissalId: "auth-promotion",
+        },
       },
       // suppress until auth resolves to avoid flash on startup
       condition: () =>
@@ -202,10 +210,6 @@ export function createToastRegistry({
         !hasProLlmConfigured,
     },
   ];
-}
-
-export function isDesktopUpdateToastId(id: string): boolean {
-  return id.startsWith(DESKTOP_UPDATE_TOAST_PREFIX);
 }
 
 export function createDesktopUpdateToast(
@@ -230,7 +234,7 @@ export function createDesktopUpdateToast(
       primaryAction: busy
         ? undefined
         : { label: "Restart", onClick: update.installUpdate },
-      dismissible: true,
+      lifecycle: { type: "persistent", dismissal: "session" },
     };
   }
 
@@ -240,44 +244,44 @@ export function createDesktopUpdateToast(
         ? ""
         : ` (${Math.round(update.progress * 100)}%)`;
     return {
-      id,
+      id: `${id}:downloading`,
       description: `Downloading Anarlog ${update.version}${progress}`,
-      dismissible: true,
+      lifecycle: { type: "condition-bound" },
       loading: true,
     };
   }
 
   if (update.status === "failed") {
     return {
-      id,
+      id: `${id}:failed`,
       description: update.errorMessage || "The update download failed",
       primaryAction: busy
         ? undefined
         : { label: "Retry", onClick: update.downloadUpdate },
-      dismissible: true,
+      lifecycle: { type: "persistent", dismissal: "session" },
       variant: "error",
     };
   }
 
   return {
-    id,
+    id: `${id}:available`,
     description: `Anarlog ${update.version} is available`,
     primaryAction: busy
       ? undefined
       : { label: "Download", onClick: update.downloadUpdate },
-    dismissible: true,
-    loading: update.downloadStarting,
+    lifecycle: { type: "persistent", dismissal: "day" },
   };
 }
 
 export function getToastToShow(
   registry: ToastRegistryEntry[],
-  isDismissed: (id: string) => boolean,
+  isDismissed: (toast: ToastType) => boolean,
 ): ToastType | null {
   for (const entry of registry) {
     if (
       entry.condition() &&
-      (!entry.toast.dismissible || !isDismissed(entry.toast.id))
+      (entry.toast.lifecycle.type === "condition-bound" ||
+        !isDismissed(entry.toast))
     ) {
       return entry.toast;
     }
@@ -300,7 +304,7 @@ export function createDevtoolsToastPreview({
           label: "Add",
           onClick: onOpenLLMSettings,
         },
-        dismissible: false,
+        lifecycle: { type: "condition-bound" },
       };
     case "transcription-model":
       return {
@@ -310,7 +314,7 @@ export function createDevtoolsToastPreview({
           label: "Add",
           onClick: onOpenSTTSettings,
         },
-        dismissible: false,
+        lifecycle: { type: "condition-bound" },
       };
     case "transcription-error":
       return {
@@ -320,14 +324,14 @@ export function createDevtoolsToastPreview({
           label: "Settings",
           onClick: onOpenSTTSettings,
         },
-        dismissible: true,
+        lifecycle: { type: "condition-bound" },
         variant: "error",
       };
     case "download":
       return {
         id: "devtools-downloading-model",
         description: "Downloading model",
-        dismissible: false,
+        lifecycle: { type: "condition-bound" },
         loading: true,
       };
     case "pro":
@@ -338,7 +342,7 @@ export function createDevtoolsToastPreview({
           label: "Upgrade",
           onClick: onSignIn,
         },
-        dismissible: true,
+        lifecycle: { type: "persistent", dismissal: "session" },
       };
   }
 }

--- a/apps/desktop/src/sidebar/toast/types.ts
+++ b/apps/desktop/src/sidebar/toast/types.ts
@@ -12,12 +12,20 @@ export type DownloadProgress = {
   progress: number;
 };
 
+export type ToastLifecycle =
+  | { type: "condition-bound" }
+  | {
+      type: "persistent";
+      dismissal: "permanent" | "session" | "day";
+      dismissalId?: string;
+    };
+
 export type ToastType = {
   id: string;
   icon?: ReactNode;
   description: ReactNode;
   primaryAction?: ToastAction;
-  dismissible: boolean;
+  lifecycle: ToastLifecycle;
   variant?: "default" | "error" | "warning";
   loading?: boolean;
 };

--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -203,6 +203,7 @@ const clearLiveInterval = (intervalId?: LiveIntervalId) => {
 const notifyTranscriptionStalled = () => {
   sonnerToast.warning("Live transcription stalled", {
     id: "live-transcription-stalled",
+    duration: Infinity,
     description:
       "Anarlog keeps recording. The missing part of the transcript will be rebuilt from the recording when you stop listening.",
   });

--- a/apps/desktop/src/stt/capture-lifecycle.ts
+++ b/apps/desktop/src/stt/capture-lifecycle.ts
@@ -332,9 +332,12 @@ export function useCaptureLifecycle(sessionId: string) {
         details: Parameters<OnStoppedCallback>[1],
         requestRecoveryOnFailure: boolean,
       ) => {
+        sonnerToast.dismiss("recording-without-transcription");
+        sonnerToast.dismiss("live-transcription-stalled");
+        sonnerToast.dismiss("meeting-disclosure-send-failed");
         const notifyFailure = (message: string, id: string) => {
           if (requestRecoveryOnFailure) {
-            sonnerToast.error(message, { id });
+            sonnerToast.error(message, { id, duration: Infinity });
           }
         };
         const requestRecovery = async () => {

--- a/apps/desktop/src/stt/meeting-chat-capture.test.ts
+++ b/apps/desktop/src/stt/meeting-chat-capture.test.ts
@@ -9,12 +9,14 @@ const {
   listMicUsingApplicationsMock,
   persistMeetingChatRecordsMock,
   sonnerToastWarningMock,
+  sonnerToastDismissMock,
   captureSettingState,
 } = vi.hoisted(() => ({
   captureMeetingChatMessagesMock: vi.fn(),
   listMicUsingApplicationsMock: vi.fn(),
   persistMeetingChatRecordsMock: vi.fn(),
   sonnerToastWarningMock: vi.fn(),
+  sonnerToastDismissMock: vi.fn(),
   captureSettingState: { value: true },
 }));
 
@@ -30,7 +32,10 @@ vi.mock("~/stt/meeting-chat-records", () => ({
 }));
 
 vi.mock("@anlg/ui/components/ui/toast", () => ({
-  sonnerToast: { warning: sonnerToastWarningMock },
+  sonnerToast: {
+    warning: sonnerToastWarningMock,
+    dismiss: sonnerToastDismissMock,
+  },
 }));
 
 vi.mock("~/settings/queries", () => ({
@@ -622,7 +627,7 @@ describe("startMeetingChatCapture", () => {
       "Meeting chat capture needs Accessibility permission in Settings",
       {
         id: "meeting-chat-capture-warning",
-        duration: 6_000,
+        duration: Infinity,
       },
     );
   });

--- a/apps/desktop/src/stt/meeting-chat-capture.ts
+++ b/apps/desktop/src/stt/meeting-chat-capture.ts
@@ -18,6 +18,7 @@ export function startMeetingChatCapture({
   isEnabled?: () => boolean | Promise<boolean>;
   excludedTexts?: string[];
 }) {
+  sonnerToast.dismiss("meeting-chat-capture-warning");
   const excludedMessages = new Set(excludedTexts.map(normalizeMessageText));
   const seenSignatures = new Set<string>();
   let baselineContext: { bundleId: string; contextId: string } | null = null;
@@ -211,7 +212,7 @@ function showCaptureWarning(warnings: string[], previousWarning: string) {
       "Meeting chat capture needs Accessibility permission in Settings",
       {
         id: "meeting-chat-capture-warning",
-        duration: 6_000,
+        duration: Infinity,
       },
     );
   }

--- a/apps/desktop/src/stt/meeting-disclosure.ts
+++ b/apps/desktop/src/stt/meeting-disclosure.ts
@@ -61,7 +61,7 @@ function meetingDisclosureFailure(reason: unknown): MeetingDisclosureOutcome {
   console.warn("[listener] meeting disclosure was not sent", reason);
   sonnerToast.warning(
     "Recording started, but Anarlog could not post the meeting chat disclosure.",
-    { id: "meeting-disclosure-send-failed" },
+    { id: "meeting-disclosure-send-failed", duration: Infinity },
   );
   return { status: "notSent", reason: detail };
 }

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -53,6 +53,7 @@ const {
   audioSourceMetadataMock,
   sonnerToastWarningMock,
   sonnerToastErrorMock,
+  sonnerToastDismissMock,
   startMeetingChatCaptureMock,
   stopMeetingChatCaptureMock,
   catalogLocalSessionAudioMock,
@@ -101,6 +102,7 @@ const {
   audioSourceMetadataMock: vi.fn(),
   sonnerToastWarningMock: vi.fn(),
   sonnerToastErrorMock: vi.fn(),
+  sonnerToastDismissMock: vi.fn(),
   startMeetingChatCaptureMock: vi.fn(),
   stopMeetingChatCaptureMock: vi.fn(),
   catalogLocalSessionAudioMock: vi.fn(),
@@ -147,6 +149,7 @@ vi.mock("@anlg/ui/components/ui/toast", () => ({
   sonnerToast: {
     warning: sonnerToastWarningMock,
     error: sonnerToastErrorMock,
+    dismiss: sonnerToastDismissMock,
   },
 }));
 
@@ -2495,7 +2498,7 @@ describe("useStartListening", () => {
 
     expect(sonnerToastErrorMock).toHaveBeenCalledWith(
       "Anarlog could not save part of the live transcript.",
-      { id: "live-transcript-persist-failed" },
+      { id: "live-transcript-persist-failed", duration: Infinity },
     );
     expect(queueAutoEnhanceIfSummaryEmptyMock).not.toHaveBeenCalled();
     expect(queueAutoEnhanceMock).not.toHaveBeenCalled();
@@ -2545,7 +2548,7 @@ describe("useStartListening", () => {
 
     expect(sonnerToastErrorMock).toHaveBeenCalledWith(
       "Anarlog could not finish saving the transcript. The recording was kept so you can try again.",
-      { id: "post-capture-transcript-incomplete" },
+      { id: "post-capture-transcript-incomplete", duration: Infinity },
     );
     expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
     expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
@@ -2584,7 +2587,7 @@ describe("useStartListening", () => {
 
     expect(sonnerToastErrorMock).toHaveBeenCalledWith(
       "Post-meeting transcription failed. The recording was kept so you can try again.",
-      { id: "post-capture-batch-failed" },
+      { id: "post-capture-batch-failed", duration: Infinity },
     );
     expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
     expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
@@ -2664,7 +2667,7 @@ describe("useStartListening", () => {
 
     expect(sonnerToastErrorMock).toHaveBeenCalledWith(
       "Anarlog could not finish saving the transcript. The recording was kept so you can try again.",
-      { id: "post-capture-transcript-incomplete" },
+      { id: "post-capture-transcript-incomplete", duration: Infinity },
     );
     expect(queueAutoEnhanceIfSummaryEmptyMock).not.toHaveBeenCalled();
     expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
@@ -2908,7 +2911,7 @@ describe("useStartListening", () => {
     expect(queueAutoEnhanceIfSummaryEmptyMock).toHaveBeenCalledOnce();
     expect(sonnerToastErrorMock).toHaveBeenCalledWith(
       "The transcript was saved, but Anarlog could not start the summary. Try generating it again.",
-      { id: "post-capture-summary-failed" },
+      { id: "post-capture-summary-failed", duration: Infinity },
     );
     expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
     expect(saveCaptureLifecycleMarkerMock).toHaveBeenCalledWith(
@@ -3390,7 +3393,7 @@ describe("useStartListening", () => {
     );
     expect(sonnerToastWarningMock).toHaveBeenCalledWith(
       "Recording started, but Anarlog could not post the meeting chat disclosure.",
-      { id: "meeting-disclosure-send-failed" },
+      { id: "meeting-disclosure-send-failed", duration: Infinity },
     );
     warn.mockRestore();
   });
@@ -3540,7 +3543,7 @@ describe("useStartListening", () => {
     );
     expect(sonnerToastWarningMock).toHaveBeenCalledWith(
       "Recording started, but Anarlog could not post the meeting chat disclosure.",
-      { id: "meeting-disclosure-send-failed" },
+      { id: "meeting-disclosure-send-failed", duration: Infinity },
     );
     warn.mockRestore();
   });

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -199,6 +199,7 @@ export function useStartListening(sessionId: string) {
     if (!conn) {
       sonnerToast.warning("Live transcription is not configured", {
         id: "recording-without-transcription",
+        duration: Infinity,
         description:
           "Audio is being saved. Choose a transcription provider to ensure this recording can be transcribed.",
         action: {

--- a/packages/ui/src/components/ui/toast.tsx
+++ b/packages/ui/src/components/ui/toast.tsx
@@ -1,7 +1,71 @@
 import type { ComponentProps, CSSProperties } from "react";
-import { Toaster as Sonner, toast as sonnerToast } from "sonner";
+import {
+  Toaster as Sonner,
+  toast as rawSonnerToast,
+  type ExternalToast,
+} from "sonner";
 
-export { sonnerToast };
+export const TOAST_DURATIONS = {
+  success: 3_000,
+  info: 4_000,
+  warning: 6_000,
+  error: 8_000,
+} as const;
+
+function withDefaultDuration(
+  duration: number,
+  options?: ExternalToast,
+): ExternalToast {
+  return { duration, ...options };
+}
+
+export const sonnerToast: typeof rawSonnerToast = Object.assign(
+  (message: Parameters<typeof rawSonnerToast>[0], options?: ExternalToast) =>
+    rawSonnerToast(message, withDefaultDuration(TOAST_DURATIONS.info, options)),
+  rawSonnerToast,
+  {
+    success: (
+      message: Parameters<typeof rawSonnerToast.success>[0],
+      options?: ExternalToast,
+    ) =>
+      rawSonnerToast.success(
+        message,
+        withDefaultDuration(TOAST_DURATIONS.success, options),
+      ),
+    info: (
+      message: Parameters<typeof rawSonnerToast.info>[0],
+      options?: ExternalToast,
+    ) =>
+      rawSonnerToast.info(
+        message,
+        withDefaultDuration(TOAST_DURATIONS.info, options),
+      ),
+    warning: (
+      message: Parameters<typeof rawSonnerToast.warning>[0],
+      options?: ExternalToast,
+    ) =>
+      rawSonnerToast.warning(
+        message,
+        withDefaultDuration(TOAST_DURATIONS.warning, options),
+      ),
+    error: (
+      message: Parameters<typeof rawSonnerToast.error>[0],
+      options?: ExternalToast,
+    ) =>
+      rawSonnerToast.error(
+        message,
+        withDefaultDuration(TOAST_DURATIONS.error, options),
+      ),
+    message: (
+      message: Parameters<typeof rawSonnerToast.message>[0],
+      options?: ExternalToast,
+    ) =>
+      rawSonnerToast.message(
+        message,
+        withDefaultDuration(TOAST_DURATIONS.info, options),
+      ),
+  },
+);
 
 type ToasterProps = ComponentProps<typeof Sonner>;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wide UX surface (many toast call sites) and changed update-notification snooze/resurface rules; behavior is well covered by tests but affects daily desktop notifications.
> 
> **Overview**
> **Toast defaults** — `@anlg/ui` wraps Sonner so success/info/warning/error/message get category-specific auto-dismiss times unless callers pass `duration: Infinity`.
> 
> **Persistent vs condition-bound** — Sidebar notifications replace `dismissible` with `lifecycle` (`condition-bound` vs `persistent` with permanent/session/day dismissal). Sign-in and Pro promos share `auth-promotion`; available updates use a **24h localStorage snooze** instead of resurfacing on window focus or meeting end. Desktop update toasts use **status-specific IDs** (`:available`, `:downloading`, `:ready`, `:failed`) so a ready update no longer inherits the downloading toast’s loading spinner.
> 
> **Operational toasts** — Recording, cloud sync device limit, session sharing, delete-session share warnings, and similar alerts stay visible until dismissed or explicitly cleared (`sonnerToast.dismiss` on recovery). `SettingsAlertToast` uses the same lifecycle model; transcription-language warning dismissals persist in **localStorage**.
> 
> **Tests** — New `toast-duration.test.ts` and broad updates to sidebar/registry/settings tests for the new dismissal rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f224a53ffda50c0426b1247d6788790ac0497a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->