### PR TITLE
Add contact profile headers and avatars

### DIFF
--- a/apps/desktop/src/contacts/contact-avatar.test.tsx
+++ b/apps/desktop/src/contacts/contact-avatar.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AvatarUploadButton } from "./contact-avatar";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("AvatarUploadButton", () => {
+  it("crops uploaded avatars to a 70 by 70 JPEG", async () => {
+    const context = {
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      fillStyle: "",
+      imageSmoothingQuality: "low",
+    };
+    const onUpload = vi.fn();
+
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:avatar"),
+      revokeObjectURL: vi.fn(),
+    });
+    vi.stubGlobal(
+      "Image",
+      class {
+        naturalHeight = 200;
+        naturalWidth = 400;
+        onerror: (() => void) | null = null;
+        onload: (() => void) | null = null;
+
+        set src(_value: string) {
+          queueMicrotask(() => this.onload?.());
+        }
+      },
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      context as unknown as CanvasRenderingContext2D,
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockImplementation(
+      function (this: HTMLCanvasElement, type, quality) {
+        expect(this.width).toBe(70);
+        expect(this.height).toBe(70);
+        expect(type).toBe("image/jpeg");
+        expect(quality).toBe(0.85);
+        return "data:image/jpeg;base64,compressed";
+      },
+    );
+
+    const { container } = render(
+      <AvatarUploadButton label="Change photo" onUpload={onUpload}>
+        <span>Avatar</span>
+      </AvatarUploadButton>,
+    );
+    const input =
+      container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toBeNull();
+    if (!input) return;
+
+    fireEvent.change(input, {
+      target: {
+        files: [new File(["avatar"], "avatar.png", { type: "image/png" })],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalledWith(
+        "data:image/jpeg;base64,compressed",
+      );
+    });
+    expect(context.drawImage).toHaveBeenCalledWith(
+      expect.anything(),
+      100,
+      0,
+      200,
+      200,
+      0,
+      0,
+      70,
+      70,
+    );
+  });
+});

--- a/apps/desktop/src/contacts/contact-avatar.tsx
+++ b/apps/desktop/src/contacts/contact-avatar.tsx
@@ -15,9 +15,7 @@ export function persistContactAvatar(
   });
 }
 
