### PR TITLE
Move Auto reset into header menu

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -3238,6 +3238,7 @@ msgstr "teammate@company.com"
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr "Tell participants when listening starts; this does not confirm consent."
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -3238,6 +3238,7 @@ msgstr ""
 msgid "Tell participants when listening starts; this does not confirm consent."
 msgstr ""
 
+#: src/templates/auto-form.tsx
 #: src/templates/details.tsx
 #: src/templates/template-form.tsx
 msgid "Template actions"

--- a/apps/desktop/src/templates/auto-form.test.tsx
+++ b/apps/desktop/src/templates/auto-form.test.tsx
@@ -367,8 +367,15 @@ describe("Auto format editor", () => {
       />,
     );
 
+    expect(
+      screen.queryByRole("menuitem", { name: "Reset to default format" }),
+    ).toBeNull();
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Template actions" }),
+      { button: 0, ctrlKey: false },
+    );
     fireEvent.click(
-      screen.getByRole("button", { name: "Reset to default format" }),
+      await screen.findByRole("menuitem", { name: "Reset to default format" }),
     );
 
     await waitFor(() =>

--- a/apps/desktop/src/templates/auto-form.tsx
+++ b/apps/desktop/src/templates/auto-form.tsx
@@ -2,6 +2,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import {
   Check,
   CircleNotch,
+  DotsThree,
   LockSimple,
   MagicWand,
   Sparkle,
@@ -13,6 +14,13 @@ import { useRef, useState } from "react";
 import { PromptEditor, type PromptEditorHandle } from "@anlg/editor/prompt";
 import { commands as templateCommands } from "@anlg/plugin-template";
 import { Button } from "@anlg/ui/components/ui/button";
+import {
+  AppFloatingPanel,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@anlg/ui/components/ui/dropdown-menu";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 import { cn } from "@anlg/utils";
 
@@ -141,32 +149,74 @@ export function AutoFormatForm({
           <Sparkle className="size-4 shrink-0 text-violet-500" />
           <span className="truncate text-sm font-semibold">Auto</span>
         </div>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className={cn([
-            "text-muted-foreground shrink-0 hover:text-black",
-            isDefault
-              ? "bg-emerald-600 text-white hover:bg-emerald-700 hover:text-white disabled:opacity-100"
-              : null,
-          ])}
-          onClick={() => {
-            void setSettingValue("selected_template_id", "").catch((error) => {
-              console.error("[templates] failed to set Auto as default", error);
-            });
-          }}
-          disabled={isDefault}
-        >
-          {isDefault ? (
-            <>
-              <Check className="size-3.5" weight="bold" />
-              <Trans>Current default</Trans>
-            </>
-          ) : (
-            <Trans>Set as default</Trans>
-          )}
-        </Button>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className={cn([
+              "text-muted-foreground shrink-0 hover:text-black",
+              isDefault
+                ? "bg-emerald-600 text-white hover:bg-emerald-700 hover:text-white disabled:opacity-100"
+                : null,
+            ])}
+            onClick={() => {
+              void setSettingValue("selected_template_id", "").catch(
+                (error) => {
+                  console.error(
+                    "[templates] failed to set Auto as default",
+                    error,
+                  );
+                },
+              );
+            }}
+            disabled={isDefault}
+          >
+            {isDefault ? (
+              <>
+                <Check className="size-3.5" weight="bold" />
+                <Trans>Current default</Trans>
+              </>
+            ) : (
+              <Trans>Set as default</Trans>
+            )}
+          </Button>
+          <form.Subscribe selector={(state) => state.values.format}>
+            {(currentFormat) => (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    aria-label={t`Template actions`}
+                    className="text-muted-foreground hover:bg-accent hover:text-foreground rounded-full"
+                  >
+                    <DotsThree size={16} />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent variant="app" align="end" className="w-56">
+                  <AppFloatingPanel className="overflow-hidden p-1">
+                    <DropdownMenuItem
+                      className="cursor-pointer"
+                      disabled={
+                        !billing.isPro ||
+                        (!isCustomized &&
+                          formatsMatch(currentFormat, defaultFormat)) ||
+                        saveMutation.isPending
+                      }
+                      onClick={() => {
+                        void resetToDefault().catch(() => {});
+                      }}
+                    >
+                      <Trans>Reset to default format</Trans>
+                    </DropdownMenuItem>
+                  </AppFloatingPanel>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </form.Subscribe>
+        </div>
       </div>
 
       <div className="scroll-fade-y min-h-0 flex-1 overflow-y-auto px-6 pt-3 pb-6">
@@ -254,25 +304,6 @@ export function AutoFormatForm({
           </form.Field>
 
           <div className="flex items-center justify-end gap-2">
-            <form.Subscribe selector={(state) => state.values.format}>
-              {(currentFormat) => (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  disabled={
-                    !billing.isPro ||
-                    (!isCustomized &&
-                      formatsMatch(currentFormat, defaultFormat)) ||
-                    saveMutation.isPending
-                  }
-                  onClick={() => {
-                    void resetToDefault().catch(() => {});
-                  }}
-                >
-                  <Trans>Reset to default format</Trans>
-                </Button>
-              )}
-            </form.Subscribe>
             {billing.isPro ? (
               <form.Subscribe
                 selector={(state) => [state.canSubmit, state.isDirty] as const}


### PR DESCRIPTION
Replace the footer reset button with a header overflow action while preserving the existing reset behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only relocation of an existing reset action with no logic or data-handling changes. Risk is limited to discoverability and interaction of the new menu trigger.
> 
> **Overview**
> Moves **Reset to default format** on the Auto summary form out of the footer and into a header overflow menu next to **Set as default**, matching the existing `Template actions` pattern used by other template screens.
> 
> Reset behavior and disable rules are unchanged; only the entry point moves. Tests now open the menu before clicking reset, and locale catalogs pick up the shared `Template actions` string for `auto-form.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00889f7cbdda36d256c87f385c1252649d5f40fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->