### PR TITLE
Fix Slack paths for Nango proxy

### DIFF
--- a/crates/slack-web/src/client.rs
+++ b/crates/slack-web/src/client.rs
@@ -5,6 +5,11 @@ use crate::types::{
     ListConversationsResponse, PostMessageRequest, PostMessageResponse, SlackResponse,
 };
 
+// Nango's Slack provider base URL already includes `/api`.
+const POST_MESSAGE_PATH: &str = "/chat.postMessage";
+const LIST_CONVERSATIONS_PATH: &str =
+    "/conversations.list?exclude_archived=true&limit=200&types=public_channel,private_channel";
+
 pub struct SlackWebClient<C> {
     http: C,
 }
@@ -21,7 +26,7 @@ impl<C: HttpClient> SlackWebClient<C> {
         let body = serde_json::to_vec(&req)?;
         let bytes = self
             .http
-            .post("/api/chat.postMessage", body, "application/json")
+            .post(POST_MESSAGE_PATH, body, "application/json")
             .await
             .map_err(Error::Http)?;
         let response: SlackResponse<PostMessageResponse> = serde_json::from_slice(&bytes)?;
@@ -31,12 +36,21 @@ impl<C: HttpClient> SlackWebClient<C> {
     pub async fn list_conversations(&self) -> Result<ListConversationsResponse, Error> {
         let bytes = self
             .http
-            .get(
-                "/api/conversations.list?exclude_archived=true&limit=200&types=public_channel,private_channel",
-            )
+            .get(LIST_CONVERSATIONS_PATH)
             .await
             .map_err(Error::Http)?;
         let response: SlackResponse<ListConversationsResponse> = serde_json::from_slice(&bytes)?;
         response.into_result()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LIST_CONVERSATIONS_PATH, POST_MESSAGE_PATH};
+
+    #[test]
+    fn endpoints_are_relative_to_nango_slack_api_base_url() {
+        assert!(!POST_MESSAGE_PATH.starts_with("/api/"));
+        assert!(!LIST_CONVERSATIONS_PATH.starts_with("/api/"));
     }
 }


### PR DESCRIPTION
- Fix Slack paths used by the Nango proxy to correct routing and endpoint handling- Ensure Slack-related requests are routed through the proper proxy paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Slack API routing used for posting messages and listing channels via the Nango proxy. Small, targeted fix, but incorrect paths would break live Slack integration calls.
> 
> **Overview**
> Fixes Slack requests through the Nango proxy by dropping the extra `/api` prefix from `chat.postMessage` and `conversations.list` paths. Nango’s Slack base URL already includes `/api`, so the old paths were incorrectly doubled.
> 
> Extracts those endpoints into constants and adds a regression test that asserts they stay relative to the Nango Slack API base URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a67297351f0b0ccc9101d0fa82e899898c83c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->