### PR TITLE
feat(cloudsync): long-poll the witness log to wake remote devices

### DIFF
--- a/apps/api/openapi.gen.json
+++ b/apps/api/openapi.gen.json
@@ -2714,6 +2714,65 @@
         ]
       }
     },
+    "/sync/e2ee/witness/{workspace_id}/wait": {
+      "get": {
+        "tags": [
+          "sync"
+        ],
+        "operationId": "wait_e2ee_witness",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "description": "Personal workspace ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "afterSequence",
+            "in": "query",
+            "description": "Last witness sequence known to the caller",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Witness head state, held until it advances past the cursor or the hold expires",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/E2eeWitnessWaitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid witness cursor"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Witness workspace access denied"
+          },
+          "502": {
+            "description": "Witness service unavailable"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/sync/shares/{share_id}/attachments/finalize": {
       "post": {
         "tags": [
@@ -5801,6 +5860,23 @@
             "type": "integer",
             "format": "int64",
             "minimum": 0
+          }
+        }
+      },
+      "E2eeWitnessWaitResponse": {
+        "type": "object",
+        "required": [
+          "initialized",
+          "headSequence"
+        ],
+        "properties": {
+          "headSequence": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "initialized": {
+            "type": "boolean"
           }
         }
       },

--- a/crates/api-sync/src/routes/e2ee_witness.rs
+++ b/crates/api-sync/src/routes/e2ee_witness.rs
@@ -21,6 +21,10 @@ const MAX_WITNESS_PAGE_BYTES: i32 = 48 * 1024 * 1024;
 const WITNESS_PAGE_SIZE: i32 = 1024;
 const LEGACY_WITNESS_PAGE_SIZE: i32 = 3;
 const WITNESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+const WITNESS_WAIT_HOLD: std::time::Duration = std::time::Duration::from_secs(25);
+const WITNESS_WAIT_RECHECK: std::time::Duration = std::time::Duration::from_secs(10);
+const WITNESS_WAIT_HEAD_LIMIT: i32 = 1;
+const WITNESS_WAIT_HEAD_BYTES: i32 = 1024;
 
 #[derive(Clone, Debug, Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -50,6 +54,20 @@ pub struct ReadE2eeWitnessQuery {
     #[serde(default)]
     after_sequence: u64,
     through_sequence: Option<u64>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WaitE2eeWitnessQuery {
+    #[serde(default)]
+    after_sequence: u64,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct E2eeWitnessWaitResponse {
+    initialized: bool,
+    head_sequence: u64,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -130,13 +148,14 @@ struct PostgrestError {
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(read_e2ee_witness, publish_e2ee_witness),
+    paths(read_e2ee_witness, publish_e2ee_witness, wait_e2ee_witness),
     components(schemas(
         E2eeWitnessEvent,
         PublishE2eeWitnessRequest,
         PublishE2eeWitnessResponse,
         E2eeWitnessPageEvent,
-        E2eeWitnessPage
+        E2eeWitnessPage,
+        E2eeWitnessWaitResponse
     ))
 )]
 pub struct ApiDoc;
@@ -151,6 +170,7 @@ pub fn router() -> Router<AppState> {
             "/e2ee/witness/{workspace_id}",
             get(read_e2ee_witness).post(publish_e2ee_witness),
         )
+        .route("/e2ee/witness/{workspace_id}/wait", get(wait_e2ee_witness))
         .layer(DefaultBodyLimit::max(MAX_WITNESS_REQUEST_BYTES))
 }
 
@@ -208,6 +228,125 @@ async fn read_e2ee_witness(
         [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
         Json(page),
     ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/e2ee/witness/{workspace_id}/wait",
+    tag = "sync",
+    params(
+        ("workspace_id" = String, Path, description = "Personal workspace ID"),
+        ("afterSequence" = Option<u64>, Query, description = "Last witness sequence known to the caller")
+    ),
+    responses(
+        (status = 200, description = "Witness head state, held until it advances past the cursor or the hold expires", body = E2eeWitnessWaitResponse),
+        (status = 400, description = "Invalid witness cursor"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Witness workspace access denied"),
+        (status = 502, description = "Witness service unavailable")
+    )
+)]
+async fn wait_e2ee_witness(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Path(workspace_id): Path<String>,
+    Query(query): Query<WaitE2eeWitnessQuery>,
+) -> Result<(
+    [(header::HeaderName, HeaderValue); 1],
+    Json<E2eeWitnessWaitResponse>,
+)> {
+    require_personal_workspace(&auth, &workspace_id)?;
+    i64::try_from(query.after_sequence)
+        .map_err(|_| SyncError::BadRequest("E2EE witness cursor is invalid".to_string()))?;
+    let wake = state.witness_wakes.subscribe(&workspace_id);
+    let deadline = tokio::time::Instant::now() + WITNESS_WAIT_HOLD;
+    loop {
+        let notified = wake.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        let head = read_witness_head(&state, &auth.claims.sub, &workspace_id).await?;
+        let now = tokio::time::Instant::now();
+        if head.head_sequence > query.after_sequence || !head.initialized || now >= deadline {
+            return Ok((
+                [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
+                Json(head),
+            ));
+        }
+        tokio::select! {
+            () = &mut notified => {}
+            () = tokio::time::sleep(WITNESS_WAIT_RECHECK.min(deadline - now)) => {}
+        }
+    }
+}
+
+async fn read_witness_head(
+    state: &AppState,
+    actor_user_id: &str,
+    workspace_id: &str,
+) -> Result<E2eeWitnessWaitResponse> {
+    let response = state
+        .client
+        .post(format!(
+            "{}/rest/v1/rpc/read_e2ee_freshness_page_v2",
+            state.config.supabase_url
+        ))
+        .header("apikey", &state.config.supabase_service_role_key)
+        .bearer_auth(&state.config.supabase_service_role_key)
+        .timeout(WITNESS_TIMEOUT)
+        // through=0 keeps the event window empty, so the page RPC returns the
+        // head-only singleton row without materializing any event ciphertext.
+        .json(&ReadRpcRequest {
+            p_actor_user_id: actor_user_id,
+            p_workspace_id: workspace_id,
+            p_after_sequence: 0,
+            p_through_sequence: Some(0),
+            p_limit: WITNESS_WAIT_HEAD_LIMIT,
+            p_max_bytes: WITNESS_WAIT_HEAD_BYTES,
+        })
+        .send()
+        .await
+        .map_err(|error| witness_transport_error(error, "wait"))?;
+    let (status, bytes) = read_bounded_response(response, "wait").await?;
+    let (status, bytes) = if is_missing_v2_rpc(status, &bytes) {
+        let response = state
+            .client
+            .post(format!(
+                "{}/rest/v1/rpc/read_e2ee_freshness_page",
+                state.config.supabase_url
+            ))
+            .header("apikey", &state.config.supabase_service_role_key)
+            .bearer_auth(&state.config.supabase_service_role_key)
+            .timeout(WITNESS_TIMEOUT)
+            .json(&LegacyReadRpcRequest {
+                p_actor_user_id: actor_user_id,
+                p_workspace_id: workspace_id,
+                p_after_sequence: 0,
+                p_through_sequence: Some(0),
+                p_limit: WITNESS_WAIT_HEAD_LIMIT,
+            })
+            .send()
+            .await
+            .map_err(|error| witness_transport_error(error, "wait"))?;
+        read_bounded_response(response, "wait").await?
+    } else {
+        (status, bytes)
+    };
+    if !status.is_success() {
+        return Err(map_postgrest_error(status, &bytes));
+    }
+    let rows = serde_json::from_slice::<Vec<ReadRpcRow>>(&bytes).map_err(|error| {
+        tracing::warn!(%error, "Supabase E2EE witness head response was invalid");
+        SyncError::E2eeWitnessServiceUnavailable
+    })?;
+    let Some(first) = rows.first() else {
+        return Err(SyncError::E2eeWitnessServiceUnavailable);
+    };
+    let head_sequence =
+        u64::try_from(first.head_sequence).map_err(|_| SyncError::E2eeWitnessServiceUnavailable)?;
+    Ok(E2eeWitnessWaitResponse {
+        initialized: first.initialized_at.is_some(),
+        head_sequence,
+    })
 }
 
 async fn read_witness_page(
@@ -338,6 +477,7 @@ async fn publish_e2ee_witness(
         .to_rfc3339();
     let head_sequence =
         u64::try_from(row.head_sequence).map_err(|_| SyncError::E2eeWitnessServiceUnavailable)?;
+    state.witness_wakes.notify(&workspace_id);
     Ok((
         [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
         Json(PublishE2eeWitnessResponse {
@@ -710,6 +850,180 @@ mod tests {
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response_json(response).await["headSequence"], 1);
+    }
+
+    #[tokio::test]
+    async fn wait_returns_immediately_when_the_head_is_ahead() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/read_e2ee_freshness_page_v2"))
+            .and(body_partial_json(json!({
+                "p_actor_user_id": OWNER,
+                "p_workspace_id": OWNER,
+                "p_through_sequence": 0,
+                "p_limit": 1,
+                "p_max_bytes": 1024
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "initialized_at": "2026-07-17T00:00:00Z",
+                "head_sequence": 5,
+                "through_sequence": 5,
+                "event_sequence": null,
+                "record_id": null,
+                "payload_hash": null,
+                "payload": null
+            }])))
+            .mount(&server)
+            .await;
+
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            test_router(&server).oneshot(request(
+                Method::GET,
+                &format!("/e2ee/witness/{OWNER}/wait?afterSequence=3"),
+                None,
+            )),
+        )
+        .await
+        .expect("an advanced head must resolve the wait immediately")
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["initialized"], true);
+        assert_eq!(body["headSequence"], 5);
+    }
+
+    #[tokio::test]
+    async fn wait_reports_an_uninitialized_witness_immediately() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/read_e2ee_freshness_page_v2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "initialized_at": null,
+                "head_sequence": 0,
+                "through_sequence": 0,
+                "event_sequence": null,
+                "record_id": null,
+                "payload_hash": null,
+                "payload": null
+            }])))
+            .mount(&server)
+            .await;
+
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            test_router(&server).oneshot(request(
+                Method::GET,
+                &format!("/e2ee/witness/{OWNER}/wait?afterSequence=0"),
+                None,
+            )),
+        )
+        .await
+        .expect("an uninitialized witness must resolve the wait immediately")
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["initialized"], false);
+        assert_eq!(body["headSequence"], 0);
+    }
+
+    #[derive(Clone)]
+    struct HeadFromCounter {
+        head: std::sync::Arc<std::sync::atomic::AtomicI64>,
+    }
+
+    impl wiremock::Respond for HeadFromCounter {
+        fn respond(&self, _request: &wiremock::Request) -> ResponseTemplate {
+            let head = self.head.load(std::sync::atomic::Ordering::SeqCst);
+            ResponseTemplate::new(200).set_body_json(json!([{
+                "initialized_at": "2026-07-17T00:00:00Z",
+                "head_sequence": head,
+                "through_sequence": head,
+                "event_sequence": null,
+                "record_id": null,
+                "payload_hash": null,
+                "payload": null
+            }]))
+        }
+    }
+
+    #[derive(Clone)]
+    struct PublishBumpsCounter {
+        head: std::sync::Arc<std::sync::atomic::AtomicI64>,
+    }
+
+    impl wiremock::Respond for PublishBumpsCounter {
+        fn respond(&self, _request: &wiremock::Request) -> ResponseTemplate {
+            let head = self
+                .head
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                .saturating_add(1);
+            ResponseTemplate::new(200).set_body_json(json!([{
+                "initialized_at": "2026-07-17T00:00:00Z",
+                "head_sequence": head
+            }]))
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_wakes_when_a_publish_lands_on_the_same_instance() {
+        let server = MockServer::start().await;
+        let head = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(3));
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/read_e2ee_freshness_page_v2"))
+            .respond_with(HeadFromCounter {
+                head: std::sync::Arc::clone(&head),
+            })
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/publish_e2ee_freshness_events"))
+            .respond_with(PublishBumpsCounter {
+                head: std::sync::Arc::clone(&head),
+            })
+            .mount(&server)
+            .await;
+
+        let router = test_router(&server);
+        let waiter = router.clone();
+        let wait = tokio::spawn(async move {
+            waiter
+                .oneshot(request(
+                    Method::GET,
+                    &format!("/e2ee/witness/{OWNER}/wait?afterSequence=3"),
+                    None,
+                ))
+                .await
+                .unwrap()
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let publish = router
+            .oneshot(request(
+                Method::POST,
+                &format!("/e2ee/witness/{OWNER}"),
+                Some(json!({
+                    "initialize": false,
+                    "events": [{
+                        "recordId": RECORD_ID,
+                        "payloadHash": PAYLOAD_HASH,
+                        "payload": "opaque"
+                    }]
+                })),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(publish.status(), StatusCode::OK);
+
+        // Well under the 10s periodic recheck, so only the publish wake can
+        // explain a prompt response.
+        let response = tokio::time::timeout(std::time::Duration::from_secs(5), wait)
+            .await
+            .expect("a same-instance publish must wake the held wait")
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["headSequence"], 4);
     }
 
     #[test]

--- a/crates/api-sync/src/state.rs
+++ b/crates/api-sync/src/state.rs
@@ -1,4 +1,5 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::Semaphore;
 
@@ -7,12 +8,39 @@ use crate::config::SyncConfig;
 const UPSTREAM_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const ATTACHMENT_VERIFICATION_CONCURRENCY: usize = 1;
 
+/// Instance-local wake channels for witness long-polls. Publishes on this
+/// instance wake waiters immediately; cross-instance publishes are covered by
+/// the long-poll's periodic storage recheck.
+#[derive(Clone, Default)]
+pub struct WitnessWakes {
+    inner: Arc<Mutex<HashMap<String, Arc<tokio::sync::Notify>>>>,
+}
+
+impl WitnessWakes {
+    pub(crate) fn subscribe(&self, workspace_id: &str) -> Arc<tokio::sync::Notify> {
+        Arc::clone(
+            self.inner
+                .lock()
+                .unwrap()
+                .entry(workspace_id.to_string())
+                .or_default(),
+        )
+    }
+
+    pub(crate) fn notify(&self, workspace_id: &str) {
+        if let Some(notify) = self.inner.lock().unwrap().get(workspace_id) {
+            notify.notify_waiters();
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub config: SyncConfig,
     pub client: reqwest::Client,
     pub storage: anlg_supabase_storage::SupabaseStorage,
     pub attachment_verification_slots: Arc<Semaphore>,
+    pub witness_wakes: WitnessWakes,
 }
 
 impl AppState {
@@ -35,6 +63,7 @@ impl AppState {
             attachment_verification_slots: Arc::new(Semaphore::new(
                 ATTACHMENT_VERIFICATION_CONCURRENCY,
             )),
+            witness_wakes: WitnessWakes::default(),
         }
     }
 }

--- a/plugins/db/src/e2ee_witness.rs
+++ b/plugins/db/src/e2ee_witness.rs
@@ -118,6 +118,13 @@ struct ReadEvent {
     payload: String,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct WaitResponse {
+    initialized: bool,
+    head_sequence: u64,
+}
+
 impl E2eeWitnessClient {
     pub(crate) fn new(config: crate::CloudsyncE2eeWitness, workspace_id: &str) -> io::Result<Self> {
         let endpoint = reqwest::Url::parse(&config.endpoint)
@@ -440,6 +447,42 @@ impl E2eeWitnessClient {
     async fn read_page(&self, after: u64, through: Option<u64>) -> io::Result<ReadPage> {
         self.read_page_cancellable(after, through, &E2eeWitnessCancellation::default())
             .await
+    }
+
+    /// Long-poll the witness service until its head advances past `after` or
+    /// the server's hold expires. Returns the new head when it advanced.
+    pub(crate) async fn wait_for_remote_head(
+        &self,
+        after: u64,
+        cancellation: &E2eeWitnessCancellation,
+    ) -> io::Result<Option<u64>> {
+        let mut endpoint = self.endpoint.clone();
+        endpoint
+            .path_segments_mut()
+            .map_err(|()| invalid_data("E2EE witness endpoint is invalid"))?
+            .push("wait");
+        let response = self
+            .send_with_rate_limit_retry(
+                || {
+                    self.client
+                        .get(endpoint.clone())
+                        .bearer_auth(&self.access_token)
+                        .query(&[("afterSequence", after)])
+                },
+                cancellation,
+            )
+            .await?;
+        let status = response.status();
+        let bytes = cancellation.run_network(read_bounded(response)).await??;
+        if !status.is_success() {
+            return Err(io::Error::other(format!(
+                "E2EE witness wait was rejected with status {status}"
+            )));
+        }
+        let response: WaitResponse = serde_json::from_slice(&bytes)
+            .map_err(|_| invalid_data("E2EE witness wait response is invalid"))?;
+        Ok((response.initialized && response.head_sequence > after)
+            .then_some(response.head_sequence))
     }
 
     async fn read_page_cancellable(

--- a/plugins/db/src/e2ee_witness/tests.rs
+++ b/plugins/db/src/e2ee_witness/tests.rs
@@ -647,3 +647,75 @@ fn retry_after_delays_are_bounded_and_allow_immediate_test_retries() {
     headers.insert(reqwest::header::RETRY_AFTER, "120".parse().unwrap());
     assert_eq!(retry_after_delay(&headers), MAX_RETRY_AFTER);
 }
+
+#[tokio::test]
+async fn wait_for_remote_head_reports_only_advanced_heads() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/sync/e2ee/witness/user-a/wait"))
+        .and(wiremock::matchers::query_param("afterSequence", "3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "initialized": true,
+            "headSequence": 5,
+        })))
+        .mount(&server)
+        .await;
+    let client = E2eeWitnessClient::new(
+        crate::CloudsyncE2eeWitness {
+            endpoint: format!("{}/sync/e2ee/witness/user-a", server.uri()),
+            access_token: "access-token".to_string(),
+        },
+        "user-a",
+    )
+    .unwrap();
+
+    let head = client
+        .wait_for_remote_head(3, &E2eeWitnessCancellation::default())
+        .await
+        .unwrap();
+
+    assert_eq!(head, Some(5));
+}
+
+#[tokio::test]
+async fn wait_for_remote_head_ignores_stale_and_uninitialized_heads() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/sync/e2ee/witness/user-a/wait"))
+        .and(wiremock::matchers::query_param("afterSequence", "5"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "initialized": true,
+            "headSequence": 5,
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/sync/e2ee/witness/user-a/wait"))
+        .and(wiremock::matchers::query_param("afterSequence", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "initialized": false,
+            "headSequence": 0,
+        })))
+        .mount(&server)
+        .await;
+    let client = E2eeWitnessClient::new(
+        crate::CloudsyncE2eeWitness {
+            endpoint: format!("{}/sync/e2ee/witness/user-a", server.uri()),
+            access_token: "access-token".to_string(),
+        },
+        "user-a",
+    )
+    .unwrap();
+
+    let stale = client
+        .wait_for_remote_head(5, &E2eeWitnessCancellation::default())
+        .await
+        .unwrap();
+    let uninitialized = client
+        .wait_for_remote_head(0, &E2eeWitnessCancellation::default())
+        .await
+        .unwrap();
+
+    assert_eq!(stale, None);
+    assert_eq!(uninitialized, None);
+}

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -13,6 +13,7 @@ mod e2ee_sync;
 mod open;
 mod recovery;
 mod sync_result;
+mod witness_watch;
 
 pub(crate) use e2ee_sync::CloudsyncTokenConfiguration;
 use e2ee_sync::E2eeSyncHook;
@@ -143,6 +144,7 @@ pub struct PluginDbRuntime {
     cloudsync_auth_generation: std::sync::Arc<std::sync::atomic::AtomicU64>,
     cloudsync_auth_changed: std::sync::Arc<tokio::sync::Notify>,
     cloudsync_focus_nudge_at: std::sync::Mutex<Option<std::time::Instant>>,
+    _witness_watch: witness_watch::WitnessWatchTask,
     #[cfg(test)]
     pause_transaction_after_begin: std::sync::atomic::AtomicBool,
     #[cfg(test)]
@@ -186,6 +188,10 @@ impl PluginDbRuntime {
     pub fn new(db: std::sync::Arc<Db>) -> Self {
         let e2ee_sync_hook = std::sync::Arc::new(E2eeSyncHook::default());
         db.set_cloudsync_sync_hook(e2ee_sync_hook.clone());
+        let witness_watch = witness_watch::spawn_witness_watch(
+            std::sync::Arc::clone(&db),
+            std::sync::Arc::clone(&e2ee_sync_hook),
+        );
         Self {
             db: std::sync::Arc::clone(&db),
             schema_ready: tokio::sync::OnceCell::new(),
@@ -193,6 +199,7 @@ impl PluginDbRuntime {
             executor: DbExecutor::new(std::sync::Arc::clone(&db)),
             live_query_runtime: LiveQueryRuntime::new(db),
             e2ee_sync_hook,
+            _witness_watch: witness_watch,
             scheduled_cloudsync_full_resync: Default::default(),
             cloudsync_full_resync_task: Default::default(),
             cloudsync_control_operation: Default::default(),

--- a/plugins/db/src/runtime/e2ee_sync.rs
+++ b/plugins/db/src/runtime/e2ee_sync.rs
@@ -39,6 +39,7 @@ impl CloudsyncTokenConfiguration {
 pub(super) struct E2eeSyncHook {
     keys: std::sync::RwLock<HashMap<String, anlg_e2ee::WorkspaceKey>>,
     witness: std::sync::RwLock<Option<crate::e2ee_witness::E2eeWitnessClient>>,
+    pub(super) witness_changed: tokio::sync::Notify,
     activities: std::sync::RwLock<HashSet<CloudsyncActivity>>,
     pub(super) activity_changed: tokio::sync::Notify,
     reconciliation_requested_epoch: std::sync::atomic::AtomicU64,
@@ -93,6 +94,7 @@ impl E2eeSyncHook {
     pub(super) fn clear(&self) {
         self.keys.write().unwrap().clear();
         *self.witness.write().unwrap() = None;
+        self.witness_changed.notify_waiters();
         let requested = self
             .reconciliation_requested_epoch
             .load(std::sync::atomic::Ordering::Acquire);
@@ -113,6 +115,7 @@ impl E2eeSyncHook {
 
     pub(super) fn set_witness(&self, witness: crate::e2ee_witness::E2eeWitnessClient) {
         *self.witness.write().unwrap() = Some(witness);
+        self.witness_changed.notify_waiters();
         self.request_reconciliation();
     }
 

--- a/plugins/db/src/runtime/tests/mod.rs
+++ b/plugins/db/src/runtime/tests/mod.rs
@@ -86,3 +86,4 @@ mod open_and_status;
 mod recovery_protocol;
 mod recovery_schedule;
 mod sync_hook;
+mod witness_watch;

--- a/plugins/db/src/runtime/tests/witness_watch.rs
+++ b/plugins/db/src/runtime/tests/witness_watch.rs
@@ -1,0 +1,150 @@
+use serde_json::json;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use super::*;
+
+async fn wait_requests(server: &MockServer) -> Vec<wiremock::Request> {
+    server
+        .received_requests()
+        .await
+        .expect("failed to inspect witness requests")
+        .into_iter()
+        .filter(|request| request.url.path().ends_with("/wait"))
+        .collect()
+}
+
+#[tokio::test]
+async fn watcher_polls_the_witness_and_stops_when_it_is_cleared() {
+    let db = std::sync::Arc::new(Db::connect_memory_plain().await.unwrap());
+    anlg_db_app::prepare_schema(db.as_ref()).await.unwrap();
+    let runtime = PluginDbRuntime::new(std::sync::Arc::clone(&db));
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(wiremock::matchers::path("/sync/e2ee/witness/user-a/wait"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "initialized": true,
+            "headSequence": 1,
+        })))
+        .mount(&server)
+        .await;
+    let witness = crate::e2ee_witness::E2eeWitnessClient::new(
+        crate::CloudsyncE2eeWitness {
+            endpoint: format!("{}/sync/e2ee/witness/user-a", server.uri()),
+            access_token: "access-token".to_string(),
+        },
+        "user-a",
+    )
+    .unwrap();
+
+    assert!(
+        wait_requests(&server).await.is_empty(),
+        "the watcher polled before a witness was configured"
+    );
+    runtime.e2ee_sync_hook.set_witness(witness);
+
+    let requests = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            let requests = wait_requests(&server).await;
+            if requests.len() >= 2 {
+                return requests;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("the watcher did not start long-polling the witness");
+    assert_eq!(
+        requests[0].url.query(),
+        Some("afterSequence=0"),
+        "the first poll must start from the local witness cursor"
+    );
+    assert_eq!(
+        requests[1].url.query(),
+        Some("afterSequence=1"),
+        "an advanced head must move the poll cursor forward"
+    );
+
+    runtime.e2ee_sync_hook.clear();
+    tokio::time::sleep(std::time::Duration::from_millis(1_500)).await;
+    let settled = wait_requests(&server).await.len();
+    tokio::time::sleep(std::time::Duration::from_millis(2_500)).await;
+    assert_eq!(
+        wait_requests(&server).await.len(),
+        settled,
+        "the watcher kept polling after the witness was cleared"
+    );
+}
+
+#[tokio::test]
+async fn watcher_restarts_the_cursor_when_the_witness_workspace_changes() {
+    let db = std::sync::Arc::new(Db::connect_memory_plain().await.unwrap());
+    anlg_db_app::prepare_schema(db.as_ref()).await.unwrap();
+    let runtime = PluginDbRuntime::new(std::sync::Arc::clone(&db));
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(wiremock::matchers::path("/sync/e2ee/witness/user-a/wait"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "initialized": true,
+            "headSequence": 7,
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(wiremock::matchers::path("/sync/e2ee/witness/user-b/wait"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "initialized": true,
+            "headSequence": 0,
+        })))
+        .mount(&server)
+        .await;
+    let witness_for = |workspace: &str| {
+        crate::e2ee_witness::E2eeWitnessClient::new(
+            crate::CloudsyncE2eeWitness {
+                endpoint: format!("{}/sync/e2ee/witness/{workspace}", server.uri()),
+                access_token: "access-token".to_string(),
+            },
+            workspace,
+        )
+        .unwrap()
+    };
+
+    runtime.e2ee_sync_hook.set_witness(witness_for("user-a"));
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            if wait_requests(&server)
+                .await
+                .iter()
+                .any(|request| request.url.query() == Some("afterSequence=7"))
+            {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("the watcher never advanced past the first workspace's head");
+
+    runtime.e2ee_sync_hook.set_witness(witness_for("user-b"));
+    let first_swap_query = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            let request = wait_requests(&server)
+                .await
+                .into_iter()
+                .find(|request| request.url.path().contains("user-b"));
+            if let Some(request) = request {
+                return request.url.query().map(str::to_string);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("the watcher never polled the swapped witness");
+    assert_eq!(
+        first_swap_query.as_deref(),
+        Some("afterSequence=0"),
+        "a swapped witness must not inherit the previous workspace's trigger cursor"
+    );
+}

--- a/plugins/db/src/runtime/witness_watch.rs
+++ b/plugins/db/src/runtime/witness_watch.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use anlg_db_core::Db;
+
+use super::e2ee_sync::E2eeSyncHook;
+use crate::e2ee_witness::E2eeWitnessCancellation;
+
+const WATCH_POLL_PACING: std::time::Duration = std::time::Duration::from_secs(1);
+const WATCH_ERROR_BACKOFF_MIN: std::time::Duration = std::time::Duration::from_secs(5);
+const WATCH_ERROR_BACKOFF_MAX: std::time::Duration = std::time::Duration::from_secs(300);
+
+pub(super) struct WitnessWatchTask {
+    _shutdown_tx: tokio::sync::oneshot::Sender<()>,
+}
+
+/// Long-polls the witness service so remote changes trigger a sync round
+/// promptly instead of waiting for the next background interval. The task
+/// parks while no witness is configured and follows witness swaps via the
+/// hook's change notifications; dropping the returned handle stops it.
+pub(super) fn spawn_witness_watch(db: Arc<Db>, hook: Arc<E2eeSyncHook>) -> WitnessWatchTask {
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    tauri::async_runtime::spawn(async move {
+        let mut error_backoff = WATCH_ERROR_BACKOFF_MIN;
+        let mut last_triggered: u64 = 0;
+        let mut watched_workspace: Option<String> = None;
+        loop {
+            let witness_changed = hook.witness_changed.notified();
+            tokio::pin!(witness_changed);
+            witness_changed.as_mut().enable();
+            let Some(witness) = hook.witness() else {
+                tokio::select! {
+                    _ = &mut shutdown_rx => return,
+                    () = &mut witness_changed => {}
+                }
+                continue;
+            };
+            // A swapped witness (sign-out, account switch) starts over in a new
+            // sequence space; carrying last_triggered across would suppress wakes
+            // until the new head outgrows the old workspace's sequence.
+            if watched_workspace.as_deref() != Some(witness.workspace_id()) {
+                last_triggered = 0;
+                watched_workspace = Some(witness.workspace_id().to_string());
+            }
+
+            tokio::select! {
+                _ = &mut shutdown_rx => return,
+                () = tokio::time::sleep(WATCH_POLL_PACING) => {}
+            }
+
+            let cursor =
+                match anlg_db_app::e2ee_witness_cursor(db.pool(), witness.workspace_id()).await {
+                    Ok(cursor) => cursor,
+                    Err(error) => {
+                        tracing::debug!(%error, "witness watch could not read the local cursor");
+                        tokio::select! {
+                            _ = &mut shutdown_rx => return,
+                            () = tokio::time::sleep(error_backoff) => {}
+                            () = &mut witness_changed => {}
+                        }
+                        error_backoff = (error_backoff * 2).min(WATCH_ERROR_BACKOFF_MAX);
+                        continue;
+                    }
+                };
+            let after = cursor.max(last_triggered);
+
+            let cancellation = E2eeWitnessCancellation::default();
+            let wait = witness.wait_for_remote_head(after, &cancellation);
+            tokio::pin!(wait);
+            let result = tokio::select! {
+                _ = &mut shutdown_rx => return,
+                () = &mut witness_changed => continue,
+                result = &mut wait => result,
+            };
+            match result {
+                Ok(Some(head)) => {
+                    last_triggered = head;
+                    error_backoff = WATCH_ERROR_BACKOFF_MIN;
+                    db.cloudsync_request_sync();
+                }
+                Ok(None) => {
+                    error_backoff = WATCH_ERROR_BACKOFF_MIN;
+                }
+                Err(error) => {
+                    tracing::debug!(%error, "witness watch long-poll failed");
+                    tokio::select! {
+                        _ = &mut shutdown_rx => return,
+                        () = tokio::time::sleep(error_backoff) => {}
+                        () = &mut witness_changed => {}
+                    }
+                    error_backoff = (error_backoff * 2).min(WATCH_ERROR_BACKOFF_MAX);
+                }
+            }
+        }
+    });
+    WitnessWatchTask {
+        _shutdown_tx: shutdown_tx,
+    }
+}


### PR DESCRIPTION
After wake-on-write, receive latency was still bounded by the 30s
polling interval: a device only discovered remote changes on its own
next tick. Every E2EE sync already publishes witness events through
api-sync, so the witness head is a content-free change signal.

api-sync gains GET /e2ee/witness/{workspace}/wait: it holds up to 25s
until the head advances past the caller cursor, woken instantly by
same-instance publishes via an in-process registry and by a 10s
storage recheck across instances. The desktop runtime spawns a watcher
that long-polls with the local witness cursor and nudges the sync loop
when the head advances; the local cursor catching up after a sync
keeps a device from waking on its own publishes. The watcher parks
while no witness is configured, follows witness swaps, and stops when
the runtime drops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches E2EE sync timing and adds long-lived HTTP holds on api-sync; behavior is scoped to witness polling with tests, but multi-instance wake is best-effort (10s recheck) and could affect sync load under many concurrent waiters.
> 
> **Overview**
> Adds **long-polling on the E2EE witness head** so clients learn about remote changes without waiting on the ~30s sync poll. The witness sequence is treated as a content-free change signal.
> 
> **api-sync** exposes `GET /sync/e2ee/witness/{workspace_id}/wait` with optional `afterSequence`. The handler holds the request for up to **25s**, returning when the head moves past the cursor, the witness is still uninitialized, or the hold expires. Same-instance publishes wake waiters immediately via an in-process `WitnessWakes` registry; a **10s** storage recheck covers other instances. Head reads use the existing freshness RPC with an empty event window (`through_sequence: 0`).
> 
> The **desktop db plugin** adds `wait_for_remote_head` on `E2eeWitnessClient` and a background **witness watch** task that long-polls with the local witness cursor and calls `cloudsync_request_sync()` when the remote head advances. `E2eeSyncHook` notifies on witness set/clear so the watcher parks when unconfigured and resets its cursor on workspace swaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c28d2f3069450e8e717c41302e01c9438e02fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->