### PR TITLE
fix/structure-only-note-ux

### DIFF
--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -137,31 +137,6 @@ vi.mock("~/session-sharing/comment-anchors", () => ({
 
 vi.mock("~/session/components/shared", () => ({
   useCanShowTranscript: () => hoisted.canShowTranscript,
-  hasStoredNoteContent: (value: unknown) => {
-    if (typeof value !== "string" || !value.trim()) {
-      return false;
-    }
-
-    try {
-      const hasText = (node: unknown): boolean => {
-        if (!node || typeof node !== "object") {
-          return false;
-        }
-        const content = node as {
-          text?: string;
-          content?: unknown[];
-        };
-        return (
-          Boolean(content.text?.trim()) ||
-          Boolean(content.content?.some(hasText))
-        );
-      };
-
-      return hasText(JSON.parse(value));
-    } catch {
-      return true;
-    }
-  },
 }));
 
 vi.mock("~/session/queries", () => ({
@@ -536,6 +511,59 @@ describe("RawEditor", () => {
       screen.getByRole("button", { name: "Project Kickoff" }),
     ).not.toBeNull();
     expect(hoisted.persistChange).not.toHaveBeenCalled();
+  });
+
+  it("hides template suggestions for structure-only content", () => {
+    hoisted.userTemplates = [
+      {
+        id: "default-project-kickoff",
+        title: "Project Kickoff",
+        pinned: false,
+        icon: { type: "emoji", value: "🚀" },
+        sections: [{ title: "Goals", description: "" }],
+      },
+    ];
+
+    render(<RawEditor sessionId="session-1" />);
+
+    const onDocumentChange = hoisted.noteEditorProps[
+      hoisted.noteEditorProps.length - 1
+    ]?.onDocumentChange as (content: unknown) => void;
+
+    act(() => {
+      onDocumentChange({
+        type: "doc",
+        content: [
+          {
+            type: "taskList",
+            content: [{ type: "taskItem", content: [{ type: "paragraph" }] }],
+          },
+        ],
+      });
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Project Kickoff" }),
+    ).toBeNull();
+
+    act(() => {
+      onDocumentChange({
+        type: "doc",
+        content: [{ type: "paragraph" }, { type: "paragraph" }],
+      });
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Project Kickoff" }),
+    ).toBeNull();
+
+    act(() => {
+      onDocumentChange({ type: "doc", content: [{ type: "paragraph" }] });
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Project Kickoff" }),
+    ).not.toBeNull();
   });
 
   it("prioritizes event-aware template suggestions", () => {

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -26,10 +26,7 @@ import { openEditorLink } from "~/editor-bridge/open-editor-link";
 import { sessionMentionDropConfig } from "~/editor-bridge/session-mention-drop";
 import { SessionNodeView } from "~/editor-bridge/session-view";
 import { useSessionCommentAnchors } from "~/session-sharing/comment-anchors";
-import {
-  hasStoredNoteContent,
-  useCanShowTranscript,
-} from "~/session/components/shared";
+import { useCanShowTranscript } from "~/session/components/shared";
 import { useAttachmentResolver } from "~/session/hooks/useAttachmentResolver";
 import { useUpdateSession } from "~/session/queries";
 import { removeDocumentTitle } from "~/session/title-content";
@@ -47,6 +44,16 @@ const defaultSuggestedTemplateIds = [
   "default-daily-standup",
   "default-one-on-one-meeting",
 ];
+// Structural check: any block beyond a single empty paragraph (checkbox, list,
+// extra empty lines) counts as content, unlike the text-based hasStoredNoteContent
+export function isPristineNoteDoc(doc: JSONContent): boolean {
+  const content = doc.content ?? [];
+  if (content.length === 0) return true;
+  if (content.length > 1) return false;
+  const node = content[0];
+  return node.type === "paragraph" && !node.content?.length;
+}
+
 const contextualTemplateRules = [
   {
     id: "default-sales-discovery-call",
@@ -111,7 +118,7 @@ export const RawEditor = forwardRef<
       [rawMd, sessionTitle],
     );
     const persistedIsMemoEmpty = useMemo(
-      () => !hasStoredNoteContent(JSON.stringify(initialContent)),
+      () => isPristineNoteDoc(initialContent),
       [initialContent],
     );
     const [liveMemoState, setLiveMemoState] = useState(() => ({
@@ -182,7 +189,7 @@ export const RawEditor = forwardRef<
 
     const handleDocumentChange = useCallback(
       (input: JSONContent) => {
-        const isEmpty = !hasStoredNoteContent(JSON.stringify(input));
+        const isEmpty = isPristineNoteDoc(input);
         setLiveMemoState((current) => {
           if (current.sessionId === sessionId && current.isEmpty === isEmpty) {
             return current;

--- a/packages/editor/src/note/keymap.test.ts
+++ b/packages/editor/src/note/keymap.test.ts
@@ -237,7 +237,7 @@ describe("buildKeymap", () => {
     });
   });
 
-  it("keeps the first task item separate from a previous bullet list", () => {
+  it("lifts the first task item to a paragraph instead of merging into a previous bullet list", () => {
     const doc = schema.node("doc", null, [
       schema.node("bulletList", null, [
         schema.node("listItem", null, [
@@ -259,7 +259,87 @@ describe("buildKeymap", () => {
     ]);
     const { state } = runBackspaceAtTextStart(doc, "two");
 
-    expect(state.doc.toJSON()).toEqual(doc.toJSON());
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "one" }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "two" }],
+        },
+      ],
+    });
+  });
+
+  it("lifts the first task item to a paragraph when the list starts the doc", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("taskList", null, [
+        schema.node(
+          "taskItem",
+          {
+            status: "todo",
+            checked: false,
+            taskId: "task-1",
+            taskItemId: "task-item-1",
+          },
+          [schema.node("paragraph", null, [schema.text("two")])],
+        ),
+        schema.node(
+          "taskItem",
+          {
+            status: "todo",
+            checked: false,
+            taskId: "task-2",
+            taskItemId: "task-item-2",
+          },
+          [schema.node("paragraph", null, [schema.text("three")])],
+        ),
+      ]),
+    ]);
+    const { state } = runBackspaceAtTextStart(doc, "two");
+
+    expect(state.doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "two" }],
+        },
+        {
+          type: "taskList",
+          content: [
+            {
+              type: "taskItem",
+              attrs: {
+                status: "todo",
+                checked: false,
+                taskId: "task-2",
+                taskItemId: "task-item-2",
+              },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "three" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
   });
 
   it("joins later task item paragraphs within the same task item", () => {

--- a/packages/editor/src/note/keymap.ts
+++ b/packages/editor/src/note/keymap.ts
@@ -198,7 +198,10 @@ function joinTaskItemBackward(
   const itemIndex = $from.index(itemDepth - 1);
   const currentItem = list.child(itemIndex);
   if (itemIndex === 0) {
-    return currentItem.firstChild?.content.size ? true : false;
+    // Lift instead of falling through to joinBackward, which would merge the
+    // item's text into the preceding block and silently destroy the task
+    if (!currentItem.firstChild?.content.size) return false;
+    return liftListItem(schema.nodes.taskItem)(state, dispatch);
   }
 
   const previousItem = list.child(itemIndex - 1);


### PR DESCRIPTION
Summary- Fix when editing structure notes and first task items so keyboard and suggestions behave correctly.

What changed- Backspace at of first task item now lifts the item out of the list into paragraph instead of swallowing the; allows removing while text.
- suggestion now hides when the note has structure (e.g., empty checkbox or extra empty paragraphs) by using a structural pristine-doc check of text-basedStoredNoteContent.

Why- Prevents the backspace key from being swallowed when removing checkboxes with text.
- Prevents template suggestions from the caret in documents that structurally non-empty but text-emptyRisks- Low: small behavioral changes to back handling template overlay gating; tested for described.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX changes to template overlay gating and task-list Backspace; behavior is covered by new/updated unit tests.
> 
> **Overview**
> **Session raw note** template suggestions now use **`isPristineNoteDoc`**, a structural “empty memo” check, instead of **`hasStoredNoteContent`**. Empty checkboxes, task lists, or extra blank paragraphs no longer count as pristine, so the suggested-template overlay hides while users are editing structure-only notes; a single empty paragraph still shows suggestions.
> 
> **Note editor keymap**: Backspace at the start of the **first** task item in a list now **lifts** that item into a normal paragraph via `liftListItem`, instead of falling through to `joinBackward` (which merged text into the previous block and broke removing task items). Covered by updated/added keymap tests and a new **`RawEditor`** test for structure-only template visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b246425fb77fcf71a3b94eb1c92a528cc1c3790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->