### PR TITLE
fix(stt): split oversized recordings across provider upload limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10687,6 +10687,7 @@ name = "listener2-core"
 version = "0.1.0"
 dependencies = [
  "aspasia",
+ "async-stream",
  "audio-chunking",
  "audio-utils",
  "axum 0.8.9",

--- a/crates/listener2-core/Cargo.toml
+++ b/crates/listener2-core/Cargo.toml
@@ -35,8 +35,9 @@ thiserror = { workspace = true }
 
 ractor = { workspace = true, features = ["async-trait"] }
 
+async-stream = { workspace = true }
 futures-util = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -323,6 +323,13 @@ pub(super) fn format_user_friendly_error(error: &str) -> String {
     {
         return "Could not connect to the transcription service. Please check your internet connection.".to_string();
     }
+    if error_lower.contains("413")
+        || error_lower.contains("payload too large")
+        || error_lower.contains("file too large")
+        || error_lower.contains("upload limit")
+    {
+        return "This recording is too large for the selected transcription provider. Try another provider or split the recording.".to_string();
+    }
     if error_lower.contains("invalid audio")
         || error_lower.contains("unsupported format")
         || error_lower.contains("codec")
@@ -460,5 +467,14 @@ mod tests {
         let params = batch_params(BatchProvider::Am, "http://localhost:50060/v1");
 
         assert!(expects_progressive_batch(&params));
+    }
+
+    #[test]
+    fn provider_upload_limit_errors_are_explained() {
+        let message = format_user_friendly_error(
+            r#"UnexpectedStatus { status: 400, body: "Audio file exceeds the 25 MB multipart upload limit." }"#,
+        );
+
+        assert!(message.starts_with("This recording is too large"));
     }
 }

--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -1,6 +1,7 @@
 mod accumulator;
 mod progressive;
 mod simple;
+mod upload;
 
 use std::sync::Arc;
 

--- a/crates/listener2-core/src/batch/progressive/actor.rs
+++ b/crates/listener2-core/src/batch/progressive/actor.rs
@@ -309,6 +309,27 @@ pub(super) fn report_stream_start_failure(
         anarlog.error.user_message = %message,
         "{context}"
     );
+    report_start_failure(myself, notifier, failure.into(), context);
+}
+
+/// For failures that already carry user-facing copy, unlike the provider errors
+/// that `report_stream_start_failure` has to translate first.
+pub(super) fn report_start_failure(
+    myself: &ActorRef<BatchMsg>,
+    notifier: &BatchStartNotifier,
+    error: crate::Error,
+    context: &str,
+) {
+    tracing::error!(error = %error, "{context}");
+
+    let failure = match error {
+        crate::Error::BatchFailed(failure) => failure,
+        error => crate::BatchFailure::ProgressiveStartFailed {
+            provider: "openai".to_string(),
+            message: error.to_string(),
+        },
+    };
+
     notify_start_result(notifier, Err(failure.clone().into()));
     let _ = myself.send_message(BatchMsg::StreamStartFailed(failure));
 }

--- a/crates/listener2-core/src/batch/progressive/bootstrap.rs
+++ b/crates/listener2-core/src/batch/progressive/bootstrap.rs
@@ -4,8 +4,10 @@ use tracing::Instrument;
 
 use super::ProgressiveProvider;
 use super::actor::{
-    BatchArgs, BatchMsg, BatchStartNotifier, process_provider_stream, report_stream_start_failure,
+    BatchArgs, BatchMsg, BatchStartNotifier, process_provider_stream, report_start_failure,
+    report_stream_start_failure,
 };
