### PR TITLE
feat(web): redesign account page to match homepage tone

### DIFF
--- a/apps/web/src/routes/_view/app/-account-access.tsx
+++ b/apps/web/src/routes/_view/app/-account-access.tsx
@@ -1,22 +1,17 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
-
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@anlg/ui/components/ui/accordion";
 
 import { signOutFn } from "@/functions/auth";
-import { deleteAccount } from "@/functions/billing";
 import { captureOperationalError } from "@/lib/error-reporting";
 import { resetPrivateRouteAnalyticsIdentity } from "@/lib/private-route-analytics";
 
+import {
+  accountCardClassName,
+  accountPillDangerClassName,
+} from "./-account-ui";
+
 export function AccountAccessSection() {
   const navigate = useNavigate();
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const signOut = useMutation({
     mutationFn: async () => {
@@ -39,115 +34,22 @@ export function AccountAccessSection() {
     },
   });
 
-  const deleteAccountMutation = useMutation({
-    mutationFn: () => deleteAccount(),
-    onSuccess: () => {
-      navigate({ to: "/" });
-    },
-    onError: (error) => {
-      captureOperationalError(error, {
-        operation: "account_delete",
-      });
-    },
-  });
-
   return (
-    <div className="border-color-brand surface rounded-lg border">
-      <div className="px-8 pt-8">
-        <h3 className="text-color mb-2 font-sans text-lg font-semibold">
-          Access
-        </h3>
-        <p className="text-color-secondary text-sm">
-          Session controls and destructive account actions
-        </p>
-      </div>
-
-      <div className="border-color-brand flex w-full flex-col border-b p-8">
-        <div className="flex flex-col gap-4 md:flex-row md:justify-between">
-          <div className="text-color-secondary text-base">Sign out</div>
-          <div className="flex items-center gap-3">
-            <p className="text-base">End your current session on this device</p>
-            <button
-              onClick={() => signOut.mutate()}
-              disabled={signOut.isPending}
-              className="border-color-brand text-color-secondary flex h-7 items-center rounded-full border bg-linear-to-b from-white to-stone-50 px-3 text-xs shadow-xs transition-all hover:scale-[102%] hover:shadow-md active:scale-[98%] disabled:opacity-50 disabled:hover:scale-100"
-            >
-              {signOut.isPending ? "Signing out..." : "Sign out"}
-            </button>
-          </div>
+    <div className={accountCardClassName}>
+      <div className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
+        <div>
+          <p className="text-base font-medium text-[#181613]">Sign out</p>
+          <p className="mt-1 text-sm leading-6 text-[#756b5d]">
+            End your current session on this device.
+          </p>
         </div>
-      </div>
-
-      <div className="px-8 py-8">
-        <Accordion
-          type="single"
-          collapsible
-          onValueChange={(value) => {
-            if (!value) {
-              setShowDeleteConfirm(false);
-              deleteAccountMutation.reset();
-            }
-          }}
+        <button
+          onClick={() => signOut.mutate()}
+          disabled={signOut.isPending}
+          className={accountPillDangerClassName}
         >
-          <AccordionItem value="delete-account" className="border-none">
-            <AccordionTrigger className="py-4 font-sans text-base text-red-700 hover:text-red-800 hover:no-underline">
-              Delete account
-            </AccordionTrigger>
-            <AccordionContent className="pb-4">
-              <div className="rounded-md border border-red-200 bg-red-50 p-4">
-                <p className="text-sm text-red-900">
-                  Anarlog is a local-first app. Your notes, transcripts, and
-                  meeting data stay on your device. Deleting your account only
-                  removes cloud-stored data.
-                </p>
-
-                {showDeleteConfirm ? (
-                  <div className="mt-4 space-y-3">
-                    <p className="text-sm text-red-800">
-                      This permanently deletes your account and cloud data.
-                    </p>
-
-                    {deleteAccountMutation.isError && (
-                      <p className="text-sm text-red-600">
-                        {deleteAccountMutation.error?.message ||
-                          "Failed to delete account"}
-                      </p>
-                    )}
-
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        onClick={() => deleteAccountMutation.mutate()}
-                        disabled={deleteAccountMutation.isPending}
-                        className="flex h-8 items-center rounded-full bg-linear-to-t from-stone-600 to-stone-500 px-4 text-sm text-white shadow-md transition-all hover:scale-[102%] hover:shadow-lg active:scale-[98%] disabled:opacity-50 disabled:hover:scale-100"
-                      >
-                        {deleteAccountMutation.isPending
-                          ? "Deleting..."
-                          : "Yes, delete my account"}
-                      </button>
-                      <button
-                        onClick={() => {
-                          setShowDeleteConfirm(false);
-                          deleteAccountMutation.reset();
-                        }}
-                        disabled={deleteAccountMutation.isPending}
-                        className="flex h-8 items-center rounded-full border border-red-200 bg-white px-4 text-sm text-red-700 transition-all hover:border-red-300 hover:text-red-800 disabled:opacity-50"
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  <button
-                    onClick={() => setShowDeleteConfirm(true)}
-                    className="mt-4 flex h-8 cursor-pointer items-center rounded-full border border-red-200 bg-white px-4 text-sm text-red-700 transition-all hover:border-red-300 hover:text-red-800"
-                  >
-                    Continue
-                  </button>
-                )}
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+          {signOut.isPending ? "Signing out..." : "Sign out"}
+        </button>
       </div>
     </div>
   );

--- a/apps/web/src/routes/_view/app/-account-danger.tsx
+++ b/apps/web/src/routes/_view/app/-account-danger.tsx
@@ -1,0 +1,112 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@anlg/ui/components/ui/accordion";
+import { cn } from "@anlg/utils";
+
+import { deleteAccount } from "@/functions/billing";
+import { captureOperationalError } from "@/lib/error-reporting";
+
+import {
+  accountCardClassName,
+  accountPillDangerClassName,
+} from "./-account-ui";
+
+export function DangerAreaSection() {
+  const navigate = useNavigate();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const deleteAccountMutation = useMutation({
+    mutationFn: () => deleteAccount(),
+    onSuccess: () => {
+      navigate({ to: "/" });
+    },
+    onError: (error) => {
+      captureOperationalError(error, {
+        operation: "account_delete",
+      });
+    },
+  });
+
+  return (
+    <div className={accountCardClassName}>
+      <div className="px-6 py-2 sm:px-8">
+        <Accordion
+          type="single"
+          collapsible
+          onValueChange={(value) => {
+            if (!value) {
+              setShowDeleteConfirm(false);
+              deleteAccountMutation.reset();
+            }
+          }}
+        >
+          <AccordionItem value="delete-account" className="border-none">
+            <AccordionTrigger className="py-4 font-sans text-base font-medium text-red-700 hover:text-red-800 hover:no-underline">
+              Delete account
+            </AccordionTrigger>
+            <AccordionContent className="pb-6">
+              <div className="rounded-xl border border-red-200 bg-red-50 p-4">
+                <p className="text-sm leading-6 text-red-900">
+                  Anarlog is a local-first app. Your notes, transcripts, and
+                  meeting data stay on your device. Deleting your account only
+                  removes cloud-stored data.
+                </p>
+
+                {showDeleteConfirm ? (
+                  <div className="mt-4 space-y-3">
+                    <p className="text-sm text-red-800">
+                      This permanently deletes your account and cloud data.
+                    </p>
+
+                    {deleteAccountMutation.isError && (
+                      <p className="text-sm text-red-600">
+                        {deleteAccountMutation.error?.message ||
+                          "Failed to delete account"}
+                      </p>
+                    )}
+
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        onClick={() => deleteAccountMutation.mutate()}
+                        disabled={deleteAccountMutation.isPending}
+                        className="flex h-9 cursor-pointer items-center justify-center rounded-full bg-red-700 px-4 text-sm font-medium text-white transition-colors hover:bg-red-800 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {deleteAccountMutation.isPending
+                          ? "Deleting..."
+                          : "Yes, delete my account"}
+                      </button>
+                      <button
+                        onClick={() => {
+                          setShowDeleteConfirm(false);
+                          deleteAccountMutation.reset();
+                        }}
+                        disabled={deleteAccountMutation.isPending}
+                        className={accountPillDangerClassName}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setShowDeleteConfirm(true)}
+                    className={cn([accountPillDangerClassName, "mt-4"])}
+                  >
+                    Continue
+                  </button>
+                )}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_view/app/-account-plan.tsx
+++ b/apps/web/src/routes/_view/app/-account-plan.tsx
@@ -1,0 +1,77 @@
+import { Link } from "@tanstack/react-router";
+
+import { useAccountSession } from "./-account-session";
+import {
+  accountCardClassName,
+  accountPillPrimaryClassName,
+  accountPillSecondaryClassName,
+} from "./-account-ui";
+
+export function PlanSection() {
+  const { data, isPending } = useAccountSession();
+  const billing = data?.billing;
+
+  const planLabel = billing?.isTrialing
+    ? "Pro trial"
+    : billing?.isPaid
+      ? billing.isLite && !billing.isPro
+        ? "Lite"
+        : "Pro"
+      : "Free";
+
+  const planDetail = billing?.isTrialing
+    ? billing.trialEnd
+      ? `${billing.trialDaysRemaining} ${
+          billing.trialDaysRemaining === 1 ? "day" : "days"
+        } left · ends ${billing.trialEnd.toLocaleDateString("en-US", {
+          month: "long",
+          day: "numeric",
+        })}.`
+      : "Your trial is running."
+    : billing?.isPaid
+      ? "Thanks for supporting Anarlog."
+      : "On-device basics, free forever.";
+
+  return (
+    <div className={accountCardClassName}>
+      <div className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
+        {isPending ? (
+          <p className="text-sm leading-6 text-[#756b5d]">
+            Checking your plan...
+          </p>
+        ) : (
+          <>
+            <div>
+              <p className="text-base font-medium text-[#181613]">
+                You're on{" "}
+                <mark className="bg-[#fff0b3] px-1 font-semibold">
+                  {planLabel}
+                </mark>
+              </p>
+              <p className="mt-1 text-sm leading-6 text-[#756b5d]">
+                {planDetail}
+              </p>
+            </div>
+            {billing?.isPaid || billing?.isTrialing ? (
+              <Link to="/app/portal/" className={accountPillSecondaryClassName}>
+                Manage billing
+              </Link>
+            ) : (
+              <Link
+                to="/app/checkout/"
+                search={{
+                  period: "monthly",
+                  trial: "false",
+                  source: "settings",
+                }}
+                className={accountPillPrimaryClassName}
+              >
+                Upgrade to Pro
+              </Link>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_view/app/-account-profile-info.tsx
+++ b/apps/web/src/routes/_view/app/-account-profile-info.tsx
@@ -1,12 +1,26 @@
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 
+import { cn } from "@anlg/utils";
+
+import {
+  authInputClassName,
+  authNoticeClassName,
+} from "@/components/auth-shell";
 import { updateUserEmail } from "@/functions/auth";
+
+import { useAccountSession } from "./-account-session";
+import {
+  accountCardClassName,
+  accountPillPrimaryClassName,
+  accountPillSecondaryClassName,
+} from "./-account-ui";
 
 export function ProfileInfoSection({ email }: { email?: string }) {
   const [isEditing, setIsEditing] = useState(false);
   const [newEmail, setNewEmail] = useState("");
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const { data: accountSession } = useAccountSession();
 
   const updateEmailMutation = useMutation({
     mutationFn: async (email: string) => {
@@ -39,41 +53,35 @@ export function ProfileInfoSection({ email }: { email?: string }) {
   };
 
   return (
-    <div className="border-color-brand surface rounded-lg border">
-      <div className="px-8 pt-8">
-        <h3 className="text-color mb-2 font-sans text-lg font-semibold">
-          Profile
-        </h3>
-        <p className="text-color-secondary text-sm">
-          Your personal information
-        </p>
-      </div>
-
-      <div className="flex w-full flex-col p-8">
-        <div className="flex flex-col gap-4 md:flex-row md:justify-between">
-          <div className="text-color-secondary text-base">Email</div>
+    <div className={cn([accountCardClassName, "p-6 sm:p-8"])}>
+      <div className="flex flex-col gap-4">
+        <div
+          className={cn([
+            "flex flex-col gap-3 md:flex-row md:justify-between",
+            isEditing ? "md:items-start" : "md:items-center",
+          ])}
+        >
+          <span className="text-sm font-medium text-[#756b5d]">Email</span>
           {isEditing ? (
             <form
               onSubmit={handleSubmit}
-              className="flex w-full flex-1 flex-col justify-start gap-3 md:justify-end"
+              className="flex w-full flex-col gap-3 md:max-w-[420px]"
             >
-              <div className="flex w-full justify-start gap-2 md:justify-end">
-                <input
-                  type="email"
-                  value={newEmail}
-                  onChange={(e) => setNewEmail(e.target.value)}
-                  placeholder={email || "Enter new email"}
-                  className="border-color-brand flex-1 rounded-md border px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-stone-900 focus:outline-none"
-                  autoFocus
-                />
-              </div>
+              <input
+                type="email"
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+                placeholder={email || "Enter new email"}
+                className={authInputClassName}
+                autoFocus
+              />
               {updateEmailMutation.isError && (
                 <p className="text-sm text-red-600">
                   {updateEmailMutation.error?.message ||
                     "Failed to update email"}
                 </p>
               )}
-              <div className="flex w-full justify-start gap-2 md:justify-end">
+              <div className="flex justify-start gap-2 md:justify-end">
                 <button
                   type="submit"
                   disabled={
@@ -81,7 +89,7 @@ export function ProfileInfoSection({ email }: { email?: string }) {
                     !newEmail ||
                     newEmail === email
                   }
-                  className="flex h-8 items-center rounded-full bg-linear-to-t from-stone-600 to-stone-500 px-4 text-sm text-white shadow-md transition-all hover:scale-[102%] hover:shadow-lg active:scale-[98%] disabled:opacity-50 disabled:hover:scale-100"
+                  className={accountPillPrimaryClassName}
                 >
                   {updateEmailMutation.isPending ? "Saving..." : "Save"}
                 </button>
@@ -89,21 +97,23 @@ export function ProfileInfoSection({ email }: { email?: string }) {
                   type="button"
                   onClick={handleCancel}
                   disabled={updateEmailMutation.isPending}
-                  className="border-color-brand text-color-secondary flex h-8 items-center rounded-full border bg-linear-to-b from-white to-stone-50 px-4 text-sm shadow-xs transition-all hover:scale-[102%] hover:shadow-md active:scale-[98%] disabled:opacity-50"
+                  className={accountPillSecondaryClassName}
                 >
                   Cancel
                 </button>
               </div>
             </form>
           ) : (
-            <div className="flex items-center gap-3">
-              <div className="text-base">{email || "Not available"}</div>
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="text-base text-[#181613]">
+                {email || "Not available"}
+              </span>
               <button
                 onClick={() => {
                   setIsEditing(true);
                   setSuccessMessage(null);
                 }}
-                className="flex h-7 items-center rounded-full border border-neutral-300 bg-linear-to-b from-white to-stone-50 px-3 text-xs text-neutral-700 shadow-xs transition-all hover:scale-[102%] hover:shadow-md active:scale-[98%]"
+                className={accountPillSecondaryClassName}
               >
                 Change
               </button>
@@ -112,8 +122,24 @@ export function ProfileInfoSection({ email }: { email?: string }) {
         </div>
 
         {successMessage && (
-          <div className="rounded-md border border-green-200 bg-green-50 p-3">
-            <p className="text-sm text-green-800">{successMessage}</p>
+          <div className={authNoticeClassName}>
+            <p className="text-sm font-medium text-[#4f4940]">
+              {successMessage}
+            </p>
+          </div>
+        )}
+
+        {accountSession?.createdAt && (
+          <div className="flex flex-col gap-3 border-t border-[#ede7dc] pt-4 md:flex-row md:items-center md:justify-between">
+            <span className="text-sm font-medium text-[#756b5d]">
+              Member since
+            </span>
+            <span className="text-base text-[#181613]">
+              {new Date(accountSession.createdAt).toLocaleDateString("en-US", {
+                month: "long",
+                year: "numeric",
+              })}
+            </span>
           </div>
         )}
       </div>

--- a/apps/web/src/routes/_view/app/-account-session.ts
+++ b/apps/web/src/routes/_view/app/-account-session.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import { jwtDecode } from "jwt-decode";
+
+import { deriveBillingInfo, type SupabaseJwtPayload } from "@anlg/supabase";
+
+import { getSupabaseBrowserClient } from "@/functions/supabase";
+
+export function useAccountSession() {
+  return useQuery({
+    queryKey: ["account-session"],
+    queryFn: async () => {
+      const supabase = getSupabaseBrowserClient();
+      const { data } = await supabase.auth.getSession();
+      const session = data.session;
+      if (!session) {
+        return null;
+      }
+
+      return {
+        billing: deriveBillingInfo(
+          jwtDecode<SupabaseJwtPayload>(session.access_token),
+        ),
+        createdAt: session.user.created_at ?? null,
+      };
+    },
+  });
+}

--- a/apps/web/src/routes/_view/app/-account-session.ts
+++ b/apps/web/src/routes/_view/app/-account-session.ts
@@ -5,9 +5,11 @@ import { deriveBillingInfo, type SupabaseJwtPayload } from "@anlg/supabase";
 
 import { getSupabaseBrowserClient } from "@/functions/supabase";
 
+export const accountSessionQueryKey = ["account-session"];
+
 export function useAccountSession() {
   return useQuery({
-    queryKey: ["account-session"],
+    queryKey: accountSessionQueryKey,
     queryFn: async () => {
       const supabase = getSupabaseBrowserClient();
       const { data } = await supabase.auth.getSession();

--- a/apps/web/src/routes/_view/app/-account-ui.tsx
+++ b/apps/web/src/routes/_view/app/-account-ui.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@anlg/utils";
+
+export const accountCardClassName = cn([
+  "overflow-hidden rounded-[24px] border border-[#e5ddcf] bg-white",
+  "shadow-[0_18px_50px_rgba(24,22,19,0.08)]",
+]);
+
+export const accountPillPrimaryClassName = cn([
+  "flex h-9 cursor-pointer items-center justify-center rounded-full px-4",
+  "bg-[#181613] text-sm font-medium text-white",
+  "transition-colors hover:bg-[#4f4940]",
+  "disabled:cursor-not-allowed disabled:opacity-50",
+]);
+
+export const accountPillSecondaryClassName = cn([
+  "flex h-9 cursor-pointer items-center justify-center rounded-full border border-[#d9d1c5] bg-white px-4",
+  "text-sm font-medium text-[#181613]",
+  "transition-colors hover:bg-[#f7f4ef]",
+  "disabled:cursor-not-allowed disabled:opacity-50",
+]);
+
+export const accountPillDangerClassName = cn([
+  "flex h-9 cursor-pointer items-center justify-center rounded-full border border-red-200 bg-white px-4",
+  "text-sm font-medium text-red-700",
+  "transition-colors hover:border-red-300 hover:text-red-800",
+  "disabled:cursor-not-allowed disabled:opacity-50",
+]);

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -1,15 +1,19 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { ArrowRight } from "@phosphor-icons/react";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { jwtDecode } from "jwt-decode";
 import { useEffect } from "react";
 import { z } from "zod";
 
 import { deriveBillingInfo, type SupabaseJwtPayload } from "@anlg/supabase";
 
+import { AnarlogLogo } from "@/components/anarlog-logo";
 import { desktopSchemeSchema } from "@/functions/desktop-flow";
 import { getSupabaseBrowserClient } from "@/functions/supabase";
 import { useAnalytics } from "@/hooks/use-posthog";
 
 import { AccountAccessSection } from "./-account-access";
+import { DangerAreaSection } from "./-account-danger";
+import { PlanSection } from "./-account-plan";
 import { ProfileInfoSection } from "./-account-profile-info";
 
 const validateSearch = z
@@ -90,50 +94,104 @@ function Component() {
   ]);
 
   return (
-    <div>
-      <div className="mx-auto min-h-[calc(100vh-200px)] max-w-6xl">
-        <div className="border-color-brand flex items-center justify-start border-b py-20">
-          <h1 className="text-color text-left font-mono text-3xl font-medium">
-            Welcome back {user?.email?.split("@")[0] || "Guest"}
+    <main className="min-h-screen bg-white text-[#181613]">
+      <div className="mx-auto w-full max-w-[700px] px-5 pt-10 pb-16 md:px-8 md:pt-12 md:pb-24">
+        <Link to="/" aria-label="Anarlog home" className="inline-flex">
+          <AnarlogLogo className="h-8 w-auto" />
+        </Link>
+
+        <header className="mt-12 md:mt-16">
+          <p className="font-hand text-2xl leading-none font-semibold text-[#756b5d]">
+            Your account
+          </p>
+          <h1 className="font-hand mt-4 text-5xl leading-[0.98] font-semibold tracking-normal text-balance md:text-6xl">
+            Welcome back,{" "}
+            <mark className="bg-[#fff0b3] px-1 text-[#181613]">
+              {user?.email?.split("@")[0] || "Guest"}
+            </mark>
           </h1>
-        </div>
+        </header>
 
-        <div className="mx-auto mt-8 flex flex-col gap-10 pb-20">
-          <section className="space-y-4">
-            <div className="space-y-2 px-1">
-              <div>
-                <h2 className="text-fg font-mono text-2xl font-medium">
-                  Profile and account access
-                </h2>
-                <p className="text-fg-muted text-sm">
-                  Update your email here. Billing and integrations are managed
-                  in the desktop app.
-                </p>
-              </div>
-            </div>
-
-            <div className="space-y-6">
+        <div className="mt-14 flex flex-col gap-14 md:mt-16">
+          <section>
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+              Profile
+            </h2>
+            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
+              The email attached to your account, and how long you've been
+              around.
+            </p>
+            <div className="mt-6">
               <ProfileInfoSection email={user?.email} />
             </div>
           </section>
 
-          <section className="space-y-4">
-            <div className="space-y-2 px-1">
-              <div>
-                <h2 className="text-color font-mono text-2xl font-medium">
-                  Session controls
-                </h2>
-                <p className="text-color-muted text-sm">
-                  Sign out quickly, while keeping account deletion tucked behind
-                  an extra deliberate step.
-                </p>
-              </div>
+          <section>
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+              Your plan
+            </h2>
+            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
+              Billing runs through Stripe, and you can also manage it from the
+              desktop app.
+            </p>
+            <div className="mt-6">
+              <PlanSection />
             </div>
+          </section>
 
-            <AccountAccessSection />
+          <section>
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+              Session controls
+            </h2>
+            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
+              Sign out quickly whenever you need to.
+            </p>
+            <div className="mt-6">
+              <AccountAccessSection />
+            </div>
+          </section>
+
+          <section>
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+              Danger area
+            </h2>
+            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
+              Account deletion lives here, tucked behind an extra deliberate
+              step.
+            </p>
+            <div className="mt-6">
+              <DangerAreaSection />
+            </div>
+          </section>
+
+          <section>
+            <article
+              className="overflow-hidden rounded-[3px] border border-[#eadfce] bg-[#fffaf0] px-7 py-9 shadow-[0_18px_50px_rgba(68,54,36,0.12)] sm:px-10 sm:py-12"
+              style={{
+                backgroundImage:
+                  "linear-gradient(115deg, rgba(255, 250, 240, 0.9), rgba(246, 236, 218, 0.82)), url('/textures/crumpled-paper.webp')",
+                backgroundPosition: "center",
+                backgroundSize: "cover",
+              }}
+            >
+              <h2 className="font-hand text-3xl leading-none font-semibold text-[#363029]">
+                Anarlog lives on your desktop
+              </h2>
+              <p className="mt-4 max-w-xl text-base leading-7 text-[#363029]">
+                Notes, transcripts, and integrations all live in the app, on
+                your device. Grab it if you haven't already.
+              </p>
+              <Link
+                to="/download/"
+                className="mt-6 inline-flex items-center gap-2 rounded-full bg-[#181613] px-5 py-3 text-sm font-medium text-white"
+              >
+                <span>Download for free</span>
+                <ArrowRight size={16} weight="bold" aria-hidden="true" />
+              </Link>
+            </article>
           </section>
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -1,4 +1,5 @@
 import { ArrowRight } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { jwtDecode } from "jwt-decode";
 import { useEffect } from "react";
@@ -15,6 +16,7 @@ import { AccountAccessSection } from "./-account-access";
 import { DangerAreaSection } from "./-account-danger";
 import { PlanSection } from "./-account-plan";
 import { ProfileInfoSection } from "./-account-profile-info";
+import { accountSessionQueryKey } from "./-account-session";
 
 const validateSearch = z
   .object({
@@ -43,6 +45,7 @@ function Component() {
   const { user } = Route.useLoaderData();
   const search = Route.useSearch();
   const { identify: identifyPosthog, track } = useAnalytics();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (!search.success && search.trial !== "started") {
@@ -63,6 +66,9 @@ function Component() {
     const syncBillingAnalytics = async () => {
       const supabase = getSupabaseBrowserClient();
       const { data } = await supabase.auth.refreshSession();
+      // The refreshed JWT carries the post-checkout billing claims; cached
+      // account-session data is stale until it re-reads the session.
+      void queryClient.invalidateQueries({ queryKey: accountSessionQueryKey });
       const accessToken = data.session?.access_token;
       const userId = data.session?.user.id;
 
@@ -84,6 +90,7 @@ function Component() {
     void syncBillingAnalytics();
   }, [
     identifyPosthog,
+    queryClient,
     search.checkout,
     search.checkout_type,
     search.scheme,


### PR DESCRIPTION
The account page still used the old mono/grey card style while the
homepage and auth pages moved to the warm handwritten look. Rebuild it
on the homepage language: centered 700px column, Caveat headings with a
highlighted greeting, warm paper cards, and shared pill buttons in
-account-ui.tsx. Sign out and delete actions use destructive red pills.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new web billing CTAs and post-checkout cache invalidation; delete-account behavior is relocated but still calls the same API.
> 
> **Overview**
> Replaces the old mono/grey account layout with the warm homepage-style **700px** column: logo, handwritten headings, highlighted greeting, and shared card/pill styles in `-account-ui.tsx`.
> 
> **Profile** and **session** blocks are restyled; **sign out** is split from destructive actions and **delete account** moves into a dedicated **Danger area** accordion (`DangerAreaSection`) with the same confirm flow as before.
> 
> Adds **`useAccountSession`** (JWT billing + member `createdAt`) and a new **Your plan** section with upgrade / manage-billing links—where the old copy pointed people to the desktop app only. After checkout success, **`account-session`** is invalidated so plan UI picks up refreshed JWT claims.
> 
> A paper-texture **Download** promo closes the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025656b83470cadaca748f6249836bb1c0225c8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->