### PR TITLE
Extend YC founder perk to one year

### DIFF
--- a/apps/web/src/lib/yc-perk-promotion.test.ts
+++ b/apps/web/src/lib/yc-perk-promotion.test.ts
@@ -6,7 +6,6 @@ import {
   createYcPromotionCode,
   getOrCreateYcPromotionCode,
   getYcPerkClaimId,
-  YC_FOUNDER_COUPON_ID,
 } from "./yc-perk-promotion.ts";
 
 const claimId = "0123456789abcdef0123456789abcdef";
@@ -75,7 +74,7 @@ test("reports an existing redeemed promotion code as claimed", async () => {
   );
 });
 
-test("creates a single-use promotion code for the YC coupon", async () => {
+test("creates a single-use promotion code for the one-year YC coupon", async () => {
   const calls: Array<{ params: unknown; options: unknown }> = [];
   const stripe = {
     promotionCodes: {
@@ -94,7 +93,7 @@ test("creates a single-use promotion code for the YC coupon", async () => {
   assert.deepEqual(calls, [
     {
       params: {
-        promotion: { type: "coupon", coupon: YC_FOUNDER_COUPON_ID },
+        promotion: { type: "coupon", coupon: "yc-founders-1-year-free" },
         code,
         max_redemptions: 1,
         metadata: { claim_id: claimId, source: "yc_perk_page" },

--- a/apps/web/src/lib/yc-perk-promotion.ts
+++ b/apps/web/src/lib/yc-perk-promotion.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import type Stripe from "stripe";
 
-export const YC_FOUNDER_COUPON_ID = "yc-founders-3-months-free";
+export const YC_FOUNDER_COUPON_ID = "yc-founders-1-year-free";
 
 export function getYcPerkClaimId(email: string) {
   return createHash("sha256").update(email.trim().toLowerCase()).digest("hex");

--- a/apps/web/src/routes/yc/index.tsx
+++ b/apps/web/src/routes/yc/index.tsx
@@ -13,7 +13,7 @@ import { validateYcVerificationUrl, ycPerkRequestSchema } from "@/lib/yc-perk";
 
 const title = "YC founder perk · Anarlog";
 const description =
-  "YC founders get three months of Anarlog Pro free for private, bot-free meeting notes.";
+  "YC founders get one year of Anarlog Pro free for private, bot-free meeting notes.";
 
 const invalidVerificationMessages = {
   not_verified: "This YC link is no longer active.",
@@ -91,8 +91,7 @@ function YcPerkPage() {
             Build the company. Keep every decision.
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-[#4f4940]">
-            Get 3 months of Anarlog Pro free for private, bot-free meeting
-            notes.
+            Get 1 year of Anarlog Pro free for private, bot-free meeting notes.
           </p>
 
           <div className="mx-auto mt-8 max-w-xl">


### PR DESCRIPTION
Update the YC landing page and promotion-code generation to use the live 12-month Stripe coupon.

Validation: formatting, UI build, Supabase package checks, web typecheck, 214 web tests, and media figure check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Stripe coupon new YC promotion codes attach to, affecting billing/redemption value for founders; copy-only risk on the landing page.
> 
> **Overview**
> **Extends the YC founder perk from three months to one year** of Anarlog Pro, aligned with the live Stripe coupon.
> 
> `YC_FOUNDER_COUPON_ID` in `yc-perk-promotion.ts` now points at **`yc-founders-1-year-free`** instead of `yc-founders-3-months-free`, so new single-use promotion codes created via `getOrCreateYcPromotionCode` redeem against the 12-month coupon. The `/yc` landing page SEO description and hero copy are updated to say **1 year** instead of 3 months. Tests assert the new coupon id and renamed test title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f42bd306014008a622f57901a096755826d922a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->