### PR TITLE
feat(web): group footer links into labeled columns

### DIFF
--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -1,48 +1,98 @@
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 
+import { fetchUser } from "@/functions/auth";
+
+const footerGroups = [
+  {
+    title: "Product",
+    links: [
+      { label: "Download", to: "/download/" },
+      { label: "Blog", to: "/blog/" },
+      { label: "Changelog", to: "/changelog/" },
+      { label: "Status", href: "https://status.anarlog.so" },
+    ],
+  },
+  {
+    title: "Community",
+    links: [
+      { label: "GitHub", href: "https://github.com/fastrepl/anarlog" },
+      { label: "X", href: "https://x.com/anarlogapp" },
+      { label: "Discord", to: "/discord/" },
+    ],
+  },
+  {
+    title: "Legal",
+    links: [
+      { label: "Privacy", to: "/privacy/" },
+      { label: "Terms", to: "/terms/" },
+    ],
+  },
+];
+
 export function SiteFooter() {
+  const { data: user } = useQuery({
+    queryKey: ["auth-user"],
+    queryFn: () => fetchUser(),
+  });
+
   return (
-    <footer className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-5 px-5 py-8 text-xs text-[#4f4940] md:px-8">
-      <a
-        href="https://fastrepl.com"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 text-xs text-[#756b5d] opacity-75 transition-opacity hover:opacity-100"
-      >
-        <img src="/icons/fastrepl.svg" alt="Fastrepl" className="h-4 w-auto" />
-        <span>© 2026</span>
-      </a>
-      <nav className="flex flex-wrap gap-x-5 gap-y-2">
-        <Link to="/download/" className="hover:text-[#181613]">
-          Download
-        </Link>
+    <footer className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-5 py-10 text-xs text-[#4f4940] sm:flex-row sm:justify-between md:px-8">
+      <div className="flex flex-col gap-2.5 self-start">
         <a
-          href="https://github.com/fastrepl/anarlog"
-          className="hover:text-[#181613]"
+          href="https://fastrepl.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs text-[#756b5d] opacity-75 transition-opacity hover:opacity-100"
         >
-          GitHub
+          <img
+            src="/icons/fastrepl.svg"
+            alt="Fastrepl"
+            className="h-4 w-auto"
+          />
+          <span>© 2026</span>
         </a>
-        <a href="https://x.com/anarlogapp" className="hover:text-[#181613]">
-          X
-        </a>
-        <Link to="/discord/" className="hover:text-[#181613]">
-          Discord
-        </Link>
-        <Link to="/blog/" className="hover:text-[#181613]">
-          Blog
-        </Link>
-        <Link to="/changelog/" className="hover:text-[#181613]">
-          Changelog
-        </Link>
-        <a href="https://status.anarlog.so" className="hover:text-[#181613]">
-          Status
-        </a>
-        <Link to="/privacy/" className="hover:text-[#181613]">
-          Privacy
-        </Link>
-        <Link to="/terms/" className="hover:text-[#181613]">
-          Terms
-        </Link>
+        {user ? (
+          <Link to="/app/account/" className="w-fit hover:text-[#181613]">
+            Account
+          </Link>
+        ) : (
+          <Link
+            to="/auth/"
+            search={{ flow: "web" }}
+            className="w-fit hover:text-[#181613]"
+          >
+            Get started
+          </Link>
+        )}
+      </div>
+      <nav className="grid grid-cols-2 gap-x-12 gap-y-8 sm:grid-cols-3 sm:gap-x-16">
+        {footerGroups.map((group) => (
+          <div key={group.title} className="flex flex-col gap-2.5">
+            <span className="tracking-[0.04em] text-[#756b5d]">
+              {group.title}
+            </span>
+            {group.links.map((link) =>
+              link.to ? (
+                <Link
+                  key={link.label}
+                  to={link.to}
+                  className="w-fit hover:text-[#181613]"
+                >
+                  {link.label}
+                </Link>
+              ) : (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  className="w-fit hover:text-[#181613]"
+                >
+                  {link.label}
+                </a>
+              ),
+            )}
+          </div>
+        ))}
       </nav>
     </footer>
   );


### PR DESCRIPTION
Replace the flat 9-link footer row with Product, Community, and Legal
columns so related links read together. Links move into a footerGroups
array rendered as a responsive grid (2 columns on mobile, 3 on desktop).
The brand block gains an auth-aware link under the copyright mark:
Account for signed-in users, Get started (to /auth/) otherwise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only footer changes using the existing `fetchUser` query pattern; no auth or data-model changes.
> 
> **Overview**
> **Replaces the flat footer link row** with **Product**, **Community**, and **Legal** columns driven by a `footerGroups` config, rendered in a responsive grid (2 columns on small screens, 3 on `sm+`).
> 
> The **Fastrepl / copyright block** now loads the current user via `fetchUser` and shows **Account** when signed in or **Get started** (`/auth/?flow=web`) when not. Footer layout shifts from a single horizontal bar to a column stack on mobile with brand + auth CTA on the left and grouped nav on the right.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daf94b67e3ebbfd8078accd85d2ee3c2bccf560d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->