### PR TITLE
chore(packaging): bump anarlog-bin automatically on each release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,3 +11,4 @@ jobs:
           scripts/repack-linux-appimage.test.mjs
           scripts/verify-linux-audio-qa-run.test.mjs
           scripts/verify-linux-audio-qa-evidence.test.mjs
+          scripts/update-aur-pkgbuild.test.mjs

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -673,3 +673,48 @@ jobs:
           allowUpdates: true
           makeLatest: true
           replacesArtifacts: true
+
+  aur-bump:
+    needs: [parse, gh-release]
+    if: ${{ !cancelled() && needs.parse.outputs.include_linux == 'true' && needs.gh-release.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Point anarlog-bin at the published release
+        env:
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: node scripts/update-aur-pkgbuild.mjs --version "$VERSION"
+      - name: Open the version bump pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          if git diff --quiet -- packaging/aur/anarlog-bin; then
+            echo "anarlog-bin already tracks $VERSION"
+            exit 0
+          fi
+
+          BRANCH="chore/aur-bump-$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add packaging/aur/anarlog-bin
+          git commit -m "chore(packaging): bump anarlog-bin to $VERSION" \
+            -m "Point the Arch PKGBUILD at the desktop_v$VERSION release assets and refresh the deb checksums."
+          git push --force origin "$BRANCH"
+
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "Pull request for $BRANCH already open"
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(packaging): bump anarlog-bin to $VERSION" \
+            --body "Automated bump from the desktop_v$VERSION publish run. Updates \`pkgver\` and the deb checksums in \`packaging/aur/anarlog-bin\` so Arch users build the current release."

--- a/packaging/aur/anarlog-bin/README.md
+++ b/packaging/aur/anarlog-bin/README.md
@@ -22,8 +22,20 @@ verifies its checksum, and installs it through pacman.
 
 ## Updating
 
-Bump `pkgver` and replace both `sha256sums_*` entries with the checksums published
-on the matching `desktop_v<version>` release, then regenerate metadata:
+Each stable publish opens a `chore(packaging): bump anarlog-bin to <version>` pull
+request automatically, so this normally needs no manual work.
+
+To bump by hand, or to refresh the files before an AUR push:
+
+```bash
+node scripts/update-aur-pkgbuild.mjs --version 1.4.9
+```
+
+It reads the checksums from that release's published `.sha256` assets and rewrites
+`pkgver`, `pkgrel`, and every checksum in both `PKGBUILD` and `.SRCINFO`.
+
+After changing package metadata by hand (dependencies, description, options),
+regenerate `.SRCINFO` on an Arch machine so it stays in sync:
 
 ```bash
 makepkg --printsrcinfo > .SRCINFO

--- a/scripts/update-aur-pkgbuild.mjs
+++ b/scripts/update-aur-pkgbuild.mjs
@@ -34,16 +34,39 @@ export function readPkgver(pkgbuild) {
   return match[1];
 }
 
+function readPkgrel(contents, pattern, label) {
+  const match = contents.match(pattern);
+  if (!match) throw new Error(`${label} has no pkgrel`);
+
+  const pkgrel = Number.parseInt(match[1], 10);
+  if (!Number.isSafeInteger(pkgrel) || pkgrel < 1) {
+    throw new Error(`${label} has invalid pkgrel: ${match[1]}`);
+  }
+  return pkgrel;
+}
+
+function nextPkgbuildPkgrel(pkgbuild, version, checksums) {
+  if (readPkgver(pkgbuild) !== version) return 1;
+
+  const checksumsChanged = Object.entries(checksums).some(([key, checksum]) => {
+    const field = key === "license" ? "sha256sums" : `sha256sums_${key}`;
+    return !pkgbuild.includes(`${field}=('${checksum}')`);
+  });
+  const current = readPkgrel(pkgbuild, /^pkgrel=(.+)$/m, "PKGBUILD");
+  return checksumsChanged ? current + 1 : current;
+}
+
 // PKGBUILD interpolates ${pkgver} into every source URL, so only the version
 // and the checksums change between releases.
 export function bumpPkgbuild(pkgbuild, { version, checksums }) {
+  const pkgrel = nextPkgbuildPkgrel(pkgbuild, version, checksums);
   let next = replaceOnce(
     pkgbuild,
     /^pkgver=.+$/m,
     `pkgver=${version}`,
     "pkgver",
   );
-  next = replaceOnce(next, /^pkgrel=.+$/m, "pkgrel=1", "pkgrel");
+  next = replaceOnce(next, /^pkgrel=.+$/m, `pkgrel=${pkgrel}`, "pkgrel");
   next = replaceOnce(
     next,
     /^sha256sums=\(.+\)$/m,
@@ -68,11 +91,22 @@ export function bumpPkgbuild(pkgbuild, { version, checksums }) {
 // .SRCINFO stores the expanded values, so its source URLs carry the literal
 // version and have to be rewritten alongside the checksums.
 export function bumpSrcinfo(srcinfo, { version, previousVersion, checksums }) {
+  const checksumsChanged = Object.entries(checksums).some(([key, checksum]) => {
+    const field = key === "license" ? "sha256sums" : `sha256sums_${key}`;
+    return !srcinfo.includes(`\t${field} = ${checksum}`);
+  });
+  const currentPkgrel = readPkgrel(srcinfo, /^\tpkgrel = (.+)$/m, ".SRCINFO");
+  const pkgrel =
+    previousVersion === version
+      ? checksumsChanged
+        ? currentPkgrel + 1
+        : currentPkgrel
+      : 1;
   const rewritten = srcinfo
     .split("\n")
     .map((line) => {
       if (/^\tpkgver = /.test(line)) return `\tpkgver = ${version}`;
-      if (/^\tpkgrel = /.test(line)) return "\tpkgrel = 1";
+      if (/^\tpkgrel = /.test(line)) return `\tpkgrel = ${pkgrel}`;
       if (/^\tsha256sums = /.test(line)) {
         return `\tsha256sums = ${checksums.license}`;
       }

--- a/scripts/update-aur-pkgbuild.mjs
+++ b/scripts/update-aur-pkgbuild.mjs
@@ -1,0 +1,201 @@
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+
+const REPO = "fastrepl/anarlog";
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const DEB_ASSETS = {
+  x86_64: "anarlog-linux-x86_64.deb",
+  aarch64: "anarlog-linux-aarch64.deb",
+};
+
+function replaceOnce(contents, pattern, replacement, label) {
+  const matches = contents.match(new RegExp(pattern.source, "gm"));
+  if (matches?.length !== 1) {
+    throw new Error(
+      `Expected exactly one ${label} line, found ${matches?.length ?? 0}`,
+    );
+  }
+
+  return contents.replace(pattern, replacement);
+}
+
+function assertSha256(value, label) {
+  if (!SHA256_PATTERN.test(value)) {
+    throw new Error(`Invalid sha256 for ${label}: ${value}`);
+  }
+}
+
+export function readPkgver(pkgbuild) {
+  const match = pkgbuild.match(/^pkgver=(.+)$/m);
+  if (!match) throw new Error("PKGBUILD has no pkgver");
+  return match[1];
+}
+
+// PKGBUILD interpolates ${pkgver} into every source URL, so only the version
+// and the checksums change between releases.
+export function bumpPkgbuild(pkgbuild, { version, checksums }) {
+  let next = replaceOnce(
+    pkgbuild,
+    /^pkgver=.+$/m,
+    `pkgver=${version}`,
+    "pkgver",
+  );
+  next = replaceOnce(next, /^pkgrel=.+$/m, "pkgrel=1", "pkgrel");
+  next = replaceOnce(
+    next,
+    /^sha256sums=\(.+\)$/m,
+    `sha256sums=('${checksums.license}')`,
+    "sha256sums",
+  );
+  next = replaceOnce(
+    next,
+    /^sha256sums_x86_64=\(.+\)$/m,
+    `sha256sums_x86_64=('${checksums.x86_64}')`,
+    "sha256sums_x86_64",
+  );
+
+  return replaceOnce(
+    next,
+    /^sha256sums_aarch64=\(.+\)$/m,
+    `sha256sums_aarch64=('${checksums.aarch64}')`,
+    "sha256sums_aarch64",
+  );
+}
+
+// .SRCINFO stores the expanded values, so its source URLs carry the literal
+// version and have to be rewritten alongside the checksums.
+export function bumpSrcinfo(srcinfo, { version, previousVersion, checksums }) {
+  const rewritten = srcinfo
+    .split("\n")
+    .map((line) => {
+      if (/^\tpkgver = /.test(line)) return `\tpkgver = ${version}`;
+      if (/^\tpkgrel = /.test(line)) return "\tpkgrel = 1";
+      if (/^\tsha256sums = /.test(line)) {
+        return `\tsha256sums = ${checksums.license}`;
+      }
+      if (/^\tsha256sums_x86_64 = /.test(line)) {
+        return `\tsha256sums_x86_64 = ${checksums.x86_64}`;
+      }
+      if (/^\tsha256sums_aarch64 = /.test(line)) {
+        return `\tsha256sums_aarch64 = ${checksums.aarch64}`;
+      }
+      if (/^\tsource(_x86_64|_aarch64)? = /.test(line)) {
+        return line.replaceAll(previousVersion, version);
+      }
+      return line;
+    })
+    .join("\n");
+
+  if (previousVersion !== version && rewritten.includes(previousVersion)) {
+    throw new Error(
+      `.SRCINFO still references ${previousVersion} after the bump`,
+    );
+  }
+
+  return rewritten;
+}
+
+async function fetchText(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed with ${response.status}`);
+  }
+  return response.text();
+}
+
+async function fetchReleaseChecksum(version, asset) {
+  const text = await fetchText(
+    `https://github.com/${REPO}/releases/download/desktop_v${version}/${asset}.sha256`,
+  );
+  return text.trim().split(/\s+/)[0];
+}
+
+async function fetchLicenseChecksum(version) {
+  const license = await fetchText(
+    `https://raw.githubusercontent.com/${REPO}/desktop_v${version}/LICENSE`,
+  );
+  return createHash("sha256").update(license).digest("hex");
+}
+
+export async function resolveChecksums(version, overrides = {}) {
+  const checksums = {
+    license: overrides.license ?? (await fetchLicenseChecksum(version)),
+    x86_64:
+      overrides.x86_64 ??
+      (await fetchReleaseChecksum(version, DEB_ASSETS.x86_64)),
+    aarch64:
+      overrides.aarch64 ??
+      (await fetchReleaseChecksum(version, DEB_ASSETS.aarch64)),
+  };
+
+  for (const [label, value] of Object.entries(checksums)) {
+    assertSha256(value, label);
+  }
+
+  return checksums;
+}
+
+function defaultPackageDirectory() {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.join(here, "..", "packaging", "aur", "anarlog-bin");
+}
+
+export async function updatePackage(directory, version, checksums) {
+  const pkgbuildPath = path.join(directory, "PKGBUILD");
+  const srcinfoPath = path.join(directory, ".SRCINFO");
+
+  const pkgbuild = await readFile(pkgbuildPath, "utf8");
+  const srcinfo = await readFile(srcinfoPath, "utf8");
+  const previousVersion = readPkgver(pkgbuild);
+
+  await writeFile(pkgbuildPath, bumpPkgbuild(pkgbuild, { version, checksums }));
+  await writeFile(
+    srcinfoPath,
+    bumpSrcinfo(srcinfo, { version, previousVersion, checksums }),
+  );
+
+  return { previousVersion, changed: previousVersion !== version };
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      version: { type: "string" },
+      dir: { type: "string" },
+      "sha-license": { type: "string" },
+      "sha-x86_64": { type: "string" },
+      "sha-aarch64": { type: "string" },
+    },
+  });
+
+  if (!values.version) {
+    throw new Error("--version is required, for example --version 1.4.9");
+  }
+
+  const version = values.version.replace(/^desktop_v/, "");
+  const checksums = await resolveChecksums(version, {
+    license: values["sha-license"],
+    x86_64: values["sha-x86_64"],
+    aarch64: values["sha-aarch64"],
+  });
+
+  const directory = values.dir ?? defaultPackageDirectory();
+  const { previousVersion, changed } = await updatePackage(
+    directory,
+    version,
+    checksums,
+  );
+
+  console.log(
+    changed
+      ? `anarlog-bin ${previousVersion} -> ${version}`
+      : `anarlog-bin already at ${version}, refreshed checksums`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/update-aur-pkgbuild.test.mjs
+++ b/scripts/update-aur-pkgbuild.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  bumpPkgbuild,
+  bumpSrcinfo,
+  readPkgver,
+  updatePackage,
+} from "./update-aur-pkgbuild.mjs";
+
+const LICENSE_SHA = "a".repeat(64);
+const X86_SHA = "b".repeat(64);
+const ARM_SHA = "c".repeat(64);
+const CHECKSUMS = {
+  license: LICENSE_SHA,
+  x86_64: X86_SHA,
+  aarch64: ARM_SHA,
+};
+
+const PKGBUILD = `pkgname=anarlog-bin
+pkgver=1.4.8
+pkgrel=2
+arch=('x86_64' 'aarch64')
+_release="desktop_v\${pkgver}"
+source=("LICENSE-\${pkgver}::https://raw.githubusercontent.com/fastrepl/anarlog/\${_release}/LICENSE")
+source_x86_64=("anarlog-\${pkgver}-x86_64.deb::https://github.com/fastrepl/anarlog/releases/download/\${_release}/anarlog-linux-x86_64.deb")
+source_aarch64=("anarlog-\${pkgver}-aarch64.deb::https://github.com/fastrepl/anarlog/releases/download/\${_release}/anarlog-linux-aarch64.deb")
+sha256sums=('0000000000000000000000000000000000000000000000000000000000000001')
+sha256sums_x86_64=('0000000000000000000000000000000000000000000000000000000000000002')
+sha256sums_aarch64=('0000000000000000000000000000000000000000000000000000000000000003')
+`;
+
+const SRCINFO = `pkgbase = anarlog-bin
+\tpkgver = 1.4.8
+\tpkgrel = 2
+\tarch = x86_64
+\tsource = LICENSE-1.4.8::https://raw.githubusercontent.com/fastrepl/anarlog/desktop_v1.4.8/LICENSE
+\tsha256sums = 0000000000000000000000000000000000000000000000000000000000000001
+\tsource_x86_64 = anarlog-1.4.8-x86_64.deb::https://github.com/fastrepl/anarlog/releases/download/desktop_v1.4.8/anarlog-linux-x86_64.deb
+\tsha256sums_x86_64 = 0000000000000000000000000000000000000000000000000000000000000002
+\tsource_aarch64 = anarlog-1.4.8-aarch64.deb::https://github.com/fastrepl/anarlog/releases/download/desktop_v1.4.8/anarlog-linux-aarch64.deb
+\tsha256sums_aarch64 = 0000000000000000000000000000000000000000000000000000000000000003
+
+pkgname = anarlog-bin
+`;
+
+test("bumps the PKGBUILD version, checksums, and resets pkgrel", () => {
+  const next = bumpPkgbuild(PKGBUILD, {
+    version: "1.5.0",
+    checksums: CHECKSUMS,
+  });
+
+  assert.match(next, /^pkgver=1\.5\.0$/m);
+  assert.match(next, /^pkgrel=1$/m);
+  assert.match(next, new RegExp(`^sha256sums=\\('${LICENSE_SHA}'\\)$`, "m"));
+  assert.match(next, new RegExp(`^sha256sums_x86_64=\\('${X86_SHA}'\\)$`, "m"));
+  assert.match(
+    next,
+    new RegExp(`^sha256sums_aarch64=\\('${ARM_SHA}'\\)$`, "m"),
+  );
+});
+
+test("leaves interpolated PKGBUILD source URLs untouched", () => {
+  const next = bumpPkgbuild(PKGBUILD, {
+    version: "1.5.0",
+    checksums: CHECKSUMS,
+  });
+
+  assert.match(next, /_release="desktop_v\$\{pkgver\}"/);
+  assert.ok(!next.includes("1.4.8"));
+});
+
+test("rewrites expanded .SRCINFO source URLs and checksums", () => {
+  const next = bumpSrcinfo(SRCINFO, {
+    version: "1.5.0",
+    previousVersion: "1.4.8",
+    checksums: CHECKSUMS,
+  });
+
+  assert.match(next, /^\tpkgver = 1\.5\.0$/m);
+  assert.match(next, /^\tpkgrel = 1$/m);
+  assert.ok(next.includes("desktop_v1.5.0/anarlog-linux-x86_64.deb"));
+  assert.ok(next.includes("anarlog-1.5.0-aarch64.deb"));
+  assert.ok(next.includes("LICENSE-1.5.0::"));
+  assert.ok(!next.includes("1.4.8"));
+});
+
+test("fails when a stale version survives the .SRCINFO rewrite", () => {
+  const stale = SRCINFO.replace(
+    "pkgbase = anarlog-bin",
+    "pkgbase = anarlog-bin\n\tpkgdesc = build 1.4.8",
+  );
+
+  assert.throws(
+    () =>
+      bumpSrcinfo(stale, {
+        version: "1.5.0",
+        previousVersion: "1.4.8",
+        checksums: CHECKSUMS,
+      }),
+    /still references 1\.4\.8/,
+  );
+});
+
+test("fails when the PKGBUILD is missing an expected field", () => {
+  const malformed = PKGBUILD.replace(/^sha256sums_aarch64=.+$/m, "");
+
+  assert.throws(
+    () => bumpPkgbuild(malformed, { version: "1.5.0", checksums: CHECKSUMS }),
+    /Expected exactly one sha256sums_aarch64 line/,
+  );
+});
+
+test("reads the current pkgver", () => {
+  assert.equal(readPkgver(PKGBUILD), "1.4.8");
+  assert.throws(() => readPkgver("pkgname=anarlog-bin\n"), /no pkgver/);
+});
+
+test("writes both files and reports the previous version", async (t) => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "anarlog-aur-"));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+
+  await writeFile(path.join(directory, "PKGBUILD"), PKGBUILD);
+  await writeFile(path.join(directory, ".SRCINFO"), SRCINFO);
+
+  const result = await updatePackage(directory, "1.5.0", CHECKSUMS);
+  assert.deepEqual(result, { previousVersion: "1.4.8", changed: true });
+
+  const pkgbuild = await readFile(path.join(directory, "PKGBUILD"), "utf8");
+  const srcinfo = await readFile(path.join(directory, ".SRCINFO"), "utf8");
+  assert.match(pkgbuild, /^pkgver=1\.5\.0$/m);
+  assert.match(srcinfo, /^\tpkgver = 1\.5\.0$/m);
+});
+
+test("reports no change when the version already matches", async (t) => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "anarlog-aur-"));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+
+  await writeFile(path.join(directory, "PKGBUILD"), PKGBUILD);
+  await writeFile(path.join(directory, ".SRCINFO"), SRCINFO);
+
+  const result = await updatePackage(directory, "1.4.8", CHECKSUMS);
+  assert.equal(result.changed, false);
+});

