### PR TITLE
Remove cancel hover from current plan

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr "Can transcribe while the meeting is happening."
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -469,7 +469,6 @@ msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
 #: src/session-sharing/comments.tsx
-#: src/settings/general/account.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx
 #: src/settings/todo/github.tsx

--- a/apps/desktop/src/settings/general/account.test.tsx
+++ b/apps/desktop/src/settings/general/account.test.tsx
@@ -148,7 +148,7 @@ describe("SettingsAccount", () => {
     });
   });
 
-  it("keeps the manage-plan control once the trial has a payment method", () => {
+  it("renders the current plan as status once the trial has a payment method", () => {
     mocks.billing = {
       canStartTrial: { data: false, isPending: false },
       hasPaymentMethod: true,
@@ -164,5 +164,7 @@ describe("SettingsAccount", () => {
       screen.queryByRole("button", { name: "Add payment method" }),
     ).toBeNull();
     expect(screen.getByText("Current plan")).toBeTruthy();
+    expect(screen.queryByText("Cancel")).toBeNull();
+    expect(screen.queryByRole("button", { name: /Current plan/ })).toBeNull();
   });
 });

--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -191,8 +191,8 @@ function PlanBillingSection({
 
   const [actionPending, setActionPending] = useState(false);
 
-  // A cardless trial cancels at the end unless a card is added, so the plan
-  // control has to be "Add payment method" rather than hover-to-Cancel.
+  // A cardless trial cancels at the end unless a card is added, so replace the
+  // static current-plan status with an explicit payment-method action.
   const needsPaymentMethod = isTrialing && !hasPaymentMethod;
 
   const openBillingUrl = useCallback(
@@ -274,57 +274,15 @@ function PlanBillingSection({
       }
 
       if (compact) {
-        if (!isPaid) {
-          return (
-            <span className="text-muted-foreground text-xs">
-              {action.label}
-            </span>
-          );
-        }
-
         return (
-          <button
-            type="button"
-            onClick={handleOpenBillingPortal}
-            disabled={actionPending}
-            className={cn([
-              "group text-muted-foreground hover:text-muted-foreground relative min-w-[88px] text-xs font-medium transition-colors disabled:opacity-50",
-            ])}
-          >
-            <span className="block transition-opacity duration-150 group-hover:opacity-0">
-              {action.label}
-            </span>
-            <span className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover:opacity-100">
-              <Trans>Cancel</Trans>
-            </span>
-          </button>
-        );
-      }
-
-      if (!isPaid) {
-        return (
-          <div className="border-border bg-muted text-muted-foreground flex h-8 w-full items-center justify-center rounded-full border text-xs">
-            {action.label}
-          </div>
+          <span className="text-muted-foreground text-xs">{action.label}</span>
         );
       }
 
       return (
-        <button
-          type="button"
-          onClick={handleOpenBillingPortal}
-          disabled={actionPending}
-          className={cn([
-            "group border-border from-card to-background text-muted-foreground relative flex h-8 w-full items-center justify-center overflow-hidden rounded-full border bg-linear-to-b text-xs font-medium shadow-xs transition-all hover:scale-[102%] hover:shadow-md active:scale-[98%] disabled:opacity-50 disabled:hover:scale-100",
-          ])}
-        >
-          <span className="transition-opacity duration-150 group-hover:opacity-0">
-            {action.label}
-          </span>
-          <span className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover:opacity-100">
-            <Trans>Cancel</Trans>
-          </span>
-        </button>
+        <div className="border-border bg-muted text-muted-foreground flex h-8 w-full items-center justify-center rounded-full border text-xs">
+          {action.label}
+        </div>
       );
     }
 


### PR DESCRIPTION
Render the current plan as non-interactive status and keep billing changes under Manage billing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized account-settings UX change with updated tests; billing still goes through Manage billing and trial payment-method flows.
> 
> **Overview**
> **Plan & Billing** no longer treats the active tier row as a cancel shortcut. Paid users on the current plan see **non-interactive** status (e.g. “Current plan”) instead of a button that opened the billing portal on click or revealed **Cancel** on hover.
> 
> **Add payment method** is unchanged for cardless trials. **Manage billing** in the section header remains the path to the billing portal for paid accounts.
> 
> Locale catalogs drop the obsolete `account.tsx` source line on the shared **Cancel** string after that UI was removed from account settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e25e17f6812a8aa60506d7499ab850fa22200d93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->