### PR TITLE
chore(ci): authenticate api_cd to Infisical via GitHub OIDC

### DIFF
--- a/.github/workflows/api_cd.yaml
+++ b/.github/workflows/api_cd.yaml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency: api-fly-deploy
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
@@ -34,6 +37,19 @@ jobs:
         with:
           platform: linux
       - uses: ./.github/actions/infisical_install
+      # Machine-identity OIDC login instead of a static service token: scopes
+      # live in the identity's editable project role, so secret reorganizations
+      # never require re-minting a token into GitHub secrets.
+      - name: Infisical OIDC login
+        run: |
+          set -euo pipefail
+          oidc_jwt=$(curl -sSf -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}" | jq -r '.value')
+          infisical_token=$(infisical login --method=oidc-auth \
+            --machine-identity-id=7dde9440-cec4-4cf0-a13f-1588ba67feb2 \
+            --jwt="$oidc_jwt" --silent --plain)
+          echo "::add-mask::$infisical_token"
+          echo "INFISICAL_TOKEN=$infisical_token" >> "$GITHUB_ENV"
       - name: Verify encrypted CloudSync
         run: |
           set -euo pipefail
@@ -53,7 +69,6 @@ jobs:
 
           python3 .github/scripts/verify_cloudsync_e2ee.py "$cloudsync_secrets_json"
         env:
-          INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
           INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
       - run: |
           set -euo pipefail
@@ -130,7 +145,6 @@ jobs:
           fi
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-          INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
           INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
       - run: flyctl deploy --config apps/api/fly.toml --dockerfile apps/api/Dockerfile --remote-only --build-arg APP_VERSION=${{ needs.compute-version.outputs.version }}
         env:


### PR DESCRIPTION
The API deploy has been failing since Aug 10: its legacy Infisical service token is scoped to /anarlog/ai + /anarlog/cloudsync only, and OPENROUTER_API_KEY in /anarlog/ai became a cross-folder reference to /anarlog, which the frozen token cannot expand (403). Service-token scopes are immutable, so this class of breakage recurs on every secrets reorganization.

Switch the deploy job to machine-identity auth via GitHub Actions OIDC (fastrepl_github, Viewer role, subject bound to repo:fastrepl/*). Permissions now live in the identity's editable project role, and the long-lived INFISICAL_TOKEN GitHub secret is no longer used by this workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deploy secret retrieval and depends on Infisical OIDC/machine-identity configuration; misconfiguration would block API deploys but does not alter runtime app code.
> 
> **Overview**
> **API CD** no longer uses a long-lived `INFISICAL_TOKEN` GitHub secret. The **deploy** job now requests **`id-token: write`**, runs an **Infisical OIDC login** step (GitHub Actions JWT → `infisical login --method=oidc-auth` with a fixed machine identity), masks the token, and sets **`INFISICAL_TOKEN`** in the job environment for the existing `infisical export` steps.
> 
> Infisical access for deploy is therefore tied to the machine identity’s **editable project role** instead of an immutable service-token path scope, which avoids 403s when secrets move or use cross-folder references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce989b34d9bceaedf852606b5b7fd1ca5671e72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->