### PR TITLE
Refine local live speaker diarization

### DIFF
--- a/apps/desktop/src/stt/capture-lifecycle.ts
+++ b/apps/desktop/src/stt/capture-lifecycle.ts
@@ -39,6 +39,7 @@ import type {
   LiveTranscriptPersistCallback,
   OnStoppedCallback,
 } from "~/store/zustand/listener/transcript";
+import { isRealtimeLocalModel } from "~/stt/capabilities";
 import {
   type CaptureLifecycleMarker,
   clearCaptureLifecycleMarker,
@@ -157,7 +158,7 @@ export function useCaptureLifecycle(sessionId: string) {
     useConfigValue("audio_retention"),
   );
   const rememberSpeakers = useConfigValue("remember_speakers") === true;
-  const { conn } = useSTTConnection();
+  const { conn, localBatchDiarizationAvailable } = useSTTConnection();
   const runBatch = useRunBatch(sessionId);
   const setBatchTranscriptionPending = useListener(
     (state) => state.setBatchTranscriptionPending,
@@ -165,9 +166,13 @@ export function useCaptureLifecycle(sessionId: string) {
 
   const runBatchRef = useRef(runBatch);
   const canRunBatchRef = useRef(canRunBatchTranscription(conn));
+  const localBatchDiarizationAvailableRef = useRef(
+    localBatchDiarizationAvailable,
+  );
   const stopMeetingChatCaptureRef = useRef<(() => Promise<void>) | null>(null);
   runBatchRef.current = runBatch;
   canRunBatchRef.current = canRunBatchTranscription(conn);
+  localBatchDiarizationAvailableRef.current = localBatchDiarizationAvailable;
 
   const stopMeetingChatTasks = useCallback(async () => {
     const stop = stopMeetingChatCaptureRef.current;
@@ -201,14 +206,20 @@ export function useCaptureLifecycle(sessionId: string) {
         recoveredMarker?.ownerUserId ?? session?.user_id ?? "";
       const provider = recoveredMarker?.provider ?? conn?.provider;
       const model = recoveredMarker?.model ?? conn?.model;
-      const refineSpeakerDiarization =
-        provider === "anarlog" &&
-        model === "cloud" &&
+      const hasMultipleRemoteParticipants =
         new Set(
           participantHumanIds.filter(
             (humanId) => humanId && humanId !== ownerUserId,
           ),
         ).size > 1;
+      const shouldUseLocalBatchForSpeakerDiarization = () =>
+        hasMultipleRemoteParticipants &&
+        localBatchDiarizationAvailableRef.current &&
+        isRealtimeLocalModel(model);
+      const shouldRefineSpeakerDiarization = () =>
+        hasMultipleRemoteParticipants &&
+        ((provider === "anarlog" && model === "cloud") ||
+          shouldUseLocalBatchForSpeakerDiarization());
       const cloudsyncLeaseKey = `${sessionId}:${transcriptId}`;
       let pendingSummaryMode = recoveredMarker?.summaryMode;
       let completionTracked = false;
@@ -380,6 +391,9 @@ export function useCaptureLifecycle(sessionId: string) {
         }
         await transcriptPersistence.flush();
         transcriptCreated ??= await transcriptExists(transcriptId);
+        const useLocalBatchForSpeakerDiarization =
+          shouldUseLocalBatchForSpeakerDiarization();
+        const refineSpeakerDiarization = shouldRefineSpeakerDiarization();
 
         const postCaptureAction = pendingSummaryMode
           ? ("enhance_only" as const)
@@ -419,6 +433,14 @@ export function useCaptureLifecycle(sessionId: string) {
                 : 0;
             await runBatchRef.current(details.audioPath!, {
               deferAudioFinalization: true,
+              ...(useLocalBatchForSpeakerDiarization
+                ? {
+                    provider: "soniqo",
+                    model: "soniqo-parakeet-batch",
+                    baseUrl: "soniqo://local",
+                    apiKey: "",
+                  }
+                : {}),
               promotion:
                 preserveExistingTranscript || transcriptCreated
                   ? {
@@ -696,7 +718,7 @@ export function useCaptureLifecycle(sessionId: string) {
           canRunBatchRef.current &&
           (!details.liveTranscriptionActive ||
             details.needsBatchRepair ||
-            refineSpeakerDiarization)
+            shouldRefineSpeakerDiarization())
         ) {
           updateBatchTranscriptionPending(true);
         }

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -1206,6 +1206,32 @@ describe("useRunBatch", () => {
     );
   });
 
+  test("uses an explicit local batch target for speaker refinement", async () => {
+    startTranscriptionMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav", {
+        provider: "soniqo",
+        model: "soniqo-parakeet-batch",
+        baseUrl: "soniqo://local",
+        apiKey: "",
+      });
+    });
+
+    expect(startTranscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "soniqo",
+        model: "soniqo-parakeet-batch",
+        base_url: "soniqo://local",
+        api_key: "",
+      }),
+      expect.any(Object),
+    );
+    expect(sonnerToastWarningMock).not.toHaveBeenCalled();
+  });
+
   test("falls back to local Soniqo when the selected provider is not batch-capable", async () => {
     useSTTConnectionMock.mockReturnValue({
       conn: {

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -40,6 +40,7 @@ import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
 type RunOptions = {
   deferAudioFinalization?: boolean;
   handlePersist?: BatchPersistCallback;
+  provider?: string;
   model?: string;
   baseUrl?: string;
   apiKey?: string;
@@ -715,10 +716,11 @@ export const useRunBatch = (sessionId: string) => {
         getTranscriptionLanguages(aiLanguage, spokenLanguages);
       const currentPlatform = platform();
       const currentArch = arch();
+      const selectedProviderId = options?.provider ?? conn?.provider;
       const selectedModel = options?.model ?? conn?.model;
       const selectedProvider =
-        conn && selectedModel
-          ? getBatchProvider(conn.provider, selectedModel)
+        selectedProviderId && selectedModel
+          ? getBatchProvider(selectedProviderId, selectedModel)
           : null;
       const selectedTarget =
         conn && selectedModel && selectedProvider
@@ -732,7 +734,7 @@ export const useRunBatch = (sessionId: string) => {
           : null;
       const selectedTargetSupported =
         selectedTarget &&
-        (!isOnDeviceSttModel(conn?.provider, selectedModel) ||
+        (!isOnDeviceSttModel(selectedProviderId, selectedModel) ||
           isDesktopLocalSttAvailable(currentPlatform, currentArch))
           ? await canUseBatchTarget(
               selectedTarget.provider,

--- a/apps/desktop/src/stt/useSTTConnection.test.ts
+++ b/apps/desktop/src/stt/useSTTConnection.test.ts
@@ -40,6 +40,7 @@ vi.mock("~/shared/config", () => ({
 vi.mock("~/stt/capabilities", () => ({
   isAnarlogCloudSttModel: () => true,
   isOnDeviceSttModel: () => false,
+  isRealtimeLocalModel: () => false,
 }));
 
 import { useSTTConnection } from "./useSTTConnection";

--- a/apps/desktop/src/stt/useSTTConnection.ts
+++ b/apps/desktop/src/stt/useSTTConnection.ts
@@ -10,7 +10,12 @@ import { env } from "~/env";
 import { type ProviderId } from "~/settings/ai/stt/shared";
 import { useAiProvider } from "~/settings/providers";
 import { useConfigValues } from "~/shared/config";
-import { isAnarlogCloudSttModel, isOnDeviceSttModel } from "~/stt/capabilities";
+import {
+  isAnarlogCloudSttModel,
+  isOnDeviceSttModel,
+  isRealtimeLocalModel,
+} from "~/stt/capabilities";
+import { localSttQueries } from "~/stt/useLocalSttModel";
 
 export const useSTTConnection = () => {
   const auth = useAuth();
@@ -36,6 +41,10 @@ export const useSTTConnection = () => {
     current_stt_provider,
     current_stt_model,
   );
+  const localBatchModel = useQuery({
+    ...localSttQueries.isDownloaded("soniqo-parakeet-batch"),
+    enabled: isRealtimeLocalModel(current_stt_model),
+  });
 
   const local = useQuery({
     enabled: isLocalModel,
@@ -129,6 +138,7 @@ export const useSTTConnection = () => {
   return {
     conn: connection,
     local,
+    localBatchDiarizationAvailable: localBatchModel.data === true,
     isLocalModel,
     isCloudModel,
   };

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -941,6 +941,75 @@ describe("useStartListening", () => {
     );
   });
 
+  test.each([
+    { provider: "soniqo", model: "soniqo-parakeet-streaming" },
+    { provider: "apple_speech", model: "apple-speech" },
+  ])(
+    "refines complete multi-speaker $model transcripts with the installed local batch model",
+    async ({ provider, model }) => {
+      useSTTConnectionMock.mockReturnValue({
+        conn: {
+          provider,
+          model,
+          baseUrl: "soniqo://local",
+          apiKey: "",
+        },
+        localBatchDiarizationAvailable: true,
+      });
+      useSessionParticipantHumanIdsMock.mockReturnValue([
+        "user-1",
+        "lex",
+        "george",
+      ]);
+      const { result } = renderHook(() => useStartListening("session-1"));
+
+      await act(async () => {
+        await result.current();
+      });
+
+      const callbacks = startMock.mock.calls[0]?.[1];
+      callbacks?.handlePersist?.({
+        new_words: [
+          {
+            id: "live-word",
+            text: "hello",
+            start_ms: 0,
+            end_ms: 500,
+            channel: 1,
+          },
+        ],
+        replaced_ids: [],
+        partials: [],
+      });
+      await act(async () => {
+        await callbacks?.onStopped?.("session-1", {
+          durationSeconds: 42,
+          audioPath: "/tmp/session.wav",
+          requestedLiveTranscription: true,
+          liveTranscriptionActive: true,
+          needsBatchRepair: false,
+        });
+      });
+
+      expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav", {
+        deferAudioFinalization: true,
+        provider: "soniqo",
+        model: "soniqo-parakeet-batch",
+        baseUrl: "soniqo://local",
+        apiKey: "",
+        promotion: {
+          scope: "current_capture",
+          audioOffsetMs: 0,
+          replaceTranscriptId: "generated-id",
+          startedAt: expect.any(Number),
+        },
+      });
+      expect(queueAutoEnhanceIfSummaryEmptyMock).toHaveBeenCalledWith(
+        "session-1",
+      );
+    },
+  );
+
   test("waits for the native capture lease to release before stop settles", async () => {
     let finishLeaseRelease: (() => void) | undefined;
     endCloudsyncActivityMock.mockImplementationOnce(

--- a/packages/changelog/content/1.4.9.md
+++ b/packages/changelog/content/1.4.9.md
@@ -20,8 +20,9 @@ summary: "Anarlog 1.4.9 adds Team workspace management, relationship briefs, exa
 - Avoid failures from unsupported temperature settings on newer models, and
   stop automatic summary retries after a bounded backoff instead of retrying
   forever
-- Match two diarized speakers to two named participants after recording even
-  when the generated summary refers to them only with generic speaker labels
+- Reliably match two speakers to two named participants after recording,
+  including local live transcription when the batch model is installed and
+  summaries that use only generic speaker labels
 
 ## Teams and contacts
 


### PR DESCRIPTION
Use the already-installed Soniqo batch model to settle multi-speaker transcripts after Parakeet Streaming or Apple Speech capture. Keep the repair local and preserve live capture behavior when the batch model is unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when post-stop batch runs and which STT target is used for multi-speaker sessions; mistakes could skip refinement or run unexpected batch jobs, but scope is gated on participant count, model type, and batch install state.
> 
> **Overview**
> **Post-capture speaker refinement** now applies to **local live** models (Parakeet Streaming, Apple Speech), not only Anarlog cloud. When the session has more than one remote participant and **`soniqo-parakeet-batch`** is already installed, capture stop triggers the same batch-then-enhance path used for cloud diarization settlement.
> 
> `useSTTConnection` exposes **`localBatchDiarizationAvailable`** (download check for the batch model when a realtime local model is selected). Capture lifecycle uses that plus **`isRealtimeLocalModel`** to decide refinement and passes an explicit **Soniqo local batch** target (`provider` / `model` / `soniqo://local`) into **`useRunBatch`**, which now accepts an optional **`provider`** override so refinement does not depend on the active live connection’s provider.
> 
> If the batch model is not installed, behavior stays as before (no local refinement pass). Tests cover explicit local batch invocation and end-to-end stop → batch for streaming and Apple Speech.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aacf3bf6c23db3f3381f10c31a12e502d6b7b90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->