### PR TITLE
Make the default template state unmistakable

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -1021,7 +1021,6 @@ msgstr "Created {createdAt}"
 msgid "Current default"
 msgstr "Current default"
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr "Customized"
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr "Date and time are required"
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr "Default"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -1021,7 +1021,6 @@ msgstr ""
 msgid "Current default"
 msgstr ""
 
-#: src/templates/auto-form.tsx
 #: src/templates/template-sidebar.tsx
 msgid "Customized"
 msgstr ""
@@ -1039,7 +1038,6 @@ msgid "Date and time are required"
 msgstr ""
 
 #: src/settings/appearance/app-icon.tsx
-#: src/templates/auto-form.tsx
 msgid "Default"
 msgstr ""
 

--- a/apps/desktop/src/templates/auto-form.tsx
+++ b/apps/desktop/src/templates/auto-form.tsx
@@ -1,5 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
+  Check,
   CircleNotch,
   LockSimple,
   MagicWand,
@@ -11,7 +12,6 @@ import { useRef, useState } from "react";
 
 import { PromptEditor, type PromptEditorHandle } from "@anlg/editor/prompt";
 import { commands as templateCommands } from "@anlg/plugin-template";
-import { Badge } from "@anlg/ui/components/ui/badge";
 import { Button } from "@anlg/ui/components/ui/button";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 import { cn } from "@anlg/utils";
@@ -140,9 +140,6 @@ export function AutoFormatForm({
         <div className="flex min-w-0 items-center gap-2">
           <Sparkle className="size-4 shrink-0 text-violet-500" />
           <span className="truncate text-sm font-semibold">Auto</span>
-          <Badge variant="secondary" className="h-5 rounded-full text-[10px]">
-            {isCustomized ? <Trans>Customized</Trans> : <Trans>Default</Trans>}
-          </Badge>
         </div>
         <Button
           type="button"
@@ -150,7 +147,9 @@ export function AutoFormatForm({
           variant="ghost"
           className={cn([
             "text-muted-foreground shrink-0 hover:text-black",
-            isDefault ? "bg-muted hover:bg-accent text-black" : null,
+            isDefault
+              ? "bg-emerald-600 text-white hover:bg-emerald-700 hover:text-white disabled:opacity-100"
+              : null,
           ])}
           onClick={() => {
             void setSettingValue("selected_template_id", "").catch((error) => {
@@ -160,7 +159,10 @@ export function AutoFormatForm({
           disabled={isDefault}
         >
           {isDefault ? (
-            <Trans>Current default</Trans>
+            <>
+              <Check className="size-3.5" weight="bold" />
+              <Trans>Current default</Trans>
+            </>
           ) : (
             <Trans>Set as default</Trans>
           )}

--- a/apps/desktop/src/templates/template-form.tsx
+++ b/apps/desktop/src/templates/template-form.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import { DotsThree, Heart, Plus, X } from "@phosphor-icons/react";
+import { Check, DotsThree, Heart, Plus, X } from "@phosphor-icons/react";
 import { useForm } from "@tanstack/react-form";
 import { useRef, useState } from "react";
 
@@ -230,13 +230,23 @@ export function TemplateForm({
             size="sm"
             variant="ghost"
             onClick={setSelectedTemplateId}
+            aria-pressed={isDefault}
             title={isDefault ? "Remove as default" : "Set as default"}
             className={cn([
               "text-muted-foreground shrink-0 hover:text-black",
-              isDefault ? "bg-muted hover:bg-accent text-black" : null,
+              isDefault
+                ? "bg-emerald-600 text-white hover:bg-emerald-700 hover:text-white"
+                : null,
             ])}
           >
-            {isDefault ? "Current default" : "Set as default"}
+            {isDefault ? (
+              <>
+                <Check className="size-3.5" weight="bold" />
+                Current default
+              </>
+            ) : (
+              "Set as default"
+            )}
           </Button>
           <Button
             type="button"


### PR DESCRIPTION
Add a leading checkmark and filled green treatment to the active default button across template views.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only styling and badge removal in template forms; no logic, auth, or data-handling changes.
> 
> **Overview**
> Makes the active default template easier to spot in both Auto and custom template views.
> 
> The **Current default** button now uses a filled emerald style with a leading checkmark. On Auto, the old Customized/Default badge next to the title is removed so default status lives only on that button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit decf0de8db686b37c1a8e7db53c9cad9b5e30ce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->