### PR TITLE
feat(supabase): add shared workspace creation and lifecycle RPCs

### DIFF
--- a/supabase/migrations/20260811130000_shared_workspace_lifecycle.sql
+++ b/supabase/migrations/20260811130000_shared_workspace_lifecycle.sql
@@ -1,0 +1,534 @@
+CREATE OR REPLACE FUNCTION private.create_workspace(
+  p_name text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  membership_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_name text := btrim(p_name);
+  v_workspace_id uuid;
+  v_membership_id uuid;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM auth.users AS actor
+    WHERE actor.id = v_actor_id
+      AND actor.email_confirmed_at IS NOT NULL
+      AND COALESCE(actor.is_anonymous, false) = false
+  ) THEN
+    RAISE EXCEPTION 'workspace operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_name IS NULL
+    OR char_length(v_name) < 1
+    OR char_length(v_name) > 120
+    OR v_name ~ '[[:cntrl:]]'
+  THEN
+    RAISE EXCEPTION 'invalid workspace name'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF (
+    SELECT count(*)
+    FROM public.workspaces AS workspace
+    WHERE workspace.owner_user_id = v_actor_id
+      AND workspace.kind = 'shared'
+      AND workspace.deleted_at IS NULL
+  ) >= 20 THEN
+    RAISE EXCEPTION 'workspace limit reached'
+      USING ERRCODE = '22023';
+  END IF;
+
+  INSERT INTO public.workspaces (id, owner_user_id, kind, name)
+  VALUES (gen_random_uuid(), v_actor_id, 'shared', v_name)
+  RETURNING id INTO v_workspace_id;
+
+  INSERT INTO public.workspace_memberships (workspace_id, user_id, role)
+  VALUES (v_workspace_id, v_actor_id, 'owner')
+  RETURNING id INTO v_membership_id;
+
+  RETURN QUERY
+  SELECT v_workspace_id, v_membership_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.rename_workspace(
+  p_workspace_id uuid,
+  p_name text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  workspace_name text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_actor_role text;
+  v_name text := btrim(p_name);
+BEGIN
+  SELECT membership.role
+  INTO v_actor_role
+  FROM public.workspaces AS workspace
+  JOIN public.workspace_memberships AS membership
+    ON membership.workspace_id = workspace.id
+  JOIN auth.users AS actor
+    ON actor.id = membership.user_id
+  WHERE workspace.id = p_workspace_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+    AND membership.user_id = v_actor_id
+    AND membership.role IN ('owner', 'admin')
+    AND membership.deleted_at IS NULL
+    AND actor.email_confirmed_at IS NOT NULL
+    AND COALESCE(actor.is_anonymous, false) = false
+  FOR UPDATE OF workspace;
+
+  IF v_actor_role IS NULL THEN
+    RAISE EXCEPTION 'workspace operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_name IS NULL
+    OR char_length(v_name) < 1
+    OR char_length(v_name) > 120
+    OR v_name ~ '[[:cntrl:]]'
+  THEN
+    RAISE EXCEPTION 'invalid workspace name'
+      USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.workspaces
+  SET
+    name = v_name,
+    updated_at = now()
+  WHERE id = p_workspace_id;
+
+  RETURN QUERY
+  SELECT p_workspace_id, v_name;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.set_workspace_membership_role(
+  p_workspace_id uuid,
+  p_user_id uuid,
+  p_role text
+)
+RETURNS TABLE (
+  membership_id uuid,
+  membership_role text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_owner_user_id uuid;
+  v_target public.workspace_memberships%ROWTYPE;
+BEGIN
+  IF p_role IS NULL OR p_role NOT IN ('admin', 'member') THEN
+    RAISE EXCEPTION 'invalid workspace role'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT workspace.owner_user_id
+  INTO v_owner_user_id
+  FROM public.workspaces AS workspace
+  JOIN public.workspace_memberships AS membership
+    ON membership.workspace_id = workspace.id
+  JOIN auth.users AS actor
+    ON actor.id = membership.user_id
+  WHERE workspace.id = p_workspace_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+    AND workspace.owner_user_id = v_actor_id
+    AND membership.user_id = v_actor_id
+    AND membership.role = 'owner'
+    AND membership.deleted_at IS NULL
+    AND actor.email_confirmed_at IS NOT NULL
+    AND COALESCE(actor.is_anonymous, false) = false
+  FOR UPDATE OF workspace;
+
+  IF v_owner_user_id IS NULL THEN
+    RAISE EXCEPTION 'workspace membership operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT membership.*
+  INTO v_target
+  FROM public.workspace_memberships AS membership
+  WHERE membership.workspace_id = p_workspace_id
+    AND membership.user_id = p_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND
+    OR v_target.deleted_at IS NOT NULL
+    OR v_target.user_id = v_owner_user_id
+    OR v_target.role = 'owner'
+  THEN
+    RAISE EXCEPTION 'workspace membership operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_target.role <> p_role THEN
+    UPDATE public.workspace_memberships
+    SET
+      role = p_role,
+      updated_at = now()
+    WHERE id = v_target.id;
+  END IF;
+
+  RETURN QUERY
+  SELECT v_target.id, p_role;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.transfer_workspace_ownership(
+  p_workspace_id uuid,
+  p_user_id uuid
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  owner_user_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_current_owner_id uuid;
+  v_target public.workspace_memberships%ROWTYPE;
+BEGIN
+  SELECT workspace.owner_user_id
+  INTO v_current_owner_id
+  FROM public.workspaces AS workspace
+  JOIN public.workspace_memberships AS membership
+    ON membership.workspace_id = workspace.id
+  JOIN auth.users AS actor
+    ON actor.id = membership.user_id
+  WHERE workspace.id = p_workspace_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+    AND workspace.owner_user_id = v_actor_id
+    AND membership.user_id = v_actor_id
+    AND membership.role = 'owner'
+    AND membership.deleted_at IS NULL
+    AND actor.email_confirmed_at IS NOT NULL
+    AND COALESCE(actor.is_anonymous, false) = false
+  FOR UPDATE OF workspace;
+
+  IF v_current_owner_id IS NULL THEN
+    RAISE EXCEPTION 'workspace ownership operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT membership.*
+  INTO v_target
+  FROM public.workspace_memberships AS membership
+  JOIN auth.users AS target_user
+    ON target_user.id = membership.user_id
+  WHERE membership.workspace_id = p_workspace_id
+    AND membership.user_id = p_user_id
+    AND membership.deleted_at IS NULL
+    AND target_user.email_confirmed_at IS NOT NULL
+    AND COALESCE(target_user.is_anonymous, false) = false
+  FOR UPDATE OF membership;
+
+  IF NOT FOUND OR v_target.user_id = v_current_owner_id THEN
+    RAISE EXCEPTION 'workspace ownership operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.workspaces
+  SET
+    owner_user_id = v_target.user_id,
+    updated_at = now()
+  WHERE id = p_workspace_id;
+
+  UPDATE public.workspace_memberships
+  SET
+    role = 'admin',
+    updated_at = now()
+  WHERE workspace_memberships.workspace_id = p_workspace_id
+    AND workspace_memberships.user_id = v_current_owner_id;
+
+  UPDATE public.workspace_memberships
+  SET
+    role = 'owner',
+    updated_at = now()
+  WHERE id = v_target.id;
+
+  RETURN QUERY
+  SELECT p_workspace_id, v_target.user_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.leave_workspace(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  membership_id uuid,
+  left_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_membership public.workspace_memberships%ROWTYPE;
+  v_left_at timestamptz;
+BEGIN
+  SELECT membership.*
+  INTO v_membership
+  FROM public.workspace_memberships AS membership
+  JOIN public.workspaces AS workspace
+    ON workspace.id = membership.workspace_id
+  WHERE membership.workspace_id = p_workspace_id
+    AND membership.user_id = v_actor_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+  FOR UPDATE OF membership;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'workspace membership operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_membership.role = 'owner' AND v_membership.deleted_at IS NULL THEN
+    RAISE EXCEPTION 'owner must transfer ownership before leaving'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF v_membership.deleted_at IS NULL THEN
+    v_left_at := now();
+
+    UPDATE public.workspace_memberships
+    SET
+      deleted_at = v_left_at,
+      updated_at = v_left_at
+    WHERE id = v_membership.id;
+  ELSE
+    v_left_at := v_membership.deleted_at;
+  END IF;
+
+  RETURN QUERY
+  SELECT v_membership.id, v_left_at;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.delete_workspace(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  deleted_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_owner_user_id uuid;
+  v_deleted_at timestamptz := now();
+BEGIN
+  SELECT workspace.owner_user_id
+  INTO v_owner_user_id
+  FROM public.workspaces AS workspace
+  JOIN public.workspace_memberships AS membership
+    ON membership.workspace_id = workspace.id
+  JOIN auth.users AS actor
+    ON actor.id = membership.user_id
+  WHERE workspace.id = p_workspace_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+    AND workspace.owner_user_id = v_actor_id
+    AND membership.user_id = v_actor_id
+    AND membership.role = 'owner'
+    AND membership.deleted_at IS NULL
+    AND actor.email_confirmed_at IS NOT NULL
+    AND COALESCE(actor.is_anonymous, false) = false
+  FOR UPDATE OF workspace;
+
+  IF v_owner_user_id IS NULL THEN
+    RAISE EXCEPTION 'workspace operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.workspace_invitations
+  SET
+    revoked_by_user_id = v_actor_id,
+    revoked_at = v_deleted_at,
+    updated_at = v_deleted_at
+  WHERE workspace_invitations.workspace_id = p_workspace_id
+    AND accepted_at IS NULL
+    AND revoked_at IS NULL;
+
+  UPDATE public.workspaces
+  SET
+    deleted_at = v_deleted_at,
+    updated_at = v_deleted_at
+  WHERE id = p_workspace_id;
+
+  RETURN QUERY
+  SELECT p_workspace_id, v_deleted_at;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.create_workspace(text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.rename_workspace(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.set_workspace_membership_role(uuid, uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.transfer_workspace_ownership(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.leave_workspace(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.delete_workspace(uuid)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION private.create_workspace(text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.rename_workspace(uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.set_workspace_membership_role(uuid, uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.transfer_workspace_ownership(uuid, uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.leave_workspace(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.delete_workspace(uuid)
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.create_workspace(
+  p_name text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  membership_id uuid
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.create_workspace(p_name);
+$$;
+
+CREATE OR REPLACE FUNCTION public.rename_workspace(
+  p_workspace_id uuid,
+  p_name text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  workspace_name text
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.rename_workspace(p_workspace_id, p_name);
+$$;
+
+CREATE OR REPLACE FUNCTION public.set_workspace_membership_role(
+  p_workspace_id uuid,
+  p_user_id uuid,
+  p_role text
+)
+RETURNS TABLE (
+  membership_id uuid,
+  membership_role text
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.set_workspace_membership_role(p_workspace_id, p_user_id, p_role);
+$$;
+
+CREATE OR REPLACE FUNCTION public.transfer_workspace_ownership(
+  p_workspace_id uuid,
+  p_user_id uuid
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  owner_user_id uuid
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.transfer_workspace_ownership(p_workspace_id, p_user_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.leave_workspace(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  membership_id uuid,
+  left_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.leave_workspace(p_workspace_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.delete_workspace(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  deleted_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.delete_workspace(p_workspace_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.create_workspace(text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.rename_workspace(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.set_workspace_membership_role(uuid, uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.transfer_workspace_ownership(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.leave_workspace(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.delete_workspace(uuid)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_workspace(text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rename_workspace(uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.set_workspace_membership_role(uuid, uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.transfer_workspace_ownership(uuid, uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.leave_workspace(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_workspace(uuid)
+  TO authenticated;

--- a/supabase/tests/008-workspace-invitations.sql
+++ b/supabase/tests/008-workspace-invitations.sql
@@ -813,8 +813,8 @@ select tests.clear_authentication();
 reset role;
 
 select ok(
-  to_regprocedure('public.create_shared_workspace(text)') is null,
-  'Client shared-workspace creation remains disabled pending ownership lifecycle rules'
+  to_regprocedure('public.create_workspace(text)') is not null,
+  'Client shared-workspace creation is served by the lifecycle RPCs (031)'
 );
 
 select * from finish();

--- a/supabase/tests/031-shared-workspace-lifecycle.sql
+++ b/supabase/tests/031-shared-workspace-lifecycle.sql
@@ -1,0 +1,437 @@
+begin;
+select plan(27);
+
+select tests.create_supabase_user('lifecycle_owner', 'lifecycle-owner@example.com');
+select tests.create_supabase_user('lifecycle_member', 'lifecycle-member@example.com');
+select tests.create_supabase_user('lifecycle_outsider', 'lifecycle-outsider@example.com');
+select tests.create_supabase_user('lifecycle_unconfirmed', 'lifecycle-unconfirmed@example.com');
+
+create temporary table workspace_lifecycle_test_state (
+  name text primary key,
+  workspace_id uuid,
+  membership_id uuid,
+  invitation_id uuid,
+  invite_token text,
+  left_at timestamptz
+);
+
+grant all on workspace_lifecycle_test_state to authenticated, service_role;
+
+reset role;
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('lifecycle_owner'),
+  tests.get_supabase_uid('lifecycle_member'),
+  tests.get_supabase_uid('lifecycle_outsider')
+);
+
+update auth.users
+set email_confirmed_at = null
+where id = tests.get_supabase_uid('lifecycle_unconfirmed');
+
+select ok(
+  has_function_privilege('authenticated', 'public.create_workspace(text)', 'EXECUTE')
+    and has_function_privilege('authenticated', 'public.rename_workspace(uuid,text)', 'EXECUTE')
+    and has_function_privilege('authenticated', 'public.set_workspace_membership_role(uuid,uuid,text)', 'EXECUTE')
+    and has_function_privilege('authenticated', 'public.transfer_workspace_ownership(uuid,uuid)', 'EXECUTE')
+    and has_function_privilege('authenticated', 'public.leave_workspace(uuid)', 'EXECUTE')
+    and has_function_privilege('authenticated', 'public.delete_workspace(uuid)', 'EXECUTE')
+    and not has_function_privilege('anon', 'public.create_workspace(text)', 'EXECUTE')
+    and not has_function_privilege('anon', 'public.rename_workspace(uuid,text)', 'EXECUTE')
+    and not has_function_privilege('anon', 'public.set_workspace_membership_role(uuid,uuid,text)', 'EXECUTE')
+    and not has_function_privilege('anon', 'public.transfer_workspace_ownership(uuid,uuid)', 'EXECUTE')
+    and not has_function_privilege('anon', 'public.leave_workspace(uuid)', 'EXECUTE')
+    and not has_function_privilege('anon', 'public.delete_workspace(uuid)', 'EXECUTE'),
+  'Only authenticated clients can execute workspace lifecycle RPC wrappers'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where (
+      namespace.nspname = 'private'
+      and proc.proname in (
+        'create_workspace',
+        'rename_workspace',
+        'set_workspace_membership_role',
+        'transfer_workspace_ownership',
+        'leave_workspace',
+        'delete_workspace'
+      )
+      and (
+        not proc.prosecdef
+        or not ('search_path=""' = any(coalesce(proc.proconfig, array[]::text[])))
+      )
+    )
+    or (
+      namespace.nspname = 'public'
+      and proc.proname in (
+        'create_workspace',
+        'rename_workspace',
+        'set_workspace_membership_role',
+        'transfer_workspace_ownership',
+        'leave_workspace',
+        'delete_workspace'
+      )
+      and (
+        proc.prosecdef
+        or not ('search_path=""' = any(coalesce(proc.proconfig, array[]::text[])))
+      )
+    )
+  ),
+  'Privileged lifecycle implementations are private and every RPC uses an empty search path'
+);
+
+select tests.authenticate_as('lifecycle_unconfirmed');
+
+select throws_ok(
+  $$select * from public.create_workspace('Shadow Org')$$,
+  '42501',
+  'workspace operation not permitted',
+  'An unconfirmed account cannot create shared workspaces'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('lifecycle_owner');
+
+select lives_ok(
+  $$
+    insert into workspace_lifecycle_test_state (name, workspace_id, membership_id)
+    select 'hq', workspace_id, membership_id
+    from public.create_workspace('  Lifecycle HQ  ')
+  $$,
+  'A confirmed user can create a shared workspace'
+);
+
+select ok(
+  exists (
+    select 1
+    from public.workspaces as workspace
+    join public.workspace_memberships as membership
+      on membership.workspace_id = workspace.id
+    where workspace.id = (
+        select workspace_id from workspace_lifecycle_test_state where name = 'hq'
+      )
+      and workspace.kind = 'shared'
+      and workspace.name = 'Lifecycle HQ'
+      and workspace.owner_user_id = auth.uid()
+      and workspace.deleted_at is null
+      and membership.user_id = auth.uid()
+      and membership.role = 'owner'
+      and membership.deleted_at is null
+  ),
+  'Creation trims the name and grants the creator an owner membership'
+);
+
+select throws_ok(
+  $$select * from public.create_workspace('   ')$$,
+  '22023',
+  'invalid workspace name',
+  'Blank workspace names are rejected'
+);
+
+select lives_ok(
+  $$
+    insert into workspace_lifecycle_test_state (name, invitation_id, invite_token)
+    select 'member_invite', invitation_id, invite_token
+    from public.create_workspace_invitation(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      'lifecycle-member@example.com'
+    )
+  $$,
+  'The owner can invite a member into the new workspace'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('lifecycle_member');
+
+select lives_ok(
+  $$
+    insert into workspace_lifecycle_test_state (name, workspace_id, membership_id)
+    select 'member_membership', workspace_id, membership_id
+    from public.accept_workspace_invitation(
+      (select invitation_id from workspace_lifecycle_test_state where name = 'member_invite'),
+      (select invite_token from workspace_lifecycle_test_state where name = 'member_invite')
+    )
+  $$,
+  'The invited member can accept and join'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('lifecycle_owner');
+
+select results_eq(
+  $$
+    select membership_role
+    from public.set_workspace_membership_role(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      tests.get_supabase_uid('lifecycle_member'),
+      'admin'
+    )
+  $$,
+  array['admin'::text],
+  'The owner can promote a member to admin'
+);
+
+select throws_ok(
+  $$
+    select * from public.set_workspace_membership_role(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      tests.get_supabase_uid('lifecycle_owner'),
+      'member'
+    )
+  $$,
+  '42501',
+  'workspace membership operation not permitted',
+  'The owner role cannot be changed through role management'
+);
+
+select throws_ok(
+  $$
+    select * from public.set_workspace_membership_role(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      tests.get_supabase_uid('lifecycle_member'),
+      'owner'
+    )
+  $$,
+  '22023',
+  'invalid workspace role',
+  'Ownership cannot be granted through role management'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('lifecycle_member');
+
+select results_eq(
+  $$
+    select workspace_name
+    from public.rename_workspace(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      'Lifecycle Core'
+    )
+  $$,
+  array['Lifecycle Core'::text],
+  'A promoted admin can rename the workspace'
+);
+
+select throws_ok(
+  $$
+    select * from public.set_workspace_membership_role(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      tests.get_supabase_uid('lifecycle_member'),
+      'member'
+    )
+  $$,
+  '42501',
+  'workspace membership operation not permitted',
+  'Admins cannot change roles; only the owner can'
+);
+
+select throws_ok(
+  $$
+    select * from public.transfer_workspace_ownership(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      tests.get_supabase_uid('lifecycle_member')
+    )
+  $$,
+  '42501',
+  'workspace ownership operation not permitted',
+  'Admins cannot transfer ownership to themselves'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('lifecycle_owner');
+
+select throws_ok(
+  $$
+    select * from public.transfer_workspace_ownership(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      tests.get_supabase_uid('lifecycle_outsider')
+    )
+  $$,
+  '42501',
+  'workspace ownership operation not permitted',
+  'Ownership cannot be transferred to a non-member'
+);
+
+select lives_ok(
+  $$
+    select * from public.transfer_workspace_ownership(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      tests.get_supabase_uid('lifecycle_member')
+    )
+  $$,
+  'The owner can transfer ownership to an active member'
+);
+
+select tests.clear_authentication();
+reset role;
+
+select ok(
+  exists (
+    select 1
+    from public.workspaces as workspace
+    where workspace.id = (
+        select workspace_id from workspace_lifecycle_test_state where name = 'hq'
+      )
+      and workspace.owner_user_id = tests.get_supabase_uid('lifecycle_member')
+  )
+  and exists (
+    select 1
+    from public.workspace_memberships as membership
+    where membership.workspace_id = (
+        select workspace_id from workspace_lifecycle_test_state where name = 'hq'
+      )
+      and membership.user_id = tests.get_supabase_uid('lifecycle_owner')
+      and membership.role = 'admin'
+      and membership.deleted_at is null
+  )
+  and exists (
+    select 1
+    from public.workspace_memberships as membership
+    where membership.workspace_id = (
+        select workspace_id from workspace_lifecycle_test_state where name = 'hq'
+      )
+      and membership.user_id = tests.get_supabase_uid('lifecycle_member')
+      and membership.role = 'owner'
+      and membership.deleted_at is null
+  ),
+  'Transfer swaps the owner column and both membership roles atomically'
+);
+
+select tests.authenticate_as('lifecycle_owner');
+
+select throws_ok(
+  $$
+    select * from public.delete_workspace(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq')
+    )
+  $$,
+  '42501',
+  'workspace operation not permitted',
+  'A demoted previous owner cannot delete the workspace'
+);
+
+select lives_ok(
+  $$
+    update workspace_lifecycle_test_state
+    set left_at = departure.left_at
+    from public.leave_workspace(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq')
+    ) as departure
+    where name = 'hq'
+  $$,
+  'A non-owner can leave the workspace'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from public.workspaces
+    where id = (
+      select workspace_id from workspace_lifecycle_test_state where name = 'hq'
+    )
+  $$,
+  array[0::bigint],
+  'Leaving immediately removes the workspace from the member projection'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('lifecycle_member');
+
+select throws_ok(
+  $$
+    select * from public.leave_workspace(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq')
+    )
+  $$,
+  '22023',
+  'owner must transfer ownership before leaving',
+  'The owner must hand off the workspace before leaving'
+);
+
+select lives_ok(
+  $$
+    insert into workspace_lifecycle_test_state (name, invitation_id)
+    select 'pending_invite', invitation_id
+    from public.create_workspace_invitation(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      'lifecycle-outsider@example.com'
+    )
+  $$,
+  'The new owner can still invite before deletion'
+);
+
+select lives_ok(
+  $$
+    select * from public.delete_workspace(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq')
+    )
+  $$,
+  'The owner can soft delete the workspace'
+);
+
+select tests.clear_authentication();
+reset role;
+
+select ok(
+  exists (
+    select 1
+    from public.workspaces as workspace
+    where workspace.id = (
+        select workspace_id from workspace_lifecycle_test_state where name = 'hq'
+      )
+      and workspace.deleted_at is not null
+  )
+  and not exists (
+    select 1
+    from public.workspace_invitations as invitation
+    where invitation.workspace_id = (
+        select workspace_id from workspace_lifecycle_test_state where name = 'hq'
+      )
+      and invitation.accepted_at is null
+      and invitation.revoked_at is null
+  ),
+  'Deletion soft deletes the workspace and revokes its pending invitations'
+);
+
+select tests.authenticate_as('lifecycle_outsider');
+
+select throws_ok(
+  $$
+    select * from public.rename_workspace(
+      (select workspace_id from workspace_lifecycle_test_state where name = 'hq'),
+      'Hijacked'
+    )
+  $$,
+  '42501',
+  'workspace operation not permitted',
+  'Deleted workspaces reject lifecycle operations'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('lifecycle_owner');
+
+select lives_ok(
+  $$
+    select count(*)
+    from generate_series(1, 20) as bulk(i),
+    lateral public.create_workspace('Bulk ' || bulk.i::text)
+  $$,
+  'A user can own up to twenty active shared workspaces'
+);
+
+select throws_ok(
+  $$select * from public.create_workspace('One Too Many')$$,
+  '22023',
+  'workspace limit reached',
+  'The owned-workspace cap rejects the twenty-first active workspace'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Shared workspaces could never exist: the invitation and membership
RPCs shipped in 20260716145904 all require kind = 'shared', but no
client path created such workspaces, leaving them dead code.

Add six authenticated RPCs following the private/public wrapper
pattern: create_workspace (trimmed name validation, cap of 20 active
owned workspaces), rename_workspace (owner or admin),
set_workspace_membership_role (owner-only admin<->member changes),
transfer_workspace_ownership (demotes the previous owner to admin),
leave_workspace (idempotent; owners must transfer first), and
delete_workspace (soft delete that also revokes pending invitations;
existing triggers restrict shares and bump access versions).

Cover the lifecycle with pgTAP (031) and update the 008 sentinel that
asserted client workspace creation stays disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New SECURITY DEFINER RPCs govern workspace ownership, membership roles, and deletion—authorization bugs would have broad multi-tenant impact; coverage in 031 mitigates but production behavior still warrants careful review.
> 
> **Overview**
> Adds **six authenticated lifecycle RPCs** so clients can create and manage `shared` workspaces (previously only service-role inserts could provision them, leaving invitation flows without a normal creation path).
> 
> **`create_workspace`** validates trimmed names (1–120 chars, no control chars), requires a confirmed non-anonymous user, caps active owned shared workspaces at **20**, and inserts the workspace plus an **owner** membership. **`rename_workspace`** allows owner or admin on non-deleted shared workspaces. **`set_workspace_membership_role`** is owner-only and only toggles **admin** ↔ **member** (not owner). **`transfer_workspace_ownership`** moves `owner_user_id` to a confirmed member, demoting the prior owner to admin. **`leave_workspace`** soft-deletes membership (idempotent); owners must transfer first. **`delete_workspace`** soft-deletes the workspace and revokes pending invitations.
> 
> Implementation follows the existing **private `SECURITY DEFINER` + public `SECURITY INVOKER` wrapper** pattern with empty `search_path` and execute grants limited to **authenticated**. pgTAP **031** exercises the full lifecycle; **008** now asserts `public.create_workspace(text)` exists instead of expecting creation to stay disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b242aab8f4bacd35ba9c4f644220a7fcb5cdeed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->