### PR TITLE
fix(desktop): keep note view tabs pill-shaped on Windows

### DIFF
--- a/apps/desktop/src/session/components/note-input/header-enhanced.tsx
+++ b/apps/desktop/src/session/components/note-input/header-enhanced.tsx
@@ -242,7 +242,7 @@ function HeaderViewEnhancedActive({
         true,
         "tray",
         cn([
-          "max-w-56 min-w-[62px] gap-1.5 pr-1.5 pl-2",
+          "max-w-56 min-w-[62px] gap-1.5 px-2",
           isGenerating ? "cursor-not-allowed opacity-70" : "cursor-pointer",
           isError
             ? [

--- a/apps/desktop/src/session/components/note-input/header-shared.tsx
+++ b/apps/desktop/src/session/components/note-input/header-shared.tsx
@@ -88,7 +88,7 @@ export function iconHeaderViewClassName(
   const heightClassName = size === "tray" ? "h-[26px]" : "h-7";
 
   return cn([
-    "group/header-view flex shrink-0 items-center justify-center rounded-full transition-colors select-none [&>svg]:shrink-0",
+    "group/header-view flex shrink-0 items-center justify-center rounded-full transition-colors select-none [corner-shape:round] [&>svg]:shrink-0",
     isActive
       ? [
           "text-foreground bg-white shadow-xs",

--- a/apps/desktop/src/session/components/note-input/header-transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/header-transcript.tsx
@@ -102,7 +102,7 @@ function HeaderViewTranscriptButton({
         live
           ? [
               "group/transcript-live",
-              isActive ? "w-[98px] min-w-[98px] gap-1.5 pr-1.5 pl-2" : null,
+              isActive ? "w-[98px] min-w-[98px] gap-1.5 px-2" : null,
               isActive
                 ? live.degraded
                   ? [

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -57,7 +57,7 @@ export function Header({
             className={cn([
               "pointer-events-auto relative z-10 w-fit max-w-full overflow-visible",
               shouldUseViewSwitcher
-                ? "bg-foreground/10 dark:bg-accent/55 flex h-[30px] items-center gap-[2px] rounded-full p-[2px]"
+                ? "bg-foreground/10 dark:bg-accent/55 flex h-[30px] items-center gap-[2px] rounded-full p-[2px] [corner-shape:round]"
                 : null,
             ])}
           >


### PR DESCRIPTION
The global `corner-shape: squircle` rule in packages/ui applies to every
element, so `rounded-full` renders as a superellipse in Chromium-based
WebView2 on Windows while macOS WKWebView (no corner-shape support) falls
back to a true pill. Opt the tab strip and its buttons back into
`corner-shape: round` so both platforms match.

Also make the active summary and live transcript tabs use symmetric
horizontal padding instead of `pl-2 pr-1.5`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CSS/UI styling tweaks with no logic, data, or security impact.
> 
> **Overview**
> Overrides the global `corner-shape: squircle` on the session note view switcher and its tab buttons with `[corner-shape:round]`, so `rounded-full` stays a true pill on Windows WebView2 instead of a squircle.
> 
> Also switches active summary and live transcript tabs to symmetric `px-2` padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d178d7cdfd9e5d37cf4ca8cd1c2cb9443801226a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->