### PR TITLE
feat(settings): sync theme, app icon, and week start across devices

### DIFF
--- a/apps/desktop/src/settings/queries.test.tsx
+++ b/apps/desktop/src/settings/queries.test.tsx
@@ -150,16 +150,27 @@ describe("SQLite settings", () => {
 
     const statements = mocks.executeTransaction.mock.calls[0][0];
     expect(statements).toHaveLength(2);
-    expect(statements[0].sql).toContain("INSERT INTO app_settings");
+    expect(statements[0].sql).toContain("INSERT INTO synced_preferences");
+    expect(statements[0].sql).toContain("cloudsync_workspace_binding");
     expect(statements[0].sql).toContain("ON CONFLICT(id) DO UPDATE");
     expect(statements[0].params.slice(0, 2)).toEqual([
       "theme",
       JSON.stringify("dark"),
     ]);
+    expect(statements[1].sql).toContain("INSERT INTO app_settings");
     expect(statements[1].params.slice(0, 2)).toEqual([
       "notification_event",
       JSON.stringify(false),
     ]);
+  });
+
+  it("prefers the synced row over a stale device-local row", () => {
+    const result = parseSettingRows([
+      { id: "theme", value_json: JSON.stringify("light") },
+      { id: "theme", value_json: JSON.stringify("dark") },
+    ]);
+
+    expect(result.values.theme).toBe("dark");
   });
 
   it("applies the automatic update policy when it changes", async () => {

--- a/apps/desktop/src/settings/queries.ts
+++ b/apps/desktop/src/settings/queries.ts
@@ -19,6 +19,7 @@ import {
 } from "~/settings/legacy-snapshots";
 import {
   SETTING_DEFINITIONS,
+  SYNCED_SETTING_KEYS,
   type SettingKey,
   type SettingValue,
   type SettingValues,
@@ -54,13 +55,18 @@ const MIGRATED_SUMMARY_INSTRUCTIONS_HEADER = `# Custom Summary Instructions
 
 For structure, formatting, tone, and emphasis, these instructions take precedence over the Format Requirements. They do not override the requirements to stay accurate, use only the provided source material, and return only the summary.`;
 
+// Synced rows sort after device rows so parseSettingRows' last-write-wins map
+// prefers the synced value when a key exists in both tables.
+const SETTING_ROWS_SQL = `
+  SELECT id, value_json, 0 AS source_rank FROM app_settings
+  UNION ALL
+  SELECT id, value_json, 1 AS source_rank FROM synced_preferences
+  ORDER BY id, source_rank
+`;
+
 export function useStoredSettingValuesQuery() {
   return useLiveQuery<AppSettingRow, StoredSettingValues>({
-    sql: `
-      SELECT id, value_json
-      FROM app_settings
-      ORDER BY id
-    `,
+    sql: SETTING_ROWS_SQL,
     mapRows: parseSettingRows,
   });
 }
@@ -89,9 +95,7 @@ export function useStoredSettingValue<K extends SettingKey>(
 }
 
 export async function getStoredSettingValues(): Promise<StoredSettingValues> {
-  const rows = await liveQueryClient.execute<AppSettingRow>(
-    `SELECT id, value_json FROM app_settings ORDER BY id`,
-  );
+  const rows = await liveQueryClient.execute<AppSettingRow>(SETTING_ROWS_SQL);
   return parseSettingRows(rows);
 }
 
@@ -283,7 +287,20 @@ export function parseSettingRows(rows: AppSettingRow[]): StoredSettingValues {
 async function persistSettingValues(values: SettingValues): Promise<void> {
   const now = new Date().toISOString();
   const statements = Object.entries(values).map(([key, value]) => ({
-    sql: `
+    sql: SYNCED_SETTING_KEYS.has(key as SettingKey)
+      ? `
+      INSERT INTO synced_preferences (id, workspace_id, value_json, updated_at)
+      VALUES (?, NULLIF((
+        SELECT json_extract(value_json, '$.workspace_id')
+        FROM app_settings
+        WHERE id = 'cloudsync_workspace_binding'
+      ), ''), ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        workspace_id = excluded.workspace_id,
+        value_json = excluded.value_json,
+        updated_at = excluded.updated_at
+    `
+      : `
       INSERT INTO app_settings (id, value_json, updated_at)
       VALUES (?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET

--- a/apps/desktop/src/settings/schema.ts
+++ b/apps/desktop/src/settings/schema.ts
@@ -73,11 +73,13 @@ export const SETTING_DEFINITIONS = {
     type: "string",
     path: ["general", "theme"],
     default: "system" as string,
+    synced: true,
   },
   app_icon: {
     type: "string",
     path: ["general", "app_icon"],
     default: "default" as string,
+    synced: true,
   },
   save_recordings: {
     type: "boolean",
@@ -197,6 +199,7 @@ export const SETTING_DEFINITIONS = {
   week_start: {
     type: "string",
     path: ["general", "week_start"],
+    synced: true,
   },
   selected_template_id: {
     type: "string",
@@ -295,6 +298,14 @@ export const SETTING_DEFINITIONS = {
 } as const;
 
 export type SettingKey = keyof typeof SETTING_DEFINITIONS;
+
+// Keys marked `synced` persist to the E2EE-replicated synced_preferences table
+// instead of the device-local app_settings table.
+export const SYNCED_SETTING_KEYS: ReadonlySet<SettingKey> = new Set(
+  (Object.keys(SETTING_DEFINITIONS) as SettingKey[]).filter(
+    (key) => "synced" in SETTING_DEFINITIONS[key],
+  ),
+);
 
 type SettingTypeMap = {
   boolean: boolean;

--- a/crates/db-app/migrations/20260810120000_synced_preferences.sql
+++ b/crates/db-app/migrations/20260810120000_synced_preferences.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS synced_preferences (
+  id            TEXT PRIMARY KEY NOT NULL,
+  workspace_id  TEXT NOT NULL DEFAULT '',
+  value_json    TEXT NOT NULL DEFAULT 'null',
+  updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+) STRICT;

--- a/crates/db-app/migrations/20260810120100_e2ee_dirty_synced_preferences_triggers.sql
+++ b/crates/db-app/migrations/20260810120100_e2ee_dirty_synced_preferences_triggers.sql
@@ -1,0 +1,60 @@
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_synced_preferences_insert
+AFTER INSERT ON synced_preferences
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM e2ee_apply_guard
+  WHERE workspace_id = NEW.workspace_id
+    AND table_name = 'synced_preferences'
+    AND row_id = NEW.id
+)
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  VALUES (NEW.workspace_id, 'synced_preferences', NEW.id)
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_synced_preferences_update
+AFTER UPDATE ON synced_preferences
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  SELECT OLD.workspace_id, 'synced_preferences', OLD.id
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM e2ee_apply_guard
+    WHERE workspace_id = OLD.workspace_id
+      AND table_name = 'synced_preferences'
+      AND row_id = OLD.id
+  )
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  SELECT NEW.workspace_id, 'synced_preferences', NEW.id
+  WHERE (NEW.workspace_id <> OLD.workspace_id OR NEW.id <> OLD.id)
+    AND NOT EXISTS (
+    SELECT 1
+    FROM e2ee_apply_guard
+    WHERE workspace_id = NEW.workspace_id
+      AND table_name = 'synced_preferences'
+      AND row_id = NEW.id
+  )
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_synced_preferences_delete
+AFTER DELETE ON synced_preferences
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM e2ee_apply_guard
+  WHERE workspace_id = OLD.workspace_id
+    AND table_name = 'synced_preferences'
+    AND row_id = OLD.id
+)
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  VALUES (OLD.workspace_id, 'synced_preferences', OLD.id)
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;

--- a/crates/db-app/migrations/20260810120200_synced_preferences_backfill.sql
+++ b/crates/db-app/migrations/20260810120200_synced_preferences_backfill.sql
@@ -1,0 +1,12 @@
+INSERT INTO synced_preferences (id, workspace_id, value_json, updated_at)
+SELECT
+  settings.id,
+  json_extract(binding.value_json, '$.workspace_id'),
+  settings.value_json,
+  settings.updated_at
+FROM app_settings AS settings
+JOIN app_settings AS binding ON binding.id = 'cloudsync_workspace_binding'
+WHERE settings.id IN ('theme', 'app_icon', 'week_start')
+  AND json_type(binding.value_json, '$.workspace_id') = 'text'
+  AND json_extract(binding.value_json, '$.workspace_id') <> ''
+ON CONFLICT(id) DO NOTHING;

--- a/crates/db-app/migrations/20260810120300_synced_preferences_backfill_legacy.sql
+++ b/crates/db-app/migrations/20260810120300_synced_preferences_backfill_legacy.sql
@@ -1,0 +1,37 @@
+-- Devices that never wrote theme/app_icon/week_start directly still carry the
+-- values inside the imported legacy documents, which reads treat as live
+-- settings. Mirror the read fallback order (settings document, then main
+-- values document) so those preferences also start syncing without a user
+-- edit. Direct rows won via the previous backfill's insert; DO NOTHING keeps
+-- that precedence.
+INSERT INTO synced_preferences (id, workspace_id, value_json, updated_at)
+SELECT
+  keys.id,
+  json_extract(binding.value_json, '$.workspace_id'),
+  json_quote(CASE
+    WHEN json_type(legacy_settings.value_json, '$.general.' || keys.id) = 'text'
+      THEN json_extract(legacy_settings.value_json, '$.general.' || keys.id)
+    ELSE json_extract(legacy_main.value_json, '$.' || keys.id)
+  END),
+  CASE
+    WHEN json_type(legacy_settings.value_json, '$.general.' || keys.id) = 'text'
+      THEN legacy_settings.updated_at
+    ELSE legacy_main.updated_at
+  END
+FROM (
+  SELECT 'theme' AS id
+  UNION ALL
+  SELECT 'app_icon'
+  UNION ALL
+  SELECT 'week_start'
+) AS keys
+JOIN app_settings AS binding ON binding.id = 'cloudsync_workspace_binding'
+LEFT JOIN app_settings AS legacy_settings ON legacy_settings.id = 'legacy_settings_document'
+LEFT JOIN app_settings AS legacy_main ON legacy_main.id = 'legacy_main_values_document'
+WHERE json_type(binding.value_json, '$.workspace_id') = 'text'
+  AND json_extract(binding.value_json, '$.workspace_id') <> ''
+  AND (
+    json_type(legacy_settings.value_json, '$.general.' || keys.id) = 'text'
+    OR json_type(legacy_main.value_json, '$.' || keys.id) = 'text'
+  )
+ON CONFLICT(id) DO NOTHING;

--- a/crates/db-app/src/cloudsync.rs
+++ b/crates/db-app/src/cloudsync.rs
@@ -111,6 +111,7 @@ static CLOUDSYNC_TABLE_REGISTRY: LazyLock<Vec<CloudsyncTableSpec>> = LazyLock::n
         ("session_participants", false),
         ("session_tags", false),
         ("sessions", false),
+        ("synced_preferences", false),
         ("tags", false),
         ("templates", false),
         ("transcripts", false),

--- a/crates/db-app/src/e2ee.rs
+++ b/crates/db-app/src/e2ee.rs
@@ -31,6 +31,7 @@ pub const E2EE_DOMAIN_TABLES: &[&str] = &[
     "session_documents",
     "session_participants",
     "sessions",
+    "synced_preferences",
     "transcripts",
 ];
 

--- a/crates/db-app/src/e2ee/tests/roundtrip.rs
+++ b/crates/db-app/src/e2ee/tests/roundtrip.rs
@@ -114,6 +114,7 @@ async fn reconstructs_every_protected_table_and_applies_deletions() {
         ("session_documents", "document-1"),
         ("session_participants", "participant-1"),
         ("sessions", "session-1"),
+        ("synced_preferences", "preference-1"),
         ("transcripts", "transcript-1"),
     ] {
         let sql = format!("INSERT INTO {table} (id, workspace_id) VALUES (?, 'workspace-a')");

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -283,6 +283,30 @@ pub const APP_MIGRATION_STEPS: &[anlg_db_migrate::MigrationStep] = &[
         scope: anlg_db_migrate::MigrationScope::Plain,
         sql: include_str!("../migrations/20260804110000_session_share_activation.sql"),
     },
+    anlg_db_migrate::MigrationStep {
+        id: "20260810120000_synced_preferences",
+        scope: anlg_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260810120000_synced_preferences.sql"),
+    },
+    anlg_db_migrate::MigrationStep {
+        id: "20260810120100_e2ee_dirty_synced_preferences_triggers",
+        scope: anlg_db_migrate::MigrationScope::CloudsyncAlter {
+            table_name: "synced_preferences",
+        },
+        sql: include_str!(
+            "../migrations/20260810120100_e2ee_dirty_synced_preferences_triggers.sql"
+        ),
+    },
+    anlg_db_migrate::MigrationStep {
+        id: "20260810120200_synced_preferences_backfill",
+        scope: anlg_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260810120200_synced_preferences_backfill.sql"),
+    },
+    anlg_db_migrate::MigrationStep {
+        id: "20260810120300_synced_preferences_backfill_legacy",
+        scope: anlg_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260810120300_synced_preferences_backfill_legacy.sql"),
+    },
 ];
 
 pub fn schema() -> anlg_db_migrate::DbSchema {

--- a/crates/db-app/src/schema_tests/encrypted_replica.rs
+++ b/crates/db-app/src/schema_tests/encrypted_replica.rs
@@ -9,7 +9,7 @@ fn cloudsync_registry_enables_only_the_encrypted_replica() {
         .map(|table| table.table_name.as_str())
         .collect();
 
-    assert_eq!(registry.len(), 20);
+    assert_eq!(registry.len(), 21);
     assert_eq!(enabled, vec!["e2ee_records"]);
     assert!(
         !registry
@@ -33,6 +33,7 @@ fn cloudsync_registry_enables_only_the_encrypted_replica() {
             .any(|table| { table.table_name == "workspace_memberships" && !table.enabled })
     );
     assert!(cloudsync_alter_guard_required("sessions"));
+    assert!(cloudsync_alter_guard_required("synced_preferences"));
     assert!(cloudsync_alter_guard_required("e2ee_records"));
     assert!(!cloudsync_alter_guard_required("workspaces"));
     assert!(!cloudsync_alter_guard_required("workspace_memberships"));
@@ -249,7 +250,7 @@ fn e2ee_dirty_rows_is_local_only_with_scoped_domain_triggers() {
 
     let trigger_migrations: Vec<_> = APP_MIGRATION_STEPS
         .iter()
-        .filter(|step| step.id.starts_with("2026072312") && step.id.ends_with("_triggers"))
+        .filter(|step| step.id.contains("_e2ee_dirty_") && step.id.ends_with("_triggers"))
         .collect();
     assert_eq!(trigger_migrations.len(), E2EE_DOMAIN_TABLES.len());
     for table_name in E2EE_DOMAIN_TABLES {
@@ -275,7 +276,13 @@ async fn e2ee_dirty_rows_migration_seeds_existing_domain_rows_and_tombstones() {
     .await
     .unwrap();
 
-    for table_name in E2EE_DOMAIN_TABLES {
+    // Only the domain tables that predate the dirty-rows migration were backfilled.
+    let backfilled_tables: Vec<&str> = E2EE_DOMAIN_TABLES
+        .iter()
+        .copied()
+        .filter(|table_name| *table_name != "synced_preferences")
+        .collect();
+    for table_name in &backfilled_tables {
         let insert_sql = format!(
             "INSERT INTO {table_name} (id, workspace_id, deleted_at)
                  VALUES (?, 'workspace-a', NULL), (?, 'workspace-a', '2026-07-23T00:00:00Z')"
@@ -309,8 +316,8 @@ async fn e2ee_dirty_rows_migration_seeds_existing_domain_rows_and_tombstones() {
     .fetch_all(db.pool())
     .await
     .unwrap();
-    assert_eq!(dirty_rows.len(), E2EE_DOMAIN_TABLES.len() * 3);
-    for table_name in E2EE_DOMAIN_TABLES {
+    assert_eq!(dirty_rows.len(), backfilled_tables.len() * 3);
+    for table_name in &backfilled_tables {
         assert!(dirty_rows.contains(&(
             "workspace-a".to_string(),
             table_name.to_string(),
@@ -330,6 +337,103 @@ async fn e2ee_dirty_rows_migration_seeds_existing_domain_rows_and_tombstones() {
             1,
         )));
     }
+}
+
+#[tokio::test]
+async fn synced_preferences_migration_backfills_settings_and_marks_them_dirty() {
+    let db = Db::connect_memory_plain().await.unwrap();
+    anlg_db_migrate::migrate(
+        &db,
+        anlg_db_migrate::DbSchema {
+            steps: migration_steps_before("20260810120000_synced_preferences"),
+            validate_cloudsync_table: cloudsync_alter_guard_required,
+        },
+    )
+    .await
+    .unwrap();
+
+    sqlx::raw_sql(
+        "INSERT INTO app_settings (id, value_json, updated_at) VALUES
+           ('cloudsync_workspace_binding', '{\"workspace_id\":\"workspace-a\"}', '2026-08-10T00:00:00Z'),
+           ('theme', '\"dark\"', '2026-08-01T00:00:00Z'),
+           ('app_icon', '\"anagram\"', '2026-08-02T00:00:00Z'),
+           ('microphone_device', '\"builtin\"', '2026-08-03T00:00:00Z')",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    anlg_db_migrate::migrate(&db, schema()).await.unwrap();
+
+    let preferences: Vec<(String, String, String, String)> = sqlx::query_as(
+        "SELECT id, workspace_id, value_json, updated_at
+             FROM synced_preferences
+             ORDER BY id",
+    )
+    .fetch_all(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        preferences,
+        vec![
+            (
+                "app_icon".to_string(),
+                "workspace-a".to_string(),
+                "\"anagram\"".to_string(),
+                "2026-08-02T00:00:00Z".to_string(),
+            ),
+            (
+                "theme".to_string(),
+                "workspace-a".to_string(),
+                "\"dark\"".to_string(),
+                "2026-08-01T00:00:00Z".to_string(),
+            ),
+        ]
+    );
+
+    let dirty_rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT workspace_id, row_id
+             FROM e2ee_dirty_rows
+             WHERE table_name = 'synced_preferences'
+             ORDER BY row_id",
+    )
+    .fetch_all(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        dirty_rows,
+        vec![
+            ("workspace-a".to_string(), "app_icon".to_string()),
+            ("workspace-a".to_string(), "theme".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn synced_preferences_backfill_is_skipped_without_a_workspace_binding() {
+    let db = Db::connect_memory_plain().await.unwrap();
+    anlg_db_migrate::migrate(
+        &db,
+        anlg_db_migrate::DbSchema {
+            steps: migration_steps_before("20260810120000_synced_preferences"),
+            validate_cloudsync_table: cloudsync_alter_guard_required,
+        },
+    )
+    .await
+    .unwrap();
+
+    sqlx::query("INSERT INTO app_settings (id, value_json) VALUES ('theme', '\"dark\"')")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    anlg_db_migrate::migrate(&db, schema()).await.unwrap();
+
+    let preference_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM synced_preferences")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(preference_count, 0);
 }
 
 #[tokio::test]
@@ -541,7 +645,11 @@ async fn e2ee_dirty_triggers_apply_to_initialized_cloudsync_tables() {
     )
     .await
     .unwrap();
-    for table_name in E2EE_DOMAIN_TABLES {
+    // synced_preferences does not exist yet at this point in the migration history.
+    for table_name in E2EE_DOMAIN_TABLES
+        .iter()
+        .filter(|table_name| **table_name != "synced_preferences")
+    {
         db.cloudsync_init(table_name, None, None).await.unwrap();
     }
 

--- a/crates/db-app/src/schema_tests/migrations.rs
+++ b/crates/db-app/src/schema_tests/migrations.rs
@@ -73,6 +73,7 @@ async fn migrations_apply_cleanly() {
             "shared_session_attachment_cache",
             "shared_session_cache",
             "storage_migration_state",
+            "synced_preferences",
             "tags",
             "templates",
             "transcripts",
@@ -235,7 +236,11 @@ async fn search_index_migrations_apply_to_initialized_cloudsync_tables() {
     )
     .await
     .unwrap();
-    for table_name in E2EE_DOMAIN_TABLES {
+    // synced_preferences does not exist yet at this point in the migration history.
+    for table_name in E2EE_DOMAIN_TABLES
+        .iter()
+        .filter(|table_name| **table_name != "synced_preferences")
+    {
         db.cloudsync_init(table_name, None, None).await.unwrap();
     }
 
@@ -370,6 +375,69 @@ async fn prepare_schema_recreates_templates_after_repair_migration_was_already_a
     assert_eq!(
         icon_json,
         r##"{"type":"icon","value":"notebook-tabs","color":"#9ca3af"}"##
+    );
+}
+
+#[tokio::test]
+async fn synced_preferences_backfill_reads_legacy_documents() {
+    let db = Db::connect_memory_plain().await.unwrap();
+    anlg_db_migrate::migrate(
+        &db,
+        anlg_db_migrate::DbSchema {
+            steps: migration_steps_before("20260810120000_synced_preferences"),
+            validate_cloudsync_table: cloudsync_alter_guard_required,
+        },
+    )
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r#"INSERT INTO app_settings (id, value_json, updated_at) VALUES
+             ('cloudsync_workspace_binding', '{"workspace_id":"ws-1"}', '2026-08-01T00:00:00.000Z'),
+             ('theme', '"dark"', '2026-08-02T00:00:00.000Z'),
+             ('legacy_settings_document',
+              '{"general":{"theme":"light","app_icon":"classic"}}',
+              '2026-08-03T00:00:00.000Z'),
+             ('legacy_main_values_document',
+              '{"app_icon":"shadowed","week_start":"monday"}',
+              '2026-08-04T00:00:00.000Z')"#,
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    anlg_db_migrate::migrate(&db, schema()).await.unwrap();
+
+    let rows = sqlx::query_as::<_, (String, String, String, String)>(
+        "SELECT id, workspace_id, value_json, updated_at FROM synced_preferences ORDER BY id",
+    )
+    .fetch_all(db.pool())
+    .await
+    .unwrap();
+
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "app_icon".to_string(),
+                "ws-1".to_string(),
+                "\"classic\"".to_string(),
+                "2026-08-03T00:00:00.000Z".to_string(),
+            ),
+            (
+                "theme".to_string(),
+                "ws-1".to_string(),
+                "\"dark\"".to_string(),
+                "2026-08-02T00:00:00.000Z".to_string(),
+            ),
+            (
+                "week_start".to_string(),
+                "ws-1".to_string(),
+                "\"monday\"".to_string(),
+                "2026-08-04T00:00:00.000Z".to_string(),
+            ),
+        ],
+        "direct rows win, then the settings document, then the main values document"
     );
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -614,6 +614,13 @@ export const appSettings = sqliteTable("app_settings", {
   updatedAt: text("updated_at").notNull().default(currentTimestamp),
 });
 
+export const syncedPreferences = sqliteTable("synced_preferences", {
+  id: text("id").primaryKey().notNull(),
+  workspaceId: text("workspace_id").notNull().default(""),
+  valueJson: text("value_json").notNull().default("null"),
+  updatedAt: text("updated_at").notNull().default(currentTimestamp),
+});
+
 export const migrationImportRuns = sqliteTable("migration_import_runs", {
   id: text("id").primaryKey().notNull(),
   importerVersion: integer("importer_version").notNull().default(1),


### PR DESCRIPTION
UI preferences lived only in the device-local app_settings table, so
appearance choices never followed the user across devices. Add a
CloudSync-safe synced_preferences table wired through the E2EE replica:
E2EE_DOMAIN_TABLES entry, registry entry (wake-on-write), dirty-row
triggers, and a one-time backfill that copies existing theme/app_icon/
week_start values under the bound workspace so they upload without
waiting for the next user edit.

On the desktop side, setting keys marked `synced` in SETTING_DEFINITIONS
now persist to synced_preferences (workspace id resolved from the
cloudsync binding), while reads union both tables with the synced row
winning so legacy device-local values keep working as fallbacks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches E2EE domain tables, migration backfills, and settings persistence; wrong merge order or backfill could mis-sync UI prefs across devices.
> 
> **Overview**
> Adds a **`synced_preferences`** SQLite table and wires it into the existing E2EE replica path (domain table list, CloudSync registry entry, dirty-row triggers). One-time migrations copy **`theme`**, **`app_icon`**, and **`week_start`** from `app_settings` or legacy documents when a workspace binding exists, then mark those rows dirty so they upload without waiting for an edit.
> 
> On desktop, keys marked **`synced`** in `SETTING_DEFINITIONS` write to `synced_preferences` (workspace id from `cloudsync_workspace_binding`); everything else still uses `app_settings`. Reads **union** both tables with synced rows ordered last so they win over stale device-local copies while legacy fallbacks keep working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1103b4826104595f18f85b24ca35906fb67598a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->