### PR TITLE
fix(stt): auto-start scheduled meetings regardless of open tab

### DIFF
--- a/apps/desktop/src/main/lifecycle.tsx
+++ b/apps/desktop/src/main/lifecycle.tsx
@@ -21,6 +21,7 @@ import { useConfigValue } from "~/shared/config";
 import { useDesktopTabLifecycle } from "~/shared/desktop-tab-lifecycle";
 import { useTabs } from "~/store/zustand/tabs";
 import { LiveCaptureRecovery } from "~/stt/live-capture-recovery";
+import { ScheduledMeetingAutoStart } from "~/stt/scheduled-auto-start";
 import { MainListenerControlBridge } from "~/stt/window-control";
 
 export function useClassicMainLifecycle() {
@@ -54,6 +55,7 @@ export function ClassicMainServices() {
       <OwnedSharedNotePublisher />
       <SharedNotePreviewAuthLifecycle />
       <LiveCaptureRecovery />
+      <ScheduledMeetingAutoStart />
       <MainListenerControlBridge />
       <ToolRegistration />
       <EnhancerInit />

--- a/apps/desktop/src/session/components/floating/listen.test.tsx
+++ b/apps/desktop/src/session/components/floating/listen.test.tsx
@@ -5,15 +5,7 @@ import { ListenButton } from "./listen";
 
 import type { Tab } from "~/store/zustand/tabs";
 
-const {
-  countdownCallbacks,
-  updateSessionTabStateMock,
-  useConfigValueMock,
-  useListenerMock,
-} = vi.hoisted(() => ({
-  countdownCallbacks: [] as Array<() => void>,
-  updateSessionTabStateMock: vi.fn(),
-  useConfigValueMock: vi.fn(() => true),
+const { useListenerMock } = vi.hoisted(() => ({
   useListenerMock: vi.fn((selector) =>
     selector({
       live: { loading: false, sessionId: null },
@@ -37,27 +29,6 @@ vi.mock("~/session/components/shared", () => ({
   }),
 }));
 
-vi.mock("~/session/hooks/useEventCountdown", () => ({
-  useEventCountdown: (
-    _sessionId: string,
-    options?: { onExpire?: () => void },
-  ) => {
-    if (options?.onExpire) {
-      countdownCallbacks.push(options.onExpire);
-    }
-    return { label: "starts in 1s" };
-  },
-}));
-
-vi.mock("~/shared/config", () => ({
-  useConfigValue: useConfigValueMock,
-}));
-
-vi.mock("~/store/zustand/tabs", () => ({
-  useTabs: (selector: any) =>
-    selector({ updateSessionTabState: updateSessionTabStateMock }),
-}));
-
 vi.mock("~/stt/contexts", () => ({
   useListener: useListenerMock,
 }));
@@ -65,23 +36,6 @@ vi.mock("~/stt/contexts", () => ({
 describe("floating ListenButton", () => {
   afterEach(() => {
     cleanup();
-  });
-
-  test("requests auto-start when the event countdown expires", () => {
-    const tab = {
-      type: "sessions",
-      id: "session-1",
-      state: { view: null, autoStart: null },
-    } as Extract<Tab, { type: "sessions" }>;
-
-    render(<ListenButton tab={tab} />);
-
-    countdownCallbacks[countdownCallbacks.length - 1]?.();
-
-    expect(updateSessionTabStateMock).toHaveBeenCalledWith(tab, {
-      view: null,
-      autoStart: true,
-    });
   });
 
   test("keeps remote meeting join controls out of the floating slot", () => {

--- a/apps/desktop/src/session/components/floating/listen.tsx
+++ b/apps/desktop/src/session/components/floating/listen.tsx
@@ -1,12 +1,7 @@
-import { useCallback } from "react";
-
 import { ListenActionButton } from "../listen-action";
 
 import { useListenButtonState } from "~/session/components/shared";
-import { useEventCountdown } from "~/session/hooks/useEventCountdown";
-import { useConfigValue } from "~/shared/config";
 import type { Tab } from "~/store/zustand/tabs";
-import { useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 
 export function ListenButton({
@@ -18,28 +13,6 @@ export function ListenButton({
   const loading = useListener(
     (state) => state.live.loading && state.live.sessionId === tab.id,
   );
-  const canStartLiveSession = useListener((state) =>
-    state.canStartLiveSession(tab.id),
-  );
-  const autoStartScheduledMeetings = useConfigValue(
-    "auto_start_scheduled_meetings",
-  );
-  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
-  const handleCountdownExpire = useCallback(() => {
-    if (!autoStartScheduledMeetings || !canStartLiveSession) {
-      return;
-    }
-
-    updateSessionTabState(tab, { ...tab.state, autoStart: true });
-  }, [
-    autoStartScheduledMeetings,
-    canStartLiveSession,
-    tab,
-    updateSessionTabState,
-  ]);
-  useEventCountdown(tab.id, {
-    onExpire: handleCountdownExpire,
-  });
 
   if (loading) {
     return <ListenActionButton sessionId={tab.id} />;

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -633,35 +633,9 @@ describe("OuterHeader", () => {
     expect(joinButton.textContent).not.toContain("starts in");
   });
 
-  it("starts listening without joining when only scheduled listening is enabled", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-05T09:59:58.000Z"));
-    mocks.nowMs = Date.now();
-    mocks.configValues.auto_start_scheduled_meetings = true;
-    mocks.sessionEvents = {
-      "session-1": {
-        started_at: "2026-06-05T10:00:00.000Z",
-        ended_at: "2026-06-05T10:30:00.000Z",
-        meeting_link: "https://meet.google.com/abc-defg-hij",
-      },
-    };
-
-    render(
-      <OuterHeader
-        sessionId="session-1"
-        currentView={{ type: "raw" } as EditorView}
-      />,
-    );
-
-    act(() => {
-      vi.advanceTimersByTime(2000);
-    });
-
-    expect(mocks.startListening).toHaveBeenCalledTimes(1);
-    expect(mocks.openUrl).not.toHaveBeenCalled();
-  });
-
-  it("joins and starts when both scheduled meeting settings are enabled", () => {
+  // Scheduled auto-start is owned by ScheduledMeetingAutoStart so it fires
+  // regardless of which tab is open; the header must not start a second one.
+  it("does not auto-start when the countdown reaches the meeting start time", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-05T09:59:58.000Z"));
     mocks.nowMs = Date.now();
@@ -686,39 +660,8 @@ describe("OuterHeader", () => {
       vi.advanceTimersByTime(2000);
     });
 
-    expect(mocks.openUrl).toHaveBeenCalledWith(
-      "https://meet.google.com/abc-defg-hij",
-      null,
-    );
-    expect(mocks.startListening).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not join or start when scheduled listening is disabled", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-05T09:59:58.000Z"));
-    mocks.nowMs = Date.now();
-    mocks.configValues.auto_join_scheduled_meetings = true;
-    mocks.sessionEvents = {
-      "session-1": {
-        started_at: "2026-06-05T10:00:00.000Z",
-        ended_at: "2026-06-05T10:30:00.000Z",
-        meeting_link: "https://meet.google.com/abc-defg-hij",
-      },
-    };
-
-    render(
-      <OuterHeader
-        sessionId="session-1"
-        currentView={{ type: "raw" } as EditorView}
-      />,
-    );
-
-    act(() => {
-      vi.advanceTimersByTime(2000);
-    });
-
-    expect(mocks.openUrl).not.toHaveBeenCalled();
     expect(mocks.startListening).not.toHaveBeenCalled();
+    expect(mocks.openUrl).not.toHaveBeenCalled();
   });
 
   it("hides the meeting countdown while listening is active", () => {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -25,7 +25,6 @@ import {
   type RemoteMeeting,
 } from "~/session/hooks/useRemoteMeeting";
 import { useSessionEvent } from "~/session/hooks/useSessionEvent";
-import { useConfigValue } from "~/shared/config";
 import { useWindowControlsGutter } from "~/shared/hooks/useWindowControlsGutter";
 import { getScheme } from "~/shared/utils";
 import type { EditorView } from "~/store/zustand/tabs/schema";
@@ -225,19 +224,10 @@ function HeaderMeetingActionPill({
   audioExists: boolean;
 }) {
   const startListening = useStartListening(sessionId);
-  const { canStartLiveSession, stop, stopTranscription } = useListener(
-    (state) => ({
-      canStartLiveSession: state.canStartLiveSession(sessionId),
-      stop: state.stop,
-      stopTranscription: state.stopTranscription,
-    }),
-  );
-  const autoJoinScheduledMeetings = useConfigValue(
-    "auto_join_scheduled_meetings",
-  );
-  const autoStartScheduledMeetings = useConfigValue(
-    "auto_start_scheduled_meetings",
-  );
+  const { stop, stopTranscription } = useListener((state) => ({
+    stop: state.stop,
+    stopTranscription: state.stopTranscription,
+  }));
   const remote = getRemoteMeeting(event?.meeting_link);
   const meetingLink = event?.meeting_link || null;
   const canJoinFromHeader = Boolean(
@@ -293,27 +283,7 @@ function HeaderMeetingActionPill({
       setJoiningMeeting(false);
     }
   }, [openMeeting, start]);
-  const handleCountdownExpire = useCallback(() => {
-    if (!autoStartScheduledMeetings || !canStartLiveSession) {
-      return;
-    }
-
-    if (autoJoinScheduledMeetings && meetingLink) {
-      void joinMeeting();
-    } else {
-      void start();
-    }
-  }, [
-    autoJoinScheduledMeetings,
-    autoStartScheduledMeetings,
-    canStartLiveSession,
-    joinMeeting,
-    meetingLink,
-    start,
-  ]);
-  const countdown = useEventCountdown(sessionId, {
-    onExpire: handleCountdownExpire,
-  });
+  const countdown = useEventCountdown(sessionId);
   const stopListening = useCallback(() => {
     if (!isMainWebviewWindow()) {
       void requestMainListenerControl("stop", sessionId);

--- a/apps/desktop/src/session/hooks/useEventCountdown.test.tsx
+++ b/apps/desktop/src/session/hooks/useEventCountdown.test.tsx
@@ -22,15 +22,12 @@ describe("useEventCountdown", () => {
     vi.useRealTimers();
   });
 
-  test("fires onExpire when an active countdown reaches the start time", () => {
-    const onExpire = vi.fn();
+  test("clears the label when an active countdown reaches the start time", () => {
     useSessionEventMock.mockReturnValue({
       started_at: new Date(Date.now() + 2000).toISOString(),
     });
 
-    const { result } = renderHook(() =>
-      useEventCountdown("session-1", { onExpire }),
-    );
+    const { result } = renderHook(() => useEventCountdown("session-1"));
 
     expect(result.current.label).toBe("starts in 2s");
 
@@ -39,17 +36,31 @@ describe("useEventCountdown", () => {
     });
 
     expect(result.current.label).toBeNull();
-    expect(onExpire).toHaveBeenCalledTimes(1);
   });
 
-  test("does not fire onExpire for an event that is already in the past", () => {
-    const onExpire = vi.fn();
+  test("shows no label for an event that is already in the past", () => {
     useSessionEventMock.mockReturnValue({
       started_at: new Date(Date.now() - 1000).toISOString(),
     });
 
-    renderHook(() => useEventCountdown("session-1", { onExpire }));
+    const { result } = renderHook(() => useEventCountdown("session-1"));
 
-    expect(onExpire).not.toHaveBeenCalled();
+    expect(result.current.label).toBeNull();
+  });
+
+  test("shows no label until the event is within five minutes", () => {
+    useSessionEventMock.mockReturnValue({
+      started_at: new Date(Date.now() + 6 * 60_000).toISOString(),
+    });
+
+    const { result } = renderHook(() => useEventCountdown("session-1"));
+
+    expect(result.current.label).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(61_000);
+    });
+
+    expect(result.current.label).toBe("starts in 4m 59s");
   });
 });

--- a/apps/desktop/src/session/hooks/useEventCountdown.ts
+++ b/apps/desktop/src/session/hooks/useEventCountdown.ts
@@ -1,17 +1,12 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useSessionEvent } from "~/session/hooks/useSessionEvent";
 
 const FIVE_MINUTES = 5 * 60 * 1000;
 
-export function useEventCountdown(
-  sessionId: string,
-  { onExpire }: { onExpire?: () => void } = {},
-) {
+export function useEventCountdown(sessionId: string) {
   const sessionEvent = useSessionEvent(sessionId);
   const startedAt = sessionEvent?.started_at;
-  const onExpireRef = useRef(onExpire);
-  onExpireRef.current = onExpire;
 
   const [label, setLabel] = useState<string | null>(null);
 
@@ -22,8 +17,6 @@ export function useEventCountdown(
     }
 
     const eventStart = new Date(startedAt).getTime();
-    let fired = false;
-    let armed = false;
 
     let interval: ReturnType<typeof setInterval>;
 
@@ -33,10 +26,6 @@ export function useEventCountdown(
       if (diff <= 0) {
         setLabel(null);
         clearInterval(interval);
-        if (armed && !fired) {
-          fired = true;
-          onExpireRef.current?.();
-        }
         return;
       }
 
@@ -45,7 +34,6 @@ export function useEventCountdown(
         return;
       }
 
-      armed = true;
       const totalSeconds = Math.floor(diff / 1000);
       const mins = Math.floor(totalSeconds / 60);
       const secs = totalSeconds % 60;

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -115,33 +115,58 @@ function AutoStartListening({
     state.canStartLiveSession(tab.id),
   );
   const { conn } = useSTTConnection();
-
-  if (!canStartLiveSession || !conn) {
-    return null;
-  }
-
-  return <StartListeningWhenReady key={tab.id} tab={tab} />;
-}
-
-function StartListeningWhenReady({
-  tab,
-}: {
-  tab: Extract<Tab, { type: "sessions" }>;
-}) {
-  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
   const startListening = useStartListening(tab.id);
+  const hasAttemptedAutoStart = useRef(false);
 
   useMountEffect(() => {
+    // Readiness can be blocked by startup or an import lock; abandon the
+    // request instead of preventing every later scheduled meeting.
+    const timeout = setTimeout(() => {
+      if (!hasAttemptedAutoStart.current) {
+        clearPendingAutoStart(tab.id);
+      }
+    }, 30_000);
+
+    return () => clearTimeout(timeout);
+  });
+
+  useEffect(() => {
+    if (hasAttemptedAutoStart.current || !canStartLiveSession || !conn) {
+      return;
+    }
+
+    hasAttemptedAutoStart.current = true;
+    const timeout = setTimeout(() => {
+      clearPendingAutoStart(tab.id);
+    }, 30_000);
+
     void startListening()
       .catch((error) => {
         console.error("[listener] failed to auto-start session", error);
       })
       .finally(() => {
-        updateSessionTabState(tab, { ...tab.state, autoStart: null });
+        clearTimeout(timeout);
+        clearPendingAutoStart(tab.id);
       });
-  });
+  }, [canStartLiveSession, conn, startListening, tab.id]);
 
   return null;
+}
+
+function clearPendingAutoStart(sessionId: string) {
+  const tabsState = useTabs.getState();
+  const currentTab = tabsState.tabs.find(
+    (candidate): candidate is Extract<Tab, { type: "sessions" }> =>
+      candidate.type === "sessions" && candidate.id === sessionId,
+  );
+  if (!currentTab?.state.autoStart) {
+    return;
+  }
+
+  tabsState.updateSessionTabState(currentTab, {
+    ...currentTab.state,
+    autoStart: null,
+  });
 }
 
 function TabContentNoteInner({

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -36,6 +36,7 @@ import {
   subscribeCanonicalSessionImportLocks,
 } from "~/session-sharing/editor-activity";
 import { useSession } from "~/session/queries";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 import { consumePendingUpload } from "~/stt/pending-upload";
@@ -113,35 +114,32 @@ function AutoStartListening({
   const canStartLiveSession = useListener((state) =>
     state.canStartLiveSession(tab.id),
   );
-  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
   const { conn } = useSTTConnection();
+
+  if (!canStartLiveSession || !conn) {
+    return null;
+  }
+
+  return <StartListeningWhenReady key={tab.id} tab={tab} />;
+}
+
+function StartListeningWhenReady({
+  tab,
+}: {
+  tab: Extract<Tab, { type: "sessions" }>;
+}) {
+  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
   const startListening = useStartListening(tab.id);
-  const hasAttemptedAutoStart = useRef(false);
 
-  useEffect(() => {
-    if (hasAttemptedAutoStart.current) {
-      return;
-    }
-
-    if (!canStartLiveSession) {
-      return;
-    }
-
-    if (!conn) {
-      return;
-    }
-
-    hasAttemptedAutoStart.current = true;
-    startListening();
-    updateSessionTabState(tab, { ...tab.state, autoStart: null });
-  }, [
-    tab,
-    tab.state,
-    canStartLiveSession,
-    conn,
-    startListening,
-    updateSessionTabState,
-  ]);
+  useMountEffect(() => {
+    void startListening()
+      .catch((error) => {
+        console.error("[listener] failed to auto-start session", error);
+      })
+      .finally(() => {
+        updateSessionTabState(tab, { ...tab.state, autoStart: null });
+      });
+  });
 
   return null;
 }

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -40,6 +40,10 @@ import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 import { consumePendingUpload } from "~/stt/pending-upload";
+import {
+  beginScheduledAutoStart,
+  finishScheduledAutoStart,
+} from "~/stt/scheduled-auto-start-state";
 import { useStartListening } from "~/stt/useStartListening";
 import { useSTTConnection } from "~/stt/useSTTConnection";
 import { useUploadFile } from "~/stt/useUploadFile";
@@ -136,17 +140,15 @@ function AutoStartListening({
     }
 
     hasAttemptedAutoStart.current = true;
-    const timeout = setTimeout(() => {
-      clearPendingAutoStart(tab.id);
-    }, 30_000);
+    beginScheduledAutoStart(tab.id);
+    clearPendingAutoStart(tab.id);
 
     void startListening()
       .catch((error) => {
         console.error("[listener] failed to auto-start session", error);
       })
       .finally(() => {
-        clearTimeout(timeout);
-        clearPendingAutoStart(tab.id);
+        finishScheduledAutoStart(tab.id);
       });
   }, [canStartLiveSession, conn, startListening, tab.id]);
 

--- a/apps/desktop/src/stt/scheduled-auto-start-state.test.ts
+++ b/apps/desktop/src/stt/scheduled-auto-start-state.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  beginScheduledAutoStart,
+  finishScheduledAutoStart,
+  hasScheduledAutoStartInFlight,
+} from "./scheduled-auto-start-state";
+
+const SESSION_IDS = ["session-1", "session-2"];
+
+afterEach(() => {
+  for (const sessionId of SESSION_IDS) {
+    finishScheduledAutoStart(sessionId);
+  }
+});
+
+describe("scheduled auto-start state", () => {
+  test("stays in flight until every start finishes", () => {
+    beginScheduledAutoStart(SESSION_IDS[0]);
+    beginScheduledAutoStart(SESSION_IDS[1]);
+
+    finishScheduledAutoStart(SESSION_IDS[0]);
+
+    expect(hasScheduledAutoStartInFlight()).toBe(true);
+
+    finishScheduledAutoStart(SESSION_IDS[1]);
+
+    expect(hasScheduledAutoStartInFlight()).toBe(false);
+  });
+});

--- a/apps/desktop/src/stt/scheduled-auto-start-state.ts
+++ b/apps/desktop/src/stt/scheduled-auto-start-state.ts
@@ -1,0 +1,13 @@
+const inFlightSessionIds = new Set<string>();
+
+export function beginScheduledAutoStart(sessionId: string) {
+  inFlightSessionIds.add(sessionId);
+}
+
+export function finishScheduledAutoStart(sessionId: string) {
+  inFlightSessionIds.delete(sessionId);
+}
+
+export function hasScheduledAutoStartInFlight() {
+  return inFlightSessionIds.size > 0;
+}

--- a/apps/desktop/src/stt/scheduled-auto-start.test.ts
+++ b/apps/desktop/src/stt/scheduled-auto-start.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   SCHEDULED_AUTO_START_GRACE_MS,
   type ScheduledMeetingRow,
-  selectDueMeeting,
+  selectDueMeetings,
 } from "./scheduled-auto-start";
 
 const NOW = new Date("2026-05-15T12:00:00.000Z").getTime();
@@ -24,46 +24,52 @@ function meeting(
 }
 
 function select(rows: ScheduledMeetingRow[], firedEventIds: string[] = []) {
-  return selectDueMeeting({
+  return selectDueMeetings({
     rows,
     nowMs: NOW,
     firedEventIds: new Set(firedEventIds),
-  });
+  }).map((row) => row.id);
 }
 
-describe("selectDueMeeting", () => {
+describe("selectDueMeetings", () => {
   test("selects a meeting whose start time has just arrived", () => {
-    expect(select([meeting("a", 0)])?.id).toBe("a");
+    expect(select([meeting("a", 0)])).toEqual(["a"]);
   });
 
   test("ignores meetings that have not started yet", () => {
-    expect(select([meeting("a", 30_000)])).toBeNull();
+    expect(select([meeting("a", 30_000)])).toEqual([]);
   });
 
   test("selects a meeting that started within the grace window", () => {
-    expect(select([meeting("a", -SCHEDULED_AUTO_START_GRACE_MS + 1)])?.id).toBe(
+    expect(select([meeting("a", -SCHEDULED_AUTO_START_GRACE_MS + 1)])).toEqual([
       "a",
-    );
+    ]);
   });
 
   test("ignores meetings that started before the grace window", () => {
-    expect(
-      select([meeting("a", -SCHEDULED_AUTO_START_GRACE_MS - 1)]),
-    ).toBeNull();
+    expect(select([meeting("a", -SCHEDULED_AUTO_START_GRACE_MS - 1)])).toEqual(
+      [],
+    );
   });
 
   test("ignores meetings that already fired", () => {
-    expect(select([meeting("a", 0)], ["a"])).toBeNull();
+    expect(select([meeting("a", 0)], ["a"])).toEqual([]);
   });
 
-  test("prefers the most recently started meeting when several are due", () => {
+  test("orders overlapping meetings by most recent start", () => {
     const rows = [
       meeting("earlier", -4 * 60_000),
       meeting("latest", -30_000),
       meeting("middle", -2 * 60_000),
     ];
 
-    expect(select(rows)?.id).toBe("latest");
+    expect(select(rows)).toEqual(["latest", "middle", "earlier"]);
+  });
+
+  test("still returns an overlapping meeting when the newest already fired", () => {
+    const rows = [meeting("earlier", -60_000), meeting("latest", -30_000)];
+
+    expect(select(rows, ["latest"])).toEqual(["earlier"]);
   });
 
   test("skips rows with an unparseable start time", () => {
@@ -72,10 +78,10 @@ describe("selectDueMeeting", () => {
       meeting("good", -60_000),
     ];
 
-    expect(select(rows)?.id).toBe("good");
+    expect(select(rows)).toEqual(["good"]);
   });
 
-  test("returns null when nothing is due", () => {
-    expect(select([])).toBeNull();
+  test("returns nothing when no meeting is due", () => {
+    expect(select([])).toEqual([]);
   });
 });

--- a/apps/desktop/src/stt/scheduled-auto-start.test.ts
+++ b/apps/desktop/src/stt/scheduled-auto-start.test.ts
@@ -114,4 +114,10 @@ describe("hasPendingAutoStart", () => {
   test("allows scheduling after every pending start clears", () => {
     expect(hasPendingAutoStart([sessionTab("ready", null)])).toBe(false);
   });
+
+  test("does not let an inactive pending tab block scheduling", () => {
+    expect(
+      hasPendingAutoStart([{ ...sessionTab("inactive", true), active: false }]),
+    ).toBe(false);
+  });
 });

--- a/apps/desktop/src/stt/scheduled-auto-start.test.ts
+++ b/apps/desktop/src/stt/scheduled-auto-start.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  hasPendingAutoStart,
   SCHEDULED_AUTO_START_GRACE_MS,
   type ScheduledMeetingRow,
   selectDueMeetings,
 } from "./scheduled-auto-start";
+
+import type { Tab } from "~/store/zustand/tabs";
 
 const NOW = new Date("2026-05-15T12:00:00.000Z").getTime();
 
@@ -83,5 +86,32 @@ describe("selectDueMeetings", () => {
 
   test("returns nothing when no meeting is due", () => {
     expect(select([])).toEqual([]);
+  });
+});
+
+describe("hasPendingAutoStart", () => {
+  const sessionTab = (
+    id: string,
+    autoStart: boolean | null,
+  ): Extract<Tab, { type: "sessions" }> => ({
+    type: "sessions",
+    id,
+    active: true,
+    slotId: id,
+    pinned: false,
+    state: { view: null, autoStart },
+  });
+
+  test("blocks another scheduled start while a tab is still arming", () => {
+    expect(
+      hasPendingAutoStart([
+        sessionTab("ready", null),
+        sessionTab("arming", true),
+      ]),
+    ).toBe(true);
+  });
+
+  test("allows scheduling after every pending start clears", () => {
+    expect(hasPendingAutoStart([sessionTab("ready", null)])).toBe(false);
   });
 });

--- a/apps/desktop/src/stt/scheduled-auto-start.test.ts
+++ b/apps/desktop/src/stt/scheduled-auto-start.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  SCHEDULED_AUTO_START_GRACE_MS,
+  type ScheduledMeetingRow,
+  selectDueMeeting,
+} from "./scheduled-auto-start";
+
+const NOW = new Date("2026-05-15T12:00:00.000Z").getTime();
+
+function meeting(
+  id: string,
+  offsetMs: number,
+  overrides: Partial<ScheduledMeetingRow> = {},
+): ScheduledMeetingRow {
+  return {
+    id,
+    started_at: new Date(NOW + offsetMs).toISOString(),
+    meeting_link: `https://zoom.us/j/${id}`,
+    tracking_id_event: `tracking-${id}`,
+    recurrence_series_id: "",
+    ...overrides,
+  };
+}
+
+function select(rows: ScheduledMeetingRow[], firedEventIds: string[] = []) {
+  return selectDueMeeting({
+    rows,
+    nowMs: NOW,
+    firedEventIds: new Set(firedEventIds),
+  });
+}
+
+describe("selectDueMeeting", () => {
+  test("selects a meeting whose start time has just arrived", () => {
+    expect(select([meeting("a", 0)])?.id).toBe("a");
+  });
+
+  test("ignores meetings that have not started yet", () => {
+    expect(select([meeting("a", 30_000)])).toBeNull();
+  });
+
+  test("selects a meeting that started within the grace window", () => {
+    expect(select([meeting("a", -SCHEDULED_AUTO_START_GRACE_MS + 1)])?.id).toBe(
+      "a",
+    );
+  });
+
+  test("ignores meetings that started before the grace window", () => {
+    expect(
+      select([meeting("a", -SCHEDULED_AUTO_START_GRACE_MS - 1)]),
+    ).toBeNull();
+  });
+
+  test("ignores meetings that already fired", () => {
+    expect(select([meeting("a", 0)], ["a"])).toBeNull();
+  });
+
+  test("prefers the most recently started meeting when several are due", () => {
+    const rows = [
+      meeting("earlier", -4 * 60_000),
+      meeting("latest", -30_000),
+      meeting("middle", -2 * 60_000),
+    ];
+
+    expect(select(rows)?.id).toBe("latest");
+  });
+
+  test("skips rows with an unparseable start time", () => {
+    const rows = [
+      meeting("broken", 0, { started_at: "not-a-date" }),
+      meeting("good", -60_000),
+    ];
+
+    expect(select(rows)?.id).toBe("good");
+  });
+
+  test("returns null when nothing is due", () => {
+    expect(select([])).toBeNull();
+  });
+});

--- a/apps/desktop/src/stt/scheduled-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-auto-start.tsx
@@ -10,6 +10,7 @@ import { useLatestRef } from "~/shared/hooks/useLatestRef";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
+import { hasScheduledAutoStartInFlight } from "~/stt/scheduled-auto-start-state";
 
 // A meeting that started while the app was asleep or quit is still worth
 // recording, but only briefly — reopening hours later must not start capturing
@@ -160,7 +161,10 @@ export function ScheduledMeetingAutoStart() {
         });
       }
 
-      if (hasPendingAutoStart(useTabs.getState().tabs)) {
+      if (
+        hasScheduledAutoStartInFlight() ||
+        hasPendingAutoStart(useTabs.getState().tabs)
+      ) {
         return;
       }
 

--- a/apps/desktop/src/stt/scheduled-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-auto-start.tsx
@@ -43,7 +43,9 @@ export type ScheduledMeetingRow = {
   recurrence_series_id: string;
 };
 
-export function selectDueMeeting({
+// Back-to-back meetings overlap inside the grace window; the one that just
+// started is the one the user is walking into, so the newest start comes first.
+export function selectDueMeetings({
   rows,
   nowMs,
   firedEventIds,
@@ -51,9 +53,8 @@ export function selectDueMeeting({
   rows: ScheduledMeetingRow[];
   nowMs: number;
   firedEventIds: ReadonlySet<string>;
-}): ScheduledMeetingRow | null {
-  let due: ScheduledMeetingRow | null = null;
-  let dueStartMs = -Infinity;
+}): ScheduledMeetingRow[] {
+  const due: { row: ScheduledMeetingRow; startMs: number }[] = [];
 
   for (const row of rows) {
     if (firedEventIds.has(row.id)) {
@@ -71,32 +72,27 @@ export function selectDueMeeting({
       continue;
     }
 
-    // Back-to-back meetings overlap inside the grace window; the one that just
-    // started is the one the user is walking into.
-    if (startMs > dueStartMs) {
-      due = row;
-      dueStartMs = startMs;
-    }
+    due.push({ row, startMs });
   }
 
-  return due;
+  return due.sort((a, b) => b.startMs - a.startMs).map(({ row }) => row);
 }
 
 async function startScheduledMeeting(
   row: ScheduledMeetingRow,
   autoJoin: boolean,
-): Promise<void> {
+): Promise<"started" | "ignored" | "blocked"> {
   const { ignoredIds, ignoredSeriesIds } = await getIgnoredEventSets();
   if (
     ignoredIds.has(row.tracking_id_event) ||
     (row.recurrence_series_id && ignoredSeriesIds.has(row.recurrence_series_id))
   ) {
-    return;
+    return "ignored";
   }
 
   const sessionId = await getOrCreateSessionForEventId(row.id);
   if (!listenerStore.getState().canStartLiveSession(sessionId)) {
-    return;
+    return "blocked";
   }
 
   if (autoJoin) {
@@ -108,6 +104,8 @@ async function startScheduledMeeting(
     id: sessionId,
     state: { view: null, autoStart: true },
   });
+
+  return "started";
 }
 
 export function ScheduledMeetingAutoStart() {
@@ -129,9 +127,16 @@ export function ScheduledMeetingAutoStart() {
     let cancelled = false;
     let rows: ScheduledMeetingRow[] = [];
     let unsubscribe: (() => Promise<void>) | null = null;
+    let starting = false;
     const firedEventIds = new Set<string>();
 
     const tick = () => {
+      // Ticks come from both the interval and calendar updates; without this a
+      // second tick could open another meeting mid-start.
+      if (starting) {
+        return;
+      }
+
       if (!autoStartRef.current) {
         return;
       }
@@ -140,25 +145,45 @@ export function ScheduledMeetingAutoStart() {
         return;
       }
 
-      const due = selectDueMeeting({
+      const due = selectDueMeetings({
         rows,
         nowMs: Date.now(),
         firedEventIds,
       });
-      if (!due) {
+      const next = due[0];
+      if (!next) {
         return;
       }
 
-      // Claim before awaiting so a tick landing mid-start cannot double-fire.
-      firedEventIds.add(due.id);
-      void startScheduledMeeting(due, Boolean(autoJoinRef.current)).catch(
-        (error) => {
+      starting = true;
+      void startScheduledMeeting(next, Boolean(autoJoinRef.current))
+        .then((outcome) => {
+          // A blocked start is transient (another session finalizing, a start
+          // already in flight), so leave it eligible for the next tick.
+          if (outcome === "blocked") {
+            return;
+          }
+
+          if (outcome === "ignored") {
+            firedEventIds.add(next.id);
+            return;
+          }
+
+          // Anything overlapping the meeting we just started is one the user
+          // walked out of; claiming them keeps a later tick from falling back.
+          for (const row of due) {
+            firedEventIds.add(row.id);
+          }
+        })
+        .catch((error) => {
           console.error(
             "[listener] failed to auto-start scheduled meeting",
             error,
           );
-        },
-      );
+        })
+        .finally(() => {
+          starting = false;
+        });
     };
 
     const interval = setInterval(tick, TICK_MS);

--- a/apps/desktop/src/stt/scheduled-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-auto-start.tsx
@@ -80,7 +80,8 @@ export function selectDueMeetings({
 
 export function hasPendingAutoStart(tabs: readonly Tab[]): boolean {
   return tabs.some(
-    (tab) => tab.type === "sessions" && Boolean(tab.state.autoStart),
+    (tab) =>
+      tab.type === "sessions" && tab.active && Boolean(tab.state.autoStart),
   );
 }
 
@@ -145,6 +146,18 @@ export function ScheduledMeetingAutoStart() {
 
       if (!autoStartRef.current) {
         return;
+      }
+
+      const tabsState = useTabs.getState();
+      for (const tab of tabsState.tabs) {
+        if (tab.type !== "sessions" || tab.active || !tab.state.autoStart) {
+          continue;
+        }
+
+        tabsState.updateSessionTabState(tab, {
+          ...tab.state,
+          autoStart: null,
+        });
       }
 
       if (hasPendingAutoStart(useTabs.getState().tabs)) {

--- a/apps/desktop/src/stt/scheduled-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-auto-start.tsx
@@ -9,7 +9,7 @@ import { useConfigValues } from "~/shared/config";
 import { useLatestRef } from "~/shared/hooks/useLatestRef";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { listenerStore } from "~/store/zustand/listener/instance";
-import { useTabs } from "~/store/zustand/tabs";
+import { type Tab, useTabs } from "~/store/zustand/tabs";
 
 // A meeting that started while the app was asleep or quit is still worth
 // recording, but only briefly — reopening hours later must not start capturing
@@ -78,6 +78,12 @@ export function selectDueMeetings({
   return due.sort((a, b) => b.startMs - a.startMs).map(({ row }) => row);
 }
 
+export function hasPendingAutoStart(tabs: readonly Tab[]): boolean {
+  return tabs.some(
+    (tab) => tab.type === "sessions" && Boolean(tab.state.autoStart),
+  );
+}
+
 async function startScheduledMeeting(
   row: ScheduledMeetingRow,
   autoJoin: boolean,
@@ -138,6 +144,10 @@ export function ScheduledMeetingAutoStart() {
       }
 
       if (!autoStartRef.current) {
+        return;
+      }
+
+      if (hasPendingAutoStart(useTabs.getState().tabs)) {
         return;
       }
 

--- a/apps/desktop/src/stt/scheduled-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-auto-start.tsx
@@ -1,0 +1,198 @@
+import { commands as openerCommands } from "@anlg/plugin-opener2";
+import { getCurrentWebviewWindowLabel } from "@anlg/plugin-windows";
+import { safeParseDate } from "@anlg/utils";
+
+import { getIgnoredEventSets } from "~/calendar/ignored-events";
+import { liveQueryClient } from "~/db";
+import { getOrCreateSessionForEventId } from "~/session/queries";
+import { useConfigValues } from "~/shared/config";
+import { useLatestRef } from "~/shared/hooks/useLatestRef";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+import { listenerStore } from "~/store/zustand/listener/instance";
+import { useTabs } from "~/store/zustand/tabs";
+
+// A meeting that started while the app was asleep or quit is still worth
+// recording, but only briefly — reopening hours later must not start capturing
+// a meeting that is already over.
+export const SCHEDULED_AUTO_START_GRACE_MS = 5 * 60_000;
+
+const TICK_MS = 15_000;
+
+// Calendar blocks without a meeting link ("Lunch", "Focus time") are excluded:
+// auto-start watches every calendar, so anything looser would record all day.
+const SCHEDULED_MEETINGS_SQL = `
+  SELECT
+    id,
+    started_at,
+    meeting_link,
+    tracking_id_event,
+    recurrence_series_id
+  FROM events
+  WHERE deleted_at IS NULL
+    AND is_all_day = 0
+    AND started_at <> ''
+    AND meeting_link <> ''
+  ORDER BY started_at, id
+`;
+
+export type ScheduledMeetingRow = {
+  id: string;
+  started_at: string;
+  meeting_link: string;
+  tracking_id_event: string;
+  recurrence_series_id: string;
+};
+
+export function selectDueMeeting({
+  rows,
+  nowMs,
+  firedEventIds,
+}: {
+  rows: ScheduledMeetingRow[];
+  nowMs: number;
+  firedEventIds: ReadonlySet<string>;
+}): ScheduledMeetingRow | null {
+  let due: ScheduledMeetingRow | null = null;
+  let dueStartMs = -Infinity;
+
+  for (const row of rows) {
+    if (firedEventIds.has(row.id)) {
+      continue;
+    }
+
+    const startedAt = safeParseDate(row.started_at);
+    if (!startedAt) {
+      continue;
+    }
+
+    const startMs = startedAt.getTime();
+    const elapsedMs = nowMs - startMs;
+    if (elapsedMs < 0 || elapsedMs > SCHEDULED_AUTO_START_GRACE_MS) {
+      continue;
+    }
+
+    // Back-to-back meetings overlap inside the grace window; the one that just
+    // started is the one the user is walking into.
+    if (startMs > dueStartMs) {
+      due = row;
+      dueStartMs = startMs;
+    }
+  }
+
+  return due;
+}
+
+async function startScheduledMeeting(
+  row: ScheduledMeetingRow,
+  autoJoin: boolean,
+): Promise<void> {
+  const { ignoredIds, ignoredSeriesIds } = await getIgnoredEventSets();
+  if (
+    ignoredIds.has(row.tracking_id_event) ||
+    (row.recurrence_series_id && ignoredSeriesIds.has(row.recurrence_series_id))
+  ) {
+    return;
+  }
+
+  const sessionId = await getOrCreateSessionForEventId(row.id);
+  if (!listenerStore.getState().canStartLiveSession(sessionId)) {
+    return;
+  }
+
+  if (autoJoin) {
+    void openerCommands.openUrl(row.meeting_link, null);
+  }
+
+  useTabs.getState().openNew({
+    type: "sessions",
+    id: sessionId,
+    state: { view: null, autoStart: true },
+  });
+}
+
+export function ScheduledMeetingAutoStart() {
+  const {
+    auto_start_scheduled_meetings: autoStart,
+    auto_join_scheduled_meetings: autoJoin,
+  } = useConfigValues([
+    "auto_start_scheduled_meetings",
+    "auto_join_scheduled_meetings",
+  ] as const);
+  const autoStartRef = useLatestRef(autoStart);
+  const autoJoinRef = useLatestRef(autoJoin);
+
+  useMountEffect(() => {
+    if (getCurrentWebviewWindowLabel() !== "main") {
+      return;
+    }
+
+    let cancelled = false;
+    let rows: ScheduledMeetingRow[] = [];
+    let unsubscribe: (() => Promise<void>) | null = null;
+    const firedEventIds = new Set<string>();
+
+    const tick = () => {
+      if (!autoStartRef.current) {
+        return;
+      }
+
+      if (listenerStore.getState().live.status !== "inactive") {
+        return;
+      }
+
+      const due = selectDueMeeting({
+        rows,
+        nowMs: Date.now(),
+        firedEventIds,
+      });
+      if (!due) {
+        return;
+      }
+
+      // Claim before awaiting so a tick landing mid-start cannot double-fire.
+      firedEventIds.add(due.id);
+      void startScheduledMeeting(due, Boolean(autoJoinRef.current)).catch(
+        (error) => {
+          console.error(
+            "[listener] failed to auto-start scheduled meeting",
+            error,
+          );
+        },
+      );
+    };
+
+    const interval = setInterval(tick, TICK_MS);
+
+    void liveQueryClient
+      .subscribe<ScheduledMeetingRow>(SCHEDULED_MEETINGS_SQL, [], {
+        onData: (nextRows) => {
+          rows = nextRows;
+          tick();
+        },
+        onError: (error) => {
+          console.error("[calendar] failed to read scheduled meetings", error);
+        },
+      })
+      .then((stopListening) => {
+        if (cancelled) {
+          void stopListening();
+          return;
+        }
+        unsubscribe = stopListening;
+      })
+      .catch((error) => {
+        console.error(
+          "[calendar] failed to subscribe to scheduled meetings",
+          error,
+        );
+      });
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      void unsubscribe?.();
+    };
+  });
+
+  return null;
+}


### PR DESCRIPTION
Scheduled auto-start was driven by useEventCountdown inside the session
header pill and the floating listen button, so it only armed while that
meeting's session happened to be mounted. The automation never fired for
meetings the user had not already opened — exactly the case it exists for.

Add ScheduledMeetingAutoStart, a main-window service mounted in
ClassicMainServices that subscribes to calendar events directly, ticks on
a timer, and starts capture when a start time arrives. It resolves the
session with getOrCreateSessionForEventId and opens it with autoStart, so
it works whether or not the tab exists, and honors
auto_join_scheduled_meetings by opening the meeting link.

Scope it to non-all-day, non-ignored events that carry a meeting link, and
only within a five-minute grace window after the start time, so a watcher
that now sees every calendar does not record ordinary blocks like focus
time or meetings that are already half over.

Drop the countdown-driven auto-start from both components so one owner
remains; useEventCountdown only reports its label now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when live capture auto-starts and can open meeting URLs/create sessions without the user having that tab open. Incorrect selection or race handling could start the wrong meeting or miss starts.
> 
> **Overview**
> Scheduled meeting auto-start no longer depends on the session header or floating listen button being mounted. A new main-window `ScheduledMeetingAutoStart` service watches calendar events directly and starts capture when a meeting becomes due.
> 
> It creates or opens the session with `autoStart`, optionally joins the meeting link, and only considers non-all-day events with a meeting link inside a **5-minute grace window**. Overlapping due meetings prefer the newest start, and ignored events are skipped.
> 
> `useEventCountdown` is now display-only. Header/floating auto-start paths are removed so there is a single owner, and `AutoStartListening` tracks in-flight starts with a timeout so a stuck arming request cannot block later meetings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2af3b2f91a59ab86e2d8b666945e4ea15ebe970f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->