### PR TITLE
Add docs to website footer

### DIFF
--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -11,6 +11,7 @@ const footerGroups = [
       { label: "Enterprise", to: "/enterprise/" },
       { label: "Blog", to: "/blog/" },
       { label: "Changelog", to: "/changelog/" },
+      { label: "Docs", href: "https://docs.anarlog.so" },
       { label: "Status", href: "https://status.anarlog.so" },
     ],
   },


### PR DESCRIPTION
Link the shared site footer to the Anarlog documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single footer navigation link addition with no logic, auth, or data-handling changes.
> 
> **Overview**
> Adds a **Docs** link to the Product section of `site-footer`, pointing to `https://docs.anarlog.so`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e7f8fb0a0ff180bd89b28e7007e88cda9ca6b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->