### PR TITLE
Make toolbar titles readable in dark mode

### DIFF
--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -283,6 +283,7 @@ describe("TitleInput", () => {
     expect(input.className).toContain("appearance-none");
     expect(input.className).toContain("p-0");
     expect(input.className).toContain("truncate");
+    expect(input.className).toContain("dark:text-white");
     expect(input.className).not.toContain("font-mono");
   });
 

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -443,7 +443,7 @@ const TitleInputInner = memo(
               "border-none bg-transparent focus:outline-hidden",
               "placeholder:text-muted-foreground text-left",
               variant === "breadcrumb"
-                ? "h-5 appearance-none p-0 text-sm leading-5 text-neutral-700 focus:underline"
+                ? "h-5 appearance-none p-0 text-sm leading-5 text-neutral-700 focus:underline dark:text-white"
                 : "text-xl font-semibold",
               variant === "breadcrumb" &&
                 (isTitleFocused


### PR DESCRIPTION
Use white text for compact session titles and cover the styling with a regression assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change on title input styling only; no auth, data, or behavior changes.
> 
> **Overview**
> Breadcrumb-style session titles (toolbar/header compact titles) were hard to read in dark mode because they stayed on `text-neutral-700`. This PR adds **`dark:text-white`** on the breadcrumb `TitleInput` input so title text contrasts on dark backgrounds.
> 
> A regression test in **`title-input.test.tsx`** now expects **`dark:text-white`** in the breadcrumb styling case alongside the existing sans-serif/truncate assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1650eef73d0f7539667c48b3518ad886db85d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->