### PR TITLE
Tighten calendar navigation controls

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -235,17 +235,17 @@ export function CalendarView() {
         <ButtonGroup
           data-tauri-drag-region="false"
           className={cn([
-            "border-border h-8 overflow-hidden rounded-full border",
+            "border-border h-7 overflow-hidden rounded-full border",
             "bg-card",
           ])}
         >
           <Button
             variant="ghost"
             size="icon"
-            className="hover:bg-accent h-full w-10 rounded-none border-0 bg-transparent shadow-none"
+            className="hover:bg-accent h-full w-8 rounded-none border-0 bg-transparent shadow-none"
             onClick={goToPrev}
           >
-            <CaretLeft className="h-4 w-4" />
+            <CaretLeft className="size-3.5" />
           </Button>
           <ButtonGroupSeparator className="bg-accent" />
           <Button
@@ -253,7 +253,7 @@ export function CalendarView() {
             size="sm"
             className={cn([
               "h-full rounded-none border-0",
-              "hover:bg-accent bg-transparent px-3 text-sm shadow-none",
+              "hover:bg-accent bg-transparent px-2 text-xs shadow-none",
             ])}
             onClick={goToToday}
           >
@@ -263,10 +263,10 @@ export function CalendarView() {
           <Button
             variant="ghost"
             size="icon"
-            className="hover:bg-accent h-full w-10 rounded-none border-0 bg-transparent shadow-none"
+            className="hover:bg-accent h-full w-8 rounded-none border-0 bg-transparent shadow-none"
             onClick={goToNext}
           >
-            <CaretRight className="h-4 w-4" />
+            <CaretRight className="size-3.5" />
           </Button>
         </ButtonGroup>
       </div>


### PR DESCRIPTION
Reduce the navigation pill, arrows, and Today label for a more compact header.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure visual sizing tweaks to calendar header controls with no logic or behavior changes.
> 
> **Overview**
> Makes the calendar header navigation pill more compact by shrinking its height, arrow button widths, caret icons, and the Today label padding/text size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3666527c90987541f85ebba13125e310d78a638. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->