### PR TITLE
Enable voiceprint commands in desktop

### DIFF
--- a/plugins/transcription/build.rs
+++ b/plugins/transcription/build.rs
@@ -19,6 +19,9 @@ const COMMANDS: &[&str] = &[
     "is_supported_languages_batch",
     "suggest_providers_for_languages_batch",
     "list_documented_language_codes_batch",
+    "extract_voiceprint_candidates",
+    "promote_voiceprint_candidates",
+    "cleanup_expired_voiceprint_candidates",
 ];
 
 fn main() {

--- a/plugins/transcription/permissions/autogenerated/commands/cleanup_expired_voiceprint_candidates.toml
+++ b/plugins/transcription/permissions/autogenerated/commands/cleanup_expired_voiceprint_candidates.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-cleanup-expired-voiceprint-candidates"
+description = "Enables the cleanup_expired_voiceprint_candidates command without any pre-configured scope."
+commands.allow = ["cleanup_expired_voiceprint_candidates"]
+
+[[permission]]
+identifier = "deny-cleanup-expired-voiceprint-candidates"
+description = "Denies the cleanup_expired_voiceprint_candidates command without any pre-configured scope."
+commands.deny = ["cleanup_expired_voiceprint_candidates"]

--- a/plugins/transcription/permissions/autogenerated/commands/extract_voiceprint_candidates.toml
+++ b/plugins/transcription/permissions/autogenerated/commands/extract_voiceprint_candidates.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-extract-voiceprint-candidates"
+description = "Enables the extract_voiceprint_candidates command without any pre-configured scope."
+commands.allow = ["extract_voiceprint_candidates"]
+
+[[permission]]
+identifier = "deny-extract-voiceprint-candidates"
+description = "Denies the extract_voiceprint_candidates command without any pre-configured scope."
+commands.deny = ["extract_voiceprint_candidates"]

--- a/plugins/transcription/permissions/autogenerated/commands/promote_voiceprint_candidates.toml
+++ b/plugins/transcription/permissions/autogenerated/commands/promote_voiceprint_candidates.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-promote-voiceprint-candidates"
+description = "Enables the promote_voiceprint_candidates command without any pre-configured scope."
+commands.allow = ["promote_voiceprint_candidates"]
+
+[[permission]]
+identifier = "deny-promote-voiceprint-candidates"
+description = "Denies the promote_voiceprint_candidates command without any pre-configured scope."
+commands.deny = ["promote_voiceprint_candidates"]

--- a/plugins/transcription/permissions/autogenerated/reference.md
+++ b/plugins/transcription/permissions/autogenerated/reference.md
@@ -24,6 +24,9 @@ Default permissions for the plugin
 - `allow-is-supported-languages-batch`
 - `allow-suggest-providers-for-languages-batch`
 - `allow-list-documented-language-codes-batch`
+- `allow-extract-voiceprint-candidates`
+- `allow-promote-voiceprint-candidates`
+- `allow-cleanup-expired-voiceprint-candidates`
 
 ## Permission Table
 
@@ -33,6 +36,32 @@ Default permissions for the plugin
 <th>Description</th>
 </tr>
 
+
+<tr>
+<td>
+
+`transcription:allow-cleanup-expired-voiceprint-candidates`
+
+</td>
+<td>
+
+Enables the cleanup_expired_voiceprint_candidates command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`transcription:deny-cleanup-expired-voiceprint-candidates`
+
+</td>
+<td>
+
+Denies the cleanup_expired_voiceprint_candidates command without any pre-configured scope.
+
+</td>
+</tr>
 
 <tr>
 <td>
@@ -56,6 +85,32 @@ Enables the export_to_vtt command without any pre-configured scope.
 <td>
 
 Denies the export_to_vtt command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`transcription:allow-extract-voiceprint-candidates`
+
+</td>
+<td>
+
+Enables the extract_voiceprint_candidates command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`transcription:deny-extract-voiceprint-candidates`
+
+</td>
+<td>
+
+Denies the extract_voiceprint_candidates command without any pre-configured scope.
 
 </td>
 </tr>
@@ -316,6 +371,32 @@ Enables the parse_subtitle command without any pre-configured scope.
 <td>
 
 Denies the parse_subtitle command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`transcription:allow-promote-voiceprint-candidates`
+
+</td>
+<td>
+
+Enables the promote_voiceprint_candidates command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`transcription:deny-promote-voiceprint-candidates`
+
+</td>
+<td>
+
+Denies the promote_voiceprint_candidates command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/transcription/permissions/default.toml
+++ b/plugins/transcription/permissions/default.toml
@@ -21,4 +21,7 @@ permissions = [
     "allow-is-supported-languages-batch",
     "allow-suggest-providers-for-languages-batch",
     "allow-list-documented-language-codes-batch",
+    "allow-extract-voiceprint-candidates",
+    "allow-promote-voiceprint-candidates",
+    "allow-cleanup-expired-voiceprint-candidates",
 ]

--- a/plugins/transcription/permissions/schemas/schema.json
+++ b/plugins/transcription/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the cleanup_expired_voiceprint_candidates command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-cleanup-expired-voiceprint-candidates",
+          "markdownDescription": "Enables the cleanup_expired_voiceprint_candidates command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the cleanup_expired_voiceprint_candidates command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-cleanup-expired-voiceprint-candidates",
+          "markdownDescription": "Denies the cleanup_expired_voiceprint_candidates command without any pre-configured scope."
+        },
+        {
           "description": "Enables the export_to_vtt command without any pre-configured scope.",
           "type": "string",
           "const": "allow-export-to-vtt",
@@ -305,6 +317,18 @@
           "type": "string",
           "const": "deny-export-to-vtt",
           "markdownDescription": "Denies the export_to_vtt command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the extract_voiceprint_candidates command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-extract-voiceprint-candidates",
+          "markdownDescription": "Enables the extract_voiceprint_candidates command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the extract_voiceprint_candidates command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-extract-voiceprint-candidates",
+          "markdownDescription": "Denies the extract_voiceprint_candidates command without any pre-configured scope."
         },
         {
           "description": "Enables the get_capture_snapshot command without any pre-configured scope.",
@@ -427,6 +451,18 @@
           "markdownDescription": "Denies the parse_subtitle command without any pre-configured scope."
         },
         {
+          "description": "Enables the promote_voiceprint_candidates command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-promote-voiceprint-candidates",
+          "markdownDescription": "Enables the promote_voiceprint_candidates command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the promote_voiceprint_candidates command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-promote-voiceprint-candidates",
+          "markdownDescription": "Denies the promote_voiceprint_candidates command without any pre-configured scope."
+        },
+        {
           "description": "Enables the render_transcript_segments command without any pre-configured scope.",
           "type": "string",
           "const": "allow-render-transcript-segments",
@@ -535,10 +571,10 @@
           "markdownDescription": "Denies the suggest_providers_for_languages_live command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-microphone-devices`\n- `allow-get-current-microphone-device`\n- `allow-start-capture`\n- `allow-stop-capture`\n- `allow-get-mic-muted`\n- `allow-set-mic-muted`\n- `allow-get-capture-state`\n- `allow-get-capture-snapshot`\n- `allow-is-supported-languages-live`\n- `allow-suggest-providers-for-languages-live`\n- `allow-list-documented-language-codes-live`\n- `allow-render-transcript-segments`\n- `allow-start-transcription`\n- `allow-stop-transcription`\n- `allow-run-denoise`\n- `allow-parse-subtitle`\n- `allow-export-to-vtt`\n- `allow-is-supported-languages-batch`\n- `allow-suggest-providers-for-languages-batch`\n- `allow-list-documented-language-codes-batch`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-microphone-devices`\n- `allow-get-current-microphone-device`\n- `allow-start-capture`\n- `allow-stop-capture`\n- `allow-get-mic-muted`\n- `allow-set-mic-muted`\n- `allow-get-capture-state`\n- `allow-get-capture-snapshot`\n- `allow-is-supported-languages-live`\n- `allow-suggest-providers-for-languages-live`\n- `allow-list-documented-language-codes-live`\n- `allow-render-transcript-segments`\n- `allow-start-transcription`\n- `allow-stop-transcription`\n- `allow-run-denoise`\n- `allow-parse-subtitle`\n- `allow-export-to-vtt`\n- `allow-is-supported-languages-batch`\n- `allow-suggest-providers-for-languages-batch`\n- `allow-list-documented-language-codes-batch`\n- `allow-extract-voiceprint-candidates`\n- `allow-promote-voiceprint-candidates`\n- `allow-cleanup-expired-voiceprint-candidates`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-microphone-devices`\n- `allow-get-current-microphone-device`\n- `allow-start-capture`\n- `allow-stop-capture`\n- `allow-get-mic-muted`\n- `allow-set-mic-muted`\n- `allow-get-capture-state`\n- `allow-get-capture-snapshot`\n- `allow-is-supported-languages-live`\n- `allow-suggest-providers-for-languages-live`\n- `allow-list-documented-language-codes-live`\n- `allow-render-transcript-segments`\n- `allow-start-transcription`\n- `allow-stop-transcription`\n- `allow-run-denoise`\n- `allow-parse-subtitle`\n- `allow-export-to-vtt`\n- `allow-is-supported-languages-batch`\n- `allow-suggest-providers-for-languages-batch`\n- `allow-list-documented-language-codes-batch`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-microphone-devices`\n- `allow-get-current-microphone-device`\n- `allow-start-capture`\n- `allow-stop-capture`\n- `allow-get-mic-muted`\n- `allow-set-mic-muted`\n- `allow-get-capture-state`\n- `allow-get-capture-snapshot`\n- `allow-is-supported-languages-live`\n- `allow-suggest-providers-for-languages-live`\n- `allow-list-documented-language-codes-live`\n- `allow-render-transcript-segments`\n- `allow-start-transcription`\n- `allow-stop-transcription`\n- `allow-run-denoise`\n- `allow-parse-subtitle`\n- `allow-export-to-vtt`\n- `allow-is-supported-languages-batch`\n- `allow-suggest-providers-for-languages-batch`\n- `allow-list-documented-language-codes-batch`\n- `allow-extract-voiceprint-candidates`\n- `allow-promote-voiceprint-candidates`\n- `allow-cleanup-expired-voiceprint-candidates`"
         }
       ]
     }


### PR DESCRIPTION
Generate and grant the Tauri permissions needed for voiceprint candidate extraction, promotion, and cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Permission and build registration only; no command logic changes in this diff, following the same pattern as existing transcription commands.
> 
> **Overview**
> Registers three voiceprint lifecycle commands on the transcription Tauri plugin—`extract_voiceprint_candidates`, `promote_voiceprint_candidates`, and `cleanup_expired_voiceprint_candidates`—in `build.rs` so they are exposed to the desktop shell.
> 
> Adds the matching autogenerated allow/deny permission entries, updates the permission schema and reference docs, and includes all three **allow** permissions in the plugin **default** set so the frontend can invoke them without custom capability config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab6826b82d90855738ad6d273056857bb10d77c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->