### PR TITLE
Rely on source order for local UI layering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ SQLite is the primary data store (schema and migrations in `crates/db-app/`, des
 - Do not write comments unless code is non-obvious. Comments should explain "why", not "what".
 - Use `cn` from `@anlg/utils` for conditional classNames. Always pass an array, split by logical grouping.
 - Use `motion/react` instead of `framer-motion`.
+- Prefer DOM order for local overlap and portals for cross-tree floating UI. Use `z-index` only inside a bounded stacking context with explicit sibling ordering; do not add arbitrary global or escalating values.
 
 ## CLI TUI Command Architecture
 

--- a/apps/desktop/src/audio-player/timeline.tsx
+++ b/apps/desktop/src/audio-player/timeline.tsx
@@ -144,7 +144,7 @@ export function Timeline({
                   className={cn([
                     "absolute right-0 bottom-full mb-1",
                     "border-border bg-card rounded-lg border shadow-md",
-                    "z-50 py-1",
+                    "py-1",
                   ])}
                 >
                   {PLAYBACK_RATES.map((rate) => (

--- a/apps/desktop/src/calendar/components/sidebar.tsx
+++ b/apps/desktop/src/calendar/components/sidebar.tsx
@@ -317,7 +317,7 @@ function ProviderAccordionItem({
             type="button"
             onClick={handleUpgradeToPro}
             disabled={isUpgradingToPro}
-            className="border-primary bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-ring pointer-events-none absolute top-1/2 right-1 z-10 flex shrink-0 translate-x-1 -translate-y-1/2 items-center gap-1 rounded-full border-2 px-3 py-1 text-xs font-medium opacity-0 shadow-[0_4px_14px_rgba(87,83,78,0.18)] transition-all duration-150 group-focus-within/row:pointer-events-auto group-focus-within/row:translate-x-0 group-focus-within/row:opacity-100 group-hover/row:pointer-events-auto group-hover/row:translate-x-0 group-hover/row:opacity-100 focus-visible:ring-2 focus-visible:outline-none disabled:opacity-70"
+            className="border-primary bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-ring pointer-events-none absolute top-1/2 right-1 flex shrink-0 translate-x-1 -translate-y-1/2 items-center gap-1 rounded-full border-2 px-3 py-1 text-xs font-medium opacity-0 shadow-[0_4px_14px_rgba(87,83,78,0.18)] transition-all duration-150 group-focus-within/row:pointer-events-auto group-focus-within/row:translate-x-0 group-focus-within/row:opacity-100 group-hover/row:pointer-events-auto group-hover/row:translate-x-0 group-hover/row:opacity-100 focus-visible:ring-2 focus-visible:outline-none disabled:opacity-70"
             aria-label={t`Upgrade to Pro for ${provider.displayName}`}
           >
             {isUpgradingToPro && (

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -137,9 +137,7 @@ export function ChatMessageInput({
           <div
             className={cn([
               "flex shrink-0 items-center",
-              isFloating
-                ? "absolute right-0 bottom-0.5 z-10"
-                : "justify-between",
+              isFloating ? "absolute right-0 bottom-0.5" : "justify-between",
             ])}
           >
             <div />

--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -117,9 +117,12 @@ describe("PersistentChatPanel", () => {
       "true",
     );
     const floatingFrame = document.querySelector("[data-chat-floating-frame]");
+    const floatingOverlay = floatingFrame?.parentElement;
     const panel = document.querySelector<HTMLElement>("[data-chat-panel]");
 
     await waitFor(() => {
+      expect(floatingOverlay?.parentElement).toBe(document.body);
+      expect(floatingOverlay?.className).not.toContain("z-");
       expect(floatingFrame?.className).toContain("items-end");
       expect(floatingFrame?.className).toContain("justify-center");
       expect(floatingFrame?.className).toContain("px-3");

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from "motion/react";
 import { useLayoutEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { cn } from "@anlg/utils";
@@ -117,11 +118,15 @@ export function PersistentChatPanel({
     willChange: "transform",
   };
 
-  return (
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
     <AnimatePresence initial={false}>
       {isVisible && (
         <motion.div
-          className="pointer-events-none fixed z-100"
+          className="pointer-events-none fixed"
           style={
             containerRect
               ? {
@@ -183,7 +188,8 @@ export function PersistentChatPanel({
           </div>
         </motion.div>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body,
   );
 }
 

--- a/apps/desktop/src/session/components/floating/options-menu.tsx
+++ b/apps/desktop/src/session/components/floating/options-menu.tsx
@@ -56,7 +56,7 @@ export function OptionsMenu({
 
   const moreButton = (
     <button
-      className="text-primary-foreground/70 hover:text-primary-foreground dark:text-primary/65 dark:hover:text-primary absolute top-1/2 right-2 z-10 -translate-y-1/2 cursor-pointer transition-colors disabled:opacity-50"
+      className="text-primary-foreground/70 hover:text-primary-foreground dark:text-primary/65 dark:hover:text-primary absolute top-1/2 right-2 -translate-y-1/2 cursor-pointer transition-colors disabled:opacity-50"
       disabled={disabled}
       onClick={(e) => {
         e.stopPropagation();

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
@@ -77,7 +77,7 @@ export function ParticipantChip({
           className="animate-shimmer pointer-events-none absolute inset-0 -translate-x-full bg-linear-to-r from-transparent via-white/60 to-transparent"
         />
       )}
-      <span className="relative z-10">{displayName}</span>
+      <span className="relative">{displayName}</span>
       {canEnhance && (
         <EnhanceContactButton
           isEnhancing={isEnhancing}
@@ -94,7 +94,7 @@ export function ParticipantChip({
         type="button"
         variant="ghost"
         size="sm"
-        className="relative z-10 ml-0.5 h-3 w-3 p-0 hover:bg-transparent"
+        className="relative ml-0.5 h-3 w-3 p-0 hover:bg-transparent"
         onClick={(e) => {
           e.stopPropagation();
           handleRemove();
@@ -126,7 +126,7 @@ function EnhanceContactButton({
           variant="ghost"
           size="sm"
           aria-label={t`Enhance contact ${label}`}
-          className="text-muted-foreground hover:text-foreground relative z-10 ml-0.5 h-3.5 w-3.5 p-0 hover:bg-transparent"
+          className="text-muted-foreground hover:text-foreground relative ml-0.5 h-3.5 w-3.5 p-0 hover:bg-transparent"
           disabled={isDisabled}
           onClick={(e) => {
             e.stopPropagation();

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/dropdown.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/dropdown.tsx
@@ -47,7 +47,7 @@ export function ParticipantDropdown({
     <div
       ref={floatingRef}
       style={floatingStyles}
-      className="bg-popover z-50 overflow-hidden rounded-md border shadow-md"
+      className="bg-popover overflow-hidden rounded-md border shadow-md"
       onMouseDown={(event) => {
         event.preventDefault();
         event.stopPropagation();

--- a/apps/desktop/src/session/components/outer-header/overflow/export-modal.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/export-modal.tsx
@@ -2,7 +2,6 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { useMutation } from "@tanstack/react-query";
 import { downloadDir, join } from "@tauri-apps/api/path";
 import { useMemo, useState } from "react";
-import { createPortal } from "react-dom";
 
 import { json2md } from "@anlg/editor/markdown";
 import { commands as analyticsCommands } from "@anlg/plugin-analytics";
@@ -13,6 +12,12 @@ import {
 } from "@anlg/plugin-export";
 import { commands as fs2Commands } from "@anlg/plugin-fs2";
 import { commands as openerCommands } from "@anlg/plugin-opener2";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@anlg/ui/components/ui/dialog";
 import { cn } from "@anlg/utils";
 
 import { formatDate, formatDuration } from "./export-utils";
@@ -392,14 +397,14 @@ export function ExportModal({
     return null;
   }
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 bg-black/20 backdrop-blur-xs"
-      onClick={() => onOpenChange(false)}
-    >
-      <div
-        className="absolute top-1/2 left-1/2 w-full max-w-xs -translate-x-1/2 -translate-y-1/2 px-4"
-        onClick={(e) => e.stopPropagation()}
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        overlayClassName="bg-black/20 backdrop-blur-xs"
+        className={cn([
+          "w-full max-w-xs gap-0 border-0 bg-transparent p-4 shadow-none sm:rounded-none",
+          "[&>button:last-child]:hidden",
+        ])}
       >
         <div
           className={cn([
@@ -409,12 +414,12 @@ export function ExportModal({
           ])}
         >
           <div className="flex flex-col gap-1">
-            <h2 className="text-base font-semibold">
+            <DialogTitle className="text-base leading-normal font-semibold">
               <Trans>Export</Trans>
-            </h2>
-            <p className="text-muted-foreground text-sm">
+            </DialogTitle>
+            <DialogDescription className="text-muted-foreground text-sm">
               <Trans>Choose a file format and what to include.</Trans>
-            </p>
+            </DialogDescription>
           </div>
 
           <div className="flex flex-col gap-4">
@@ -498,8 +503,7 @@ export function ExportModal({
                 : t`Export`}
           </button>
         </div>
-      </div>
-    </div>,
-    document.body,
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/desktop/src/settings/ai/shared/anarlog-cloud-button.tsx
+++ b/apps/desktop/src/settings/ai/shared/anarlog-cloud-button.tsx
@@ -53,7 +53,7 @@ export function AnlgCloudCTAButton({
           ])}
         />
       )}
-      <span className="relative z-10">{buttonLabel}</span>
+      <span className="relative">{buttonLabel}</span>
     </button>
   );
 }

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -986,7 +986,7 @@ function LocalModelDropdownActions({ model }: { model: LocalModel }) {
     <div
       data-model-actions-pending={deleteModel.isPending || undefined}
       className={cn([
-        "absolute top-0 right-0 bottom-0 z-10 flex items-center justify-end gap-1 rounded-r-full pl-6",
+        "absolute top-0 right-0 bottom-0 flex items-center justify-end gap-1 rounded-r-full pl-6",
         "pointer-events-none opacity-0 transition-opacity duration-150",
         "group-hover/model-row:pointer-events-auto group-hover/model-row:opacity-100",
         "group-focus-within/model-row:pointer-events-auto group-focus-within/model-row:opacity-100",

--- a/apps/desktop/src/settings/general/spoken-languages.tsx
+++ b/apps/desktop/src/settings/general/spoken-languages.tsx
@@ -184,7 +184,7 @@ export function SpokenLanguagesView({
           <div
             id="language-options"
             role="listbox"
-            className="border-border bg-card absolute top-full right-0 left-0 z-10 mt-1 flex max-h-60 w-full flex-col overflow-hidden overflow-y-auto rounded-2xl border shadow-md"
+            className="border-border bg-card absolute top-full right-0 left-0 mt-1 flex max-h-60 w-full flex-col overflow-hidden overflow-y-auto rounded-2xl border shadow-md"
           >
             {filteredLanguages.length > 0 ? (
               filteredLanguages.map((langCode, index) => (

--- a/apps/desktop/src/shared/open-note-dialog.test.tsx
+++ b/apps/desktop/src/shared/open-note-dialog.test.tsx
@@ -60,6 +60,14 @@ describe("OpenNoteDialog", () => {
 
   afterEach(cleanup);
 
+  it("closes through the shared dialog escape behavior", () => {
+    render(<OpenNoteDialog open onOpenChange={mocks.onOpenChange} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(mocks.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it("opens a durable shared note from All Notes", () => {
     mocks.notes = [
       {
@@ -94,6 +102,10 @@ describe("OpenNoteDialog", () => {
 
     render(<OpenNoteDialog open onOpenChange={mocks.onOpenChange} />);
 
+    expect(screen.getByRole("dialog", { name: "Find a note..." })).toBeTruthy();
+    expect(
+      document.querySelector("[data-open-note-dialog-drag-region]"),
+    ).toBeTruthy();
     expect(screen.getByText("All Notes")).toBeTruthy();
     const sharedNote = screen.getByRole("option", {
       name: "Shared roadmap",

--- a/apps/desktop/src/shared/open-note-dialog.tsx
+++ b/apps/desktop/src/shared/open-note-dialog.tsx
@@ -9,9 +9,13 @@ import {
   useMemo,
   useState,
 } from "react";
-import { createPortal } from "react-dom";
 import { useHotkeys } from "react-hotkeys-hook";
 
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@anlg/ui/components/ui/dialog";
 import { cn } from "@anlg/utils";
 
 import { trackAnalyticsEvent } from "~/analytics";
@@ -226,37 +230,46 @@ export function OpenNoteDialog({
 
   if (!open) return null;
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 bg-black/20 backdrop-blur-xs"
-      onClick={() => handleOpenChange(false)}
-    >
-      <div
-        data-tauri-drag-region
-        className="absolute top-0 right-0 left-0 h-[15%]"
-        onClick={(e) => e.stopPropagation()}
-      />
-      <div
-        className="absolute top-[15%] left-1/2 w-full max-w-lg -translate-x-1/2 px-4"
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        aria-describedby={undefined}
+        overlayClassName="bg-black/20 backdrop-blur-xs"
+        overlayChildren={
+          <div
+            data-open-note-dialog-drag-region
+            data-tauri-drag-region
+            className="absolute top-0 right-0 left-0 h-[15%]"
+            onClick={(event) => event.stopPropagation()}
+          />
+        }
+        className={cn([
+          "top-[15%] w-full max-w-lg -translate-y-0 gap-0 border-0 bg-transparent px-4 py-0 shadow-none sm:rounded-none",
+          "data-[state=closed]:animate-none data-[state=open]:animate-none",
+          "[&>button:last-child]:hidden",
+        ])}
         style={{ marginLeft: mainContentCenterOffset }}
+        onPointerDownOutside={(event) => {
+          const target = event.detail.originalEvent.target;
+          if (
+            target instanceof Element &&
+            target.closest("[data-open-note-dialog-drag-region]")
+          ) {
+            event.preventDefault();
+          }
+        }}
       >
+        <DialogTitle className="sr-only">
+          <Trans>Find a note...</Trans>
+        </DialogTitle>
         <div
           className={cn([
             "border-border/80 bg-background rounded-2xl border",
             "shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)]",
             "overflow-hidden",
           ])}
-          onClick={(e) => e.stopPropagation()}
         >
-          <CommandPrimitive
-            shouldFilter={false}
-            className="flex flex-col"
-            onKeyDown={(e) => {
-              if (e.key === "Escape") {
-                handleOpenChange(false);
-              }
-            }}
-          >
+          <CommandPrimitive shouldFilter={false} className="flex flex-col">
             <div className="border-border/60 flex items-center gap-3 border-b px-4 py-3">
               <MagnifyingGlass className="text-muted-foreground h-4 w-4 shrink-0" />
               <CommandPrimitive.Input
@@ -362,8 +375,7 @@ export function OpenNoteDialog({
             </CommandPrimitive.List>
           </CommandPrimitive>
         </div>
-      </div>
-    </div>,
-    document.body,
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/src/components/home-page/hero-section.tsx
+++ b/apps/web/src/components/home-page/hero-section.tsx
@@ -381,7 +381,7 @@ function DownloadButton() {
       {open && (
         <div
           role="menu"
-          className="surface border-color-brand absolute top-[calc(100%+0.5rem)] left-0 z-10 w-72 max-w-[calc(100vw-2.5rem)] rounded-2xl border p-2 text-left shadow-[0_14px_40px_rgba(24,22,19,0.12)]"
+          className="surface border-color-brand absolute top-[calc(100%+0.5rem)] left-0 w-72 max-w-[calc(100vw-2.5rem)] rounded-2xl border p-2 text-left shadow-[0_14px_40px_rgba(24,22,19,0.12)]"
         >
           {orderedSections.map((section) =>
             section.downloads.map((download) => {

--- a/apps/web/src/components/home-page/hero-section.tsx
+++ b/apps/web/src/components/home-page/hero-section.tsx
@@ -118,15 +118,15 @@ function HeroWorkflowDemo() {
   return (
     <div className="relative left-1/2 mt-10 w-screen max-w-[500px] -translate-x-1/2 px-8 sm:px-10">
       <div
-        className="pointer-events-none absolute top-10 bottom-24 left-8 z-0 w-12 rounded-full bg-neutral-950/10 blur-2xl sm:left-10"
+        className="pointer-events-none absolute top-10 bottom-24 left-8 w-12 rounded-full bg-neutral-950/10 blur-2xl sm:left-10"
         aria-hidden="true"
       />
       <div
-        className="pointer-events-none absolute top-10 right-8 bottom-24 z-0 w-12 rounded-full bg-neutral-950/10 blur-2xl sm:right-10"
+        className="pointer-events-none absolute top-10 right-8 bottom-24 w-12 rounded-full bg-neutral-950/10 blur-2xl sm:right-10"
         aria-hidden="true"
       />
       <div
-        className="relative z-10 mx-auto max-w-[420px] overflow-hidden rounded-3xl border-x border-t border-neutral-200 bg-white shadow-[0_24px_70px_rgba(24,22,19,0.08)] [corner-shape:squircle]"
+        className="relative mx-auto max-w-[420px] overflow-hidden rounded-3xl border-x border-t border-neutral-200 bg-white shadow-[0_24px_70px_rgba(24,22,19,0.08)] [corner-shape:squircle]"
         style={{
           WebkitMaskImage:
             "linear-gradient(to bottom, black 0%, black calc(100% - 5rem), transparent 100%)",
@@ -297,7 +297,7 @@ function HeroWorkflowDemo() {
         </div>
       </div>
       <div
-        className="pointer-events-none absolute right-0 bottom-0 left-0 z-10 h-28 bg-linear-to-t from-white to-transparent"
+        className="pointer-events-none absolute right-0 bottom-0 left-0 h-28 bg-linear-to-t from-white to-transparent"
         aria-hidden="true"
       />
     </div>

--- a/apps/web/src/components/home-page/social-proof-sections.tsx
+++ b/apps/web/src/components/home-page/social-proof-sections.tsx
@@ -260,15 +260,6 @@ export function CredibilityLogoMarquee() {
 
       <div className="relative left-1/2 w-screen -translate-x-1/2 overflow-hidden bg-white motion-reduce:overflow-visible">
         <div
-          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-16 bg-linear-to-r from-white to-transparent motion-reduce:hidden md:w-32"
-          aria-hidden="true"
-        />
-        <div
-          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-16 bg-linear-to-l from-white to-transparent motion-reduce:hidden md:w-32"
-          aria-hidden="true"
-        />
-
-        <div
           className="animate-scroll-left flex w-max items-center motion-reduce:mx-auto motion-reduce:w-full motion-reduce:max-w-6xl motion-reduce:animate-none motion-reduce:justify-center motion-reduce:px-6"
           style={{ animationDuration: "36s" }}
           aria-hidden="true"
@@ -298,6 +289,14 @@ export function CredibilityLogoMarquee() {
             </div>
           ))}
         </div>
+        <div
+          className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-linear-to-r from-white to-transparent motion-reduce:hidden md:w-32"
+          aria-hidden="true"
+        />
+        <div
+          className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-linear-to-l from-white to-transparent motion-reduce:hidden md:w-32"
+          aria-hidden="true"
+        />
       </div>
       <h2
         id="credibility-heading"

--- a/packages/editor/src/node-views/image-view.tsx
+++ b/packages/editor/src/node-views/image-view.tsx
@@ -280,17 +280,17 @@ export const ResizableImageView = forwardRef<
           <>
             <div
               aria-hidden="true"
-              className="absolute top-0 right-0 z-10 h-full w-6"
+              className="absolute top-0 right-0 h-full w-6"
             />
             <div
               aria-hidden="true"
-              className="absolute top-0 left-0 z-10 h-full w-6"
+              className="absolute top-0 left-0 h-full w-6"
             />
             <button
               type="button"
               aria-label="Resize image from left"
               onPointerDown={(event) => handleResizeStart("left", event)}
-              className="border-border bg-card/95 absolute top-1/2 left-1 z-20 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border shadow-sm backdrop-blur-sm"
+              className="border-border bg-card/95 absolute top-1/2 left-1 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border shadow-sm backdrop-blur-sm"
             >
               <span className="bg-muted-foreground h-8 w-1 rounded-full" />
             </button>
@@ -298,7 +298,7 @@ export const ResizableImageView = forwardRef<
               type="button"
               aria-label="Resize image from right"
               onPointerDown={(event) => handleResizeStart("right", event)}
-              className="border-border bg-card/95 absolute top-1/2 right-1 z-20 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border shadow-sm backdrop-blur-sm"
+              className="border-border bg-card/95 absolute top-1/2 right-1 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border shadow-sm backdrop-blur-sm"
             >
               <span className="bg-muted-foreground h-8 w-1 rounded-full" />
             </button>

--- a/packages/editor/src/styles/prosemirror/mention.css
+++ b/packages/editor/src/styles/prosemirror/mention.css
@@ -9,7 +9,6 @@
     0 4px 6px -4px rgb(0 0 0 / 0.1);
   padding: 0.25rem;
   overflow: hidden;
-  z-index: 999;
   max-width: 280px;
 }
 

--- a/packages/editor/src/widgets/format-toolbar.tsx
+++ b/packages/editor/src/widgets/format-toolbar.tsx
@@ -144,10 +144,10 @@ export function FormatToolbar({
       role="toolbar"
       aria-label="Format selection"
       className={cn([
-        "bg-popover ring-border fixed flex items-center gap-0.5 rounded-xl p-1 ring-1",
+        "bg-popover ring-border fixed z-50 flex items-center gap-0.5 rounded-xl p-1 ring-1",
         "shadow-lg",
       ])}
-      style={{ top: 0, left: 0, zIndex: 40 }}
+      style={{ top: 0, left: 0 }}
       onMouseDown={(e) => e.preventDefault()}
     >
       {canFormatSelection &&

--- a/packages/editor/src/widgets/mention.tsx
+++ b/packages/editor/src/widgets/mention.tsx
@@ -209,8 +209,8 @@ export function MentionSuggestion({ config }: { config: MentionConfig }) {
     <div
       ref={popupRef}
       data-editor-escape-consumer
-      className="mention-container"
-      style={{ position: "absolute", top: 0, left: 0, zIndex: 9999 }}
+      className="mention-container z-50"
+      style={{ position: "absolute", top: 0, left: 0 }}
     >
       {items.map((item, index) => (
         <button

--- a/packages/editor/src/widgets/slash-command.tsx
+++ b/packages/editor/src/widgets/slash-command.tsx
@@ -357,7 +357,7 @@ export function SlashCommandMenu() {
       ref={popupRef}
       data-editor-escape-consumer
       className={cn([
-        "absolute z-[9999] max-h-64 w-[224px]",
+        "absolute z-50 max-h-64 w-[224px]",
         "bg-popover text-popover-foreground ring-border overflow-y-auto rounded-[1rem] p-1 ring-1",
         "text-sm shadow-lg",
       ])}

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -14,6 +14,7 @@ type DialogContentProps = React.ComponentPropsWithoutRef<
 > & {
   showOverlay?: boolean;
   overlayClassName?: string;
+  overlayChildren?: React.ReactNode;
 };
 
 const DialogOverlay = React.forwardRef<
@@ -36,11 +37,22 @@ const DialogContent = React.forwardRef<
   DialogContentProps
 >(
   (
-    { className, children, showOverlay = true, overlayClassName, ...props },
+    {
+      className,
+      children,
+      showOverlay = true,
+      overlayClassName,
+      overlayChildren,
+      ...props
+    },
     ref,
   ) => (
     <DialogPortal>
-      {showOverlay ? <DialogOverlay className={overlayClassName} /> : null}
+      {showOverlay ? (
+        <DialogOverlay className={overlayClassName}>
+          {overlayChildren}
+        </DialogOverlay>
+      ) : null}
       <DialogPrimitive.Content
         ref={ref}
         className={cn([


### PR DESCRIPTION
Remove redundant z-index values from editor portals and local overlap effects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stacking and overlay behavior for floating chat plus export/open-note dialogs, so regressions in focus, escape, or layering are possible. No auth or data-path changes.
> 
> **Overview**
> Codifies a stacking rule: prefer **DOM order** for local overlap and **portals** for cross-tree floating UI, instead of escalating global `z-index` values.
> 
> Removes redundant local `z-*` classes across desktop, web, and editor surfaces where source order already controls layering. Portals the floating chat panel to `document.body` (dropping `z-100`), and standardizes editor floating UI (format toolbar, mentions, slash menu) to a single `z-50`.
> 
> Migrates the export and open-note modals from hand-rolled portal overlays onto the shared `Dialog`, extending `DialogContent` with `overlayChildren` so open-note can keep its Tauri drag region.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c04db1627c96a08612c2e6bd71e3847e934e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->