### PR TITLE
Harden Windows audio source recovery

### DIFF
--- a/crates/audio-actual/src/mic.rs
+++ b/crates/audio-actual/src/mic.rs
@@ -33,6 +33,14 @@ pub struct MicInput {
 const MIC_READ_CHUNK_SIZE: usize = 256;
 const MIC_BUFFER_SIZE: usize = MIC_READ_CHUNK_SIZE * 256;
 
+fn default_stream_config_error_type(error: &cpal::DefaultStreamConfigError) -> &'static str {
+    match error {
+        cpal::DefaultStreamConfigError::DeviceNotAvailable => "device_not_available",
+        cpal::DefaultStreamConfigError::StreamTypeNotSupported => "stream_type_not_supported",
+        cpal::DefaultStreamConfigError::BackendSpecific { .. } => "backend_specific",
+    }
+}
+
 fn build_stream_error_type(error: &cpal::BuildStreamError) -> &'static str {
     match error {
         cpal::BuildStreamError::DeviceNotAvailable => "device_not_available",
@@ -115,7 +123,12 @@ impl MicInput {
 
         let device_name = get_device_name(&device);
         let config = device.default_input_config().map_err(|err| {
-            tracing::error!(error = %err, device_name, "mic_default_input_config_failed");
+            tracing::error!(
+                error = %err,
+                error.type = default_stream_config_error_type(&err),
+                device_name,
+                "mic_default_input_config_failed"
+            );
             crate::Error::MicOpenFailed
         })?;
         tracing::info!(
@@ -358,6 +371,28 @@ impl AsyncSource for MicStream {
 mod tests {
     use super::*;
     use futures_util::StreamExt;
+
+    #[test]
+    fn default_stream_config_errors_have_stable_types() {
+        assert_eq!(
+            default_stream_config_error_type(&cpal::DefaultStreamConfigError::DeviceNotAvailable),
+            "device_not_available"
+        );
+        assert_eq!(
+            default_stream_config_error_type(
+                &cpal::DefaultStreamConfigError::StreamTypeNotSupported
+            ),
+            "stream_type_not_supported"
+        );
+        assert_eq!(
+            default_stream_config_error_type(&cpal::DefaultStreamConfigError::BackendSpecific {
+                err: cpal::BackendSpecificError {
+                    description: "private driver detail".to_string(),
+                },
+            }),
+            "backend_specific"
+        );
+    }
 
     #[test]
     fn build_stream_errors_have_stable_types() {

--- a/crates/audio-actual/src/mic.rs
+++ b/crates/audio-actual/src/mic.rs
@@ -33,6 +33,16 @@ pub struct MicInput {
 const MIC_READ_CHUNK_SIZE: usize = 256;
 const MIC_BUFFER_SIZE: usize = MIC_READ_CHUNK_SIZE * 256;
 
+fn build_stream_error_type(error: &cpal::BuildStreamError) -> &'static str {
+    match error {
+        cpal::BuildStreamError::DeviceNotAvailable => "device_not_available",
+        cpal::BuildStreamError::StreamConfigNotSupported => "stream_config_not_supported",
+        cpal::BuildStreamError::InvalidArgument => "invalid_argument",
+        cpal::BuildStreamError::StreamIdOverflow => "stream_id_overflow",
+        cpal::BuildStreamError::BackendSpecific { .. } => "backend_specific",
+    }
+}
+
 impl MicInput {
     pub fn device_name(&self) -> String {
         self.device
@@ -235,7 +245,11 @@ impl MicInput {
                 };
 
                 let stream = stream.map_err(|err| {
-                    tracing::error!(error = %err, "mic_stream_build_failed");
+                    tracing::error!(
+                        error = %err,
+                        error.type = build_stream_error_type(&err),
+                        "mic_stream_build_failed"
+                    );
                     format!("failed to build microphone stream: {err}")
                 })?;
 
@@ -344,6 +358,34 @@ impl AsyncSource for MicStream {
 mod tests {
     use super::*;
     use futures_util::StreamExt;
+
+    #[test]
+    fn build_stream_errors_have_stable_types() {
+        assert_eq!(
+            build_stream_error_type(&cpal::BuildStreamError::DeviceNotAvailable),
+            "device_not_available"
+        );
+        assert_eq!(
+            build_stream_error_type(&cpal::BuildStreamError::StreamConfigNotSupported),
+            "stream_config_not_supported"
+        );
+        assert_eq!(
+            build_stream_error_type(&cpal::BuildStreamError::InvalidArgument),
+            "invalid_argument"
+        );
+        assert_eq!(
+            build_stream_error_type(&cpal::BuildStreamError::StreamIdOverflow),
+            "stream_id_overflow"
+        );
+        assert_eq!(
+            build_stream_error_type(&cpal::BuildStreamError::BackendSpecific {
+                err: cpal::BackendSpecificError {
+                    description: "private driver detail".to_string(),
+                },
+            }),
+            "backend_specific"
+        );
+    }
 
     fn rms(samples: &[f32]) -> f32 {
         (samples.iter().map(|sample| sample * sample).sum::<f32>() / samples.len() as f32).sqrt()

--- a/crates/listener-core/src/actors/session/supervisor.rs
+++ b/crates/listener-core/src/actors/session/supervisor.rs
@@ -12,7 +12,7 @@ use crate::actors::session::types::{
 use crate::actors::{ListenerConfigUpdate, ListenerInitError, ListenerMsg};
 use owhisper_client::AdapterKind;
 
-use self::children::{ChildKind, RESTART_BUDGET};
+use self::children::ChildKind;
 use self::mode::SessionModeState;
 
 const LISTENER_RETRY_DELAYS: [Duration; 5] = [
@@ -156,8 +156,12 @@ impl Actor for SessionActor {
     ) -> Result<(), ActorProcessingErr> {
         let span = session_span(&state.ctx.params.session_id);
         async {
-            state.source_restarts.maybe_reset(&RESTART_BUDGET);
-            state.recorder_restarts.maybe_reset(&RESTART_BUDGET);
+            state
+                .source_restarts
+                .maybe_reset(&children::SOURCE_RESTART_BUDGET);
+            state
+                .recorder_restarts
+                .maybe_reset(&children::RECORDER_RESTART_BUDGET);
 
             if state.shutting_down {
                 return Ok(());

--- a/crates/listener-core/src/actors/session/supervisor/children.rs
+++ b/crates/listener-core/src/actors/session/supervisor/children.rs
@@ -30,6 +30,10 @@ const RETRY_STRATEGY: RetryStrategy = RetryStrategy {
 
 const CHILD_STOP_TIMEOUT: Duration = Duration::from_secs(30);
 
+fn source_restart_delay(restart_count: u32) -> Duration {
+    Duration::from_secs(1 << restart_count.saturating_sub(1).min(2))
+}
+
 pub(super) fn identify_child(state: &SessionState, cell: &ActorCell) -> Option<ChildKind> {
     if state
         .source_cell
@@ -136,6 +140,17 @@ pub(super) async fn try_restart_source(
 ) -> bool {
     if count_against_budget && !state.source_restarts.record_restart(&RESTART_BUDGET) {
         return false;
+    }
+
+    if count_against_budget {
+        let restart_count = state.source_restarts.count();
+        let delay = source_restart_delay(restart_count);
+        tracing::info!(
+            restart_count,
+            delay_ms = delay.as_millis() as u64,
+            "source_restart_backoff"
+        );
+        tokio::time::sleep(delay).await;
     }
 
     let sup = supervisor_cell;
@@ -262,5 +277,18 @@ async fn stop_child(cell: &ActorCell, reason: &str, child: &str) {
         .await
     {
         tracing::warn!(?error, %child, "child_stop_and_wait_failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_restart_backoff_is_capped() {
+        assert_eq!(source_restart_delay(1), Duration::from_secs(1));
+        assert_eq!(source_restart_delay(2), Duration::from_secs(2));
+        assert_eq!(source_restart_delay(3), Duration::from_secs(4));
+        assert_eq!(source_restart_delay(10), Duration::from_secs(4));
     }
 }

--- a/crates/listener-core/src/actors/session/supervisor/children.rs
+++ b/crates/listener-core/src/actors/session/supervisor/children.rs
@@ -17,9 +17,21 @@ pub(super) enum ChildKind {
     Recorder,
 }
 
-pub(super) const RESTART_BUDGET: RestartBudget = RestartBudget {
-    max_restarts: 3,
-    max_window: Duration::from_secs(15),
+const MAX_RESTARTS: u32 = 3;
+const RESTART_FAILURE_WINDOW_SECS: u64 = 15;
+const SOURCE_RESTART_BACKOFF_ALLOWANCE_SECS: u64 = 1 + 2 + 4;
+
+pub(super) const SOURCE_RESTART_BUDGET: RestartBudget = RestartBudget {
+    max_restarts: MAX_RESTARTS,
+    max_window: Duration::from_secs(
+        RESTART_FAILURE_WINDOW_SECS + SOURCE_RESTART_BACKOFF_ALLOWANCE_SECS,
+    ),
+    reset_after: Some(Duration::from_secs(30)),
+};
+
+pub(super) const RECORDER_RESTART_BUDGET: RestartBudget = RestartBudget {
+    max_restarts: MAX_RESTARTS,
+    max_window: Duration::from_secs(RESTART_FAILURE_WINDOW_SECS),
     reset_after: Some(Duration::from_secs(30)),
 };
 
@@ -138,7 +150,7 @@ pub(super) async fn try_restart_source(
     state: &mut SessionState,
     count_against_budget: bool,
 ) -> bool {
-    if count_against_budget && !state.source_restarts.record_restart(&RESTART_BUDGET) {
+    if count_against_budget && !state.source_restarts.record_restart(&SOURCE_RESTART_BUDGET) {
         return false;
     }
 
@@ -183,7 +195,10 @@ pub(super) async fn try_restart_recorder(
     supervisor_cell: ActorCell,
     state: &mut SessionState,
 ) -> bool {
-    if !state.recorder_restarts.record_restart(&RESTART_BUDGET) {
+    if !state
+        .recorder_restarts
+        .record_restart(&RECORDER_RESTART_BUDGET)
+    {
         return false;
     }
 
@@ -290,5 +305,17 @@ mod tests {
         assert_eq!(source_restart_delay(2), Duration::from_secs(2));
         assert_eq!(source_restart_delay(3), Duration::from_secs(4));
         assert_eq!(source_restart_delay(10), Duration::from_secs(4));
+    }
+
+    #[test]
+    fn source_restart_budget_excludes_backoff() {
+        let total_backoff = (1..=SOURCE_RESTART_BUDGET.max_restarts)
+            .map(source_restart_delay)
+            .sum::<Duration>();
+
+        assert_eq!(
+            SOURCE_RESTART_BUDGET.max_window,
+            RECORDER_RESTART_BUDGET.max_window + total_backoff
+        );
     }
 }

--- a/crates/listener-core/src/actors/source/mod.rs
+++ b/crates/listener-core/src/actors/source/mod.rs
@@ -260,7 +260,7 @@ impl Actor for SourceActor {
                     }
                 }
                 SourceMsg::StreamFailed(reason) => {
-                    tracing::error!(%reason, "source_stream_failed_stopping");
+                    tracing::warn!(%reason, "source_stream_failed_stopping");
                     st.runtime.emit_error(SessionErrorEvent::AudioError {
                         session_id: st.session_id.clone(),
                         error: reason.clone(),


### PR DESCRIPTION
Back off source restarts, retain safe CPAL error categories, and suppress duplicate downstream Sentry events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live session supervision and restart timing for the audio source path; behavior is bounded and unit-tested but affects recovery under real device/driver failures.
> 
> **Overview**
> Improves **audio source recovery** when capture dies (e.g. flaky Windows CPAL streams) and tightens **observability** so alerts group on stable categories instead of noisy duplicate errors.
> 
> **Session supervisor:** Source restarts now use **exponential backoff** (1s → 2s → 4s, capped) before respawning when the failure counts against the budget. **Source** and **recorder** get separate restart budgets; the source window is widened by the sum of backoff delays so sleep time does not falsely exhaust the restart limit. Device-change restarts still skip budget/backoff where applicable.
> 
> **Mic (`audio-actual`):** CPAL default-config and stream-build failures log an **`error.type`** field (`device_not_available`, `stream_config_not_supported`, `backend_specific`, etc.) instead of relying only on raw driver strings—useful for Sentry/metrics without leaking backend details.
> 
> **Source actor:** `source_stream_failed_stopping` is logged at **warn** instead of **error** while still emitting the fatal `AudioError` session event—reduces duplicate downstream error reporting when the stream failure is already surfaced elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2719026b928a84b5f65fc37b0756c4a7833ef39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->