### PR TITLE
fix(desktop): reserve 600px min width for automations center area

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -36,10 +36,7 @@ import { useShell } from "~/contexts/shell";
 import { scrollElementByWheel } from "~/shared/dom/scroll-wheel";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { useWindowControlsGutter } from "~/shared/hooks/useWindowControlsGutter";
-import {
-  NOTE_SURFACE_MIN_WIDTH_PX,
-  usesNoteSurfaceMinWidth,
-} from "~/shared/main/layout-widths";
+import { getMainContentMinWidth } from "~/shared/main/layout-widths";
 import { useOpenNoteDialog } from "~/shared/open-note-dialog";
 import { useNewNote } from "~/shared/useNewNote";
 import type { SidebarNoteFilter } from "~/sidebar/note-filter";
@@ -80,7 +77,7 @@ export function ClassicMainBody() {
   leftSidebarPanelConstraintsRef.current = leftSidebarPanelConstraints;
 
   const isOnboarding = currentTab?.type === "onboarding";
-  const reserveNoteSurfaceMinWidth = usesNoteSurfaceMinWidth(currentTab);
+  const mainContentMinWidth = getMainContentMinWidth(currentTab);
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
@@ -541,11 +538,7 @@ export function ClassicMainBody() {
           id="classic-main-content"
           order={2}
           className="min-h-0 flex-1 overflow-hidden"
-          style={{
-            minWidth: reserveNoteSurfaceMinWidth
-              ? NOTE_SURFACE_MIN_WIDTH_PX
-              : undefined,
-          }}
+          style={{ minWidth: mainContentMinWidth }}
         >
           <div
             data-main-content-panel

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -231,6 +231,19 @@ describe("MainChatPanels", () => {
     expect(mocks.persistentChatPanel).not.toHaveBeenCalled();
   });
 
+  it("reserves enough main-body width for a 600px automations surface beside the sidebar", () => {
+    mocks.currentTab = { type: "automations" };
+    mocks.leftSidebarExpanded = true;
+
+    render(
+      <MainChatPanels>
+        <div data-testid="main-content" />
+      </MainChatPanels>,
+    );
+
+    expect(screen.getAllByTestId("panel")[0]?.dataset.minWidth).toBe("800");
+  });
+
   it("reserves enough main-body width for a 500px note surface beside the sidebar", () => {
     mocks.currentTab = { type: "sessions" };
     mocks.leftSidebarExpanded = true;

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -9,6 +9,7 @@ import {
 } from "@anlg/ui/components/ui/resizable";
 
 import {
+  AUTOMATIONS_SURFACE_MIN_WIDTH_PX,
   NOTE_SURFACE_MIN_WIDTH_PX,
   usesNoteSurfaceMinWidth,
 } from "./layout-widths";
@@ -125,6 +126,13 @@ function getMainBodyMinWidth({
   leftSidebarExpanded: boolean;
   noteSurfaceMinWidth: number;
 }) {
+  if (currentTab?.type === "automations") {
+    return (
+      AUTOMATIONS_SURFACE_MIN_WIDTH_PX +
+      (leftSidebarExpanded ? LEFT_SIDEBAR_MIN_WIDTH_PX : 0)
+    );
+  }
+
   if (!usesNoteSurfaceMinWidth(currentTab)) {
     return undefined;
   }

--- a/apps/desktop/src/shared/main/layout-widths.ts
+++ b/apps/desktop/src/shared/main/layout-widths.ts
@@ -1,6 +1,7 @@
 import type { Tab } from "~/store/zustand/tabs";
 
 export const NOTE_SURFACE_MIN_WIDTH_PX = 500;
+export const AUTOMATIONS_SURFACE_MIN_WIDTH_PX = 600;
 
 export function usesNoteSurfaceMinWidth(tab: Pick<Tab, "type"> | null) {
   return (
@@ -9,4 +10,11 @@ export function usesNoteSurfaceMinWidth(tab: Pick<Tab, "type"> | null) {
     tab?.type === "shared_note_preview" ||
     tab?.type === "empty"
   );
+}
+
+export function getMainContentMinWidth(tab: Pick<Tab, "type"> | null) {
+  if (tab?.type === "automations") {
+    return AUTOMATIONS_SURFACE_MIN_WIDTH_PX;
+  }
+  return usesNoteSurfaceMinWidth(tab) ? NOTE_SURFACE_MIN_WIDTH_PX : undefined;
 }


### PR DESCRIPTION
The automations tab had no main-content minimum, so the fixed 200px
custom sidebar and the always-open right chat panel could squeeze the
automation detail pane arbitrarily narrow.

Add AUTOMATIONS_SURFACE_MIN_WIDTH_PX (600) with a getMainContentMinWidth
helper in layout-widths, apply it to the classic-main-content panel, and
reserve 600px + sidebar width for the main body panel so the right chat
panel cannot shrink the center below its minimum.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop layout-only changes with a regression test; no auth, data, or API impact.
> 
> **Overview**
> The **automations** tab previously had no minimum width on the main content area, so the custom sidebar and docked right chat could squeeze the automation detail pane too narrow.
> 
> This PR introduces **`AUTOMATIONS_SURFACE_MIN_WIDTH_PX` (600)** and a shared **`getMainContentMinWidth`** helper. The classic main content panel uses that helper for its `minWidth`, and **`MainChatPanels`** reserves **600px plus left sidebar width** on the main-body panel when the automations tab is active—matching the existing note-surface pattern (500px + sidebar).
> 
> A test asserts the main-body panel gets **800px** minimum with the sidebar expanded (600 + 200).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd2d5b4c41aa106a6c2517494696ad6101c1b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->