### PR TITLE
Retry Cloud API snapshots after sync settling

### DIFF
--- a/apps/desktop/src/cloud-api/client.test.ts
+++ b/apps/desktop/src/cloud-api/client.test.ts
@@ -425,6 +425,97 @@ describe("cloud API client", () => {
     vi.useRealTimers();
   });
 
+  it("retries a scheduled snapshot after a transient invalid request", async () => {
+    vi.useFakeTimers();
+    mocks.getSession.mockResolvedValue(authSession("user-scheduled-retry"));
+    mocks.fetch.mockImplementation(async (input: string | URL | Request) => {
+      if (!String(input).includes("/v1/sync-snapshots/")) {
+        return new Response(
+          JSON.stringify({ enabled: true, updated_at: null }),
+          { status: 200 },
+        );
+      }
+      if (
+        mocks.fetch.mock.calls.filter(([url]) =>
+          String(url).includes("/v1/sync-snapshots/"),
+        ).length === 1
+      ) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "invalid_request",
+              message: "Snapshot rows are still settling",
+            },
+          }),
+          { status: 400 },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    scheduleCloudApiSnapshotSync("meeting-scheduled-retry");
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    expect(mocks.getCloudSnapshot).toHaveBeenCalledOnce();
+    expect(consoleError).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(mocks.getCloudSnapshot).toHaveBeenCalledTimes(2);
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("retries the latest live snapshot when an immediate sync supersedes a scheduled retry", async () => {
+    vi.useFakeTimers();
+    mocks.getSession.mockResolvedValue(authSession("user-superseded-retry"));
+    mocks.fetch.mockImplementation(async (input: string | URL | Request) => {
+      if (!String(input).includes("/v1/sync-snapshots/")) {
+        return new Response(
+          JSON.stringify({ enabled: true, updated_at: null }),
+          { status: 200 },
+        );
+      }
+      const uploadCount = mocks.fetch.mock.calls.filter(([url]) =>
+        String(url).includes("/v1/sync-snapshots/"),
+      ).length;
+      if (uploadCount <= 2) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "invalid_request",
+              message: "Snapshot rows are still settling",
+            },
+          }),
+          { status: 400 },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    scheduleCloudApiSnapshotSync("meeting-superseded-retry");
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(mocks.getCloudSnapshot).toHaveBeenCalledOnce();
+
+    syncCloudApiSnapshotBestEffort("meeting-superseded-retry");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mocks.getCloudSnapshot).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(mocks.getCloudSnapshot).toHaveBeenCalledTimes(3);
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+    vi.useRealTimers();
+  });
+
   it("deletes a pending snapshot after its local meeting disappears", async () => {
     mocks.getSession.mockResolvedValue(authSession("user-gone"));
     mocks.getCloudSnapshot.mockResolvedValue({

--- a/apps/desktop/src/cloud-api/client.ts
+++ b/apps/desktop/src/cloud-api/client.ts
@@ -6,6 +6,7 @@ import { supabase } from "~/auth/client";
 import { env } from "~/env";
 
 const REQUEST_TIMEOUT_MS = 30_000;
+const SCHEDULED_INVALID_REQUEST_RETRY_DELAYS_MS = [5_000, 15_000] as const;
 
 export type CloudApiSettings = {
   enabled: boolean;
@@ -425,7 +426,7 @@ export function syncCloudApiSnapshotBestEffort(sessionId: string): void {
       }
       addPendingChange(current.user.id, sessionId, "upserts");
       try {
-        await syncCloudApiSnapshotForUser(sessionId, current.user.id);
+        await syncLiveCloudApiSnapshot(sessionId, current.user.id, intent);
       } catch (error) {
         if (shouldRetry(error)) {
           addPendingChange(current.user.id, sessionId, "upserts");
@@ -478,7 +479,7 @@ export function scheduleCloudApiSnapshotSync(sessionId: string): void {
         if (snapshotIntents.get(sessionId) !== intent) {
           return;
         }
-        void syncCloudApiSnapshotForUser(sessionId, current.user.id)
+        void syncLiveCloudApiSnapshot(sessionId, current.user.id, intent)
           .catch((error: unknown) => {
             if (shouldRetry(error)) {
               addPendingChange(current.user.id, sessionId, "upserts");
@@ -493,6 +494,33 @@ export function scheduleCloudApiSnapshotSync(sessionId: string): void {
       clearSnapshotIntent(sessionId, intent);
       reportBackgroundError(error);
     });
+}
+
+async function syncLiveCloudApiSnapshot(
+  sessionId: string,
+  userId: string,
+  intent: SnapshotIntent,
+) {
+  for (
+    let attempt = 0;
+    snapshotIntents.get(sessionId) === intent;
+    attempt += 1
+  ) {
+    try {
+      await syncCloudApiSnapshotForUser(sessionId, userId);
+      return;
+    } catch (error) {
+      const retryDelay = SCHEDULED_INVALID_REQUEST_RETRY_DELAYS_MS[attempt];
+      if (
+        !(error instanceof CloudApiClientError) ||
+        error.code !== "invalid_request" ||
+        retryDelay === undefined
+      ) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, retryDelay));
+    }
+  }
 }
 
 export function scheduleCloudApiBackfillRetry(): void {


### PR DESCRIPTION
Retry live Cloud API uploads against freshly read local data while related CloudSync rows settle. Keep backfill and permanent invalid-request behavior unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes background upload timing and error handling for live sync paths only; mis-handling intent or retries could cause duplicate uploads or missed syncs, but scope is limited and backfill paths are untouched.
> 
> **Overview**
> **Live Cloud API snapshot uploads** (debounced `scheduleCloudApiSnapshotSync` and `syncCloudApiSnapshotBestEffort`) now go through `syncLiveCloudApiSnapshot`, which re-reads the local snapshot and retries the upload when the API returns **`invalid_request`** (e.g. rows still settling), with delays of **5s** and **15s**.
> 
> Retries are tied to the current snapshot **intent** and stop if the meeting is deleted or a newer upsert supersedes the in-flight work, so an immediate sync can continue retrying the latest data instead of failing once. **Explicit** `syncCloudApiSnapshot` and **backfill** still call `syncCloudApiSnapshotForUser` directly, so permanent `invalid_request` behavior there is unchanged.
> 
> Tests cover scheduled retry after a transient 400 and retry continuing after an immediate sync supersedes a scheduled attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5be67dc670ec93554cd2b80fe9cbf2f82507e201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->