### PR TITLE
fix(api): exclude retired Linear teams from team listing

### DIFF
--- a/crates/linear/src/client.rs
+++ b/crates/linear/src/client.rs
@@ -55,7 +55,7 @@ impl<C: HttpClient> LinearClient<C> {
 
         let query = r#"
             query ListTeams($first: Int!, $after: String) {
-                teams(first: $first, after: $after) {
+                teams(first: $first, after: $after, filter: { retiredAt: { null: true } }) {
                     nodes {
                         id
                         name


### PR DESCRIPTION
The automation team picker showed retired teams because the ListTeams
GraphQL query fetched all teams. Filter on retiredAt being null so only
active teams are returned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single query filter with no API contract change; low risk unless callers relied on seeing retired teams.
> 
> **Overview**
> **Linear team listings now omit retired teams** by adding a GraphQL filter `retiredAt: { null: true }` on the `ListTeams` query in `LinearClient::list_teams`.
> 
> That change applies everywhere this client method is used (including the automation team picker fed by `linearListTeams`), so retired teams no longer appear as selectable options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 858c874ce1876a5f45bc756d8fef66f7504b26d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->