### PR TITLE
fix(supabase): stop double-counting seats when a new account accepts

### DIFF
--- a/supabase/migrations/20260812120000_fix_seat_usage_and_grant_validation.sql
+++ b/supabase/migrations/20260812120000_fix_seat_usage_and_grant_validation.sql
@@ -1,0 +1,197 @@
+-- An invitation stopped holding a seat only when its invitee_user_id matched a
+-- seated member, but that column is NULL for anyone invited before they had an
+-- account, and accept_workspace_invitation only stamps it after inserting the
+-- membership. The invitee was therefore counted twice mid-acceptance, so a team
+-- that bought exactly N seats could never seat anyone new.
+CREATE OR REPLACE FUNCTION private.workspace_seat_usage(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  seat_limit integer,
+  used_seats integer
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    workspace.seat_limit,
+    (
+      (
+        SELECT count(*)
+        FROM public.workspace_memberships AS membership
+        WHERE membership.workspace_id = workspace.id
+          AND membership.deleted_at IS NULL
+      )
+      + (
+        SELECT count(*)
+        FROM public.workspace_invitations AS invitation
+        WHERE invitation.workspace_id = workspace.id
+          AND invitation.accepted_at IS NULL
+          AND invitation.revoked_at IS NULL
+          AND invitation.expires_at > now()
+          -- Match on email as well as id: the id is still unset while a
+          -- brand-new account is being seated.
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.workspace_memberships AS seated
+            LEFT JOIN auth.users AS seated_user
+              ON seated_user.id = seated.user_id
+            WHERE seated.workspace_id = invitation.workspace_id
+              AND seated.deleted_at IS NULL
+              AND (
+                seated.user_id = invitation.invitee_user_id
+                OR lower(btrim(seated_user.email)) = invitation.invitee_email
+              )
+          )
+      )
+    )::integer
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = p_workspace_id;
+$$;
+
+REVOKE ALL ON FUNCTION private.workspace_seat_usage(uuid)
+  FROM PUBLIC, anon, authenticated;
+
+-- The issuer check cast userId to uuid without the guard the grant loop uses,
+-- so a malformed id surfaced a raw 22P02 instead of the validation message.
+CREATE OR REPLACE FUNCTION private.set_workspace_e2ee_key(
+  p_workspace_id uuid,
+  p_key_id text,
+  p_grants jsonb
+)
+RETURNS TABLE (
+  out_key_id text,
+  out_granted_member_count integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_grant jsonb;
+  v_member_id uuid;
+  v_granted integer := 0;
+  v_includes_issuer boolean;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.workspaces AS workspace
+    JOIN public.workspace_memberships AS membership
+      ON membership.workspace_id = workspace.id
+    JOIN auth.users AS actor
+      ON actor.id = membership.user_id
+    WHERE workspace.id = p_workspace_id
+      AND workspace.kind = 'shared'
+      AND workspace.deleted_at IS NULL
+      AND membership.user_id = v_actor_id
+      AND membership.role IN ('owner', 'admin')
+      AND membership.deleted_at IS NULL
+      AND actor.email_confirmed_at IS NOT NULL
+      AND COALESCE(actor.is_anonymous, false) = false
+  ) THEN
+    RAISE EXCEPTION 'E2EE key operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_key_id IS NULL OR p_key_id !~ '^[A-Za-z0-9_-]{22}$' THEN
+    RAISE EXCEPTION 'E2EE key identity is invalid'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_grants IS NULL OR jsonb_typeof(p_grants) <> 'array' THEN
+    RAISE EXCEPTION 'E2EE key grants are invalid'
+      USING ERRCODE = '22023';
+  END IF;
+
+  BEGIN
+    SELECT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(p_grants) AS candidate
+      WHERE (candidate ->> 'userId')::uuid = v_actor_id
+    )
+    INTO v_includes_issuer;
+  EXCEPTION WHEN invalid_text_representation THEN
+    RAISE EXCEPTION 'E2EE key grants are invalid'
+      USING ERRCODE = '22023';
+  END;
+
+  -- The issuer must keep their own access, otherwise a rotation could lock the
+  -- workspace out of its own data.
+  IF NOT v_includes_issuer THEN
+    RAISE EXCEPTION 'E2EE key grants must include the issuing member'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM 1
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = p_workspace_id
+  FOR UPDATE;
+
+  UPDATE public.workspace_e2ee_keys
+  SET retired_at = now()
+  WHERE workspace_e2ee_keys.workspace_id = p_workspace_id
+    AND workspace_e2ee_keys.key_id <> p_key_id
+    AND workspace_e2ee_keys.retired_at IS NULL;
+
+  INSERT INTO public.workspace_e2ee_keys (workspace_id, key_id, created_by_user_id)
+  VALUES (p_workspace_id, p_key_id, v_actor_id)
+  ON CONFLICT (workspace_id, key_id) DO UPDATE SET retired_at = NULL;
+
+  FOR v_grant IN SELECT * FROM jsonb_array_elements(p_grants)
+  LOOP
+    BEGIN
+      v_member_id := (v_grant ->> 'userId')::uuid;
+    EXCEPTION WHEN invalid_text_representation THEN
+      RAISE EXCEPTION 'E2EE key grants are invalid'
+        USING ERRCODE = '22023';
+    END;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.workspace_memberships AS membership
+      WHERE membership.workspace_id = p_workspace_id
+        AND membership.user_id = v_member_id
+        AND membership.deleted_at IS NULL
+    ) THEN
+      RAISE EXCEPTION 'E2EE key grants must target active members'
+        USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO public.workspace_e2ee_key_grants (
+      workspace_id,
+      key_id,
+      member_user_id,
+      ephemeral_public_key,
+      nonce,
+      ciphertext,
+      issued_by_user_id
+    ) VALUES (
+      p_workspace_id,
+      p_key_id,
+      v_member_id,
+      v_grant ->> 'ephemeralPublicKey',
+      v_grant ->> 'nonce',
+      v_grant ->> 'ciphertext',
+      v_actor_id
+    )
+    ON CONFLICT (workspace_id, key_id, member_user_id) DO NOTHING;
+  END LOOP;
+
+  SELECT count(*)
+  INTO v_granted
+  FROM public.workspace_e2ee_key_grants AS grant_row
+  WHERE grant_row.workspace_id = p_workspace_id
+    AND grant_row.key_id = p_key_id;
+
+  RETURN QUERY
+  SELECT p_key_id, v_granted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.set_workspace_e2ee_key(uuid, text, jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION private.set_workspace_e2ee_key(uuid, text, jsonb)
+  TO authenticated;

--- a/supabase/tests/035-seat-usage-new-account-invitee.sql
+++ b/supabase/tests/035-seat-usage-new-account-invitee.sql
@@ -1,0 +1,109 @@
+begin;
+select plan(5);
+
+select tests.create_supabase_user('cap_owner', 'cap-owner@example.com');
+
+create temporary table cap_test_state (
+  name text primary key,
+  workspace_id uuid,
+  invitation_id uuid,
+  invite_token text
+);
+
+grant all on cap_test_state to authenticated, service_role;
+
+reset role;
+
+update auth.users
+set email_confirmed_at = now()
+where id = tests.get_supabase_uid('cap_owner');
+
+select tests.authenticate_as('cap_owner');
+
+insert into cap_test_state (name, workspace_id)
+select 'hq', workspace_id from public.create_workspace('Cap HQ');
+
+select tests.clear_authentication();
+reset role;
+
+-- Two seats: the owner plus exactly one teammate.
+update public.workspaces
+set seat_limit = 2
+where id = (select workspace_id from cap_test_state where name = 'hq');
+
+select tests.authenticate_as('cap_owner');
+
+select lives_ok(
+  $$
+    insert into cap_test_state (name, invitation_id, invite_token)
+    select 'newcomer', invitation_id, invite_token
+    from public.create_workspace_invitation(
+      (select workspace_id from cap_test_state where name = 'hq'),
+      'newcomer@example.com'
+    )
+  $$,
+  'The owner can invite someone who has no account yet'
+);
+
+select results_eq(
+  $$
+    select used_seats
+    from public.get_workspace_seat_usage(
+      (select workspace_id from cap_test_state where name = 'hq')
+    )
+  $$,
+  array[2],
+  'The pending invitation holds the second seat'
+);
+
+select tests.clear_authentication();
+reset role;
+
+-- The invitee only signs up now, so the invitation still has a NULL
+-- invitee_user_id when the membership row is created.
+select tests.create_supabase_user('cap_newcomer', 'newcomer@example.com');
+
+update auth.users
+set email_confirmed_at = now()
+where id = tests.get_supabase_uid('cap_newcomer');
+
+select tests.authenticate_as('cap_newcomer');
+
+select lives_ok(
+  $$
+    select * from public.accept_workspace_invitation(
+      (select invitation_id from cap_test_state where name = 'newcomer'),
+      (select invite_token from cap_test_state where name = 'newcomer')
+    )
+  $$,
+  'Someone invited before they had an account can still take their seat'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('cap_owner');
+
+select results_eq(
+  $$
+    select used_seats
+    from public.get_workspace_seat_usage(
+      (select workspace_id from cap_test_state where name = 'hq')
+    )
+  $$,
+  array[2],
+  'Seating the invitee does not double-count the invitation it consumed'
+);
+
+select throws_ok(
+  $$
+    select * from public.create_workspace_invitation(
+      (select workspace_id from cap_test_state where name = 'hq'),
+      'one-too-many@example.com'
+    )
+  $$,
+  '22023',
+  'workspace seat limit reached',
+  'The seat cap still holds once every seat is taken'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Found by a review of the Teams work. A pending invitation stopped holding a seat only once its `invitee_user_id` matched a seated member, but that column stays NULL for anyone invited before they had an Anarlog account, and `accept_workspace_invitation` only stamps it *after* inserting the membership row.

Mid-acceptance the same person therefore held two seats, so **a team that bought exactly N seats and invited N-1 new people could never seat any of them** — acceptance aborted with "workspace seat limit reached". Verified against a local database before and after.

Match invitations by invitee email as well as id, which is stable from the moment the invitation is created. Adds `tests/035` reproducing the exact scenario (invite an address with no account, sign up, accept at the seat limit).

Also guards the uuid cast in the `set_workspace_e2ee_key` issuer check, which raised a raw 22P02 instead of the validation error the grant loop already produces — clients surface these messages to managers verbatim.

The buggy migration is merged but **not yet deployed**, so this lands ahead of it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches seat-limit enforcement and E2EE grant validation (security-sensitive paths), but the changes are narrow bug fixes with a regression test and the buggy seat logic is not yet deployed.
> 
> **Overview**
> Fixes seat accounting so a brand-new invitee can accept at the seat limit. `workspace_seat_usage` previously only excluded pending invites when `invitee_user_id` matched a member, but that id stays NULL until after membership insert—so mid-acceptance the same person counted twice and acceptance failed with "workspace seat limit reached".
> 
> Pending invites are now also matched by invitee email against seated members. Adds a regression test covering invite-before-signup at a hard seat cap.
> 
> Also wraps the issuer `userId` uuid cast in `set_workspace_e2ee_key` so malformed grants return the validation error instead of a raw `22P02`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9931087361d2d2310b27db515391543f526baf78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->