### PR TITLE
fix(content): correct stale Pro pricing across blog articles

### DIFF
--- a/apps/web/content/articles/best-ai-notetaker-for-in-person-meetings.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-in-person-meetings.mdx
@@ -84,7 +84,7 @@ Includes customizable templates for different meeting types, and offers conversa
 
 #### Pricing
 
-Free forever for local transcription, BYOK, and all core features. Managed cloud service is $25/month for the easiest setup.
+Free forever for local transcription, BYOK, and all core features. Managed cloud service is $15/month or $150/year for the easiest setup.
 
 For organizations with procurement requirements, evaluate the exact desktop configuration and any enabled AI, CloudSync, or sharing services before adoption.
 

--- a/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
@@ -70,7 +70,7 @@ The AI can work completely hands-off, generating organized notes without any inp
 
 - Zero lock-in—local SQLite storage, portable exports, and open-source code
 - [Free forever](/blog/free-ai-notetakers) for local transcription, BYOK, and all core features
-- Your choice of AI stack—managed cloud ($25/mo), bring your own keys, or run local
+- Your choice of AI stack—managed cloud ($15/mo), bring your own keys, or run local
 - Works without internet—great for secure environments
 - True file ownership—works with Obsidian, Notion, VS Code, anything
 - IT teams can audit the code and approve the AI provider
@@ -82,7 +82,7 @@ The AI can work completely hands-off, generating organized notes without any inp
 
 #### Pricing
 
-Anarlog is free forever for local transcription, BYOK, and all core features. Managed cloud service is $25/month for the easiest setup.
+Anarlog is free forever for local transcription, BYOK, and all core features. Managed cloud service is $15/month or $150/year for the easiest setup.
 
 For teams with compliance or procurement requirements, evaluate the exact desktop configuration and any enabled AI, CloudSync, or sharing services before adoption.
 

--- a/apps/web/content/articles/best-ai-notetaker.mdx
+++ b/apps/web/content/articles/best-ai-notetaker.mdx
@@ -22,7 +22,7 @@ I've spent considerable time testing these tools. I even built one myself. If yo
 
 | Tool          | Platform                            | Best For                              | Pricing                                    |
 | ------------- | ----------------------------------- | ------------------------------------- | ------------------------------------------ |
-| Anarlog      | macOS                               | Zero lock-in, complete control        | Free forever (local + BYOK). Cloud $25/mo  |
+| Anarlog      | macOS                               | Zero lock-in, complete control        | Free forever (local + BYOK). Cloud $15/mo  |
 | Obsidian + AI | Windows, macOS, Linux, iOS, Android | Knowledge management                  | Free (Sync $5/mo, Publish $10/mo)          |
 | Granola       | macOS, iPhone                       | Active note takers during meetings    | Free trial, then $14/mo                    |
 | Notion        | Web, Windows, macOS, iOS, Android   | Teams already using Notion            | Free (Business $24/mo for AI)              |
@@ -96,7 +96,7 @@ This works best for engineers and developers who want files over apps, companies
 
 #### Pricing:
 
-Anarlog is free forever for local transcription, BYOK, and all core features. Managed cloud service is $25/month for the easiest setup without managing API keys.
+Anarlog is free forever for local transcription, BYOK, and all core features. Managed cloud service is $15/month or $150/year for the easiest setup without managing API keys.
 
 ### 2. Obsidian with AI Plugins - Best for Knowledge Management
 

--- a/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
+++ b/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
@@ -64,7 +64,7 @@ Anarlog doesn't join your Google Meet as a bot. Instead, it captures both your m
 
 #### Pricing
 
-Unlimited free plan with local transcription or bring-your-own-key. Pro is $25/month for managed cloud service.
+Unlimited free plan with local transcription or bring-your-own-key. Pro is $15/month or $150/year for managed cloud service.
 
 ### 2. Fireflies AI: the conversation intelligence platform
 

