### PR TITLE
Personalize subscription welcome emails

### DIFF
--- a/apps/stripe/src/subscription-welcome-email.test.ts
+++ b/apps/stripe/src/subscription-welcome-email.test.ts
@@ -70,10 +70,31 @@ describe("sendSubscriptionWelcomeEmail", () => {
         apiKey: "loops-key",
         transactionalId: "cmsq3t8ns0ffi0jydc6uzj1rt",
         email: "subscriber@example.com",
-        dataVariables: {},
+        dataVariables: { firstName: "Ada" },
         idempotencyKey: "evt_first_subscription_payment",
       },
     ]);
+  });
+
+  it("falls back to a friendly greeting when the customer has no name", async () => {
+    const sends: Array<Record<string, unknown>> = [];
+
+    await sendSubscriptionWelcomeEmail(
+      invoiceEvent(),
+      dependencies({
+        getCustomer: async () =>
+          ({
+            id: "cus_subscriber",
+            email: "subscriber@example.com",
+            name: null,
+          }) as Stripe.Customer,
+        sendTransactional: async (payload) => {
+          sends.push(payload);
+        },
+      }),
+    );
+
+    expect(sends[0]?.dataVariables).toEqual({ firstName: "there" });
   });
 
   it("sends when a trial converts on its first positive invoice", async () => {

--- a/apps/stripe/src/subscription-welcome-email.ts
+++ b/apps/stripe/src/subscription-welcome-email.ts
@@ -62,7 +62,9 @@ export async function sendSubscriptionWelcomeEmail(
     apiKey: activeDependencies.apiKey,
     transactionalId: SUBSCRIPTION_WELCOME_TRANSACTIONAL_ID,
     email: customer.email,
-    dataVariables: {},
+    dataVariables: {
+      firstName: customer.name?.trim().split(/\s+/)[0] || "there",
+    },
     idempotencyKey: event.id,
   });
 


### PR DESCRIPTION
Pass the Stripe customer first name to Loops with a friendly fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small email personalization change using already-fetched customer data; no auth, billing, or send-trigger logic changes.
> 
> **Overview**
> Subscription welcome emails now include the Stripe customer's **first name** in Loops `dataVariables`, instead of sending an empty payload.
> 
> The name is taken from the first word of `customer.name`, with a friendly fallback to `"there"` when no name is available. Tests cover both the named and nameless cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5bb46c65263b05ccb4917269c1420ccccc4c3ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->