### PR TITLE
Prevent workspace billing migration deadlock

### DIFF
--- a/supabase/migrations/20260811170000_workspace_billing_and_seats.sql
+++ b/supabase/migrations/20260811170000_workspace_billing_and_seats.sql
@@ -2,6 +2,19 @@
 -- billing survives an ownership transfer and members inherit entitlement from
 -- the workspace subscription instead of buying their own.
 
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+
+-- Token refreshes read auth.users before the workspace tables. Lock in that
+-- same order so concurrent refreshes cannot deadlock against this migration.
+LOCK TABLE
+  auth.users,
+  public.workspaces,
+  public.workspace_memberships,
+  public.workspace_invitations
+IN ACCESS EXCLUSIVE MODE;
+
 ALTER TABLE public.workspaces
   ADD COLUMN stripe_customer_id text,
   ADD COLUMN seat_limit integer,
@@ -304,3 +317,5 @@ BEGIN
   RETURN event;
 END;
 $$;
+
+COMMIT;


### PR DESCRIPTION
Acquire auth and workspace table locks in a consistent order before applying billing DDL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ACCESS EXCLUSIVE locking on auth.users and workspace tables during deploy, which can briefly block token refreshes, but the change is a targeted deadlock-prevention fix.
> 
> **Overview**
> Wraps the workspace billing migration in an explicit transaction and **pre-locks** `auth.users` plus the workspace tables in the same order token refreshes use, so concurrent auth hooks cannot deadlock against the DDL.
> 
> Also sets a **30s** `lock_timeout` so the migration fails fast instead of hanging if locks cannot be acquired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66ec76f91216d98ad8510d0ece31a154c314453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->