### PR TITLE
fix/privacy-copy

### DIFF
--- a/apps/web/src/components/home-page/privacy-section.tsx
+++ b/apps/web/src/components/home-page/privacy-section.tsx
@@ -21,9 +21,9 @@ const privacyCommitments = [
     visual: "files",
   },
   {
-    title: "Use your own stack",
+    title: "Own your AI stack",
     description:
-      "Export your data or process it with local models, your own API keys, and the tools you trust.",
+      "Run models on your device, bring your own keys, or use our AI.",
     visual: "key",
   },
 ];
@@ -50,7 +50,7 @@ export function PrivacySection() {
                 className="flex flex-col px-6 py-3 text-center md:w-[31%] md:p-4"
               >
                 <PrivacyVisual type={commitment.visual} />
-                <h3 className="mt-3 text-base font-medium text-[#4f4940] md:mt-5">
+                <h3 className="mt-5 text-base font-medium text-[#4f4940] md:mt-7">
                   {commitment.title}
                 </h3>
                 <p className="mx-auto mt-1 max-w-[17rem] text-sm leading-6 text-[#4f4940]">
@@ -111,7 +111,7 @@ function PrivacyVisual({
     return (
       <div className="flex h-24 items-center justify-center select-none md:h-28 md:w-full">
         <div
-          className="relative h-24 w-52 md:h-28 md:w-60"
+          className="relative h-20 w-44 md:h-24 md:w-48"
           role="img"
           aria-label="AI option cards cycling between cloud, key, and chip"
         >

--- a/apps/web/src/components/home-page/privacy-section.tsx
+++ b/apps/web/src/components/home-page/privacy-section.tsx
@@ -11,7 +11,7 @@ const privacyCommitments = [
   {
     title: "Invisible while you meet",
     description:
-      "No bot joins the participant list, and Anarlog's floating controls stay hidden when you share your screen.",
+      "No bot joins the meeting, and Anarlog stays hidden while sharing screens.",
     visual: "meeting",
   },
   {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -371,24 +371,24 @@
     0%,
     26% {
       z-index: 3;
-      transform: translate(1.6rem, 0.45rem) rotate(8deg) scale(1);
+      transform: translate(1.3rem, 0.35rem) rotate(8deg) scale(1);
     }
 
     36%,
     60% {
       z-index: 1;
-      transform: translate(-1.75rem, 0.9rem) rotate(-14deg) scale(0.92);
+      transform: translate(-1.4rem, 0.7rem) rotate(-14deg) scale(0.92);
     }
 
     70%,
     94% {
       z-index: 2;
-      transform: translate(-0.15rem, 0.25rem) rotate(-5deg) scale(0.96);
+      transform: translate(-0.1rem, 0.2rem) rotate(-5deg) scale(0.96);
     }
 
     100% {
       z-index: 3;
-      transform: translate(1.6rem, 0.45rem) rotate(8deg) scale(1);
+      transform: translate(1.3rem, 0.35rem) rotate(8deg) scale(1);
     }
   }
 
@@ -396,24 +396,24 @@
     0%,
     26% {
       z-index: 2;
-      transform: translate(-0.15rem, 0.25rem) rotate(-5deg) scale(0.96);
+      transform: translate(-0.1rem, 0.2rem) rotate(-5deg) scale(0.96);
     }
 
     36%,
     60% {
       z-index: 3;
-      transform: translate(1.6rem, 0.45rem) rotate(8deg) scale(1);
+      transform: translate(1.3rem, 0.35rem) rotate(8deg) scale(1);
     }
 
     70%,
     94% {
       z-index: 1;
-      transform: translate(-1.75rem, 0.9rem) rotate(-14deg) scale(0.92);
+      transform: translate(-1.4rem, 0.7rem) rotate(-14deg) scale(0.92);
     }
 
     100% {
       z-index: 2;
-      transform: translate(-0.15rem, 0.25rem) rotate(-5deg) scale(0.96);
+      transform: translate(-0.1rem, 0.2rem) rotate(-5deg) scale(0.96);
     }
   }
 
@@ -421,24 +421,24 @@
     0%,
     26% {
       z-index: 1;
-      transform: translate(-1.75rem, 0.9rem) rotate(-14deg) scale(0.92);
+      transform: translate(-1.4rem, 0.7rem) rotate(-14deg) scale(0.92);
     }
 
     36%,
     60% {
       z-index: 2;
-      transform: translate(-0.15rem, 0.25rem) rotate(-5deg) scale(0.96);
+      transform: translate(-0.1rem, 0.2rem) rotate(-5deg) scale(0.96);
     }
 
     70%,
     94% {
       z-index: 3;
-      transform: translate(1.6rem, 0.45rem) rotate(8deg) scale(1);
+      transform: translate(1.3rem, 0.35rem) rotate(8deg) scale(1);
     }
 
     100% {
       z-index: 1;
-      transform: translate(-1.75rem, 0.9rem) rotate(-14deg) scale(0.92);
+      transform: translate(-1.4rem, 0.7rem) rotate(-14deg) scale(0.92);
     }
   }
 
@@ -447,17 +447,17 @@
     top: 0.2rem;
     left: 50%;
     display: flex;
-    width: 4.25rem;
-    height: 5.75rem;
+    width: 3.4rem;
+    height: 4.6rem;
     align-items: center;
     justify-content: center;
     overflow: hidden;
     border: 1.5px solid #d6d3cc;
-    border-radius: 0.42rem;
+    border-radius: 0.35rem;
     background: #fffefa;
     box-shadow: 0 10px 18px rgba(24, 22, 19, 0.14);
     color: #181613;
-    margin-left: -2.125rem;
+    margin-left: -1.7rem;
     animation-duration: 9s;
     animation-iteration-count: infinite;
     animation-timing-function: ease-in-out;
@@ -471,15 +471,15 @@
 
   .ai-option-card-face {
     display: flex;
-    width: 2.35rem;
-    height: 2.35rem;
+    width: 1.9rem;
+    height: 1.9rem;
     align-items: center;
     justify-content: center;
   }
 
   .ai-option-card-face svg {
-    width: 2rem;
-    height: 2rem;
+    width: 1.6rem;
+    height: 1.6rem;
     stroke-width: 2.4;
   }
 
@@ -487,7 +487,7 @@
     position: absolute;
     display: flex;
     align-items: center;
-    font-size: 0.82rem;
+    font-size: 0.7rem;
     font-weight: 700;
     line-height: 0.86;
     letter-spacing: 0;
@@ -499,13 +499,13 @@
   }
 
   .ai-option-card-corner-top {
-    top: 0.42rem;
-    left: 0.42rem;
+    top: 0.35rem;
+    left: 0.35rem;
   }
 
   .ai-option-card-corner-bottom {
-    right: 0.42rem;
-    bottom: 0.42rem;
+    right: 0.35rem;
+    bottom: 0.35rem;
     transform: rotate(180deg);
   }
 
@@ -533,17 +533,17 @@
 
     .ai-option-card-cloud {
       z-index: 3;
-      transform: translate(1.6rem, 0.45rem) rotate(8deg) scale(1);
+      transform: translate(1.3rem, 0.35rem) rotate(8deg) scale(1);
     }
 
     .ai-option-card-key {
       z-index: 2;
-      transform: translate(-0.15rem, 0.25rem) rotate(-5deg) scale(0.96);
+      transform: translate(-0.1rem, 0.2rem) rotate(-5deg) scale(0.96);
     }
 
     .ai-option-card-chip {
       z-index: 1;
-      transform: translate(-1.75rem, 0.9rem) rotate(-14deg) scale(0.92);
+      transform: translate(-1.4rem, 0.7rem) rotate(-14deg) scale(0.92);
     }
   }
 }


