### PR TITLE
Use a split action for connected imports

### DIFF
--- a/apps/desktop/src/imports/screen.test.tsx
+++ b/apps/desktop/src/imports/screen.test.tsx
@@ -137,6 +137,7 @@ describe("MeetingImportScreen", () => {
     expect(screen.getAllByRole("button", { name: "Use files" })).toHaveLength(
       2,
     );
+    expect(screen.queryByRole("menuitem", { name: "Use files" })).toBeNull();
     expect(
       screen.getAllByRole("button", { name: "Choose files" }),
     ).toHaveLength(3);
@@ -147,6 +148,21 @@ describe("MeetingImportScreen", () => {
       container.querySelectorAll('img[src^="data:image/png;base64,"]'),
     ).toHaveLength(5);
     expect(container.querySelector("iconify-icon")).toBeNull();
+  });
+
+  it("offers file import from the connected provider menu", async () => {
+    mockDetected(["granola"]);
+
+    renderImports();
+
+    const trigger = await screen.findByRole("button", {
+      name: "Use files",
+    });
+    fireEvent.pointerDown(trigger);
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Use files" }),
+    ).toBeTruthy();
   });
 
   it("renders the same detected list in the compact onboarding layout", async () => {

--- a/apps/desktop/src/imports/screen.tsx
+++ b/apps/desktop/src/imports/screen.tsx
@@ -1,6 +1,7 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
   ArrowsClockwise,
+  CaretDown,
   CircleNotch,
   DownloadSimple,
   PlugsConnected,
@@ -16,6 +17,14 @@ import { type ReactNode, useRef } from "react";
 
 import { commands as importerCommands } from "@anlg/plugin-importer";
 import { Button } from "@anlg/ui/components/ui/button";
+import { ButtonGroup } from "@anlg/ui/components/ui/button-group";
+import {
+  AppFloatingPanel,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@anlg/ui/components/ui/dropdown-menu";
 import { cn } from "@anlg/utils";
 
 import {
@@ -367,50 +376,83 @@ export function MeetingImportScreen({
                           </Button>
                         </>
                       ) : (
+                        <ButtonGroup>
+                          <Button
+                            type="button"
+                            size="sm"
+                            disabled={
+                              credentialsQuery?.isPending ||
+                              cancelConnectMutation.isPending ||
+                              connectionCancellationRequested ||
+                              (connectMutation.isPending && !connecting)
+                            }
+                            onClick={() => {
+                              if (connecting) {
+                                connectAbortController.current?.abort();
+                                cancelConnectMutation.mutate(provider.id);
+                                return;
+                              }
+                              connectMutation.mutate(provider);
+                            }}
+                          >
+                            {credentialsQuery?.isPending ||
+                            connecting ||
+                            cancellingConnection ? (
+                              <CircleNotch className="size-3.5 animate-spin" />
+                            ) : (
+                              <PlugsConnected className="size-3.5" />
+                            )}
+                            {connecting || cancellingConnection ? (
+                              <Trans>Cancel</Trans>
+                            ) : credentialsQuery?.isPending ? (
+                              <Trans>Checking connection</Trans>
+                            ) : (
+                              <Trans>Connect & import</Trans>
+                            )}
+                          </Button>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                type="button"
+                                size="sm"
+                                aria-label={t`Use files`}
+                                disabled={fileImportMutation.isPending}
+                                className="before:bg-primary-foreground/20 relative w-6 px-0 before:absolute before:inset-y-1.5 before:left-0 before:w-px"
+                              >
+                                <CaretDown className="size-3.5" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent
+                              variant="app"
+                              align="end"
+                              className="w-40"
+                            >
+                              <AppFloatingPanel className="p-1">
+                                <DropdownMenuItem
+                                  onClick={() =>
+                                    fileImportMutation.mutate(provider)
+                                  }
+                                >
+                                  <DownloadSimple />
+                                  <Trans>Use files</Trans>
+                                </DropdownMenuItem>
+                              </AppFloatingPanel>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </ButtonGroup>
+                      )}
+                      {connected ? (
                         <Button
                           type="button"
                           size="sm"
-                          disabled={
-                            credentialsQuery?.isPending ||
-                            cancelConnectMutation.isPending ||
-                            connectionCancellationRequested ||
-                            (connectMutation.isPending && !connecting)
-                          }
-                          onClick={() => {
-                            if (connecting) {
-                              connectAbortController.current?.abort();
-                              cancelConnectMutation.mutate(provider.id);
-                              return;
-                            }
-                            connectMutation.mutate(provider);
-                          }}
+                          variant="ghost"
+                          disabled={fileImportMutation.isPending}
+                          onClick={() => fileImportMutation.mutate(provider)}
                         >
-                          {credentialsQuery?.isPending ||
-                          connecting ||
-                          cancellingConnection ? (
-                            <CircleNotch className="size-3.5 animate-spin" />
-                          ) : (
-                            <PlugsConnected className="size-3.5" />
-                          )}
-                          {connecting || cancellingConnection ? (
-                            <Trans>Cancel</Trans>
-                          ) : credentialsQuery?.isPending ? (
-                            <Trans>Checking connection</Trans>
-                          ) : (
-                            <Trans>Connect & import</Trans>
-                          )}
+                          <DownloadSimple className="size-3.5" />
+                          <Trans>Use files</Trans>
                         </Button>
-                      )}
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="ghost"
-                        disabled={fileImportMutation.isPending}
-                        onClick={() => fileImportMutation.mutate(provider)}
-                      >
-                        <DownloadSimple className="size-3.5" />
-                        <Trans>Use files</Trans>
-                      </Button>
+                      ) : null}
                     </div>
                   ) : (
                     <Button


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only change to import action layout; connect and file-import behavior are unchanged.
> 
> **Overview**
> For **disconnected** connected-import providers, **Use files** is no longer a separate sibling button. It moves into a caret dropdown beside **Connect & import**, so connect stays the primary action.
> 
> Already-connected providers still show **Use files** as a standalone ghost button. Tests cover the new menu trigger and menuitem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45d73b92647b08d0263bcb4b8cbaa07e88e7377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->