### PR TITLE
feat(supabase): bill Team plans to the workspace and inherit entitlement

### DIFF
--- a/supabase/migrations/20260811170000_workspace_billing_and_seats.sql
+++ b/supabase/migrations/20260811170000_workspace_billing_and_seats.sql
@@ -1,0 +1,306 @@
+-- Team plans are billed to the workspace, not to whoever happens to own it, so
+-- billing survives an ownership transfer and members inherit entitlement from
+-- the workspace subscription instead of buying their own.
+
+ALTER TABLE public.workspaces
+  ADD COLUMN stripe_customer_id text,
+  ADD COLUMN seat_limit integer,
+  ADD CONSTRAINT workspaces_seat_limit_check CHECK (
+    seat_limit IS NULL OR seat_limit > 0
+  ),
+  ADD CONSTRAINT workspaces_billing_is_shared_check CHECK (
+    stripe_customer_id IS NULL OR kind = 'shared'
+  );
+
+CREATE UNIQUE INDEX workspaces_stripe_customer_key
+  ON public.workspaces(stripe_customer_id)
+  WHERE stripe_customer_id IS NOT NULL;
+
+-- Seats are consumed by people who hold access and by invitations that can
+-- still be accepted, so an admin cannot oversubscribe by queueing invites.
+CREATE OR REPLACE FUNCTION private.workspace_seat_usage(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  seat_limit integer,
+  used_seats integer
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    workspace.seat_limit,
+    (
+      (
+        SELECT count(*)
+        FROM public.workspace_memberships AS membership
+        WHERE membership.workspace_id = workspace.id
+          AND membership.deleted_at IS NULL
+      )
+      + (
+        SELECT count(*)
+        FROM public.workspace_invitations AS invitation
+        WHERE invitation.workspace_id = workspace.id
+          AND invitation.accepted_at IS NULL
+          AND invitation.revoked_at IS NULL
+          AND invitation.expires_at > now()
+          -- Mid-acceptance the membership lands before the invitation is
+          -- stamped accepted; without this the same person holds two seats.
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.workspace_memberships AS seated
+            WHERE seated.workspace_id = invitation.workspace_id
+              AND seated.user_id = invitation.invitee_user_id
+              AND seated.deleted_at IS NULL
+          )
+      )
+    )::integer
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = p_workspace_id;
+$$;
+
+REVOKE ALL ON FUNCTION private.workspace_seat_usage(uuid)
+  FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION private.enforce_workspace_seat_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_workspace_id uuid := NEW.workspace_id;
+  v_usage record;
+BEGIN
+  -- Nested rather than one condition: plpgsql resolves OLD/NEW field references
+  -- even in branches that cannot run, and invitations have no deleted_at.
+  IF TG_TABLE_NAME = 'workspace_memberships' THEN
+    IF TG_OP = 'UPDATE' THEN
+      -- Reactivating a soft-deleted row takes a seat again; nothing else does.
+      IF NOT (OLD.deleted_at IS NOT NULL AND NEW.deleted_at IS NULL) THEN
+        RETURN NEW;
+      END IF;
+    ELSIF NEW.deleted_at IS NOT NULL THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  SELECT * INTO v_usage FROM private.workspace_seat_usage(v_workspace_id);
+
+  IF v_usage.seat_limit IS NOT NULL AND v_usage.used_seats > v_usage.seat_limit THEN
+    RAISE EXCEPTION 'workspace seat limit reached'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.enforce_workspace_seat_limit()
+  FROM PUBLIC, anon, authenticated;
+
+CREATE CONSTRAINT TRIGGER on_workspace_membership_seat_limit
+  AFTER INSERT OR UPDATE OF deleted_at ON public.workspace_memberships
+  DEFERRABLE INITIALLY IMMEDIATE
+  FOR EACH ROW EXECUTE FUNCTION private.enforce_workspace_seat_limit();
+
+CREATE CONSTRAINT TRIGGER on_workspace_invitation_seat_limit
+  AFTER INSERT ON public.workspace_invitations
+  DEFERRABLE INITIALLY IMMEDIATE
+  FOR EACH ROW EXECUTE FUNCTION private.enforce_workspace_seat_limit();
+
+CREATE OR REPLACE FUNCTION private.get_workspace_seat_usage(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  seat_limit integer,
+  used_seats integer,
+  is_billed boolean
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.workspaces AS workspace
+    JOIN public.workspace_memberships AS membership
+      ON membership.workspace_id = workspace.id
+    WHERE workspace.id = p_workspace_id
+      AND workspace.deleted_at IS NULL
+      AND membership.user_id = auth.uid()
+      AND membership.role IN ('owner', 'admin')
+      AND membership.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'workspace billing operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    usage.seat_limit,
+    usage.used_seats,
+    workspace.stripe_customer_id IS NOT NULL
+  FROM public.workspaces AS workspace
+  CROSS JOIN LATERAL private.workspace_seat_usage(workspace.id) AS usage
+  WHERE workspace.id = p_workspace_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.get_workspace_seat_usage(uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION private.get_workspace_seat_usage(uuid)
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_workspace_seat_usage(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  seat_limit integer,
+  used_seats integer,
+  is_billed boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT * FROM private.get_workspace_seat_usage(p_workspace_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.get_workspace_seat_usage(uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_workspace_seat_usage(uuid)
+  TO authenticated;
+
+-- The auth hook now unions two sources of entitlement: what the account bought
+-- for itself, and what any workspace it belongs to bought on its behalf. Which
+-- features a Team plan carries stays a Stripe product decision, so no gate in
+-- the app has to learn about team plans.
+GRANT SELECT ON TABLE public.workspaces TO supabase_auth_admin;
+GRANT SELECT ON TABLE public.workspace_memberships TO supabase_auth_admin;
+
+CREATE POLICY "Allow auth admin to read workspaces"
+ON public.workspaces
+AS PERMISSIVE FOR SELECT
+TO supabase_auth_admin
+USING (true);
+
+CREATE POLICY "Allow auth admin to read workspace memberships"
+ON public.workspace_memberships
+AS PERMISSIVE FOR SELECT
+TO supabase_auth_admin
+USING (true);
+
+-- search_path is pinned here rather than left to the ALTER in
+-- 20260714134923: CREATE OR REPLACE resets attributes it does not restate.
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SET search_path = ''
+AS $$
+DECLARE
+  claims jsonb;
+  entitlements jsonb := '[]'::jsonb;
+  v_user_id uuid := (event->>'user_id')::uuid;
+  v_customer_id text;
+  v_subscription_status text;
+  v_trial_end bigint;
+  v_has_payment_method boolean;
+BEGIN
+  SELECT p.stripe_customer_id INTO v_customer_id
+  FROM public.profiles p
+  WHERE p.id = v_user_id;
+
+  SELECT
+    COALESCE(
+      jsonb_agg(DISTINCT granted.lookup_key ORDER BY granted.lookup_key)
+        FILTER (WHERE granted.lookup_key IS NOT NULL),
+      '[]'::jsonb
+    )
+  INTO entitlements
+  FROM (
+    SELECT ae.lookup_key
+    FROM public.profiles p
+    JOIN stripe.active_entitlements ae
+      ON ae.customer = p.stripe_customer_id
+    WHERE p.id = v_user_id
+
+    UNION
+
+    SELECT ae.lookup_key
+    FROM public.workspace_memberships m
+    JOIN public.workspaces w
+      ON w.id = m.workspace_id
+    JOIN stripe.active_entitlements ae
+      ON ae.customer = w.stripe_customer_id
+    WHERE m.user_id = v_user_id
+      AND m.deleted_at IS NULL
+      AND w.deleted_at IS NULL
+      AND w.stripe_customer_id IS NOT NULL
+  ) AS granted;
+
+  IF v_customer_id IS NOT NULL THEN
+    SELECT
+      s.status::text,
+      (s.trial_end #>> '{}')::bigint,
+      s.default_payment_method IS NOT NULL
+        OR c.invoice_settings->>'default_payment_method' IS NOT NULL
+        OR c.default_source IS NOT NULL
+    INTO v_subscription_status, v_trial_end, v_has_payment_method
+    FROM stripe.subscriptions s
+    JOIN stripe.customers c ON c.id = s.customer
+    WHERE s.customer = v_customer_id
+      AND s.status IN ('trialing', 'active')
+    ORDER BY
+      CASE s.status WHEN 'active' THEN 1 WHEN 'trialing' THEN 2 END,
+      s.created DESC
+    LIMIT 1;
+  END IF;
+
+  -- A member with no subscription of their own still reads as subscribed while
+  -- a workspace covers them; personal billing state wins when both exist.
+  IF v_subscription_status IS NULL THEN
+    SELECT s.status::text
+    INTO v_subscription_status
+    FROM public.workspace_memberships m
+    JOIN public.workspaces w
+      ON w.id = m.workspace_id
+    JOIN stripe.subscriptions s
+      ON s.customer = w.stripe_customer_id
+    WHERE m.user_id = v_user_id
+      AND m.deleted_at IS NULL
+      AND w.deleted_at IS NULL
+      AND w.stripe_customer_id IS NOT NULL
+      AND s.status IN ('trialing', 'active')
+    ORDER BY
+      CASE s.status WHEN 'active' THEN 1 WHEN 'trialing' THEN 2 END,
+      s.created DESC
+    LIMIT 1;
+  END IF;
+
+  claims := event->'claims';
+  claims := jsonb_set(claims, '{entitlements}', entitlements);
+
+  IF v_subscription_status IS NOT NULL THEN
+    claims := jsonb_set(claims, '{subscription_status}', to_jsonb(v_subscription_status));
+  END IF;
+
+  IF v_trial_end IS NOT NULL THEN
+    claims := jsonb_set(claims, '{trial_end}', to_jsonb(v_trial_end));
+  END IF;
+
+  IF v_has_payment_method IS NOT NULL THEN
+    claims := jsonb_set(claims, '{has_payment_method}', to_jsonb(v_has_payment_method));
+  END IF;
+
+  event := jsonb_set(event, '{claims}', claims);
+
+  RETURN event;
+END;
+$$;

--- a/supabase/tests/033-workspace-billing-and-seats.sql
+++ b/supabase/tests/033-workspace-billing-and-seats.sql
@@ -1,0 +1,226 @@
+begin;
+select plan(14);
+
+select tests.create_supabase_user('seat_owner', 'seat-owner@example.com');
+select tests.create_supabase_user('seat_member', 'seat-member@example.com');
+select tests.create_supabase_user('seat_extra', 'seat-extra@example.com');
+
+create temporary table workspace_billing_test_state (
+  name text primary key,
+  workspace_id uuid,
+  invitation_id uuid,
+  invite_token text
+);
+
+grant all on workspace_billing_test_state to authenticated, service_role;
+
+reset role;
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('seat_owner'),
+  tests.get_supabase_uid('seat_member'),
+  tests.get_supabase_uid('seat_extra')
+);
+
+select tests.authenticate_as('seat_owner');
+
+select lives_ok(
+  $$
+    insert into workspace_billing_test_state (name, workspace_id)
+    select 'hq', workspace_id from public.create_workspace('Seat HQ')
+  $$,
+  'The owner creates a shared workspace'
+);
+
+select results_eq(
+  $$
+    select seat_limit, used_seats, is_billed
+    from public.get_workspace_seat_usage(
+      (select workspace_id from workspace_billing_test_state where name = 'hq')
+    )
+  $$,
+  $$values (null::integer, 1, false)$$,
+  'A new workspace is unbilled, unlimited, and consumes one seat for its owner'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('seat_member');
+
+select throws_ok(
+  $$
+    select * from public.get_workspace_seat_usage(
+      (select workspace_id from workspace_billing_test_state where name = 'hq')
+    )
+  $$,
+  '42501',
+  'workspace billing operation not permitted',
+  'Non-members cannot read workspace seat usage'
+);
+
+select tests.clear_authentication();
+reset role;
+
+-- Billing is provisioned server-side after checkout completes.
+update public.workspaces
+set stripe_customer_id = 'cus_seat_team', seat_limit = 2
+where id = (select workspace_id from workspace_billing_test_state where name = 'hq');
+
+insert into stripe.customers (id)
+values ('cus_seat_team')
+on conflict (id) do nothing;
+
+insert into stripe.subscriptions (id, customer, status)
+values ('sub_seat_team', 'cus_seat_team', 'active'::stripe.subscription_status)
+on conflict (id) do nothing;
+
+insert into stripe.active_entitlements (id, customer, lookup_key)
+values ('ent_seat_team', 'cus_seat_team', 'hyprnote_pro')
+on conflict (id) do nothing;
+
+select tests.clear_authentication();
+select tests.authenticate_as('seat_owner');
+
+select results_eq(
+  $$
+    select seat_limit, used_seats, is_billed
+    from public.get_workspace_seat_usage(
+      (select workspace_id from workspace_billing_test_state where name = 'hq')
+    )
+  $$,
+  $$values (2, 1, true)$$,
+  'Managers see the purchased seat count and current usage'
+);
+
+select lives_ok(
+  $$
+    insert into workspace_billing_test_state (name, invitation_id, invite_token)
+    select 'member_invite', invitation_id, invite_token
+    from public.create_workspace_invitation(
+      (select workspace_id from workspace_billing_test_state where name = 'hq'),
+      'seat-member@example.com'
+    )
+  $$,
+  'An invitation fits within the purchased seats'
+);
+
+select results_eq(
+  $$
+    select used_seats
+    from public.get_workspace_seat_usage(
+      (select workspace_id from workspace_billing_test_state where name = 'hq')
+    )
+  $$,
+  array[2],
+  'A pending invitation holds a seat so it cannot be oversubscribed'
+);
+
+select throws_ok(
+  $$
+    select * from public.create_workspace_invitation(
+      (select workspace_id from workspace_billing_test_state where name = 'hq'),
+      'seat-extra@example.com'
+    )
+  $$,
+  '22023',
+  'workspace seat limit reached',
+  'Inviting past the purchased seats is refused'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('seat_member');
+
+select lives_ok(
+  $$
+    select * from public.accept_workspace_invitation(
+      (select invitation_id from workspace_billing_test_state where name = 'member_invite'),
+      (select invite_token from workspace_billing_test_state where name = 'member_invite')
+    )
+  $$,
+  'Accepting a held seat converts the invitation into a membership'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from public.workspaces
+    where id = (select workspace_id from workspace_billing_test_state where name = 'hq')
+  $$,
+  array[1::bigint],
+  'The member sees the workspace they joined'
+);
+
+select tests.clear_authentication();
+reset role;
+
+select results_eq(
+  $$
+    select public.custom_access_token_hook(
+      jsonb_build_object(
+        'user_id', tests.get_supabase_uid('seat_member')::text,
+        'claims', '{}'::jsonb
+      )
+    ) -> 'claims' -> 'entitlements'
+  $$,
+  array['["hyprnote_pro"]'::jsonb],
+  'A member inherits the workspace entitlement without buying their own plan'
+);
+
+select results_eq(
+  $$
+    select public.custom_access_token_hook(
+      jsonb_build_object(
+        'user_id', tests.get_supabase_uid('seat_member')::text,
+        'claims', '{}'::jsonb
+      )
+    ) -> 'claims' ->> 'subscription_status'
+  $$,
+  array['active'::text],
+  'An otherwise unsubscribed member reads as covered by the workspace plan'
+);
+
+select results_eq(
+  $$
+    select public.custom_access_token_hook(
+      jsonb_build_object(
+        'user_id', tests.get_supabase_uid('seat_extra')::text,
+        'claims', '{}'::jsonb
+      )
+    ) -> 'claims' -> 'entitlements'
+  $$,
+  array['[]'::jsonb],
+  'Someone outside the workspace inherits nothing'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('seat_owner');
+
+select lives_ok(
+  $$
+    select * from public.revoke_workspace_membership(
+      (select workspace_id from workspace_billing_test_state where name = 'hq'),
+      tests.get_supabase_uid('seat_member')
+    )
+  $$,
+  'The owner frees a seat by revoking the member'
+);
+
+select tests.clear_authentication();
+reset role;
+
+select results_eq(
+  $$
+    select public.custom_access_token_hook(
+      jsonb_build_object(
+        'user_id', tests.get_supabase_uid('seat_member')::text,
+        'claims', '{}'::jsonb
+      )
+    ) -> 'claims' -> 'entitlements'
+  $$,
+  array['[]'::jsonb],
+  'A removed member immediately stops inheriting the workspace entitlement'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Subscriptions attached to auth.users, so there was no way to buy a plan
for a team: every member needed their own. Seats did not exist at all.

Give shared workspaces their own Stripe customer and seat limit, so
billing follows the workspace rather than whoever owns it today and
survives an ownership transfer. The auth hook now unions the account's
own entitlements with those of any workspace it belongs to, and falls
back to the workspace subscription status when the member has none of
their own -- which feature set a Team plan carries stays a Stripe product
decision, so no existing hyprnote_pro gate has to learn about teams.

Enforce seats with a constraint trigger rather than in one RPC, so every
path is covered: memberships and still-open invitations both hold a seat,
and an invitation stops holding one once its invitee is seated.

Also restate SET search_path on the auth hook: CREATE OR REPLACE drops
attributes it does not repeat, which would have silently undone the
hardening applied in 20260714134923.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication claims and billing enforcement in Postgres; mistakes could grant or deny paid access incorrectly or block legitimate invites/memberships.
> 
> **Overview**
> **Shared workspaces can carry their own Stripe customer and seat limit**, so team billing stays on the workspace (not the owner) and only applies to `kind = 'shared'` workspaces.
> 
> **Seat enforcement is database-wide via constraint triggers** on `workspace_memberships` and `workspace_invitations`: usage counts active members plus open, unexpired invites (with a guard so accept does not double-count), and blocks inserts/reactivations that would exceed `seat_limit`. Owners/admins can read usage through **`get_workspace_seat_usage`**.
> 
> **`custom_access_token_hook` now merges personal and workspace Stripe entitlements** and, when the user has no personal subscription, sets **`subscription_status`** from an active workspace subscription. **`supabase_auth_admin`** gets read access to workspaces/memberships for the hook. The hook replacement **re-applies `SET search_path = ''`** so prior hardening is not lost on `CREATE OR REPLACE`.
> 
> Adds **pgTAP coverage** for seat limits, invite holding, entitlement inheritance, and revocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed647ac2d863a73e4037fe0070640299a0232520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->