### PR DESCRIPTION
Summary- Tighten and shorten privacy card copy: "Invisible while you meet" description changed to "No bot joins the meeting, and Anarlog stays hidden while sharing screens."
- Retitle third privacy tile to "Own your AI stack" with updated description: "Run models on your device, bring your own keys, or use our AI."
- Visual/UI adjustments to AI-stack cards: scale the playing-card visual down ~20%, reduce card/ icon/corner ranks, adjust shuffle keyframe offsets, and add more spacing each tile's visual and heading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Homepage copy and CSS-only visual tweaks with no logic, auth, or data handling changes.
> 
> **Overview**
> Updates the homepage **Privacy** section (`privacy-section.tsx`) marketing copy and the third tile’s **AI stack** visual treatment.
> 
> **Copy:** The “Invisible while you meet” blurb is shortened (no bot in the meeting; Anarlog hidden when screen sharing). The third commitment is retitled **“Own your AI stack”** with new body text covering on-device models, BYOK, or Anarlog’s AI.
> 
> **Layout:** Heading spacing above each tile title increases (`mt-5` / `md:mt-7`). The AI playing-card container is smaller (`h-20 w-44` / `md:h-24 md:w-48`).
> 
> **Styles:** In `styles.css`, `.ai-option-card` and related shuffle keyframes are scaled down (~20%): card dimensions, icon/corner sizes, translate offsets, and `prefers-reduced-motion` static poses are adjusted to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f90eaa89fd13b341a3129498e5844243e45e428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->