### PR TITLE
feat(e2ee): distribute shared workspace keys per member

### DIFF
--- a/crates/e2ee/src/lib.rs
+++ b/crates/e2ee/src/lib.rs
@@ -1,11 +1,15 @@
 #![forbid(unsafe_code)]
 
 mod blob;
+mod member;
 
 pub use blob::{
     ATTACHMENT_BLOB_CHUNK_SIZE, ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES,
     AttachmentBlobCiphertextMetadata, AttachmentBlobContext, AttachmentBlobError,
     AttachmentBlobMetadata, AttachmentBlobPlaintextMetadata, AttachmentBlobResult,
+};
+pub use member::{
+    MemberIdentityKey, WorkspaceKeyGrant, WorkspaceKeyring, seal_workspace_key_for_member,
 };
 
 use base64::Engine;
@@ -49,6 +53,10 @@ pub enum Error {
     InvalidDeviceEnrollmentKey,
     #[error("the device enrollment package is invalid")]
     InvalidDeviceEnrollmentPackage,
+    #[error("the member identity key is invalid")]
+    InvalidMemberIdentityKey,
+    #[error("the workspace key grant is invalid")]
+    InvalidWorkspaceKeyGrant,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -243,6 +251,10 @@ impl RecoveryKey {
         URL_SAFE_NO_PAD.encode(&digest[..16])
     }
 
+    pub(crate) fn expose_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
     pub fn workspace_key(&self, workspace_id: &str) -> Result<WorkspaceKey> {
         let workspace_id = workspace_id.trim();
         if workspace_id.is_empty() || workspace_id.len() > 256 {
@@ -272,6 +284,27 @@ impl Clone for WorkspaceKey {
 }
 
 impl WorkspaceKey {
+    /// Mints a random shared-workspace key.
+    ///
+    /// Unlike [`RecoveryKey::workspace_key`], this is tied to no member, so it
+    /// can be handed to several of them and rotated without anyone's recovery
+    /// key changing.
+    pub fn generate() -> Result<Self> {
+        let mut bytes = [0_u8; 32];
+        getrandom::fill(&mut bytes).map_err(|_| Error::RandomnessUnavailable)?;
+        let key = Self::new(bytes);
+        bytes.zeroize();
+        Ok(key)
+    }
+
+    pub(crate) fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self::new(bytes)
+    }
+
+    pub(crate) fn expose_bytes(&self) -> &Zeroizing<[u8; 32]> {
+        &self.bytes
+    }
+
     fn new(bytes: [u8; 32]) -> Self {
         let digest = Sha256::digest([b"anarlog-e2ee-key-id-v1".as_slice(), &bytes].concat());
         let key_id = URL_SAFE_NO_PAD.encode(&digest[..16]);

--- a/crates/e2ee/src/member.rs
+++ b/crates/e2ee/src/member.rs
@@ -1,0 +1,477 @@
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chacha20poly1305::aead::{Aead, Payload};
+use chacha20poly1305::{KeyInit, XChaCha20Poly1305, XNonce};
+use hkdf::Hkdf;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+
+use crate::{Envelope, Error, RecoveryKey, Result, WorkspaceKey};
+
+const MEMBER_IDENTITY_KDF_SALT: &[u8] = b"anarlog-e2ee-member-identity-v1";
+const MEMBER_IDENTITY_INFO: &[u8] = b"x25519";
+const GRANT_KDF_SALT: &[u8] = b"anarlog-e2ee-workspace-key-grant-kdf-v1";
+const GRANT_AAD_DOMAIN: &[u8] = b"anarlog-e2ee-workspace-key-grant-v1";
+
+/// Account-level X25519 keypair derived from the recovery key.
+///
+/// Every device holding the recovery key re-derives the same secret, so a grant
+/// sealed once reaches all of that member's devices without the issuer ever
+/// learning the recipient's recovery key.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct MemberIdentityKey([u8; 32]);
+
+impl MemberIdentityKey {
+    pub fn public_key(&self) -> String {
+        let secret = x25519_dalek::StaticSecret::from(self.0);
+        URL_SAFE_NO_PAD.encode(x25519_dalek::PublicKey::from(&secret).as_bytes())
+    }
+
+    pub fn open_workspace_key(
+        &self,
+        workspace_id: &str,
+        member_user_id: &str,
+        grant: &WorkspaceKeyGrant,
+    ) -> Result<WorkspaceKey> {
+        let ephemeral_public = decode_grant_bytes(&grant.ephemeral_public_key)?;
+        let nonce: [u8; 24] = URL_SAFE_NO_PAD
+            .decode(&grant.nonce)
+            .map_err(|_| Error::InvalidWorkspaceKeyGrant)?
+            .try_into()
+            .map_err(|_| Error::InvalidWorkspaceKeyGrant)?;
+        let ciphertext = URL_SAFE_NO_PAD
+            .decode(&grant.ciphertext)
+            .map_err(|_| Error::InvalidWorkspaceKeyGrant)?;
+        let shared = x25519_dalek::StaticSecret::from(self.0)
+            .diffie_hellman(&x25519_dalek::PublicKey::from(ephemeral_public));
+        if !shared.was_contributory() {
+            return Err(Error::InvalidWorkspaceKeyGrant);
+        }
+        let cipher = grant_cipher(
+            shared.as_bytes(),
+            workspace_id,
+            member_user_id,
+            &grant.key_id,
+        )?;
+        let plaintext = cipher
+            .decrypt(
+                &XNonce::from(nonce),
+                Payload {
+                    msg: &ciphertext,
+                    aad: &grant_aad(workspace_id, member_user_id, &grant.key_id),
+                },
+            )
+            .map_err(|_| Error::AuthenticationFailed)?;
+        let mut bytes: [u8; 32] = Zeroizing::new(plaintext)
+            .as_slice()
+            .try_into()
+            .map_err(|_| Error::InvalidWorkspaceKeyGrant)?;
+        let key = WorkspaceKey::from_bytes(bytes);
+        bytes.zeroize();
+        // A grant whose label disagrees with its contents is never usable: the
+        // keyring indexes by key_id, so accepting it would silently shadow the
+        // real key for that id.
+        if key.key_id() != grant.key_id {
+            return Err(Error::InvalidWorkspaceKeyGrant);
+        }
+        Ok(key)
+    }
+}
+
+/// A shared workspace key sealed to one member's identity key.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WorkspaceKeyGrant {
+    pub key_id: String,
+    pub ephemeral_public_key: String,
+    pub nonce: String,
+    pub ciphertext: String,
+}
+
+pub fn seal_workspace_key_for_member(
+    key: &WorkspaceKey,
+    recipient_public_key: &str,
+    workspace_id: &str,
+    member_user_id: &str,
+) -> Result<WorkspaceKeyGrant> {
+    let recipient_public = decode_grant_bytes(recipient_public_key)?;
+    let mut ephemeral_bytes = [0_u8; 32];
+    getrandom::fill(&mut ephemeral_bytes).map_err(|_| Error::RandomnessUnavailable)?;
+    let ephemeral_secret = x25519_dalek::StaticSecret::from(ephemeral_bytes);
+    ephemeral_bytes.zeroize();
+    let ephemeral_public = x25519_dalek::PublicKey::from(&ephemeral_secret);
+    let shared = ephemeral_secret.diffie_hellman(&x25519_dalek::PublicKey::from(recipient_public));
+    if !shared.was_contributory() {
+        return Err(Error::InvalidMemberIdentityKey);
+    }
+    let key_id = key.key_id().to_string();
+    let cipher = grant_cipher(shared.as_bytes(), workspace_id, member_user_id, &key_id)?;
+    let mut nonce = [0_u8; 24];
+    getrandom::fill(&mut nonce).map_err(|_| Error::RandomnessUnavailable)?;
+    let ciphertext = cipher
+        .encrypt(
+            &XNonce::from(nonce),
+            Payload {
+                msg: key.expose_bytes().as_slice(),
+                aad: &grant_aad(workspace_id, member_user_id, &key_id),
+            },
+        )
+        .map_err(|_| Error::InvalidWorkspaceKeyGrant)?;
+    Ok(WorkspaceKeyGrant {
+        key_id,
+        ephemeral_public_key: URL_SAFE_NO_PAD.encode(ephemeral_public.as_bytes()),
+        nonce: URL_SAFE_NO_PAD.encode(nonce),
+        ciphertext: URL_SAFE_NO_PAD.encode(ciphertext),
+    })
+}
+
+/// Every workspace key generation a member can still read.
+///
+/// Rotation mints a new key and leaves earlier ones in place, so history stays
+/// readable while writes move to the newest generation.
+pub struct WorkspaceKeyring {
+    active: WorkspaceKey,
+    retired: Vec<WorkspaceKey>,
+}
+
+impl WorkspaceKeyring {
+    pub fn new(active: WorkspaceKey) -> Self {
+        Self {
+            active,
+            retired: Vec::new(),
+        }
+    }
+
+    /// Adds an older generation. Re-adding the active key or a duplicate is a
+    /// no-op so callers can replay grant lists without bookkeeping.
+    pub fn insert_retired(&mut self, key: WorkspaceKey) {
+        if self.get(key.key_id()).is_some() {
+            return;
+        }
+        self.retired.push(key);
+    }
+
+    pub fn active(&self) -> &WorkspaceKey {
+        &self.active
+    }
+
+    pub fn get(&self, key_id: &str) -> Option<&WorkspaceKey> {
+        if self.active.key_id() == key_id {
+            return Some(&self.active);
+        }
+        self.retired.iter().find(|key| key.key_id() == key_id)
+    }
+
+    pub fn open_field(
+        &self,
+        workspace_id: &str,
+        record_id: &str,
+        payload: &str,
+    ) -> Result<crate::OpenedField> {
+        let envelope: Envelope =
+            serde_json::from_str(payload).map_err(|_| Error::InvalidPayload)?;
+        self.get(&envelope.key_id)
+            .ok_or(Error::UnknownKey)?
+            .open_field(workspace_id, record_id, payload)
+    }
+}
+
+impl RecoveryKey {
+    pub fn member_identity_key(&self) -> Result<MemberIdentityKey> {
+        let hkdf = Hkdf::<Sha256>::new(Some(MEMBER_IDENTITY_KDF_SALT), self.expose_bytes());
+        let mut bytes = [0_u8; 32];
+        hkdf.expand(MEMBER_IDENTITY_INFO, &mut bytes)
+            .map_err(|_| Error::InvalidMemberIdentityKey)?;
+        Ok(MemberIdentityKey(bytes))
+    }
+}
+
+fn decode_grant_bytes(value: &str) -> Result<[u8; 32]> {
+    URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|_| Error::InvalidMemberIdentityKey)?
+        .try_into()
+        .map_err(|_| Error::InvalidMemberIdentityKey)
+}
+
+fn grant_cipher(
+    shared_secret: &[u8; 32],
+    workspace_id: &str,
+    member_user_id: &str,
+    key_id: &str,
+) -> Result<XChaCha20Poly1305> {
+    if workspace_id.trim().is_empty() || member_user_id.trim().is_empty() || key_id.is_empty() {
+        return Err(Error::InvalidWorkspaceKeyGrant);
+    }
+    let hkdf = Hkdf::<Sha256>::new(Some(GRANT_KDF_SALT), shared_secret);
+    let mut key = Zeroizing::new([0_u8; 32]);
+    hkdf.expand(
+        &grant_aad(workspace_id, member_user_id, key_id),
+        key.as_mut(),
+    )
+    .map_err(|_| Error::InvalidWorkspaceKeyGrant)?;
+    Ok(XChaCha20Poly1305::new_from_slice(key.as_ref())
+        .expect("XChaCha20Poly1305 accepts 32-byte keys"))
+}
+
+fn grant_aad(workspace_id: &str, member_user_id: &str, key_id: &str) -> Vec<u8> {
+    let mut aad = Vec::new();
+    for value in [
+        GRANT_AAD_DOMAIN,
+        workspace_id.as_bytes(),
+        member_user_id.as_bytes(),
+        key_id.as_bytes(),
+    ] {
+        aad.extend_from_slice(&(value.len() as u64).to_be_bytes());
+        aad.extend_from_slice(value);
+    }
+    aad
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    const WORKSPACE: &str = "workspace-shared";
+    const ALICE: &str = "user-alice";
+    const BOB: &str = "user-bob";
+    const WRITER: &str = "00000000000000000000000000000001";
+
+    fn recovery_key(seed: u8) -> RecoveryKey {
+        RecoveryKey::parse(&format!(
+            "anarlog-e2ee-v1:{}",
+            URL_SAFE_NO_PAD.encode([seed; 32])
+        ))
+        .unwrap()
+    }
+
+    fn seal(key: &WorkspaceKey, value: &str) -> crate::SealedField {
+        key.seal_field(
+            WORKSPACE,
+            "sessions",
+            "session-1",
+            "title",
+            WRITER,
+            1,
+            false,
+            json!(value),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn shared_workspace_keys_are_random_per_generation() {
+        let first = WorkspaceKey::generate().unwrap();
+        let second = WorkspaceKey::generate().unwrap();
+
+        assert_ne!(first.key_id(), second.key_id());
+    }
+
+    #[test]
+    fn shared_keys_are_not_derivable_from_any_members_recovery_key() {
+        let shared = WorkspaceKey::generate().unwrap();
+        let derived = recovery_key(1).workspace_key(WORKSPACE).unwrap();
+
+        assert_ne!(shared.key_id(), derived.key_id());
+    }
+
+    #[test]
+    fn member_identities_are_deterministic_and_distinct() {
+        let alice = recovery_key(1);
+        let bob = recovery_key(2);
+
+        assert_eq!(
+            alice.member_identity_key().unwrap().public_key(),
+            alice.member_identity_key().unwrap().public_key()
+        );
+        assert_ne!(
+            alice.member_identity_key().unwrap().public_key(),
+            bob.member_identity_key().unwrap().public_key()
+        );
+    }
+
+    #[test]
+    fn grants_hand_the_shared_key_to_another_member() {
+        let key = WorkspaceKey::generate().unwrap();
+        let bob = recovery_key(2).member_identity_key().unwrap();
+
+        let grant = seal_workspace_key_for_member(&key, &bob.public_key(), WORKSPACE, BOB).unwrap();
+        let opened = bob.open_workspace_key(WORKSPACE, BOB, &grant).unwrap();
+
+        assert_eq!(opened.key_id(), key.key_id());
+
+        // Bob can now read what an existing member wrote.
+        let sealed = seal(&key, "Roadmap");
+        let field = opened
+            .open_field(WORKSPACE, &sealed.record_id, &sealed.payload)
+            .unwrap();
+        assert_eq!(field.value, json!("Roadmap"));
+    }
+
+    #[test]
+    fn grants_are_bound_to_workspace_recipient_and_key_id() {
+        let key = WorkspaceKey::generate().unwrap();
+        let bob = recovery_key(2).member_identity_key().unwrap();
+        let grant = seal_workspace_key_for_member(&key, &bob.public_key(), WORKSPACE, BOB).unwrap();
+
+        assert!(
+            bob.open_workspace_key("other-workspace", BOB, &grant)
+                .is_err()
+        );
+        assert!(bob.open_workspace_key(WORKSPACE, ALICE, &grant).is_err());
+
+        let mut relabelled = grant.clone();
+        relabelled.key_id = WorkspaceKey::generate().unwrap().key_id().to_string();
+        assert!(bob.open_workspace_key(WORKSPACE, BOB, &relabelled).is_err());
+    }
+
+    #[test]
+    fn grants_are_useless_to_everyone_except_their_recipient() {
+        let key = WorkspaceKey::generate().unwrap();
+        let bob = recovery_key(2).member_identity_key().unwrap();
+        let mallory = recovery_key(3).member_identity_key().unwrap();
+        let grant = seal_workspace_key_for_member(&key, &bob.public_key(), WORKSPACE, BOB).unwrap();
+
+        assert!(mallory.open_workspace_key(WORKSPACE, BOB, &grant).is_err());
+    }
+
+    #[test]
+    fn tampered_grants_fail_closed() {
+        let key = WorkspaceKey::generate().unwrap();
+        let bob = recovery_key(2).member_identity_key().unwrap();
+        let grant = seal_workspace_key_for_member(&key, &bob.public_key(), WORKSPACE, BOB).unwrap();
+
+        let mut tampered = grant.clone();
+        tampered.ciphertext = URL_SAFE_NO_PAD.encode([0_u8; 48]);
+        assert!(bob.open_workspace_key(WORKSPACE, BOB, &tampered).is_err());
+
+        let mut swapped = grant.clone();
+        swapped.ephemeral_public_key = URL_SAFE_NO_PAD.encode([0_u8; 32]);
+        assert!(matches!(
+            bob.open_workspace_key(WORKSPACE, BOB, &swapped),
+            Err(Error::InvalidWorkspaceKeyGrant)
+        ));
+    }
+
+    #[test]
+    fn rejects_noncontributory_recipient_public_key() {
+        let key = WorkspaceKey::generate().unwrap();
+
+        assert!(matches!(
+            seal_workspace_key_for_member(
+                &key,
+                &URL_SAFE_NO_PAD.encode([0_u8; 32]),
+                WORKSPACE,
+                BOB
+            ),
+            Err(Error::InvalidMemberIdentityKey)
+        ));
+    }
+
+    #[test]
+    fn removing_a_member_cuts_them_off_from_writes_after_rotation() {
+        let first = WorkspaceKey::generate().unwrap();
+        let bob = recovery_key(2).member_identity_key().unwrap();
+        let bobs_key = bob
+            .open_workspace_key(
+                WORKSPACE,
+                BOB,
+                &seal_workspace_key_for_member(&first, &bob.public_key(), WORKSPACE, BOB).unwrap(),
+            )
+            .unwrap();
+
+        let before = seal(&first, "Before removal");
+
+        // Bob is removed: the workspace rotates and he receives no new grant.
+        let second = WorkspaceKey::generate().unwrap();
+        let after = seal(&second, "After removal");
+
+        assert!(
+            bobs_key
+                .open_field(WORKSPACE, &after.record_id, &after.payload)
+                .is_err(),
+            "a removed member must not read writes made after rotation"
+        );
+        assert_eq!(
+            bobs_key
+                .open_field(WORKSPACE, &before.record_id, &before.payload)
+                .unwrap()
+                .value,
+            json!("Before removal"),
+            "history stays readable for whoever already held the old key"
+        );
+    }
+
+    #[test]
+    fn keyrings_read_across_generations_and_reject_unknown_keys() {
+        let first = WorkspaceKey::generate().unwrap();
+        let second = WorkspaceKey::generate().unwrap();
+        let stranger = WorkspaceKey::generate().unwrap();
+
+        let old = seal(&first, "Old");
+        let new = seal(&second, "New");
+        let foreign = seal(&stranger, "Foreign");
+
+        let mut keyring = WorkspaceKeyring::new(second.clone());
+        keyring.insert_retired(first.clone());
+        keyring.insert_retired(first);
+        keyring.insert_retired(second);
+
+        assert_eq!(keyring.active().key_id(), keyring.active().key_id());
+        assert_eq!(
+            keyring
+                .open_field(WORKSPACE, &old.record_id, &old.payload)
+                .unwrap()
+                .value,
+            json!("Old")
+        );
+        assert_eq!(
+            keyring
+                .open_field(WORKSPACE, &new.record_id, &new.payload)
+                .unwrap()
+                .value,
+            json!("New")
+        );
+        assert!(matches!(
+            keyring.open_field(WORKSPACE, &foreign.record_id, &foreign.payload),
+            Err(Error::UnknownKey)
+        ));
+    }
+
+    #[test]
+    fn rotation_rewraps_for_remaining_members_only() {
+        let members = [(ALICE, recovery_key(1)), (BOB, recovery_key(2))];
+        let removed = (String::from("user-mallory"), recovery_key(3));
+
+        let rotated = WorkspaceKey::generate().unwrap();
+        for (user_id, recovery) in &members {
+            let identity = recovery.member_identity_key().unwrap();
+            let grant =
+                seal_workspace_key_for_member(&rotated, &identity.public_key(), WORKSPACE, user_id)
+                    .unwrap();
+            assert_eq!(
+                identity
+                    .open_workspace_key(WORKSPACE, user_id, &grant)
+                    .unwrap()
+                    .key_id(),
+                rotated.key_id()
+            );
+        }
+
+        // The removed member has no grant for the rotated generation, and a
+        // grant minted for someone else does not help them.
+        let mallory = removed.1.member_identity_key().unwrap();
+        let alice_identity = members[0].1.member_identity_key().unwrap();
+        let alice_grant =
+            seal_workspace_key_for_member(&rotated, &alice_identity.public_key(), WORKSPACE, ALICE)
+                .unwrap();
+        assert!(
+            mallory
+                .open_workspace_key(WORKSPACE, &removed.0, &alice_grant)
+                .is_err()
+        );
+    }
+}

--- a/supabase/migrations/20260811150000_shared_workspace_e2ee_grants.sql
+++ b/supabase/migrations/20260811150000_shared_workspace_e2ee_grants.sql
@@ -1,0 +1,505 @@
+-- Shared workspaces cannot derive their key from one member's recovery key, so
+-- the key is minted at random and wrapped once per member against an
+-- account-level identity key. The server stores only wrapped ciphertext.
+
+CREATE TABLE public.e2ee_member_identities (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  public_key text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT e2ee_member_identities_public_key_check CHECK (
+    public_key ~ '^[A-Za-z0-9_-]{43}$'
+  )
+);
+
+CREATE TABLE public.workspace_e2ee_keys (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  key_id text NOT NULL,
+  created_by_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  retired_at timestamptz,
+  CONSTRAINT workspace_e2ee_keys_key_id_check CHECK (
+    key_id ~ '^[A-Za-z0-9_-]{22}$'
+  ),
+  CONSTRAINT workspace_e2ee_keys_workspace_key_key UNIQUE (workspace_id, key_id)
+);
+
+CREATE UNIQUE INDEX workspace_e2ee_keys_active_key
+  ON public.workspace_e2ee_keys(workspace_id)
+  WHERE retired_at IS NULL;
+
+CREATE TABLE public.workspace_e2ee_key_grants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  key_id text NOT NULL,
+  member_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  ephemeral_public_key text NOT NULL,
+  nonce text NOT NULL,
+  ciphertext text NOT NULL,
+  issued_by_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT workspace_e2ee_key_grants_shape_check CHECK (
+    key_id ~ '^[A-Za-z0-9_-]{22}$'
+    AND ephemeral_public_key ~ '^[A-Za-z0-9_-]{43}$'
+    AND nonce ~ '^[A-Za-z0-9_-]{32}$'
+    AND ciphertext ~ '^[A-Za-z0-9_-]{64}$'
+  ),
+  CONSTRAINT workspace_e2ee_key_grants_member_key_key UNIQUE (
+    workspace_id, key_id, member_user_id
+  ),
+  CONSTRAINT workspace_e2ee_key_grants_key_fkey FOREIGN KEY (workspace_id, key_id)
+    REFERENCES public.workspace_e2ee_keys(workspace_id, key_id) ON DELETE CASCADE
+);
+
+CREATE INDEX workspace_e2ee_key_grants_member_idx
+  ON public.workspace_e2ee_key_grants(member_user_id, workspace_id);
+
+ALTER TABLE public.e2ee_member_identities ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.workspace_e2ee_keys ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.workspace_e2ee_key_grants ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.e2ee_member_identities FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE public.workspace_e2ee_keys FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE public.workspace_e2ee_key_grants FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.e2ee_member_identities TO service_role;
+GRANT ALL ON TABLE public.workspace_e2ee_keys TO service_role;
+GRANT ALL ON TABLE public.workspace_e2ee_key_grants TO service_role;
+
+CREATE POLICY e2ee_member_identities_service_all
+  ON public.e2ee_member_identities
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY workspace_e2ee_keys_service_all
+  ON public.workspace_e2ee_keys
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY workspace_e2ee_key_grants_service_all
+  ON public.workspace_e2ee_key_grants
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Losing membership must also lose the wrapped key: without this a removed
+-- member could re-fetch their grant and keep unwrapping the generation they
+-- were cut off from.
+CREATE OR REPLACE FUNCTION private.purge_workspace_e2ee_grants_for_membership()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+    AND NOT (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL)
+  THEN
+    RETURN NEW;
+  END IF;
+
+  DELETE FROM public.workspace_e2ee_key_grants AS grant_row
+  WHERE grant_row.workspace_id = OLD.workspace_id
+    AND grant_row.member_user_id = OLD.user_id;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.purge_workspace_e2ee_grants_for_membership()
+  FROM PUBLIC, anon, authenticated;
+
+CREATE TRIGGER on_workspace_membership_e2ee_grants_revoked
+  AFTER DELETE OR UPDATE OF deleted_at ON public.workspace_memberships
+  FOR EACH ROW EXECUTE FUNCTION private.purge_workspace_e2ee_grants_for_membership();
+
+CREATE OR REPLACE FUNCTION private.publish_e2ee_member_identity(
+  p_public_key text
+)
+RETURNS TABLE (public_key text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM auth.users AS actor
+    WHERE actor.id = v_actor_id
+      AND actor.email_confirmed_at IS NOT NULL
+      AND COALESCE(actor.is_anonymous, false) = false
+  ) THEN
+    RAISE EXCEPTION 'E2EE identity operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_public_key IS NULL OR p_public_key !~ '^[A-Za-z0-9_-]{43}$' THEN
+    RAISE EXCEPTION 'E2EE member identity is invalid'
+      USING ERRCODE = '22023';
+  END IF;
+
+  INSERT INTO public.e2ee_member_identities AS identity (user_id, public_key)
+  VALUES (v_actor_id, p_public_key)
+  ON CONFLICT (user_id) DO UPDATE SET
+    public_key = excluded.public_key,
+    updated_at = now()
+  WHERE identity.public_key <> excluded.public_key;
+
+  RETURN QUERY
+  SELECT identity.public_key
+  FROM public.e2ee_member_identities AS identity
+  WHERE identity.user_id = v_actor_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.list_workspace_key_recipients(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  user_id uuid,
+  user_email text,
+  role text,
+  public_key text,
+  granted_key_ids text[]
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.workspaces AS workspace
+    JOIN public.workspace_memberships AS membership
+      ON membership.workspace_id = workspace.id
+    JOIN auth.users AS actor
+      ON actor.id = membership.user_id
+    WHERE workspace.id = p_workspace_id
+      AND workspace.kind = 'shared'
+      AND workspace.deleted_at IS NULL
+      AND membership.user_id = auth.uid()
+      AND membership.role IN ('owner', 'admin')
+      AND membership.deleted_at IS NULL
+      AND actor.email_confirmed_at IS NOT NULL
+      AND COALESCE(actor.is_anonymous, false) = false
+  ) THEN
+    RAISE EXCEPTION 'E2EE key operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    membership.user_id,
+    lower(btrim(member_user.email)),
+    membership.role,
+    identity.public_key,
+    COALESCE(
+      (
+        SELECT array_agg(grant_row.key_id ORDER BY grant_row.key_id)
+        FROM public.workspace_e2ee_key_grants AS grant_row
+        WHERE grant_row.workspace_id = p_workspace_id
+          AND grant_row.member_user_id = membership.user_id
+      ),
+      ARRAY[]::text[]
+    )
+  FROM public.workspace_memberships AS membership
+  JOIN auth.users AS member_user
+    ON member_user.id = membership.user_id
+  LEFT JOIN public.e2ee_member_identities AS identity
+    ON identity.user_id = membership.user_id
+  WHERE membership.workspace_id = p_workspace_id
+    AND membership.deleted_at IS NULL
+  ORDER BY membership.created_at, membership.id;
+END;
+$$;
+
+-- Serves both the first key and every rotation: the caller mints a key, wraps
+-- it for each recipient, and hands the wrapped blobs over in one call.
+-- The OUT names are prefixed because bare `key_id` would shadow the real column
+-- in the ON CONFLICT targets below.
+CREATE OR REPLACE FUNCTION private.set_workspace_e2ee_key(
+  p_workspace_id uuid,
+  p_key_id text,
+  p_grants jsonb
+)
+RETURNS TABLE (
+  out_key_id text,
+  out_granted_member_count integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_grant jsonb;
+  v_member_id uuid;
+  v_granted integer := 0;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.workspaces AS workspace
+    JOIN public.workspace_memberships AS membership
+      ON membership.workspace_id = workspace.id
+    JOIN auth.users AS actor
+      ON actor.id = membership.user_id
+    WHERE workspace.id = p_workspace_id
+      AND workspace.kind = 'shared'
+      AND workspace.deleted_at IS NULL
+      AND membership.user_id = v_actor_id
+      AND membership.role IN ('owner', 'admin')
+      AND membership.deleted_at IS NULL
+      AND actor.email_confirmed_at IS NOT NULL
+      AND COALESCE(actor.is_anonymous, false) = false
+  ) THEN
+    RAISE EXCEPTION 'E2EE key operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_key_id IS NULL OR p_key_id !~ '^[A-Za-z0-9_-]{22}$' THEN
+    RAISE EXCEPTION 'E2EE key identity is invalid'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_grants IS NULL OR jsonb_typeof(p_grants) <> 'array' THEN
+    RAISE EXCEPTION 'E2EE key grants are invalid'
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- The issuer must keep their own access, otherwise a rotation could lock the
+  -- workspace out of its own data.
+  IF NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(p_grants) AS candidate
+    WHERE (candidate ->> 'userId')::uuid = v_actor_id
+  ) THEN
+    RAISE EXCEPTION 'E2EE key grants must include the issuing member'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM 1
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = p_workspace_id
+  FOR UPDATE;
+
+  UPDATE public.workspace_e2ee_keys
+  SET retired_at = now()
+  WHERE workspace_e2ee_keys.workspace_id = p_workspace_id
+    AND workspace_e2ee_keys.key_id <> p_key_id
+    AND workspace_e2ee_keys.retired_at IS NULL;
+
+  INSERT INTO public.workspace_e2ee_keys (workspace_id, key_id, created_by_user_id)
+  VALUES (p_workspace_id, p_key_id, v_actor_id)
+  ON CONFLICT (workspace_id, key_id) DO UPDATE SET retired_at = NULL;
+
+  FOR v_grant IN SELECT * FROM jsonb_array_elements(p_grants)
+  LOOP
+    BEGIN
+      v_member_id := (v_grant ->> 'userId')::uuid;
+    EXCEPTION WHEN invalid_text_representation THEN
+      RAISE EXCEPTION 'E2EE key grants are invalid'
+        USING ERRCODE = '22023';
+    END;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.workspace_memberships AS membership
+      WHERE membership.workspace_id = p_workspace_id
+        AND membership.user_id = v_member_id
+        AND membership.deleted_at IS NULL
+    ) THEN
+      RAISE EXCEPTION 'E2EE key grants must target active members'
+        USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO public.workspace_e2ee_key_grants (
+      workspace_id,
+      key_id,
+      member_user_id,
+      ephemeral_public_key,
+      nonce,
+      ciphertext,
+      issued_by_user_id
+    ) VALUES (
+      p_workspace_id,
+      p_key_id,
+      v_member_id,
+      v_grant ->> 'ephemeralPublicKey',
+      v_grant ->> 'nonce',
+      v_grant ->> 'ciphertext',
+      v_actor_id
+    )
+    ON CONFLICT (workspace_id, key_id, member_user_id) DO NOTHING;
+  END LOOP;
+
+  SELECT count(*)
+  INTO v_granted
+  FROM public.workspace_e2ee_key_grants AS grant_row
+  WHERE grant_row.workspace_id = p_workspace_id
+    AND grant_row.key_id = p_key_id;
+
+  RETURN QUERY
+  SELECT p_key_id, v_granted;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.list_my_workspace_e2ee_grants(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  key_id text,
+  ephemeral_public_key text,
+  nonce text,
+  ciphertext text,
+  is_active boolean,
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.workspaces AS workspace
+    JOIN public.workspace_memberships AS membership
+      ON membership.workspace_id = workspace.id
+    WHERE workspace.id = p_workspace_id
+      AND workspace.deleted_at IS NULL
+      AND membership.user_id = auth.uid()
+      AND membership.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'E2EE key operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    grant_row.key_id,
+    grant_row.ephemeral_public_key,
+    grant_row.nonce,
+    grant_row.ciphertext,
+    workspace_key.retired_at IS NULL,
+    grant_row.created_at
+  FROM public.workspace_e2ee_key_grants AS grant_row
+  JOIN public.workspace_e2ee_keys AS workspace_key
+    ON workspace_key.workspace_id = grant_row.workspace_id
+    AND workspace_key.key_id = grant_row.key_id
+  WHERE grant_row.workspace_id = p_workspace_id
+    AND grant_row.member_user_id = auth.uid()
+  ORDER BY workspace_key.created_at, grant_row.created_at;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.publish_e2ee_member_identity(text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.list_workspace_key_recipients(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.set_workspace_e2ee_key(uuid, text, jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.list_my_workspace_e2ee_grants(uuid)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION private.publish_e2ee_member_identity(text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.list_workspace_key_recipients(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.set_workspace_e2ee_key(uuid, text, jsonb)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.list_my_workspace_e2ee_grants(uuid)
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.publish_e2ee_member_identity(
+  p_public_key text
+)
+RETURNS TABLE (public_key text)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT * FROM private.publish_e2ee_member_identity(p_public_key);
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_workspace_key_recipients(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  user_id uuid,
+  user_email text,
+  role text,
+  public_key text,
+  granted_key_ids text[]
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT * FROM private.list_workspace_key_recipients(p_workspace_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.set_workspace_e2ee_key(
+  p_workspace_id uuid,
+  p_key_id text,
+  p_grants jsonb
+)
+RETURNS TABLE (
+  key_id text,
+  granted_member_count integer
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT * FROM private.set_workspace_e2ee_key(p_workspace_id, p_key_id, p_grants);
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_my_workspace_e2ee_grants(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  key_id text,
+  ephemeral_public_key text,
+  nonce text,
+  ciphertext text,
+  is_active boolean,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT * FROM private.list_my_workspace_e2ee_grants(p_workspace_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.publish_e2ee_member_identity(text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_workspace_key_recipients(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.set_workspace_e2ee_key(uuid, text, jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_my_workspace_e2ee_grants(uuid)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.publish_e2ee_member_identity(text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_workspace_key_recipients(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.set_workspace_e2ee_key(uuid, text, jsonb)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_my_workspace_e2ee_grants(uuid)
+  TO authenticated;

--- a/supabase/tests/032-shared-workspace-e2ee-grants.sql
+++ b/supabase/tests/032-shared-workspace-e2ee-grants.sql
@@ -1,0 +1,328 @@
+begin;
+select plan(23);
+
+select tests.create_supabase_user('grant_owner', 'grant-owner@example.com');
+select tests.create_supabase_user('grant_member', 'grant-member@example.com');
+select tests.create_supabase_user('grant_outsider', 'grant-outsider@example.com');
+
+create temporary table workspace_grant_test_state (
+  name text primary key,
+  workspace_id uuid,
+  invitation_id uuid,
+  invite_token text
+);
+
+grant all on workspace_grant_test_state to authenticated, service_role;
+
+reset role;
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('grant_owner'),
+  tests.get_supabase_uid('grant_member'),
+  tests.get_supabase_uid('grant_outsider')
+);
+
+select ok(
+  not has_table_privilege('authenticated', 'public.e2ee_member_identities', 'SELECT')
+    and not has_table_privilege('authenticated', 'public.workspace_e2ee_keys', 'SELECT')
+    and not has_table_privilege('authenticated', 'public.workspace_e2ee_key_grants', 'SELECT')
+    and not has_table_privilege('authenticated', 'public.workspace_e2ee_key_grants', 'INSERT')
+    and not has_table_privilege('authenticated', 'public.workspace_e2ee_key_grants', 'UPDATE'),
+  'Clients cannot read or write identity, key, or grant rows directly'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where (
+      namespace.nspname = 'private'
+      and proc.proname in (
+        'publish_e2ee_member_identity',
+        'list_workspace_key_recipients',
+        'set_workspace_e2ee_key',
+        'list_my_workspace_e2ee_grants',
+        'purge_workspace_e2ee_grants_for_membership'
+      )
+      and (
+        not proc.prosecdef
+        or not ('search_path=""' = any(coalesce(proc.proconfig, array[]::text[])))
+      )
+    )
+    or (
+      namespace.nspname = 'public'
+      and proc.proname in (
+        'publish_e2ee_member_identity',
+        'list_workspace_key_recipients',
+        'set_workspace_e2ee_key',
+        'list_my_workspace_e2ee_grants'
+      )
+      and (
+        proc.prosecdef
+        or not ('search_path=""' = any(coalesce(proc.proconfig, array[]::text[])))
+      )
+    )
+  ),
+  'Privileged E2EE grant implementations are private and use an empty search path'
+);
+
+select tests.authenticate_as('grant_owner');
+
+select results_eq(
+  $$select public_key from public.publish_e2ee_member_identity(rpad('owner', 43, 'A'))$$,
+  array[rpad('owner', 43, 'A')],
+  'A member can publish an account identity public key'
+);
+
+select results_eq(
+  $$select public_key from public.publish_e2ee_member_identity(rpad('owner2', 43, 'A'))$$,
+  array[rpad('owner2', 43, 'A')],
+  'Republishing replaces the stored identity key'
+);
+
+select throws_ok(
+  $$select * from public.publish_e2ee_member_identity('too-short')$$,
+  '22023',
+  'E2EE member identity is invalid',
+  'Malformed identity keys are rejected'
+);
+
+select lives_ok(
+  $$
+    insert into workspace_grant_test_state (name, workspace_id)
+    select 'hq', workspace_id from public.create_workspace('Grant HQ')
+  $$,
+  'The owner creates a shared workspace to key'
+);
+
+select lives_ok(
+  $$
+    insert into workspace_grant_test_state (name, invitation_id, invite_token)
+    select 'member_invite', invitation_id, invite_token
+    from public.create_workspace_invitation(
+      (select workspace_id from workspace_grant_test_state where name = 'hq'),
+      'grant-member@example.com'
+    )
+  $$,
+  'The owner invites a second member'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('grant_member');
+
+select lives_ok(
+  $$
+    select * from public.accept_workspace_invitation(
+      (select invitation_id from workspace_grant_test_state where name = 'member_invite'),
+      (select invite_token from workspace_grant_test_state where name = 'member_invite')
+    )
+  $$,
+  'The invited member joins the workspace'
+);
+
+select lives_ok(
+  $$select * from public.publish_e2ee_member_identity(rpad('member', 43, 'A'))$$,
+  'The joining member publishes their identity key'
+);
+
+select throws_ok(
+  $$
+    select * from public.list_workspace_key_recipients(
+      (select workspace_id from workspace_grant_test_state where name = 'hq')
+    )
+  $$,
+  '42501',
+  'E2EE key operation not permitted',
+  'Plain members cannot enumerate key recipients'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('grant_owner');
+
+select results_eq(
+  $$
+    select user_email, public_key is not null, granted_key_ids
+    from public.list_workspace_key_recipients(
+      (select workspace_id from workspace_grant_test_state where name = 'hq')
+    )
+    order by user_email
+  $$,
+  $$
+    values
+      ('grant-member@example.com'::text, true, array[]::text[]),
+      ('grant-owner@example.com'::text, true, array[]::text[])
+  $$,
+  'Managers see every active member with their identity key and current coverage'
+);
+
+select throws_ok(
+  $$
+    select * from public.set_workspace_e2ee_key(
+      (select workspace_id from workspace_grant_test_state where name = 'hq'),
+      'not-a-valid-key-id',
+      '[]'::jsonb
+    )
+  $$,
+  '22023',
+  'E2EE key identity is invalid',
+  'Malformed workspace key identifiers are rejected'
+);
+
+select throws_ok(
+  $$
+    select * from public.set_workspace_e2ee_key(
+      (select workspace_id from workspace_grant_test_state where name = 'hq'),
+      'AAAAAAAAAAAAAAAAAAAAAA',
+      jsonb_build_array(jsonb_build_object('userId', tests.get_supabase_uid('grant_member'), 'ephemeralPublicKey', rpad('ex', 43, 'A'), 'nonce', rpad('nx', 32, 'B'), 'ciphertext', rpad('cx', 64, 'C')))
+    )
+  $$,
+  '22023',
+  'E2EE key grants must include the issuing member',
+  'A rotation that would lock out its own issuer is rejected'
+);
+
+select throws_ok(
+  $$
+    select * from public.set_workspace_e2ee_key(
+      (select workspace_id from workspace_grant_test_state where name = 'hq'),
+      'AAAAAAAAAAAAAAAAAAAAAA',
+      jsonb_build_array(
+        jsonb_build_object('userId', tests.get_supabase_uid('grant_owner'), 'ephemeralPublicKey', rpad('eo', 43, 'A'), 'nonce', rpad('no', 32, 'B'), 'ciphertext', rpad('co', 64, 'C')),
+        jsonb_build_object('userId', tests.get_supabase_uid('grant_outsider'), 'ephemeralPublicKey', rpad('ez', 43, 'A'), 'nonce', rpad('nz', 32, 'B'), 'ciphertext', rpad('cz', 64, 'C'))
+      )
+    )
+  $$,
+  '22023',
+  'E2EE key grants must target active members',
+  'Grants cannot be issued to non-members'
+);
+
+select results_eq(
+  $$
+    select key_id, granted_member_count
+    from public.set_workspace_e2ee_key(
+      (select workspace_id from workspace_grant_test_state where name = 'hq'),
+      'AAAAAAAAAAAAAAAAAAAAAA',
+      jsonb_build_array(
+        jsonb_build_object('userId', tests.get_supabase_uid('grant_owner'), 'ephemeralPublicKey', rpad('eo1', 43, 'A'), 'nonce', rpad('no1', 32, 'B'), 'ciphertext', rpad('co1', 64, 'C')),
+        jsonb_build_object('userId', tests.get_supabase_uid('grant_member'), 'ephemeralPublicKey', rpad('em1', 43, 'A'), 'nonce', rpad('nm1', 32, 'B'), 'ciphertext', rpad('cm1', 64, 'C'))
+      )
+    )
+  $$,
+  $$values ('AAAAAAAAAAAAAAAAAAAAAA'::text, 2)$$,
+  'The first workspace key is stored with a grant per member'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('grant_member');
+
+select results_eq(
+  $$
+    select key_id, is_active
+    from public.list_my_workspace_e2ee_grants(
+      (select workspace_id from workspace_grant_test_state where name = 'hq')
+    )
+  $$,
+  $$values ('AAAAAAAAAAAAAAAAAAAAAA'::text, true)$$,
+  'A member can fetch the wrapped key addressed to them'
+);
+
+select throws_ok(
+  $$
+    select * from public.set_workspace_e2ee_key(
+      (select workspace_id from workspace_grant_test_state where name = 'hq'),
+      'BBBBBBBBBBBBBBBBBBBBBB',
+      jsonb_build_array(jsonb_build_object('userId', tests.get_supabase_uid('grant_member'), 'ephemeralPublicKey', rpad('em2', 43, 'A'), 'nonce', rpad('nm2', 32, 'B'), 'ciphertext', rpad('cm2', 64, 'C')))
+    )
+  $$,
+  '42501',
+  'E2EE key operation not permitted',
+  'Plain members cannot rotate the workspace key'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('grant_outsider');
+
+select throws_ok(
+  $$
+    select * from public.list_my_workspace_e2ee_grants(
+      (select workspace_id from workspace_grant_test_state where name = 'hq')
+    )
+  $$,
+  '42501',
+  'E2EE key operation not permitted',
+  'Non-members cannot read wrapped keys for a workspace'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('grant_owner');
+
+-- Rotation: mint a second generation covering only the remaining member.
+select lives_ok(
+  $$
+    select * from public.set_workspace_e2ee_key(
+      (select workspace_id from workspace_grant_test_state where name = 'hq'),
+      'BBBBBBBBBBBBBBBBBBBBBB',
+      jsonb_build_array(
+        jsonb_build_object('userId', tests.get_supabase_uid('grant_owner'), 'ephemeralPublicKey', rpad('eo2', 43, 'A'), 'nonce', rpad('no2', 32, 'B'), 'ciphertext', rpad('co2', 64, 'C')),
+        jsonb_build_object('userId', tests.get_supabase_uid('grant_member'), 'ephemeralPublicKey', rpad('em2', 43, 'A'), 'nonce', rpad('nm2', 32, 'B'), 'ciphertext', rpad('cm2', 64, 'C'))
+      )
+    )
+  $$,
+  'A manager can rotate the workspace to a new key generation'
+);
+
+select results_eq(
+  $$
+    select key_id, is_active
+    from public.list_my_workspace_e2ee_grants(
+      (select workspace_id from workspace_grant_test_state where name = 'hq')
+    )
+  $$,
+  $$
+    values
+      ('AAAAAAAAAAAAAAAAAAAAAA'::text, false),
+      ('BBBBBBBBBBBBBBBBBBBBBB'::text, true)
+  $$,
+  'Rotation retires the previous generation while history stays readable'
+);
+
+select lives_ok(
+  $$
+    select * from public.revoke_workspace_membership(
+      (select workspace_id from workspace_grant_test_state where name = 'hq'),
+      tests.get_supabase_uid('grant_member')
+    )
+  $$,
+  'The owner revokes the member'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  $$
+    select count(*)
+    from public.workspace_e2ee_key_grants
+    where member_user_id = tests.get_supabase_uid('grant_member')
+  $$,
+  array[0::bigint],
+  'Revoking membership deletes every wrapped key that member could fetch'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from public.workspace_e2ee_key_grants
+    where member_user_id = tests.get_supabase_uid('grant_owner')
+  $$,
+  array[2::bigint],
+  'Remaining members keep their grants across both generations'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Workspace keys were derived from a single user's recovery key via HKDF,
so no second member could ever compute one -- the blocking gap for
multi-member workspaces.

Add a shared key path alongside the derived one: WorkspaceKey::generate
mints a random key belonging to no member, and each member publishes an
account-level X25519 identity derived from their recovery key so any of
their devices can unwrap. Managers wrap the key per recipient with
ephemeral ECDH, binding workspace, recipient, and key id into the AAD so
a grant cannot be replayed elsewhere. WorkspaceKeyring reads across
generations by envelope key id, keeping history readable after rotation.

Store the wrapped blobs server-side (identities, key generations, grants)
behind owner/admin RPCs; the server only ever holds ciphertext. Removing
a member deletes their grants by trigger, so after a rotation they can
no longer fetch a key for anything written since.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core E2EE key distribution, rotation, and access revocation; mistakes could lock workspaces out or leak keys to removed members.
> 
> **Overview**
> Adds **shared-workspace E2EE** so multiple members can use the same encryption key without deriving it from one person’s recovery key.
> 
> The **`e2ee` crate** gains `WorkspaceKey::generate`, recovery-derived **`MemberIdentityKey`** (X25519), per-member **`WorkspaceKeyGrant`** sealing/unsealing (ephemeral ECDH + XChaCha20-Poly1305 with workspace/recipient/key-id binding), and **`WorkspaceKeyring`** for decrypting history across rotated generations.
> 
> A **Supabase migration** stores only wrapped ciphertext (member identity public keys, key generations, per-member grants) behind **owner/admin** RPCs (`set_workspace_e2ee_key`, `list_workspace_key_recipients`, etc.) and **members** fetching their grants. **Membership revocation** triggers deletion of that member’s grants. **pgTAP** tests cover privileges, rotation, and revocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 152ac418eb0fcc3ed61c9f64af557aa65c4edaac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->