### PR TITLE
Fix shared link previews

### DIFF
--- a/apps/api/openapi.gen.json
+++ b/apps/api/openapi.gen.json
@@ -1495,6 +1495,43 @@
         }
       }
     },
+    "/shared-notes/links/{link_id}/preview": {
+      "get": {
+        "tags": [
+          "shared-notes"
+        ],
+        "operationId": "read_short_link_shared_note_preview",
+        "parameters": [
+          {
+            "name": "link_id",
+            "in": "path",
+            "description": "Session share link ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Short-link shared note preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SharedNoteLinkPreview"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Shared note unavailable"
+          },
+          "502": {
+            "description": "Shared note service unavailable"
+          }
+        }
+      }
+    },
     "/shared-notes/public/{slug}": {
       "get": {
         "tags": [
@@ -9669,6 +9706,36 @@
           }
         },
         "additionalProperties": false
+      },
+      "SharedNoteLinkPreview": {
+        "type": "object",
+        "required": [
+          "shareId",
+          "title",
+          "summary",
+          "participants",
+          "meetingAt"
+        ],
+        "properties": {
+          "meetingAt": {
+            "type": "string"
+          },
+          "participants": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shareId": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       },
       "SharedNoteLinkPreviewRequest": {
         "type": "object",

--- a/apps/api/src/openapi.rs
+++ b/apps/api/src/openapi.rs
@@ -275,6 +275,7 @@ mod tests {
         for (path, method) in [
             ("/shared-notes/public/{slug}", "get"),
             ("/shared-notes/link/{share_id}", "post"),
+            ("/shared-notes/links/{link_id}/preview", "get"),
             ("/shared-notes/public/{slug}/handoff", "post"),
             ("/shared-notes/link/{share_id}/handoff", "post"),
             ("/shared-notes/handoffs/claim", "post"),

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1464,10 +1464,8 @@ describe("SessionShareButton", () => {
       "enable-link",
     ]);
     const copied = new URL(mocks.clipboardWriteText.mock.calls[0]![0]);
-    expect(copied.pathname).toBe(`/share/link/${SHARE_ID}/`);
-    expect(copied.searchParams.get("preview")).toBe(
-      "80383f974f22964fd6b7ae851b6ccc9180ed4e6fcb2e415bafcab6d822139238",
-    );
+    expect(copied.pathname).toBe(`/t/${LINK_ID}/`);
+    expect(copied.search).toBe("");
     expect(copied.hash).toBe(`#token=${TOKEN}`);
     expect(mocks.markSessionShareActivated).toHaveBeenCalledWith(
       USER_ID,

--- a/apps/desktop/src/session-sharing/management.ts
+++ b/apps/desktop/src/session-sharing/management.ts
@@ -18,7 +18,6 @@ import {
   buildPublicSessionShareUrl,
   buildSessionInvitationUrl,
   buildSessionShareLinkUrl,
-  createSessionShareLinkPreviewToken,
   type ShareDesktopScheme,
 } from "./urls";
 
@@ -125,18 +124,13 @@ export async function enableAndCopySessionShareLink({
     }
     if (!link.linkToken) throw new ShareManagementError();
     assertActive();
-    const previewToken = await createSessionShareLinkPreviewToken(
-      link.linkToken,
-    );
-    assertActive();
     const desktopScheme = await getSessionShareDesktopScheme();
     assertActive();
     await copyText(
       buildSessionShareLinkUrl({
         appBaseUrl: env.VITE_APP_URL,
-        shareId,
+        linkId: link.linkId,
         linkToken: link.linkToken,
-        previewToken,
         desktopScheme,
       }),
     );

--- a/apps/desktop/src/session-sharing/urls.test.ts
+++ b/apps/desktop/src/session-sharing/urls.test.ts
@@ -5,13 +5,12 @@ import {
   buildPublicSessionShareUrl,
   buildSessionInvitationUrl,
   buildSessionShareLinkUrl,
-  createSessionShareLinkPreviewToken,
 } from "./urls";
 
 const shareId = "33333333-3333-4333-8333-333333333333";
+const linkId = "44444444-4444-4444-8444-444444444444";
 const invitationId = "55555555-5555-4555-8555-555555555555";
 const token = "t".repeat(43);
-const previewToken = "a".repeat(64);
 const publicSlug = `s_${"a".repeat(32)}`;
 
 describe("session share URLs", () => {
@@ -19,22 +18,14 @@ describe("session share URLs", () => {
     const url = new URL(
       buildSessionShareLinkUrl({
         appBaseUrl: "https://anarlog.so",
-        shareId,
+        linkId,
         linkToken: token,
-        previewToken,
       }),
     );
 
-    expect(url.pathname).toBe(`/share/link/${shareId}/`);
-    expect(url.searchParams.get("preview")).toBe(previewToken);
-    expect(url.searchParams.has("token")).toBe(false);
+    expect(url.pathname).toBe(`/t/${linkId}/`);
+    expect(url.search).toBe("");
     expect(url.hash).toBe(`#token=${token}`);
-  });
-
-  it("derives a metadata-only preview token from the bearer token", async () => {
-    await expect(createSessionShareLinkPreviewToken(token)).resolves.toBe(
-      "80383f974f22964fd6b7ae851b6ccc9180ed4e6fcb2e415bafcab6d822139238",
-    );
   });
 
   it("places invitation tokens only in the fragment", () => {
@@ -70,14 +61,12 @@ describe("session share URLs", () => {
     const linkUrl = new URL(
       buildSessionShareLinkUrl({
         appBaseUrl: "https://anarlog.so",
-        shareId,
+        linkId,
         linkToken: token,
-        previewToken,
         desktopScheme: "anarlog-staging",
       }),
     );
     expect(linkUrl.searchParams.get("scheme")).toBe("anarlog-staging");
-    expect(linkUrl.searchParams.get("preview")).toBe(previewToken);
     expect(linkUrl.hash).toBe(`#token=${token}`);
 
     const publicUrl = new URL(
@@ -103,33 +92,29 @@ describe("session share URLs", () => {
     expect(() =>
       buildSessionShareLinkUrl({
         appBaseUrl: "javascript:alert(1)",
-        shareId,
+        linkId,
         linkToken: token,
-        previewToken,
       }),
     ).toThrow("Share URL is unavailable");
     expect(() =>
       buildSessionShareLinkUrl({
         appBaseUrl: "https://anarlog.so?token=old",
-        shareId,
+        linkId,
         linkToken: token,
-        previewToken,
       }),
     ).toThrow("Share URL is unavailable");
     expect(() =>
       buildSessionShareLinkUrl({
         appBaseUrl: "https://anarlog.so",
-        shareId,
+        linkId,
         linkToken: "bad?token",
-        previewToken,
       }),
     ).toThrow("Share URL is unavailable");
     expect(() =>
       buildSessionShareLinkUrl({
         appBaseUrl: "https://anarlog.so",
-        shareId,
+        linkId: "bad-link",
         linkToken: token,
-        previewToken: "bad-preview",
       }),
     ).toThrow("Share URL is unavailable");
   });

--- a/apps/desktop/src/session-sharing/urls.ts
+++ b/apps/desktop/src/session-sharing/urls.ts
@@ -4,43 +4,25 @@ const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const PUBLIC_SLUG_PATTERN = /^s_[0-9a-f]{32}$/;
 const CAPABILITY_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
-const LINK_PREVIEW_TOKEN_PATTERN = /^[0-9a-f]{64}$/;
 
 export type ShareDesktopScheme = DesktopScheme;
 
 export function buildSessionShareLinkUrl({
   appBaseUrl,
-  shareId,
+  linkId,
   linkToken,
-  previewToken,
   desktopScheme,
 }: {
   appBaseUrl: string;
-  shareId: string;
+  linkId: string;
   linkToken: string;
-  previewToken: string;
   desktopScheme?: ShareDesktopScheme;
 }) {
-  assertUuid(shareId);
+  assertUuid(linkId);
   assertCapabilityToken(linkToken);
-  if (!LINK_PREVIEW_TOKEN_PATTERN.test(previewToken)) {
-    throw invalidUrl();
-  }
-  const url = withDesktopScheme(
-    appUrl(appBaseUrl, `/share/link/${shareId}/`),
-    desktopScheme,
-  );
-  url.searchParams.set("preview", previewToken);
-  return withToken(url, linkToken);
-}
-
-export async function createSessionShareLinkPreviewToken(linkToken: string) {
-  assertCapabilityToken(linkToken);
-  const digest = new Uint8Array(
-    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(linkToken)),
-  );
-  return Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join(
-    "",
+  return withToken(
+    withDesktopScheme(appUrl(appBaseUrl, `/t/${linkId}/`), desktopScheme),
+    linkToken,
   );
 }
 

--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -10,6 +10,13 @@ VITE_APP_URL = "https://anarlog.so"
 NODE_OPTIONS = "--max-old-space-size=4096"
 NODE_VERSION = "22"
 
+[functions]
+included_files = [
+  "public/fonts/Redaction70-Regular.otf",
+  "public/fonts/SF-Pro-Text-Bold.otf",
+  "public/fonts/SF-Pro-Text-Regular.otf",
+]
+
 [images]
 # https://docs.netlify.com/build/image-cdn/overview/#remote-path
 remote_images = [

--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -12,6 +12,7 @@ NODE_VERSION = "22"
 
 [functions]
 included_files = [
+  "public/fonts/fonts.conf",
   "public/fonts/Redaction70-Regular.otf",
   "public/fonts/SF-Pro-Text-Bold.otf",
   "public/fonts/SF-Pro-Text-Regular.otf",

--- a/apps/web/public/fonts/fonts.conf
+++ b/apps/web/public/fonts/fonts.conf
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
+  <dir prefix="relative">.</dir>
+  <cachedir>/tmp/fontconfig-cache</cachedir>
+</fontconfig>

--- a/apps/web/src/lib/auth-route-privacy.test.ts
+++ b/apps/web/src/lib/auth-route-privacy.test.ts
@@ -15,6 +15,7 @@ test("keeps auth, callback, recovery, and share routes telemetry private", () =>
     "/reset-password/",
     "/update-password/",
     "/share/link/example/",
+    "/t/example/",
   ]) {
     assert.equal(isTelemetryPrivateLocation(pathname), true);
   }

--- a/apps/web/src/lib/og-image.test.ts
+++ b/apps/web/src/lib/og-image.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { join } from "node:path";
 import test from "node:test";
 import sharp from "sharp";
 
@@ -27,6 +28,11 @@ test("renders blog metadata into a post-specific image", async () => {
   assert.doesNotMatch(svg, /<rect x=/);
 
   const response = await renderBlogOgImage({ title: "Dynamic blog post" });
+  assert.ok(
+    process.env.FONTCONFIG_FILE?.endsWith(
+      join("public", "fonts", "fonts.conf"),
+    ),
+  );
   const metadata = await sharp(
     Buffer.from(await response.arrayBuffer()),
   ).metadata();

--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import sharp from "sharp";
 
 import {
@@ -16,6 +18,10 @@ const OG_HEIGHT = 630;
 const CACHE_CONTROL =
   "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800";
 const SHARED_NOTE_CACHE_CONTROL = "public, max-age=0, s-maxage=60";
+const SERIF_FONT_FAMILY = "Redaction 70, Georgia, serif";
+const SANS_FONT_FAMILY = "SF Pro Text, Arial, sans-serif";
+
+let ogFontsReady: Promise<void> | undefined;
 
 type BlogOgImageInput = {
   title: string;
@@ -146,7 +152,7 @@ function createParticipantAvatarStack(
       const centerX = 100 + index * 42;
       const gradientId = `avatar-gradient-${index}`;
       const clipId = `avatar-clip-${index}`;
-      return `<defs>${createAvatarGradientSvg(avatar.seed, gradientId)}<clipPath id="${clipId}"><circle cx="${centerX}" cy="${centerY}" r="28"/></clipPath></defs><g data-avatar="participant" data-avatar-renderer="app"><circle cx="${centerX}" cy="${centerY}" r="28" fill="url(#${gradientId})"/>${avatar.image ? `<image href="${avatar.image}" x="${centerX - 28}" y="${centerY - 28}" width="56" height="56" preserveAspectRatio="xMidYMid slice" clip-path="url(#${clipId})"/>` : ""}<circle cx="${centerX}" cy="${centerY}" r="30" fill="none" stroke="#f4f0e8" stroke-width="4"/><text x="${centerX}" y="${centerY + 7}" fill="#ffffff" fill-opacity="0.82" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" text-anchor="middle" style="mix-blend-mode:overlay">${escapeXml(avatar.label)}</text></g>`;
+      return `<defs>${createAvatarGradientSvg(avatar.seed, gradientId)}<clipPath id="${clipId}"><circle cx="${centerX}" cy="${centerY}" r="28"/></clipPath></defs><g data-avatar="participant" data-avatar-renderer="app"><circle cx="${centerX}" cy="${centerY}" r="28" fill="url(#${gradientId})"/>${avatar.image ? `<image href="${avatar.image}" x="${centerX - 28}" y="${centerY - 28}" width="56" height="56" preserveAspectRatio="xMidYMid slice" clip-path="url(#${clipId})"/>` : ""}<circle cx="${centerX}" cy="${centerY}" r="30" fill="none" stroke="#f4f0e8" stroke-width="4"/><text x="${centerX}" y="${centerY + 7}" fill="#ffffff" fill-opacity="0.82" font-family="${SANS_FONT_FAMILY}" font-size="18" font-weight="700" text-anchor="middle" style="mix-blend-mode:overlay">${escapeXml(avatar.label)}</text></g>`;
     })
     .reverse()
     .join("");
@@ -205,16 +211,16 @@ export function createBlogOgSvg(input: BlogOgImageInput) {
   ${title
     .map(
       (line, index) =>
-        `<text x="86" y="${titleStartY + index * 86}" fill="#181613" font-family="Georgia, 'Times New Roman', serif" font-size="76" font-weight="700">${escapeXml(line)}</text>`,
+        `<text x="86" y="${titleStartY + index * 86}" fill="#181613" font-family="${SERIF_FONT_FAMILY}" font-size="76" font-weight="700">${escapeXml(line)}</text>`,
     )
     .join("")}
   ${description
     .map(
       (line, index) =>
-        `<text x="90" y="${descriptionStartY + index * 42}" fill="#57534e" font-family="Arial, Helvetica, sans-serif" font-size="32" font-weight="500">${escapeXml(line)}</text>`,
+        `<text x="90" y="${descriptionStartY + index * 42}" fill="#57534e" font-family="${SANS_FONT_FAMILY}" font-size="32" font-weight="500">${escapeXml(line)}</text>`,
     )
     .join("")}
-  <text x="86" y="552" fill="#756b5d" font-family="Arial, Helvetica, sans-serif" font-size="26" font-weight="600">${escapeXml(meta || "anarlog.so")}</text>
+  <text x="86" y="552" fill="#756b5d" font-family="${SANS_FONT_FAMILY}" font-size="26" font-weight="600">${escapeXml(meta || "anarlog.so")}</text>
   ${createAnarlogWordmark({ x: 962, y: 516, width: 152 })}
 </svg>`;
 }
@@ -262,19 +268,20 @@ export function createSharedNoteOgSvg(
   ${title
     .map(
       (line, index) =>
-        `<text x="72" y="${titleStartY + index * 82}" fill="#181613" font-family="Georgia, 'Times New Roman', serif" font-size="${titleFontSize}" font-weight="700">${escapeXml(line)}</text>`,
+        `<text x="72" y="${titleStartY + index * 82}" fill="#181613" font-family="${SERIF_FONT_FAMILY}" font-size="${titleFontSize}" font-weight="700">${escapeXml(line)}</text>`,
     )
     .join("")}
-  ${summary ? `<text data-summary="meeting" x="72" y="${summaryY}" fill="#57534e" font-family="Arial, Helvetica, sans-serif" font-size="31" font-weight="500">${escapeXml(summary)}</text>` : ""}
+  ${summary ? `<text data-summary="meeting" x="72" y="${summaryY}" fill="#57534e" font-family="${SANS_FONT_FAMILY}" font-size="31" font-weight="500">${escapeXml(summary)}</text>` : ""}
   ${createParticipantAvatarStack(avatarParticipants, avatarImages, footerCenterY)}
-  <text x="${participantX}" y="${footerCenterY + 9}"${participantTextLength} fill="#37322d" font-family="Arial, Helvetica, sans-serif" font-size="27" font-weight="600">${escapeXml(participantSummary)}</text>
+  <text x="${participantX}" y="${footerCenterY + 9}"${participantTextLength} fill="#37322d" font-family="${SANS_FONT_FAMILY}" font-size="27" font-weight="600">${escapeXml(participantSummary)}</text>
   <circle cx="${separatorX}" cy="${footerCenterY}" r="3" fill="#9d9387"/>
-  <text x="${dateX}" y="${footerCenterY + 9}" fill="#57534e" font-family="Arial, Helvetica, sans-serif" font-size="27" font-weight="500">${escapeXml(date)}</text>
+  <text x="${dateX}" y="${footerCenterY + 9}" fill="#57534e" font-family="${SANS_FONT_FAMILY}" font-size="27" font-weight="500">${escapeXml(date)}</text>
   ${createAnarlogWordmark({ x: 963, y: 477, width: 165 })}
 </svg>`;
 }
 
 async function renderOgImage(svg: string, cacheControl: string) {
+  await ensureOgFonts();
   const png = await sharp(Buffer.from(svg)).png().toBuffer();
 
   return new Response(new Uint8Array(png), {
@@ -283,6 +290,44 @@ async function renderOgImage(svg: string, cacheControl: string) {
       "Content-Type": "image/png",
     },
   });
+}
+
+function ensureOgFonts() {
+  if (!ogFontsReady) {
+    ogFontsReady = registerOgFonts();
+  }
+  return ogFontsReady;
+}
+
+async function registerOgFonts() {
+  for (const [filename, font] of [
+    ["Redaction70-Regular.otf", "Redaction 70 12"],
+    ["SF-Pro-Text-Regular.otf", "SF Pro Text 12"],
+    ["SF-Pro-Text-Bold.otf", "SF Pro Text Bold 12"],
+  ] as const) {
+    await sharp({
+      text: {
+        text: "Anarlog",
+        font,
+        fontfile: resolveOgFont(filename),
+        rgba: true,
+      },
+    })
+      .png()
+      .toBuffer();
+  }
+}
+
+function resolveOgFont(filename: string) {
+  const candidates = [
+    join(process.cwd(), "public", "fonts", filename),
+    join(process.cwd(), "apps", "web", "public", "fonts", filename),
+  ];
+  const path = candidates.find(existsSync);
+  if (!path) {
+    throw new Error(`Open Graph font is unavailable: ${filename}`);
+  }
+  return path;
 }
 
 export async function renderBlogOgImage(input: BlogOgImageInput) {

--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -20,8 +20,9 @@ const CACHE_CONTROL =
 const SHARED_NOTE_CACHE_CONTROL = "public, max-age=0, s-maxage=60";
 const SERIF_FONT_FAMILY = "Redaction 70, Georgia, serif";
 const SANS_FONT_FAMILY = "SF Pro Text, Arial, sans-serif";
+const FONT_CONFIG_FILENAME = "fonts.conf";
 
-let ogFontsReady: Promise<void> | undefined;
+let ogFontsConfigured = false;
 
 type BlogOgImageInput = {
   title: string;
@@ -281,7 +282,7 @@ export function createSharedNoteOgSvg(
 }
 
 async function renderOgImage(svg: string, cacheControl: string) {
-  await ensureOgFonts();
+  configureOgFonts();
   const png = await sharp(Buffer.from(svg)).png().toBuffer();
 
   return new Response(new Uint8Array(png), {
@@ -292,42 +293,16 @@ async function renderOgImage(svg: string, cacheControl: string) {
   });
 }
 
-function ensureOgFonts() {
-  if (!ogFontsReady) {
-    ogFontsReady = registerOgFonts();
-  }
-  return ogFontsReady;
-}
+function configureOgFonts() {
+  if (ogFontsConfigured) return;
+  ogFontsConfigured = true;
 
-async function registerOgFonts() {
-  for (const [filename, font] of [
-    ["Redaction70-Regular.otf", "Redaction 70 12"],
-    ["SF-Pro-Text-Regular.otf", "SF Pro Text 12"],
-    ["SF-Pro-Text-Bold.otf", "SF Pro Text Bold 12"],
-  ] as const) {
-    await sharp({
-      text: {
-        text: "Anarlog",
-        font,
-        fontfile: resolveOgFont(filename),
-        rgba: true,
-      },
-    })
-      .png()
-      .toBuffer();
-  }
-}
-
-function resolveOgFont(filename: string) {
   const candidates = [
-    join(process.cwd(), "public", "fonts", filename),
-    join(process.cwd(), "apps", "web", "public", "fonts", filename),
+    join(process.cwd(), "public", "fonts", FONT_CONFIG_FILENAME),
+    join(process.cwd(), "apps", "web", "public", "fonts", FONT_CONFIG_FILENAME),
   ];
-  const path = candidates.find(existsSync);
-  if (!path) {
-    throw new Error(`Open Graph font is unavailable: ${filename}`);
-  }
-  return path;
+  const fontConfigPath = candidates.find(existsSync);
+  if (fontConfigPath) process.env.FONTCONFIG_FILE = fontConfigPath;
 }
 
 export async function renderBlogOgImage(input: BlogOgImageInput) {
@@ -335,6 +310,7 @@ export async function renderBlogOgImage(input: BlogOgImageInput) {
 }
 
 export async function renderSharedNoteOgImage(input: SharedNoteOgImageInput) {
+  configureOgFonts();
   const participantPresentation = createSharedNoteParticipantPresentation(
     input.participants ?? [],
   );

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -37,6 +37,10 @@ export function getLinkSharedNoteOgImageUrl(
   return url.toString();
 }
 
+export function getShortLinkSharedNoteOgImageUrl(linkId: string) {
+  return `${ANARLOG_SITE_URL}/api/og/share/t/${encodeURIComponent(linkId)}`;
+}
+
 type StructuredDataNode = Record<string, unknown>;
 
 export function getStructuredDataGraph(nodes: StructuredDataNode[]) {

--- a/apps/web/src/lib/share-route-privacy.test.ts
+++ b/apps/web/src/lib/share-route-privacy.test.ts
@@ -21,6 +21,7 @@ test("identifies every shared-note route as telemetry private", () => {
     "/share/abc/",
     "/share/invite/abc/",
     "/share/link/abc/",
+    "/t/abc/",
     "/share/public/s_abc/",
   ]) {
     assert.equal(isShareRoutePathname(pathname), true);
@@ -31,6 +32,7 @@ test("identifies every shared-note route as telemetry private", () => {
 test("identifies only invitation and link routes as capability routes", () => {
   assert.equal(isCapabilityShareRoutePathname("/share/invite/abc/"), true);
   assert.equal(isCapabilityShareRoutePathname("/share/link/abc/"), true);
+  assert.equal(isCapabilityShareRoutePathname("/t/abc/"), true);
   assert.equal(isCapabilityShareRoutePathname("/share/abc/"), false);
   assert.equal(isCapabilityShareRoutePathname("/share/public/s_abc/"), false);
 });

--- a/apps/web/src/lib/share-route-privacy.ts
+++ b/apps/web/src/lib/share-route-privacy.ts
@@ -4,13 +4,19 @@ const SHARE_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 let inMemoryToken: { pathname: string; token: string } | null = null;
 
 export function isShareRoutePathname(pathname: string) {
-  return pathname === "/share" || pathname.startsWith("/share/");
+  return (
+    pathname === "/share" ||
+    pathname.startsWith("/share/") ||
+    pathname === "/t" ||
+    pathname.startsWith("/t/")
+  );
 }
 
 export function isCapabilityShareRoutePathname(pathname: string) {
   return (
     /^\/share\/invite\/[^/]+\/?$/.test(pathname) ||
-    /^\/share\/link\/[^/]+\/?$/.test(pathname)
+    /^\/share\/link\/[^/]+\/?$/.test(pathname) ||
+    /^\/t\/[^/]+\/?$/.test(pathname)
   );
 }
 

--- a/apps/web/src/lib/shared-note-api.ts
+++ b/apps/web/src/lib/shared-note-api.ts
@@ -2,12 +2,15 @@ import { env } from "@/env";
 import { isShareRouteToken } from "@/lib/share-route-privacy";
 import {
   parseGatewaySharedNote,
+  parseSharedNoteLinkPreview,
   parseSharedNotePreview,
   parseSharedNoteAttachmentDownload,
   parseShareHandoff,
   linkSharePreviewTokenSchema,
   publicShareSlugSchema,
+  shareLinkIdSchema,
   shareIdSchema,
+  type SharedNoteLinkPreview,
   type SharedNoteSnapshot,
   type SharedNotePreview,
   type SharedNoteAttachmentDownload,
@@ -24,6 +27,11 @@ export type SharedNoteReadResult =
 
 export type SharedNotePreviewReadResult =
   | { status: "ready"; preview: SharedNotePreview }
+  | { status: "unavailable" }
+  | { status: "error" };
+
+export type SharedNoteLinkPreviewReadResult =
+  | { status: "ready"; preview: SharedNoteLinkPreview }
   | { status: "unavailable" }
   | { status: "error" };
 
@@ -115,6 +123,31 @@ export async function fetchLinkSharedNotePreviewResult(
 
   try {
     return { status: "ready", preview: parseSharedNotePreview(result.value) };
+  } catch {
+    return { status: "error" };
+  }
+}
+
+export async function fetchShortLinkSharedNotePreviewResult(
+  linkId: string,
+  signal?: AbortSignal,
+): Promise<SharedNoteLinkPreviewReadResult> {
+  const parsedLinkId = shareLinkIdSchema.safeParse(linkId);
+  if (!parsedLinkId.success) {
+    return { status: "unavailable" };
+  }
+
+  const result = await requestJsonResult(
+    `/shared-notes/links/${encodeURIComponent(parsedLinkId.data)}/preview`,
+    { method: "GET", signal },
+  );
+  if (result.status !== "ready") return result;
+
+  try {
+    return {
+      status: "ready",
+      preview: parseSharedNoteLinkPreview(result.value),
+    };
   } catch {
     return { status: "error" };
   }

--- a/apps/web/src/lib/shared-note-meta.test.ts
+++ b/apps/web/src/lib/shared-note-meta.test.ts
@@ -5,10 +5,12 @@ import {
   getLinkShareHead,
   getPrivateShareHead,
   getPublicShareHead,
+  getShortLinkShareHead,
   privateShareHeaders,
 } from "./shared-note-meta.ts";
 
 const shareId = "00000000-0000-4000-8000-000000000001";
+const linkId = "00000000-0000-4000-8000-000000000002";
 const previewToken = "a".repeat(64);
 
 test("private share metadata disables indexing, referrers, and AI indexing", () => {
@@ -69,6 +71,24 @@ test("link previews fail closed without a valid preview result", () => {
   assert.deepEqual(
     getLinkShareHead(shareId, previewToken, null),
     getPrivateShareHead(),
+  );
+});
+
+test("short links receive note-specific social metadata without a query token", () => {
+  const head = getShortLinkShareHead(linkId, {
+    title: "Sprint planning",
+    summary: "The team agreed on the next sprint's priorities.",
+    participants: ["John Jeong", "Sungbin Jo"],
+    meetingAt: "2026-08-06T00:00:00Z",
+  });
+
+  assert.ok(
+    head.meta.some(
+      (meta) =>
+        "property" in meta &&
+        meta.property === "og:image" &&
+        meta.content === `https://anarlog.so/api/og/share/t/${linkId}`,
+    ),
   );
 });
 

--- a/apps/web/src/lib/shared-note-meta.ts
+++ b/apps/web/src/lib/shared-note-meta.ts
@@ -2,6 +2,7 @@ import {
   ANARLOG_SITE_URL,
   getLinkSharedNoteOgImageUrl,
   getPublicSharedNoteOgImageUrl,
+  getShortLinkSharedNoteOgImageUrl,
 } from "./seo.ts";
 import {
   getSharedNoteDescription,
@@ -38,6 +39,39 @@ export function getLinkShareHead(
   const title = preview.title || "Shared note";
   const description = getPreviewDescription(preview);
   const imageUrl = getLinkSharedNoteOgImageUrl(shareId, previewToken);
+
+  return {
+    meta: [
+      ...getPrivateShareMeta(`${title} · Anarlog`),
+      { name: "description", content: description },
+      { property: "og:type", content: "article" },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:image", content: imageUrl },
+      { property: "og:image:type", content: "image/png" },
+      { property: "og:image:width", content: "1200" },
+      { property: "og:image:height", content: "630" },
+      { property: "og:image:alt", content: `Preview of ${title}` },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+      { name: "twitter:image", content: imageUrl },
+      { name: "twitter:image:alt", content: `Preview of ${title}` },
+    ],
+  };
+}
+
+export function getShortLinkShareHead(
+  linkId: string,
+  preview: SharedNotePreview | null | undefined,
+) {
+  if (!preview) {
+    return getPrivateShareHead();
+  }
+
+  const title = preview.title || "Shared note";
+  const description = getPreviewDescription(preview);
+  const imageUrl = getShortLinkSharedNoteOgImageUrl(linkId);
 
   return {
     meta: [

--- a/apps/web/src/lib/shared-notes.test.ts
+++ b/apps/web/src/lib/shared-notes.test.ts
@@ -18,6 +18,7 @@ import {
   parseSharedNoteAttachmentDownload,
   parseSharedNoteComment,
   parseSharedNoteCommentPage,
+  parseSharedNoteLinkPreview,
   parseSharedNotePreview,
   parseSharedNoteWebEditConflict,
   parseSharedNoteWebEditSnapshot,
@@ -118,6 +119,22 @@ test("bounds preview summaries by Unicode scalar count", () => {
   assert.equal(parseSharedNotePreview(preview).summary, summary);
   assert.throws(() =>
     parseSharedNotePreview({ ...preview, summary: "😀".repeat(181) }),
+  );
+});
+
+test("parses a short-link preview with its resolved share ID", () => {
+  const shareId = "00000000-0000-4000-8000-000000000001";
+  const preview = parseSharedNoteLinkPreview({
+    shareId,
+    title: "Weekly sync",
+    summary: "Decisions and next steps.",
+    participants: ["John Jeong"],
+    meetingAt: "2026-07-17T12:00:00Z",
+  });
+
+  assert.equal(preview.shareId, shareId);
+  assert.throws(() =>
+    parseSharedNoteLinkPreview({ ...preview, shareId: "not-a-uuid" }),
   );
 });
 

--- a/apps/web/src/lib/shared-notes.ts
+++ b/apps/web/src/lib/shared-notes.ts
@@ -6,6 +6,7 @@ const MAX_BODY_NODES = 50_000;
 const MAX_TITLE_BYTES = 4096;
 
 export const shareIdSchema = z.string().uuid();
+export const shareLinkIdSchema = z.string().uuid();
 export const invitationIdSchema = z.string().uuid();
 export const publicShareSlugSchema = z.string().regex(/^s_[0-9a-f]{32}$/);
 export const linkSharePreviewTokenSchema = z.string().regex(/^[0-9a-f]{64}$/);
@@ -89,6 +90,10 @@ export type SharedNotePreview = {
   summary: string;
   participants: string[];
   meetingAt: string;
+};
+
+export type SharedNoteLinkPreview = SharedNotePreview & {
+  shareId: string;
 };
 
 export type SharedNoteWebEditSnapshot = {
@@ -272,6 +277,10 @@ const sharedNotePreviewSchema = z
   })
   .strict();
 
+const sharedNoteLinkPreviewSchema = sharedNotePreviewSchema
+  .extend({ shareId: shareIdSchema })
+  .strict();
+
 const webEditSnapshotSchema = gatewaySnapshotSchema
   .extend({
     accessVersion: z.number().int().positive().safe(),
@@ -439,6 +448,17 @@ export function parseGatewaySharedNote(value: unknown): SharedNoteSnapshot {
 
 export function parseSharedNotePreview(value: unknown): SharedNotePreview {
   const parsed = sharedNotePreviewSchema.parse(value);
+  return {
+    ...parsed,
+    title: parseTitle(parsed.title),
+    meetingAt: parseTimestamp(parsed.meetingAt),
+  };
+}
+
+export function parseSharedNoteLinkPreview(
+  value: unknown,
+): SharedNoteLinkPreview {
+  const parsed = sharedNoteLinkPreviewSchema.parse(value);
   return {
     ...parsed,
     title: parseTitle(parsed.title),

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as PricingIndexRouteImport } from './routes/pricing/index'
 import { Route as EnterpriseIndexRouteImport } from './routes/enterprise/index'
 import { Route as ChangelogIndexRouteImport } from './routes/changelog/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as TLinkIdRouteImport } from './routes/t/$linkId'
 import { Route as ShareShareIdRouteImport } from './routes/share/$shareId'
 import { Route as ChangelogVersionRouteImport } from './routes/changelog/$version'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
@@ -75,6 +76,7 @@ import { Route as ApiAdminContentDeleteRouteImport } from './routes/api/admin/co
 import { Route as ApiAdminContentCreateRouteImport } from './routes/api/admin/content/create'
 import { Route as ApiAdminContentAuditRouteImport } from './routes/api/admin/content/audit'
 import { Route as ApiAdminBlogUploadImageRouteImport } from './routes/api/admin/blog/upload-image'
+import { Route as ApiOgShareTLinkIdRouteImport } from './routes/api/og/share/t/$linkId'
 import { Route as ApiOgSharePublicPublicSlugRouteImport } from './routes/api/og/share/public/$publicSlug'
 import { Route as ApiOgShareLinkShareIdRouteImport } from './routes/api/og/share/link/$shareId'
 
@@ -145,6 +147,11 @@ const ChangelogIndexRoute = ChangelogIndexRouteImport.update({
 const BlogIndexRoute = BlogIndexRouteImport.update({
   id: '/blog/',
   path: '/blog/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TLinkIdRoute = TLinkIdRouteImport.update({
+  id: '/t/$linkId',
+  path: '/t/$linkId',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ShareShareIdRoute = ShareShareIdRouteImport.update({
@@ -414,6 +421,11 @@ const ApiAdminBlogUploadImageRoute = ApiAdminBlogUploadImageRouteImport.update({
   path: '/api/admin/blog/upload-image',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiOgShareTLinkIdRoute = ApiOgShareTLinkIdRouteImport.update({
+  id: '/api/og/share/t/$linkId',
+  path: '/api/og/share/t/$linkId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiOgSharePublicPublicSlugRoute =
   ApiOgSharePublicPublicSlugRouteImport.update({
     id: '/api/og/share/public/$publicSlug',
@@ -442,6 +454,7 @@ export interface FileRoutesByFullPath {
   '/blog/$slug': typeof BlogSlugRoute
   '/changelog/$version': typeof ChangelogVersionRoute
   '/share/$shareId': typeof ShareShareIdRoute
+  '/t/$linkId': typeof TLinkIdRoute
   '/blog/': typeof BlogIndexRoute
   '/changelog/': typeof ChangelogIndexRoute
   '/enterprise/': typeof EnterpriseIndexRoute
@@ -494,6 +507,7 @@ export interface FileRoutesByFullPath {
   '/api/og/blog/$slug': typeof ApiOgBlogSlugRoute
   '/api/og/share/link/$shareId': typeof ApiOgShareLinkShareIdRoute
   '/api/og/share/public/$publicSlug': typeof ApiOgSharePublicPublicSlugRoute
+  '/api/og/share/t/$linkId': typeof ApiOgShareTLinkIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -510,6 +524,7 @@ export interface FileRoutesByTo {
   '/blog/$slug': typeof BlogSlugRoute
   '/changelog/$version': typeof ChangelogVersionRoute
   '/share/$shareId': typeof ShareShareIdRoute
+  '/t/$linkId': typeof TLinkIdRoute
   '/blog': typeof BlogIndexRoute
   '/changelog': typeof ChangelogIndexRoute
   '/enterprise': typeof EnterpriseIndexRoute
@@ -562,6 +577,7 @@ export interface FileRoutesByTo {
   '/api/og/blog/$slug': typeof ApiOgBlogSlugRoute
   '/api/og/share/link/$shareId': typeof ApiOgShareLinkShareIdRoute
   '/api/og/share/public/$publicSlug': typeof ApiOgSharePublicPublicSlugRoute
+  '/api/og/share/t/$linkId': typeof ApiOgShareTLinkIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -581,6 +597,7 @@ export interface FileRoutesById {
   '/blog/$slug': typeof BlogSlugRoute
   '/changelog/$version': typeof ChangelogVersionRoute
   '/share/$shareId': typeof ShareShareIdRoute
+  '/t/$linkId': typeof TLinkIdRoute
   '/blog/': typeof BlogIndexRoute
   '/changelog/': typeof ChangelogIndexRoute
   '/enterprise/': typeof EnterpriseIndexRoute
@@ -633,6 +650,7 @@ export interface FileRoutesById {
   '/api/og/blog/$slug': typeof ApiOgBlogSlugRoute
   '/api/og/share/link/$shareId': typeof ApiOgShareLinkShareIdRoute
   '/api/og/share/public/$publicSlug': typeof ApiOgSharePublicPublicSlugRoute
+  '/api/og/share/t/$linkId': typeof ApiOgShareTLinkIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -652,6 +670,7 @@ export interface FileRouteTypes {
     | '/blog/$slug'
     | '/changelog/$version'
     | '/share/$shareId'
+    | '/t/$linkId'
     | '/blog/'
     | '/changelog/'
     | '/enterprise/'
@@ -704,6 +723,7 @@ export interface FileRouteTypes {
     | '/api/og/blog/$slug'
     | '/api/og/share/link/$shareId'
     | '/api/og/share/public/$publicSlug'
+    | '/api/og/share/t/$linkId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -720,6 +740,7 @@ export interface FileRouteTypes {
     | '/blog/$slug'
     | '/changelog/$version'
     | '/share/$shareId'
+    | '/t/$linkId'
     | '/blog'
     | '/changelog'
     | '/enterprise'
@@ -772,6 +793,7 @@ export interface FileRouteTypes {
     | '/api/og/blog/$slug'
     | '/api/og/share/link/$shareId'
     | '/api/og/share/public/$publicSlug'
+    | '/api/og/share/t/$linkId'
   id:
     | '__root__'
     | '/'
@@ -790,6 +812,7 @@ export interface FileRouteTypes {
     | '/blog/$slug'
     | '/changelog/$version'
     | '/share/$shareId'
+    | '/t/$linkId'
     | '/blog/'
     | '/changelog/'
     | '/enterprise/'
@@ -842,6 +865,7 @@ export interface FileRouteTypes {
     | '/api/og/blog/$slug'
     | '/api/og/share/link/$shareId'
     | '/api/og/share/public/$publicSlug'
+    | '/api/og/share/t/$linkId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -860,6 +884,7 @@ export interface RootRouteChildren {
   BlogSlugRoute: typeof BlogSlugRoute
   ChangelogVersionRoute: typeof ChangelogVersionRoute
   ShareShareIdRoute: typeof ShareShareIdRoute
+  TLinkIdRoute: typeof TLinkIdRoute
   BlogIndexRoute: typeof BlogIndexRoute
   ChangelogIndexRoute: typeof ChangelogIndexRoute
   EnterpriseIndexRoute: typeof EnterpriseIndexRoute
@@ -899,6 +924,7 @@ export interface RootRouteChildren {
   ApiOgBlogSlugRoute: typeof ApiOgBlogSlugRoute
   ApiOgShareLinkShareIdRoute: typeof ApiOgShareLinkShareIdRoute
   ApiOgSharePublicPublicSlugRoute: typeof ApiOgSharePublicPublicSlugRoute
+  ApiOgShareTLinkIdRoute: typeof ApiOgShareTLinkIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -999,6 +1025,13 @@ declare module '@tanstack/react-router' {
       path: '/blog'
       fullPath: '/blog/'
       preLoaderRoute: typeof BlogIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/t/$linkId': {
+      id: '/t/$linkId'
+      path: '/t/$linkId'
+      fullPath: '/t/$linkId'
+      preLoaderRoute: typeof TLinkIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/share/$shareId': {
@@ -1365,6 +1398,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAdminBlogUploadImageRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/og/share/t/$linkId': {
+      id: '/api/og/share/t/$linkId'
+      path: '/api/og/share/t/$linkId'
+      fullPath: '/api/og/share/t/$linkId'
+      preLoaderRoute: typeof ApiOgShareTLinkIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/og/share/public/$publicSlug': {
       id: '/api/og/share/public/$publicSlug'
       path: '/api/og/share/public/$publicSlug'
@@ -1446,6 +1486,7 @@ const rootRouteChildren: RootRouteChildren = {
   BlogSlugRoute: BlogSlugRoute,
   ChangelogVersionRoute: ChangelogVersionRoute,
   ShareShareIdRoute: ShareShareIdRoute,
+  TLinkIdRoute: TLinkIdRoute,
   BlogIndexRoute: BlogIndexRoute,
   ChangelogIndexRoute: ChangelogIndexRoute,
   EnterpriseIndexRoute: EnterpriseIndexRoute,
@@ -1485,6 +1526,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiOgBlogSlugRoute: ApiOgBlogSlugRoute,
   ApiOgShareLinkShareIdRoute: ApiOgShareLinkShareIdRoute,
   ApiOgSharePublicPublicSlugRoute: ApiOgSharePublicPublicSlugRoute,
+  ApiOgShareTLinkIdRoute: ApiOgShareTLinkIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/api/og/share/t/$linkId.ts
+++ b/apps/web/src/routes/api/og/share/t/$linkId.ts
@@ -1,0 +1,41 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { renderSharedNoteOgImage } from "@/lib/og-image";
+import { fetchShortLinkSharedNotePreviewResult } from "@/lib/shared-note-api";
+import { shareLinkIdSchema } from "@/lib/shared-notes";
+
+export const Route = createFileRoute("/api/og/share/t/$linkId")({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        const linkId = shareLinkIdSchema.safeParse(params.linkId);
+        if (!linkId.success) return notFound();
+
+        const result = await fetchShortLinkSharedNotePreviewResult(linkId.data);
+        if (result.status === "unavailable") return notFound();
+        if (result.status === "error") return serviceUnavailable();
+
+        return renderSharedNoteOgImage({
+          title: result.preview.title || "Shared note",
+          summary: result.preview.summary,
+          participants: result.preview.participants,
+          meetingAt: result.preview.meetingAt,
+        });
+      },
+    },
+  },
+});
+
+function notFound() {
+  return new Response("Not found", {
+    status: 404,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+function serviceUnavailable() {
+  return new Response("Unable to load shared note", {
+    status: 503,
+    headers: { "Cache-Control": "no-store" },
+  });
+}

--- a/apps/web/src/routes/share/link/$shareId.tsx
+++ b/apps/web/src/routes/share/link/$shareId.tsx
@@ -41,6 +41,7 @@ import {
   linkSharePreviewTokenSchema,
   sharedNoteDesktopSchemeSchema,
   shareIdSchema,
+  type SharedNoteDesktopScheme,
   type SharedNotePreview,
 } from "@/lib/shared-notes";
 
@@ -86,28 +87,31 @@ export const Route = createFileRoute("/share/link/$shareId")({
 function Component() {
   const { preview } = Route.useLoaderData();
   const { shareId } = Route.useParams();
+  const { scheme } = Route.useSearch();
   const { user } = Route.useRouteContext();
   return (
     <ClientOnly fallback={<SharedNoteLoading />}>
       <LinkSharedNoteClient
         currentUserId={user?.id ?? null}
         meetingMetadata={preview}
+        scheme={scheme}
         shareId={shareId}
       />
     </ClientOnly>
   );
 }
 
-function LinkSharedNoteClient({
+export function LinkSharedNoteClient({
   currentUserId,
   meetingMetadata,
+  scheme,
   shareId,
 }: {
   currentUserId: string | null;
   meetingMetadata: SharedNotePreview | null;
+  scheme: SharedNoteDesktopScheme;
   shareId: string;
 }) {
-  const { scheme } = Route.useSearch();
   const pathname = window.location.pathname;
   const continuation = useShareRouteContinuation(pathname);
   const hasToken = continuation.token !== null;

--- a/apps/web/src/routes/t/$linkId.tsx
+++ b/apps/web/src/routes/t/$linkId.tsx
@@ -1,0 +1,59 @@
+import { ClientOnly, createFileRoute } from "@tanstack/react-router";
+
+import {
+  SharedNoteLoading,
+  SharedNoteUnavailable,
+} from "@/components/shared-note-viewer";
+import { fetchUser } from "@/functions/auth";
+import { prepareShareRoutePrivacy } from "@/lib/share-route-privacy";
+import { fetchShortLinkSharedNotePreviewResult } from "@/lib/shared-note-api";
+import {
+  getPrivateShareHead,
+  getShortLinkShareHead,
+  privateShareHeaders,
+} from "@/lib/shared-note-meta";
+import {
+  shareLinkIdSchema,
+  sharedNoteDesktopSchemeSchema,
+} from "@/lib/shared-notes";
+import { LinkSharedNoteClient } from "@/routes/share/link/$shareId";
+
+export const Route = createFileRoute("/t/$linkId")({
+  validateSearch: (search) => ({
+    scheme: sharedNoteDesktopSchemeSchema.parse(search.scheme),
+  }),
+  beforeLoad: async () => {
+    prepareShareRoutePrivacy();
+    return { user: await fetchUser() };
+  },
+  loader: async ({ params }) => {
+    const linkId = shareLinkIdSchema.safeParse(params.linkId);
+    if (!linkId.success) return null;
+    const result = await fetchShortLinkSharedNotePreviewResult(linkId.data);
+    return result.status === "ready" ? result.preview : null;
+  },
+  head: ({ loaderData, params }) =>
+    loaderData
+      ? getShortLinkShareHead(params.linkId, loaderData)
+      : getPrivateShareHead(),
+  headers: () => privateShareHeaders,
+  component: Component,
+});
+
+function Component() {
+  const preview = Route.useLoaderData();
+  const { scheme } = Route.useSearch();
+  const { user } = Route.useRouteContext();
+  if (!preview) return <SharedNoteUnavailable />;
+
+  return (
+    <ClientOnly fallback={<SharedNoteLoading />}>
+      <LinkSharedNoteClient
+        currentUserId={user?.id ?? null}
+        meetingMetadata={preview}
+        scheme={scheme}
+        shareId={preview.shareId}
+      />
+    </ClientOnly>
+  );
+}

--- a/apps/web/src/routes/t/$linkId.tsx
+++ b/apps/web/src/routes/t/$linkId.tsx
@@ -1,7 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
 import { ClientOnly, createFileRoute } from "@tanstack/react-router";
 
 import {
   SharedNoteLoading,
+  SharedNoteTransientError,
   SharedNoteUnavailable,
 } from "@/components/shared-note-viewer";
 import { fetchUser } from "@/functions/auth";
@@ -15,6 +17,7 @@ import {
 import {
   shareLinkIdSchema,
   sharedNoteDesktopSchemeSchema,
+  type SharedNoteDesktopScheme,
 } from "@/lib/shared-notes";
 import { LinkSharedNoteClient } from "@/routes/share/link/$shareId";
 
@@ -28,32 +31,84 @@ export const Route = createFileRoute("/t/$linkId")({
   },
   loader: async ({ params }) => {
     const linkId = shareLinkIdSchema.safeParse(params.linkId);
-    if (!linkId.success) return null;
-    const result = await fetchShortLinkSharedNotePreviewResult(linkId.data);
-    return result.status === "ready" ? result.preview : null;
+    if (!linkId.success) return { status: "unavailable" } as const;
+    return fetchShortLinkSharedNotePreviewResult(linkId.data);
   },
   head: ({ loaderData, params }) =>
-    loaderData
-      ? getShortLinkShareHead(params.linkId, loaderData)
+    loaderData?.status === "ready"
+      ? getShortLinkShareHead(params.linkId, loaderData.preview)
       : getPrivateShareHead(),
   headers: () => privateShareHeaders,
   component: Component,
 });
 
 function Component() {
-  const preview = Route.useLoaderData();
+  const previewResult = Route.useLoaderData();
+  const { linkId } = Route.useParams();
   const { scheme } = Route.useSearch();
   const { user } = Route.useRouteContext();
-  if (!preview) return <SharedNoteUnavailable />;
+  if (previewResult.status === "unavailable") {
+    return <SharedNoteUnavailable />;
+  }
 
   return (
     <ClientOnly fallback={<SharedNoteLoading />}>
-      <LinkSharedNoteClient
-        currentUserId={user?.id ?? null}
-        meetingMetadata={preview}
-        scheme={scheme}
-        shareId={preview.shareId}
-      />
+      {previewResult.status === "ready" ? (
+        <LinkSharedNoteClient
+          currentUserId={user?.id ?? null}
+          meetingMetadata={previewResult.preview}
+          scheme={scheme}
+          shareId={previewResult.preview.shareId}
+        />
+      ) : (
+        <ShortLinkSharedNoteClient
+          currentUserId={user?.id ?? null}
+          linkId={linkId}
+          scheme={scheme}
+        />
+      )}
     </ClientOnly>
+  );
+}
+
+function ShortLinkSharedNoteClient({
+  currentUserId,
+  linkId,
+  scheme,
+}: {
+  currentUserId: string | null;
+  linkId: string;
+  scheme: SharedNoteDesktopScheme;
+}) {
+  const previewQuery = useQuery({
+    queryKey: ["shared-note-short-link-preview", linkId],
+    queryFn: ({ signal }) =>
+      fetchShortLinkSharedNotePreviewResult(linkId, signal),
+    gcTime: 0,
+    retry: false,
+    staleTime: 0,
+  });
+
+  if (previewQuery.isPending) return <SharedNoteLoading />;
+  if (previewQuery.isError || previewQuery.data.status === "error") {
+    return (
+      <SharedNoteTransientError
+        retry={() => {
+          void previewQuery.refetch();
+        }}
+      />
+    );
+  }
+  if (previewQuery.data.status === "unavailable") {
+    return <SharedNoteUnavailable />;
+  }
+
+  return (
+    <LinkSharedNoteClient
+      currentUserId={currentUserId}
+      meetingMetadata={previewQuery.data.preview}
+      scheme={scheme}
+      shareId={previewQuery.data.preview.shareId}
+    />
   );
 }

--- a/crates/api-sync/src/shared_notes.rs
+++ b/crates/api-sync/src/shared_notes.rs
@@ -211,6 +211,16 @@ pub struct SharedNotePreview {
 
 #[derive(Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct SharedNoteLinkPreview {
+    share_id: String,
+    title: String,
+    summary: String,
+    participants: Vec<String>,
+    meeting_at: String,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SharedAttachmentDownload {
     id: String,
     filename: String,
@@ -243,6 +253,11 @@ struct LinkRpcRequest<'a> {
 struct LinkPreviewRpcRequest<'a> {
     p_share_id: &'a str,
     p_preview_token: &'a str,
+}
+
+#[derive(Serialize)]
+struct LinkIdRpcRequest<'a> {
+    p_link_id: &'a str,
 }
 
 #[derive(Serialize)]
@@ -315,6 +330,16 @@ struct GatewayPreviewRow {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GatewayLinkPreviewRow {
+    share_id: String,
+    title: String,
+    body_json: Value,
+    participants: Vec<String>,
+    meeting_at: String,
+}
+
+#[derive(Deserialize)]
 struct GatewayClaimSnapshotRow {
     share_id: String,
     schema_version: i16,
@@ -353,6 +378,7 @@ struct GatewayHandoffRow {
         read_public_shared_note_preview,
         read_link_shared_note,
         read_link_shared_note_preview,
+        read_short_link_shared_note_preview,
         create_public_shared_note_handoff,
         create_link_shared_note_handoff,
         claim_shared_note_handoff,
@@ -370,6 +396,7 @@ struct GatewayHandoffRow {
         SharedNoteInvitationEmailRequest,
         SharedNoteSnapshot,
         SharedNotePreview,
+        SharedNoteLinkPreview,
         SharedNoteHandoff,
         SharedAttachmentDownload
     ))
@@ -395,6 +422,10 @@ pub fn router(state: SharedNotesState) -> Router {
             "/shared-notes/link/{share_id}/preview",
             post(read_link_shared_note_preview)
                 .layer(DefaultBodyLimit::max(MAX_LINK_REQUEST_BYTES)),
+        )
+        .route(
+            "/shared-notes/links/{link_id}/preview",
+            get(read_short_link_shared_note_preview),
         )
         .route(
             "/shared-notes/public/{slug}/handoff",
@@ -588,6 +619,34 @@ async fn read_link_shared_note_preview(
     )
     .await?;
     Ok(Json(validate_preview(row)?))
+}
+
+#[utoipa::path(
+    get,
+    path = "/shared-notes/links/{link_id}/preview",
+    tag = "shared-notes",
+    params(("link_id" = String, Path, description = "Session share link ID")),
+    responses(
+        (status = 200, description = "Short-link shared note preview", body = SharedNoteLinkPreview),
+        (status = 404, description = "Shared note unavailable"),
+        (status = 502, description = "Shared note service unavailable")
+    )
+)]
+async fn read_short_link_shared_note_preview(
+    State(state): State<SharedNotesState>,
+    Path(link_id): Path<String>,
+) -> Result<Json<SharedNoteLinkPreview>> {
+    let link_id = canonical_uuid_v4(&link_id).ok_or(SyncError::SharedNoteNotFound)?;
+    let row = rpc_single(
+        &state,
+        "gateway_read_session_share_link_preview_by_id",
+        &LinkIdRpcRequest {
+            p_link_id: &link_id,
+        },
+        MAX_SNAPSHOT_RESPONSE_BYTES,
+    )
+    .await?;
+    Ok(Json(validate_link_preview(row)?))
 }
 
 #[utoipa::path(
@@ -923,6 +982,23 @@ fn validate_preview(row: GatewayPreviewRow) -> Result<SharedNotePreview> {
         summary,
         participants,
         meeting_at: row.meeting_at,
+    })
+}
+
+fn validate_link_preview(row: GatewayLinkPreviewRow) -> Result<SharedNoteLinkPreview> {
+    let share_id = canonical_uuid_v4(&row.share_id).ok_or(SyncError::SnapshotServiceUnavailable)?;
+    let preview = validate_preview(GatewayPreviewRow {
+        title: row.title,
+        body_json: row.body_json,
+        participants: row.participants,
+        meeting_at: row.meeting_at,
+    })?;
+    Ok(SharedNoteLinkPreview {
+        share_id,
+        title: preview.title,
+        summary: preview.summary,
+        participants: preview.participants,
+        meeting_at: preview.meeting_at,
     })
 }
 

--- a/crates/api-sync/src/shared_notes/tests.rs
+++ b/crates/api-sync/src/shared_notes/tests.rs
@@ -13,6 +13,7 @@ const SHARE_ID: &str = "11111111-1111-4111-8111-111111111111";
 const PUBLIC_SLUG: &str = "s_0123456789abcdef0123456789abcdef";
 const LINK_TOKEN: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 const LINK_PREVIEW_TOKEN: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const LINK_ID: &str = "77777777-7777-4777-8777-777777777777";
 const HANDOFF_ID: &str = "22222222-2222-4222-8222-222222222222";
 const LEASE_ID: &str = "55555555-5555-4555-8555-555555555555";
 const ATTACHMENT_ID: &str = "33333333-3333-4333-8333-333333333333";
@@ -444,6 +445,51 @@ async fn returns_only_link_preview_metadata() {
             "summary": "The team aligned on launch scope and remaining blockers.",
             "participants": ["John Jeong", "Sungbin Jo"],
             "meetingAt": "2026-08-06T01:30:00Z"
+        })
+    );
+}
+
+#[tokio::test]
+async fn resolves_short_link_preview_metadata() {
+    let server = MockServer::start().await;
+    mount_rpc(
+        &server,
+        "gateway_read_session_share_link_preview_by_id",
+        json!({ "p_link_id": LINK_ID }),
+        json!([{
+            "share_id": SHARE_ID,
+            "title": "Planning & decisions",
+            "body_json": {
+                "type": "doc",
+                "content": [{
+                    "type": "paragraph",
+                    "content": [{ "type": "text", "text": "The team aligned." }]
+                }]
+            },
+            "participants": ["John Jeong", "Sungbin Jo"],
+            "meeting_at": "2026-08-12T01:30:00Z"
+        }]),
+    )
+    .await;
+
+    let response = test_router(&server)
+        .oneshot(
+            Request::get(format!("/shared-notes/links/{LINK_ID}/preview"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(response).await,
+        json!({
+            "shareId": SHARE_ID,
+            "title": "Planning & decisions",
+            "summary": "The team aligned.",
+            "participants": ["John Jeong", "Sungbin Jo"],
+            "meetingAt": "2026-08-12T01:30:00Z"
         })
     );
 }

--- a/supabase/migrations/20260812140000_session_share_short_links.sql
+++ b/supabase/migrations/20260812140000_session_share_short_links.sql
@@ -1,0 +1,65 @@
+CREATE OR REPLACE FUNCTION private.gateway_read_session_share_link_preview_by_id(
+  p_link_id uuid
+)
+RETURNS TABLE (
+  share_id uuid,
+  title text,
+  body_json jsonb,
+  participants text[],
+  meeting_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    share.id,
+    snapshot.title,
+    snapshot.body_json,
+    COALESCE(metadata.participants, ARRAY[]::text[]),
+    COALESCE(metadata.meeting_at, snapshot.published_at)
+  FROM public.session_share_links AS link
+  JOIN public.session_shares AS share
+    ON share.id = link.share_id
+  JOIN public.workspaces AS workspace
+    ON workspace.id = share.workspace_id
+  JOIN public.session_share_snapshots AS snapshot
+    ON snapshot.share_id = share.id
+  LEFT JOIN public.session_share_preview_metadata AS metadata
+    ON metadata.share_id = share.id
+  WHERE link.id = p_link_id
+    AND link.revoked_at IS NULL
+    AND share.general_scope = 'link'
+    AND share.deleted_at IS NULL
+    AND workspace.deleted_at IS NULL;
+$$;
+
+CREATE OR REPLACE FUNCTION public.gateway_read_session_share_link_preview_by_id(
+  p_link_id uuid
+)
+RETURNS TABLE (
+  share_id uuid,
+  title text,
+  body_json jsonb,
+  participants text[],
+  meeting_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.gateway_read_session_share_link_preview_by_id(p_link_id);
+$$;
+
+REVOKE ALL ON FUNCTION private.gateway_read_session_share_link_preview_by_id(uuid)
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.gateway_read_session_share_link_preview_by_id(uuid)
+  FROM PUBLIC, anon, authenticated, service_role;
+
+GRANT EXECUTE ON FUNCTION private.gateway_read_session_share_link_preview_by_id(uuid)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.gateway_read_session_share_link_preview_by_id(uuid)
+  TO service_role;

--- a/supabase/tests/036-session-share-short-links.sql
+++ b/supabase/tests/036-session-share-short-links.sql
@@ -1,0 +1,120 @@
+begin;
+select plan(3);
+
+select tests.create_supabase_user(
+  'short_link_owner',
+  'short-link-owner@example.com'
+);
+
+update auth.users
+set email_confirmed_at = now()
+where id = tests.get_supabase_uid('short_link_owner');
+
+create temporary table short_link_test_state (
+  name text primary key,
+  workspace_id uuid,
+  share_id uuid,
+  link_id uuid
+);
+
+grant all on short_link_test_state to anon, authenticated, service_role;
+
+insert into short_link_test_state (name, workspace_id)
+values ('workspace', gen_random_uuid());
+
+select tests.authenticate_as_service_role();
+
+insert into public.workspaces (id, owner_user_id, kind, name)
+select
+  workspace_id,
+  tests.get_supabase_uid('short_link_owner'),
+  'shared',
+  'Short link workspace'
+from short_link_test_state
+where name = 'workspace';
+
+insert into public.workspace_memberships (workspace_id, user_id, role)
+select
+  workspace_id,
+  tests.get_supabase_uid('short_link_owner'),
+  'owner'
+from short_link_test_state
+where name = 'workspace';
+
+select tests.clear_authentication();
+select tests.authenticate_as_hyprnote_pro('short_link_owner');
+
+insert into short_link_test_state (name, share_id)
+select 'share', share_id
+from public.create_session_share(
+  (select workspace_id from short_link_test_state where name = 'workspace'),
+  'short-link-session'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select *
+from public.publish_session_share_snapshot_with_preview_cas(
+  (select share_id from short_link_test_state where name = 'share'),
+  tests.get_supabase_uid('short_link_owner'),
+  0,
+  '30000000-0000-4000-8000-000000000001',
+  'Short link preview',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Private meeting summary."}]}]}'::jsonb,
+  ARRAY[]::uuid[],
+  true,
+  ARRAY['John Jeong'],
+  '2026-08-12T01:30:00Z'::timestamptz
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_hyprnote_pro('short_link_owner');
+
+insert into short_link_test_state (name, share_id, link_id)
+select 'link', share_id, link_id
+from public.enable_session_share_link(
+  (select share_id from short_link_test_state where name = 'share')
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select is(
+  (
+    select preview.share_id
+    from public.gateway_read_session_share_link_preview_by_id(
+      (select link_id from short_link_test_state where name = 'link')
+    ) as preview
+  ),
+  (select share_id from short_link_test_state where name = 'share'),
+  'An active link ID resolves its share without exposing the bearer token'
+);
+
+select is(
+  (
+    select preview.title
+    from public.gateway_read_session_share_link_preview_by_id(
+      (select link_id from short_link_test_state where name = 'link')
+    ) as preview
+  ),
+  'Short link preview',
+  'An active link ID exposes only preview metadata'
+);
+
+update public.session_share_links
+set revoked_at = now()
+where id = (select link_id from short_link_test_state where name = 'link');
+
+select is_empty(
+  $$
+    select *
+    from public.gateway_read_session_share_link_preview_by_id(
+      (select link_id from short_link_test_state where name = 'link')
+    )
+  $$,
+  'Revoked link IDs no longer resolve preview metadata'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Bundle OG fonts and copy compact private URLs backed by rotating link IDs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the private share URL and public preview surface: link IDs alone can now fetch preview metadata. Scoped to preview-only data with revoked-link checks, but still security-adjacent.
> 
> **Overview**
> **Switches private share links to compact `/t/{linkId}` URLs** that keep the bearer token in the fragment and drop the old `?preview=` SHA-256 token.
> 
> Adds a public `GET /shared-notes/links/{link_id}/preview` path (DB RPC + API + web `/t/$linkId` route and OG image endpoint) so social crawlers can resolve title/summary/participants by link ID without the bearer token. Revoked or non-link shares fail closed.
> 
> Also bundles Redaction/SF Pro fonts into Netlify functions and points Sharp at `fonts.conf` so OG images render with the intended typefaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72a5de88f32cfff1e76b6f63f148e7b332e36b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->