### PR TITLE
feat(web): add self-serve management sections to account page

### DIFF
--- a/apps/web/src/functions/account-shares.ts
+++ b/apps/web/src/functions/account-shares.ts
@@ -1,0 +1,116 @@
+import { createServerFn } from "@tanstack/react-start";
+import { setResponseHeader } from "@tanstack/react-start/server";
+import { z } from "zod";
+
+import {
+  getSupabaseAdminClient,
+  getSupabaseServerClient,
+} from "@/functions/supabase";
+
+const accessibleSessionRowSchema = z.object({
+  share_id: z.string().uuid(),
+  manage_access: z.boolean(),
+});
+
+const shareDetailRowSchema = z.object({
+  id: z.string().uuid(),
+  general_scope: z.enum(["restricted", "workspace", "link", "public"]),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+const snapshotRowSchema = z.object({
+  share_id: z.string().uuid(),
+  title: z.string(),
+});
+
+export type ManagedShare = {
+  shareId: string;
+  title: string;
+  scope: "restricted" | "workspace" | "link" | "public";
+  updatedAt: string;
+};
+
+export type ManagedSharesResult =
+  | { status: "ready"; shares: ManagedShare[] }
+  | { status: "error" };
+
+export const listMyManagedShares = createServerFn({ method: "GET" }).handler(
+  async (): Promise<ManagedSharesResult> => {
+    setResponseHeader("Cache-Control", "no-store");
+
+    const supabase = getSupabaseServerClient();
+    const { data, error } = await supabase.rpc("list_my_accessible_sessions");
+    if (error || !Array.isArray(data)) {
+      return { status: "error" };
+    }
+
+    const parsedRows = z.array(accessibleSessionRowSchema).safeParse(data);
+    if (!parsedRows.success) {
+      return { status: "error" };
+    }
+
+    const managedIds = parsedRows.data
+      .filter((row) => row.manage_access)
+      .map((row) => row.share_id);
+    if (managedIds.length === 0) {
+      return { status: "ready", shares: [] };
+    }
+
+    const admin = getSupabaseAdminClient();
+    const [sharesRes, snapshotsRes] = await Promise.all([
+      admin
+        .from("session_shares")
+        .select("id, general_scope, created_at, updated_at")
+        .in("id", managedIds)
+        .is("deleted_at", null),
+      admin
+        .from("session_share_snapshots")
+        .select("share_id, title")
+        .in("share_id", managedIds),
+    ]);
+    if (sharesRes.error || snapshotsRes.error) {
+      return { status: "error" };
+    }
+
+    const parsedShares = z
+      .array(shareDetailRowSchema)
+      .safeParse(sharesRes.data);
+    const parsedSnapshots = z
+      .array(snapshotRowSchema)
+      .safeParse(snapshotsRes.data);
+    if (!parsedShares.success || !parsedSnapshots.success) {
+      return { status: "error" };
+    }
+
+    const titles = new Map(
+      parsedSnapshots.data.map((row) => [row.share_id, row.title]),
+    );
+
+    const shares = parsedShares.data
+      .map((row) => ({
+        shareId: row.id,
+        title: titles.get(row.id) ?? "",
+        scope: row.general_scope,
+        updatedAt: row.updated_at,
+      }))
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+
+    return { status: "ready", shares };
+  },
+);
+
+export const restrictMyShare = createServerFn({ method: "POST" })
+  .inputValidator(z.object({ shareId: z.string().uuid() }))
+  .handler(async ({ data }) => {
+    const supabase = getSupabaseServerClient();
+    const { error } = await supabase.rpc("set_session_share_scope", {
+      p_share_id: data.shareId,
+      p_general_scope: "restricted",
+    });
+
+    if (error) {
+      return { success: false as const, message: error.message };
+    }
+    return { success: true as const };
+  });

--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -319,6 +319,20 @@ export const signOutFn = createServerFn({ method: "POST" }).handler(
   },
 );
 
+export const signOutEverywhereFn = createServerFn({ method: "POST" }).handler(
+  async () => {
+    const supabase = getSupabaseServerClient();
+    const { error } = await supabase.auth.signOut({ scope: "global" });
+
+    if (error) {
+      return { success: false, message: error.message };
+    }
+
+    clearServerAnalyticsIdentity();
+    return { success: true };
+  },
+);
+
 export const exchangeOAuthCode = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({

--- a/apps/web/src/routes/_view/app/-account-access.tsx
+++ b/apps/web/src/routes/_view/app/-account-access.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 
-import { signOutFn } from "@/functions/auth";
+import { signOutEverywhereFn, signOutFn } from "@/functions/auth";
 import { captureOperationalError } from "@/lib/error-reporting";
 import { resetPrivateRouteAnalyticsIdentity } from "@/lib/private-route-analytics";
 
@@ -34,6 +34,27 @@ export function AccountAccessSection() {
     },
   });
 
+  const signOutEverywhere = useMutation({
+    mutationFn: async () => {
+      const res = await signOutEverywhereFn();
+      if (res.success) {
+        return true;
+      }
+
+      throw new Error(res.message);
+    },
+    onSuccess: () => {
+      resetPrivateRouteAnalyticsIdentity();
+      navigate({ to: "/" });
+    },
+    onError: (error) => {
+      captureOperationalError(error, {
+        operation: "account_sign_out_everywhere",
+      });
+      navigate({ to: "/" });
+    },
+  });
+
   return (
     <div className={accountCardClassName}>
       <div className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
@@ -45,10 +66,30 @@ export function AccountAccessSection() {
         </div>
         <button
           onClick={() => signOut.mutate()}
-          disabled={signOut.isPending}
+          disabled={signOut.isPending || signOutEverywhere.isPending}
           className={accountPillDangerClassName}
         >
           {signOut.isPending ? "Signing out..." : "Sign out"}
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-4 border-t border-[#ede7dc] p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
+        <div>
+          <p className="text-base font-medium text-[#181613]">
+            Sign out everywhere
+          </p>
+          <p className="mt-1 text-sm leading-6 text-[#756b5d]">
+            End sessions on every device where you're signed in.
+          </p>
+        </div>
+        <button
+          onClick={() => signOutEverywhere.mutate()}
+          disabled={signOut.isPending || signOutEverywhere.isPending}
+          className={accountPillDangerClassName}
+        >
+          {signOutEverywhere.isPending
+            ? "Signing out..."
+            : "Sign out everywhere"}
         </button>
       </div>
     </div>

--- a/apps/web/src/routes/_view/app/-account-api-keys.tsx
+++ b/apps/web/src/routes/_view/app/-account-api-keys.tsx
@@ -1,0 +1,119 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { listKeys, revokeKey } from "@anlg/api-client";
+
+import {
+  AccountRequestError,
+  getAuthorizedApiClient,
+  isPlanGated,
+} from "./-account-api";
+import {
+  accountCardClassName,
+  accountPillDangerClassName,
+} from "./-account-ui";
+
+const apiKeysQueryKey = ["account-api-keys"];
+
+export function ApiKeysSection() {
+  const queryClient = useQueryClient();
+
+  const keysQuery = useQuery({
+    queryKey: apiKeysQueryKey,
+    // Skip the SSR fetch: the browser-only access token throws on the
+    // server, and this data is session-scoped anyway.
+    enabled: typeof window !== "undefined",
+    queryFn: async () => {
+      const client = await getAuthorizedApiClient();
+      const { data, error, response } = await listKeys({ client });
+      if (error || !data) {
+        throw new AccountRequestError(
+          "Failed to load API keys",
+          response?.status,
+        );
+      }
+      return data;
+    },
+  });
+
+  const revoke = useMutation({
+    mutationFn: async (keyId: string) => {
+      const client = await getAuthorizedApiClient();
+      const { error } = await revokeKey({ client, path: { key_id: keyId } });
+      if (error) {
+        throw new Error("Failed to revoke API key");
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: apiKeysQueryKey });
+    },
+  });
+
+  const keys = keysQuery.data ?? [];
+
+  return (
+    <div className={accountCardClassName}>
+      {keysQuery.isPending ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          Checking your API keys...
+        </p>
+      ) : keysQuery.isError ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          {isPlanGated(keysQuery.error)
+            ? "Cloud API keys come with Pro. Create and use them from the desktop app."
+            : "We could not load your API keys. Refresh the page to try again."}
+        </p>
+      ) : keys.length === 0 ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          No API keys yet. Create one from the desktop app to use the Cloud API.
+        </p>
+      ) : (
+        <ul className="divide-y divide-[#ede7dc]">
+          {keys.map((key) => (
+            <li
+              key={key.id}
+              className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between sm:px-8"
+            >
+              <div>
+                <p className="text-base font-medium text-[#181613]">
+                  {key.name}{" "}
+                  <span className="font-mono text-sm text-[#756b5d]">
+                    {key.key_prefix}...
+                  </span>
+                </p>
+                <p className="mt-1 text-sm leading-6 text-[#756b5d]">
+                  Created{" "}
+                  {new Date(key.created_at).toLocaleDateString("en-US", {
+                    month: "long",
+                    day: "numeric",
+                  })}
+                  {key.last_used_at
+                    ? ` · last used ${new Date(
+                        key.last_used_at,
+                      ).toLocaleDateString("en-US", {
+                        month: "long",
+                        day: "numeric",
+                      })}`
+                    : " · never used"}
+                </p>
+              </div>
+              <button
+                onClick={() => revoke.mutate(key.id)}
+                disabled={revoke.isPending}
+                className={accountPillDangerClassName}
+              >
+                {revoke.isPending && revoke.variables === key.id
+                  ? "Revoking..."
+                  : "Revoke"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {revoke.isError && (
+        <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
+          {revoke.error?.message || "Failed to revoke API key"}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/_view/app/-account-api-keys.tsx
+++ b/apps/web/src/routes/_view/app/-account-api-keys.tsx
@@ -2,11 +2,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { listKeys, revokeKey } from "@anlg/api-client";
 
-import {
-  AccountRequestError,
-  getAuthorizedApiClient,
-  isPlanGated,
-} from "./-account-api";
+import { getAuthorizedApiClient } from "./-account-api";
+import { useAccountSession } from "./-account-session";
 import {
   accountCardClassName,
   accountPillDangerClassName,
@@ -16,6 +13,7 @@ const apiKeysQueryKey = ["account-api-keys"];
 
 export function ApiKeysSection() {
   const queryClient = useQueryClient();
+  const session = useAccountSession();
 
   const keysQuery = useQuery({
     queryKey: apiKeysQueryKey,
@@ -24,12 +22,9 @@ export function ApiKeysSection() {
     enabled: typeof window !== "undefined",
     queryFn: async () => {
       const client = await getAuthorizedApiClient();
-      const { data, error, response } = await listKeys({ client });
+      const { data, error } = await listKeys({ client });
       if (error || !data) {
-        throw new AccountRequestError(
-          "Failed to load API keys",
-          response?.status,
-        );
+        throw new Error("Failed to load API keys");
       }
       return data;
     },
@@ -52,19 +47,21 @@ export function ApiKeysSection() {
 
   return (
     <div className={accountCardClassName}>
-      {keysQuery.isPending ? (
+      {keysQuery.isPending || session.isPending ? (
         <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
           Checking your API keys...
         </p>
       ) : keysQuery.isError ? (
         <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
-          {isPlanGated(keysQuery.error)
-            ? "Cloud API keys come with Pro. Create and use them from the desktop app."
-            : "We could not load your API keys. Refresh the page to try again."}
+          We could not load your API keys. Refresh the page to try again.
         </p>
       ) : keys.length === 0 ? (
         <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
-          No API keys yet. Create one from the desktop app to use the Cloud API.
+          {/* Listing keys is not plan-gated, so an empty list is the only
+              signal a free user gets; creating one is Pro-only. */}
+          {session.data?.billing.isPro
+            ? "No API keys yet. Create one from the desktop app to use the Cloud API."
+            : "Cloud API keys come with Pro. Create and use them from the desktop app."}
         </p>
       ) : (
         <ul className="divide-y divide-[#ede7dc]">

--- a/apps/web/src/routes/_view/app/-account-api.ts
+++ b/apps/web/src/routes/_view/app/-account-api.ts
@@ -10,18 +10,3 @@ export async function getAuthorizedApiClient() {
     headers: { Authorization: `Bearer ${token}` },
   });
 }
-
-export class AccountRequestError extends Error {
-  constructor(
-    message: string,
-    readonly status?: number,
-  ) {
-    super(message);
-  }
-}
-
-// Only a 403 means the plan does not cover the resource; every other failure is
-// a load error and must not be reported to the user as a missing entitlement.
-export function isPlanGated(error: unknown) {
-  return error instanceof AccountRequestError && error.status === 403;
-}

--- a/apps/web/src/routes/_view/app/-account-api.ts
+++ b/apps/web/src/routes/_view/app/-account-api.ts
@@ -1,0 +1,27 @@
+import { createClient } from "@anlg/api-client/client";
+
+import { env } from "@/env";
+import { getAccessToken } from "@/functions/access-token";
+
+export async function getAuthorizedApiClient() {
+  const token = await getAccessToken();
+  return createClient({
+    baseUrl: env.VITE_API_URL,
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+export class AccountRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+  }
+}
+
+// Only a 403 means the plan does not cover the resource; every other failure is
+// a load error and must not be reported to the user as a missing entitlement.
+export function isPlanGated(error: unknown) {
+  return error instanceof AccountRequestError && error.status === 403;
+}

--- a/apps/web/src/routes/_view/app/-account-devices.tsx
+++ b/apps/web/src/routes/_view/app/-account-devices.tsx
@@ -1,0 +1,112 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+
+import { getSupabaseBrowserClient } from "@/functions/supabase";
+
+import {
+  accountCardClassName,
+  accountPillDangerClassName,
+} from "./-account-ui";
+
+const deviceRowSchema = z.object({
+  id: z.string(),
+  device_name: z.string().nullable(),
+  created_at: z.string(),
+  last_seen_at: z.string(),
+});
+
+const devicesQueryKey = ["account-sync-devices"];
+
+export function DevicesSection() {
+  const queryClient = useQueryClient();
+
+  const devicesQuery = useQuery({
+    queryKey: devicesQueryKey,
+    // Skip the SSR fetch: the browser-only Supabase client throws on the
+    // server, and this data is session-scoped anyway.
+    enabled: typeof window !== "undefined",
+    queryFn: async () => {
+      const supabase = getSupabaseBrowserClient();
+      const { data, error } = await supabase
+        .from("sync_devices")
+        .select("id, device_name, created_at, last_seen_at")
+        .order("last_seen_at", { ascending: false });
+      if (error) {
+        throw new Error(error.message);
+      }
+      return z.array(deviceRowSchema).parse(data);
+    },
+  });
+
+  const removeDevice = useMutation({
+    mutationFn: async (deviceId: string) => {
+      const supabase = getSupabaseBrowserClient();
+      const { error } = await supabase
+        .from("sync_devices")
+        .delete()
+        .eq("id", deviceId);
+      if (error) {
+        throw new Error(error.message);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: devicesQueryKey });
+    },
+  });
+
+  const devices = devicesQuery.data ?? [];
+
+  return (
+    <div className={accountCardClassName}>
+      {devicesQuery.isPending ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          Checking your devices...
+        </p>
+      ) : devicesQuery.isError ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          Couldn't load your devices. Refresh to try again.
+        </p>
+      ) : devices.length === 0 ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          No synced devices yet. Devices appear here once sync is on.
+        </p>
+      ) : (
+        <ul className="divide-y divide-[#ede7dc]">
+          {devices.map((device) => (
+            <li
+              key={device.id}
+              className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between sm:px-8"
+            >
+              <div>
+                <p className="text-base font-medium text-[#181613]">
+                  {device.device_name || "Unnamed device"}
+                </p>
+                <p className="mt-1 text-sm leading-6 text-[#756b5d]">
+                  Last seen{" "}
+                  {new Date(device.last_seen_at).toLocaleDateString("en-US", {
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </p>
+              </div>
+              <button
+                onClick={() => removeDevice.mutate(device.id)}
+                disabled={removeDevice.isPending}
+                className={accountPillDangerClassName}
+              >
+                {removeDevice.isPending && removeDevice.variables === device.id
+                  ? "Removing..."
+                  : "Remove"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {removeDevice.isError && (
+        <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
+          {removeDevice.error?.message || "Failed to remove device"}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/_view/app/-account-integrations.tsx
+++ b/apps/web/src/routes/_view/app/-account-integrations.tsx
@@ -3,11 +3,8 @@ import { Link } from "@tanstack/react-router";
 
 import { listConnections } from "@anlg/api-client";
 
-import {
-  AccountRequestError,
-  getAuthorizedApiClient,
-  isPlanGated,
-} from "./-account-api";
+import { getAuthorizedApiClient } from "./-account-api";
+import { useAccountSession } from "./-account-session";
 import {
   accountCardClassName,
   accountPillDangerClassName,
@@ -26,6 +23,8 @@ const INTEGRATION_NAMES: Record<string, string> = {
 const connectionsQueryKey = ["account-integrations"];
 
 export function IntegrationsSection() {
+  const session = useAccountSession();
+
   const connectionsQuery = useQuery({
     queryKey: connectionsQueryKey,
     // Skip the SSR fetch: the browser-only access token throws on the
@@ -33,12 +32,9 @@ export function IntegrationsSection() {
     enabled: typeof window !== "undefined",
     queryFn: async () => {
       const client = await getAuthorizedApiClient();
-      const { data, error, response } = await listConnections({ client });
+      const { data, error } = await listConnections({ client });
       if (error || !data) {
-        throw new AccountRequestError(
-          "Failed to load connections",
-          response?.status,
-        );
+        throw new Error("Failed to load connections");
       }
       return data.connections;
     },
@@ -48,20 +44,21 @@ export function IntegrationsSection() {
 
   return (
     <div className={accountCardClassName}>
-      {connectionsQuery.isPending ? (
+      {connectionsQuery.isPending || session.isPending ? (
         <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
           Checking your connections...
         </p>
       ) : connectionsQuery.isError ? (
         <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
-          {isPlanGated(connectionsQuery.error)
-            ? "Integrations come with Pro and connect from the desktop app."
-            : "We could not load your connections. Refresh the page to try again."}
+          We could not load your connections. Refresh the page to try again.
         </p>
       ) : connections.length === 0 ? (
         <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
-          Nothing connected yet. Connect calendars and tools from the desktop
-          app.
+          {/* The API gates /integration on any paid entitlement, so Lite users
+              already have access and must not see the upsell. */}
+          {session.data?.billing.isPaid
+            ? "Nothing connected yet. Connect calendars and tools from the desktop app."
+            : "Integrations come with a paid plan and connect from the desktop app."}
         </p>
       ) : (
         <ul className="divide-y divide-[#ede7dc]">

--- a/apps/web/src/routes/_view/app/-account-integrations.tsx
+++ b/apps/web/src/routes/_view/app/-account-integrations.tsx
@@ -1,0 +1,122 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+
+import { listConnections } from "@anlg/api-client";
+
+import {
+  AccountRequestError,
+  getAuthorizedApiClient,
+  isPlanGated,
+} from "./-account-api";
+import {
+  accountCardClassName,
+  accountPillDangerClassName,
+  accountPillSecondaryClassName,
+} from "./-account-ui";
+
+const INTEGRATION_NAMES: Record<string, string> = {
+  "google-calendar": "Google Calendar",
+  outlook: "Outlook Calendar",
+  linear: "Linear",
+  github: "GitHub",
+  slack: "Slack",
+  notion: "Notion",
+};
+
+const connectionsQueryKey = ["account-integrations"];
+
+export function IntegrationsSection() {
+  const connectionsQuery = useQuery({
+    queryKey: connectionsQueryKey,
+    // Skip the SSR fetch: the browser-only access token throws on the
+    // server, and this data is session-scoped anyway.
+    enabled: typeof window !== "undefined",
+    queryFn: async () => {
+      const client = await getAuthorizedApiClient();
+      const { data, error, response } = await listConnections({ client });
+      if (error || !data) {
+        throw new AccountRequestError(
+          "Failed to load connections",
+          response?.status,
+        );
+      }
+      return data.connections;
+    },
+  });
+
+  const connections = connectionsQuery.data ?? [];
+
+  return (
+    <div className={accountCardClassName}>
+      {connectionsQuery.isPending ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          Checking your connections...
+        </p>
+      ) : connectionsQuery.isError ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          {isPlanGated(connectionsQuery.error)
+            ? "Integrations come with Pro and connect from the desktop app."
+            : "We could not load your connections. Refresh the page to try again."}
+        </p>
+      ) : connections.length === 0 ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          Nothing connected yet. Connect calendars and tools from the desktop
+          app.
+        </p>
+      ) : (
+        <ul className="divide-y divide-[#ede7dc]">
+          {connections.map((connection) => {
+            const hasError = !!connection.last_error_type;
+            return (
+              <li
+                key={connection.connection_id}
+                className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between sm:px-8"
+              >
+                <div>
+                  <p className="text-base font-medium text-[#181613]">
+                    {INTEGRATION_NAMES[connection.integration_id] ??
+                      connection.integration_id}
+                  </p>
+                  <p className="mt-1 text-sm leading-6 text-[#756b5d]">
+                    {hasError
+                      ? connection.last_error_description ||
+                        "Connection needs attention."
+                      : "Connected."}
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  {hasError && (
+                    <Link
+                      to="/app/integration/"
+                      search={{
+                        flow: "web",
+                        integration_id: connection.integration_id,
+                        connection_id: connection.connection_id,
+                        action: "reconnect",
+                      }}
+                      className={accountPillSecondaryClassName}
+                    >
+                      Reconnect
+                    </Link>
+                  )}
+                  <Link
+                    to="/app/integration/"
+                    search={{
+                      flow: "web",
+                      integration_id: connection.integration_id,
+                      connection_id: connection.connection_id,
+                      action: "disconnect",
+                    }}
+                    className={accountPillDangerClassName}
+                  >
+                    Disconnect
+                  </Link>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/_view/app/-account-session.ts
+++ b/apps/web/src/routes/_view/app/-account-session.ts
@@ -10,6 +10,9 @@ export const accountSessionQueryKey = ["account-session"];
 export function useAccountSession() {
   return useQuery({
     queryKey: accountSessionQueryKey,
+    // Skip the SSR fetch: the browser-only Supabase client throws on the
+    // server, and this data is session-scoped anyway.
+    enabled: typeof window !== "undefined",
     queryFn: async () => {
       const supabase = getSupabaseBrowserClient();
       const { data } = await supabase.auth.getSession();

--- a/apps/web/src/routes/_view/app/-account-shares.tsx
+++ b/apps/web/src/routes/_view/app/-account-shares.tsx
@@ -1,0 +1,121 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+
+import {
+  listMyManagedShares,
+  restrictMyShare,
+} from "@/functions/account-shares";
+
+import {
+  accountCardClassName,
+  accountPillDangerClassName,
+  accountPillSecondaryClassName,
+} from "./-account-ui";
+
+const SCOPE_LABELS = {
+  public: "Public",
+  link: "Anyone with the link",
+  workspace: "Workspace",
+  restricted: "Invited people only",
+} as const;
+
+const sharesQueryKey = ["account-managed-shares"];
+
+export function SharedNotesSection() {
+  const queryClient = useQueryClient();
+
+  const sharesQuery = useQuery({
+    queryKey: sharesQueryKey,
+    // Skip the SSR fetch: this data is session-scoped and better fetched
+    // client-side like the rest of the account queries.
+    enabled: typeof window !== "undefined",
+    queryFn: async () => {
+      const result = await listMyManagedShares();
+      if (result.status !== "ready") {
+        throw new Error("Failed to load shared notes");
+      }
+      return result.shares;
+    },
+  });
+
+  const restrict = useMutation({
+    mutationFn: async (shareId: string) => {
+      const result = await restrictMyShare({ data: { shareId } });
+      if (!result.success) {
+        throw new Error(result.message);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: sharesQueryKey });
+    },
+  });
+
+  const shares = sharesQuery.data ?? [];
+
+  return (
+    <div className={accountCardClassName}>
+      {sharesQuery.isPending ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          Checking your shared notes...
+        </p>
+      ) : sharesQuery.isError ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          Couldn't load your shared notes. Refresh to try again.
+        </p>
+      ) : shares.length === 0 ? (
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          You haven't shared any notes yet. Notes you share from the desktop app
+          show up here.
+        </p>
+      ) : (
+        <ul className="divide-y divide-[#ede7dc]">
+          {shares.map((share) => (
+            <li
+              key={share.shareId}
+              className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between sm:px-8"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-base font-medium text-[#181613]">
+                  {share.title || "Untitled note"}
+                </p>
+                <p className="mt-1 text-sm leading-6 text-[#756b5d]">
+                  {SCOPE_LABELS[share.scope]} · updated{" "}
+                  {new Date(share.updatedAt).toLocaleDateString("en-US", {
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Link
+                  to="/share/$shareId/"
+                  params={{ shareId: share.shareId }}
+                  search={{ scheme: "anarlog" }}
+                  className={accountPillSecondaryClassName}
+                >
+                  Open
+                </Link>
+                {share.scope !== "restricted" && (
+                  <button
+                    onClick={() => restrict.mutate(share.shareId)}
+                    disabled={restrict.isPending}
+                    className={accountPillDangerClassName}
+                  >
+                    {restrict.isPending && restrict.variables === share.shareId
+                      ? "Restricting..."
+                      : "Restrict"}
+                  </button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      {restrict.isError && (
+        <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
+          {restrict.error?.message || "Failed to restrict shared note"}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -13,10 +13,14 @@ import { getSupabaseBrowserClient } from "@/functions/supabase";
 import { useAnalytics } from "@/hooks/use-posthog";
 
 import { AccountAccessSection } from "./-account-access";
+import { ApiKeysSection } from "./-account-api-keys";
 import { DangerAreaSection } from "./-account-danger";
+import { DevicesSection } from "./-account-devices";
+import { IntegrationsSection } from "./-account-integrations";
 import { PlanSection } from "./-account-plan";
 import { ProfileInfoSection } from "./-account-profile-info";
 import { accountSessionQueryKey } from "./-account-session";
+import { SharedNotesSection } from "./-account-shares";
 
 const validateSearch = z
   .object({
@@ -143,6 +147,55 @@ function Component() {
             </p>
             <div className="mt-6">
               <PlanSection />
+            </div>
+          </section>
+
+          <section>
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+              Integrations
+            </h2>
+            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
+              Calendars and tools connected to Anarlog.
+            </p>
+            <div className="mt-6">
+              <IntegrationsSection />
+            </div>
+          </section>
+
+          <section>
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+              Synced devices
+            </h2>
+            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
+              Anarlog syncs up to five devices. Remove one to free a slot.
+            </p>
+            <div className="mt-6">
+              <DevicesSection />
+            </div>
+          </section>
+
+          <section>
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+              Shared notes
+            </h2>
+            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
+              Notes you've shared with others. Restricting a note turns off link
+              and public access.
+            </p>
+            <div className="mt-6">
+              <SharedNotesSection />
+            </div>
+          </section>
+
+          <section>
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+              Cloud API keys
+            </h2>
+            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
+              Keys that let your own tools talk to the Anarlog Cloud API.
+            </p>
+            <div className="mt-6">
+              <ApiKeysSection />
             </div>
           </section>
 


### PR DESCRIPTION
The web account page showed identity and billing but offered no way to
manage the cloud-side objects that live there. Add sections backed by
existing APIs and RLS:

- Synced devices: list sync_devices with last-seen and a Remove action
  so users can free one of the five sync slots
- Integrations: list Nango connections via the cloud API with
  reconnect/disconnect links into the existing /app/integration flows
- Shared notes: new account-shares server fns list manageable shares
  (via list_my_accessible_sessions + admin lookups) and restrict a
  share back to invited-only via set_session_share_scope
- Cloud API keys: list and revoke keys via the cloud API
- Session controls: new sign-out-everywhere action using global scope

Account queries are gated to the client since they depend on
browser-only Supabase/token helpers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth (global sign-out), share visibility (restrict scope), API key revocation, and sync device deletion; authorization relies on existing RPCs/RLS/API rather than new backend rules.
> 
> **Overview**
> Expands the web **account** page beyond profile and billing with self-serve management for cloud-side objects, all loaded **client-only** (`enabled: typeof window !== "undefined"`) because session data depends on browser Supabase/token helpers.
> 
> New sections: **Integrations** (list Nango connections via Cloud API; reconnect/disconnect links into `/app/integration/`), **Synced devices** (list/delete `sync_devices` via RLS), **Shared notes** (`listMyManagedShares` / `restrictMyShare` server fns using `list_my_accessible_sessions`, admin title lookups, and `set_session_share_scope`), and **Cloud API keys** (list/revoke via `getAuthorizedApiClient` + existing API client).
> 
> **Session controls** add **Sign out everywhere** via new `signOutEverywhereFn` (`signOut({ scope: "global" })`), alongside the existing local sign-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a374f4693b9866e363763529edf75547607e698e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->