### PR TITLE
Use an unfilled default indicator

### DIFF
--- a/apps/desktop/src/templates/auto-form.tsx
+++ b/apps/desktop/src/templates/auto-form.tsx
@@ -157,7 +157,7 @@ export function AutoFormatForm({
             className={cn([
               "text-muted-foreground shrink-0 hover:text-black",
               isDefault
-                ? "bg-emerald-600 text-white hover:bg-emerald-700 hover:text-white disabled:opacity-100"
+                ? "text-emerald-600 hover:bg-transparent hover:text-emerald-700 disabled:opacity-100 dark:text-emerald-400 dark:hover:text-emerald-300"
                 : null,
             ])}
             onClick={() => {

--- a/apps/desktop/src/templates/template-form.tsx
+++ b/apps/desktop/src/templates/template-form.tsx
@@ -235,7 +235,7 @@ export function TemplateForm({
             className={cn([
               "text-muted-foreground shrink-0 hover:text-black",
               isDefault
-                ? "bg-emerald-600 text-white hover:bg-emerald-700 hover:text-white"
+                ? "text-emerald-600 hover:bg-transparent hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
                 : null,
             ])}
           >


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic className-only UI change with no logic, data, or security impact.
> 
> **Overview**
> Updates the **Current default** button styling on Auto and custom template forms from a filled emerald background to an unfilled emerald text style, including dark-mode variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deeca25855e8202b9259495caad0b8aed454b66e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->