### PR TITLE
Tighten app icon selection rings

### DIFF
--- a/apps/desktop/src/settings/appearance/app-icon.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.tsx
@@ -84,9 +84,9 @@ export function AppIconSelector() {
               aria-label={labels[option]}
               title={labels[option]}
               className={cn([
-                "group text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex cursor-pointer items-center justify-center rounded-[22px] border bg-transparent p-1 transition-[border-color,scale] duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.98]",
+                "group text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex cursor-pointer items-center justify-center rounded-[22px] border bg-transparent p-0.5 transition-[border-color,scale] duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.98]",
                 selected
-                  ? "border-foreground/50"
+                  ? "border-blue-500"
                   : "border-border hover:border-foreground/30",
               ])}
               onClick={() => {


### PR DESCRIPTION
Reduce selector padding and highlight the active icon with a blue border.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI styling tweak to selection chrome; no logic, auth, or data handling changes.
> 
> **Overview**
> Tightens the app icon picker in appearance settings by reducing button padding (`p-1` → `p-0.5`) and highlighting the selected icon with a **blue** border instead of a muted foreground border.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2da747ddb0a813b2624167a67610432851d4cf5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->