### PR TITLE
Simplify related contact notes

### DIFF
--- a/apps/desktop/src/contacts/details.tsx
+++ b/apps/desktop/src/contacts/details.tsx
@@ -2,7 +2,6 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import {
   Buildings,
   CircleNotch,
-  FileText,
   MagnifyingGlass,
   MinusCircle,
   Plus,
@@ -35,6 +34,7 @@ import {
   updateHuman,
   useHumanSessions,
 } from "./queries";
+import { RelatedNotesSection } from "./related-notes";
 import { ContactFacehash } from "./shared";
 
 export function DetailsColumn({
@@ -248,38 +248,10 @@ export function DetailsColumn({
               <ContactSummarySection summary={contactSummary} />
             )}
 
-            <div className="p-6">
-              <h3 className="text-muted-foreground mb-4 text-sm font-medium">
-                <Trans>Related Notes</Trans>
-              </h3>
-              <div className="flex flex-col gap-2">
-                {personSessions.length > 0 ? (
-                  personSessions.map((session) => (
-                    <button
-                      key={session.id}
-                      onClick={() => handleSessionClick(session.id)}
-                      className="border-border hover:bg-accent w-full rounded-md border p-3 text-left transition-colors"
-                    >
-                      <div className="mb-1 flex items-center gap-2">
-                        <FileText className="text-muted-foreground h-4 w-4" />
-                        <span className="text-sm font-medium">
-                          {session.title || t`Untitled Note`}
-                        </span>
-                      </div>
-                      {session.createdAt && (
-                        <div className="text-muted-foreground mt-1 text-xs">
-                          {new Date(session.createdAt).toLocaleDateString()}
-                        </div>
-                      )}
-                    </button>
-                  ))
-                ) : (
-                  <p className="text-muted-foreground text-sm">
-                    <Trans>No related notes found</Trans>
-                  </p>
-                )}
-              </div>
-            </div>
+            <RelatedNotesSection
+              sessions={personSessions}
+              onSessionClick={handleSessionClick}
+            />
 
             <div className="pb-96" />
           </div>

--- a/apps/desktop/src/contacts/related-notes.test.tsx
+++ b/apps/desktop/src/contacts/related-notes.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  onSessionClick: vi.fn(),
+}));
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  useLingui: () => ({
+    t: (strings: TemplateStringsArray, ...values: unknown[]) =>
+      strings.reduce(
+        (message, part, index) =>
+          `${message}${part}${index < values.length ? String(values[index]) : ""}`,
+        "",
+      ),
+  }),
+}));
+
+import { RelatedNotesSection } from "./related-notes";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("RelatedNotesSection", () => {
+  it("renders a compact newest-first list and opens a note", () => {
+    const { container } = render(
+      <RelatedNotesSection
+        sessions={makeSessions()}
+        onSessionClick={mocks.onSessionClick}
+      />,
+    );
+
+    expect(noteTitles(container)).toEqual(["Recent planning", "Alpha review"]);
+
+    fireEvent.click(screen.getByRole("button", { name: /Recent planning/ }));
+    expect(mocks.onSessionClick).toHaveBeenCalledWith("recent");
+  });
+
+  it("filters by title and clears the search with Escape", () => {
+    const { container } = render(
+      <RelatedNotesSection
+        sessions={makeSessions()}
+        onSessionClick={mocks.onSessionClick}
+      />,
+    );
+    const search = screen.getByPlaceholderText("Search...");
+
+    fireEvent.change(search, { target: { value: "alpha" } });
+    expect(noteTitles(container)).toEqual(["Alpha review"]);
+
+    fireEvent.keyDown(search, { key: "Escape" });
+    expect(noteTitles(container)).toEqual(["Recent planning", "Alpha review"]);
+  });
+
+  it("lets the user sort oldest first", () => {
+    const { container } = render(
+      <RelatedNotesSection
+        sessions={makeSessions()}
+        onSessionClick={mocks.onSessionClick}
+      />,
+    );
+    const trigger = screen.getByRole("button", { name: "Sort options" });
+
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "Oldest" }));
+
+    expect(noteTitles(container)).toEqual(["Alpha review", "Recent planning"]);
+  });
+});
+
+function noteTitles(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll("li button span:nth-child(2)"),
+  ).map((element) => element.textContent ?? "");
+}
+
+function makeSessions() {
+  return [
+    {
+      id: "alpha",
+      title: "Alpha review",
+      createdAt: "2026-08-01T12:00:00.000Z",
+      sourceUpdatedAt: "2026-08-01T12:00:00.000Z",
+    },
+    {
+      id: "recent",
+      title: "Recent planning",
+      createdAt: "2026-08-10T12:00:00.000Z",
+      sourceUpdatedAt: "2026-08-10T12:00:00.000Z",
+    },
+  ];
+}

