### PR TITLE
Add give-a-month referral program

### DIFF
--- a/apps/stripe/src/referral-rewards.test.ts
+++ b/apps/stripe/src/referral-rewards.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import type Stripe from "stripe";
+
+import { issueReferralReward } from "./referral-rewards";
+
+function invoiceEvent(overrides: Partial<Stripe.Invoice> = {}): Stripe.Event {
+  return {
+    id: "evt_referral",
+    type: "invoice.paid",
+    data: {
+      object: {
+        id: "in_referral_first",
+        customer: "cus_referred",
+        amount_paid: 1500,
+        currency: "usd",
+        ...overrides,
+      } as Stripe.Invoice,
+    },
+  } as Stripe.Event;
+}
+
+describe("issueReferralReward", () => {
+  it("ignores zero-value trial invoices", async () => {
+    const result = await issueReferralReward(invoiceEvent({ amount_paid: 0 }), {
+      getReferredUserId: async () => {
+        throw new Error("should not resolve customer");
+      },
+      prepareReward: async () => null,
+      createCredit: async () => "cbtxn_unused",
+      completeReward: async () => true,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("credits the referrer after the referred user's first payment", async () => {
+    const calls: string[] = [];
+    const result = await issueReferralReward(invoiceEvent(), {
+      getReferredUserId: async (customerId) => {
+        calls.push(`customer:${customerId}`);
+        return "user_referred";
+      },
+      prepareReward: async (userId, invoiceId) => {
+        calls.push(`prepare:${userId}:${invoiceId}`);
+        return {
+          referral_id: "referral_1",
+          referrer_user_id: "user_referrer",
+          referrer_customer_id: "cus_referrer",
+          reward_amount_cents: 1500,
+          reward_currency: "usd",
+        };
+      },
+      createCredit: async (reward, invoiceId) => {
+        calls.push(
+          `credit:${reward.referrer_customer_id}:${reward.reward_amount_cents}:${invoiceId}`,
+        );
+        return "cbtxn_referral";
+      },
+      completeReward: async (referralId, invoiceId, transactionId) => {
+        calls.push(`complete:${referralId}:${invoiceId}:${transactionId}`);
+        return true;
+      },
+    });
+
+    expect(result).toEqual({
+      referralId: "referral_1",
+      referrerUserId: "user_referrer",
+      amount: 1500,
+      currency: "usd",
+    });
+    expect(calls).toEqual([
+      "customer:cus_referred",
+      "prepare:user_referred:in_referral_first",
+      "credit:cus_referrer:1500:in_referral_first",
+      "complete:referral_1:in_referral_first:cbtxn_referral",
+    ]);
+  });
+
+  it("fails closed when the paid invoice currency differs", async () => {
+    await expect(
+      issueReferralReward(invoiceEvent({ currency: "eur" }), {
+        getReferredUserId: async () => "user_referred",
+        prepareReward: async () => ({
+          referral_id: "referral_1",
+          referrer_user_id: "user_referrer",
+          referrer_customer_id: "cus_referrer",
+          reward_amount_cents: 1500,
+          reward_currency: "usd",
+        }),
+        createCredit: async () => "cbtxn_unused",
+        completeReward: async () => true,
+      }),
+    ).rejects.toThrow("Referral reward currency does not match paid invoice");
+  });
+});

--- a/apps/stripe/src/referral-rewards.ts
+++ b/apps/stripe/src/referral-rewards.ts
@@ -1,0 +1,144 @@
+import type Stripe from "stripe";
+
+type PreparedReward = {
+  referral_id: string;
+  referrer_user_id: string;
+  referrer_customer_id: string;
+  reward_amount_cents: number;
+  reward_currency: string;
+};
+
+type ReferralRewardDependencies = {
+  getReferredUserId: (customerId: string) => Promise<string | null>;
+  prepareReward: (
+    referredUserId: string,
+    invoiceId: string,
+  ) => Promise<PreparedReward | null>;
+  createCredit: (reward: PreparedReward, invoiceId: string) => Promise<string>;
+  completeReward: (
+    referralId: string,
+    invoiceId: string,
+    balanceTransactionId: string,
+  ) => Promise<boolean>;
+};
+
+export async function issueReferralReward(
+  event: Stripe.Event,
+  dependencies?: ReferralRewardDependencies,
+) {
+  if (event.type !== "invoice.paid") {
+    return null;
+  }
+
+  const invoice = event.data.object as Stripe.Invoice;
+  if (invoice.amount_paid <= 0) {
+    return null;
+  }
+
+  const customerId =
+    typeof invoice.customer === "string"
+      ? invoice.customer
+      : invoice.customer?.id;
+  if (!customerId) {
+    return null;
+  }
+
+  const activeDependencies =
+    dependencies ?? (await createDefaultDependencies());
+  const referredUserId = await activeDependencies.getReferredUserId(customerId);
+  if (!referredUserId) {
+    return null;
+  }
+
+  const reward = await activeDependencies.prepareReward(
+    referredUserId,
+    invoice.id,
+  );
+  if (!reward) {
+    return null;
+  }
+  if (invoice.currency !== reward.reward_currency) {
+    throw new Error("Referral reward currency does not match paid invoice");
+  }
+
+  const balanceTransactionId = await activeDependencies.createCredit(
+    reward,
+    invoice.id,
+  );
+  const completed = await activeDependencies.completeReward(
+    reward.referral_id,
+    invoice.id,
+    balanceTransactionId,
+  );
+  if (!completed) {
+    throw new Error("Referral reward could not be completed");
+  }
+
+  return {
+    referralId: reward.referral_id,
+    referrerUserId: reward.referrer_user_id,
+    amount: reward.reward_amount_cents,
+    currency: reward.reward_currency,
+  };
+}
+
+async function createDefaultDependencies(): Promise<ReferralRewardDependencies> {
+  const [billingBridge, stripeIntegration, supabaseIntegration] =
+    await Promise.all([
+      import("./billing-bridge"),
+      import("./integration/stripe"),
+      import("./integration/supabase"),
+    ]);
+
+  return {
+    async getReferredUserId(customerId) {
+      const customer = await billingBridge.getStripeCustomer(customerId);
+      return customer ? billingBridge.getUserIdFromCustomer(customer) : null;
+    },
+    async prepareReward(referredUserId, invoiceId) {
+      const { data, error } = await supabaseIntegration.supabaseAdmin.rpc(
+        "prepare_referral_reward",
+        {
+          p_referred_user_id: referredUserId,
+          p_invoice_id: invoiceId,
+        },
+      );
+      if (error) {
+        throw error;
+      }
+      return ((data ?? []) as PreparedReward[])[0] ?? null;
+    },
+    async createCredit(reward, invoiceId) {
+      const transaction =
+        await stripeIntegration.stripe.customers.createBalanceTransaction(
+          reward.referrer_customer_id,
+          {
+            amount: -reward.reward_amount_cents,
+            currency: reward.reward_currency,
+            description: "Anarlog referral reward",
+            metadata: {
+              referral_id: reward.referral_id,
+              qualifying_invoice_id: invoiceId,
+              referrer_user_id: reward.referrer_user_id,
+            },
+          },
+          { idempotencyKey: `referral-reward:${reward.referral_id}` },
+        );
+      return transaction.id;
+    },
+    async completeReward(referralId, invoiceId, balanceTransactionId) {
+      const { data, error } = await supabaseIntegration.supabaseAdmin.rpc(
+        "complete_referral_reward",
+        {
+          p_referral_id: referralId,
+          p_invoice_id: invoiceId,
+          p_balance_transaction_id: balanceTransactionId,
+        },
+      );
+      if (error) {
+        throw error;
+      }
+      return data === true;
+    },
+  };
+}

--- a/apps/stripe/src/routes/webhook.ts
+++ b/apps/stripe/src/routes/webhook.ts
@@ -6,6 +6,7 @@ import { env } from "../env";
 import { captureOperationalError } from "../error-reporting";
 import type { AppBindings } from "../hono-bindings";
 import { stripeSync } from "../integration/stripe-sync";
+import { issueReferralReward } from "../referral-rewards";
 import { sendSubscriptionWelcomeEmail } from "../subscription-welcome-email";
 import { sendTrialEndingEmail } from "../trial-emails";
 
@@ -58,6 +59,16 @@ webhook.post("/stripe", async (c) => {
       tags: { event_type: stripeEvent.type },
     });
     return c.json({ error: "billing_bridge_sync_failed" }, 500);
+  }
+
+  try {
+    await issueReferralReward(stripeEvent);
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "referral_reward_issue",
+      tags: { event_type: stripeEvent.type },
+    });
+    return c.json({ error: "referral_reward_failed" }, 500);
   }
 
   try {

--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -12,6 +12,7 @@ import {
   type NewAccountAuthMethod,
   shouldOfferNewAccountTrialCheckoutFallback,
 } from "@/functions/new-account-trial-policy";
+import { claimPendingReferral } from "@/functions/referrals";
 import {
   getSupabaseAdminClient,
   getSupabaseDesktopFlowClient,
@@ -48,6 +49,7 @@ async function prepareNewAccountTrial(
 
   let result: Awaited<ReturnType<typeof ensureNewAccountTrial>>;
   try {
+    await claimPendingReferral(supabase);
     result = await ensureNewAccountTrial(session.access_token);
   } catch (error) {
     captureOperationalError(error, {

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -11,6 +11,10 @@ import { createClient } from "@anlg/api-client/client";
 import { env, requireEnv } from "@/env";
 import { getRequestAppOrigin } from "@/functions/app-origin";
 import { desktopSchemeSchema } from "@/functions/desktop-flow";
+import {
+  claimPendingReferral,
+  getReferralTrialDays,
+} from "@/functions/referrals";
 import { getStripeClient } from "@/functions/stripe";
 import {
   getSupabaseAdminClient,
@@ -257,6 +261,7 @@ async function createCheckoutUrl({
   scheme,
   trial = false,
   reservationId,
+  trialDays,
   source = "unknown",
   returnTo,
 }: {
@@ -266,6 +271,7 @@ async function createCheckoutUrl({
   scheme?: z.infer<typeof desktopSchemeSchema>;
   trial?: boolean;
   reservationId?: string;
+  trialDays?: number;
   source?:
     | "onboarding"
     | "settings"
@@ -341,7 +347,12 @@ async function createCheckoutUrl({
             source,
             user_id: user.id,
           },
-          ...(trial ? WEB_TRIAL_CHECKOUT_FIELDS.subscription_data : {}),
+          ...(trial
+            ? {
+                ...WEB_TRIAL_CHECKOUT_FIELDS.subscription_data,
+                ...(trialDays ? { trial_period_days: trialDays } : {}),
+              }
+            : {}),
         },
       },
       trial ? { idempotencyKey: `trial-checkout-${reservationId}` } : undefined,
@@ -399,7 +410,9 @@ export const createCheckoutSession = createServerFn({ method: "POST" })
     const returnTo = sanitizeInternalReturnPath(data.returnTo);
 
     let reservationId: string | undefined;
+    let trialDays: number | undefined;
     if (data.trial) {
+      await claimPendingReferral(supabase);
       const { data: reservations, error } = await supabase.rpc(
         "reserve_pro_trial",
         { p_channel: "web" },
@@ -416,6 +429,7 @@ export const createCheckoutSession = createServerFn({ method: "POST" })
         throw new Error("Trial is not available for this account");
       }
       reservationId = parsedReservationId.data;
+      trialDays = (await getReferralTrialDays(supabase)) ?? undefined;
     }
 
     try {
@@ -458,6 +472,7 @@ export const createCheckoutSession = createServerFn({ method: "POST" })
         scheme: data.scheme,
         trial: data.trial,
         reservationId,
+        trialDays,
         source: data.source,
         returnTo,
       });

--- a/apps/web/src/functions/referrals.ts
+++ b/apps/web/src/functions/referrals.ts
@@ -1,0 +1,116 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import {
+  deleteCookie,
+  getCookie,
+  setCookie,
+  setResponseHeader,
+} from "@tanstack/react-start/server";
+import { z } from "zod";
+
+import { getRequestAppOrigin } from "@/functions/app-origin";
+import { getSupabaseServerClient } from "@/functions/supabase";
+
+const REFERRAL_COOKIE = "anarlog-referral";
+const REFERRAL_COOKIE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+const referralCodeSchema = z.string().regex(/^[a-f0-9]{24}$/);
+
+type ReferralInviteRow = {
+  slot: number;
+  code: string;
+  status: "available" | "trial_started" | "reward_earned";
+  reward_amount_cents: number;
+  reward_currency: string;
+};
+
+export const persistReferralAttribution = createServerFn({ method: "POST" })
+  .inputValidator(referralCodeSchema)
+  .handler(async ({ data: code }) => {
+    setPrivateResponseHeaders();
+    const supabase = getSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (user) {
+      deleteCookie(REFERRAL_COOKIE, { path: "/" });
+      return "existing_account" as const;
+    }
+
+    setCookie(REFERRAL_COOKIE, code, {
+      httpOnly: true,
+      maxAge: REFERRAL_COOKIE_MAX_AGE_SECONDS,
+      path: "/",
+      sameSite: "lax",
+      secure: getRequestAppOrigin().startsWith("https://"),
+    });
+    return "stored" as const;
+  });
+
+export const claimPendingReferral = createServerOnlyFn(
+  async (supabase: SupabaseClient) => {
+    const rawCode = getCookie(REFERRAL_COOKIE);
+    const parsedCode = referralCodeSchema.safeParse(rawCode);
+    if (!parsedCode.success) {
+      if (rawCode) {
+        deleteCookie(REFERRAL_COOKIE, { path: "/" });
+      }
+      return false;
+    }
+
+    const { data, error } = await supabase.rpc("claim_referral", {
+      p_code: parsedCode.data,
+    });
+    if (error) {
+      throw error;
+    }
+
+    deleteCookie(REFERRAL_COOKIE, { path: "/" });
+    return data === true;
+  },
+);
+
+export const getReferralTrialDays = createServerOnlyFn(
+  async (supabase: SupabaseClient) => {
+    const { data, error } = await supabase.rpc("get_referral_trial_days");
+    if (error) {
+      throw error;
+    }
+    return typeof data === "number" ? data : null;
+  },
+);
+
+export const getReferralInvites = createServerFn({ method: "POST" }).handler(
+  async () => {
+    setPrivateResponseHeaders();
+    const supabase = getSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user?.id || user.is_anonymous) {
+      throw new Error("Unauthorized");
+    }
+
+    const { data, error } = await supabase.rpc(
+      "get_or_create_referral_invites",
+    );
+    if (error) {
+      throw error;
+    }
+
+    const appOrigin = getRequestAppOrigin();
+    return ((data ?? []) as ReferralInviteRow[]).map((invite) => ({
+      slot: invite.slot,
+      status: invite.status,
+      rewardAmountCents: invite.reward_amount_cents,
+      rewardCurrency: invite.reward_currency,
+      url: `${appOrigin}/invite/${invite.code}`,
+    }));
+  },
+);
+
+function setPrivateResponseHeaders() {
+  setResponseHeader("Cache-Control", "private, no-store");
+  setResponseHeader("Referrer-Policy", "no-referrer");
+  setResponseHeader("X-Robots-Tag", "noindex, nofollow, noarchive, nosnippet");
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as ChangelogIndexRouteImport } from './routes/changelog/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as TLinkIdRouteImport } from './routes/t/$linkId'
 import { Route as ShareShareIdRouteImport } from './routes/share/$shareId'
+import { Route as InviteCodeRouteImport } from './routes/invite/$code'
 import { Route as ChangelogVersionRouteImport } from './routes/changelog/$version'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiTemplatesRouteImport } from './routes/api/templates'
@@ -157,6 +158,11 @@ const TLinkIdRoute = TLinkIdRouteImport.update({
 const ShareShareIdRoute = ShareShareIdRouteImport.update({
   id: '/share/$shareId',
   path: '/share/$shareId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const InviteCodeRoute = InviteCodeRouteImport.update({
+  id: '/invite/$code',
+  path: '/invite/$code',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ChangelogVersionRoute = ChangelogVersionRouteImport.update({
@@ -453,6 +459,7 @@ export interface FileRoutesByFullPath {
   '/api/templates': typeof ApiTemplatesRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/changelog/$version': typeof ChangelogVersionRoute
+  '/invite/$code': typeof InviteCodeRoute
   '/share/$shareId': typeof ShareShareIdRoute
   '/t/$linkId': typeof TLinkIdRoute
   '/blog/': typeof BlogIndexRoute
@@ -523,6 +530,7 @@ export interface FileRoutesByTo {
   '/api/templates': typeof ApiTemplatesRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/changelog/$version': typeof ChangelogVersionRoute
+  '/invite/$code': typeof InviteCodeRoute
   '/share/$shareId': typeof ShareShareIdRoute
   '/t/$linkId': typeof TLinkIdRoute
   '/blog': typeof BlogIndexRoute
@@ -596,6 +604,7 @@ export interface FileRoutesById {
   '/api/templates': typeof ApiTemplatesRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/changelog/$version': typeof ChangelogVersionRoute
+  '/invite/$code': typeof InviteCodeRoute
   '/share/$shareId': typeof ShareShareIdRoute
   '/t/$linkId': typeof TLinkIdRoute
   '/blog/': typeof BlogIndexRoute
@@ -669,6 +678,7 @@ export interface FileRouteTypes {
     | '/api/templates'
     | '/blog/$slug'
     | '/changelog/$version'
+    | '/invite/$code'
     | '/share/$shareId'
     | '/t/$linkId'
     | '/blog/'
@@ -739,6 +749,7 @@ export interface FileRouteTypes {
     | '/api/templates'
     | '/blog/$slug'
     | '/changelog/$version'
+    | '/invite/$code'
     | '/share/$shareId'
     | '/t/$linkId'
     | '/blog'
@@ -811,6 +822,7 @@ export interface FileRouteTypes {
     | '/api/templates'
     | '/blog/$slug'
     | '/changelog/$version'
+    | '/invite/$code'
     | '/share/$shareId'
     | '/t/$linkId'
     | '/blog/'
@@ -883,6 +895,7 @@ export interface RootRouteChildren {
   ApiTemplatesRoute: typeof ApiTemplatesRoute
   BlogSlugRoute: typeof BlogSlugRoute
   ChangelogVersionRoute: typeof ChangelogVersionRoute
+  InviteCodeRoute: typeof InviteCodeRoute
   ShareShareIdRoute: typeof ShareShareIdRoute
   TLinkIdRoute: typeof TLinkIdRoute
   BlogIndexRoute: typeof BlogIndexRoute
@@ -1039,6 +1052,13 @@ declare module '@tanstack/react-router' {
       path: '/share/$shareId'
       fullPath: '/share/$shareId'
       preLoaderRoute: typeof ShareShareIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/invite/$code': {
+      id: '/invite/$code'
+      path: '/invite/$code'
+      fullPath: '/invite/$code'
+      preLoaderRoute: typeof InviteCodeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/changelog/$version': {
@@ -1485,6 +1505,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTemplatesRoute: ApiTemplatesRoute,
   BlogSlugRoute: BlogSlugRoute,
   ChangelogVersionRoute: ChangelogVersionRoute,
+  InviteCodeRoute: InviteCodeRoute,
   ShareShareIdRoute: ShareShareIdRoute,
   TLinkIdRoute: TLinkIdRoute,
   BlogIndexRoute: BlogIndexRoute,

--- a/apps/web/src/routes/_view/app/-account-referrals.tsx
+++ b/apps/web/src/routes/_view/app/-account-referrals.tsx
@@ -1,0 +1,154 @@
+import { Check, Copy } from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { getReferralInvites } from "@/functions/referrals";
+import { useAnalytics } from "@/hooks/use-posthog";
+
+import { useAccountSession } from "./-account-session";
+import {
+  accountCardClassName,
+  accountPillSecondaryClassName,
+} from "./-account-ui";
+
+const referralInvitesQueryKey = ["referral-invites"];
+
+export function ReferralSection({ ineligible }: { ineligible: boolean }) {
+  const session = useAccountSession();
+  const { track } = useAnalytics();
+  const [copiedSlot, setCopiedSlot] = useState<number | null>(null);
+  const isPaid = session.data?.billing.isPaid === true;
+  const invitesQuery = useQuery({
+    queryKey: referralInvitesQueryKey,
+    enabled: typeof window !== "undefined" && isPaid,
+    queryFn: () => getReferralInvites(),
+  });
+
+  if (session.isPending) {
+    return (
+      <div className={accountCardClassName}>
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          Checking your referral invites...
+        </p>
+      </div>
+    );
+  }
+
+  if (!isPaid) {
+    return (
+      <div className={accountCardClassName}>
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          {ineligible
+            ? "Referral invites are for new accounts. Ask your friend to send the link to someone who has not used Anarlog before."
+            : "Referral invites unlock when you become a Pro subscriber."}
+        </p>
+      </div>
+    );
+  }
+
+  if (invitesQuery.isPending) {
+    return (
+      <div className={accountCardClassName}>
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          Preparing your three invites...
+        </p>
+      </div>
+    );
+  }
+
+  if (invitesQuery.isError || !invitesQuery.data?.length) {
+    return (
+      <div className={accountCardClassName}>
+        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+          We could not load your referral invites. Refresh the page to try
+          again.
+        </p>
+      </div>
+    );
+  }
+
+  const invites = invitesQuery.data;
+  const earnedRewards = invites.filter(
+    (invite) => invite.status === "reward_earned",
+  ).length;
+  const rewardAmount = invites[0]?.rewardAmountCents ?? 0;
+  const rewardCurrency = invites[0]?.rewardCurrency ?? "usd";
+  const availableInvites = invites.filter(
+    (invite) => invite.status === "available",
+  ).length;
+  const earnedCredit = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: rewardCurrency.toUpperCase(),
+    maximumFractionDigits: 0,
+  }).format((earnedRewards * rewardAmount) / 100);
+
+  const handleCopy = async (slot: number, url: string) => {
+    await navigator.clipboard.writeText(url);
+    setCopiedSlot(slot);
+    track("referral_link_copied", {
+      slot,
+      available_invites: availableInvites,
+    });
+    setTimeout(() => setCopiedSlot(null), 2_000);
+  };
+
+  return (
+    <div className={accountCardClassName}>
+      {ineligible && (
+        <p className="border-b border-[#ede7dc] bg-[#fffaf0] px-6 py-4 text-sm leading-6 text-[#756b5d] sm:px-8">
+          Referral invites are for new accounts. Your own three links are below.
+        </p>
+      )}
+      <ul className="divide-y divide-[#ede7dc]">
+        {invites.map((invite) => (
+          <li
+            key={invite.slot}
+            className="flex items-center justify-between gap-4 px-6 py-5 sm:px-8"
+          >
+            <div>
+              <p className="text-base font-medium text-[#181613]">
+                Invite {invite.slot}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-[#756b5d]">
+                {statusLabel(invite.status)}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => handleCopy(invite.slot, invite.url)}
+              className={accountPillSecondaryClassName}
+            >
+              {copiedSlot === invite.slot ? (
+                <>
+                  <Check className="mr-2 size-4" />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="mr-2 size-4" />
+                  Copy link
+                </>
+              )}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <p className="border-t border-[#ede7dc] px-6 py-4 text-sm leading-6 text-[#756b5d] sm:px-8">
+        {earnedRewards > 0
+          ? `${earnedCredit} in referral credit earned.`
+          : "Your friend gets 30 days of Pro. You earn $15 after their first payment."}
+      </p>
+    </div>
+  );
+}
+
+function statusLabel(status: "available" | "trial_started" | "reward_earned") {
+  switch (status) {
+    case "trial_started":
+      return "Trial started";
+    case "reward_earned":
+      return "Reward earned";
+    default:
+      return "Available";
+  }
+}

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -19,6 +19,7 @@ import { DevicesSection } from "./-account-devices";
 import { IntegrationsSection } from "./-account-integrations";
 import { PlanSection } from "./-account-plan";
 import { ProfileInfoSection } from "./-account-profile-info";
+import { ReferralSection } from "./-account-referrals";
 import { accountSessionQueryKey } from "./-account-session";
 import { SharedNotesSection } from "./-account-shares";
 
@@ -36,6 +37,7 @@ const validateSearch = z
       "feature_gate",
       "unknown",
     ]),
+    referral: z.enum(["ineligible"]),
   })
   .partial();
 
@@ -134,6 +136,19 @@ function Component() {
             </p>
             <div className="mt-6">
               <ProfileInfoSection email={user?.email} />
+            </div>
+          </section>
+
+          <section id="referrals" className="scroll-mt-8">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+              Refer friends
+            </h2>
+            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
+              Give a month of Anarlog Pro and get a month when your friend
+              becomes a subscriber.
+            </p>
+            <div className="mt-6">
+              <ReferralSection ineligible={search.referral === "ineligible"} />
             </div>
           </section>
 

--- a/apps/web/src/routes/invite/$code.tsx
+++ b/apps/web/src/routes/invite/$code.tsx
@@ -1,0 +1,32 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { persistReferralAttribution } from "@/functions/referrals";
+
+export const Route = createFileRoute("/invite/$code")({
+  params: {
+    parse: (params) => ({
+      code: z
+        .string()
+        .regex(/^[a-f0-9]{24}$/)
+        .parse(params.code),
+    }),
+  },
+  head: () => ({
+    meta: [{ name: "robots", content: "noindex, nofollow" }],
+  }),
+  beforeLoad: async ({ params }) => {
+    const result = await persistReferralAttribution({ data: params.code });
+    if (result === "existing_account") {
+      throw redirect({ href: "/app/account?referral=ineligible" } as any);
+    }
+
+    throw redirect({
+      to: "/auth/",
+      search: {
+        flow: "web",
+        redirect: "/app/account#referrals",
+      },
+    });
+  },
+});

--- a/crates/api-subscription/src/routes/billing.rs
+++ b/crates/api-subscription/src/routes/billing.rs
@@ -13,7 +13,7 @@ use crate::stripe::{
     create_trial_subscription, customer_has_subscription_history, get_or_create_customer,
     trial_subscription_idempotency_key,
 };
-use crate::trial::{Interval, StartTrialQuery, StartTrialResponse, TrialOutcome};
+use crate::trial::{Interval, StartTrialQuery, StartTrialResponse, TrialOutcome, pro_trial_days};
 
 #[utoipa::path(
     post,
@@ -144,6 +144,25 @@ pub async fn start_trial(
         Ok(false) => {}
     }
 
+    let trial_days: u32 = match state
+        .supabase
+        .rpc::<Option<u32>>("get_referral_trial_days", &auth.token, None)
+        .await
+    {
+        Ok(days) => days.unwrap_or_else(pro_trial_days),
+        Err(e) => {
+            release_trial_reservation(&state, user_id, &reservation.reservation_id).await;
+            return emit_and_respond(
+                state.config.analytics.as_deref(),
+                distinct_id,
+                user_id,
+                source,
+                TrialOutcome::RpcError(e.to_string()),
+            )
+            .await;
+        }
+    };
+
     let price_id = match query.interval {
         Interval::Monthly => &state.config.stripe.stripe_monthly_price_id,
         Interval::Yearly => &state.config.stripe.stripe_yearly_price_id,
@@ -163,20 +182,25 @@ pub async fn start_trial(
         }
     };
 
-    let outcome =
-        match create_trial_subscription(&state.stripe, &customer_id, price_id, idempotency_key)
-            .await
-        {
-            Ok(trial_end) => TrialOutcome::Started(query.interval, trial_end),
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    reservation_id = %reservation.reservation_id,
-                    "trial_subscription_create_failed_reservation_retained"
-                );
-                TrialOutcome::StripeError(e.to_string())
-            }
-        };
+    let outcome = match create_trial_subscription(
+        &state.stripe,
+        &customer_id,
+        price_id,
+        trial_days,
+        idempotency_key,
+    )
+    .await
+    {
+        Ok(trial_end) => TrialOutcome::Started(query.interval, trial_end),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                reservation_id = %reservation.reservation_id,
+                "trial_subscription_create_failed_reservation_retained"
+            );
+            TrialOutcome::StripeError(e.to_string())
+        }
+    };
 
     emit_and_respond(
         state.config.analytics.as_deref(),

--- a/crates/api-subscription/src/stripe.rs
+++ b/crates/api-subscription/src/stripe.rs
@@ -14,7 +14,6 @@ use stripe_core::customer::{
 
 use crate::error::{Result, SubscriptionError};
 use crate::supabase::SupabaseClient;
-use crate::trial::pro_trial_days;
 
 #[derive(Debug, Deserialize)]
 struct Profile {
@@ -252,9 +251,10 @@ pub(crate) async fn create_trial_subscription(
     stripe: &stripe::Client,
     customer_id: &str,
     price_id: &str,
+    trial_days: u32,
     idempotency_key: stripe::IdempotencyKey,
 ) -> Result<Option<i64>> {
-    let create_sub = build_trial_subscription(customer_id, price_id);
+    let create_sub = build_trial_subscription(customer_id, price_id, trial_days);
 
     let start = Instant::now();
     let subscription = create_sub
@@ -296,14 +296,18 @@ pub(crate) async fn customer_has_subscription_history(
     Ok(!subscriptions.data.is_empty())
 }
 
-fn build_trial_subscription(customer_id: &str, price_id: &str) -> CreateSubscription {
+fn build_trial_subscription(
+    customer_id: &str,
+    price_id: &str,
+    trial_days: u32,
+) -> CreateSubscription {
     let mut item = CreateSubscriptionItems::new();
     item.price = Some(price_id.to_string());
 
     CreateSubscription::new()
         .customer(customer_id)
         .items(vec![item])
-        .trial_period_days(pro_trial_days())
+        .trial_period_days(trial_days)
         .trial_settings(CreateSubscriptionTrialSettings::new(
             CreateSubscriptionTrialSettingsEndBehavior::new(
                 CreateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod::Cancel,
@@ -416,8 +420,12 @@ mod tests {
 
     #[test]
     fn native_trials_are_cardless_and_cancel_if_no_card_is_added() {
-        let request = serde_json::to_value(build_trial_subscription("cus_test", "price_test"))
-            .expect("trial subscription should serialize");
+        let request = serde_json::to_value(build_trial_subscription(
+            "cus_test",
+            "price_test",
+            pro_trial_days(),
+        ))
+        .expect("trial subscription should serialize");
         let request = &request["inner"];
 
         assert_eq!(request["customer"], json!("cus_test"));
@@ -427,6 +435,15 @@ mod tests {
             json!("cancel")
         );
         assert!(request.get("default_payment_method").is_none());
+    }
+
+    #[test]
+    fn referral_trial_uses_the_requested_duration() {
+        let request = serde_json::to_value(build_trial_subscription("cus_test", "price_test", 30))
+            .expect("trial subscription should serialize");
+        let request = &request["inner"];
+
+        assert_eq!(request["trial_period_days"], json!(30));
     }
 
     #[test]

--- a/supabase/migrations/20260812160000_referrals.sql
+++ b/supabase/migrations/20260812160000_referrals.sql
@@ -1,0 +1,339 @@
+CREATE TABLE private.referral_invites (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  referrer_user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  slot smallint NOT NULL CHECK (slot BETWEEN 1 AND 3),
+  code text NOT NULL UNIQUE CHECK (code ~ '^[a-f0-9]{24}$'),
+  referred_user_id uuid UNIQUE REFERENCES auth.users (id) ON DELETE SET NULL,
+  claimed_at timestamptz,
+  qualifying_invoice_id text UNIQUE,
+  qualified_at timestamptz,
+  reward_balance_transaction_id text UNIQUE,
+  rewarded_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT referral_invites_referrer_slot_key
+    UNIQUE (referrer_user_id, slot),
+  CONSTRAINT referral_invites_claim_shape CHECK (
+    (referred_user_id IS NULL AND claimed_at IS NULL)
+    OR (referred_user_id IS NOT NULL AND claimed_at IS NOT NULL)
+  ),
+  CONSTRAINT referral_invites_qualification_shape CHECK (
+    (qualifying_invoice_id IS NULL AND qualified_at IS NULL)
+    OR (qualifying_invoice_id IS NOT NULL AND qualified_at IS NOT NULL)
+  ),
+  CONSTRAINT referral_invites_reward_shape CHECK (
+    (reward_balance_transaction_id IS NULL AND rewarded_at IS NULL)
+    OR (
+      reward_balance_transaction_id IS NOT NULL
+      AND rewarded_at IS NOT NULL
+      AND qualifying_invoice_id IS NOT NULL
+    )
+  )
+);
+
+CREATE INDEX referral_invites_referred_user_idx
+  ON private.referral_invites (referred_user_id)
+  WHERE referred_user_id IS NOT NULL;
+
+REVOKE ALL ON TABLE private.referral_invites
+  FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_or_create_referral_invites()
+RETURNS TABLE (
+  slot smallint,
+  code text,
+  status text,
+  reward_amount_cents integer,
+  reward_currency text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+BEGIN
+  IF v_user_id IS NULL OR NOT EXISTS (
+    SELECT 1
+    FROM public.profiles AS profile
+    JOIN stripe.subscriptions AS subscription
+      ON subscription.customer = profile.stripe_customer_id
+    WHERE profile.id = v_user_id
+      AND subscription.status = 'active'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM private.account_deletion_jobs AS deletion
+        WHERE deletion.owner_user_id = v_user_id
+      )
+  ) THEN
+    RETURN;
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(v_user_id::text, 180001)
+  );
+
+  INSERT INTO private.referral_invites (
+    referrer_user_id,
+    slot,
+    code
+  )
+  SELECT
+    v_user_id,
+    generated_slot,
+    encode(extensions.gen_random_bytes(12), 'hex')
+  FROM generate_series(1, 3) AS generated_slot
+  ON CONFLICT ON CONSTRAINT referral_invites_referrer_slot_key DO NOTHING;
+
+  RETURN QUERY
+  SELECT
+    referral.slot,
+    referral.code,
+    CASE
+      WHEN referral.rewarded_at IS NOT NULL THEN 'reward_earned'
+      WHEN referral.referred_user_id IS NOT NULL THEN 'trial_started'
+      ELSE 'available'
+    END,
+    1500,
+    'usd'
+  FROM private.referral_invites AS referral
+  WHERE referral.referrer_user_id = v_user_id
+  ORDER BY referral.slot;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_or_create_referral_invites()
+  IS 'Returns three referral slots for active paid subscribers, creating missing slots atomically.';
+
+REVOKE ALL ON FUNCTION public.get_or_create_referral_invites()
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_or_create_referral_invites()
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.claim_referral(p_code text)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_referral private.referral_invites%ROWTYPE;
+  v_customer_id text;
+BEGIN
+  IF v_user_id IS NULL OR p_code !~ '^[a-f0-9]{24}$' THEN
+    RETURN false;
+  END IF;
+
+  SELECT referral.*
+  INTO v_referral
+  FROM private.referral_invites AS referral
+  WHERE referral.code = p_code
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_referral.referrer_user_id = v_user_id THEN
+    RETURN false;
+  END IF;
+
+  IF v_referral.referred_user_id = v_user_id THEN
+    RETURN true;
+  END IF;
+
+  IF v_referral.referred_user_id IS NOT NULL
+    OR EXISTS (
+      SELECT 1
+      FROM private.referral_invites AS existing
+      WHERE existing.referred_user_id = v_user_id
+    )
+    OR NOT EXISTS (
+      SELECT 1
+      FROM auth.users AS auth_user
+      WHERE auth_user.id = v_user_id
+        AND COALESCE(auth_user.is_anonymous, false) = false
+        AND auth_user.created_at >= now() - interval '7 days'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM private.account_deletion_jobs AS deletion
+          WHERE deletion.owner_user_id = v_user_id
+        )
+    )
+    OR NOT EXISTS (
+      SELECT 1
+      FROM public.profiles AS referrer_profile
+      JOIN stripe.subscriptions AS referrer_subscription
+        ON referrer_subscription.customer = referrer_profile.stripe_customer_id
+      WHERE referrer_profile.id = v_referral.referrer_user_id
+        AND referrer_subscription.status = 'active'
+    )
+  THEN
+    RETURN false;
+  END IF;
+
+  SELECT profile.stripe_customer_id
+  INTO v_customer_id
+  FROM public.profiles AS profile
+  WHERE profile.id = v_user_id;
+
+  IF NOT FOUND OR (
+    v_customer_id IS NOT NULL AND EXISTS (
+      SELECT 1
+      FROM stripe.subscriptions AS subscription
+      WHERE subscription.customer = v_customer_id
+    )
+  ) THEN
+    RETURN false;
+  END IF;
+
+  UPDATE private.referral_invites
+  SET
+    referred_user_id = v_user_id,
+    claimed_at = clock_timestamp()
+  WHERE id = v_referral.id;
+
+  RETURN true;
+END;
+$$;
+
+COMMENT ON FUNCTION public.claim_referral(text)
+  IS 'Claims one available referral slot for a new, trial-eligible account.';
+
+REVOKE ALL ON FUNCTION public.claim_referral(text)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.claim_referral(text)
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_referral_trial_days()
+RETURNS integer
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT CASE
+    WHEN EXISTS (
+      SELECT 1
+      FROM private.referral_invites AS referral
+      WHERE referral.referred_user_id = auth.uid()
+    ) THEN 30
+    ELSE NULL
+  END;
+$$;
+
+COMMENT ON FUNCTION public.get_referral_trial_days()
+  IS 'Returns the extended Pro trial duration for a referred account, otherwise null.';
+
+REVOKE ALL ON FUNCTION public.get_referral_trial_days()
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_referral_trial_days()
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.prepare_referral_reward(
+  p_referred_user_id uuid,
+  p_invoice_id text
+)
+RETURNS TABLE (
+  referral_id uuid,
+  referrer_user_id uuid,
+  referrer_customer_id text,
+  reward_amount_cents integer,
+  reward_currency text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_referral private.referral_invites%ROWTYPE;
+  v_referrer_customer_id text;
+BEGIN
+  IF p_referred_user_id IS NULL
+    OR p_invoice_id IS NULL
+    OR p_invoice_id !~ '^in_[A-Za-z0-9]+$'
+  THEN
+    RETURN;
+  END IF;
+
+  SELECT referral.*
+  INTO v_referral
+  FROM private.referral_invites AS referral
+  WHERE referral.referred_user_id = p_referred_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_referral.rewarded_at IS NOT NULL THEN
+    RETURN;
+  END IF;
+
+  IF v_referral.qualifying_invoice_id IS NULL THEN
+    UPDATE private.referral_invites
+    SET
+      qualifying_invoice_id = p_invoice_id,
+      qualified_at = clock_timestamp()
+    WHERE id = v_referral.id;
+    v_referral.qualifying_invoice_id := p_invoice_id;
+  ELSIF v_referral.qualifying_invoice_id <> p_invoice_id THEN
+    RETURN;
+  END IF;
+
+  SELECT profile.stripe_customer_id
+  INTO v_referrer_customer_id
+  FROM public.profiles AS profile
+  WHERE profile.id = v_referral.referrer_user_id;
+
+  IF v_referrer_customer_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY SELECT
+    v_referral.id,
+    v_referral.referrer_user_id,
+    v_referrer_customer_id,
+    1500,
+    'usd';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.prepare_referral_reward(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.prepare_referral_reward(uuid, text)
+  TO service_role;
+
+CREATE OR REPLACE FUNCTION public.complete_referral_reward(
+  p_referral_id uuid,
+  p_invoice_id text,
+  p_balance_transaction_id text
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_updated integer;
+BEGIN
+  IF p_referral_id IS NULL
+    OR p_invoice_id IS NULL
+    OR p_balance_transaction_id IS NULL
+    OR p_balance_transaction_id !~ '^cbtxn_[A-Za-z0-9]+$'
+  THEN
+    RETURN false;
+  END IF;
+
+  UPDATE private.referral_invites AS referral
+  SET
+    reward_balance_transaction_id = p_balance_transaction_id,
+    rewarded_at = clock_timestamp()
+  WHERE referral.id = p_referral_id
+    AND referral.qualifying_invoice_id = p_invoice_id
+    AND (
+      referral.reward_balance_transaction_id IS NULL
+      OR referral.reward_balance_transaction_id = p_balance_transaction_id
+    );
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated = 1;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.complete_referral_reward(uuid, text, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.complete_referral_reward(uuid, text, text)
+  TO service_role;

--- a/supabase/tests/034-referrals.sql
+++ b/supabase/tests/034-referrals.sql
@@ -1,0 +1,243 @@
+begin;
+select plan(18);
+
+select tests.create_supabase_user('referrer_paid', 'referrer-paid@example.com');
+select tests.create_supabase_user('referrer_free', 'referrer-free@example.com');
+select tests.create_supabase_user('referred_new', 'referred-new@example.com');
+select tests.create_supabase_user('referred_other', 'referred-other@example.com');
+
+update public.profiles
+set stripe_customer_id = 'cus_referrer_paid'
+where id = tests.get_supabase_uid('referrer_paid');
+
+insert into stripe.customers (id) values ('cus_referrer_paid');
+insert into stripe.subscriptions (id, customer, status, created)
+values (
+  'sub_referrer_paid',
+  'cus_referrer_paid',
+  'active',
+  extract(epoch from now())::integer
+);
+
+select ok(
+  has_function_privilege(
+    'authenticated',
+    'public.get_or_create_referral_invites()',
+    'EXECUTE'
+  )
+    and has_function_privilege(
+      'authenticated',
+      'public.claim_referral(text)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'authenticated',
+      'public.get_referral_trial_days()',
+      'EXECUTE'
+    ),
+  'Authenticated users can call the referral-facing RPCs'
+);
+
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    'public.prepare_referral_reward(uuid,text)',
+    'EXECUTE'
+  )
+    and not has_function_privilege(
+      'authenticated',
+      'public.complete_referral_reward(uuid,text,text)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.prepare_referral_reward(uuid,text)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.complete_referral_reward(uuid,text,text)',
+      'EXECUTE'
+    ),
+  'Only the billing service can prepare and complete rewards'
+);
+
+select tests.authenticate_as('referrer_free');
+select results_eq(
+  $$select count(*) from public.get_or_create_referral_invites()$$,
+  array[0::bigint],
+  'Free users do not receive referral slots'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('referrer_paid');
+
+select results_eq(
+  $$
+    select slot, status, reward_amount_cents, reward_currency
+    from public.get_or_create_referral_invites()
+  $$,
+  $$
+    values
+      (1::smallint, 'available'::text, 1500, 'usd'::text),
+      (2::smallint, 'available'::text, 1500, 'usd'::text),
+      (3::smallint, 'available'::text, 1500, 'usd'::text)
+  $$,
+  'An active paid subscriber receives three available referral slots'
+);
+
+select is(
+  (select count(*) from public.get_or_create_referral_invites()),
+  3::bigint,
+  'Fetching referral slots is idempotent'
+);
+
+create temporary table referral_test_state as
+select slot, code
+from public.get_or_create_referral_invites();
+
+select is(
+  public.claim_referral((select code from referral_test_state where slot = 1)),
+  false,
+  'A subscriber cannot claim their own referral'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('referred_new');
+
+select is(
+  public.claim_referral((select code from referral_test_state where slot = 1)),
+  true,
+  'A new account can claim an available referral'
+);
+
+select is(
+  public.claim_referral((select code from referral_test_state where slot = 1)),
+  true,
+  'Claiming the same referral again is idempotent'
+);
+
+select is(
+  public.get_referral_trial_days(),
+  30,
+  'A referred account receives a 30-day Pro trial'
+);
+
+select is(
+  public.claim_referral((select code from referral_test_state where slot = 2)),
+  false,
+  'One account cannot consume multiple referral slots'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('referred_other');
+
+select is(
+  public.claim_referral((select code from referral_test_state where slot = 1)),
+  false,
+  'A claimed referral cannot be consumed by another account'
+);
+
+select is(
+  public.get_referral_trial_days(),
+  null,
+  'A non-referred account keeps the standard trial duration'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('referrer_paid');
+
+select is(
+  (
+    select status
+    from public.get_or_create_referral_invites()
+    where slot = 1
+  ),
+  'trial_started',
+  'The referrer sees when an invite starts a trial'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  $$
+    select referrer_user_id, referrer_customer_id,
+      reward_amount_cents, reward_currency
+    from public.prepare_referral_reward(
+      tests.get_supabase_uid('referred_new'),
+      'in_referralfirst'
+    )
+  $$,
+  $$
+    values (
+      tests.get_supabase_uid('referrer_paid'),
+      'cus_referrer_paid'::text,
+      1500,
+      'usd'::text
+    )
+  $$,
+  'The first paid invoice prepares a $15 referrer credit'
+);
+
+select is(
+  (
+    select count(*)
+    from public.prepare_referral_reward(
+      tests.get_supabase_uid('referred_new'),
+      'in_referralfirst'
+    )
+  ),
+  1::bigint,
+  'Reward preparation retries return the same pending reward'
+);
+
+select is(
+  public.complete_referral_reward(
+    (
+      select referral_id
+      from public.prepare_referral_reward(
+        tests.get_supabase_uid('referred_new'),
+        'in_referralfirst'
+      )
+    ),
+    'in_referralfirst',
+    'cbtxn_referralreward'
+  ),
+  true,
+  'The billing service can complete the prepared reward'
+);
+
+select is(
+  (
+    select count(*)
+    from public.prepare_referral_reward(
+      tests.get_supabase_uid('referred_new'),
+      'in_referralfirst'
+    )
+  ),
+  0::bigint,
+  'A completed reward cannot be prepared again'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('referrer_paid');
+
+select is(
+  (
+    select status
+    from public.get_or_create_referral_invites()
+    where slot = 1
+  ),
+  'reward_earned',
+  'The referrer sees when the reward is earned'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Create referral slots, 30-day invite trials, paid-conversion credits, and the account referral UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches billing, Stripe customer balance credits, trial duration, and auth/signup claim flows. Failures in the webhook reward path can return 500 and affect invoice processing.
> 
> **Overview**
> Adds a **give-a-month referral program**: paid subscribers get three invite links; referred new accounts get a **30-day Pro trial**, and the referrer earns a **$15 Stripe credit** after the friend’s first paid invoice.
> 
> **Invite + claim flow.** New `/invite/$code` stores attribution in an httpOnly cookie for anonymous visitors, then sends them to signup. Auth and web trial checkout claim the pending code via `claim_referral`, limited to recent trial-eligible accounts.
> 
> **Rewards.** On `invoice.paid`, the Stripe webhook prepares and completes the reward through Supabase RPCs, then credits the referrer’s Stripe customer balance idempotently. Currency mismatches fail closed.
> 
> **UI + trials.** Account settings gain a Refer friends section to copy invite links and track status. Native and web trial creation now honor `get_referral_trial_days` so referred users get 30 days instead of the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fd3afe0c76c925ad9059cdb89acfe49debee1ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->