### PR TITLE
feat(web): add enterprise page with founder call booking

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -151,12 +151,6 @@ status = 301
 force = true
 
 [[redirects]]
-from = "/enterprise"
-to = "/"
-status = 301
-force = true
-
-[[redirects]]
 from = "/roadmap"
 to = "/changelog/"
 status = 301

--- a/apps/web/src/components/enterprise-callout.tsx
+++ b/apps/web/src/components/enterprise-callout.tsx
@@ -1,0 +1,23 @@
+import { Link } from "@tanstack/react-router";
+
+export function EnterpriseCallout() {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-3xl border border-[#eadfce] bg-[#fffaf0] p-6 text-left [corner-shape:squircle] md:flex-row md:justify-between">
+      <div>
+        <p className="text-sm font-semibold text-[#181613]">
+          Rolling Anarlog out to a team?
+        </p>
+        <p className="mt-1 text-sm leading-6 text-[#4f4940]">
+          Workspace admin, SSO, and a self-hosted server for regulated
+          environments — shaped with early partners.
+        </p>
+      </div>
+      <Link
+        to="/enterprise/"
+        className="inline-flex h-11 shrink-0 items-center justify-center rounded-full bg-[#181613] px-6 text-sm font-medium text-white transition-all hover:scale-[102%] hover:bg-[#4f4940] active:scale-[98%]"
+      >
+        Talk to sales
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/components/home-page/pricing-section.tsx
+++ b/apps/web/src/components/home-page/pricing-section.tsx
@@ -7,7 +7,13 @@ import {
 } from "@anlg/pricing";
 import { cn } from "@anlg/utils";
 
-export function PricingSection() {
+import { EnterpriseCallout } from "@/components/enterprise-callout";
+
+export function PricingSection({
+  compareLink = false,
+}: {
+  compareLink?: boolean;
+}) {
   return (
     <section id="pricing" className="pt-24 pb-8 md:pt-28 md:pb-10">
       <div>
@@ -25,6 +31,21 @@ export function PricingSection() {
           <PricingCard key={plan.id} plan={plan} />
         ))}
       </div>
+
+      <div className="relative left-1/2 mt-6 w-screen max-w-[760px] -translate-x-1/2 px-5 md:px-8">
+        <EnterpriseCallout />
+      </div>
+
+      {compareLink ? (
+        <div className="mt-8">
+          <Link
+            to="/pricing/"
+            className="text-sm text-[#756b5d] underline decoration-[#d9cdb8] underline-offset-4 transition-colors hover:text-[#181613]"
+          >
+            Compare with other AI notetakers
+          </Link>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/components/home-page/privacy-section.tsx
+++ b/apps/web/src/components/home-page/privacy-section.tsx
@@ -71,40 +71,7 @@ function PrivacyVisual({
   type: (typeof privacyCommitments)[number]["visual"];
 }) {
   if (type === "files") {
-    return (
-      <div className="flex h-20 items-center justify-center gap-2 select-none md:h-28 md:w-full md:justify-between md:gap-1">
-        <img
-          src="/icons/file.webp"
-          alt=""
-          className="w-10 rotate-[3deg] object-contain transition-transform duration-300 ease-out hover:rotate-[7deg]"
-          draggable={false}
-        />
-        <img
-          src="/icons/file.webp"
-          alt=""
-          className="w-10 rotate-[-5deg] object-contain transition-transform duration-300 ease-out hover:rotate-[-9deg]"
-          draggable={false}
-        />
-        <img
-          src="/icons/folderchar.svg"
-          alt=""
-          className="w-14 object-contain transition-transform duration-300 ease-out hover:rotate-[3deg]"
-          draggable={false}
-        />
-        <img
-          src="/icons/file.webp"
-          alt=""
-          className="w-10 rotate-[6deg] object-contain transition-transform duration-300 ease-out hover:rotate-[10deg]"
-          draggable={false}
-        />
-        <img
-          src="/icons/file.webp"
-          alt=""
-          className="w-10 rotate-[-4deg] object-contain transition-transform duration-300 ease-out hover:rotate-[-8deg]"
-          draggable={false}
-        />
-      </div>
-    );
+    return <LocalFilesVisual />;
   }
 
   if (type === "key") {
@@ -135,6 +102,47 @@ function PrivacyVisual({
     );
   }
 
+  return <MeetingCaptureVisual />;
+}
+
+export function LocalFilesVisual() {
+  return (
+    <div className="flex h-20 items-center justify-center gap-2 select-none md:h-28 md:w-full md:justify-between md:gap-1">
+      <img
+        src="/icons/file.webp"
+        alt=""
+        className="w-10 rotate-[3deg] object-contain transition-transform duration-300 ease-out hover:rotate-[7deg]"
+        draggable={false}
+      />
+      <img
+        src="/icons/file.webp"
+        alt=""
+        className="w-10 rotate-[-5deg] object-contain transition-transform duration-300 ease-out hover:rotate-[-9deg]"
+        draggable={false}
+      />
+      <img
+        src="/icons/folderchar.svg"
+        alt=""
+        className="w-14 object-contain transition-transform duration-300 ease-out hover:rotate-[3deg]"
+        draggable={false}
+      />
+      <img
+        src="/icons/file.webp"
+        alt=""
+        className="w-10 rotate-[6deg] object-contain transition-transform duration-300 ease-out hover:rotate-[10deg]"
+        draggable={false}
+      />
+      <img
+        src="/icons/file.webp"
+        alt=""
+        className="w-10 rotate-[-4deg] object-contain transition-transform duration-300 ease-out hover:rotate-[-8deg]"
+        draggable={false}
+      />
+    </div>
+  );
+}
+
+export function MeetingCaptureVisual() {
   return (
     <div className="flex h-20 items-center justify-center select-none md:h-28 md:w-full">
       <div className="flex w-full max-w-[260px] items-center gap-3 rounded-2xl border border-neutral-200 bg-white py-2 pr-3 pl-4 text-left shadow-[0_3px_10px_rgba(24,22,19,0.04)]">

--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -8,6 +8,7 @@ const footerGroups = [
     title: "Product",
     links: [
       { label: "Download", to: "/download/" },
+      { label: "Enterprise", to: "/enterprise/" },
       { label: "Blog", to: "/blog/" },
       { label: "Changelog", to: "/changelog/" },
       { label: "Status", href: "https://status.anarlog.so" },

--- a/apps/web/src/lib/enterprise.ts
+++ b/apps/web/src/lib/enterprise.ts
@@ -1,0 +1,1 @@
+export const BOOK_CALL_URL = "https://cal.com/team/fastrepl/hi";

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as AuthRouteImport } from './routes/auth'
 import { Route as ViewRouteRouteImport } from './routes/_view/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as YcIndexRouteImport } from './routes/yc/index'
+import { Route as EnterpriseIndexRouteImport } from './routes/enterprise/index'
 import { Route as ChangelogIndexRouteImport } from './routes/changelog/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as ShareShareIdRouteImport } from './routes/share/$shareId'
@@ -128,6 +129,11 @@ const IndexRoute = IndexRouteImport.update({
 const YcIndexRoute = YcIndexRouteImport.update({
   id: '/yc/',
   path: '/yc/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EnterpriseIndexRoute = EnterpriseIndexRouteImport.update({
+  id: '/enterprise/',
+  path: '/enterprise/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ChangelogIndexRoute = ChangelogIndexRouteImport.update({
@@ -462,6 +468,7 @@ export interface FileRoutesByFullPath {
   '/share/$shareId': typeof ShareShareIdRoute
   '/blog/': typeof BlogIndexRoute
   '/changelog/': typeof ChangelogIndexRoute
+  '/enterprise/': typeof EnterpriseIndexRoute
   '/yc/': typeof YcIndexRoute
   '/app/account': typeof ViewAppAccountRoute
   '/app/checkout': typeof ViewAppCheckoutRoute
@@ -533,6 +540,7 @@ export interface FileRoutesByTo {
   '/share/$shareId': typeof ShareShareIdRoute
   '/blog': typeof BlogIndexRoute
   '/changelog': typeof ChangelogIndexRoute
+  '/enterprise': typeof EnterpriseIndexRoute
   '/yc': typeof YcIndexRoute
   '/app/account': typeof ViewAppAccountRoute
   '/app/checkout': typeof ViewAppCheckoutRoute
@@ -607,6 +615,7 @@ export interface FileRoutesById {
   '/share/$shareId': typeof ShareShareIdRoute
   '/blog/': typeof BlogIndexRoute
   '/changelog/': typeof ChangelogIndexRoute
+  '/enterprise/': typeof EnterpriseIndexRoute
   '/yc/': typeof YcIndexRoute
   '/_view/app/account': typeof ViewAppAccountRoute
   '/_view/app/checkout': typeof ViewAppCheckoutRoute
@@ -681,6 +690,7 @@ export interface FileRouteTypes {
     | '/share/$shareId'
     | '/blog/'
     | '/changelog/'
+    | '/enterprise/'
     | '/yc/'
     | '/app/account'
     | '/app/checkout'
@@ -752,6 +762,7 @@ export interface FileRouteTypes {
     | '/share/$shareId'
     | '/blog'
     | '/changelog'
+    | '/enterprise'
     | '/yc'
     | '/app/account'
     | '/app/checkout'
@@ -825,6 +836,7 @@ export interface FileRouteTypes {
     | '/share/$shareId'
     | '/blog/'
     | '/changelog/'
+    | '/enterprise/'
     | '/yc/'
     | '/_view/app/account'
     | '/_view/app/checkout'
@@ -898,6 +910,7 @@ export interface RootRouteChildren {
   ShareShareIdRoute: typeof ShareShareIdRoute
   BlogIndexRoute: typeof BlogIndexRoute
   ChangelogIndexRoute: typeof ChangelogIndexRoute
+  EnterpriseIndexRoute: typeof EnterpriseIndexRoute
   YcIndexRoute: typeof YcIndexRoute
   ApiAssetsSplatRoute: typeof ApiAssetsSplatRoute
   ApiTweetIdRoute: typeof ApiTweetIdRoute
@@ -1010,6 +1023,13 @@ declare module '@tanstack/react-router' {
       path: '/yc'
       fullPath: '/yc/'
       preLoaderRoute: typeof YcIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/enterprise/': {
+      id: '/enterprise/'
+      path: '/enterprise'
+      fullPath: '/enterprise/'
+      preLoaderRoute: typeof EnterpriseIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/changelog/': {
@@ -1508,6 +1528,7 @@ const rootRouteChildren: RootRouteChildren = {
   ShareShareIdRoute: ShareShareIdRoute,
   BlogIndexRoute: BlogIndexRoute,
   ChangelogIndexRoute: ChangelogIndexRoute,
+  EnterpriseIndexRoute: EnterpriseIndexRoute,
   YcIndexRoute: YcIndexRoute,
   ApiAssetsSplatRoute: ApiAssetsSplatRoute,
   ApiTweetIdRoute: ApiTweetIdRoute,

--- a/apps/web/src/routes/enterprise/index.tsx
+++ b/apps/web/src/routes/enterprise/index.tsx
@@ -1,0 +1,311 @@
+import { BellRinging, CheckCircle, HardDrives } from "@phosphor-icons/react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { cn } from "@anlg/utils";
+
+import { AnarlogLogo } from "@/components/anarlog-logo";
+import {
+  LocalFilesVisual,
+  MeetingCaptureVisual,
+} from "@/components/home-page/privacy-section";
+import { SiteFooter } from "@/components/site-footer";
+import { BOOK_CALL_URL } from "@/lib/enterprise";
+import { getCanonicalUrl } from "@/lib/seo";
+
+const title = "Enterprise · Anarlog";
+const description =
+  "Anarlog for teams and enterprises: end-to-end encrypted meeting notes with no meeting bots, workspace admin controls, and a self-hostable server. Book a call with the founder.";
+
+export const Route = createFileRoute("/enterprise/")({
+  component: EnterprisePage,
+  head: () => ({
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:url", content: getCanonicalUrl("/enterprise") },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+      { name: "twitter:url", content: getCanonicalUrl("/enterprise") },
+    ],
+    links: [{ rel: "canonical", href: getCanonicalUrl("/enterprise") }],
+  }),
+});
+
+const pillarRows = [
+  [
+    {
+      title: "Private by architecture",
+      body: "Notes live in local SQLite, and cloud sync is end-to-end encrypted — our servers only ever hold ciphertext.",
+      Visual: LocalFilesVisual,
+    },
+    {
+      title: "No bots in your meetings",
+      body: "Anarlog listens locally. Nothing joins your calls, and nothing appears in participant lists.",
+      Visual: MeetingCaptureVisual,
+    },
+    {
+      title: "Consent on your terms",
+      body: "Recording disclosure and consent defaults set once, org-wide — every meeting meets the same bar.",
+      Visual: ConsentNoticeVisual,
+    },
+  ],
+  [
+    {
+      title: "Admin without surveillance",
+      body: "Members, roles, seats, and org-wide policies built on metadata — never on anyone's notes.",
+      Visual: WorkspaceAdminVisual,
+    },
+    {
+      title: "Self-host the whole stack",
+      body: "Run the Anarlog server on infrastructure you control for regulated environments.",
+      Visual: SelfHostVisual,
+    },
+  ],
+];
+
+function EnterprisePage() {
+  return (
+    <main className="min-h-screen bg-white text-[#181613]">
+      <div className="mx-auto w-full max-w-[700px] px-5 pt-4 pb-8 md:px-8 md:pt-4 md:pb-12">
+        <div className="min-w-0 text-center">
+          <section className="pt-10 pb-4 md:pt-12 md:pb-6">
+            <Link to="/" aria-label="Anarlog home" className="inline-flex">
+              <AnarlogLogo className="h-8 w-auto md:h-9" />
+            </Link>
+            <h1 className="font-hand mt-12 text-4xl leading-none font-semibold text-[#181613] md:mt-16 md:text-5xl">
+              Meeting memory your company owns
+            </h1>
+            <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-[#4f4940]">
+              Bring Anarlog to your whole team without handing your
+              conversations to another cloud. Notes stay on your machines, sync
+              is end-to-end encrypted, and no bot ever joins a call.
+            </p>
+            <div className="mt-8">
+              <BookCallButton />
+            </div>
+            <p className="mt-3 text-xs text-[#756b5d]">
+              30 minutes, directly with the founder. No SDR queue.
+            </p>
+          </section>
+
+          <section className="pt-12 pb-4 md:pt-16 md:pb-6">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+              Why teams pick Anarlog
+            </h2>
+            <div className="relative left-1/2 mt-6 w-screen max-w-[1120px] -translate-x-1/2">
+              <div className="flex flex-col gap-4 md:gap-8">
+                {pillarRows.map((row) => (
+                  <div
+                    key={row[0].title}
+                    className={cn([
+                      "grid gap-4 md:flex md:items-start md:gap-0",
+                      row.length === 3
+                        ? "md:justify-between"
+                        : "md:justify-evenly",
+                    ])}
+                  >
+                    {row.map((pillar) => (
+                      <div
+                        key={pillar.title}
+                        className="flex flex-col px-6 py-3 text-center md:w-[31%] md:p-4"
+                      >
+                        <pillar.Visual />
+                        <h3 className="mt-5 text-base font-medium text-[#4f4940] md:mt-7">
+                          {pillar.title}
+                        </h3>
+                        <p className="mx-auto mt-1 max-w-[17rem] text-sm leading-6 text-[#4f4940]">
+                          {pillar.body}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="pt-12 pb-4 md:pt-14 md:pb-6">
+            <div
+              className="flex items-center justify-center pb-4 select-none"
+              aria-hidden="true"
+            >
+              <span className="partner-hand-left inline-flex">
+                <PartnerHandSvg
+                  sleeve="#181613"
+                  className="h-12 w-auto md:h-14"
+                />
+              </span>
+              <span className="partner-hand-right mt-2.5 -ml-12 inline-flex md:-ml-14">
+                <PartnerHandSvg
+                  sleeve="#eadfce"
+                  className="h-12 w-auto -scale-x-100 md:h-14"
+                />
+              </span>
+            </div>
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              Built with early partners
+            </h2>
+            <p className="mx-auto mt-5 max-w-2xl text-base leading-7 text-[#4f4940]">
+              Team workspaces with admin controls, SSO and SCIM, and the
+              self-hosted server are in active development. Early enterprise
+              partners work directly with the founding team and shape what ships
+              first.
+            </p>
+          </section>
+
+          <section className="pt-8 pb-20 md:pt-10 md:pb-24">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              Talk to us
+            </h2>
+            <p className="mx-auto mt-5 max-w-lg text-base leading-7 text-[#4f4940]">
+              Tell us about your team and your compliance needs — we'll show you
+              what works today and what lands next.
+            </p>
+            <div className="mt-8 flex flex-col items-center gap-4">
+              <BookCallButton />
+              <Link
+                to="/pricing/"
+                className="text-sm text-[#756b5d] underline decoration-[#d9cdb8] underline-offset-4 transition-colors hover:text-[#181613]"
+              >
+                Compare plans and pricing
+              </Link>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <SiteFooter />
+    </main>
+  );
+}
+
+function PartnerHandSvg({
+  sleeve,
+  className,
+}: {
+  sleeve: string;
+  className?: string;
+}) {
+  return (
+    <svg
+      viewBox="0 0 128 60"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M30 20 H78 C98 20 114 27 117 38 C119 47 108 52 92 51 L38 51 C32 51 28 46 28 40 Z"
+        fill="#fffaf0"
+        stroke="#181613"
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M82 22 C88 12 102 13 106 21 C109 27 103 31 95 30"
+        fill="#fffaf0"
+        stroke="#181613"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M104 33 C109 34 113 37 115 41 M96 48 C101 48 106 47 110 45"
+        stroke="#181613"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <rect
+        x="2"
+        y="12"
+        width="26"
+        height="42"
+        rx="7"
+        fill={sleeve}
+        stroke="#181613"
+        strokeWidth="2.5"
+      />
+    </svg>
+  );
+}
+
+function ConsentNoticeVisual() {
+  return (
+    <div className="flex h-20 items-center justify-center select-none md:h-28 md:w-full">
+      <div className="flex w-full max-w-[260px] items-center gap-3 rounded-2xl border border-neutral-200 bg-white py-2 pr-3 pl-4 text-left shadow-[0_3px_10px_rgba(24,22,19,0.04)]">
+        <BellRinging size={28} className="text-stone-700" aria-hidden="true" />
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-stone-800">
+            Consent notice sent
+          </span>
+          <span className="text-sm text-stone-400">org-wide policy</span>
+        </div>
+        <CheckCircle
+          size={20}
+          weight="fill"
+          className="ml-auto text-emerald-500"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceAdminVisual() {
+  return (
+    <div className="flex h-20 items-center justify-center select-none md:h-28 md:w-full">
+      <div className="flex w-full max-w-[260px] items-center gap-3 rounded-2xl border border-neutral-200 bg-white py-2 pr-3 pl-4 text-left shadow-[0_3px_10px_rgba(24,22,19,0.04)]">
+        <div className="flex -space-x-2.5" aria-hidden="true">
+          {["S", "B", "A"].map((initial) => (
+            <span
+              key={initial}
+              className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-white bg-[#eadfce] text-xs font-semibold text-[#756b5d] [corner-shape:round]"
+            >
+              {initial}
+            </span>
+          ))}
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-stone-800">
+            Design team
+          </span>
+          <span className="text-sm text-stone-400">12 seats</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SelfHostVisual() {
+  return (
+    <div className="flex h-20 items-center justify-center select-none md:h-28 md:w-full">
+      <div className="flex w-full max-w-[260px] items-center gap-3 rounded-2xl border border-neutral-200 bg-white py-2 pr-3 pl-4 text-left shadow-[0_3px_10px_rgba(24,22,19,0.04)]">
+        <HardDrives size={28} className="text-stone-700" aria-hidden="true" />
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-stone-800">
+            notes.acme.internal
+          </span>
+          <span className="text-sm text-stone-400">your infrastructure</span>
+        </div>
+        <span
+          className="ml-auto h-2.5 w-2.5 rounded-full bg-emerald-500 [corner-shape:round]"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  );
+}
+
+function BookCallButton() {
+  return (
+    <a
+      href={BOOK_CALL_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex h-11 items-center justify-center rounded-full bg-[#181613] px-6 text-sm font-medium text-white transition-all hover:scale-[102%] hover:bg-[#4f4940] active:scale-[98%]"
+    >
+      Book a call with the founder
+    </a>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -522,7 +522,68 @@
     animation-name: ai-card-shuffle-chip;
   }
 
+  @keyframes partner-hand-left {
+    0% {
+      transform: translateX(-3.5rem) rotate(-9deg);
+    }
+    55% {
+      transform: translateX(0) rotate(0deg);
+    }
+    70% {
+      transform: translateX(0) translateY(-0.2rem) rotate(-1.5deg);
+    }
+    85% {
+      transform: translateX(0) translateY(0.15rem) rotate(1deg);
+    }
+    100% {
+      transform: translateX(0) translateY(0) rotate(0deg);
+    }
+  }
+
+  @keyframes partner-hand-right {
+    0% {
+      transform: translateX(3.5rem) rotate(9deg);
+    }
+    55% {
+      transform: translateX(0) rotate(0deg);
+    }
+    70% {
+      transform: translateX(0) translateY(0.2rem) rotate(1.5deg);
+    }
+    85% {
+      transform: translateX(0) translateY(-0.15rem) rotate(-1deg);
+    }
+    100% {
+      transform: translateX(0) translateY(0) rotate(0deg);
+    }
+  }
+
+  /* Scroll-linked: hands meet as the section scrolls in, wiggle while
+     scrolling continues. Without support they stay statically clasped. */
+  @supports (animation-timeline: view()) {
+    .partner-hand-left,
+    .partner-hand-right {
+      animation-timing-function: linear;
+      animation-fill-mode: both;
+      animation-timeline: view();
+      animation-range: entry 0% cover 45%;
+    }
+
+    .partner-hand-left {
+      animation-name: partner-hand-left;
+    }
+
+    .partner-hand-right {
+      animation-name: partner-hand-right;
+    }
+  }
+
   @media (prefers-reduced-motion: reduce) {
+    .partner-hand-left,
+    .partner-hand-right {
+      animation: none;
+    }
+
     .meeting-audio-bar {
       animation: none;
       transform: scaleY(0.7);

--- a/apps/web/src/utils/sitemap.ts
+++ b/apps/web/src/utils/sitemap.ts
@@ -42,6 +42,14 @@ export function getSitemap(): Sitemap<TRoutes> {
         priority: 0.9,
         changeFrequency: "weekly",
       },
+      "/enterprise/": {
+        priority: 0.8,
+        changeFrequency: "monthly",
+      },
+      "/pricing/": {
+        priority: 0.9,
+        changeFrequency: "monthly",
+      },
       "/yc/": {
         priority: 0.7,
         changeFrequency: "monthly",


### PR DESCRIPTION
Enterprise buyers had no path to a sales conversation: no `/enterprise` route,
no contact CTA anywhere, and a Char-era redirect sent `/enterprise` to the
homepage.

- Add an `/enterprise` landing page pitching E2EE, bot-free capture, team admin,
  and self-hosting, with Cal.com booking CTAs
- Reuse an `EnterpriseCallout` band on the homepage pricing section and the
  `/pricing` comparison page
- Link Enterprise from the footer and add the route to the sitemap
- Drop the stale `/enterprise` → home redirect from netlify.toml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-only static routes and redirects; no auth, billing, or data-path changes.
> 
> **Overview**
> Adds a real **`/enterprise/`** marketing route so team buyers can learn about enterprise positioning and book a founder call via Cal.com (`BOOK_CALL_URL`), instead of being sent home by a legacy Netlify redirect.
> 
> **Discovery and CTAs:** New **`EnterpriseCallout`** sits under plan cards in **`PricingSection`**, with an optional **`compareLink`** prop for a link to **`/pricing/`**. Footer gains an Enterprise link; the sitemap lists **`/enterprise/`** and **`/pricing/`**.
> 
> **Enterprise page:** Landing content covers E2EE, bot-free capture, consent, admin, and self-hosting, reusing exported **`LocalFilesVisual`** / **`MeetingCaptureVisual`** from the privacy section plus scroll-linked partner-hand CSS (with reduced-motion fallbacks).
> 
> **Routing:** Removes **`/enterprise` → `/`** from **`netlify.toml`** so the new page is served.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a8f44f9c72cbccae255217e0d016153ed39e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->