### PR TITLE
Allow canceling import connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18614,6 +18614,7 @@ dependencies = [
  "tauri-specta",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "url",
  "uuid",
 ]

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -499,6 +499,7 @@ msgstr "Calendar connected"
 msgid "Can transcribe while the meeting is happening."
 msgstr "Can transcribe while the meeting is happening."
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -499,6 +499,7 @@ msgstr ""
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session-sharing/comments.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/settings/general/storage/legacy-cleanup.tsx

--- a/apps/desktop/src/imports/connected-import.test.ts
+++ b/apps/desktop/src/imports/connected-import.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   beginConnectedImport: vi.fn(),
+  cancelConnectedImport: vi.fn(),
   completeConnectedImport: vi.fn(),
   syncConnectedImport: vi.fn(),
   openUrl: vi.fn(),
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@anlg/plugin-importer", () => ({
   commands: {
     beginConnectedImport: mocks.beginConnectedImport,
+    cancelConnectedImport: mocks.cancelConnectedImport,
     completeConnectedImport: mocks.completeConnectedImport,
     syncConnectedImport: mocks.syncConnectedImport,
   },
@@ -39,6 +41,7 @@ vi.mock("./queries", () => ({
 }));
 
 import {
+  cancelConnectedImport,
   connectConnectedImport,
   connectedImportSyncQueryOptions,
 } from "./connected-import";
