### PR TITLE
Reduce calendar chevron padding

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -242,7 +242,7 @@ export function CalendarView() {
           <Button
             variant="ghost"
             size="icon"
-            className="hover:bg-accent h-full w-8 rounded-none border-0 bg-transparent shadow-none"
+            className="hover:bg-accent h-full w-7 rounded-none border-0 bg-transparent shadow-none"
             onClick={goToPrev}
           >
             <CaretLeft className="size-3.5" />
@@ -263,7 +263,7 @@ export function CalendarView() {
           <Button
             variant="ghost"
             size="icon"
-            className="hover:bg-accent h-full w-8 rounded-none border-0 bg-transparent shadow-none"
+            className="hover:bg-accent h-full w-7 rounded-none border-0 bg-transparent shadow-none"
             onClick={goToNext}
           >
             <CaretRight className="size-3.5" />


### PR DESCRIPTION
Narrow the previous and next controls while preserving their icon sizing and alignment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI spacing tweak with no logic, data, or security impact.
> 
> **Overview**
> Narrows the calendar prev/next chevron buttons from `w-8` to `w-7`, tightening padding around the icons without changing icon size or behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a986011380668b7a318e7831fdc33e20b4e8a872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->