### PR TITLE
feat(web): render pricing cards and hero mockup as squircles

### DIFF
--- a/apps/web/src/components/home-page/hero-section.tsx
+++ b/apps/web/src/components/home-page/hero-section.tsx
@@ -126,7 +126,7 @@ function HeroWorkflowDemo() {
         aria-hidden="true"
       />
       <div
-        className="relative z-10 mx-auto max-w-[420px] overflow-hidden rounded-xl border-x border-t border-neutral-200 bg-white shadow-[0_24px_70px_rgba(24,22,19,0.08)] [corner-shape:squircle]"
+        className="relative z-10 mx-auto max-w-[420px] overflow-hidden rounded-3xl border-x border-t border-neutral-200 bg-white shadow-[0_24px_70px_rgba(24,22,19,0.08)] [corner-shape:squircle]"
         style={{
           WebkitMaskImage:
             "linear-gradient(to bottom, black 0%, black calc(100% - 5rem), transparent 100%)",

--- a/apps/web/src/components/home-page/pricing-section.tsx
+++ b/apps/web/src/components/home-page/pricing-section.tsx
@@ -37,7 +37,7 @@ function PricingCard({ plan }: { plan: MarketingPlanData }) {
   return (
     <article
       className={cn([
-        "flex min-h-[30rem] flex-col rounded-[3px] border bg-white p-6 transition-all duration-200",
+        "flex min-h-[30rem] flex-col rounded-3xl border bg-white p-6 transition-all duration-200 [corner-shape:squircle]",
         plan.popular
           ? "border-[#181613]/30 shadow-[0_22px_60px_rgba(24,22,19,0.14)] ring-1 ring-[#181613]/10"
           : "border-neutral-200 opacity-[0.58] shadow-[0_10px_32px_rgba(24,22,19,0.05)] focus-within:opacity-100 focus-within:shadow-[0_16px_46px_rgba(24,22,19,0.08)] hover:opacity-100 hover:shadow-[0_16px_46px_rgba(24,22,19,0.08)]",


### PR DESCRIPTION
Pricing cards move from rounded-[3px] to rounded-3xl with
corner-shape:squircle, and the hero mockup window frame bumps from
rounded-xl to rounded-2xl so its existing squircle corner-shape is
actually visible. Browsers without corner-shape support fall back to
plain rounded corners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only Tailwind/className changes on marketing components with graceful fallback for unsupported corner-shape.
> 
> **Overview**
> **Homepage marketing polish:** pricing plan cards and the hero workflow mockup frame now use larger corner radii with CSS **`corner-shape: squircle`** so the shape reads consistently with other squircle UI on the page.
> 
> **Pricing cards** go from near-square **`rounded-[3px]`** to **`rounded-3xl`** and gain **`[corner-shape:squircle]`**. **Hero mockup** keeps its existing squircle hint but bumps the frame from **`rounded-xl`** to **`rounded-3xl`** so the effect is visible. Browsers without **`corner-shape`** support still get standard rounded corners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d50de0c8a58adbc5d4362b85831c9e758883c24c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->