### PR TITLE
feat(pricing): restructure Pro tier and drop the partial feature state

### DIFF
--- a/apps/web/src/components/home-page/pricing-section.tsx
+++ b/apps/web/src/components/home-page/pricing-section.tsx
@@ -30,9 +30,7 @@ export function PricingSection() {
 }
 
 function PricingCard({ plan }: { plan: MarketingPlanData }) {
-  const visibleFeatures = plan.features.filter(
-    (feature) => feature.included === true,
-  );
+  const visibleFeatures = plan.features.filter((feature) => feature.included);
 
   return (
     <article

--- a/packages/pricing/src/plan-feature-list.tsx
+++ b/packages/pricing/src/plan-feature-list.tsx
@@ -1,4 +1,4 @@
-import { Barricade, CheckCircle, XCircle } from "@phosphor-icons/react";
+import { CheckCircle, XCircle } from "@phosphor-icons/react";
 
 import { cn } from "@anlg/utils";
 
@@ -11,23 +11,12 @@ export function PlanFeatureList({
   features: PlanFeature[];
   dense?: boolean;
 }) {
-  const getPartialFeatureTooltip = (feature: PlanFeature) =>
-    feature.tooltip
-      ? `Currently in development. ${feature.tooltip}`
-      : "Currently in development";
-
   return (
     <div
       className={cn([dense ? "flex flex-col gap-1.5" : "flex flex-col gap-3"])}
     >
       {features.map((feature) => {
-        const Icon =
-          feature.included === true
-            ? CheckCircle
-            : feature.included === "partial"
-              ? Barricade
-              : XCircle;
-        const isPartial = feature.included === "partial";
+        const Icon = feature.included ? CheckCircle : XCircle;
         const iconContainerClassName = cn([
           dense
             ? "flex h-4 shrink-0 items-center"
@@ -35,14 +24,18 @@ export function PlanFeatureList({
         ]);
         const iconClassName = cn([
           dense ? "size-3.5" : "size-4.5",
-          feature.included === true
+          feature.included
             ? "text-emerald-600 dark:text-emerald-400"
-            : isPartial
-              ? "text-foreground"
-              : "text-red-500 dark:text-red-400",
+            : "text-red-500 dark:text-red-400",
         ]);
-        const featureContent = (
-          <>
+
+        return (
+          <div
+            key={feature.label}
+            className={cn([
+              dense ? "flex items-start gap-1.5" : "flex items-start gap-3",
+            ])}
+          >
             <div className={iconContainerClassName}>
               <Icon className={iconClassName} />
             </div>
@@ -57,9 +50,9 @@ export function PlanFeatureList({
                 <span
                   className={cn([
                     dense ? "text-xs" : "text-sm",
-                    feature.included === false
-                      ? "text-muted-foreground"
-                      : "text-foreground",
+                    feature.included
+                      ? "text-foreground"
+                      : "text-muted-foreground",
                   ])}
                 >
                   {feature.label}
@@ -71,32 +64,6 @@ export function PlanFeatureList({
                 </div>
               )}
             </div>
-          </>
-        );
-
-        return (
-          <div
-            key={feature.label}
-            className={cn([
-              dense ? "flex items-start gap-1.5" : "flex items-start gap-3",
-            ])}
-          >
-            {isPartial ? (
-              <button
-                type="button"
-                title={getPartialFeatureTooltip(feature)}
-                className={cn([
-                  "flex w-full items-start border-0 bg-transparent p-0 text-left",
-                  dense ? "gap-1.5" : "gap-3",
-                  "focus-visible:ring-ring cursor-help rounded-sm focus-visible:ring-2 focus-visible:outline-none",
-                ])}
-                aria-label={`${feature.label}: ${getPartialFeatureTooltip(feature)}`}
-              >
-                {featureContent}
-              </button>
-            ) : (
-              featureContent
-            )}
           </div>
         );
       })}

--- a/packages/pricing/src/tiers.ts
+++ b/packages/pricing/src/tiers.ts
@@ -1,7 +1,7 @@
 export type PlanTier = "free" | "pro";
 export type PlanFeature = {
   label: string;
-  included: boolean | "partial";
+  included: boolean;
   tooltip?: string;
 };
 
@@ -62,11 +62,11 @@ export const MARKETING_PLAN_TIERS: MarketingPlanData[] = [
         tooltip:
           "Local REST API with API keys, plus signed webhooks when meetings finish and summaries are generated.",
       },
-      { label: "Transcript Editor", included: "partial" },
-      { label: "Shortcuts", included: "partial" },
+      { label: "Transcript Editor", included: true },
+      { label: "Shortcuts", included: true },
+      { label: "Manual Speaker Labeling", included: true },
       { label: "Cloud Transcription", included: false },
       { label: "Cloud LLM", included: false },
-      { label: "Speaker Identification", included: false },
     ],
   },
   {
@@ -83,26 +83,30 @@ export const MARKETING_PLAN_TIERS: MarketingPlanData[] = [
       { label: "Everything in Free", included: true },
       { label: "Cloud Transcription", included: true },
       { label: "Cloud LLM", included: true },
-      { label: "Local-cloud Sync", included: true },
+      { label: "Better Speaker Identification", included: true },
       {
-        label: "Cloud API & Connectors",
+        label: "Integrations",
         included: true,
         tooltip:
-          "Hosted API and MCP connectors for Claude, ChatGPT, and other agents — no desktop app required.",
+          "Slack, Notion, Linear, GitHub, Google Calendar, and Outlook Calendar.",
       },
-      { label: "Speaker Identification", included: "partial" },
-      { label: "Connect to Google Calendar", included: true },
-      { label: "Connect to Outlook Calendar", included: true },
-      { label: "Advanced Templates", included: "partial" },
       {
-        label: "Connect to OpenClaw",
-        included: "partial",
-        tooltip: "Select which notes to sync",
+        label: "Automations",
+        included: true,
+        tooltip:
+          "Run follow-up work automatically when a meeting ends — post a recap, update a page, or create issues.",
       },
+      { label: "Cloud Sync", included: true },
       {
         label: "Shareable Links",
-        included: "partial",
+        included: true,
         tooltip: "DocSend-like: view tracking, expiration, revocation",
+      },
+      {
+        label: "Cloud API, MCP & Webhooks",
+        included: true,
+        tooltip:
+          "Hosted API, MCP connectors for Claude and ChatGPT, and signed webhooks — no desktop app required.",
       },
     ],
   },
@@ -114,7 +118,7 @@ export const PLAN_TIERS: PlanTierData[] = MARKETING_PLAN_TIERS.map((plan) => ({
   price: plan.price ? `$${plan.price.monthly}` : "$0",
   period: "/month",
   subtitle: plan.price?.yearly ? `or $${plan.price.yearly}/year` : null,
-  features: plan.features.filter((feature) => feature.included === true),
+  features: plan.features.filter((feature) => feature.included),
 }));
 
 export const TIER_ORDER: Record<PlanTier, number> = {


### PR DESCRIPTION
The Pro card was hiding its best differentiators. Marking a feature "partial"
did not soften it — both renderers filtered to `included === true`, so
Shareable Links, Speaker Identification, Advanced Templates and Connect to
OpenClaw were deleted from the card entirely. Automations and the
Slack/Notion/Linear integrations were never listed at all despite being gated
on `isPro` in the app.

- Remove the partial state so every feature is simply in or out, and drop the
  Barricade icon, in-development tooltip, and button wrapper that existed only
  to render it
- Regroup Pro around Integrations, Automations, Cloud Sync and Shareable Links,
  and rename "Cloud API & Connectors" to "Cloud API, MCP & Webhooks" so
  "connectors" stops colliding with "integrations" — the two named different
  things
- Reframe speaker identification as a Free/Pro delta rather than a Pro-only
  feature. Manual speaker labeling has no billing gate (`SpeakerLabelManager`
  and `speaker_hints` in `stt/utils.ts`), so Free claiming
  `Speaker Identification: false` understated it. Free now lists Manual Speaker
  Labeling and Pro lists Better Speaker Identification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3fe576dc062f540a18488bc4043fba85724501ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->