--- a/apps/web/content/articles/char-vs-meetily.mdx
+++ b/apps/web/content/articles/char-vs-meetily.mdx
@@ -28,8 +28,7 @@ Meetily is a private transcription recorder. It records, transcribes locally, an
 |                  | **Anarlog**                                                             | **Meetily**                                             |
 | **Platform**     | macOS (check download page for updates)                              | macOS, Windows                                          |
 | **Free tier**    | On-device Transcription and Bring Your Own AI Model (cloud or local) | Ollama                                                  |
-| **Entry paid**   | $8/mo (Lite)                                                         | $10/mo (Pro)                                            |
-| **Pro**          | $25/mo or $250/year                                                  | $10/mo                                                  |
+| **Paid**         | $15/mo or $150/year (Pro)                                            | $10/mo (Pro)                                            |
 | **License**      | MIT                                                                  | MIT                                                     |
 | **GitHub stars** | [8,213](https://github.com/fastrepl/anarlog)                            | [11,081](https://github.com/Zackriya-Solutions/meetily) |
 | **Calendar**     | Google, Apple, Outlook                                               | Not available                                           |
@@ -84,9 +83,8 @@ Meetily's community edition works out of the box with Ollama. No account require
 
 Anarlog's free tier offers unlimited local transcription and requires a BYOK API key for AI summaries (OpenAI, Anthropic, Deepgram) or a local model via Ollama or LM Studio. Two minutes of setup if you have keys already. 
 
-- **Anarlog Lite: $8/month.** Cloud transcription, speaker identification, calendar integrations, sync, shareable links.
+- **Anarlog Pro: $15/month or $150/year.** Cloud transcription, cloud LLM, speaker identification, calendar connections, local-cloud sync, and DocSend-style shareable links with view tracking and expiration.
 - **Meetily Pro: $10/month.** Enhanced accuracy, auto-meeting detection, PDF and DOCX export, improved diarization. 14-day free trial.
-- **Anarlog Pro: $25/month or $250/year.** Everything in Lite plus granular sync control and DocSend-style shareable links with view tracking and expiration.
 
 ## **When Should You Use Meetily?**
 
@@ -107,4 +105,4 @@ Anarlog's free tier offers unlimited local transcription and requires a BYOK API
 
 Anarlog is free to download. The free tier works offline with a local model through Ollama or LM Studio. No subscription required to start.
 
-[Download Anarlog for Mac](https://anarlog.so/download) and run your first meeting with full local processing. Upgrade to Lite at $8/month if you want cloud transcription and speaker identification without managing API keys.
+[Download Anarlog for Mac](https://anarlog.so/download) and run your first meeting with full local processing. Upgrade to Pro at $15/month if you want cloud transcription and speaker identification without managing API keys.

--- a/apps/web/content/articles/fathom-ai-alternatives.mdx
+++ b/apps/web/content/articles/fathom-ai-alternatives.mdx
@@ -27,7 +27,7 @@ If any of that bothers you, here are the top Fathom AI alternatives.
 
 | Tool      | Best For                                           | Starting Price                  |
 | --------- | -------------------------------------------------- | ------------------------------- |
-| Anarlog  | Zero lock-in, complete control                     | Free forever (local + BYOK). Cloud: $25/mo |
+| Anarlog  | Zero lock-in, complete control                     | Free forever (local + BYOK). Cloud: $15/mo |
 | Avoma     | Sales teams needing coaching & deal intelligence   | $19/mo base ($54-109 realistic) |
 | Read AI   | Teams wanting unified search across communications | $19.75/mo                       |
 | Fireflies | Teams needing deep conversation analytics          | Free (Pro: $18/mo)              |

--- a/apps/web/content/articles/fireflies-ai-alternatives.mdx
+++ b/apps/web/content/articles/fireflies-ai-alternatives.mdx
@@ -62,7 +62,7 @@ Fireflies does what it promises for basic transcription and automation, especial
 
 | Tool      | Best For                                                 | Pricing                                           | Platforms                                        |
 | --------- | -------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------ |
-| Anarlog  | Zero lock-in, complete control over data and AI stack    | Free forever (local + BYOK). Cloud: $25/mo        | All platforms (system audio capture) + in-person |
+| Anarlog  | Zero lock-in, complete control over data and AI stack    | Free forever (local + BYOK). Cloud: $15/mo        | All platforms (system audio capture) + in-person |
 | Avoma     | Sales teams needing revenue intelligence                 | $29-39/month base + $35-70/month add-ons          | Zoom, Teams, Google Meet, Webex                  |
 | Otter AI  | Teams wanting established platform with collaboration    | $16.99/user/mo (Free: 300 min)                    | Zoom, Teams, Google Meet                         |
 | MeetGeek  | Teams needing automated workflows & meeting analytics    | $19/user/mo (Free: 3 hours of transcription/mo)   | Zoom, Teams, Google Meet, Webex + 50 languages   |

--- a/apps/web/content/articles/free-transcription-software.mdx
+++ b/apps/web/content/articles/free-transcription-software.mdx
@@ -99,7 +99,7 @@ Zero lock-in means you can switch AI providers anytime and your files work with 
 
 ![Anarlog pricing](/api/assets/blog/articles/free-transcription-software/screenshot-2026-03-04-at-9-01-49-pm.png)
 
-Free forever for local transcription, BYOK, and all core features. The managed cloud service ($25/month) adds the easiest setup without managing API keys.
+Free forever for local transcription, BYOK, and all core features. The managed cloud service ($15/month or $150/year) adds the easiest setup without managing API keys.
 
 For teams with procurement requirements, evaluate the exact desktop configuration and any enabled AI, CloudSync, or sharing services before adoption.
 

--- a/apps/web/content/articles/is-fireflies-ai-safe.mdx
+++ b/apps/web/content/articles/is-fireflies-ai-safe.mdx
@@ -138,7 +138,7 @@ Check out our [Fireflies AI Alternatives](/blog/fireflies-ai-alternatives) artic
 
 **Your choice of AI stack:**
 
-Managed cloud service ($25/mo), bring your own API keys, or run local models via Ollama. You choose which AI processes your data—not Fireflies.
+Managed cloud service ($15/mo), bring your own API keys, or run local models via Ollama. You choose which AI processes your data—not Fireflies.
 
 **Universal compatibility without bots:**
 

--- a/apps/web/content/articles/mac-productivity-apps.mdx
+++ b/apps/web/content/articles/mac-productivity-apps.mdx
@@ -20,7 +20,7 @@ If you're a Mac user looking to actually get more done (not just feel productive
 
 | Tool             | Best For                                                                | Pricing                             |
 | ---------------- | ----------------------------------------------------------------------- | ----------------------------------- |
-| Anarlog             | AI note-taker with complete control over data and AI stack              | Free, Pro $25/mo                    |
+| Anarlog             | AI note-taker with complete control over data and AI stack              | Free, Pro $15/mo                    |
 | Cowork           | AI agent that handles tedious file work and research                    | Claude Pro/Team/Enterprise required |
 | Raycast          | Replacing Spotlight with a command center that actually does things     | Free, Pro $10/mo                    |
 | Obsidian         | Building a personal knowledge base with files you actually own          | Free, Sync $8/mo                    |
@@ -71,7 +71,7 @@ Meetings suck, but they're inevitable. The next best thing is making sure you ne
 
 #### Pricing:
 
-Unlimited free plan with local transcription or bring-your-own-key. Pro is $25/month for managed cloud service.
+Unlimited free plan with local transcription or bring-your-own-key. Pro is $15/month or $150/year for managed cloud service.
 
 ### 2. Cowork: best AI agent for file management and research on Mac
 

--- a/apps/web/content/articles/markdown-note-taking-apps.mdx
+++ b/apps/web/content/articles/markdown-note-taking-apps.mdx
@@ -20,7 +20,7 @@ This list covers five apps, each strong for a specific use case, so you can find
 | &nbsp;   | &nbsp;                         | &nbsp;          | &nbsp;          | &nbsp;            |
 | -------- | ------------------------------ | --------------- | --------------- | ----------------- |
 | **App**  | **Best For**                   | **Open Source** | **Local Files** | **Price**         |
-| Anarlog     | Meeting notes                  | ✅               | ✅               | Free / $25/mo     |
+| Anarlog     | Meeting notes                  | ✅               | ✅               | Free / $15/mo     |
 | Obsidian | Personal knowledge management  | ❌               | ✅               | Free / $4/mo sync |
 | Logseq   | Daily journaling & outlining   | ✅               | ✅               | Free              |
 | Joplin   | Cross-device sync with privacy | ✅               | ✅               | Free / 2.99€/mo   |
@@ -64,7 +64,7 @@ This list covers five apps, each strong for a specific use case, so you can find
 
 #### Pricing:
 
-Free plan with local transcription or bring-your-own-key. Pro is $25/month for the managed cloud service.
+Free plan with local transcription or bring-your-own-key. Pro is $15/month or $150/year for the managed cloud service.
 
 ### 2. Obsidian - best markdown note-taking app for personal knowledge management
 

--- a/apps/web/content/articles/meeting-productivity-tools.mdx
+++ b/apps/web/content/articles/meeting-productivity-tools.mdx
@@ -64,7 +64,7 @@ That design is deliberate. Engineers, developers, and privacy-conscious professi
 
 #### Pricing
 
-Free with local transcription or bring-your-own API keys. Pro is $25/month for the managed cloud service.
+Free with local transcription or bring-your-own API keys. Pro is $15/month or $150/year for the managed cloud service.
 
 ### 2. Calendly: best for scheduling without the email back-and-forth
 

--- a/apps/web/content/articles/mistral-api-key.mdx
+++ b/apps/web/content/articles/mistral-api-key.mdx
@@ -102,6 +102,6 @@ The workflow is simple: record, transcribe locally, summarize with your own Mist
 
 The local meeting record, audio, transcript, and summary remain on your device by default. Anarlog stores meeting data in local SQLite; if you enable cloud AI, CloudSync, or sharing, assess those services independently for the data you send to them.
 
-Plus, all core features, local transcription, and BYOK stay completely free. You’re already paying for the API key, you shouldn’t have to pay twice. But if you want cloud services and don't want to manage keys at all, there is a $8/month plan you can check out. 
+Plus, all core features, local transcription, and BYOK stay completely free. You’re already paying for the API key, you shouldn’t have to pay twice. But if you want cloud services and don't want to manage keys at all, there is a $15/month plan you can check out. 
 
 To connect Mistral, open Anarlog's settings, go to API Keys, paste your key, and that's it. Try it out for free now - [Download Anarlog for macOS](https://anarlog.so/download/).

--- a/apps/web/content/articles/open-source-meeting-transcription-software.mdx
+++ b/apps/web/content/articles/open-source-meeting-transcription-software.mdx
@@ -169,7 +169,7 @@ Ready to try it? [Download Anarlog for macOS](/download) or [check out the sourc
 
 ### 1. Are open-source transcription tools really free?
 
-Yes, all three are open source. Anarlog and Amical are [free](/blog/free-transcription-software/) for all users. Anarlog is free forever for local transcription and BYOK. The managed cloud service is $25/month, and Enterprise tier has custom pricing.
+Yes, all three are open source. Anarlog and Amical are [free](/blog/free-transcription-software/) for all users. Anarlog is free forever for local transcription and BYOK. The managed cloud service is $15/month or $150/year.
 
 Meetily is free for individual users under the MIT license. Organizations (2-100 users) and enterprises (100+ users) can request custom plans, but pricing isn't publicly listed.
 
@@ -189,6 +189,6 @@ With larger Whisper models, accuracy typically reaches 90-95% for clear English 
 
 Local processing can reduce the number of external processors in a workflow, but it does not make a tool automatically compliant. Regulated teams still need to assess retention, access controls, agreements, security controls, and every enabled provider.
 
-Organizations needing formal compliance documentation can use Anarlog or Meetily's enterprise plans, which include dedicated support.
+Anarlog has no separate enterprise tier; Pro is the only paid plan. Meetily offers custom organizational and enterprise plans for teams that need dedicated support.
 
 &nbsp;

--- a/apps/web/content/articles/plaud-ai-alternatives.mdx
+++ b/apps/web/content/articles/plaud-ai-alternatives.mdx
@@ -103,7 +103,7 @@ Meeting data is stored locally in SQLite. You can export Markdown when you need 
 
 Anarlog is free forever for local transcription, BYOK, and all core features. No artificial caps, no trial that expires.
 
-The managed cloud service is $25/month for those who want the easiest setup without managing API keys. Most people never need to pay—the free plan handles meeting notes completely.
+The managed cloud service is $15/month or $150/year for those who want the easiest setup without managing API keys. Most people never need to pay—the free plan handles meeting notes completely.
 
 For teams with procurement requirements, evaluate the exact desktop configuration and any enabled AI, CloudSync, or sharing services before adoption.
 

--- a/apps/web/content/articles/read-ai-alternatives.mdx
+++ b/apps/web/content/articles/read-ai-alternatives.mdx
@@ -44,7 +44,7 @@ The AI stack is yours to pick: Anarlog's managed cloud service, your own API key
 
 For companies that blocked Read AI over data residency, Anarlog is one of the few tools where "local-first" means exactly what it says, because you can read the source code to verify it.
 
-It runs on macOS and Linux. Windows support isn't here yet, and there's no mobile app, no built-in CRM sync, no engagement scoring. Anarlog focuses on transcription, notes, and AI summaries with complete data ownership. Free for unlimited local transcription or BYOK setups. Pro is $25/month for managed cloud. 45+ languages.
+It runs on macOS and Linux. Windows support isn't here yet, and there's no mobile app, no built-in CRM sync, no engagement scoring. Anarlog focuses on transcription, notes, and AI summaries with complete data ownership. Free for unlimited local transcription or BYOK setups. Pro is $15/month or $150/year for managed cloud. 45+ languages.
 
 ### 2. Jamie
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -16,7 +16,7 @@ If you don't want your meeting audio on someone else's servers, these are your o
 |              |             |                 |                                               |                    |                                |
 | ------------ | ----------- | --------------- | --------------------------------------------- | ------------------ | ------------------------------ |
 | **Tool**     | **License** | **Platform**    | **Local STT**                                 | **Local LLM**      | **Pricing**                    |
-| **Anarlog**     | MIT         | macOS           | Parakeet V3, Parakeet Batch + 7 cloud         | Ollama / LM Studio | Free (local) · $8–$25/mo cloud |
+| **Anarlog**     | MIT         | macOS           | Parakeet V3, Parakeet Batch + 7 cloud         | Ollama / LM Studio | Free (local) · $15/mo cloud |
 | **Meetily**  | MIT         | Windows, macOS  | Whisper, Parakeet                             | Ollama             | Free · $10/mo Pro              |
 | **Scriberr** | MIT         | Docker (web)    | Whisper.cpp                                   | Ollama             | Free                           |
 | **Vibe**     | MIT         | Win, Mac, Linux | Whisper.cpp                                   | No built-in        | Free                           |
@@ -55,7 +55,7 @@ Calendar integration (Apple, Google, Outlook) with auto-record on event start. A
 
 #### Pricing
 
-Free for fully local use (on-device STT + local LLM). Cloud features available at $8–$25/month.
+Free for fully local use (on-device STT + local LLM). Cloud features available at $15/month or $150/year.
 
 ### 2. Meetily
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -20,7 +20,7 @@ I spent weeks testing alternatives that remove that ceiling in different ways. H
 |                  |                      |                                                                           |                                         |
 | ---------------- | -------------------- | ------------------------------------------------------------------------- | --------------------------------------- |
 | **Tool**         | **Chrome extension** | **Best For**                                                              | **Pricing**                             |
-| **Anarlog**         | No                   | Developers and tech founder who want control over their data and AI stack | Free (local/BYOK); Pro $25/mo           |
+| **Anarlog**         | No                   | Developers and tech founder who want control over their data and AI stack | Free (local/BYOK); Pro $15/mo           |
 | **Otter.ai**     | Yes                  | Teams that need cross-meeting search and a mature knowledge base          | Free (300 min/mo); Pro $16.99/mo        |
 | **Granola**      | No                   | Individuals who want a notepad-first workflow without a meeting bot       | ~$14/mo (Business)                      |
 | **Fathom**       | Yes                  | Solo users who want unlimited free transcription with fast summaries      | Free (unlimited); Team from $32/user/mo |
@@ -57,7 +57,7 @@ It transcribes in real time while you take notes in a built-in editor, then comb
 
 #### Pricing
 
-Free with on-device transcription and bring-your-own keys; Lite at $8/month adds cloud transcription and speaker ID; Pro at $25/month adds sync, integrations, and shareable links.
+Free with on-device transcription and bring-your-own keys; Pro at $15/month or $150/year adds cloud transcription, speaker ID, sync, integrations, and shareable links.
 
 ### 2. Otter.ai
 

--- a/apps/web/content/articles/tldv-alternatives.mdx
+++ b/apps/web/content/articles/tldv-alternatives.mdx
@@ -14,7 +14,7 @@ So, if you're in the market for a tl;dv alternative, I have compiled the best op
 
 | Tool         | Best for                                      | Pricing                                   | Bot-free? |
 | ------------ | --------------------------------------------- | ----------------------------------------- | --------- |
-| Anarlog         | Data ownership, privacy, offline use          | Free (local + BYOK). Cloud: $25/mo        | Yes       |
+| Anarlog         | Data ownership, privacy, offline use          | Free (local + BYOK). Cloud: $15/mo        | Yes       |
 | Fathom       | Free unlimited recording, small teams         | Free. Premium: $19/mo                     | No        |
 | Grain        | Video clips and customer highlights           | Free (5 recordings). Starter: $15/mo      | No        |
 | Fireflies    | Conversation analytics at a lower price       | Free (limited). Pro: $18/mo               | No        |
@@ -36,7 +36,7 @@ tl;dv sends your audio to their servers, then to Anthropic for processing. You g
 
 Anarlog skips the video entirely and gives you text-based meeting intelligence with complete data ownership.
 
-tl;dv Pro is $29/month. Anarlog is free for local transcription and BYOK, or $25/month for managed cloud. If you left tl;dv over pricing or privacy, the gap here is still meaningful.
+tl;dv Pro is $29/month. Anarlog is free for local transcription and BYOK, or $15/month for managed cloud. If you left tl;dv over pricing or privacy, the gap here is still meaningful.
 
 #### Top Features
 
@@ -64,7 +64,7 @@ tl;dv Pro is $29/month. Anarlog is free for local transcription and BYOK, or $25
 
 #### Pricing
 
-Free forever for local transcription, BYOK, and all core features. Managed cloud is $25/month.
+Free forever for local transcription, BYOK, and all core features. Managed cloud is $15/month or $150/year.
 
 <CtaCard title="Try Anarlog for free" description="Open-source meeting notes. Your data stays on your device." buttonText="Download Anarlog" buttonUrl="/download" />
 

--- a/apps/web/content/articles/tldv-review.mdx
+++ b/apps/web/content/articles/tldv-review.mdx
@@ -181,7 +181,7 @@ But tl;dv is priced at a premium without offering premium features until you hit
 
 - Work in healthcare, legal, finance, or other privacy-sensitive fields where bot visibility and cloud processing create compliance issues. Anarlog might be worth exploring.
 - Need to capture in-person meetings, use diverse platforms beyond the big three, or require offline functionality.
-- Want better value. At $29/month for Pro, you're paying 50-70% more than competitors like Anarlog ($8), Fireflies ($18), Otter ($16.99), or MeetGeek ($19) for similar conversation intelligence.
+- Want better value. At $29/month for Pro, you're paying 50-95% more than competitors like Anarlog ($15), Fireflies ($18), Otter ($16.99), or MeetGeek ($19) for similar conversation intelligence.
 - Work in technical fields needing custom vocabulary or have multilingual teams with strong accents.
 - Just need basic transcription and highlights. Fathom offers this completely free.
 
@@ -197,7 +197,7 @@ Anarlog doesn't record meeting video, so it's not a one-to-one tl;dv alternative
 - **Offline capability.** Record, transcribe, and summarize meetings anywhere without internet. Perfect for travel, secure environments, or unreliable connectivity.
 - **No vendor lock-in.** Choose your own AI providers—OpenAI, Anthropic, Gemini, Ollama, or custom endpoints.
 - **Open source.** Inspect the code, audit security, and customize for your organization's needs.
-- **Better pricing.** Free forever for local transcription, BYOK, and all core features. Managed cloud is $25/month versus tl;dv's $29/month.
+- **Better pricing.** Free forever for local transcription, BYOK, and all core features. Managed cloud is $15/month versus tl;dv's $29/month.
 
 <Image src="/api/assets/blog/tldv-review/tldv-6.webp" alt="Anarlog vs tl;dv comparison" />
 

--- a/apps/web/content/articles/transcription-software-mac.mdx
+++ b/apps/web/content/articles/transcription-software-mac.mdx
@@ -56,7 +56,7 @@ It works as both a real-time meeting assistant and a file transcription tool. Co
 - Export as Markdown, PDF, or Rich Text
 - Custom vocabulary support
 
-#### Managed Cloud ($25/month)
+#### Managed Cloud ($15/month)
 
 - Unlimited AI chat with your transcripts
 - Custom template building


### PR DESCRIPTION
Blog articles still advertised a $25/mo ($250/yr) Pro plan and an $8/mo
Lite tier, neither of which exists. packages/pricing is the single source
of truth for the pricing card on both the marketing site and the desktop
app, and it defines only Free and Pro at $15/mo or $150/yr.

Update every Anarlog price mention across 21 articles to $15/$150,
collapse the retired Lite tier into Pro in the Meetily and Tactiq
comparisons, and drop the Anarlog enterprise-plan claim from the
open-source transcription FAQ since Pro is the only paid plan. Adjust the
tl;dv price-gap figure from 50-70% to 50-95% to match the new number.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX edits with no application, billing, or auth logic changes.
> 
> **Overview**
> **Blog pricing is brought in line with the current Free + Pro offering** ($15/month or $150/year managed cloud), replacing stale **$25/mo**, **$250/year**, and **$8/mo Lite** copy across comparison tables, pricing sections, and CTAs.
> 
> **Competitor-style articles** (`char-vs-meetily`, `tactiq-alternatives`) now describe a single paid **Pro** tier instead of Lite vs Pro. **`open-source-meeting-transcription-software`** drops the claim that Anarlog has a separate enterprise paid plan (Pro is the only paid plan). **`tldv-review`** updates the price-gap vs Anarlog from **50–70%** to **50–95%** to match the new number.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e23030da9aed1cb4160bd1049468f4f2132435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->