### PR TITLE
Send a welcome email after first subscription payment

### DIFF
--- a/apps/stripe/src/routes/webhook.ts
+++ b/apps/stripe/src/routes/webhook.ts
@@ -6,6 +6,7 @@ import { env } from "../env";
 import { captureOperationalError } from "../error-reporting";
 import type { AppBindings } from "../hono-bindings";
 import { stripeSync } from "../integration/stripe-sync";
+import { sendSubscriptionWelcomeEmail } from "../subscription-welcome-email";
 import { sendTrialEndingEmail } from "../trial-emails";
 
 export const webhook = new Hono<AppBindings>();
@@ -65,6 +66,17 @@ webhook.post("/stripe", async (c) => {
     captureOperationalError(error, {
       operation: "billing_analytics_capture",
       level: "warning",
+      tags: {
+        event_type: stripeEvent.type,
+      },
+    });
+  }
+
+  try {
+    await sendSubscriptionWelcomeEmail(stripeEvent);
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "subscription_welcome_email_send",
       tags: {
         event_type: stripeEvent.type,
       },

--- a/apps/stripe/src/subscription-welcome-email.test.ts
+++ b/apps/stripe/src/subscription-welcome-email.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import type Stripe from "stripe";
+
+import {
+  sendSubscriptionWelcomeEmail,
+  type SubscriptionWelcomeEmailDependencies,
+} from "./subscription-welcome-email";
+
+function invoiceEvent(overrides: Partial<Stripe.Invoice> = {}): Stripe.Event {
+  return {
+    id: "evt_first_subscription_payment",
+    type: "invoice.paid",
+    data: {
+      object: {
+        id: "in_first_subscription_payment",
+        amount_paid: 1500,
+        billing_reason: "subscription_create",
+        created: 1_786_500_000,
+        customer: "cus_subscriber",
+        parent: {
+          type: "subscription_details",
+          quote_details: null,
+          subscription_details: {
+            metadata: null,
+            subscription: "sub_anarlog_pro",
+          },
+        },
+        ...overrides,
+      } as Stripe.Invoice,
+    },
+  } as Stripe.Event;
+}
+
+function dependencies(
+  overrides: Partial<SubscriptionWelcomeEmailDependencies> = {},
+): SubscriptionWelcomeEmailDependencies {
+  return {
+    apiKey: "loops-key",
+    getCustomer: async () =>
+      ({
+        id: "cus_subscriber",
+        email: "subscriber@example.com",
+        name: "Ada Lovelace",
+      }) as Stripe.Customer,
+    hasEarlierPaidSubscriptionInvoice: async () => false,
+    sendTransactional: async () => {},
+    ...overrides,
+  };
+}
+
+describe("sendSubscriptionWelcomeEmail", () => {
+  it("sends after the first paid subscription invoice", async () => {
+    const sends: Array<Record<string, unknown>> = [];
+
+    const result = await sendSubscriptionWelcomeEmail(
+      invoiceEvent(),
+      dependencies({
+        sendTransactional: async (payload) => {
+          sends.push(payload);
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      invoiceId: "in_first_subscription_payment",
+      transactionalId: "cmsq3t8ns0ffi0jydc6uzj1rt",
+    });
+    expect(sends).toEqual([
+      {
+        apiKey: "loops-key",
+        transactionalId: "cmsq3t8ns0ffi0jydc6uzj1rt",
+        email: "subscriber@example.com",
+        dataVariables: {},
+        idempotencyKey: "evt_first_subscription_payment",
+      },
+    ]);
+  });
+
+  it("sends when a trial converts on its first positive invoice", async () => {
+    let sent = false;
+
+    await sendSubscriptionWelcomeEmail(
+      invoiceEvent({ billing_reason: "subscription_cycle" }),
+      dependencies({
+        sendTransactional: async () => {
+          sent = true;
+        },
+      }),
+    );
+
+    expect(sent).toBeTrue();
+  });
+
+  it("does not send on a renewal", async () => {
+    const result = await sendSubscriptionWelcomeEmail(
+      invoiceEvent({ billing_reason: "subscription_cycle" }),
+      dependencies({
+        hasEarlierPaidSubscriptionInvoice: async () => true,
+        sendTransactional: async () => {
+          throw new Error("should not send");
+        },
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("ignores zero-value trial invoices", async () => {
+    const result = await sendSubscriptionWelcomeEmail(
+      invoiceEvent({ amount_paid: 0 }),
+      dependencies({
+        hasEarlierPaidSubscriptionInvoice: async () => {
+          throw new Error("should not inspect invoice history");
+        },
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("ignores paid invoices that are not subscription-backed", async () => {
+    const result = await sendSubscriptionWelcomeEmail(
+      invoiceEvent({ billing_reason: "manual", parent: null }),
+      dependencies({
+        hasEarlierPaidSubscriptionInvoice: async () => {
+          throw new Error("should not inspect invoice history");
+        },
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/stripe/src/subscription-welcome-email.ts
+++ b/apps/stripe/src/subscription-welcome-email.ts
@@ -1,0 +1,127 @@
+import type Stripe from "stripe";
+
+const SUBSCRIPTION_WELCOME_TRANSACTIONAL_ID = "cmsq3t8ns0ffi0jydc6uzj1rt";
+
+type SendTransactional = (args: {
+  apiKey: string;
+  transactionalId: string;
+  email: string;
+  dataVariables: Record<string, string | number>;
+  idempotencyKey: string;
+}) => Promise<void>;
+
+export type SubscriptionWelcomeEmailDependencies = {
+  apiKey: string | undefined;
+  getCustomer: (customerId: string) => Promise<Stripe.Customer | null>;
+  hasEarlierPaidSubscriptionInvoice: (
+    customerId: string,
+    invoice: Stripe.Invoice,
+  ) => Promise<boolean>;
+  sendTransactional: SendTransactional;
+};
+
+export async function sendSubscriptionWelcomeEmail(
+  event: Stripe.Event,
+  dependencies?: SubscriptionWelcomeEmailDependencies,
+) {
+  if (event.type !== "invoice.paid") {
+    return null;
+  }
+
+  const invoice = event.data.object as Stripe.Invoice;
+  if (invoice.amount_paid <= 0 || !isSubscriptionInvoice(invoice)) {
+    return null;
+  }
+
+  const customerId = getCustomerId(invoice);
+  if (!customerId) {
+    return null;
+  }
+
+  const activeDependencies =
+    dependencies ?? (await createDefaultDependencies());
+  if (!activeDependencies.apiKey) {
+    return null;
+  }
+
+  if (
+    await activeDependencies.hasEarlierPaidSubscriptionInvoice(
+      customerId,
+      invoice,
+    )
+  ) {
+    return null;
+  }
+
+  const customer = await activeDependencies.getCustomer(customerId);
+  if (!customer?.email) {
+    return null;
+  }
+
+  await activeDependencies.sendTransactional({
+    apiKey: activeDependencies.apiKey,
+    transactionalId: SUBSCRIPTION_WELCOME_TRANSACTIONAL_ID,
+    email: customer.email,
+    dataVariables: {},
+    idempotencyKey: event.id,
+  });
+
+  return {
+    invoiceId: invoice.id,
+    transactionalId: SUBSCRIPTION_WELCOME_TRANSACTIONAL_ID,
+  };
+}
+
+async function createDefaultDependencies(): Promise<SubscriptionWelcomeEmailDependencies> {
+  const [billingBridge, stripeIntegration, loops, environment] =
+    await Promise.all([
+      import("./billing-bridge"),
+      import("./integration/stripe"),
+      import("./loops"),
+      import("./env"),
+    ]);
+
+  return {
+    apiKey: environment.env.LOOPS_API_KEY,
+    getCustomer: billingBridge.getStripeCustomer,
+    async hasEarlierPaidSubscriptionInvoice(customerId, invoice) {
+      for await (const candidate of stripeIntegration.stripe.invoices.list({
+        customer: customerId,
+        status: "paid",
+        created: { lte: invoice.created },
+        limit: 100,
+      })) {
+        if (
+          candidate.id !== invoice.id &&
+          candidate.amount_paid > 0 &&
+          isSubscriptionInvoice(candidate)
+        ) {
+          return true;
+        }
+      }
+      return false;
+    },
+    sendTransactional: loops.sendLoopsTransactional,
+  };
+}
+
+function getCustomerId(invoice: Stripe.Invoice) {
+  if (typeof invoice.customer === "string") {
+    return invoice.customer;
+  }
+  return invoice.customer?.id ?? null;
+}
+
+function isSubscriptionInvoice(invoice: Stripe.Invoice) {
+  const legacySubscription = (
+    invoice as Stripe.Invoice & {
+      subscription?: string | Stripe.Subscription | null;
+    }
+  ).subscription;
+
+  return (
+    invoice.parent?.subscription_details != null ||
+    legacySubscription != null ||
+    invoice.billing_reason?.startsWith("subscription") === true
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the Stripe billing webhook path and customer email sending, including a Stripe invoice-history lookup to avoid renewals. Errors are isolated so they do not fail webhook processing.
> 
> **Overview**
> Sends a **Loops welcome email** when a customer’s *first* paid subscription invoice succeeds, including trial conversions.
> 
> Hooks `sendSubscriptionWelcomeEmail` into the Stripe webhook after analytics capture. It only fires on positive `invoice.paid` subscription invoices with no earlier paid subscription invoice, and uses the Stripe event id for idempotency. Failures are logged and do not fail the webhook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0f7187552f93287d0a270120869da4bf000f698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->