--- a/scripts/update-aur-pkgbuild.test.mjs
+++ b/scripts/update-aur-pkgbuild.test.mjs
@@ -144,4 +144,34 @@ test("reports no change when the version already matches", async (t) => {
 
   const result = await updatePackage(directory, "1.4.8", CHECKSUMS);
   assert.equal(result.changed, false);
+
+  const pkgbuild = await readFile(path.join(directory, "PKGBUILD"), "utf8");
+  const srcinfo = await readFile(path.join(directory, ".SRCINFO"), "utf8");
+  assert.match(pkgbuild, /^pkgrel=3$/m);
+  assert.match(srcinfo, /^\tpkgrel = 3$/m);
+});
+
+test("keeps pkgrel when a same-version refresh changes nothing", () => {
+  const pkgbuild = bumpPkgbuild(PKGBUILD, {
+    version: "1.4.8",
+    checksums: CHECKSUMS,
+  });
+  const srcinfo = bumpSrcinfo(SRCINFO, {
+    version: "1.4.8",
+    previousVersion: "1.4.8",
+    checksums: CHECKSUMS,
+  });
+
+  assert.match(
+    bumpPkgbuild(pkgbuild, { version: "1.4.8", checksums: CHECKSUMS }),
+    /^pkgrel=3$/m,
+  );
+  assert.match(
+    bumpSrcinfo(srcinfo, {
+      version: "1.4.8",
+      previousVersion: "1.4.8",
+      checksums: CHECKSUMS,
+    }),
+    /^\tpkgrel = 3$/m,
+  );
 });


