### PR TITLE
Gate app icon changes behind Pro

### DIFF
--- a/apps/desktop/src/settings/appearance/app-icon.test.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.test.tsx
@@ -14,6 +14,11 @@ const mocks = vi.hoisted(() => ({
   appIcon: "default",
   theme: "system",
   appIdentifier: "com.hyprnote.stable" as string | undefined,
+  billing: {
+    isPro: true,
+    isUpgradingToPro: false,
+    upgradeToPro: vi.fn(),
+  },
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -30,6 +35,10 @@ vi.mock("@tauri-apps/plugin-os", () => ({
 
 vi.mock("~/settings/queries", () => ({
   useSetSettingValue: () => mocks.setAppIcon,
+}));
+
+vi.mock("~/auth/billing-context", () => ({
+  useBillingAccess: () => mocks.billing,
 }));
 
 vi.mock("~/shared/config", () => ({
@@ -51,6 +60,8 @@ describe("AppIconSelector", () => {
     mocks.appIcon = "default";
     mocks.theme = "system";
     mocks.appIdentifier = "com.hyprnote.stable";
+    mocks.billing.isPro = true;
+    mocks.billing.isUpgradingToPro = false;
   });
 
   const iconOptions = () =>
@@ -81,6 +92,23 @@ describe("AppIconSelector", () => {
 
     expect(mocks.applyAppIconPreference).toHaveBeenCalledWith("dev", "system");
     expect(mocks.setAppIcon).toHaveBeenCalledWith("dev");
+  });
+
+  it("offers a Pro upgrade instead of changing icons on the free plan", () => {
+    mocks.billing.isPro = false;
+
+    render(<AppIconSelector />);
+
+    const defaultOption = screen.getByRole("radio", { name: "Default" });
+    const blueprintOption = screen.getByRole("radio", { name: "Blueprint" });
+    expect(defaultOption.getAttribute("aria-disabled")).toBe("false");
+    expect(blueprintOption.getAttribute("aria-disabled")).toBe("true");
+
+    fireEvent.click(blueprintOption);
+
+    expect(mocks.billing.upgradeToPro).toHaveBeenCalledOnce();
+    expect(mocks.applyAppIconPreference).not.toHaveBeenCalled();
+    expect(mocks.setAppIcon).not.toHaveBeenCalled();
   });
 
   it("previews both schemes for the system theme", () => {

--- a/apps/desktop/src/settings/appearance/app-icon.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.tsx
@@ -1,10 +1,12 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import { CircleNotch, LockSimple } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { getIdentifier } from "@tauri-apps/api/app";
 import { platform } from "@tauri-apps/plugin-os";
 
 import { cn } from "@anlg/utils";
 
+import { useBillingAccess } from "~/auth/billing-context";
 import { useSetSettingValue } from "~/settings/queries";
 import { useConfigValue } from "~/shared/config";
 import {
@@ -24,10 +26,11 @@ const APP_ICON_OPTIONS = [
 ] as const satisfies readonly AppIconPreference[];
 
 const PREVIEW_CLASS =
-  "size-16 transition-transform duration-150 select-none group-hover:scale-105";
+  "size-16 scale-[1.16] transition-transform duration-150 select-none group-hover:scale-[1.21]";
 
 export function AppIconSelector() {
   const { t } = useLingui();
+  const billing = useBillingAccess();
   const value = normalizeAppIconPreference(useConfigValue("app_icon"));
   const storedTheme = useConfigValue("theme") as ThemePreference;
   const theme: ThemePreference =
@@ -74,6 +77,7 @@ export function AppIconSelector() {
           const selected =
             resolveAppIconName(option, appIdentifier) === selectedIconName;
           const previewName = resolveAppIconName(option, appIdentifier);
+          const locked = !billing.isPro && !selected;
 
           return (
             <button
@@ -81,40 +85,58 @@ export function AppIconSelector() {
               type="button"
               role="radio"
               aria-checked={selected}
+              aria-disabled={locked}
               aria-label={labels[option]}
               title={labels[option]}
+              disabled={locked && billing.isUpgradingToPro}
               className={cn([
-                "group text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex cursor-pointer items-center justify-center rounded-[22px] border bg-transparent p-0.5 transition-[border-color,scale] duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.98]",
+                "group text-foreground focus-visible:ring-ring focus-visible:ring-offset-background relative flex cursor-pointer items-center justify-center rounded-[22px] border bg-transparent p-0.5 transition-[border-color,scale] duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.98] disabled:cursor-wait",
                 selected
                   ? "border-blue-500"
                   : "border-border hover:border-foreground/30",
               ])}
               onClick={() => {
+                if (locked) {
+                  billing.upgradeToPro();
+                  return;
+                }
+
                 void applyAppIconPreference(option, theme);
                 setAppIcon(option);
               }}
             >
-              {theme === "system" ? (
-                <picture>
-                  <source
-                    media="(prefers-color-scheme: dark)"
-                    srcSet={`/assets/app-icons/${previewName}-dark.png`}
-                  />
+              <span className="flex size-16 overflow-hidden rounded-[18px]">
+                {theme === "system" ? (
+                  <picture>
+                    <source
+                      media="(prefers-color-scheme: dark)"
+                      srcSet={`/assets/app-icons/${previewName}-dark.png`}
+                    />
+                    <img
+                      src={`/assets/app-icons/${previewName}-light.png`}
+                      alt=""
+                      draggable={false}
+                      className={PREVIEW_CLASS}
+                    />
+                  </picture>
+                ) : (
                   <img
-                    src={`/assets/app-icons/${previewName}-light.png`}
+                    src={`/assets/app-icons/${previewName}-${theme}.png`}
                     alt=""
                     draggable={false}
                     className={PREVIEW_CLASS}
                   />
-                </picture>
-              ) : (
-                <img
-                  src={`/assets/app-icons/${previewName}-${theme}.png`}
-                  alt=""
-                  draggable={false}
-                  className={PREVIEW_CLASS}
-                />
-              )}
+                )}
+              </span>
+              {locked ? (
+                <span className="bg-background border-border text-muted-foreground pointer-events-none absolute right-0.5 bottom-0.5 flex size-5 items-center justify-center rounded-full border shadow-sm">
+                  {billing.isUpgradingToPro ? (
+                    <CircleNotch className="size-3 animate-spin" aria-hidden />
+                  ) : (
+                    <LockSimple className="size-3" aria-hidden />
+                  )}
+                </span>
+              ) : null}
             </button>
           );
         })}


### PR DESCRIPTION
Keep the selected icon active on free plans and route other choices to the upgrade flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Pro feature gate on appearance settings using the existing billing upgrade path; no auth, data, or backend changes.
> 
> **Overview**
> Makes custom app icons a **Pro** feature while keeping the currently selected icon usable on free plans.
> 
> On free plans, non-selected icons show a lock badge and clicking them opens the existing `upgradeToPro` flow instead of applying the icon. During upgrade, locked options show a spinner and are disabled. Also slightly adjusts icon preview scaling/clipping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d1776058ba897d7150efc88263d9ac427eb42d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->