### PR TITLE
feat(web): reveal logo colors on hover in credibility marquee

### DIFF
--- a/apps/web/src/components/home-page/social-proof-sections.tsx
+++ b/apps/web/src/components/home-page/social-proof-sections.tsx
@@ -289,7 +289,7 @@ export function CredibilityLogoMarquee() {
                   src={logo.src}
                   alt=""
                   className={cn([
-                    "h-6 w-auto max-w-none object-contain opacity-65 grayscale",
+                    "h-6 w-auto max-w-none object-contain opacity-65 grayscale transition-[filter,opacity] duration-200 hover:opacity-100 hover:grayscale-0",
                     logo.className,
                   ])}
                   draggable={false}


### PR DESCRIPTION
Marquee logos render grayscale at 65% opacity; hovering one now
transitions it to full color and opacity over 200ms. Hover styles sit
behind Tailwind's hover: variant, so touch devices are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational Tailwind-only tweak on the marketing homepage with no logic, data, or auth impact.
> 
> **Overview**
> Credibility marquee logos on the home page hero still default to **65% opacity and grayscale**, but **hover** now animates them to **full color and opacity** over **200ms** via Tailwind `transition-[filter,opacity]` and `hover:grayscale-0` / `hover:opacity-100`.
> 
> Change is limited to the `CredibilityLogoMarquee` logo `img` classes in `social-proof-sections.tsx`; touch devices are unchanged because hover is variant-gated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bd18d42e45061b11f384497ec752edb611c3955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->