### PR TITLE
fix(web): render pricing card checkmarks in green

### DIFF
--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -23,6 +23,7 @@
 @source "../../node_modules/streamdown/dist/index.js";
 @source "../../../../packages/changelog/src";
 @source "../../../../packages/editor/src";
+@source "../../../../packages/pricing/src";
 
 @theme {
   --font-sans:

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6,6 +6,7 @@
 
 @source "../../../packages/changelog/src";
 @source "../../../packages/editor/src";
+@source "../../../packages/pricing/src";
 @source "../../../packages/ui/src";
 
 @theme {


### PR DESCRIPTION
The marketing pricing card showed dark checkmarks instead of green.
PlanFeatureList already sets text-emerald-600 dark:text-emerald-400 on
included features, but neither app declared an @source for
packages/pricing, so Tailwind never scanned the component and never
emitted those utility rules. The icons fell back to inherited text color.

Add the missing @source to both stylesheets. Desktop rendered correctly
only by accident — text-emerald-600 happens to appear in apps/desktop/src
elsewhere, so the rule was generated for unrelated reasons; the same is
not true of text-red-500, which the excluded-feature icons need. Adding
the directive there too removes the coincidence.

Verified in the dev server: all 20 pricing icons now compute to
oklch(0.596 0.145 163.225), and .text-emerald-600 and .text-red-500 are
present in the generated stylesheet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS build configuration only; no runtime logic, auth, or data changes.
> 
> **Overview**
> Pricing feature icons on marketing cards were inheriting default text color because Tailwind never scanned **`packages/pricing`**, so classes like **`text-emerald-600`** and **`text-red-500`** from **`PlanFeatureList`** were not emitted into the app CSS.
> 
> This adds **`@source "../../../../packages/pricing/src"`** (desktop) and **`@source "../../../packages/pricing/src"`** (web) alongside the existing changelog/editor sources so both apps generate the pricing component utilities reliably—not only when the same classes happen to appear elsewhere in the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314800291e43e96a27fe886b38a34f71e06e57fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->