### PR TITLE
Preserve recording channel separation

### DIFF
--- a/crates/listener-core/src/actors/recorder/disk.rs
+++ b/crates/listener-core/src/actors/recorder/disk.rs
@@ -29,10 +29,12 @@ pub(super) fn create_disk_sink(session_dir: &Path) -> Result<DiskSink, ActorProc
     let wav_path = session_dir.join(WAV_FILE);
     let ogg_path = session_dir.join(OGG_FILE);
     let encoded_path = session_dir.join(FINAL_AUDIO_FILE);
-    let is_stereo = prepare_existing_audio_state(&encoded_path, &ogg_path, &wav_path)?;
+    let has_existing_audio = encoded_path.exists() || ogg_path.exists() || wav_path.exists();
+    let is_stereo =
+        prepare_existing_audio_state(&encoded_path, &ogg_path, &wav_path)? || !has_existing_audio;
 
-    let mono_spec = hound::WavSpec {
-        channels: 1,
+    let spec = hound::WavSpec {
+        channels: if is_stereo { 2 } else { 1 },
         sample_rate: super::super::SAMPLE_RATE,
         bits_per_sample: 32,
         sample_format: hound::SampleFormat::Float,
@@ -41,7 +43,12 @@ pub(super) fn create_disk_sink(session_dir: &Path) -> Result<DiskSink, ActorProc
     let writer = if wav_path.exists() {
         hound::WavWriter::append(&wav_path)?
     } else {
-        hound::WavWriter::create(&wav_path, mono_spec)?
+        hound::WavWriter::create(&wav_path, spec)?
+    };
+
+    let mono_spec = hound::WavSpec {
+        channels: 1,
+        ..spec
     };
 
     let (writer_mic, writer_spk) = if is_debug_mode() {
@@ -306,7 +313,7 @@ mod tests {
     }
 
     #[test]
-    fn create_disk_sink_mixes_new_recordings_to_mono() {
+    fn create_disk_sink_preserves_new_recording_channels() {
         let dir = tempdir().unwrap();
         let session_dir = dir.path().join("session");
         std::fs::create_dir_all(&session_dir).unwrap();
@@ -316,13 +323,34 @@ mod tests {
         finalize_writer(&mut sink.writer, Some(&sink.wav_path)).unwrap();
 
         let mut reader = hound::WavReader::open(session_dir.join(WAV_FILE)).unwrap();
-        assert_eq!(reader.spec().channels, 1);
+        assert_eq!(reader.spec().channels, 2);
         assert_eq!(
             reader
                 .samples::<f32>()
                 .collect::<Result<Vec<_>, _>>()
                 .unwrap(),
-            vec![0.75, 0.25]
+            vec![0.25, 0.5, -0.25, 0.5]
+        );
+    }
+
+    #[test]
+    fn create_disk_sink_duplicates_new_single_channel_recordings() {
+        let dir = tempdir().unwrap();
+        let session_dir = dir.path().join("session");
+        std::fs::create_dir_all(&session_dir).unwrap();
+
+        let mut sink = create_disk_sink(&session_dir).unwrap();
+        write_single(&mut sink, &[0.25, -0.25]).unwrap();
+        finalize_writer(&mut sink.writer, Some(&sink.wav_path)).unwrap();
+
+        let mut reader = hound::WavReader::open(session_dir.join(WAV_FILE)).unwrap();
+        assert_eq!(reader.spec().channels, 2);
+        assert_eq!(
+            reader
+                .samples::<f32>()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![0.25, 0.25, -0.25, -0.25]
         );
     }
 

--- a/packages/changelog/content/1.4.8.md
+++ b/packages/changelog/content/1.4.8.md
@@ -12,6 +12,8 @@ summary: "Anarlog 1.4.8 connects eight meeting assistants for automatic imports 
 
 ## Recording and transcription
 
+- Preserve separate microphone and meeting-audio channels so post-recording
+  transcription and speaker labels stay accurate
 - Keep recording more reliably on Windows when an audio input temporarily
   disappears, with paced recovery instead of repeated rapid restarts
 - Stop retrying permanent OpenAI live transcription errors such as invalid


### PR DESCRIPTION
Write new recordings as stereo so batch transcription retains DirectMic and RemoteParty channels. Keep legacy mono recordings append-compatible and cover both dual- and single-input paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk audio format for new recordings and append behavior at session boundaries; wrong channel handling would affect transcription and speaker labels.
> 
> **Overview**
> **New sessions now record to stereo `audio.wav`** instead of down-mixing mic and meeting audio into mono, so batch transcription can keep **DirectMic** and **RemoteParty** on separate channels.
> 
> `create_disk_sink` treats **fresh sessions** (no existing mp3/ogg/wav) as stereo when creating the main WAV; **legacy mono** files still append in mono via `prepare_existing_audio_state`. Dual-input writes interleaved L/R; single-input on a stereo session duplicates the mono stream to both channels. Tests and the **1.4.8** changelog were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c74450b108d7b38c6965f0885006530217dce467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->