### PR TITLE
Prepare speaker attribution stack base

### DIFF
--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -336,6 +336,51 @@ describe("inferAutomaticSpeakerAssignments", () => {
     ]);
   });
 
+  it("uses public evidence with cloud models when the summary omits participant names", async () => {
+    mocks.generateText.mockImplementation(({ prompt }: { prompt: string }) => {
+      const payload = JSON.parse(prompt) as {
+        candidate: { human_id: string; summary_mentions: unknown[] };
+        clusters: Array<{
+          cluster_id: string;
+          evidence: { id: string };
+        }>;
+      };
+      expect(payload.candidate.summary_mentions).toEqual([]);
+
+      if (payload.candidate.human_id === "human-george") {
+        const cluster = payload.clusters.find((candidate) =>
+          candidate.cluster_id.endsWith(":1"),
+        )!;
+        return Promise.resolve({
+          text: JSON.stringify({
+            mapping: {
+              cluster_id: cluster.cluster_id,
+              confidence: 0.98,
+              evidence_id: cluster.evidence.id,
+            },
+          }),
+        });
+      }
+
+      return Promise.resolve({
+        text: JSON.stringify({ mapping: null }),
+      });
+    });
+
+    const updates = await inferAutomaticSpeakerAssignments({
+      generatedSummary: "The conversation explored open source AI.",
+      model: {} as LanguageModel,
+      snapshot: createSnapshot(),
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.generateText).toHaveBeenCalledTimes(2);
+    expect(automaticHumanIds(updates[0]!)).toEqual([
+      "human-lex",
+      "human-george",
+    ]);
+  });
+
   it("matches unique given names in generated summaries", async () => {
     mockDirectCandidateMatches();
 

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -368,7 +368,8 @@ describe("inferAutomaticSpeakerAssignments", () => {
     });
 
     const updates = await inferAutomaticSpeakerAssignments({
-      generatedSummary: "The conversation explored open source AI.",
+      generatedSummary:
+        "Speaker 1 asked about Llama. Speaker 2 supported open source AI.",
       model: {} as LanguageModel,
       snapshot: createSnapshot(),
       signal: new AbortController().signal,

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -108,8 +108,7 @@ export async function inferAutomaticSpeakerAssignments({
     [...clustersByTranscript.entries()].map(
       async ([transcriptId, clusters]) => {
         const directMappings: SpeakerAttributionMapping[] = [];
-        const useApplePublicEvidenceFallback =
-          isAppleFoundationModel(model) &&
+        const usePublicEvidenceFallback =
           context.candidates.length === 2 &&
           clusters.length === 2 &&
           candidates.every(
@@ -119,7 +118,7 @@ export async function inferAutomaticSpeakerAssignments({
         for (const candidate of candidates) {
           if (
             candidate.summaryMentions.length === 0 &&
-            !useApplePublicEvidenceFallback
+            !usePublicEvidenceFallback
           ) {
             continue;
           }

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -113,7 +113,9 @@ export async function inferAutomaticSpeakerAssignments({
           clusters.length === 2 &&
           candidates.every(
             (candidate) => candidate.summaryMentions.length === 0,
-          );
+          ) &&
+          (isAppleFoundationModel(model) ||
+            hasTwoGenericSpeakerLabels(generatedSummary));
 
         for (const candidate of candidates) {
           if (
@@ -215,6 +217,14 @@ function formatSpeakerAttributionPrompt(
   return isAppleFoundationModel(model)
     ? `Here is the U.S. English meeting data to evaluate:\n${json}`
     : json;
+}
+
+function hasTwoGenericSpeakerLabels(summary: string): boolean {
+  return (
+    new Set(
+      [...summary.matchAll(/\bspeaker\s+(\d+)\b/giu)].map((match) => match[1]),
+    ).size === 2
+  );
 }
 
 function buildSpeakerAttributionContext(

--- a/packages/changelog/content/1.4.9.md
+++ b/packages/changelog/content/1.4.9.md
@@ -20,6 +20,8 @@ summary: "Anarlog 1.4.9 adds Team workspace management, relationship briefs, exa
 - Avoid failures from unsupported temperature settings on newer models, and
   stop automatic summary retries after a bounded backoff instead of retrying
   forever
+- Match two diarized speakers to two named participants after recording even
+  when the generated summary refers to them only with generic speaker labels
 
 ## Teams and contacts
 


### PR DESCRIPTION
This stack base was already merged in #6732 and adds no new code relative to main. It remains in the stack so #6734 can land through GitHub's asynchronous stacked-merge endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-recording speaker-to-participant mapping when summaries lack names; wrong matches would mislabel transcript speakers, though existing confidence checks and fail-closed logic still apply.
> 
> **Overview**
> **Automatic speaker attribution** now uses the same **public-evidence fallback** for cloud models—not only Apple Foundation—when a two-person, two-cluster session has **no participant names** in the summary but the text uses **exactly two generic labels** (`Speaker 1`, `Speaker 2`, etc.).
> 
> The Apple-only `useApplePublicEvidenceFallback` path is generalized to `usePublicEvidenceFallback`, gated by a new `hasTwoGenericSpeakerLabels` helper. A regression test covers cloud models with a generic-label summary, and **1.4.9** changelog notes the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a7745926fbfee2ea41d27bd49b460be1e115663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->