@@ -85,6 +88,56 @@ describe("connected meeting imports", () => {
       "circleback-mcp",
       JSON.stringify(credentials),
     );
+  });
+
+  it("cancels an abandoned provider authorization", async () => {
+    mocks.cancelConnectedImport.mockResolvedValue({
+      status: "ok",
+      data: true,
+    });
+
+    await expect(cancelConnectedImport("circleback")).resolves.toBe(true);
+    expect(mocks.cancelConnectedImport).toHaveBeenCalledWith("circleback");
+  });
+
+  it("does not save credentials when provider authorization is cancelled", async () => {
+    mocks.beginConnectedImport.mockResolvedValue({
+      status: "ok",
+      data: {
+        providerId: "circleback",
+        authorizationUrl: "https://circleback.ai/authorize",
+      },
+    });
+    mocks.completeConnectedImport.mockResolvedValue({
+      status: "error",
+      error: "Circleback sign-in cancelled.",
+    });
+
+    await expect(connectConnectedImport(provider)).rejects.toThrow(
+      "Circleback sign-in cancelled.",
+    );
+    expect(mocks.setSecret).not.toHaveBeenCalled();
+  });
+
+  it("stops waiting for a provider callback when cancelled", async () => {
+    mocks.beginConnectedImport.mockResolvedValue({
+      status: "ok",
+      data: {
+        providerId: "circleback",
+        authorizationUrl: "https://circleback.ai/authorize",
+      },
+    });
+    mocks.completeConnectedImport.mockReturnValue(new Promise(() => {}));
+    const controller = new AbortController();
+    const connection = connectConnectedImport(provider, controller.signal);
+
+    await vi.waitFor(() => {
+      expect(mocks.completeConnectedImport).toHaveBeenCalledWith("circleback");
+    });
+    controller.abort();
+
+    await expect(connection).rejects.toThrow();
+    expect(mocks.setSecret).not.toHaveBeenCalled();
   });
 
   it("requests only meetings that are not already imported", async () => {

--- a/apps/desktop/src/imports/connected-import.ts
+++ b/apps/desktop/src/imports/connected-import.ts
@@ -57,25 +57,75 @@ export function connectedImportSyncQueryOptions(
 
 export async function connectConnectedImport(
   provider: Pick<MeetingImportProvider, "id" | "name">,
+  signal?: AbortSignal,
 ) {
+  throwIfConnectionCancelled(signal);
   const authorization = await importerCommands.beginConnectedImport(
     provider.id,
   );
   if (authorization.status === "error") throw new Error(authorization.error);
+  await cancelConnectionIfRequested(provider.id, signal);
 
   const opened = await openerCommands.openUrl(
     authorization.data.authorizationUrl,
     null,
   );
   if (opened.status === "error") throw new Error(opened.error);
+  await cancelConnectionIfRequested(provider.id, signal);
 
-  const credentials = await importerCommands.completeConnectedImport(
-    provider.id,
-  );
+  const credentials = await waitForConnectionCompletion(provider.id, signal);
   if (credentials.status === "error") throw new Error(credentials.error);
+  throwIfConnectionCancelled(signal);
 
   await writeConnectedImportCredentials(provider.id, credentials.data);
   return credentials.data;
+}
+
+export async function cancelConnectedImport(providerId: string) {
+  const result = await importerCommands.cancelConnectedImport(providerId);
+  if (result.status === "error") throw new Error(result.error);
+  return result.data;
+}
+
+async function cancelConnectionIfRequested(
+  providerId: string,
+  signal?: AbortSignal,
+) {
+  if (!signal?.aborted) return;
+  await cancelConnectedImport(providerId);
+  throwIfConnectionCancelled(signal);
+}
+
+async function waitForConnectionCompletion(
+  providerId: string,
+  signal?: AbortSignal,
+) {
+  const completion = importerCommands.completeConnectedImport(providerId);
+  if (!signal) return completion;
+  throwIfConnectionCancelled(signal);
+
+  let cancel!: () => void;
+  const cancelled = new Promise<never>((_, reject) => {
+    cancel = () => reject(connectionCancellationError(signal));
+    signal.addEventListener("abort", cancel, { once: true });
+    if (signal.aborted) cancel();
+  });
+
+  try {
+    return await Promise.race([completion, cancelled]);
+  } finally {
+    signal.removeEventListener("abort", cancel);
+  }
+}
+
+function throwIfConnectionCancelled(signal?: AbortSignal) {
+  if (signal?.aborted) throw connectionCancellationError(signal);
+}
+
+function connectionCancellationError(signal: AbortSignal) {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error("Meeting import connection cancelled");
 }
 
 export async function disconnectConnectedImport(providerId: string) {

--- a/apps/desktop/src/imports/screen.test.tsx
+++ b/apps/desktop/src/imports/screen.test.tsx
@@ -1,10 +1,17 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   detectImportSources: vi.fn(),
+  cancelConnectedImport: vi.fn(),
   connectConnectedImport: vi.fn(),
   disconnectConnectedImport: vi.fn(),
 }));
@@ -21,6 +28,7 @@ vi.mock("./queries", () => ({
 }));
 
 vi.mock("./connected-import", () => ({
+  cancelConnectedImport: mocks.cancelConnectedImport,
   connectConnectedImport: mocks.connectConnectedImport,
   disconnectConnectedImport: mocks.disconnectConnectedImport,
   connectedImportCredentialsQueryKey: (providerId: string) => [
@@ -92,6 +100,11 @@ function mockDetected(ids: string[]) {
 }
 
 describe("MeetingImportScreen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cancelConnectedImport.mockResolvedValue(true);
+  });
+
   afterEach(cleanup);
 
   it("lists only detected apps with native icons", async () => {
@@ -164,6 +177,40 @@ describe("MeetingImportScreen", () => {
       await screen.findByRole("button", { name: "Skip for now" }),
     ).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Continue" })).toBeNull();
+  });
+
+  it("lets the user cancel an abandoned browser connection and retry", async () => {
+    mockDetected(["granola"]);
+    mocks.connectConnectedImport.mockImplementation(
+      (_provider: unknown, signal: AbortSignal) =>
+        new Promise((_, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    );
+
+    renderImports();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Connect & import" }),
+    );
+    const cancelButton = await screen.findByRole("button", { name: "Cancel" });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(mocks.cancelConnectedImport.mock.calls[0]?.[0]).toBe("granola");
+      expect(
+        screen
+          .getByRole("button", { name: "Connect & import" })
+          .hasAttribute("disabled"),
+      ).toBe(false);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect & import" }));
+    await waitFor(() => {
+      expect(mocks.connectConnectedImport).toHaveBeenCalledTimes(2);
+    });
   });
 
   it("shows the empty state when nothing is detected", async () => {

--- a/apps/desktop/src/imports/screen.tsx
+++ b/apps/desktop/src/imports/screen.tsx
@@ -12,13 +12,14 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { open as selectFiles } from "@tauri-apps/plugin-dialog";
-import type { ReactNode } from "react";
+import { type ReactNode, useRef } from "react";
 
 import { commands as importerCommands } from "@anlg/plugin-importer";
 import { Button } from "@anlg/ui/components/ui/button";
 import { cn } from "@anlg/utils";
 
 import {
+  cancelConnectedImport,
   connectConnectedImport,
   connectedImportCredentialsQueryKey,
   connectedImportCredentialsQueryOptions,
@@ -82,6 +83,7 @@ export function MeetingImportScreen({
 }) {
   const { t } = useLingui();
   const queryClient = useQueryClient();
+  const connectAbortController = useRef<AbortController | null>(null);
   const detectionQuery = useQuery({
     queryKey: ["meeting-import-sources"],
     queryFn: detectImportSources,
@@ -144,13 +146,31 @@ export function MeetingImportScreen({
   });
 
   const connectMutation = useMutation({
-    mutationFn: connectConnectedImport,
+    mutationFn: async (provider: MeetingImportProvider) => {
+      const controller = new AbortController();
+      connectAbortController.current = controller;
+      try {
+        return await connectConnectedImport(provider, controller.signal);
+      } catch (error) {
+        if (controller.signal.aborted) return null;
+        throw error;
+      } finally {
+        if (connectAbortController.current === controller) {
+          connectAbortController.current = null;
+        }
+      }
+    },
     onSuccess: (credentials) => {
+      if (!credentials) return;
       queryClient.setQueryData(
         connectedImportCredentialsQueryKey(credentials.providerId),
         credentials,
       );
     },
+  });
+
+  const cancelConnectMutation = useMutation({
+    mutationFn: cancelConnectedImport,
   });
 
   const disconnectMutation = useMutation({
@@ -172,6 +192,7 @@ export function MeetingImportScreen({
   const connectedError =
     credentialQueries.find((query) => query.error)?.error ??
     connectMutation.error ??
+    cancelConnectMutation.error ??
     disconnectMutation.error ??
     syncQueries.find((query) => query.error)?.error;
   const latestResult =
@@ -255,6 +276,12 @@ export function MeetingImportScreen({
               const connecting =
                 connectMutation.isPending &&
                 connectMutation.variables.id === provider.id;
+              const connectionCancellationRequested =
+                connecting &&
+                Boolean(connectAbortController.current?.signal.aborted);
+              const cancellingConnection =
+                cancelConnectMutation.isPending &&
+                cancelConnectMutation.variables === provider.id;
               const disconnecting =
                 disconnectMutation.isPending &&
                 disconnectMutation.variables === provider.id;
@@ -345,16 +372,29 @@ export function MeetingImportScreen({
                           size="sm"
                           disabled={
                             credentialsQuery?.isPending ||
-                            connectMutation.isPending
+                            cancelConnectMutation.isPending ||
+                            connectionCancellationRequested ||
+                            (connectMutation.isPending && !connecting)
                           }
-                          onClick={() => connectMutation.mutate(provider)}
+                          onClick={() => {
+                            if (connecting) {
+                              connectAbortController.current?.abort();
+                              cancelConnectMutation.mutate(provider.id);
+                              return;
+                            }
+                            connectMutation.mutate(provider);
+                          }}
                         >
-                          {credentialsQuery?.isPending || connecting ? (
+                          {credentialsQuery?.isPending ||
+                          connecting ||
+                          cancellingConnection ? (
                             <CircleNotch className="size-3.5 animate-spin" />
                           ) : (
                             <PlugsConnected className="size-3.5" />
                           )}
-                          {credentialsQuery?.isPending ? (
+                          {connecting || cancellingConnection ? (
+                            <Trans>Cancel</Trans>
+                          ) : credentialsQuery?.isPending ? (
                             <Trans>Checking connection</Trans>
                           ) : (
                             <Trans>Connect & import</Trans>

--- a/plugins/importer/Cargo.toml
+++ b/plugins/importer/Cargo.toml
@@ -36,4 +36,5 @@ dirs = { workspace = true }
 rmcp = { workspace = true, features = ["auth", "client", "transport-streamable-http-client-reqwest"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "net", "rt-multi-thread", "macros", "sync", "time"] }
+tokio-util = { workspace = true }
 uuid = { workspace = true, features = ["v4", "v5"] }

--- a/plugins/importer/build.rs
+++ b/plugins/importer/build.rs
@@ -1,5 +1,6 @@
 const COMMANDS: &[&str] = &[
     "begin_connected_import",
+    "cancel_connected_import",
     "complete_connected_import",
     "sync_connected_import",
     "list_available_sources",

--- a/plugins/importer/js/bindings.gen.ts
+++ b/plugins/importer/js/bindings.gen.ts
@@ -14,6 +14,14 @@ async beginConnectedImport(providerId: string) : Promise<Result<ConnectedImportA
     else return { status: "error", error: e  as any };
 }
 },
+async cancelConnectedImport(providerId: string) : Promise<Result<boolean, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:importer|cancel_connected_import", { providerId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async completeConnectedImport(providerId: string) : Promise<Result<ConnectedImportCredentials, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:importer|complete_connected_import", { providerId }) };

--- a/plugins/importer/permissions/autogenerated/commands/cancel_connected_import.toml
+++ b/plugins/importer/permissions/autogenerated/commands/cancel_connected_import.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-cancel-connected-import"
+description = "Enables the cancel_connected_import command without any pre-configured scope."
+commands.allow = ["cancel_connected_import"]
+
+[[permission]]
+identifier = "deny-cancel-connected-import"
+description = "Denies the cancel_connected_import command without any pre-configured scope."
+commands.deny = ["cancel_connected_import"]

--- a/plugins/importer/permissions/autogenerated/reference.md
+++ b/plugins/importer/permissions/autogenerated/reference.md
@@ -5,6 +5,7 @@ Default permissions for the plugin
 #### This default permission set includes the following:
 
 - `allow-begin-connected-import`
+- `allow-cancel-connected-import`
 - `allow-complete-connected-import`
 - `allow-sync-connected-import`
 - `allow-list-available-sources`
@@ -43,6 +44,32 @@ Enables the begin_connected_import command without any pre-configured scope.
 <td>
 
 Denies the begin_connected_import command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`importer:allow-cancel-connected-import`
+
+</td>
+<td>
+
+Enables the cancel_connected_import command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`importer:deny-cancel-connected-import`
+
+</td>
+<td>
+
+Denies the cancel_connected_import command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/importer/permissions/default.toml
+++ b/plugins/importer/permissions/default.toml
@@ -2,6 +2,7 @@
 description = "Default permissions for the plugin"
 permissions = [
     "allow-begin-connected-import",
+    "allow-cancel-connected-import",
     "allow-complete-connected-import",
     "allow-sync-connected-import",
     "allow-list-available-sources",

--- a/plugins/importer/permissions/schemas/schema.json
+++ b/plugins/importer/permissions/schemas/schema.json
@@ -307,6 +307,18 @@
           "markdownDescription": "Denies the begin_connected_import command without any pre-configured scope."
         },
         {
+          "description": "Enables the cancel_connected_import command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-cancel-connected-import",
+          "markdownDescription": "Enables the cancel_connected_import command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the cancel_connected_import command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-cancel-connected-import",
+          "markdownDescription": "Denies the cancel_connected_import command without any pre-configured scope."
+        },
+        {
           "description": "Enables the complete_connected_import command without any pre-configured scope.",
           "type": "string",
           "const": "allow-complete-connected-import",
@@ -379,10 +391,10 @@
           "markdownDescription": "Denies the sync_connected_import command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-begin-connected-import`\n- `allow-complete-connected-import`\n- `allow-sync-connected-import`\n- `allow-list-available-sources`\n- `allow-run-import`\n- `allow-run-import-dry`\n- `allow-read-text-files`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-begin-connected-import`\n- `allow-cancel-connected-import`\n- `allow-complete-connected-import`\n- `allow-sync-connected-import`\n- `allow-list-available-sources`\n- `allow-run-import`\n- `allow-run-import-dry`\n- `allow-read-text-files`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-begin-connected-import`\n- `allow-complete-connected-import`\n- `allow-sync-connected-import`\n- `allow-list-available-sources`\n- `allow-run-import`\n- `allow-run-import-dry`\n- `allow-read-text-files`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-begin-connected-import`\n- `allow-cancel-connected-import`\n- `allow-complete-connected-import`\n- `allow-sync-connected-import`\n- `allow-list-available-sources`\n- `allow-run-import`\n- `allow-run-import-dry`\n- `allow-read-text-files`"
         }
       ]
     }

--- a/plugins/importer/src/commands.rs
+++ b/plugins/importer/src/commands.rs
@@ -20,6 +20,15 @@ pub async fn begin_connected_import(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn cancel_connected_import(
+    provider_id: String,
+    state: tauri::State<'_, crate::connected_mcp::ConnectedImportOAuthState>,
+) -> Result<bool, String> {
+    crate::connected_mcp::cancel_connection(&provider_id, &state).await
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn complete_connected_import(
     provider_id: String,
     state: tauri::State<'_, crate::connected_mcp::ConnectedImportOAuthState>,

--- a/plugins/importer/src/connected_mcp.rs
+++ b/plugins/importer/src/connected_mcp.rs
@@ -14,10 +14,12 @@ use rmcp::{
 };
 use serde_json::{Map, Value};
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex, oneshot};
+use tokio_util::sync::CancellationToken;
 use url::Url;
 
 const AUTHORIZATION_TIMEOUT: Duration = Duration::from_secs(5 * 60);
@@ -118,11 +120,18 @@ fn provider(provider_id: &str) -> Result<McpProvider, String> {
 #[derive(Default)]
 pub struct ConnectedImportOAuthState {
     pending: Mutex<Option<PendingAuthorization>>,
+    next_authorization_id: AtomicU64,
 }
 
 struct PendingAuthorization {
+    id: u64,
     provider_id: &'static str,
     provider_name: &'static str,
+    flow: Option<PendingAuthorizationFlow>,
+    cancellation: CancellationToken,
+}
+
+struct PendingAuthorizationFlow {
     manager: AuthorizationManager,
     client_secret: Option<String>,
     callback: oneshot::Receiver<Result<AuthorizationCallback, String>>,
@@ -167,19 +176,33 @@ pub async fn begin_connection(
         .await
         .map_err(|error| auth_error(provider, error))?;
 
+    let cancellation = CancellationToken::new();
+    let callback_cancellation = cancellation.clone();
     let (callback_tx, callback_rx) = oneshot::channel();
     tokio::spawn(async move {
-        let result = receive_authorization_callback(listener, provider.name).await;
+        let result = tokio::select! {
+            result = receive_authorization_callback(listener, provider.name) => result,
+            _ = callback_cancellation.cancelled() => {
+                Err(format!("{} sign-in cancelled.", provider.name))
+            }
+        };
         let _ = callback_tx.send(result);
     });
 
-    *state.pending.lock().await = Some(PendingAuthorization {
+    let pending = PendingAuthorization {
+        id: state.next_authorization_id.fetch_add(1, Ordering::Relaxed),
         provider_id: provider.id,
         provider_name: provider.name,
-        manager,
-        client_secret: client.client_secret,
-        callback: callback_rx,
-    });
+        flow: Some(PendingAuthorizationFlow {
+            manager,
+            client_secret: client.client_secret,
+            callback: callback_rx,
+        }),
+        cancellation,
+    };
+    if let Some(previous) = state.pending.lock().await.replace(pending) {
+        previous.cancellation.cancel();
+    }
 
     Ok(ConnectedImportAuthorization {
         provider_id: provider.id.to_string(),
@@ -187,35 +210,95 @@ pub async fn begin_connection(
     })
 }
 
+pub async fn cancel_connection(
+    provider_id: &str,
+    state: &ConnectedImportOAuthState,
+) -> Result<bool, String> {
+    let provider = provider(provider_id)?;
+    let mut pending = state.pending.lock().await;
+    if pending
+        .as_ref()
+        .is_none_or(|pending| pending.provider_id != provider.id)
+    {
+        return Ok(false);
+    }
+
+    if let Some(pending) = pending.take() {
+        pending.cancellation.cancel();
+    }
+    Ok(true)
+}
+
 pub async fn complete_connection(
     provider_id: &str,
     state: &ConnectedImportOAuthState,
 ) -> Result<ConnectedImportCredentials, String> {
     let provider = provider(provider_id)?;
-    let Some(PendingAuthorization {
-        provider_id: pending_provider_id,
-        provider_name,
-        manager,
-        client_secret,
-        callback,
-    }) = state.pending.lock().await.take()
-    else {
-        return Err(format!("Start {} sign-in again", provider.name));
+    let (authorization_id, provider_name, flow, cancellation) = {
+        let mut pending = state.pending.lock().await;
+        let Some(pending) = pending.as_mut() else {
+            return Err(format!("Start {} sign-in again", provider.name));
+        };
+        if pending.provider_id != provider.id {
+            return Err(format!("Start {} sign-in again", provider.name));
+        }
+        let Some(flow) = pending.flow.take() else {
+            return Err(format!("Start {} sign-in again", provider.name));
+        };
+        (
+            pending.id,
+            pending.provider_name,
+            flow,
+            pending.cancellation.clone(),
+        )
     };
-    if pending_provider_id != provider.id {
-        return Err(format!("Start {} sign-in again", provider.name));
+
+    let result = complete_pending_authorization(provider, provider_name, flow, cancellation).await;
+    let mut pending = state.pending.lock().await;
+    if pending
+        .as_ref()
+        .is_some_and(|pending| pending.id == authorization_id)
+    {
+        pending.take();
     }
+    result
+}
 
-    let callback = tokio::time::timeout(AUTHORIZATION_TIMEOUT, callback)
-        .await
-        .map_err(|_| format!("{provider_name} sign-in timed out. Try again."))?
-        .map_err(|_| format!("{provider_name} sign-in was interrupted. Try again."))??;
+async fn complete_pending_authorization(
+    provider: McpProvider,
+    provider_name: &str,
+    flow: PendingAuthorizationFlow,
+    cancellation: CancellationToken,
+) -> Result<ConnectedImportCredentials, String> {
+    let callback = tokio::select! {
+        result = tokio::time::timeout(AUTHORIZATION_TIMEOUT, flow.callback) => {
+            result
+                .map_err(|_| format!("{provider_name} sign-in timed out. Try again."))?
+                .map_err(|_| format!("{provider_name} sign-in was interrupted. Try again."))??
+        }
+        _ = cancellation.cancelled() => {
+            return Err(format!("{provider_name} sign-in cancelled."));
+        }
+    };
 
-    manager
-        .exchange_code_for_token(&callback.code, &callback.state)
-        .await
-        .map_err(|error| auth_error(provider, error))?;
-    credentials_from_manager(provider, &manager, client_secret, Some(now_epoch_secs())).await
+    tokio::select! {
+        result = flow.manager.exchange_code_for_token(&callback.code, &callback.state) => {
+            result.map_err(|error| auth_error(provider, error))?;
+        }
+        _ = cancellation.cancelled() => {
+            return Err(format!("{provider_name} sign-in cancelled."));
+        }
+    }
+    if cancellation.is_cancelled() {
+        return Err(format!("{provider_name} sign-in cancelled."));
+    }
+    credentials_from_manager(
+        provider,
+        &flow.manager,
+        flow.client_secret,
+        Some(now_epoch_secs()),
+    )
+    .await
 }
 
 pub async fn sync(

--- a/plugins/importer/src/lib.rs
+++ b/plugins/importer/src/lib.rs
@@ -19,6 +19,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
         .plugin_name(PLUGIN_NAME)
         .commands(tauri_specta::collect_commands![
             commands::begin_connected_import,
+            commands::cancel_connected_import,
             commands::complete_connected_import,
             commands::sync_connected_import,
             commands::list_available_sources::<Wry>,


### PR DESCRIPTION
Add a cancellable OAuth callback flow and restore the import connect button after cancellation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the OAuth authorization and credential-completion path for connected imports, including new cancel semantics around pending auth state. Failure modes could leave connections stuck or mishandle credentials on cancel.
> 
> **Overview**
> Users can now **cancel an abandoned browser OAuth connection** on the meeting imports screen and immediately retry, instead of being stuck waiting for the provider callback.
> 
> The connect button switches to **Cancel** while authorization is pending. Cancellation aborts the frontend wait via `AbortSignal` and calls a new `cancel_connected_import` backend command that stops the local OAuth callback listener. Cancelled flows no longer save credentials.
> 
> The importer OAuth state now tracks pending authorizations with cancellation tokens so overlapping or abandoned sign-ins can be cleaned up safely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e99f710aae3d914e30695012a5dc70454d1e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->