### PR TITLE
Prepare desktop 1.4.7 changelog

### DIFF
--- a/packages/changelog/content/1.4.7.md
+++ b/packages/changelog/content/1.4.7.md
@@ -1,0 +1,38 @@
+---
+date: "2026-08-09"
+summary: "Anarlog 1.4.7 adds Sync device management and activity history, speeds up CloudSync recovery, and improves microphone detection, transcription, notifications, and Linux compatibility."
+---
+
+## Sync
+
+- See the devices registered to your account, identify the current device,
+  remove old ones, and follow a guided recovery-key flow when adding another
+  computer
+- Open a recent activity log in Sync settings to see manual and background
+  checks, transferred data, no-change results, and failures from this app
+  session
+- Recover large synced workspaces much faster by skipping records that are
+  already up to date
+- Keep meeting snapshots consistent when uploads and deletions happen close
+  together, without losing work that still needs to retry
+
+## Recording and transcription
+
+- Keep detecting microphone activity on macOS after the default input device
+  changes or a CoreAudio listener fails
+- Use Anarlog cloud transcription normally when a previously saved custom
+  endpoint is blank
+
+## Notifications and settings
+
+- Dismiss ordinary notifications from their close button while important setup
+  prompts and in-progress operations stay visible until they are resolved
+- See update notifications with the right status and timing, including a ready
+  update without a stale loading spinner and a 24-hour snooze after dismissal
+- Find CLI and MCP tools together in a compact Developers settings card, with
+  commands and MCP configuration ready to copy
+
+## Linux
+
+- Run the AppImage more reliably on Wayland desktops by using the compatible
+  Wayland libraries provided by your system


### PR DESCRIPTION
Summarizes the user-facing Sync, recording, notification, developer settings, and Linux improvements shipping in the next stable desktop release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of release notes; no application or infrastructure code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.7.md`** for the next stable desktop release, with frontmatter (`date`, index **`summary`**) and user-facing bullets grouped by area.
> 
> **Sync** covers registered device management (current device, removal, recovery-key flow for new computers), a session activity log in settings, faster large-workspace recovery by skipping up-to-date records, and more consistent meeting snapshots when uploads and deletions overlap.
> 
> Other sections document **recording/transcription** (macOS mic detection after input changes or CoreAudio listener failures; cloud transcription when a saved custom endpoint is blank), **notifications and settings** (dismissible ordinary notifications, update notification status/snooze, consolidated Developers card for CLI/MCP), and **Linux** (more reliable AppImage on Wayland via system libraries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5457172f3c8a11f4e189416e00499abfb6c1d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->