### PR TITLE
feat(web): add Arch Linux PKGBUILD entry to download page

### DIFF
--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -32,7 +32,13 @@ test("offers macOS, Windows, and Linux downloads", () => {
     linuxDownloads.map((download) =>
       new URL(download.url).pathname.split("/").at(-1),
     ),
-    ["appimage-x86_64", "debian-x86_64", "appimage-aarch64", "debian-aarch64"],
+    [
+      "appimage-x86_64",
+      "debian-x86_64",
+      "appimage-aarch64",
+      "debian-aarch64",
+      "anarlog-bin",
+    ],
   );
 });
 

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -56,7 +56,8 @@ export const desktopDownloadSections = [
     platform: "linux",
     name: "Linux",
     status: "Beta",
-    description: "AppImage and Debian packages for x64 and ARM64.",
+    description:
+      "AppImage and Debian packages for x64 and ARM64, plus a PKGBUILD for Arch.",
     downloads: [
       {
         name: "AppImage x64",
@@ -80,6 +81,13 @@ export const desktopDownloadSections = [
         name: "Debian ARM64",
         detail: "Debian or Ubuntu on 64-bit ARM · DEB",
         url: getStableDownloadUrl("debian-aarch64"),
+        showInMenu: false,
+      },
+      {
+        name: "Arch Linux",
+        detail: "Arch-based distros · PKGBUILD",
+        url: "https://github.com/fastrepl/anarlog/tree/main/packaging/aur/anarlog-bin",
+        actionLabel: "View PKGBUILD",
         showInMenu: false,
       },
     ],

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@iconify-icon/react";
-import { DownloadSimple } from "@phosphor-icons/react";
+import { ArrowSquareOut, DownloadSimple } from "@phosphor-icons/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { SiteFooter } from "@/components/site-footer";
@@ -78,7 +78,19 @@ function Component() {
                         <span className="font-medium">{download.name}</span>
                         <a
                           href={download.url}
-                          aria-label={`Download ${download.name} for ${section.name}`}
+                          // Entries with an actionLabel link out to a package
+                          // registry rather than starting a download.
+                          {...("actionLabel" in download
+                            ? {
+                                target: "_blank",
+                                rel: "noreferrer",
+                              }
+                            : {})}
+                          aria-label={
+                            "actionLabel" in download
+                              ? `${download.actionLabel}: ${download.name}`
+                              : `Download ${download.name} for ${section.name}`
+                          }
                           onClick={() =>
                             track("download_clicked", {
                               platform: section.platform,
@@ -88,8 +100,17 @@ function Component() {
                           }
                           className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[#181613] px-4 py-3 text-[13px] font-medium text-white sm:px-5 sm:text-sm"
                         >
-                          Download
-                          <DownloadSimple size={16} aria-hidden="true" />
+                          {"actionLabel" in download ? (
+                            <>
+                              {download.actionLabel}
+                              <ArrowSquareOut size={16} aria-hidden="true" />
+                            </>
+                          ) : (
+                            <>
+                              Download
+                              <DownloadSimple size={16} aria-hidden="true" />
+                            </>
+                          )}
                         </a>
                       </div>
                     </li>


### PR DESCRIPTION
Adds an Arch Linux row to the Linux section of the download page, linking to the `packaging/aur/anarlog-bin` directory on GitHub as a "View PKGBUILD" external link rather than a direct download button.

Originally split out of #6651 to wait on an AUR publish. That is no longer a blocker: AUR account registration is unavailable (tracked in ANLG-220), so this row points at the PKGBUILD in the repo instead, which Arch and Omarchy users can build with `makepkg -si` today.

**Merge after #6651** — the link targets `tree/main/packaging/aur/anarlog-bin`, so it only resolves once the packaging PR is on `main`.

Verified locally: row renders with the external-link treatment, no console errors, 214 web tests pass, typecheck and dprint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/download-page copy and link behavior only; no auth, data, or release pipeline changes.
> 
> **Overview**
> Adds an **Arch Linux** row to the Linux download section, pointing at the in-repo `packaging/aur/anarlog-bin` PKGBUILD on GitHub instead of a CDN artifact. The Linux blurb now mentions Arch alongside AppImage and Debian builds.
> 
> Download metadata gains optional **`actionLabel`**. On the download page, entries with that field open in a new tab, use a **View PKGBUILD** label with an external-link icon, and get matching `aria-label` text instead of the default Download button.
> 
> Tests expect the fifth Linux URL path segment to be `anarlog-bin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e718e4e0b123a158c146964ec16b82a0a69f9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->