### PR TITLE
feat(cloudsync): wake sync on local writes and window focus

### DIFF
--- a/crates/db-core/src/cloudsync/runtime.rs
+++ b/crates/db-core/src/cloudsync/runtime.rs
@@ -14,8 +14,9 @@ pub(super) use background::cloudsync_activity_paused;
 #[cfg(test)]
 use background::{
     CLOUDSYNC_PROGRESS_INTERVAL, CloudsyncWake, MAX_ACTIVITY_LOG_ENTRIES, cloudsync_busy_delay,
-    cloudsync_next_delay, cloudsync_request_pending, merge_bounded_sync_results,
-    run_after_sync_hook, run_before_sync_hook, run_or_shutdown, sync_result_needs_receive_progress,
+    cloudsync_next_delay, cloudsync_request_pending, cloudsync_wake_deadline,
+    drain_pending_changes, merge_bounded_sync_results, next_synced_change, run_after_sync_hook,
+    run_before_sync_hook, run_or_shutdown, sync_result_needs_receive_progress,
     wait_for_retry_request_or_shutdown,
 };
 use background::{
@@ -254,6 +255,16 @@ impl Db {
             interrupt,
             sync_operation,
             sync_requested,
+            change_rx: self.change_notifier().subscribe(),
+            // Every registry table, enabled or not: in E2EE mode the app tables
+            // are disabled (only e2ee_records syncs directly) yet their writes
+            // must still wake the loop, since the reconcile hook picks them up
+            // at sync time.
+            synced_tables: config
+                .tables
+                .iter()
+                .map(|table| table.table_name.to_ascii_lowercase())
+                .collect(),
             runtime_state,
             sync_hook,
             config: CloudsyncLoopConfig {

--- a/crates/db-core/src/cloudsync/runtime/background.rs
+++ b/crates/db-core/src/cloudsync/runtime/background.rs
@@ -202,6 +202,7 @@ pub(super) fn record_sync_error(
 }
 const MAX_BACKOFF_SECS: u64 = 300;
 pub(super) const CLOUDSYNC_PROGRESS_INTERVAL: Duration = Duration::from_millis(200);
+pub(super) const CLOUDSYNC_CHANGE_DEBOUNCE: Duration = Duration::from_secs(1);
 
 pub(super) struct CloudsyncStepResult {
     pub(super) network: CloudsyncNetworkResult,
@@ -224,6 +225,8 @@ pub(super) struct CloudsyncLoopContext {
     pub(super) interrupt: Arc<super::super::CloudsyncInterruptHandle>,
     pub(super) sync_operation: Arc<tokio::sync::Mutex<()>>,
     pub(super) sync_requested: Arc<tokio::sync::Notify>,
+    pub(super) change_rx: tokio::sync::broadcast::Receiver<anlg_db_change::TableChange>,
+    pub(super) synced_tables: std::collections::HashSet<String>,
     pub(super) runtime_state: Arc<Mutex<CloudsyncRuntimeState>>,
     pub(super) sync_hook: Arc<Mutex<Option<Arc<dyn super::super::CloudsyncSyncHook>>>>,
     pub(super) config: CloudsyncLoopConfig,
@@ -233,6 +236,7 @@ pub(super) struct CloudsyncLoopContext {
 pub(super) enum CloudsyncWake {
     Interval,
     Requested,
+    Changed,
 }
 
 pub(super) fn cloudsync_request_pending(request_pending: bool, wake: CloudsyncWake) -> bool {
@@ -247,38 +251,101 @@ pub(super) fn cloudsync_busy_delay(request_pending: bool, interval: Duration) ->
     }
 }
 
+pub(super) fn cloudsync_wake_deadline(
+    next_sync_deadline: tokio::time::Instant,
+    change_deadline: Option<tokio::time::Instant>,
+) -> tokio::time::Instant {
+    change_deadline.map_or(next_sync_deadline, |deadline| {
+        deadline.min(next_sync_deadline)
+    })
+}
+
+/// Completes when a commit touches a CloudSync-relevant table. Irrelevant
+/// tables are skipped without completing so a pending interval timer keeps
+/// its deadline; a lagged subscription wakes conservatively.
+pub(super) async fn next_synced_change(
+    change_rx: &mut tokio::sync::broadcast::Receiver<anlg_db_change::TableChange>,
+    synced_tables: &std::collections::HashSet<String>,
+    closed: &mut bool,
+) {
+    if *closed {
+        return std::future::pending().await;
+    }
+    loop {
+        match change_rx.recv().await {
+            Ok(change) => {
+                if synced_tables.contains(&change.table.to_ascii_lowercase()) {
+                    return;
+                }
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => return,
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                *closed = true;
+                return std::future::pending().await;
+            }
+        }
+    }
+}
+
+/// Change events emitted while a sync applied remote rows (or reconciled
+/// them) are echoes of that sync, not new local work; drop them so they do
+/// not immediately schedule another round.
+pub(super) fn drain_pending_changes(
+    change_rx: &mut tokio::sync::broadcast::Receiver<anlg_db_change::TableChange>,
+) {
+    while let Ok(_) | Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) =
+        change_rx.try_recv()
+    {}
+}
+
 pub(super) async fn cloudsync_background_loop(
-    context: CloudsyncLoopContext,
+    mut context: CloudsyncLoopContext,
     mut shutdown_rx: oneshot::Receiver<()>,
 ) {
-    let mut next_sync_delay = cloudsync_next_delay(None, false, context.config.interval);
+    let mut next_sync_deadline =
+        tokio::time::Instant::now() + cloudsync_next_delay(None, false, context.config.interval);
+    let mut change_deadline: Option<tokio::time::Instant> = None;
     let mut request_pending = false;
+    let mut change_rx_closed = false;
     loop {
         let wake = tokio::select! {
             biased;
             _ = &mut shutdown_rx => break,
             _ = context.sync_requested.notified() => CloudsyncWake::Requested,
-            _ = tokio::time::sleep(next_sync_delay) => CloudsyncWake::Interval,
+            _ = tokio::time::sleep_until(cloudsync_wake_deadline(next_sync_deadline, change_deadline)) => CloudsyncWake::Interval,
+            _ = next_synced_change(&mut context.change_rx, &context.synced_tables, &mut change_rx_closed) => CloudsyncWake::Changed,
         };
+        if wake == CloudsyncWake::Changed {
+            change_deadline = Some(tokio::time::Instant::now() + CLOUDSYNC_CHANGE_DEBOUNCE);
+            continue;
+        }
         request_pending = cloudsync_request_pending(request_pending, wake);
         let Ok(sync_available) = context.sync_operation.try_lock() else {
             tracing::debug!("cloudsync interval skipped because another sync is active");
-            next_sync_delay = cloudsync_busy_delay(request_pending, context.config.interval);
+            let now = tokio::time::Instant::now();
+            next_sync_deadline =
+                now + cloudsync_busy_delay(request_pending, context.config.interval);
+            if change_deadline.is_some() {
+                change_deadline = Some(now + CLOUDSYNC_PROGRESS_INTERVAL);
+            }
             continue;
         };
         drop(sync_available);
         request_pending = false;
+        change_deadline = None;
         let Some(result) = sync_cloudsync_with_retry(&context, &mut shutdown_rx).await else {
             break;
         };
+        drain_pending_changes(&mut context.change_rx);
 
         match result {
             Ok(CloudsyncStepOutcome::Completed(step)) => {
-                next_sync_delay = cloudsync_next_delay(
-                    Some(&step.network),
-                    step.local_work_remaining,
-                    context.config.interval,
-                );
+                next_sync_deadline = tokio::time::Instant::now()
+                    + cloudsync_next_delay(
+                        Some(&step.network),
+                        step.local_work_remaining,
+                        context.config.interval,
+                    );
                 record_sync_result(
                     &context.runtime_state,
                     step.network,
@@ -287,7 +354,7 @@ pub(super) async fn cloudsync_background_loop(
                 );
             }
             Ok(CloudsyncStepOutcome::Deferred) => {
-                next_sync_delay = context.config.interval;
+                next_sync_deadline = tokio::time::Instant::now() + context.config.interval;
             }
             Err(error) => {
                 record_sync_error(

--- a/crates/db-core/src/cloudsync/runtime/background.rs
+++ b/crates/db-core/src/cloudsync/runtime/background.rs
@@ -287,15 +287,30 @@ pub(super) async fn next_synced_change(
     }
 }
 
-/// Change events emitted while a sync applied remote rows (or reconciled
-/// them) are echoes of that sync, not new local work; drop them so they do
-/// not immediately schedule another round.
+/// Change events that arrive while a sync is in flight mix echoes of that
+/// sync (applied remote rows, hook reconciliation) with real concurrent
+/// local commits, and the two are indistinguishable. Drain the queue so
+/// echoes cannot immediately schedule another round, but report whether a
+/// synced-table event was dropped so the caller can debounce one follow-up
+/// round; when the events were only echoes that round finds nothing,
+/// writes nothing, and the loop settles. A lagged subscription reports
+/// conservatively.
 pub(super) fn drain_pending_changes(
     change_rx: &mut tokio::sync::broadcast::Receiver<anlg_db_change::TableChange>,
-) {
-    while let Ok(_) | Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) =
-        change_rx.try_recv()
-    {}
+    synced_tables: &std::collections::HashSet<String>,
+) -> bool {
+    let mut synced_change_seen = false;
+    loop {
+        match change_rx.try_recv() {
+            Ok(change) => {
+                synced_change_seen |= synced_tables.contains(&change.table.to_ascii_lowercase());
+            }
+            Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => {
+                synced_change_seen = true;
+            }
+            Err(_) => return synced_change_seen,
+        }
+    }
 }
 
 pub(super) async fn cloudsync_background_loop(
@@ -336,7 +351,9 @@ pub(super) async fn cloudsync_background_loop(
         let Some(result) = sync_cloudsync_with_retry(&context, &mut shutdown_rx).await else {
             break;
         };
-        drain_pending_changes(&mut context.change_rx);
+        if drain_pending_changes(&mut context.change_rx, &context.synced_tables) {
+            change_deadline = Some(tokio::time::Instant::now() + CLOUDSYNC_CHANGE_DEBOUNCE);
+        }
 
         match result {
             Ok(CloudsyncStepOutcome::Completed(step)) => {

--- a/crates/db-core/src/cloudsync/runtime/tests/orchestration.rs
+++ b/crates/db-core/src/cloudsync/runtime/tests/orchestration.rs
@@ -647,14 +647,17 @@ async fn closed_change_subscription_never_wakes() {
 }
 
 #[tokio::test]
-async fn post_sync_drain_discards_echoed_changes() {
+async fn post_sync_drain_empties_the_queue_and_reports_synced_changes() {
     let (tx, mut rx) = tokio::sync::broadcast::channel(8);
     let synced = std::collections::HashSet::from(["sessions".to_string()]);
     let mut closed = false;
 
     tx.send(table_change("sessions", 1)).unwrap();
     tx.send(table_change("sessions", 2)).unwrap();
-    drain_pending_changes(&mut rx);
+    assert!(
+        drain_pending_changes(&mut rx, &synced),
+        "a drained synced-table change did not request a follow-up round"
+    );
 
     assert!(
         tokio::time::timeout(
@@ -664,5 +667,34 @@ async fn post_sync_drain_discards_echoed_changes() {
         .await
         .is_err(),
         "echoed changes survived the post-sync drain"
+    );
+}
+
+#[test]
+fn post_sync_drain_ignores_unrelated_changes() {
+    let (tx, mut rx) = tokio::sync::broadcast::channel(8);
+    let synced = std::collections::HashSet::from(["sessions".to_string()]);
+
+    tx.send(table_change("local_settings", 1)).unwrap();
+    assert!(
+        !drain_pending_changes(&mut rx, &synced),
+        "an unrelated drained change requested a follow-up round"
+    );
+    assert!(
+        !drain_pending_changes(&mut rx, &synced),
+        "an empty queue requested a follow-up round"
+    );
+}
+
+#[test]
+fn post_sync_drain_reports_lag_conservatively() {
+    let (tx, mut rx) = tokio::sync::broadcast::channel(1);
+    let synced = std::collections::HashSet::from(["sessions".to_string()]);
+
+    tx.send(table_change("local_settings", 1)).unwrap();
+    tx.send(table_change("local_settings", 2)).unwrap();
+    assert!(
+        drain_pending_changes(&mut rx, &synced),
+        "a lagged drain did not request a follow-up round"
     );
 }

--- a/crates/db-core/src/cloudsync/runtime/tests/orchestration.rs
+++ b/crates/db-core/src/cloudsync/runtime/tests/orchestration.rs
@@ -555,3 +555,114 @@ async fn after_sync_hook_receives_the_bounded_network_result() {
         Some(&expected)
     );
 }
+
+fn table_change(table: &str, seq: u64) -> anlg_db_change::TableChange {
+    anlg_db_change::TableChange {
+        table: table.to_string(),
+        kind: anlg_db_change::TableChangeKind::Insert,
+        seq,
+    }
+}
+
+#[test]
+fn change_wake_deadline_only_pulls_the_next_sync_earlier() {
+    let base = tokio::time::Instant::now();
+    let interval_deadline = base + Duration::from_secs(30);
+
+    assert_eq!(
+        cloudsync_wake_deadline(interval_deadline, None),
+        interval_deadline
+    );
+    assert_eq!(
+        cloudsync_wake_deadline(interval_deadline, Some(base + Duration::from_secs(1))),
+        base + Duration::from_secs(1)
+    );
+    assert_eq!(
+        cloudsync_wake_deadline(interval_deadline, Some(base + Duration::from_secs(60))),
+        interval_deadline,
+        "a change wake must never postpone the standing sync cadence"
+    );
+}
+
+#[tokio::test]
+async fn synced_table_changes_wake_and_unrelated_tables_do_not() {
+    let (tx, mut rx) = tokio::sync::broadcast::channel(8);
+    let synced = std::collections::HashSet::from(["sessions".to_string()]);
+    let mut closed = false;
+
+    tx.send(table_change("local_settings", 1)).unwrap();
+    tx.send(table_change("sessions", 2)).unwrap();
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        next_synced_change(&mut rx, &synced, &mut closed),
+    )
+    .await
+    .expect("a synced table change did not wake the loop");
+
+    tx.send(table_change("local_settings", 3)).unwrap();
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            next_synced_change(&mut rx, &synced, &mut closed),
+        )
+        .await
+        .is_err(),
+        "an unrelated table change woke the sync loop"
+    );
+}
+
+#[tokio::test]
+async fn lagged_change_subscription_wakes_conservatively() {
+    let (tx, mut rx) = tokio::sync::broadcast::channel(1);
+    let synced = std::collections::HashSet::from(["sessions".to_string()]);
+    let mut closed = false;
+
+    tx.send(table_change("local_settings", 1)).unwrap();
+    tx.send(table_change("local_settings", 2)).unwrap();
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        next_synced_change(&mut rx, &synced, &mut closed),
+    )
+    .await
+    .expect("a lagged change subscription did not wake conservatively");
+}
+
+#[tokio::test]
+async fn closed_change_subscription_never_wakes() {
+    let (tx, mut rx) = tokio::sync::broadcast::channel::<anlg_db_change::TableChange>(1);
+    let synced = std::collections::HashSet::from(["sessions".to_string()]);
+    let mut closed = false;
+    drop(tx);
+
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            next_synced_change(&mut rx, &synced, &mut closed),
+        )
+        .await
+        .is_err(),
+        "a closed change subscription completed a wake"
+    );
+    assert!(closed, "a closed change subscription was not flagged");
+}
+
+#[tokio::test]
+async fn post_sync_drain_discards_echoed_changes() {
+    let (tx, mut rx) = tokio::sync::broadcast::channel(8);
+    let synced = std::collections::HashSet::from(["sessions".to_string()]);
+    let mut closed = false;
+
+    tx.send(table_change("sessions", 1)).unwrap();
+    tx.send(table_change("sessions", 2)).unwrap();
+    drain_pending_changes(&mut rx);
+
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            next_synced_change(&mut rx, &synced, &mut closed),
+        )
+        .await
+        .is_err(),
+        "echoed changes survived the post-sync drain"
+    );
+}

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -313,6 +313,16 @@ pub fn init_with_cloudsync<R: tauri::Runtime>(
             app.manage(std::sync::Arc::new(runtime::PluginDbRuntime::new(db)));
             Ok(())
         })
+        .on_event(|app, event| {
+            if let tauri::RunEvent::WindowEvent {
+                event: tauri::WindowEvent::Focused(true),
+                ..
+            } = event
+                && let Some(runtime) = app.try_state::<ManagedState>()
+            {
+                runtime.nudge_cloudsync_on_focus();
+            }
+        })
         .build()
 }
 

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -45,6 +45,11 @@ const E2EE_CLOUDSYNC_DIRTY_ROW_LIMIT: i64 = 64;
 const CLOUDSYNC_WRITE_FILTER: &str =
     "workspace_id IN (SELECT allowed_workspace_id FROM cloudsync_writable_workspaces)";
 const CLOUDSYNC_CAPTURE_ACTIVITY: &str = "capture";
+const CLOUDSYNC_FOCUS_NUDGE_THROTTLE: std::time::Duration = std::time::Duration::from_secs(10);
+
+fn focus_nudge_due(last: Option<std::time::Instant>, now: std::time::Instant) -> bool {
+    last.is_none_or(|last| now.duration_since(last) >= CLOUDSYNC_FOCUS_NUDGE_THROTTLE)
+}
 
 #[derive(Clone)]
 pub struct QueryEventChannel(Channel<QueryEvent>);
@@ -137,6 +142,7 @@ pub struct PluginDbRuntime {
     cloudsync_activity_acquisition: tokio::sync::Mutex<()>,
     cloudsync_auth_generation: std::sync::Arc<std::sync::atomic::AtomicU64>,
     cloudsync_auth_changed: std::sync::Arc<tokio::sync::Notify>,
+    cloudsync_focus_nudge_at: std::sync::Mutex<Option<std::time::Instant>>,
     #[cfg(test)]
     pause_transaction_after_begin: std::sync::atomic::AtomicBool,
     #[cfg(test)]
@@ -193,6 +199,7 @@ impl PluginDbRuntime {
             cloudsync_activity_acquisition: Default::default(),
             cloudsync_auth_generation: Default::default(),
             cloudsync_auth_changed: Default::default(),
+            cloudsync_focus_nudge_at: Default::default(),
             #[cfg(test)]
             pause_transaction_after_begin: Default::default(),
             #[cfg(test)]
@@ -213,6 +220,20 @@ impl PluginDbRuntime {
 
     pub fn pool(&self) -> &sqlx::SqlitePool {
         self.db.pool()
+    }
+
+    /// Ask CloudSync to pull promptly when the user comes back to the app,
+    /// throttled so rapid window switches do not stack sync rounds.
+    pub fn nudge_cloudsync_on_focus(&self) {
+        let now = std::time::Instant::now();
+        {
+            let mut last = self.cloudsync_focus_nudge_at.lock().unwrap();
+            if !focus_nudge_due(*last, now) {
+                return;
+            }
+            *last = Some(now);
+        }
+        self.db.cloudsync_request_sync();
     }
 
     #[cfg(test)]

--- a/plugins/db/src/runtime/tests/activity.rs
+++ b/plugins/db/src/runtime/tests/activity.rs
@@ -679,3 +679,18 @@ fn cloudsync_activity_identifiers_are_bounded() {
     assert!(normalized_cloudsync_activity_part("a".repeat(33), "activity").is_err());
     assert!(normalized_cloudsync_activity_part("k".repeat(129), "key").is_err());
 }
+
+#[test]
+fn focus_nudges_are_throttled() {
+    let base = std::time::Instant::now();
+
+    assert!(focus_nudge_due(None, base));
+    assert!(!focus_nudge_due(
+        Some(base),
+        base + std::time::Duration::from_secs(1)
+    ));
+    assert!(focus_nudge_due(
+        Some(base),
+        base + CLOUDSYNC_FOCUS_NUDGE_THROTTLE
+    ));
+}


### PR DESCRIPTION
Cross-device sync latency was bounded by the fixed 30s polling loop:
local edits waited up to 30s to upload and the receiving device up to
30s more to pull. The background loop now subscribes to committed
table-change events and pulls its next sync deadline forward with a 1s
trailing debounce, so creates, deletes, and settled edit bursts upload
within about a second while sustained write streams keep batching
under the standing interval. Echo events from a sync applying remote
rows are drained after each round, and activity leases still batch
meetings until they end. Window focus also nudges an immediate sync
round (10s throttle) so the device the user switches to pulls promptly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CloudSync loop timing and wake logic; incorrect debounce/drain behavior could cause sync storms or missed uploads, though behavior is heavily unit-tested.
> 
> **Overview**
> **CloudSync no longer waits only on the ~30s poll timer.** The background loop subscribes to committed **table-change** events, wakes when writes hit **sync-relevant tables** (including disabled registry tables so E2EE reconcile still triggers), and pulls the next sync deadline forward with a **1s trailing debounce** so bursts batch but settled edits upload within about a second.
> 
> The loop uses **deadline-based** scheduling (`cloudsync_wake_deadline`) so change wakes never push back the standing interval. After each round, **`drain_pending_changes`** clears post-sync echo events from applied remote rows while still allowing a debounced follow-up when real concurrent writes were dropped.
> 
> On the desktop plugin, **window focus** calls **`nudge_cloudsync_on_focus`**, which **`cloudsync_request_sync()`** with a **10s throttle** so switching back to the app prompts a pull without stacking rounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04aac385cb2aa802e98f8e27441985527a7bdbdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->