### PR TITLE
Allow Cloud API snapshot commands

### DIFF
--- a/plugins/local-api/build.rs
+++ b/plugins/local-api/build.rs
@@ -10,6 +10,8 @@ const COMMANDS: &[&str] = &[
     "test_webhook",
     "dispatch_event",
     "export_meeting_markdown",
+    "get_cloud_snapshot",
+    "list_cloud_snapshot_ids",
 ];
 
 fn main() {

--- a/plugins/local-api/permissions/autogenerated/commands/get_cloud_snapshot.toml
+++ b/plugins/local-api/permissions/autogenerated/commands/get_cloud_snapshot.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-cloud-snapshot"
+description = "Enables the get_cloud_snapshot command without any pre-configured scope."
+commands.allow = ["get_cloud_snapshot"]
+
+[[permission]]
+identifier = "deny-get-cloud-snapshot"
+description = "Denies the get_cloud_snapshot command without any pre-configured scope."
+commands.deny = ["get_cloud_snapshot"]

--- a/plugins/local-api/permissions/autogenerated/commands/list_cloud_snapshot_ids.toml
+++ b/plugins/local-api/permissions/autogenerated/commands/list_cloud_snapshot_ids.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-list-cloud-snapshot-ids"
+description = "Enables the list_cloud_snapshot_ids command without any pre-configured scope."
+commands.allow = ["list_cloud_snapshot_ids"]
+
+[[permission]]
+identifier = "deny-list-cloud-snapshot-ids"
+description = "Denies the list_cloud_snapshot_ids command without any pre-configured scope."
+commands.deny = ["list_cloud_snapshot_ids"]

--- a/plugins/local-api/permissions/autogenerated/reference.md
+++ b/plugins/local-api/permissions/autogenerated/reference.md
@@ -15,6 +15,8 @@ Default permissions for the plugin
 - `allow-test-webhook`
 - `allow-dispatch-event`
 - `allow-export-meeting-markdown`
+- `allow-get-cloud-snapshot`
+- `allow-list-cloud-snapshot-ids`
 
 ## Permission Table
 
@@ -158,6 +160,32 @@ Denies the export_meeting_markdown command without any pre-configured scope.
 <tr>
 <td>
 
+`local-api:allow-get-cloud-snapshot`
+
+</td>
+<td>
+
+Enables the get_cloud_snapshot command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`local-api:deny-get-cloud-snapshot`
+
+</td>
+<td>
+
+Denies the get_cloud_snapshot command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `local-api:allow-get-status`
 
 </td>
@@ -203,6 +231,32 @@ Enables the list_api_keys command without any pre-configured scope.
 <td>
 
 Denies the list_api_keys command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`local-api:allow-list-cloud-snapshot-ids`
+
+</td>
+<td>
+
+Enables the list_cloud_snapshot_ids command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`local-api:deny-list-cloud-snapshot-ids`
+
+</td>
+<td>
+
+Denies the list_cloud_snapshot_ids command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/local-api/permissions/default.toml
+++ b/plugins/local-api/permissions/default.toml
@@ -12,4 +12,6 @@ permissions = [
   "allow-test-webhook",
   "allow-dispatch-event",
   "allow-export-meeting-markdown",
+  "allow-get-cloud-snapshot",
+  "allow-list-cloud-snapshot-ids",
 ]

--- a/plugins/local-api/permissions/schemas/schema.json
+++ b/plugins/local-api/permissions/schemas/schema.json
@@ -355,6 +355,18 @@
           "markdownDescription": "Denies the export_meeting_markdown command without any pre-configured scope."
         },
         {
+          "description": "Enables the get_cloud_snapshot command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-cloud-snapshot",
+          "markdownDescription": "Enables the get_cloud_snapshot command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_cloud_snapshot command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-cloud-snapshot",
+          "markdownDescription": "Denies the get_cloud_snapshot command without any pre-configured scope."
+        },
+        {
           "description": "Enables the get_status command without any pre-configured scope.",
           "type": "string",
           "const": "allow-get-status",
@@ -377,6 +389,18 @@
           "type": "string",
           "const": "deny-list-api-keys",
           "markdownDescription": "Denies the list_api_keys command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the list_cloud_snapshot_ids command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-list-cloud-snapshot-ids",
+          "markdownDescription": "Enables the list_cloud_snapshot_ids command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the list_cloud_snapshot_ids command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-list-cloud-snapshot-ids",
+          "markdownDescription": "Denies the list_cloud_snapshot_ids command without any pre-configured scope."
         },
         {
           "description": "Enables the list_webhooks command without any pre-configured scope.",
@@ -427,10 +451,10 @@
           "markdownDescription": "Denies the test_webhook command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-get-status`\n- `allow-set-enabled`\n- `allow-list-api-keys`\n- `allow-create-api-key`\n- `allow-revoke-api-key`\n- `allow-list-webhooks`\n- `allow-create-webhook`\n- `allow-delete-webhook`\n- `allow-test-webhook`\n- `allow-dispatch-event`\n- `allow-export-meeting-markdown`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-get-status`\n- `allow-set-enabled`\n- `allow-list-api-keys`\n- `allow-create-api-key`\n- `allow-revoke-api-key`\n- `allow-list-webhooks`\n- `allow-create-webhook`\n- `allow-delete-webhook`\n- `allow-test-webhook`\n- `allow-dispatch-event`\n- `allow-export-meeting-markdown`\n- `allow-get-cloud-snapshot`\n- `allow-list-cloud-snapshot-ids`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-get-status`\n- `allow-set-enabled`\n- `allow-list-api-keys`\n- `allow-create-api-key`\n- `allow-revoke-api-key`\n- `allow-list-webhooks`\n- `allow-create-webhook`\n- `allow-delete-webhook`\n- `allow-test-webhook`\n- `allow-dispatch-event`\n- `allow-export-meeting-markdown`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-get-status`\n- `allow-set-enabled`\n- `allow-list-api-keys`\n- `allow-create-api-key`\n- `allow-revoke-api-key`\n- `allow-list-webhooks`\n- `allow-create-webhook`\n- `allow-delete-webhook`\n- `allow-test-webhook`\n- `allow-dispatch-event`\n- `allow-export-meeting-markdown`\n- `allow-get-cloud-snapshot`\n- `allow-list-cloud-snapshot-ids`"
         }
       ]
     }


### PR DESCRIPTION
Register Cloud API snapshot commands with the local API permission generator and default capability set.

Validation:
- pnpm exec dprint fmt
- pnpm fmt:check
- cargo test --locked -p tauri-plugin-local-api
- cargo check --locked -p desktop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Permission and codegen-only changes; no command implementation or data-handling logic in this diff.
> 
> **Overview**
> Registers **`get_cloud_snapshot`** and **`list_cloud_snapshot_ids`** with the `tauri-plugin-local-api` command list in `build.rs`, which drives autogenerated allow/deny permission TOMLs, schema updates, and permission reference docs.
> 
> Adds **`allow-get-cloud-snapshot`** and **`allow-list-cloud-snapshot-ids`** to the plugin **default** capability set in `permissions/default.toml` so the desktop app can invoke these Cloud API snapshot commands from the frontend without extra ACL configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01829735ddc11fe09c3b7b7c0aab317f340b81fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->