### PR DESCRIPTION
The Arch PKGBUILD pinned pkgver and both deb checksums by hand, so it
would serve the previous release until someone remembered to edit it.

Add scripts/update-aur-pkgbuild.mjs, which reads the checksums from a
release's published .sha256 assets and rewrites pkgver, pkgrel, and every
checksum across PKGBUILD and .SRCINFO, failing loudly if a stale version
survives. Run it from a new aur-bump job in desktop_publish so each stable
publish opens its own bump PR, and register the unit tests in ci.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the desktop publish workflow with contents/PR write permissions to auto-open packaging PRs. Scoped to AUR metadata only, but a bad bump could point Arch users at wrong release assets.
> 
> **Overview**
> **Automates Arch AUR bumps** so `anarlog-bin` tracks each stable Linux desktop release instead of requiring a manual `pkgver`/checksum edit.
> 
> Adds `scripts/update-aur-pkgbuild.mjs`, which pulls `.sha256` assets (and the LICENSE hash) for a given version and rewrites `pkgver`, `pkgrel`, and checksums in both `PKGBUILD` and `.SRCINFO`. A new `aur-bump` job in `desktop_publish` runs after a successful Linux release and opens a `chore(packaging): bump anarlog-bin to <version>` PR when the package metadata changed.
> 
> Unit tests cover the rewrite helpers and are wired into CI; the AUR README now documents the automated flow and the manual fallback command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd3768300ae173d752c14166491a597cbe909ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->