### PR TITLE
refactor(desktop): drop background chip behind granted permission check

### DIFF
--- a/apps/desktop/src/onboarding/permissions.tsx
+++ b/apps/desktop/src/onboarding/permissions.tsx
@@ -76,7 +76,7 @@ function PermissionBlock({
         className={cn([
           "flex size-6 shrink-0 items-center justify-center rounded-md",
           isAuthorized
-            ? "bg-green-50 text-green-600"
+            ? "text-green-600"
             : "bg-primary-foreground/10 text-primary-foreground",
         ])}
       >


### PR DESCRIPTION
The onboarding permission row rendered its authorized checkmark inside a
green-50 rounded box, which read as a second control next to the row.
Keep the green check glyph and remove the surrounding fill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change in onboarding UI only; no logic, permissions, or data handling affected.
> 
> **Overview**
> **Onboarding permission rows** no longer show a light green rounded background behind the granted-state checkmark.
> 
> When a permission is authorized, the icon wrapper keeps `text-green-600` on the check glyph but drops `bg-green-50`, so the check reads as status on the row instead of a separate chip-like control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa49d298638ae49de74ab8e238913d7ae9636b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->