### PR TITLE
Use Infisical OIDC for Stripe deploys

### DIFF
--- a/.github/workflows/stripe_cd.yaml
+++ b/.github/workflows/stripe_cd.yaml
@@ -24,10 +24,23 @@ jobs:
     runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 60
     concurrency: stripe-fly-deploy
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - uses: ./.github/actions/infisical_install
+      - name: Infisical OIDC login
+        run: |
+          set -euo pipefail
+          oidc_jwt=$(curl -sSf -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}" | jq -r '.value')
+          infisical_token=$(infisical login --method=oidc-auth \
+            --machine-identity-id=7dde9440-cec4-4cf0-a13f-1588ba67feb2 \
+            --jwt="$oidc_jwt" --silent --plain)
+          echo "::add-mask::$infisical_token"
+          echo "INFISICAL_TOKEN=$infisical_token" >> "$GITHUB_ENV"
       - run: |
           set -euo pipefail
 
@@ -102,7 +115,6 @@ jobs:
           fi
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-          INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
 
   tag:
     needs: [compute-version, deploy]


### PR DESCRIPTION
Replace the stale static service token with the existing GitHub machine identity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only credential wiring change; deploy logic and runtime Stripe/Fly behavior are unchanged aside from how Infisical tokens are minted.
> 
> **Overview**
> Stripe production deploys now obtain **Infisical** credentials at runtime via **GitHub OIDC** and the shared machine identity (`7dde9440-cec4-4cf0-a13f-1588ba67feb2`), matching the pattern already used in `api_cd.yaml`.
> 
> The deploy job grants `id-token: write`, runs an **Infisical OIDC login** step (masked token into `GITHUB_ENV`), and drops the long-lived `secrets.INFISICAL_TOKEN` from the deploy step env. Fly deploy and post-deploy secret hash checks are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91474f61a5581725caea72bb28f537183fdff60f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->