### PR TITLE
fix(desktop): tighten sync status indicator padding

### DIFF
--- a/apps/desktop/src/main/sync-status.tsx
+++ b/apps/desktop/src/main/sync-status.tsx
@@ -259,7 +259,7 @@ export function SyncStatusIndicator() {
           data-testid="sync-status-indicator"
           className={cn([
             "fixed right-2 bottom-2 z-40",
-            "border-border/60 bg-background/90 flex size-8 items-center justify-center rounded-xl border shadow-sm backdrop-blur",
+            "border-border/60 bg-background/90 flex size-7 items-center justify-center rounded-lg border shadow-sm backdrop-blur",
             "text-muted-foreground hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground outline-hidden transition-colors",
           ])}
         >


### PR DESCRIPTION
Shrink the floating sync indicator button from size-8 to size-7 and match the corner radius so the icon has less surrounding padding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only class changes on the sync indicator; no sync logic or behavior changes.
> 
> **Overview**
> **Shrinks the floating cloud sync status button** in the desktop app so it takes less space in the corner of the window.
> 
> The trigger button’s Tailwind classes change from `size-8` / `rounded-xl` to **`size-7` / `rounded-lg`**, reducing outer padding while keeping the same `size-4` icons inside.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc2bbc7bc25b6efd65f9d85a198bea4350fb6191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->