### PR TITLE
Flatten developer settings layout

### DIFF
--- a/apps/desktop/src/settings/developers/cli.tsx
+++ b/apps/desktop/src/settings/developers/cli.tsx
@@ -2,9 +2,7 @@ import {
   ArrowSquareOut,
   CheckCircle,
   CircleNotch,
-  Code,
   Copy,
-  Terminal,
 } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -131,21 +129,14 @@ function CliSection({
   const isInstalled = status?.state === "installed";
 
   return (
-    <section className="flex flex-col gap-3">
-      <h2 className="text-muted-foreground text-sm font-medium">CLI & MCP</h2>
-      <div className="border-border bg-card divide-border divide-y overflow-hidden rounded-2xl border">
-        <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex min-w-0 gap-3">
-            <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-xl">
-              <Terminal className="size-5" />
-            </div>
-            <div className="min-w-0">
-              <h3 className="font-medium">Anarlog CLI</h3>
-              <CopyableCommand
-                command={`${commandName} --json meetings list`}
-              />
-              <CliStatus status={status} isLoading={isLoading} error={error} />
-            </div>
+    <section className="flex flex-col gap-4">
+      <h2 className="font-sans text-lg font-semibold">CLI & MCP</h2>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium">Anarlog CLI</h3>
+            <CopyableCommand command={`${commandName} --json meetings list`} />
+            <CliStatus status={status} isLoading={isLoading} error={error} />
           </div>
           <div className="flex shrink-0 gap-2">
             <Button
@@ -269,15 +260,10 @@ function McpRow({ status }: { status: EmbeddedCliStatus | undefined }) {
   );
 
   return (
-    <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex min-w-0 gap-3">
-        <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-xl">
-          <Code className="size-5" />
-        </div>
-        <div className="min-w-0">
-          <h3 className="font-medium">MCP server</h3>
-          <CopyableCommand command={`${commandName} mcp`} />
-        </div>
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <h3 className="text-sm font-medium">MCP server</h3>
+        <CopyableCommand command={`${commandName} mcp`} />
       </div>
       <div className="flex shrink-0 gap-2">
         <Button

--- a/apps/desktop/src/settings/developers/cloud-api.tsx
+++ b/apps/desktop/src/settings/developers/cloud-api.tsx
@@ -1,4 +1,4 @@
-import { ArrowSquareOut, Copy, Globe, Key } from "@phosphor-icons/react";
+import { ArrowSquareOut, Copy, Key } from "@phosphor-icons/react";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -71,33 +71,28 @@ export function CloudApiSection() {
   const enabled = settingsQuery.data?.enabled === true;
 
   return (
-    <section className="flex flex-col gap-3">
-      <h2 className="text-muted-foreground text-sm font-medium">
+    <section className="flex flex-col gap-4">
+      <h2 className="font-sans text-lg font-semibold">
         Cloud API & Connectors
       </h2>
-      <div className="border-border bg-card overflow-hidden rounded-2xl border">
-        <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex min-w-0 gap-3">
-            <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-xl">
-              <Globe className="size-5" />
-            </div>
-            <div className="min-w-0">
-              <h3 className="font-medium">Hosted access for agents</h3>
-              <p className="text-muted-foreground mt-1 text-sm leading-5">
-                Give remote agents meeting context while Anarlog is closed.
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium">Hosted access for agents</h3>
+            <p className="text-muted-foreground mt-1 text-sm leading-5">
+              Give remote agents meeting context while Anarlog is closed.
+            </p>
+            <p className="text-muted-foreground mt-2 text-xs leading-5">
+              Enabling this uploads a separate server-readable copy of meeting
+              titles, notes, summaries, participants, action items, and
+              transcripts. Encrypted sync stays end-to-end encrypted. Turning
+              this off deletes every readable copy from the server.
+            </p>
+            {settingsQuery.error && (
+              <p className="text-destructive mt-2 text-xs">
+                {settingsQuery.error.message}
               </p>
-              <p className="text-muted-foreground mt-2 text-xs leading-5">
-                Enabling this uploads a separate server-readable copy of meeting
-                titles, notes, summaries, participants, action items, and
-                transcripts. Encrypted sync stays end-to-end encrypted. Turning
-                this off deletes every readable copy from the server.
-              </p>
-              {settingsQuery.error && (
-                <p className="text-destructive mt-2 text-xs">
-                  {settingsQuery.error.message}
-                </p>
-              )}
-            </div>
+            )}
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <Button
@@ -126,7 +121,7 @@ export function CloudApiSection() {
 
         {enabled && (
           <>
-            <div className="border-border grid gap-3 border-t p-4 sm:grid-cols-2">
+            <div className="grid gap-3 sm:grid-cols-2">
               <CloudEndpoint
                 label="REST API"
                 value={CLOUD_API_BASE_URL}
@@ -138,7 +133,7 @@ export function CloudApiSection() {
                 copyMessage="Remote MCP URL copied"
               />
             </div>
-            <CloudApiKeysCard />
+            <CloudApiKeys />
           </>
         )}
       </div>
@@ -177,7 +172,7 @@ function CloudEndpoint({
   );
 }
 
-function CloudApiKeysCard() {
+function CloudApiKeys() {
   const queryClient = useQueryClient();
   const keysQuery = useQuery({
     queryKey: CLOUD_API_KEYS_QUERY_KEY,
@@ -205,7 +200,7 @@ function CloudApiKeysCard() {
   const createdKey = createMutation.data;
 
   return (
-    <div className="border-border border-t p-4">
+    <div>
       <div className="mb-3 flex items-center gap-2">
         <Key className="text-muted-foreground size-4" />
         <h4 className="text-sm font-medium">Cloud API keys</h4>

--- a/apps/desktop/src/settings/developers/devtools.tsx
+++ b/apps/desktop/src/settings/developers/devtools.tsx
@@ -1,4 +1,3 @@
-import { Wrench } from "@phosphor-icons/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { commands as windowsCommands } from "@anlg/plugin-windows";
@@ -28,33 +27,26 @@ export function DevtoolsSection() {
   }
 
   return (
-    <section className="flex flex-col gap-3">
-      <h2 className="text-muted-foreground text-sm font-medium">Devtools</h2>
-      <div className="border-border bg-card overflow-hidden rounded-2xl border">
-        <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex min-w-0 gap-3">
-            <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-xl">
-              <Wrench className="size-5" />
-            </div>
-            <div className="min-w-0">
-              <h3 className="font-medium">Devtools panel</h3>
-              <p className="text-muted-foreground mt-1 text-sm leading-5">
-                Preview notifications, toasts, updates, and billing dialogs.
-                Only available in dev and staging builds.
-              </p>
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={openMutation.isPending}
-              onClick={() => openMutation.mutate()}
-            >
-              Open panel
-            </Button>
-          </div>
+    <section className="flex flex-col gap-4">
+      <h2 className="font-sans text-lg font-semibold">Devtools</h2>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h3 className="text-sm font-medium">Devtools panel</h3>
+          <p className="text-muted-foreground mt-1 text-sm leading-5">
+            Preview notifications, toasts, updates, and billing dialogs. Only
+            available in dev and staging builds.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={openMutation.isPending}
+            onClick={() => openMutation.mutate()}
+          >
+            Open panel
+          </Button>
         </div>
       </div>
     </section>

--- a/apps/desktop/src/settings/developers/index.tsx
+++ b/apps/desktop/src/settings/developers/index.tsx
@@ -9,7 +9,7 @@ export { buildMcpConfiguration, getCliInstallNotification } from "./cli";
 
 export function SettingsDevelopers() {
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">
+    <div className="flex flex-col gap-8">
       <SettingsPageTitle title="Developers" />
       <CliSettingsSections />
       <CloudApiSection />

--- a/apps/desktop/src/settings/developers/webhooks.tsx
+++ b/apps/desktop/src/settings/developers/webhooks.tsx
@@ -1,9 +1,4 @@
-import {
-  ArrowSquareOut,
-  Copy,
-  Trash,
-  WebhooksLogo,
-} from "@phosphor-icons/react";
+import { ArrowSquareOut, Copy, Trash } from "@phosphor-icons/react";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -87,22 +82,17 @@ export function WebhooksSection() {
   const createdWebhook = createMutation.data;
 
   return (
-    <section className="flex flex-col gap-3">
-      <h2 className="text-muted-foreground text-sm font-medium">Webhooks</h2>
-      <div className="border-border bg-card overflow-hidden rounded-2xl border">
-        <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex min-w-0 gap-3">
-            <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-xl">
-              <WebhooksLogo className="size-5" />
-            </div>
-            <div className="min-w-0">
-              <h3 className="font-medium">Meeting events</h3>
-              <p className="text-muted-foreground mt-1 text-sm leading-5">
-                Receive signed events when meetings end or summaries are ready.
-                Deliveries include meeting content, so only add an endpoint you
-                trust.
-              </p>
-            </div>
+    <section className="flex flex-col gap-4">
+      <h2 className="font-sans text-lg font-semibold">Webhooks</h2>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium">Meeting events</h3>
+            <p className="text-muted-foreground mt-1 text-sm leading-5">
+              Receive signed events when meetings end or summaries are ready.
+              Deliveries include meeting content, so only add an endpoint you
+              trust.
+            </p>
           </div>
           <Button
             type="button"
@@ -118,7 +108,7 @@ export function WebhooksSection() {
           </Button>
         </div>
 
-        <div className="border-border border-t p-4">
+        <div>
           <form
             className="flex gap-2"
             onSubmit={(event) => {


### PR DESCRIPTION
Remove the card shells and decorative icon tiles so developer controls use the same flat section and row hierarchy as the rest of Settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure presentational layout/CSS changes with no logic, auth, or data-handling modifications.
> 
> **Overview**
> Aligns the Developers settings page with the rest of Settings by **removing card shells and decorative icon tiles**.
> 
> Section headings now use the shared flat hierarchy (`text-lg font-semibold`), and nested rows drop bordered containers, padding wrappers, and icons like Terminal/Globe/Wrench. Also drops the page `max-w-3xl` constraint. Behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb8b5b86ab79589a09516a95b165fc3c2a8f8d03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->