### PR TITLE
Add 1.4.9 release changelog

### DIFF
--- a/packages/changelog/content/1.4.9.md
+++ b/packages/changelog/content/1.4.9.md
@@ -1,0 +1,78 @@
+---
+date: "2026-08-13"
+summary: "Anarlog 1.4.9 adds on-device speaker memory, Team workspace management, relationship briefs, example-driven Auto formats, broader AI providers, and more reliable recording, sync, imports, sharing, and privacy controls."
+---
+
+## Speakers and transcription
+
+- Turn on **Remember speakers** to build on-device voiceprints from named
+  speakers and recognize them in later meetings; unnamed voiceprints expire
+  after 45 days
+- Transcribe long recordings through OpenAI, OpenRouter, Groq, Together AI,
+  and xAI without hitting upload limits by splitting them into smaller segments
+  and merging the results back onto one timeline
+- Start scheduled meetings automatically even when their note is not already
+  open, while ignoring ordinary calendar blocks and meetings that started more
+  than five minutes ago
+- See when a local model is warming up or reasoning, wait longer for its first
+  response, and get a notification plus Dock or taskbar attention when a
+  transcript or summary finishes in the background
+- Search the Intelligence and Transcription provider lists, use Unsloth as a
+  local model provider, and connect directly to Alibaba Cloud Model Studio,
+  Z.AI, or SiliconFlow
+- Avoid failures from unsupported temperature settings on newer models, and
+  stop automatic summary retries after a bounded backoff instead of retrying
+  forever
+
+## Teams and contacts
+
+- Create and manage shared workspaces from the new **Team** settings page:
+  invite people, manage roles and seats, transfer ownership, leave, or delete
+  a workspace according to your role
+- Keep the selected workspace in view after renaming it, see a clear
+  explanation when only admins can view the member list, and make shared
+  workspace destinations available without first opening Team settings
+- Generate a concise relationship brief from your meetings with a contact,
+  refreshed when those meetings change
+- Browse related contact notes in a compact searchable list, with newest-first
+  or oldest-first sorting and a profile header that stays identifiable while
+  you scroll
+
+## Auto formats and notes
+
+- Improve the Auto summary format from one to three past summaries by pasting
+  text or attaching Markdown files; examples are used only for that request and
+  are not saved or reused
+- Keep template suggestions out of the way after adding an empty checkbox or
+  other note structure, and turn the first task item back into a paragraph with
+  Backspace instead of swallowing the keypress
+- See the current default template more clearly and find Auto's reset action in
+  the header menu
+
+## Imports and sharing
+
+- See only meeting assistants installed on your computer during onboarding and
+  in Import settings
+- Cancel an abandoned browser connection and retry immediately, with file
+  import kept as a secondary option beside the main connect action
+- Share private notes with shorter links and get accurate title, summary, and
+  participant previews in chat and social apps
+
+## Privacy, permissions, and reliability
+
+- Control usage analytics and crash reporting independently from the new
+  Privacy settings page, with changes taking effect immediately
+- Follow a guided macOS Accessibility setup that opens System Settings and lets
+  you drag Anarlog into the permission list after the one-time system prompt is
+  gone
+- Prevent sync reconciliation from repeatedly scanning the full encrypted
+  workspace or exhausting app resources, while keeping live views current
+- Show local AI providers only while their server is reachable, keep toasts
+  readable in narrow windows, and preserve rounded note tabs and the floating
+  meeting panel on Windows
+
+<banner title="Local REST API removed" variant="warning">
+The desktop server at `127.0.0.1:33443` and its local API keys have been
+removed. Use the Cloud API for read access. Local webhooks remain available as
+a standalone Developers setting and keep working while Anarlog is running.
+</banner>


### PR DESCRIPTION
Summarizes the user-facing desktop changes since 1.4.8 and documents the local REST API removal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application or runtime behavior changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.9.md`** with user-facing release notes for Anarlog 1.4.9 (dated 2026-08-13), covering changes since 1.4.8.
> 
> The entry is grouped into speakers/transcription, Teams and contacts, Auto formats and notes, imports/sharing, and privacy/reliability. It highlights **Remember speakers**, Team workspace management, relationship briefs, example-driven Auto formats, more AI providers, and assorted reliability fixes.
> 
> A **warning banner** documents removal of the desktop local REST API at `127.0.0.1:33443` and local API keys, directing integrators to the Cloud API while noting local webhooks remain under Developers settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd869a0506ecfc203e61939689f32c0729a762bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->