### PR TITLE
fix(desktop): keep toasts 300px wide in narrow windows

### DIFF
--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -265,3 +265,25 @@
   background-color: rgb(234 179 8) !important;
   border-radius: 2px;
 }
+
+/* Sonner switches to an edge-to-edge mobile layout when the viewport is under
+   600px; a narrow desktop window should keep the regular bottom-right toast
+   layout. Selectors are doubled to out-rank sonner's mobile rules regardless
+   of stylesheet order. */
+@media (max-width: 600px) {
+  [data-sonner-toaster][data-sonner-toaster] {
+    width: var(--width);
+    left: auto;
+    right: var(--offset-right);
+  }
+
+  [data-sonner-toaster][data-sonner-toaster][data-y-position="bottom"] {
+    bottom: var(--offset-bottom);
+  }
+
+  [data-sonner-toaster][data-sonner-toaster] [data-sonner-toast] {
+    left: auto;
+    right: auto;
+    width: var(--width);
+  }
+}


### PR DESCRIPTION
Sonner's built-in @media (max-width: 600px) rules stretch toasts
edge-to-edge, which is meant for phones but also triggered in narrow
desktop windows. Add an unlayered override in globals.css that restores
the regular bottom-right 300px toast layout; doubled attribute selectors
out-rank sonner's mobile rules regardless of stylesheet order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS for toast positioning with no auth, data, or business-logic impact.
> 
> **Overview**
> **Fixes Sonner toasts going full-width** when the desktop app window is narrower than 600px. Sonner treats that breakpoint as mobile and stretches toasts edge-to-edge; narrow desktop windows should still use the normal bottom-right, fixed-width layout.
> 
> Adds an **unlayered `@media (max-width: 600px)` block** in `globals.css` that resets the toaster and toast to `var(--width)`, `var(--offset-right)`, and `var(--offset-bottom)`. **Doubled `[data-sonner-toaster]` selectors** raise specificity so these rules win over Sonner’s bundled mobile styles regardless of load order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c175c93bc6749b0ff16b38b85884a0f4c060abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->