--- a/apps/desktop/src/contacts/related-notes.tsx
+++ b/apps/desktop/src/contacts/related-notes.tsx
@@ -1,0 +1,158 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import { ArrowsDownUp, MagnifyingGlass, X } from "@phosphor-icons/react";
+import { useState } from "react";
+
+import { Button } from "@anlg/ui/components/ui/button";
+import {
+  AppFloatingPanel,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@anlg/ui/components/ui/dropdown-menu";
+
+import type { HumanSessionRecord } from "./queries";
+
+export function RelatedNotesSection({
+  sessions,
+  onSessionClick,
+}: {
+  sessions: HumanSessionRecord[];
+  onSessionClick: (id: string) => void;
+}) {
+  const { t } = useLingui();
+  const [search, setSearch] = useState("");
+  const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
+  const visibleSessions = sortAndFilterRelatedNotes(
+    sessions,
+    search,
+    sortOrder,
+  );
+
+  return (
+    <div className="p-6">
+      <div className="mb-3 flex items-center gap-1">
+        <h3 className="text-muted-foreground text-sm font-medium">
+          <Trans>Related Notes</Trans>
+        </h3>
+        {sessions.length > 1 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="text-muted-foreground hover:text-foreground size-7"
+                aria-label={t`Sort options`}
+              >
+                <ArrowsDownUp size={15} />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent variant="app" align="start">
+              <AppFloatingPanel className="overflow-hidden p-1">
+                <DropdownMenuRadioGroup
+                  value={sortOrder}
+                  onValueChange={(value) =>
+                    setSortOrder(value as "newest" | "oldest")
+                  }
+                >
+                  <DropdownMenuRadioItem value="newest">
+                    <Trans>Newest</Trans>
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="oldest">
+                    <Trans>Oldest</Trans>
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </AppFloatingPanel>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
+        <div className="border-border bg-muted/50 focus-within:bg-accent ml-auto flex h-8 w-52 max-w-[48%] items-center gap-2 rounded-lg border px-2.5 transition-colors">
+          <MagnifyingGlass className="text-muted-foreground size-3.5 shrink-0" />
+          <input
+            type="text"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") setSearch("");
+            }}
+            placeholder={t`Search...`}
+            className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm focus:outline-hidden"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch("")}
+              className="text-muted-foreground hover:text-foreground shrink-0 transition-colors"
+              aria-label={t`Clear search`}
+            >
+              <X className="size-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {visibleSessions.length > 0 ? (
+        <ul>
+          {visibleSessions.map((session) => (
+            <li key={session.id}>
+              <button
+                type="button"
+                onClick={() => onSessionClick(session.id)}
+                className="hover:bg-accent flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors"
+              >
+                <span className="bg-muted-foreground size-1.5 shrink-0 rounded-full" />
+                <span className="min-w-0 flex-1 truncate text-sm">
+                  {session.title || t`Untitled Note`}
+                </span>
+                {session.createdAt && (
+                  <time className="text-muted-foreground shrink-0 text-xs">
+                    {new Date(session.createdAt).toLocaleDateString()}
+                  </time>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-muted-foreground px-2 py-2 text-sm">
+          {sessions.length > 0 ? (
+            <Trans>No results found.</Trans>
+          ) : (
+            <Trans>No related notes found</Trans>
+          )}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function sortAndFilterRelatedNotes(
+  sessions: HumanSessionRecord[],
+  search: string,
+  sortOrder: "newest" | "oldest",
+): HumanSessionRecord[] {
+  const normalizedSearch = search.trim().toLocaleLowerCase();
+  const direction = sortOrder === "newest" ? -1 : 1;
+
+  return sessions
+    .filter(
+      (session) =>
+        !normalizedSearch ||
+        session.title.toLocaleLowerCase().includes(normalizedSearch),
+    )
+    .sort((left, right) => {
+      const dateDifference =
+        getSessionTimestamp(left.createdAt) -
+        getSessionTimestamp(right.createdAt);
+      return dateDifference !== 0
+        ? dateDifference * direction
+        : left.id.localeCompare(right.id) * direction;
+    });
+}
+
+function getSessionTimestamp(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -688,6 +688,7 @@ msgstr "Clean up legacy files?"
 msgid "Cleaning up..."
 msgstr "Cleaning up..."
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr "New Note"
 msgid "New template"
 msgstr "New template"
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr "Newest"
@@ -2045,10 +2047,11 @@ msgstr "No people in this organization"
 msgid "No recent chats"
 msgstr "No recent chats"
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr "No related notes found"
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr "Objects"
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr "Older files that differ from your current data were kept as recovery copies. No action is required."
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr "Oldest"
@@ -2426,7 +2430,7 @@ msgstr "Refresh calendars"
 msgid "Regenerate message"
 msgstr "Regenerate message"
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr "Related Notes"
 
@@ -2661,6 +2665,7 @@ msgstr "Search templates..."
 msgid "Search timezone..."
 msgstr "Search timezone..."
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr "Software Engineer"
 msgid "Something went wrong while generating the summary."
 msgstr "Something went wrong while generating the summary."
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr "Sort options"
@@ -3422,7 +3428,7 @@ msgstr "Untitled"
 msgid "Untitled automation"
 msgstr "Untitled automation"
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr "Untitled Note"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -688,6 +688,7 @@ msgstr ""
 msgid "Cleaning up..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 #: src/sidebar/automations.tsx
 #: src/sidebar/settings.tsx
@@ -1927,6 +1928,7 @@ msgstr ""
 msgid "New template"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
@@ -2045,10 +2047,11 @@ msgstr ""
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "No related notes found"
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/settings/ai/shared/model-combobox.tsx
 #: src/settings/general/searchable-select.tsx
 #: src/sidebar/settings.tsx
@@ -2107,6 +2110,7 @@ msgstr ""
 msgid "Older files that differ from your current data were kept as recovery copies. No action is required."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "Regenerate message"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Related Notes"
 msgstr ""
 
@@ -2661,6 +2665,7 @@ msgstr ""
 msgid "Search timezone..."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/session/components/note-input/search/bar.tsx
 #: src/settings/general/searchable-select.tsx
 msgid "Search..."
@@ -3021,6 +3026,7 @@ msgstr ""
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
+#: src/contacts/related-notes.tsx
 #: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
@@ -3422,7 +3428,7 @@ msgstr ""
 msgid "Untitled automation"
 msgstr ""
 
-#: src/contacts/details.tsx
+#: src/contacts/related-notes.tsx
 msgid "Untitled Note"
 msgstr ""
 


### PR DESCRIPTION
Replace note cards with a searchable bullet list and newest/oldest sorting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only contacts details change with no auth, data, or backend impact. Covered by new component tests.
> 
> **Overview**
> Replaces the bordered related-note cards on a contact’s details panel with a **compact searchable bullet list**, extracted into a new `RelatedNotesSection`.
> 
> Notes default to **newest-first**, with optional oldest sorting when there are multiple sessions, plus title search (Escape/clear). Empty and no-match states are handled separately. Adds unit coverage for list order, filtering, and sort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd0432c003de6ed117da715e1f035d6bb104c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->