+use super::segmented::{open_segmented_stream, plan_openai_segments};
 
 pub(super) async fn spawn_progressive_batch_task(
     args: BatchArgs,
@@ -168,14 +170,41 @@ async fn spawn_openai_batch_task(
 
     let rx_task = tokio::spawn(
         async move {
-            let stream = match OpenAIAdapter::transcribe_file_streaming(
-                &args.base_url,
-                &args.api_key,
-                &args.listen_params,
-                &args.file_path,
-            )
-            .await
-            {
+            let plan = match plan_openai_segments(&args.file_path, &args.provider_label).await {
+                Ok(plan) => plan,
+                Err(error) => {
+                    report_start_failure(
+                        &myself,
+                        &args.start_notifier,
+                        error,
+                        "openai progressive batch failed to prepare audio",
+                    );
+                    return;
+                }
+            };
+
+            let opened = match plan {
+                Some(plan) => {
+                    open_segmented_stream(
+                        plan,
+                        args.base_url.clone(),
+                        args.api_key.clone(),
+                        args.listen_params.clone(),
+                    )
+                    .await
+                }
+                None => {
+                    OpenAIAdapter::transcribe_file_streaming(
+                        &args.base_url,
+                        &args.api_key,
+                        &args.listen_params,
+                        &args.file_path,
+                    )
+                    .await
+                }
+            };
+
+            let stream = match opened {
                 Ok(stream) => {
                     notify_start_result(&args.start_notifier, Ok(()));
                     stream

--- a/crates/listener2-core/src/batch/progressive/mod.rs
+++ b/crates/listener2-core/src/batch/progressive/mod.rs
@@ -1,5 +1,6 @@
 mod actor;
 mod bootstrap;
+mod segmented;
 
 use std::sync::Arc;
 

--- a/crates/listener2-core/src/batch/progressive/segmented.rs
+++ b/crates/listener2-core/src/batch/progressive/segmented.rs
@@ -331,6 +331,7 @@ mod tests {
         axum::extract::State(requests): axum::extract::State<
             std::sync::Arc<std::sync::atomic::AtomicUsize>,
         >,
+        _body: axum::body::Bytes,
     ) -> impl axum::response::IntoResponse {
         let index = requests.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let body = format!(

--- a/crates/listener2-core/src/batch/progressive/segmented.rs
+++ b/crates/listener2-core/src/batch/progressive/segmented.rs
@@ -1,0 +1,438 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use owhisper_client::{AdapterKind, OpenAIAdapter, StreamingBatchStream};
+use owhisper_interface::ListenParams;
+use owhisper_interface::batch::{Response, Word};
+use owhisper_interface::batch_stream::BatchStreamEvent;
+
+use super::super::upload::{SegmentedUpload, audio_duration, segment_plan, split_batch_upload};
+
+/// The stream loop fails a segment that goes quiet for 30s, so keep the boundary
+/// between segments visible while the next request is still uploading.
+const SEGMENT_OPEN_KEEPALIVE: Duration = Duration::from_secs(10);
+
+pub(super) struct SegmentedPlan {
+    upload: SegmentedUpload,
+    segment_duration: Duration,
+    total_duration: Option<Duration>,
+}
+
+/// `None` when the recording fits OpenAI's per-request limits and can be streamed
+/// as a single upload.
+pub(super) async fn plan_openai_segments(
+    file_path: &str,
+    provider: &str,
+) -> crate::Result<Option<SegmentedPlan>> {
+    let total_duration = audio_duration(file_path);
+    let limit = AdapterKind::OpenAI.batch_upload_limit();
+
+    let Some(segment_duration) = segment_plan(file_path, total_duration, limit) else {
+        return Ok(None);
+    };
+
+    let upload = split_batch_upload(file_path, segment_duration, provider).await?;
+
+    Ok(Some(SegmentedPlan {
+        upload,
+        segment_duration,
+        total_duration,
+    }))
+}
+
+/// Streams each segment in turn as one logical stream: per-segment timestamps are
+/// shifted onto the recording's timeline, progress is rescaled across all
+/// segments, and the per-segment results are held back so the stream still ends
+/// with exactly one result covering the whole recording.
+pub(super) async fn open_segmented_stream(
+    plan: SegmentedPlan,
+    base_url: String,
+    api_key: String,
+    mut listen_params: ListenParams,
+) -> Result<StreamingBatchStream, owhisper_client::Error> {
+    let SegmentedPlan {
+        upload,
+        segment_duration,
+        total_duration,
+    } = plan;
+    listen_params.channels = 1;
+
+    let paths: Vec<PathBuf> = upload.paths().to_vec();
+    let total = paths.len();
+    let first = OpenAIAdapter::transcribe_file_streaming(
+        &base_url,
+        &api_key,
+        &listen_params,
+        paths
+            .first()
+            .expect("split_batch_upload rejects no segments"),
+    )
+    .await?;
+
+    let stream = async_stream::stream! {
+        let _upload = upload;
+        let mut merged = MergedSegments::default();
+        let mut opened = Some(first);
+
+        for (index, path) in paths.iter().enumerate() {
+            let offset = segment_duration.as_secs_f64() * index as f64;
+
+            let mut segment = match opened.take() {
+                Some(segment) => segment,
+                None => {
+                    let open = OpenAIAdapter::transcribe_file_streaming(
+                        &base_url,
+                        &api_key,
+                        &listen_params,
+                        path,
+                    );
+                    tokio::pin!(open);
+
+                    loop {
+                        match tokio::time::timeout(SEGMENT_OPEN_KEEPALIVE, &mut open).await {
+                            Ok(Ok(segment)) => break segment,
+                            Ok(Err(error)) => {
+                                yield Err(error);
+                                return;
+                            }
+                            Err(_) => yield Ok(BatchStreamEvent::Progress {
+                                percentage: index as f64 / total as f64,
+                                partial_text: Some(merged.transcript()),
+                            }),
+                        }
+                    }
+                }
+            };
+
+            let mut completed = false;
+            while let Some(item) = segment.next().await {
+                match item {
+                    Err(error) => {
+                        yield Err(error);
+                        return;
+                    }
+                    Ok(BatchStreamEvent::Result { response }) => {
+                        merged.absorb(response, offset);
+                        completed = true;
+                    }
+                    Ok(BatchStreamEvent::Terminal { duration, channels, .. }) => {
+                        merged.absorb_terminal(duration, channels);
+                        completed = true;
+                    }
+                    Ok(BatchStreamEvent::Progress { percentage, partial_text }) => {
+                        yield Ok(BatchStreamEvent::Progress {
+                            percentage: rescale(index, percentage, total),
+                            partial_text: Some(merged.with_partial(partial_text.as_deref())),
+                        });
+                    }
+                    Ok(BatchStreamEvent::Segment { mut response, percentage }) => {
+                        response.apply_offset(offset);
+                        yield Ok(BatchStreamEvent::Segment {
+                            response,
+                            percentage: rescale(index, percentage, total),
+                        });
+                    }
+                    Ok(error @ BatchStreamEvent::Error { .. }) => {
+                        yield Ok(error);
+                        return;
+                    }
+                }
+            }
+
+            // Leaving without a completion event lets the stream loop report the
+            // missing result rather than silently returning a partial transcript.
+            if !completed {
+                tracing::error!(segment = index, "segmented batch stream ended without a result");
+                return;
+            }
+        }
+
+        if let Some(event) = merged.into_event(total_duration) {
+            yield Ok(event);
+        }
+    };
+
+    Ok(Box::pin(stream))
+}
+
+fn rescale(index: usize, percentage: f64, total: usize) -> f64 {
+    ((index as f64 + percentage.clamp(0.0, 1.0)) / total as f64).clamp(0.0, 1.0)
+}
+
+#[derive(Default)]
+struct MergedSegments {
+    metadata: Option<serde_json::Value>,
+    transcripts: Vec<String>,
+    words: Vec<Word>,
+    saw_result: bool,
+    terminal: Option<(f64, u32)>,
+}
+
+impl MergedSegments {
+    fn absorb(&mut self, response: Response, offset: f64) {
+        self.saw_result = true;
+        if self.metadata.is_none() {
+            self.metadata = Some(response.metadata);
+        }
+
+        let Some(alternative) = response
+            .results
+            .channels
+            .into_iter()
+            .next()
+            .and_then(|channel| channel.alternatives.into_iter().next())
+        else {
+            return;
+        };
+
+        let transcript = alternative.transcript.trim();
+        if !transcript.is_empty() {
+            self.transcripts.push(transcript.to_string());
+        }
+        self.words
+            .extend(alternative.words.into_iter().map(|mut word| {
+                word.start += offset;
+                word.end += offset;
+                word
+            }));
+    }
+
+    fn absorb_terminal(&mut self, duration: f64, channels: u32) {
+        let (total, _) = self.terminal.unwrap_or((0.0, channels));
+        self.terminal = Some((total + duration, channels));
+    }
+
+    fn transcript(&self) -> String {
+        self.transcripts.join(" ")
+    }
+
+    fn with_partial(&self, partial: Option<&str>) -> String {
+        let partial = partial.unwrap_or_default().trim();
+        if partial.is_empty() {
+            return self.transcript();
+        }
+        if self.transcripts.is_empty() {
+            return partial.to_string();
+        }
+        format!("{} {partial}", self.transcript())
+    }
+
+    fn into_event(self, total_duration: Option<Duration>) -> Option<BatchStreamEvent> {
+        if !self.saw_result {
+            return self
+                .terminal
+                .map(|(duration, channels)| BatchStreamEvent::Terminal {
+                    request_id: String::new(),
+                    created: String::new(),
+                    duration: total_duration.map_or(duration, |total| total.as_secs_f64()),
+                    channels,
+                });
+        }
+
+        let mut metadata = self.metadata.unwrap_or_else(|| serde_json::json!({}));
+        if let (Some(object), Some(total)) = (metadata.as_object_mut(), total_duration) {
+            object.insert(
+                "duration".to_string(),
+                serde_json::json!(total.as_secs_f64()),
+            );
+        }
+
+        Some(BatchStreamEvent::Result {
+            response: Response {
+                metadata,
+                results: owhisper_interface::batch::Results {
+                    channels: vec![owhisper_interface::batch::Channel {
+                        alternatives: vec![owhisper_interface::batch::Alternatives {
+                            transcript: self.transcripts.join(" "),
+                            confidence: 1.0,
+                            words: self.words,
+                        }],
+                    }],
+                },
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result_event(transcript: &str, start: f64) -> Response {
+        Response {
+            metadata: serde_json::json!({ "timing_source": "synthetic_text" }),
+            results: owhisper_interface::batch::Results {
+                channels: vec![owhisper_interface::batch::Channel {
+                    alternatives: vec![owhisper_interface::batch::Alternatives {
+                        transcript: transcript.to_string(),
+                        confidence: 1.0,
+                        words: vec![Word {
+                            word: transcript.to_string(),
+                            start,
+                            end: start + 0.5,
+                            confidence: 1.0,
+                            channel: 0,
+                            speaker: None,
+                            punctuated_word: None,
+                        }],
+                    }],
+                }],
+            },
+        }
+    }
+
+    #[test]
+    fn merged_result_shifts_words_and_keeps_total_duration() {
+        let mut merged = MergedSegments::default();
+        merged.absorb(result_event("first", 1.0), 0.0);
+        merged.absorb(result_event("second", 2.0), 600.0);
+
+        let event = merged
+            .into_event(Some(Duration::from_secs(1_205)))
+            .expect("a result was absorbed");
+        let BatchStreamEvent::Result { response } = event else {
+            panic!("expected a result event");
+        };
+        let alternative = &response.results.channels[0].alternatives[0];
+
+        assert_eq!(alternative.transcript, "first second");
+        assert_eq!(alternative.words[0].start, 1.0);
+        assert_eq!(alternative.words[1].start, 602.0);
+        assert_eq!(response.metadata["duration"], 1205.0);
+        assert_eq!(response.metadata["timing_source"], "synthetic_text");
+    }
+
+    #[test]
+    fn partial_text_continues_across_segments() {
+        let mut merged = MergedSegments::default();
+        assert_eq!(merged.with_partial(Some("hello")), "hello");
+
+        merged.absorb(result_event("first segment", 0.0), 0.0);
+        assert_eq!(
+            merged.with_partial(Some("and then")),
+            "first segment and then"
+        );
+        assert_eq!(merged.with_partial(None), "first segment");
+    }
+
+    #[test]
+    fn progress_stays_monotonic_across_segment_boundaries() {
+        let end_of_first = rescale(0, 0.99, 5);
+        let boundary = 1.0 / 5.0;
+        let start_of_second = rescale(1, 0.03, 5);
+
+        assert!(end_of_first < boundary);
+        assert!(boundary < start_of_second);
+        assert_eq!(rescale(4, 1.0, 5), 1.0);
+    }
+
+    async fn transcription_sse(
+        axum::extract::State(requests): axum::extract::State<
+            std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        >,
+    ) -> impl axum::response::IntoResponse {
+        let index = requests.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let body = format!(
+            "data: {{\"type\":\"transcript.text.delta\",\"delta\":\"segment \"}}\n\n\
+             data: {{\"type\":\"transcript.text.delta\",\"delta\":\"{index}\"}}\n\n\
+             data: {{\"type\":\"transcript.text.done\",\"text\":\"segment {index}\"}}\n\n"
+        );
+
+        (
+            [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+            body,
+        )
+    }
+
+    #[tokio::test]
+    async fn streams_every_segment_as_one_logical_stream() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("audio.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = hound::WavWriter::create(&source, spec).unwrap();
+        for frame in 0..16_000 * 3 {
+            writer
+                .write_sample(((frame as f32) * 0.01).sin() * 0.5)
+                .unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let requests = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let app = axum::Router::new()
+            .fallback(transcription_sse)
+            .with_state(requests.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let upload = split_batch_upload(source.to_str().unwrap(), Duration::from_secs(1), "openai")
+            .await
+            .unwrap();
+        assert_eq!(upload.paths().len(), 3);
+
+        let mut stream = open_segmented_stream(
+            SegmentedPlan {
+                upload,
+                segment_duration: Duration::from_secs(1),
+                total_duration: Some(Duration::from_secs(3)),
+            },
+            format!("http://{address}/v1"),
+            "test-key".to_string(),
+            ListenParams::default(),
+        )
+        .await
+        .unwrap();
+
+        let mut progress = Vec::new();
+        let mut results = Vec::new();
+        while let Some(event) = stream.next().await {
+            match event.unwrap() {
+                BatchStreamEvent::Progress {
+                    percentage,
+                    partial_text,
+                } => progress.push((percentage, partial_text.unwrap_or_default())),
+                BatchStreamEvent::Result { response } => results.push(response),
+                other => panic!("unexpected event: {other:?}"),
+            }
+        }
+
+        assert_eq!(requests.load(std::sync::atomic::Ordering::SeqCst), 3);
+        assert_eq!(results.len(), 1, "segments must produce one merged result");
+        assert_eq!(
+            results[0].results.channels[0].alternatives[0].transcript,
+            "segment 0 segment 1 segment 2"
+        );
+        assert_eq!(results[0].metadata["duration"], 3.0);
+
+        assert!(progress.windows(2).all(|pair| pair[0].0 <= pair[1].0));
+        assert!(progress.iter().all(|(percentage, _)| *percentage <= 1.0));
+        assert_eq!(
+            progress.last().map(|(_, text)| text.as_str()),
+            Some("segment 0 segment 1 segment 2")
+        );
+    }
+
+    #[test]
+    fn segments_that_only_reach_terminal_do_not_emit_an_empty_result() {
+        let mut merged = MergedSegments::default();
+        merged.absorb_terminal(600.0, 2);
+        merged.absorb_terminal(300.0, 2);
+
+        let event = merged.into_event(None).expect("a terminal was absorbed");
+        let BatchStreamEvent::Terminal {
+            duration, channels, ..
+        } = event
+        else {
+            panic!("expected a terminal event");
+        };
+
+        assert_eq!(duration, 900.0);
+        assert_eq!(channels, 2);
+    }
+}

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -7,7 +7,8 @@ pub(super) use local::{run_apple_speech_batch, run_soniqo_batch};
 #[cfg(test)]
 use direct::{
     DIRECT_BATCH_TIMEOUT_CEILING, DIRECT_BATCH_TIMEOUT_FLOOR, direct_batch_timeout_for_audio,
-    prepare_anarlog_batch_upload, run_direct_batch_with_timeout,
+    merge_segment_responses, prepare_anarlog_batch_upload, run_direct_batch,
+    run_direct_batch_with_timeout, segment_plan,
 };
 #[cfg(test)]
 use local::{

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -5,10 +5,12 @@ pub(super) use direct::run_direct_batch_for_adapter_kind;
 pub(super) use local::{run_apple_speech_batch, run_soniqo_batch};
 
 #[cfg(test)]
+use super::upload::segment_plan;
+#[cfg(test)]
 use direct::{
     DIRECT_BATCH_TIMEOUT_CEILING, DIRECT_BATCH_TIMEOUT_FLOOR, direct_batch_timeout_for_audio,
     merge_segment_responses, prepare_anarlog_batch_upload, run_direct_batch,
-    run_direct_batch_with_timeout, segment_plan,
+    run_direct_batch_with_timeout,
 };
 #[cfg(test)]
 use local::{

--- a/crates/listener2-core/src/batch/simple/direct.rs
+++ b/crates/listener2-core/src/batch/simple/direct.rs
@@ -3,11 +3,12 @@ use std::time::Duration;
 
 use owhisper_client::{
     AdapterKind, AnarlogAdapter, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter,
-    AwsTranscribeAdapter, AzureSpeechAdapter, BatchSttAdapter, CartesiaAdapter, CohereAdapter,
-    DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, GoogleCloudAdapter,
-    GroqAdapter, MistralAdapter, OpenAIAdapter, OpenRouterAdapter, PyannoteAdapter, RevAiAdapter,
-    SonioxAdapter, SpeechmaticsAdapter, TogetherAdapter, XaiAdapter,
+    AwsTranscribeAdapter, AzureSpeechAdapter, BatchSttAdapter, BatchUploadLimit, CartesiaAdapter,
+    CohereAdapter, DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter,
+    GoogleCloudAdapter, GroqAdapter, MistralAdapter, OpenAIAdapter, OpenRouterAdapter,
+    PyannoteAdapter, RevAiAdapter, SonioxAdapter, SpeechmaticsAdapter, TogetherAdapter, XaiAdapter,
 };
+use owhisper_interface::batch::{Alternatives, Channel, Response, Results};
 use tracing::Instrument;
 
 use anlg_audio_utils::Source;
@@ -39,13 +40,14 @@ impl PreparedBatchUpload {
 }
 
 macro_rules! dispatch_batch {
-    ($ak:expr, $params:expr, $lp:expr,
+    ($ak:expr, $params:expr, $lp:expr, $limit:expr,
      { $($var:ident => $adapter:ty),+ $(,)? },
      unsupported: [$($unsup:ident),* $(,)?]
     ) => {
         match $ak {
             $(AdapterKind::$var => {
-                run_direct_batch::<$adapter>(&AdapterKind::$var.to_string(), $params, $lp).await
+                run_direct_batch::<$adapter>(&AdapterKind::$var.to_string(), $params, $lp, $limit)
+                    .await
             })+
             $(AdapterKind::$unsup => {
                 Err(crate::BatchFailure::DirectBatchUnsupported {
@@ -65,7 +67,9 @@ pub(in crate::batch) async fn run_direct_batch_for_adapter_kind(
         return run_anarlog_batch(params, listen_params).await;
     }
 
-    dispatch_batch!(adapter_kind, params, listen_params, {
+    let limit = adapter_kind.batch_upload_limit();
+
+    dispatch_batch!(adapter_kind, params, listen_params, limit, {
         Argmax => ArgmaxAdapter,
         Cartesia => CartesiaAdapter,
         Deepgram => DeepgramAdapter,
@@ -99,8 +103,13 @@ async fn run_anarlog_batch(
     let upload =
         prepare_anarlog_batch_upload(&params.file_path, ANARLOG_PROXY_MAX_AUDIO_BYTES).await?;
     params.file_path = upload.path().to_string_lossy().into_owned();
-    run_direct_batch::<AnarlogAdapter>(&AdapterKind::Anarlog.to_string(), params, listen_params)
-        .await
+    run_direct_batch::<AnarlogAdapter>(
+        &AdapterKind::Anarlog.to_string(),
+        params,
+        listen_params,
+        None,
+    )
+    .await
 }
 
 pub(super) async fn prepare_anarlog_batch_upload(
@@ -179,13 +188,171 @@ pub(super) async fn prepare_anarlog_batch_upload(
     })
 }
 
-async fn run_direct_batch<A: BatchSttAdapter>(
+pub(super) async fn run_direct_batch<A: BatchSttAdapter>(
     provider: &str,
     params: BatchParams,
     listen_params: owhisper_interface::ListenParams,
+    limit: Option<BatchUploadLimit>,
 ) -> crate::Result<BatchRunOutput> {
-    let timeout = direct_batch_timeout(&params.file_path);
-    run_direct_batch_with_timeout::<A>(provider, params, listen_params, timeout).await
+    let audio_duration = audio_duration(&params.file_path);
+    let timeout = direct_batch_timeout_for_audio(audio_duration);
+
+    match segment_plan(&params.file_path, audio_duration, limit) {
+        Some(segment_duration) => {
+            run_segmented_batch::<A>(provider, params, listen_params, segment_duration, timeout)
+                .await
+        }
+        None => run_direct_batch_with_timeout::<A>(provider, params, listen_params, timeout).await,
+    }
+}
+
+/// Recordings past a provider's upload cap or per-request duration cap are
+/// re-encoded as mono MP3 segments and sent one request at a time.
+pub(super) fn segment_plan(
+    file_path: &str,
+    audio_duration: Option<Duration>,
+    limit: Option<BatchUploadLimit>,
+) -> Option<Duration> {
+    let limit = limit?;
+    let size = std::fs::metadata(file_path).ok()?.len();
+    let too_long = audio_duration.is_some_and(|duration| duration > limit.max_duration);
+
+    (size > limit.max_bytes || too_long).then_some(limit.max_duration)
+}
+
+async fn run_segmented_batch<A: BatchSttAdapter>(
+    provider: &str,
+    params: BatchParams,
+    listen_params: owhisper_interface::ListenParams,
+    segment_duration: Duration,
+    timeout: Duration,
+) -> crate::Result<BatchRunOutput> {
+    let segments = split_batch_upload(&params.file_path, segment_duration, provider).await?;
+    tracing::info!(
+        segments = segments.paths.len(),
+        segment_seconds = segment_duration.as_secs(),
+        "batch audio split for provider upload limits"
+    );
+
+    let mut responses = Vec::with_capacity(segments.paths.len());
+    for path in &segments.paths {
+        let mut segment_params = params.clone();
+        segment_params.file_path = path.to_string_lossy().into_owned();
+
+        let output = run_direct_batch_with_timeout::<A>(
+            provider,
+            segment_params,
+            listen_params.clone(),
+            timeout,
+        )
+        .await?;
+        responses.push(output.response);
+    }
+
+    Ok(BatchRunOutput {
+        session_id: params.session_id,
+        mode: BatchRunMode::Direct,
+        response: merge_segment_responses(responses, segment_duration),
+    })
+}
+
+struct SegmentedUpload {
+    _temp_dir: tempfile::TempDir,
+    paths: Vec<PathBuf>,
+}
+
+async fn split_batch_upload(
+    file_path: &str,
+    segment_duration: Duration,
+    provider: &str,
+) -> crate::Result<SegmentedUpload> {
+    let failure = |message: &str| crate::BatchFailure::DirectRequestFailed {
+        provider: provider.to_string(),
+        message: message.to_string(),
+    };
+
+    let temp_dir = tempfile::tempdir().map_err(|error| {
+        tracing::error!(%error, "batch_audio_segment_temp_dir_failed");
+        failure("Anarlog couldn't prepare this recording for transcription.")
+    })?;
+
+    let source = PathBuf::from(file_path);
+    let output_dir = temp_dir.path().to_path_buf();
+    let paths = tokio::task::spawn_blocking(move || {
+        anlg_mp3::encode_mono_segments(&source, &output_dir, segment_duration)
+    })
+    .await
+    .map_err(|error| {
+        tracing::error!(%error, "batch_audio_segment_task_failed");
+        failure("Anarlog couldn't prepare this recording for transcription.")
+    })?
+    .map_err(|error| {
+        tracing::error!(%error, "batch_audio_segment_failed");
+        failure("Anarlog couldn't split this recording for transcription.")
+    })?;
+
+    if paths.is_empty() {
+        return Err(failure("This recording has no audio to transcribe.").into());
+    }
+
+    Ok(SegmentedUpload {
+        _temp_dir: temp_dir,
+        paths,
+    })
+}
+
+/// Segments are transcribed independently, so their timestamps restart at zero.
+pub(super) fn merge_segment_responses(
+    responses: Vec<Response>,
+    segment_duration: Duration,
+) -> Response {
+    let mut metadata = serde_json::Value::Null;
+    let mut transcripts: Vec<String> = Vec::new();
+    let mut words = Vec::new();
+
+    for (index, response) in responses.into_iter().enumerate() {
+        let offset = segment_duration.as_secs_f64() * index as f64;
+        if metadata.is_null() {
+            metadata = response.metadata;
+        }
+
+        let Some(alternative) = response
+            .results
+            .channels
+            .into_iter()
+            .next()
+            .and_then(|channel| channel.alternatives.into_iter().next())
+        else {
+            continue;
+        };
+
+        let transcript = alternative.transcript.trim();
+        if !transcript.is_empty() {
+            transcripts.push(transcript.to_string());
+        }
+        words.extend(alternative.words.into_iter().map(|mut word| {
+            word.start += offset;
+            word.end += offset;
+            word
+        }));
+    }
+
+    Response {
+        metadata: if metadata.is_null() {
+            serde_json::json!({})
+        } else {
+            metadata
+        },
+        results: Results {
+            channels: vec![Channel {
+                alternatives: vec![Alternatives {
+                    transcript: transcripts.join(" "),
+                    confidence: 1.0,
+                    words,
+                }],
+            }],
+        },
+    }
 }
 
 pub(super) async fn run_direct_batch_with_timeout<A: BatchSttAdapter>(
@@ -245,11 +412,10 @@ pub(super) async fn run_direct_batch_with_timeout<A: BatchSttAdapter>(
     .await
 }
 
-fn direct_batch_timeout(file_path: &str) -> Duration {
-    let audio_duration = anlg_audio_utils::source_from_path(file_path)
+fn audio_duration(file_path: &str) -> Option<Duration> {
+    anlg_audio_utils::source_from_path(file_path)
         .ok()
-        .and_then(|source| source.total_duration());
-    direct_batch_timeout_for_audio(audio_duration)
+        .and_then(|source| source.total_duration())
 }
 
 pub(super) fn direct_batch_timeout_for_audio(audio_duration: Option<Duration>) -> Duration {

--- a/crates/listener2-core/src/batch/simple/direct.rs
+++ b/crates/listener2-core/src/batch/simple/direct.rs
@@ -243,11 +243,40 @@ pub(super) fn merge_segment_responses(
     segment_duration: Duration,
 ) -> Response {
     let mut metadata = serde_json::Value::Null;
+    let mut speaker_labels = Vec::new();
+    let mut speaker_segments = Vec::new();
+    let mut speaker_offset = 0;
     let mut transcripts: Vec<String> = Vec::new();
     let mut words = Vec::new();
 
     for (index, response) in responses.into_iter().enumerate() {
         let offset = segment_duration.as_secs_f64() * index as f64;
+        let segment_speaker_labels = response
+            .metadata
+            .get("speaker_labels")
+            .and_then(serde_json::Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        speaker_labels.extend(segment_speaker_labels.iter().cloned());
+        speaker_segments.extend(
+            response
+                .metadata
+                .get("speaker_segments")
+                .and_then(serde_json::Value::as_array)
+                .into_iter()
+                .flatten()
+                .cloned()
+                .map(|mut segment| {
+                    for field in ["start", "end"] {
+                        if let Some(value) = segment.get_mut(field)
+                            && let Some(time) = value.as_f64()
+                        {
+                            *value = serde_json::json!(time + offset);
+                        }
+                    }
+                    segment
+                }),
+        );
         if metadata.is_null() {
             metadata = response.metadata;
         }
@@ -266,11 +295,35 @@ pub(super) fn merge_segment_responses(
         if !transcript.is_empty() {
             transcripts.push(transcript.to_string());
         }
+        let segment_speaker_count = alternative
+            .words
+            .iter()
+            .filter_map(|word| word.speaker)
+            .max()
+            .map_or(0, |speaker| speaker + 1)
+            .max(segment_speaker_labels.len());
         words.extend(alternative.words.into_iter().map(|mut word| {
             word.start += offset;
             word.end += offset;
+            word.speaker = word.speaker.map(|speaker| speaker + speaker_offset);
             word
         }));
+        speaker_offset += segment_speaker_count;
+    }
+
+    if let Some(object) = metadata.as_object_mut() {
+        if !speaker_labels.is_empty() {
+            object.insert(
+                "speaker_labels".to_string(),
+                serde_json::Value::Array(speaker_labels),
+            );
+        }
+        if !speaker_segments.is_empty() {
+            object.insert(
+                "speaker_segments".to_string(),
+                serde_json::Value::Array(speaker_segments),
+            );
+        }
     }
 
     Response {

--- a/crates/listener2-core/src/batch/simple/direct.rs
+++ b/crates/listener2-core/src/batch/simple/direct.rs
@@ -11,8 +11,7 @@ use owhisper_client::{
 use owhisper_interface::batch::{Alternatives, Channel, Response, Results};
 use tracing::Instrument;
 
-use anlg_audio_utils::Source;
-
+use super::super::upload::{audio_duration, segment_plan, split_batch_upload};
 use super::super::{
     BatchParams, BatchRunMode, BatchRunOutput, format_user_friendly_error, session_span,
 };
@@ -206,36 +205,18 @@ pub(super) async fn run_direct_batch<A: BatchSttAdapter>(
     }
 }
 
-/// Recordings past a provider's upload cap or per-request duration cap are
-/// re-encoded as mono MP3 segments and sent one request at a time.
-pub(super) fn segment_plan(
-    file_path: &str,
-    audio_duration: Option<Duration>,
-    limit: Option<BatchUploadLimit>,
-) -> Option<Duration> {
-    let limit = limit?;
-    let size = std::fs::metadata(file_path).ok()?.len();
-    let too_long = audio_duration.is_some_and(|duration| duration > limit.max_duration);
-
-    (size > limit.max_bytes || too_long).then_some(limit.max_duration)
-}
-
 async fn run_segmented_batch<A: BatchSttAdapter>(
     provider: &str,
     params: BatchParams,
-    listen_params: owhisper_interface::ListenParams,
+    mut listen_params: owhisper_interface::ListenParams,
     segment_duration: Duration,
     timeout: Duration,
 ) -> crate::Result<BatchRunOutput> {
     let segments = split_batch_upload(&params.file_path, segment_duration, provider).await?;
-    tracing::info!(
-        segments = segments.paths.len(),
-        segment_seconds = segment_duration.as_secs(),
-        "batch audio split for provider upload limits"
-    );
+    listen_params.channels = 1;
 
-    let mut responses = Vec::with_capacity(segments.paths.len());
-    for path in &segments.paths {
+    let mut responses = Vec::with_capacity(segments.paths().len());
+    for path in segments.paths() {
         let mut segment_params = params.clone();
         segment_params.file_path = path.to_string_lossy().into_owned();
 
@@ -253,51 +234,6 @@ async fn run_segmented_batch<A: BatchSttAdapter>(
         session_id: params.session_id,
         mode: BatchRunMode::Direct,
         response: merge_segment_responses(responses, segment_duration),
-    })
-}
-
-struct SegmentedUpload {
-    _temp_dir: tempfile::TempDir,
-    paths: Vec<PathBuf>,
-}
-
-async fn split_batch_upload(
-    file_path: &str,
-    segment_duration: Duration,
-    provider: &str,
-) -> crate::Result<SegmentedUpload> {
-    let failure = |message: &str| crate::BatchFailure::DirectRequestFailed {
-        provider: provider.to_string(),
-        message: message.to_string(),
-    };
-
-    let temp_dir = tempfile::tempdir().map_err(|error| {
-        tracing::error!(%error, "batch_audio_segment_temp_dir_failed");
-        failure("Anarlog couldn't prepare this recording for transcription.")
-    })?;
-
-    let source = PathBuf::from(file_path);
-    let output_dir = temp_dir.path().to_path_buf();
-    let paths = tokio::task::spawn_blocking(move || {
-        anlg_mp3::encode_mono_segments(&source, &output_dir, segment_duration)
-    })
-    .await
-    .map_err(|error| {
-        tracing::error!(%error, "batch_audio_segment_task_failed");
-        failure("Anarlog couldn't prepare this recording for transcription.")
-    })?
-    .map_err(|error| {
-        tracing::error!(%error, "batch_audio_segment_failed");
-        failure("Anarlog couldn't split this recording for transcription.")
-    })?;
-
-    if paths.is_empty() {
-        return Err(failure("This recording has no audio to transcribe.").into());
-    }
-
-    Ok(SegmentedUpload {
-        _temp_dir: temp_dir,
-        paths,
     })
 }
 
@@ -410,12 +346,6 @@ pub(super) async fn run_direct_batch_with_timeout<A: BatchSttAdapter>(
     }
     .instrument(span)
     .await
-}
-
-fn audio_duration(file_path: &str) -> Option<Duration> {
-    anlg_audio_utils::source_from_path(file_path)
-        .ok()
-        .and_then(|source| source.total_duration())
 }
 
 pub(super) fn direct_batch_timeout_for_audio(audio_duration: Option<Duration>) -> Duration {

--- a/crates/listener2-core/src/batch/simple/tests.rs
+++ b/crates/listener2-core/src/batch/simple/tests.rs
@@ -236,6 +236,52 @@ fn merges_segment_transcripts_onto_a_single_timeline() {
     assert_eq!(merged.metadata["provider"], "openrouter");
 }
 
+#[test]
+fn keeps_diarized_segment_speakers_distinct() {
+    let segment = |label: &str, speaker: usize, start: f64| Response {
+        metadata: serde_json::json!({
+            "speaker_labels": [label],
+            "speaker_segments": [{
+                "speaker": label,
+                "start": start,
+                "end": start + 0.5,
+            }],
+        }),
+        results: owhisper_interface::batch::Results {
+            channels: vec![owhisper_interface::batch::Channel {
+                alternatives: vec![owhisper_interface::batch::Alternatives {
+                    transcript: label.to_string(),
+                    confidence: 1.0,
+                    words: vec![owhisper_interface::batch::Word {
+                        word: label.to_string(),
+                        start,
+                        end: start + 0.5,
+                        confidence: 1.0,
+                        channel: 0,
+                        speaker: Some(speaker),
+                        punctuated_word: None,
+                    }],
+                }],
+            }],
+        },
+    };
+
+    let merged = merge_segment_responses(
+        vec![segment("speaker_a", 0, 1.0), segment("speaker_b", 0, 2.0)],
+        Duration::from_secs(600),
+    );
+
+    let alternative = &merged.results.channels[0].alternatives[0];
+    assert_eq!(alternative.words[0].speaker, Some(0));
+    assert_eq!(alternative.words[1].speaker, Some(1));
+    assert_eq!(
+        merged.metadata["speaker_labels"],
+        serde_json::json!(["speaker_a", "speaker_b"])
+    );
+    assert_eq!(merged.metadata["speaker_segments"][0]["start"], 1.0);
+    assert_eq!(merged.metadata["speaker_segments"][1]["start"], 602.0);
+}
+
 #[tokio::test]
 async fn oversized_audio_is_uploaded_one_segment_at_a_time() {
     SEGMENT_UPLOADS.lock().unwrap().clear();

--- a/crates/listener2-core/src/batch/simple/tests.rs
+++ b/crates/listener2-core/src/batch/simple/tests.rs
@@ -47,6 +47,64 @@ impl BatchSttAdapter for HangingHttpAdapter {
     }
 }
 
+static SEGMENT_UPLOADS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+#[derive(Clone, Default)]
+struct RecordingAdapter;
+
+impl BatchSttAdapter for RecordingAdapter {
+    fn provider_name(&self) -> &'static str {
+        "recording"
+    }
+
+    fn is_supported_languages(
+        &self,
+        _languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        true
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        _client: &'a reqwest_middleware::ClientWithMiddleware,
+        _api_base: &'a str,
+        _api_key: &'a str,
+        _params: &'a owhisper_interface::ListenParams,
+        file_path: P,
+    ) -> Pin<
+        Box<dyn Future<Output = std::result::Result<Response, owhisper_client::Error>> + Send + 'a>,
+    > {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(async move {
+            let mut uploads = SEGMENT_UPLOADS.lock().unwrap();
+            let index = uploads.len();
+            uploads.push(path.to_string_lossy().into_owned());
+
+            Ok(Response {
+                metadata: serde_json::json!({ "provider": "recording" }),
+                results: owhisper_interface::batch::Results {
+                    channels: vec![owhisper_interface::batch::Channel {
+                        alternatives: vec![owhisper_interface::batch::Alternatives {
+                            transcript: format!("segment {index}"),
+                            confidence: 1.0,
+                            words: vec![owhisper_interface::batch::Word {
+                                word: format!("segment{index}"),
+                                start: 0.25,
+                                end: 0.75,
+                                confidence: 1.0,
+                                channel: 0,
+                                speaker: None,
+                                punctuated_word: None,
+                            }],
+                        }],
+                    }],
+                },
+            })
+        })
+    }
+}
+
 #[derive(Clone)]
 struct HangingProviderState {
     request_started: Arc<Notify>,
@@ -108,6 +166,121 @@ fn direct_timeout_scales_with_audio_duration_and_is_bounded() {
         direct_batch_timeout_for_audio(Some(Duration::from_secs(24 * 60 * 60))),
         DIRECT_BATCH_TIMEOUT_CEILING
     );
+}
+
+#[test]
+fn segments_only_when_a_provider_limit_is_exceeded() {
+    let source = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
+    write_test_wav_samples(source.path(), TARGET_SAMPLE_RATE as usize);
+    let path = source.path().to_str().unwrap();
+    let size = std::fs::metadata(source.path()).unwrap().len();
+    let limit = |max_bytes, max_duration| {
+        Some(owhisper_client::BatchUploadLimit {
+            max_bytes,
+            max_duration,
+        })
+    };
+
+    assert_eq!(segment_plan(path, None, None), None);
+    assert_eq!(
+        segment_plan(path, None, limit(size, Duration::from_secs(60))),
+        None
+    );
+    assert_eq!(
+        segment_plan(path, None, limit(size - 1, Duration::from_secs(60))),
+        Some(Duration::from_secs(60))
+    );
+    assert_eq!(
+        segment_plan(
+            path,
+            Some(Duration::from_secs(61)),
+            limit(size, Duration::from_secs(60))
+        ),
+        Some(Duration::from_secs(60))
+    );
+}
+
+#[test]
+fn merges_segment_transcripts_onto_a_single_timeline() {
+    let segment = |transcript: &str, start: f64| Response {
+        metadata: serde_json::json!({ "provider": "openrouter" }),
+        results: owhisper_interface::batch::Results {
+            channels: vec![owhisper_interface::batch::Channel {
+                alternatives: vec![owhisper_interface::batch::Alternatives {
+                    transcript: transcript.to_string(),
+                    confidence: 1.0,
+                    words: vec![owhisper_interface::batch::Word {
+                        word: transcript.to_string(),
+                        start,
+                        end: start + 0.5,
+                        confidence: 1.0,
+                        channel: 0,
+                        speaker: None,
+                        punctuated_word: None,
+                    }],
+                }],
+            }],
+        },
+    };
+
+    let merged = merge_segment_responses(
+        vec![segment("first", 1.0), segment("second", 2.0)],
+        Duration::from_secs(600),
+    );
+
+    let alternative = &merged.results.channels[0].alternatives[0];
+    assert_eq!(alternative.transcript, "first second");
+    assert_eq!(alternative.words[0].start, 1.0);
+    assert_eq!(alternative.words[1].start, 602.0);
+    assert_eq!(alternative.words[1].end, 602.5);
+    assert_eq!(merged.metadata["provider"], "openrouter");
+}
+
+#[tokio::test]
+async fn oversized_audio_is_uploaded_one_segment_at_a_time() {
+    SEGMENT_UPLOADS.lock().unwrap().clear();
+    let source = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
+    write_test_wav_samples(source.path(), TARGET_SAMPLE_RATE as usize * 3);
+    let size = std::fs::metadata(source.path()).unwrap().len();
+
+    let params = BatchParams {
+        session_id: "segment-test".to_string(),
+        provider: super::super::BatchProvider::OpenRouter,
+        file_path: source.path().to_string_lossy().into_owned(),
+        model: None,
+        base_url: "https://openrouter.ai/api/v1".to_string(),
+        api_key: "test".to_string(),
+        languages: vec![anlg_language::ISO639::En.into()],
+        keywords: vec![],
+        num_speakers: None,
+        min_speakers: None,
+        max_speakers: None,
+    };
+
+    let output = run_direct_batch::<RecordingAdapter>(
+        "recording",
+        params,
+        owhisper_interface::ListenParams::default(),
+        Some(owhisper_client::BatchUploadLimit {
+            max_bytes: size - 1,
+            max_duration: Duration::from_secs(1),
+        }),
+    )
+    .await
+    .unwrap();
+
+    let uploads = SEGMENT_UPLOADS.lock().unwrap().clone();
+    assert_eq!(uploads.len(), 3, "3s of audio in 1s segments");
+    for upload in &uploads {
+        assert!(upload.ends_with(".mp3"), "segment was not re-encoded");
+        assert!(!std::path::Path::new(upload).exists(), "segment leaked");
+    }
+
+    let alternative = &output.response.results.channels[0].alternatives[0];
+    assert_eq!(alternative.transcript, "segment 0 segment 1 segment 2");
+    assert_eq!(alternative.words[0].start, 0.25);
+    assert_eq!(alternative.words[2].start, 2.25);
+    assert!(source.path().exists());
 }
 
 #[tokio::test]

--- a/crates/listener2-core/src/batch/upload.rs
+++ b/crates/listener2-core/src/batch/upload.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anlg_audio_utils::Source;
+use owhisper_client::BatchUploadLimit;
+
+pub(super) fn audio_duration(file_path: &str) -> Option<Duration> {
+    anlg_audio_utils::source_from_path(file_path)
+        .ok()
+        .and_then(|source| source.total_duration())
+}
+
+/// Recordings past a provider's upload cap or per-request duration cap are
+/// re-encoded as mono MP3 segments and sent one request at a time.
+pub(super) fn segment_plan(
+    file_path: &str,
+    audio_duration: Option<Duration>,
+    limit: Option<BatchUploadLimit>,
+) -> Option<Duration> {
+    let limit = limit?;
+    let size = std::fs::metadata(file_path).ok()?.len();
+    let too_long = audio_duration.is_some_and(|duration| duration > limit.max_duration);
+
+    (size > limit.max_bytes || too_long).then_some(limit.max_duration)
+}
+
+pub(super) struct SegmentedUpload {
+    _temp_dir: tempfile::TempDir,
+    paths: Vec<PathBuf>,
+}
+
+impl SegmentedUpload {
+    pub(super) fn paths(&self) -> &[PathBuf] {
+        &self.paths
+    }
+}
+
+pub(super) async fn split_batch_upload(
+    file_path: &str,
+    segment_duration: Duration,
+    provider: &str,
+) -> crate::Result<SegmentedUpload> {
+    let failure = |message: &str| crate::BatchFailure::DirectRequestFailed {
+        provider: provider.to_string(),
+        message: message.to_string(),
+    };
+
+    let temp_dir = tempfile::tempdir().map_err(|error| {
+        tracing::error!(%error, "batch_audio_segment_temp_dir_failed");
+        failure("Anarlog couldn't prepare this recording for transcription.")
+    })?;
+
+    let source = PathBuf::from(file_path);
+    let output_dir = temp_dir.path().to_path_buf();
+    let paths = tokio::task::spawn_blocking(move || {
+        anlg_mp3::encode_mono_segments(&source, &output_dir, segment_duration)
+    })
+    .await
+    .map_err(|error| {
+        tracing::error!(%error, "batch_audio_segment_task_failed");
+        failure("Anarlog couldn't prepare this recording for transcription.")
+    })?
+    .map_err(|error| {
+        tracing::error!(%error, "batch_audio_segment_failed");
+        failure("Anarlog couldn't split this recording for transcription.")
+    })?;
+
+    if paths.is_empty() {
+        return Err(failure("This recording has no audio to transcribe.").into());
+    }
+
+    tracing::info!(
+        segments = paths.len(),
+        segment_seconds = segment_duration.as_secs(),
+        "batch audio split for provider upload limits"
+    );
+
+    Ok(SegmentedUpload {
+        _temp_dir: temp_dir,
+        paths,
+    })
+}

--- a/crates/mp3/src/error.rs
+++ b/crates/mp3/src/error.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error("unsupported integer bit depth: {0}")]
     UnsupportedIntBitDepth(u16),
 
+    #[error("invalid segment duration: {0:?}")]
+    InvalidSegmentDuration(std::time::Duration),
+
     #[error("failed to create LAME encoder")]
     LameInit,
 

--- a/crates/mp3/src/lib.rs
+++ b/crates/mp3/src/lib.rs
@@ -1,7 +1,9 @@
 mod encoder;
 mod error;
+mod segment;
 mod wav;
 
 pub use encoder::{Mono, MonoStreamEncoder, Stereo, StereoStreamEncoder, StreamEncoder};
 pub use error::Error;
+pub use segment::encode_mono_segments;
 pub use wav::{concat_files, decode_to_wav, encode_wav};

--- a/crates/mp3/src/segment.rs
+++ b/crates/mp3/src/segment.rs
@@ -1,0 +1,127 @@
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anlg_audio_utils::Source;
+
+use crate::encoder::f32_to_i16;
+use crate::{Error, MonoStreamEncoder};
+
+const ENCODE_FRAMES: usize = 4096;
+
+/// Decodes any supported audio file, downmixes it to mono, and writes it back out
+/// as MP3 segments of at most `segment_duration`. Providers that cap upload size
+/// or time out on long audio get one request per segment.
+pub fn encode_mono_segments(
+    source_path: &Path,
+    output_dir: &Path,
+    segment_duration: Duration,
+) -> Result<Vec<PathBuf>, Error> {
+    let source = anlg_audio_utils::source_from_path(source_path)?;
+    let sample_rate: u32 = source.sample_rate().into();
+    let channels = usize::from(u16::from(source.channels())).max(1);
+    let frames_per_segment = frames_per_segment(sample_rate, segment_duration)?;
+
+    let mut paths: Vec<PathBuf> = Vec::new();
+    let mut current: Option<SegmentEncoder> = None;
+
+    for sample in anlg_audio_utils::mono_frames(source, channels) {
+        if current
+            .as_ref()
+            .is_some_and(|segment| segment.frames >= frames_per_segment)
+        {
+            current
+                .take()
+                .expect("segment was just observed")
+                .finish()?;
+        }
+
+        if current.is_none() {
+            let path = output_dir.join(format!("segment-{:04}.mp3", paths.len()));
+            current = Some(SegmentEncoder::create(&path, sample_rate)?);
+            paths.push(path);
+        }
+
+        current
+            .as_mut()
+            .expect("segment was just created")
+            .push(sample)?;
+    }
+
+    if let Some(segment) = current {
+        segment.finish()?;
+    }
+
+    Ok(paths)
+}
+
+fn frames_per_segment(sample_rate: u32, segment_duration: Duration) -> Result<usize, Error> {
+    let frames = (u128::from(sample_rate) * segment_duration.as_millis()) / 1000;
+    usize::try_from(frames)
+        .ok()
+        .filter(|frames| *frames > 0)
+        .ok_or(Error::InvalidSegmentDuration(segment_duration))
+}
+
+struct SegmentEncoder {
+    encoder: MonoStreamEncoder,
+    writer: BufWriter<File>,
+    pcm: Vec<i16>,
+    encoded: Vec<u8>,
+    frames: usize,
+}
+
+impl SegmentEncoder {
+    fn create(path: &Path, sample_rate: u32) -> Result<Self, Error> {
+        Ok(Self {
+            encoder: MonoStreamEncoder::new(sample_rate)?,
+            writer: BufWriter::new(File::create(path)?),
+            pcm: Vec::with_capacity(ENCODE_FRAMES),
+            encoded: Vec::new(),
+            frames: 0,
+        })
+    }
+
+    fn push(&mut self, sample: f32) -> Result<(), Error> {
+        self.pcm.push(f32_to_i16(sample));
+        self.frames += 1;
+
+        if self.pcm.len() >= ENCODE_FRAMES {
+            self.drain()?;
+        }
+        Ok(())
+    }
+
+    fn drain(&mut self) -> Result<(), Error> {
+        self.encoded.clear();
+        self.encoder.encode_i16(&self.pcm, &mut self.encoded)?;
+        self.writer.write_all(&self.encoded)?;
+        self.pcm.clear();
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<(), Error> {
+        self.drain()?;
+        self.encoded.clear();
+        self.encoder.flush(&mut self.encoded)?;
+        self.writer.write_all(&self.encoded)?;
+        self.writer.flush()?;
+        self.writer.get_ref().sync_all()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frames_per_segment_scales_with_sample_rate() {
+        assert_eq!(
+            frames_per_segment(16_000, Duration::from_secs(10)).unwrap(),
+            160_000
+        );
+        assert!(frames_per_segment(16_000, Duration::ZERO).is_err());
+    }
+}

--- a/crates/mp3/tests/mono_segments.rs
+++ b/crates/mp3/tests/mono_segments.rs
@@ -1,0 +1,50 @@
+mod common;
+
+use std::time::Duration;
+
+use common::{Case, TestResult, decode_mp3_bytes, write_fixture_wav};
+use mp3::encode_mono_segments;
+use tempfile::tempdir;
+
+#[test]
+fn splits_stereo_audio_into_mono_segments() -> TestResult {
+    let dir = tempdir()?;
+    let source = dir.path().join("source.wav");
+    let case = Case {
+        channels: 2,
+        frames: 16_000 * 5,
+        sample_rate: 16_000,
+    };
+    write_fixture_wav(&source, case)?;
+
+    let segments = encode_mono_segments(&source, dir.path(), Duration::from_secs(2))?;
+
+    assert_eq!(segments.len(), 3, "5s of audio in 2s segments");
+    for segment in &segments {
+        let (spec, samples) = decode_mp3_bytes(&std::fs::read(segment)?)?;
+        assert_eq!(spec.channels, 1, "segments are downmixed to mono");
+        assert_eq!(spec.sample_rate, case.sample_rate);
+        assert!(!samples.is_empty(), "segment decoded to no audio");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn keeps_short_audio_in_a_single_segment() -> TestResult {
+    let dir = tempdir()?;
+    let source = dir.path().join("source.wav");
+    write_fixture_wav(
+        &source,
+        Case {
+            channels: 1,
+            frames: 16_000,
+            sample_rate: 16_000,
+        },
+    )?;
+
+    let segments = encode_mono_segments(&source, dir.path(), Duration::from_secs(600))?;
+
+    assert_eq!(segments.len(), 1);
+    Ok(())
+}

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -66,6 +66,7 @@ use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
 use std::str::FromStr;
+use std::time::Duration;
 
 use anlg_ws_client::client::Message;
 use owhisper_interface::ListenParams;
@@ -422,6 +423,14 @@ pub fn append_provider_param(base_url: &str, provider: &str) -> String {
     }
 }
 
+const OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES: u64 = 25 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatchUploadLimit {
+    pub max_bytes: u64,
+    pub max_duration: Duration,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumString)]
 pub enum AdapterKind {
     #[strum(serialize = "aquavoice")]
@@ -499,6 +508,24 @@ impl AdapterKind {
         Provider::from_url(base_url)
             .map(Self::from)
             .unwrap_or(Self::Deepgram)
+    }
+
+    /// Providers that reject oversized multipart uploads or time out on long
+    /// audio. Recordings past either bound are split into one request per segment
+    /// instead of failing at the provider.
+    pub fn batch_upload_limit(&self) -> Option<BatchUploadLimit> {
+        let max_duration = match self {
+            // OpenRouter's upstream providers time out after 60s per request, so
+            // its segments stay well below the size cap.
+            Self::OpenRouter => Duration::from_secs(10 * 60),
+            Self::OpenAI | Self::Groq | Self::Together | Self::Xai => Duration::from_secs(25 * 60),
+            _ => return None,
+        };
+
+        Some(BatchUploadLimit {
+            max_bytes: OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES,
+            max_duration,
+        })
     }
 
     pub fn has_live_mode(&self) -> bool {

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -428,6 +428,10 @@ const OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES: u64 = 25 * 1024 * 1024;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BatchUploadLimit {
     pub max_bytes: u64,
+    /// Doubles as the length of each split segment, so it must stay short enough
+    /// that one segment of mono 64 kbps MP3 fits in `max_bytes` (~53 minutes at
+    /// 25 MB); otherwise splitting a long recording still produces oversized
+    /// uploads.
     pub max_duration: Duration,
 }
 

--- a/crates/owhisper-client/src/lib.rs
+++ b/crates/owhisper-client/src/lib.rs
@@ -23,14 +23,14 @@ pub use adapter::StreamingBatchConfig;
 pub use adapter::deepgram::DeepgramModel;
 pub use adapter::{
     AdapterKind, AnarlogAdapter, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter,
-    AwsTranscribeAdapter, AzureSpeechAdapter, BatchSttAdapter, CallbackResult, CallbackSttAdapter,
-    CartesiaAdapter, CohereAdapter, DashScopeAdapter, DeepgramAdapter, DeepgramFluxAdapter,
-    ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, GoogleCloudAdapter, GroqAdapter,
-    LanguageQuality, LanguageSupport, MistralAdapter, OpenAIAdapter, OpenRouterAdapter,
-    PyannoteAdapter, RealtimeSttAdapter, RevAiAdapter, SmallestAIAdapter, SonioxAdapter,
-    SpeechmaticsAdapter, TogetherAdapter, WhisperCppAdapter, XaiAdapter, append_provider_param,
-    documented_language_codes_batch, documented_language_codes_live, is_anarlog_proxy,
-    is_local_host, normalize_languages,
+    AwsTranscribeAdapter, AzureSpeechAdapter, BatchSttAdapter, BatchUploadLimit, CallbackResult,
+    CallbackSttAdapter, CartesiaAdapter, CohereAdapter, DashScopeAdapter, DeepgramAdapter,
+    DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, GoogleCloudAdapter,
+    GroqAdapter, LanguageQuality, LanguageSupport, MistralAdapter, OpenAIAdapter,
+    OpenRouterAdapter, PyannoteAdapter, RealtimeSttAdapter, RevAiAdapter, SmallestAIAdapter,
+    SonioxAdapter, SpeechmaticsAdapter, TogetherAdapter, WhisperCppAdapter, XaiAdapter,
+    append_provider_param, documented_language_codes_batch, documented_language_codes_live,
+    is_anarlog_proxy, is_local_host, normalize_languages,
 };
 pub use adapter::{StreamingBatchEvent, StreamingBatchStream};
 


### PR DESCRIPTION
Recordings are finalized as 128 kbps stereo MP3, so a 48-minute session is
~44 MB and OpenRouter rejects it at its 25 MB multipart cap before any
transcription runs. Only the Anarlog proxy path prepared its upload; every
BYO-key provider streamed the session file as-is.

Adds AdapterKind::batch_upload_limit for providers with an upload cap or a
per-request duration cap, and splits recordings past either bound into mono
MP3 segments (anlg_mp3::encode_mono_segments) that are transcribed one
request at a time and merged back onto a single timeline. OpenRouter uses
10-minute segments because its upstream providers time out after 60s.
Provider size rejections that still slip through now surface as readable
copy instead of raw JSON.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core batch transcription for multiple providers, including timestamp/diarization merging across segments where correctness bugs would affect final transcripts. Well covered by unit and integration tests, but still touches an important transcription path.
> 
> **Overview**
> Long BYO-key batch uploads no longer fail at OpenAI-compatible size/duration caps. Recordings past a provider limit are split into mono MP3 segments, transcribed one request at a time, and merged back onto a single timeline.
> 
> Adds `AdapterKind::batch_upload_limit` (25 MB; 10-minute segments for OpenRouter, 25-minute for OpenAI/Groq/Together/xAI) plus `anlg_mp3::encode_mono_segments`. Both **direct** and **progressive OpenAI** batch paths use the new splitter, shift word/speaker timestamps across segments, and keep progress monotonic. Upload-limit rejections that still slip through now show readable copy instead of raw provider JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7911c3ea69c44d56070eb56fa85dd3bdd17f2a5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->