### PR TITLE
Add 1.4.8 desktop changelog

### DIFF
--- a/packages/changelog/content/1.4.8.md
+++ b/packages/changelog/content/1.4.8.md
@@ -1,0 +1,27 @@
+---
+date: "2026-08-10"
+summary: "Anarlog 1.4.8 connects eight meeting assistants for automatic imports and improves recording recovery, window placement, transcription errors, billing, and app icon settings."
+---
+
+## Importing
+
+- Connect Granola, Circleback, Fireflies.ai, Krisp, Read AI, Fellow, Tactiq,
+  or Jiminny directly to bring your existing meeting history into Anarlog
+- Keep new meetings importing automatically while Anarlog is running, with
+  controls to sync now or disconnect and export files available as a fallback
+
+## Recording and transcription
+
+- Keep recording more reliably on Windows when an audio input temporarily
+  disappears, with paced recovery instead of repeated rapid restarts
+- Stop retrying permanent OpenAI live transcription errors such as invalid
+  credentials, unsupported models, or exhausted quota
+
+## Window and settings
+
+- Bring the main app back into view after an update and recover saved window
+  positions whose title bar is no longer reachable
+- See your current subscription as clear, non-interactive status while billing
+  changes stay under **Manage billing**
+- Choose the macOS Dock icon from cleaner preview controls without a check
+  badge covering the artwork


### PR DESCRIPTION
## Summary

- add the stable 1.4.8 changelog from desktop changes since 1.4.7
- exclude web-only and internal infrastructure changes

## Validation

- pnpm exec dprint fmt
- pnpm fmt:check
- pnpm -F @anlg/changelog typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application, API, or infrastructure code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.8.md`** as the public 1.4.8 release entry, matching the existing changelog frontmatter (`date`, `summary`) and sectioned bullet format used in prior versions like 1.4.7.
> 
> The new copy documents desktop-facing changes since 1.4.7: eight meeting-assistant import connectors with ongoing sync controls, Windows recording recovery when audio inputs drop, non-retry behavior for permanent OpenAI live transcription failures, post-update window visibility and off-screen position recovery, read-only subscription status in settings, and macOS Dock icon preview UI tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6c118dc9e1ff7d0816df316c70e617f09e42759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->