### PR TITLE
Add Turbo web development task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ SQLite is the primary data store (schema and migrations in `crates/db-app/`, des
 - Typecheck (TS): `pnpm -r typecheck`
 - Typecheck (Rust): `cargo check`
 - Desktop dev: `turbo dev:desktop`
-- Web dev: `pnpm -F @anlg/web dev`
+- Web dev: `turbo dev:web`
 - Dev docs: https://docs.anarlog.so
 
 ## Pre-commit verification

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "dev:desktop": "pnpm -F @anlg/desktop tauri:dev",
+    "dev:web": "pnpm -F @anlg/web dev",
     "fmt:check": "dprint check",
     "fmt": "dprint fmt",
     "lint": "pnpm lint:oxlint && pnpm lint:eslint",

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,11 @@
       "persistent": true,
       "cache": false
     },
+    "//#dev:web": {
+      "dependsOn": ["@anlg/ui#build"],
+      "persistent": true,
+      "cache": false
+    },
     "tauri:dev": {
       "persistent": true,
       "cache": false


### PR DESCRIPTION
Expose turbo dev:web with the shared UI build prerequisite and document the command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-script and documentation changes only; no runtime, auth, or data-path impact.
> 
> **Overview**
> **Web local dev** is aligned with desktop by routing through Turbo instead of calling the web package directly.
> 
> A new root **`//#dev:web`** task in `turbo.json` mirrors **`//#dev:desktop`**: it depends on **`@anlg/ui#build`**, runs as a persistent uncached dev task. Root **`package.json`** gains **`dev:web`** (`pnpm -F @anlg/web dev`). **`AGENTS.md`** now documents **`turbo dev:web`** for web development, replacing **`pnpm -F @anlg/web dev`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a415357f1b56d2c9b5fceeeb83e05eee5de648a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->