### PR TITLE
feat(web): auto-open Nango connect UI for non-calendar integrations

### DIFF
--- a/apps/web/src/hooks/use-billing.ts
+++ b/apps/web/src/hooks/use-billing.ts
@@ -1,4 +1,8 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { jwtDecode } from "jwt-decode";
 import { useCallback, useEffect, useState } from "react";
 
@@ -46,6 +50,9 @@ export function useBilling() {
       return deriveBillingInfo(jwtDecode<SupabaseJwtPayload>(accessToken));
     },
     enabled: accessToken !== undefined,
+    // Keep isReady stable across token refreshes so consumers gating on it
+    // (e.g. the integration connect flow) do not unmount mid-flow.
+    placeholderData: keepPreviousData,
     retry: false,
   });
 

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -1,4 +1,4 @@
-import Nango from "@nangohq/frontend";
+import Nango, { type ConnectUI } from "@nangohq/frontend";
 import { useNavigate } from "@tanstack/react-router";
 import { useRef, useState } from "react";
 
@@ -8,6 +8,7 @@ import { createClient } from "@anlg/api-client/client";
 import { env } from "@/env";
 import { getAccessToken } from "@/functions/access-token";
 import { useAnalytics } from "@/hooks/use-posthog";
+import { useMountEffect } from "@/hooks/useMountEffect";
 import { captureOperationalError } from "@/lib/error-reporting";
 
 import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
@@ -28,6 +29,8 @@ export function ConnectFlow() {
     "idle" | "loading" | "connecting" | "success" | "error"
   >("idle");
   const inFlightRef = useRef(false);
+  const connectUIRef = useRef<ConnectUI | null>(null);
+  const disposedRef = useRef(false);
 
   const display = getIntegrationDisplay(search.integration_id);
 
@@ -106,6 +109,8 @@ export function ConnectFlow() {
       return;
     }
 
+    if (disposedRef.current) return;
+
     updateStatus("connecting");
 
     const connect = nango.openConnectUI({
@@ -155,8 +160,25 @@ export function ConnectFlow() {
       },
     });
 
+    connectUIRef.current = connect;
     connect.setSessionToken(sessionToken);
   };
+
+  // Nango's Connect UI repeats the connect prompt, so only calendars (which
+  // must show the OAuth data-use disclosure first) wait for a manual click.
+  // The Connect UI lives outside the React tree, so unmount must close it and
+  // stop in-flight session work from opening one on a stale view.
+  useMountEffect(() => {
+    disposedRef.current = false;
+    if (!isConnectedCalendar) {
+      void handleConnect();
+    }
+    return () => {
+      disposedRef.current = true;
+      connectUIRef.current?.close();
+      connectUIRef.current = null;
+    };
+  });
 
   const isLoading = status === "loading";
   const isConnecting = status === "connecting";


### PR DESCRIPTION
The integration page showed its own "Connect <name>" prompt that Nango's
Connect UI immediately repeats, forcing an extra click. Launch the connect
flow on mount for Slack, Linear, Notion, and GitHub; calendars keep the
manual step since their page carries the OAuth data-use disclosure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth/integration entry timing and unmount behavior; billing `isReady` semantics shift slightly during JWT refresh, which gates paid integration access.
> 
> **Overview**
> **Integration connect UX:** For Slack, Linear, Notion, GitHub, and similar non-calendar integrations, the connect flow now starts automatically on mount so users skip a redundant in-app "Connect" step before Nango's UI. **Google Calendar and Outlook** still require a manual click so the OAuth data-use disclosure stays on the page first.
> 
> **Lifecycle hardening:** The Nango Connect UI is tracked in a ref, closed on unmount, and session work checks a `disposed` flag so a stale view cannot open the modal after navigation away.
> 
> **Billing hook:** The JWT billing query uses `keepPreviousData` so `isReady` does not flicker during Supabase token refresh—avoiding the integration route from swapping `ConnectFlow` for a loading state mid-OAuth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bdd647402e8c68cfd4e2c5c8936d5fe6d10b13b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->