### PR TITLE
fix(desktop): gate local LLM providers on server reachability

### DIFF
--- a/apps/desktop/src/settings/ai/llm/select.test.ts
+++ b/apps/desktop/src/settings/ai/llm/select.test.ts
@@ -142,43 +142,35 @@ describe("getLlmProviderStatus", () => {
     ]);
   });
 
-  test("keeps local providers active without API keys", () => {
-    const status = getLlmProviderStatus({
-      provider: provider("ollama"),
-      isAuthenticated: false,
-      isPaid: false,
-    });
+  test.each(["ollama", "lmstudio", "apple_foundation"])(
+    "only configures %s when its runtime is reachable, without an API key",
+    (id) => {
+      const pending = getLlmProviderStatus({
+        provider: provider(id),
+        isAuthenticated: false,
+        isPaid: false,
+      });
+      const unavailable = getLlmProviderStatus({
+        provider: provider(id),
+        isAuthenticated: false,
+        isPaid: false,
+        isAvailable: false,
+      });
+      const available = getLlmProviderStatus({
+        provider: provider(id),
+        isAuthenticated: false,
+        isPaid: false,
+        isAvailable: true,
+      });
 
-    expect(status.configured).toBe(true);
-    expect(status.listModels).toBeTypeOf("function");
-  });
-
-  test("only configures Apple Foundation Models when available", () => {
-    const pending = getLlmProviderStatus({
-      provider: provider("apple_foundation"),
-      isAuthenticated: false,
-      isPaid: false,
-    });
-    const unavailable = getLlmProviderStatus({
-      provider: provider("apple_foundation"),
-      isAuthenticated: false,
-      isPaid: false,
-      isAvailable: false,
-    });
-    const available = getLlmProviderStatus({
-      provider: provider("apple_foundation"),
-      isAuthenticated: false,
-      isPaid: false,
-      isAvailable: true,
-    });
-
-    expect(pending.configured).toBe(false);
-    expect(pending.availabilityPending).toBe(true);
-    expect(unavailable.configured).toBe(false);
-    expect(unavailable.availabilityPending).toBeUndefined();
-    expect(unavailable.listModels).toBeUndefined();
-    expect(available.configured).toBe(true);
-    expect(available.availabilityPending).toBeUndefined();
-    expect(available.listModels).toBeTypeOf("function");
-  });
+      expect(pending.configured).toBe(false);
+      expect(pending.availabilityPending).toBe(true);
+      expect(unavailable.configured).toBe(false);
+      expect(unavailable.availabilityPending).toBeUndefined();
+      expect(unavailable.listModels).toBeUndefined();
+      expect(available.configured).toBe(true);
+      expect(available.availabilityPending).toBeUndefined();
+      expect(available.listModels).toBeTypeOf("function");
+    },
+  );
 });

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -26,7 +26,7 @@ import { useBillingAccess } from "~/auth/billing-context";
 import {
   providerRowId,
   ProviderIconSlot,
-  useIsProviderReady,
+  useProviderAvailability,
 } from "~/settings/ai/shared";
 import {
   getProviderSelectionBlockers,
@@ -475,7 +475,7 @@ export function getLlmProviderStatus({
     return { configured: false };
   }
 
-  if (provider.id === "apple_foundation") {
+  if (provider.checkAvailability) {
     if (isAvailable === undefined) {
       return { configured: false, availabilityPending: true };
     }
@@ -568,18 +568,23 @@ function useConfiguredMapping(): {
 } {
   const auth = useAuth();
   const billing = useBillingAccess();
-  const appleFoundationAvailable = useIsProviderReady(
-    "apple_foundation",
-    "llm",
-    PROVIDERS,
-  );
+  const availability = useProviderAvailability("llm", PROVIDERS);
+  const { current_llm_provider } = useConfigValues([
+    "current_llm_provider",
+  ] as const);
   const { providers: configuredProviders, isReady } =
     useAiProvidersState("llm");
 
   const mapping = useMemo(() => {
     return Object.fromEntries(
-      PROVIDERS.map((provider) => {
+      PROVIDERS.map((provider: Provider) => {
         const config = configuredProviders[providerRowId("llm", provider.id)];
+        // The selected provider bypasses the reachability gate: a temporarily
+        // stopped local server should surface as a connection error, not
+        // silently re-persist the selection to another provider.
+        const isAvailable = provider.checkAvailability
+          ? provider.id === current_llm_provider || availability[provider.id]
+          : undefined;
         return [
           provider.id,
           getLlmProviderStatus({
@@ -587,18 +592,19 @@ function useConfiguredMapping(): {
             config,
             isAuthenticated: !!auth?.session,
             isPaid: billing.isPaid,
-            isAvailable:
-              provider.id === "apple_foundation"
-                ? appleFoundationAvailable
-                : undefined,
+            isAvailable,
           }),
         ];
       }),
     ) as Record<string, ProviderStatus>;
-  }, [configuredProviders, auth, billing, appleFoundationAvailable]);
+  }, [configuredProviders, auth, billing, availability, current_llm_provider]);
 
   return {
     providers: mapping,
-    isReady: isReady && mapping.apple_foundation?.availabilityPending !== true,
+    isReady:
+      isReady &&
+      Object.values(mapping).every(
+        (status) => status.availabilityPending !== true,
+      ),
   };
 }

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -2,8 +2,8 @@ import { Icon } from "@iconify-icon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { ArrowSquareOut } from "@phosphor-icons/react";
 import { type AnyFieldApi, useForm } from "@tanstack/react-form";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { type ReactNode, useState } from "react";
+import { useMutation, useQueries } from "@tanstack/react-query";
+import { type ReactNode, useMemo, useState } from "react";
 import { Streamdown } from "streamdown";
 
 import { commands as analyticsCommands } from "@anlg/plugin-analytics";
@@ -141,6 +141,66 @@ export function providerRowId(providerType: ProviderType, providerId: string) {
   return `${providerType}:${providerId}`;
 }
 
+export function useProviderAvailability(
+  providerType: ProviderType,
+  providers: readonly ProviderConfig[],
+): Record<string, boolean | undefined> {
+  const billing = useBillingAccess();
+  const configuredProviders = useAiProviders(providerType);
+
+  const inputs = providers
+    .filter((provider) => provider.checkAvailability)
+    .map((provider) => {
+      const config =
+        configuredProviders[providerRowId(providerType, provider.id)];
+      const baseUrl = String(config?.base_url || provider.baseUrl || "").trim();
+      const apiKey = String(config?.api_key || "").trim();
+      const isConfigured =
+        getProviderSelectionBlockers(provider.requirements, {
+          isAuthenticated: true,
+          isPaid: billing.isPaid,
+          config: { base_url: baseUrl, api_key: apiKey },
+        }).length === 0;
+
+      return { provider, baseUrl, apiKey, isConfigured };
+    });
+
+  const queries = useQueries({
+    queries: inputs.map(({ provider, baseUrl, apiKey, isConfigured }) => ({
+      queryKey: [
+        "ai-provider-availability",
+        providerType,
+        provider.id,
+        baseUrl,
+        apiKey,
+      ],
+      queryFn: () => provider.checkAvailability?.(baseUrl, apiKey) ?? false,
+      enabled: isConfigured,
+      retry: false,
+      refetchInterval: 5_000,
+    })),
+  });
+
+  const entries = inputs.map(
+    ({ provider, isConfigured }, index) =>
+      [
+        provider.id,
+        !isConfigured
+          ? false
+          : queries[index]?.isPending
+            ? undefined
+            : queries[index]?.data === true,
+      ] as const,
+  );
+
+  // Callers put this record in memo dependency lists, so its identity has to
+  // stay stable while the values do; a fresh object each render would recompute
+  // those memos and churn the derived listModels closures used as query keys.
+  const signature = entries.map(([id, value]) => `${id}=${value}`).join("|");
+
+  return useMemo(() => Object.fromEntries(entries), [signature]);
+}
+
 export function useIsProviderReady(
   providerId: string,
   providerType: ProviderType,
@@ -148,42 +208,25 @@ export function useIsProviderReady(
 ) {
   const billing = useBillingAccess();
   const configuredProviders = useAiProviders(providerType);
+  const availability = useProviderAvailability(providerType, providers);
   const providerDef = providers.find((p) => p.id === providerId);
-  const config = configuredProviders[providerRowId(providerType, providerId)];
 
+  if (providerDef?.checkAvailability) {
+    return availability[providerId];
+  }
+
+  const config = configuredProviders[providerRowId(providerType, providerId)];
   const baseUrl = String(config?.base_url || providerDef?.baseUrl || "").trim();
   const apiKey = String(config?.api_key || "").trim();
-  const isConfigured =
+
+  return (
     !!providerDef &&
     getProviderSelectionBlockers(providerDef.requirements, {
       isAuthenticated: true,
       isPaid: billing.isPaid,
       config: { base_url: baseUrl, api_key: apiKey },
-    }).length === 0;
-  const checkAvailability = providerDef?.checkAvailability;
-  const availabilityQuery = useQuery({
-    queryKey: [
-      "ai-provider-availability",
-      providerType,
-      providerId,
-      baseUrl,
-      apiKey,
-    ],
-    queryFn: () => checkAvailability?.(baseUrl, apiKey) ?? false,
-    enabled: isConfigured && !!checkAvailability,
-    retry: false,
-    refetchInterval: checkAvailability ? 5_000 : false,
-  });
-
-  if (!isConfigured || !checkAvailability) {
-    return isConfigured;
-  }
-
-  if (availabilityQuery.isPending) {
-    return undefined;
-  }
-
-  return availabilityQuery.data === true;
+    }).length === 0
+  );
 }
 
 export function NonAnarlogProviderCard({


### PR DESCRIPTION
Ollama and LM Studio always appeared selectable in the Intelligence model
picker because their default localhost base URLs satisfied the config-only
"configured" check, even with no server installed or running.

Generalize the apple_foundation availability special case: add a
useProviderAvailability hook (useQueries over every provider defining
checkAvailability, sharing the existing 5s-poll query keys) and gate
getLlmProviderStatus on reachability for all such providers. The currently
selected provider bypasses the gate so a temporarily stopped local server
surfaces as a connection error instead of silently re-persisting the
selection to another provider.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM provider eligibility and default-selection timing in settings; behavior is localized to AI provider configuration with clear test coverage.
> 
> **Overview**
> Local LLM providers (**Ollama**, **LM Studio**, **Apple Intelligence**) no longer count as configured just because their default URLs pass config checks—they must be **reachable** via each provider’s `checkAvailability` hook.
> 
> A new **`useProviderAvailability`** hook runs parallel availability queries (5s poll) for every provider that defines `checkAvailability`, and **`getLlmProviderStatus`** applies the same pending/unavailable/configured behavior for all of them instead of only Apple Foundation. The LLM model picker waits until **no** provider is still `availabilityPending`.
> 
> The **currently selected** LLM provider skips the reachability gate so a stopped local server shows a connection error instead of auto-switching to another provider. **`useIsProviderReady`** delegates availability providers to that shared hook instead of per-provider `useQuery`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eff9f28931208288959d43532699067607eaf59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->