### PR TITLE
Handle OpenAI realtime provider failures

### DIFF
--- a/crates/listener-core/src/actors/listener/mod.rs
+++ b/crates/listener-core/src/actors/listener/mod.rs
@@ -346,7 +346,7 @@ async fn stop_stream_task(
 
     let _ = shutdown_tx.send(());
     match tokio::time::timeout(timeout, &mut *rx_task).await {
-        Ok(Ok(responses)) => responses,
+        Ok(Ok(responses)) => discard_final_stream_errors(responses),
         Ok(Err(error)) => {
             tracing::warn!(error.message = ?error, "listener_stream_task_join_failed");
             Vec::new()
@@ -359,6 +359,29 @@ async fn stop_stream_task(
     }
 }
 
+fn discard_final_stream_errors(responses: Vec<StreamResponse>) -> Vec<StreamResponse> {
+    responses
+        .into_iter()
+        .filter_map(|response| match response {
+            StreamResponse::ErrorResponse {
+                error_code,
+                provider,
+                ..
+            } => {
+                let error_code =
+                    error_code.map_or_else(|| "unknown".to_string(), |code| code.to_string());
+                tracing::warn!(
+                    error.code = %error_code,
+                    anarlog.stt.provider.name = %provider,
+                    "stream_provider_error_during_shutdown"
+                );
+                None
+            }
+            response => Some(response),
+        })
+        .collect()
+}
+
 fn process_stream_response(
     state: &mut ListenerState,
     mut response: StreamResponse,
@@ -369,10 +392,12 @@ fn process_stream_response(
         provider,
     } = &response
     {
+        let error_code_tag =
+            error_code.map_or_else(|| "unknown".to_string(), |code| code.to_string());
         tracing::error!(
-            ?error_code,
-            %error_message,
-            %provider,
+            error.code = %error_code_tag,
+            error.message = %error_message,
+            anarlog.stt.provider.name = %provider,
             "stream_provider_error"
         );
         state
@@ -389,14 +414,11 @@ fn process_stream_response(
                         .unwrap_or_else(|| "none".to_string())
                 ),
             });
-        return Some(match *error_code {
-            Some(401) | Some(403) => DegradedError::AuthenticationFailed {
-                provider: provider.clone(),
-            },
-            _ => DegradedError::StreamError {
-                message: format!("{}: {}", provider, error_message),
-            },
-        });
+        return Some(classify_provider_error(
+            *error_code,
+            error_message,
+            provider,
+        ));
     }
 
     match state.args.mode {
@@ -427,6 +449,25 @@ fn process_stream_response(
     None
 }
 
+fn classify_provider_error(
+    error_code: Option<i32>,
+    error_message: &str,
+    provider: &str,
+) -> DegradedError {
+    match error_code {
+        Some(401) | Some(403) => DegradedError::AuthenticationFailed {
+            provider: provider.to_string(),
+        },
+        Some(400) | Some(402) | Some(404) | Some(422) => DegradedError::ProviderConfiguration {
+            provider: provider.to_string(),
+            message: error_message.to_string(),
+        },
+        _ => DegradedError::StreamError {
+            message: format!("{provider}: {error_message}"),
+        },
+    }
+}
+
 fn stop_with_degraded_error(myself: &ActorRef<ListenerMsg>, error: DegradedError) {
     let reason = serde_json::to_string(&error).ok();
     myself.stop(reason);
@@ -451,5 +492,46 @@ mod tests {
             .await
             .expect("aborted stream task should stop promptly");
         assert!(join_result.unwrap_err().is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn stream_task_shutdown_discards_queued_provider_errors() {
+        let (shutdown_tx, _shutdown_rx) = tokio::sync::oneshot::channel();
+        let mut shutdown_tx = Some(shutdown_tx);
+        let mut task = tokio::spawn(async {
+            vec![StreamResponse::ErrorResponse {
+                error_code: Some(400),
+                error_message: "invalid request".to_string(),
+                provider: "openai".to_string(),
+            }]
+        });
+
+        let responses = stop_stream_task(&mut shutdown_tx, &mut task, Duration::from_secs(1)).await;
+
+        assert!(responses.is_empty());
+    }
+
+    #[test]
+    fn permanent_provider_errors_do_not_use_the_retryable_stream_error() {
+        assert!(matches!(
+            classify_provider_error(Some(401), "invalid key", "openai"),
+            DegradedError::AuthenticationFailed { .. }
+        ));
+        assert!(matches!(
+            classify_provider_error(Some(400), "invalid model", "openai"),
+            DegradedError::ProviderConfiguration { .. }
+        ));
+        assert!(matches!(
+            classify_provider_error(Some(402), "quota exhausted", "openai"),
+            DegradedError::ProviderConfiguration { .. }
+        ));
+        assert!(matches!(
+            classify_provider_error(Some(429), "rate limited", "openai"),
+            DegradedError::StreamError { .. }
+        ));
+        assert!(matches!(
+            classify_provider_error(Some(500), "server error", "openai"),
+            DegradedError::StreamError { .. }
+        ));
     }
 }

--- a/crates/owhisper-client/src/adapter/openai/live.rs
+++ b/crates/owhisper-client/src/adapter/openai/live.rs
@@ -314,14 +314,17 @@ impl RealtimeSttAdapter for OpenAIAdapter {
             ServerEvent::ConversationItemInputAudioTranscriptionSegment { .. } => vec![],
             ServerEvent::Error { error, .. } => {
                 let error_type = error.error_type.as_deref().unwrap_or("unknown_error");
+                let provider_code = error.code.as_deref().unwrap_or("unknown_code");
                 let message = error.message.as_deref().unwrap_or("unknown error");
-                tracing::error!(
+                let error_code = openai_error_status(error_type, error.code.as_deref());
+                tracing::warn!(
                     error.type = %error_type,
-                    error = %message,
+                    error.code = %provider_code,
+                    error.message = %message,
                     "openai_error"
                 );
                 vec![StreamResponse::ErrorResponse {
-                    error_code: None,
+                    error_code,
                     error_message: format!("{error_type}: {message}"),
                     provider: "openai".to_string(),
                 }]
@@ -672,6 +675,28 @@ fn synthetic_end_ms(start_ms: u64, transcript: &str) -> u64 {
     start_ms + transcript.split_whitespace().count().max(1) as u64
 }
 
+fn openai_error_status(error_type: &str, provider_code: Option<&str>) -> Option<i32> {
+    provider_code
+        .and_then(openai_error_value_status)
+        .or_else(|| openai_error_value_status(error_type))
+}
+
+fn openai_error_value_status(value: &str) -> Option<i32> {
+    match value {
+        "authentication_error" | "invalid_api_key" => Some(401),
+        "insufficient_quota" | "billing_hard_limit_reached" => Some(402),
+        "permission_denied" | "permission_error" => Some(403),
+        "model_not_found" => Some(404),
+        "rate_limit_error" | "rate_limit_exceeded" => Some(429),
+        "server_error" => Some(500),
+        "invalid_request_error"
+        | "invalid_value"
+        | "missing_required_parameter"
+        | "unknown_parameter" => Some(400),
+        _ => None,
+    }
+}
+
 fn resample_pcm16(audio: &[u8], input_rate: u32, output_rate: u32) -> Vec<u8> {
     if input_rate == 0 || input_rate == output_rate {
         return audio.to_vec();
@@ -741,6 +766,35 @@ mod tests {
         );
         assert!(transcription.get("language").is_none());
         assert!(json["session"].get("include").is_none());
+    }
+
+    #[test]
+    fn openai_error_codes_preserve_retry_classification() {
+        let responses = OpenAIAdapter::default().parse_response(
+            r#"{"type":"error","event_id":"e1","error":{"type":"invalid_request_error","code":"invalid_value","message":"Invalid model"}}"#,
+        );
+        assert!(matches!(
+            responses.as_slice(),
+            [StreamResponse::ErrorResponse {
+                error_code: Some(400),
+                provider,
+                ..
+            }] if provider == "openai"
+        ));
+        assert_eq!(
+            openai_error_status("invalid_request_error", Some("invalid_value")),
+            Some(400)
+        );
+        assert_eq!(
+            openai_error_status("invalid_request_error", Some("insufficient_quota")),
+            Some(402)
+        );
+        assert_eq!(
+            openai_error_status("rate_limit_error", Some("rate_limit_exceeded")),
+            Some(429)
+        );
+        assert_eq!(openai_error_status("server_error", None), Some(500));
+        assert_eq!(openai_error_status("unknown_error", None), None);
     }
 
     #[test]

--- a/plugins/tracing/src/redaction.rs
+++ b/plugins/tracing/src/redaction.rs
@@ -15,6 +15,7 @@ const SAFE_TAGS: &[&str] = &[
     "anarlog.error.stage",
     "anarlog.operation",
     "anarlog.session.type",
+    "anarlog.stt.provider.name",
     "anarlog.surface",
     "enduser.pseudo.id",
     "error.code",
@@ -33,6 +34,15 @@ fn safe_identifier(value: &str) -> Option<&str> {
             .chars()
             .all(|character| character.is_ascii_alphanumeric() || "_.:/-".contains(character)))
     .then_some(value)
+}
+
+fn safe_tag_value(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => safe_identifier(value).map(str::to_owned),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
 }
 
 fn looks_like_absolute_path(value: &str) -> bool {
@@ -155,7 +165,18 @@ fn sanitize_sentry_event_with_home(
     event.logentry = None;
     event.server_name = None;
     event.request = None;
+    let safe_extra_tags = event
+        .extra
+        .iter()
+        .filter_map(|(key, value)| {
+            if !SAFE_TAGS.contains(&key.as_str()) {
+                return None;
+            }
+            safe_tag_value(value).map(|value| (key.clone(), value))
+        })
+        .collect::<Vec<_>>();
     event.extra.clear();
+    event.tags.extend(safe_extra_tags);
 
     if let Some(user) = event.user.take() {
         event.user = user.id.map(|id| User {
@@ -166,7 +187,9 @@ fn sanitize_sentry_event_with_home(
 
     for breadcrumb in &mut event.breadcrumbs {
         breadcrumb.message = None;
-        breadcrumb.data.clear();
+        breadcrumb.data.retain(|key, value| {
+            SAFE_TAGS.contains(&key.as_str()) && safe_tag_value(value).is_some()
+        });
     }
     for exception in &mut event.exception {
         exception.value = Some(format!("{} captured", exception.ty));
@@ -595,6 +618,56 @@ mod tests {
             Some(&Value::String("[HOME]/src/download_task.rs".to_string()))
         );
         assert!(!location.contains_key("private"));
+    }
+
+    #[test]
+    fn sentry_event_preserves_only_safe_provider_error_metadata() {
+        let mut event = Event {
+            message: Some("stream_provider_error".to_string()),
+            breadcrumbs: vec![Breadcrumb {
+                message: Some("provider rejected private transcript".to_string()),
+                data: [
+                    ("error.type".to_string(), json!("invalid_request_error")),
+                    ("error.code".to_string(), json!("invalid_value")),
+                    ("error.message".to_string(), json!("private transcript")),
+                ]
+                .into_iter()
+                .collect(),
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+        event.extra.extend([
+            ("error.code".to_string(), json!(400)),
+            ("anarlog.stt.provider.name".to_string(), json!("openai")),
+            ("error.message".to_string(), json!("private transcript")),
+        ]);
+
+        let event = sanitize_sentry_event_with_home(event, None);
+
+        assert_eq!(
+            event.tags.get("error.code").map(String::as_str),
+            Some("400")
+        );
+        assert_eq!(
+            event
+                .tags
+                .get("anarlog.stt.provider.name")
+                .map(String::as_str),
+            Some("openai")
+        );
+        assert!(!event.tags.contains_key("error.message"));
+        assert!(event.breadcrumbs[0].message.is_none());
+        assert_eq!(
+            event.breadcrumbs[0].data,
+            [
+                ("error.code".to_string(), json!("invalid_value")),
+                ("error.type".to_string(), json!("invalid_request_error")),
+            ]
+            .into_iter()
+            .collect()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Preserve safe provider diagnostics, stop retrying permanent errors, and suppress duplicate shutdown reports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live transcription error handling and session degradation/retry behavior; misclassification could retry permanent failures or stop sessions incorrectly, though behavior is covered by new unit tests.
> 
> **Overview**
> Improves how **OpenAI realtime** STT failures are surfaced and how the **listener** reacts, so permanent config/auth problems stop retrying and shutdown does not double-report errors.
> 
> The OpenAI live adapter now maps provider `error.type` / `code` strings to numeric **`error_code`** values on `StreamResponse::ErrorResponse` (e.g. 401/402/400 vs 429/500), logs at **warn** with structured `error.code` / `error.message`, and adds tests for that mapping.
> 
> The listener **classifies** provider errors via `classify_provider_error`: 401/403 → `AuthenticationFailed`, 400/402/404/422 → **`ProviderConfiguration`**, others stay **`StreamError`** (retryable). Stream shutdown **drops** queued provider error responses after logging `stream_provider_error_during_shutdown`, avoiding duplicate session errors on teardown.
> 
> Sentry redaction now keeps only **safe** provider metadata in tags/breadcrumbs (`error.code`, `error.type`, `anarlog.stt.provider.name`) and strips sensitive fields like `error.message` from breadcrumbs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e139b87ac2b4553f2a8b6560aecb14e247e05f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->