-// 2x the largest on-screen avatar (64px) so retina displays stay sharp
-// while uploads compress to a few KB before hitting SQLite.
-const AVATAR_RASTER_SIZE = 128;
+const AVATAR_RASTER_SIZE = 70;
 
 export function ContactImage({
   src,

--- a/apps/desktop/src/contacts/contact-page-header.test.tsx
+++ b/apps/desktop/src/contacts/contact-page-header.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ContactPageHeader } from "./contact-page-header";
+
+afterEach(cleanup);
+
+describe("ContactPageHeader", () => {
+  it("adds the compact identity beside the title when requested", () => {
+    const props = {
+      title: "Ada Lovelace",
+      compactIdentity: <span>Contact avatar</span>,
+      pinned: false,
+      onTogglePin: vi.fn(),
+      onDelete: vi.fn(),
+    };
+    const { rerender } = render(
+      <ContactPageHeader {...props} showCompactIdentity={false} />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Ada Lovelace" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Contact options" }),
+    ).not.toBeNull();
+    expect(screen.queryByText("Contact avatar")).toBeNull();
+
+    rerender(<ContactPageHeader {...props} showCompactIdentity={true} />);
+    expect(screen.getByText("Contact avatar")).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/contacts/contact-page-header.tsx
+++ b/apps/desktop/src/contacts/contact-page-header.tsx
@@ -1,5 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { DotsThree, MinusCircle, PushPin, Trash } from "@phosphor-icons/react";
+import { type ReactNode } from "react";
 
 import { Button } from "@anlg/ui/components/ui/button";
 import {
@@ -13,11 +14,17 @@ import {
 import { cn } from "@anlg/utils";
 
 export function ContactPageHeader({
+  title,
+  compactIdentity,
+  showCompactIdentity,
   pinned,
   onTogglePin,
   onDelete,
   onRemoveAvatar,
 }: {
+  title: string;
+  compactIdentity: ReactNode;
+  showCompactIdentity: boolean;
   pinned: boolean;
   onTogglePin: () => void;
   onDelete: () => void;
@@ -28,8 +35,12 @@ export function ContactPageHeader({
   return (
     <div
       data-tauri-drag-region
-      className="flex h-12 shrink-0 items-start justify-end py-0 pt-[9px] pr-1 pl-2"
+      className="flex h-12 shrink-0 items-center justify-between gap-3 pr-1 pl-3"
     >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {showCompactIdentity && compactIdentity}
+        <h2 className="min-w-0 truncate text-sm font-semibold">{title}</h2>
+      </div>
       <div
         data-tauri-drag-region="false"
         className="flex shrink-0 items-center"

--- a/apps/desktop/src/contacts/details.tsx
+++ b/apps/desktop/src/contacts/details.tsx
@@ -49,6 +49,7 @@ export function DetailsColumn({
   onDelete: (id: string) => void;
 }) {
   const { t } = useLingui();
+  const [showCompactIdentity, setShowCompactIdentity] = useState(false);
   const personSessions = useHumanSessions(human?.id ?? "");
   const duplicatesWithData = React.useMemo(
     () =>
@@ -78,6 +79,15 @@ export function DetailsColumn({
       {human ? (
         <>
           <ContactPageHeader
+            title={human.name || human.email || t`Unnamed`}
+            compactIdentity={
+              human.avatarDataUrl ? (
+                <ContactImage src={human.avatarDataUrl} size={24} />
+              ) : (
+                <ContactFacehash name={facehashName} size={24} />
+              )
+            }
+            showCompactIdentity={showCompactIdentity}
             pinned={Boolean(human.pinned)}
             onTogglePin={() => {
               void toggleContactPin("human", human.id).catch((error) => {
@@ -92,7 +102,12 @@ export function DetailsColumn({
             }
           />
 
-          <div className="flex-1 overflow-y-auto">
+          <div
+            className="flex-1 overflow-y-auto"
+            onScroll={(event) => {
+              setShowCompactIdentity(event.currentTarget.scrollTop > 0);
+            }}
+          >
             <div className="border-border flex items-center justify-center border-b py-6">
               <AvatarUploadButton
                 label={t`Change photo`}

--- a/apps/desktop/src/contacts/index.tsx
+++ b/apps/desktop/src/contacts/index.tsx
@@ -85,6 +85,7 @@ function ContactView({ tab }: { tab: Extract<Tab, { type: "contacts" }> }) {
     <div className="h-full">
       {effectiveSelection?.type === "organization" ? (
         <OrganizationDetailsColumn
+          key={effectiveSelection.id}
           organization={
             organizations.find(
               (organization) => organization.id === effectiveSelection.id,
@@ -98,6 +99,7 @@ function ContactView({ tab }: { tab: Extract<Tab, { type: "contacts" }> }) {
         />
       ) : (
         <DetailsColumn
+          key={effectiveSelection?.id ?? "empty"}
           human={
             effectiveSelection?.type === "person"
               ? (humans.find((human) => human.id === effectiveSelection.id) ??

--- a/apps/desktop/src/contacts/organization-details.tsx
+++ b/apps/desktop/src/contacts/organization-details.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@iconify-icon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Buildings, Envelope } from "@phosphor-icons/react";
+import { useState } from "react";
 
 import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { Button } from "@anlg/ui/components/ui/button";
@@ -32,6 +33,7 @@ export function OrganizationDetailsColumn({
   onDelete: (id: string) => void;
 }) {
   const { t } = useLingui();
+  const [showCompactIdentity, setShowCompactIdentity] = useState(false);
   const peopleInOrg = organization
     ? humans.filter((human) => human.organizationId === organization.id)
     : [];
@@ -41,6 +43,17 @@ export function OrganizationDetailsColumn({
       {organization ? (
         <>
           <ContactPageHeader
+            title={organization.name || t`Unnamed`}
+            compactIdentity={
+              organization.avatarDataUrl ? (
+                <ContactImage src={organization.avatarDataUrl} size={24} />
+              ) : (
+                <div className="bg-muted flex size-6 shrink-0 items-center justify-center rounded-full">
+                  <Buildings className="text-muted-foreground size-3" />
+                </div>
+              )
+            }
+            showCompactIdentity={showCompactIdentity}
             pinned={Boolean(organization.pinned)}
             onTogglePin={() => {
               void toggleContactPin("organization", organization.id).catch(
@@ -61,7 +74,12 @@ export function OrganizationDetailsColumn({
             }
           />
 
-          <div className="flex-1 overflow-y-auto">
+          <div
+            className="flex-1 overflow-y-auto"
+            onScroll={(event) => {
+              setShowCompactIdentity(event.currentTarget.scrollTop > 0);
+            }}
+          >
             <div className="border-border flex items-center justify-center border-b py-6">
               <AvatarUploadButton
                 label={t`Change photo`}

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -3347,6 +3347,7 @@ msgstr "Unlock sync"
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr "Unnamed"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -3347,6 +3347,7 @@ msgstr ""
 msgid "Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically."
 msgstr ""
 
+#: src/contacts/details.tsx
 #: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""


### PR DESCRIPTION
Show compact identities while scrolling and crop human and company avatar uploads to 70 by 70 pixels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only contacts header and avatar sizing changes with no auth, sync, or data-model risk. Existing stored avatars are unaffected until re-uploaded.
> 
> **Overview**
> Adds a sticky-style contact header that shows the **title** and a **compact avatar** once you scroll past the large profile photo on person and organization detail pages.
> 
> Also shrinks uploaded avatar rasters from **128px to 70px** JPEG crops, and remounts detail columns by contact id so scroll/header state resets when switching contacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4431f4ba8c127d08f92261d7ad53bf3797205138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->