### PR TITLE
docs(changelog): cover sync speed and synced preferences in 1.4.8

### DIFF
--- a/packages/changelog/content/1.4.8.md
+++ b/packages/changelog/content/1.4.8.md
@@ -1,7 +1,17 @@
 ---
 date: "2026-08-10"
-summary: "Anarlog 1.4.8 connects eight meeting assistants for automatic imports and improves recording recovery, window placement, transcription errors, billing, and app icon settings."
+summary: "Anarlog 1.4.8 connects eight meeting assistants for automatic imports, makes cross-device sync near-instant, syncs appearance preferences across devices, and improves recording recovery, window placement, transcription errors, and billing."
 ---
+
+## Sync
+
+- Upload local changes within about a second of settling instead of waiting
+  for the next 30-second interval, and pull promptly when you switch back to
+  the app
+- Wake your other devices as soon as a sync lands so changes appear everywhere
+  without waiting for their next polling tick
+- Sync your theme, app icon, and week start choices across devices,
+  end-to-end encrypted like the rest of your notes
 
 ## Importing
 


### PR DESCRIPTION
The 1.4.8 changelog predates the wake-on-write, witness long-poll, and synced UI preferences merges. Add a Sync section covering near-instant upload, remote device wake, and cross-device theme/app icon/week start sync, and fold them into the summary line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only edits with no runtime or product behavior changes.
> 
> **Overview**
> Updates the **1.4.8** release notes so they reflect sync work that landed after the original changelog was written.
> 
> The front-matter **summary** now calls out near-instant sync, cross-device appearance preferences, and no longer mentions app icon settings in that one-liner (those details stay under **Window and settings**).
> 
> A new **Sync** section documents faster upload (~1s after local changes settle vs 30s polling), prompt pull on app focus, waking other devices when a sync lands, and E2E-encrypted sync of theme, app icon, and week start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb164a156304ff4d56251c07ff74ea6805717fee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->