### PR TITLE
Require sign-in for connected imports

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -2203,6 +2203,7 @@ msgstr "Open the meeting link when listening starts."
 msgid "Open web copy"
 msgstr "Open web copy"
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr "Sign in for Pro"
 msgid "Sign in to Anarlog"
 msgstr "Sign in to Anarlog"
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr "Sign in to connect"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -2203,6 +2203,7 @@ msgstr ""
 msgid "Open web copy"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
 #: src/shared-notes/index.tsx
 msgid "Opening…"
@@ -2956,6 +2957,7 @@ msgstr ""
 msgid "Sign in to Anarlog"
 msgstr ""
 
+#: src/imports/screen.tsx
 #: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""

--- a/apps/desktop/src/imports/screen.test.tsx
+++ b/apps/desktop/src/imports/screen.test.tsx
@@ -14,6 +14,15 @@ const mocks = vi.hoisted(() => ({
   cancelConnectedImport: vi.fn(),
   connectConnectedImport: vi.fn(),
   disconnectConnectedImport: vi.fn(),
+  signIn: vi.fn(),
+  signedIn: true,
+}));
+
+vi.mock("~/auth", () => ({
+  useAuth: () => ({
+    session: mocks.signedIn ? {} : null,
+    signIn: mocks.signIn,
+  }),
 }));
 
 vi.mock("./detection", () => ({
@@ -102,7 +111,9 @@ function mockDetected(ids: string[]) {
 describe("MeetingImportScreen", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.signedIn = true;
     mocks.cancelConnectedImport.mockResolvedValue(true);
+    mocks.signIn.mockResolvedValue(undefined);
   });
 
   afterEach(cleanup);
@@ -163,6 +174,27 @@ describe("MeetingImportScreen", () => {
     expect(
       await screen.findByRole("menuitem", { name: "Use files" }),
     ).toBeTruthy();
+  });
+
+  it("prompts signed-out users to sign in before connecting", async () => {
+    mocks.signedIn = false;
+    mockDetected(["granola"]);
+
+    renderImports();
+
+    const signInButton = await screen.findByRole("button", {
+      name: "Sign in to connect",
+    });
+    expect(screen.getByText("Connect & import")).toBeTruthy();
+    expect(screen.getAllByText("Sign in to connect")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Use files" })).toBeTruthy();
+
+    fireEvent.click(signInButton);
+
+    await waitFor(() => {
+      expect(mocks.signIn).toHaveBeenCalledOnce();
+    });
+    expect(mocks.connectConnectedImport).not.toHaveBeenCalled();
   });
 
   it("renders the same detected list in the compact onboarding layout", async () => {

--- a/apps/desktop/src/imports/screen.tsx
+++ b/apps/desktop/src/imports/screen.tsx
@@ -48,6 +48,7 @@ import {
 } from "./queries";
 import { pauseCompetingApplicationTermination } from "./termination-pause";
 
+import { useAuth } from "~/auth";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 const IMPORT_EXTENSIONS = [
@@ -91,8 +92,10 @@ export function MeetingImportScreen({
   secondaryAction?: ReactNode;
 }) {
   const { t } = useLingui();
+  const auth = useAuth();
   const queryClient = useQueryClient();
   const connectAbortController = useRef<AbortController | null>(null);
+  const signedIn = Boolean(auth.session);
   const detectionQuery = useQuery({
     queryKey: ["meeting-import-sources"],
     queryFn: detectImportSources,
@@ -120,7 +123,7 @@ export function MeetingImportScreen({
     queries: connectedProviders.map((provider, index) =>
       connectedImportSyncQueryOptions(
         provider,
-        Boolean(credentialQueries[index]?.data),
+        signedIn && Boolean(credentialQueries[index]?.data),
       ),
     ),
   });
@@ -178,6 +181,10 @@ export function MeetingImportScreen({
     },
   });
 
+  const signInMutation = useMutation({
+    mutationFn: () => auth.signIn(),
+  });
+
   const cancelConnectMutation = useMutation({
     mutationFn: cancelConnectedImport,
   });
@@ -200,6 +207,7 @@ export function MeetingImportScreen({
 
   const connectedError =
     credentialQueries.find((query) => query.error)?.error ??
+    signInMutation.error ??
     connectMutation.error ??
     cancelConnectMutation.error ??
     disconnectMutation.error ??
@@ -281,7 +289,7 @@ export function MeetingImportScreen({
                 connectedIndex === undefined
                   ? undefined
                   : syncQueries[connectedIndex];
-              const connected = Boolean(credentialsQuery?.data);
+              const connected = signedIn && Boolean(credentialsQuery?.data);
               const connecting =
                 connectMutation.isPending &&
                 connectMutation.variables.id === provider.id;
@@ -380,13 +388,27 @@ export function MeetingImportScreen({
                           <Button
                             type="button"
                             size="sm"
-                            disabled={
-                              credentialsQuery?.isPending ||
-                              cancelConnectMutation.isPending ||
-                              connectionCancellationRequested ||
-                              (connectMutation.isPending && !connecting)
+                            variant={signedIn ? "default" : "outline"}
+                            aria-label={
+                              signedIn ? undefined : t`Sign in to connect`
                             }
+                            disabled={
+                              signedIn
+                                ? credentialsQuery?.isPending ||
+                                  cancelConnectMutation.isPending ||
+                                  connectionCancellationRequested ||
+                                  (connectMutation.isPending && !connecting)
+                                : signInMutation.isPending
+                            }
+                            className={cn([
+                              !signedIn &&
+                                "group/sign-in bg-muted hover:border-primary hover:bg-primary hover:text-primary-foreground focus-visible:border-primary focus-visible:bg-primary focus-visible:text-primary-foreground",
+                            ])}
                             onClick={() => {
+                              if (!signedIn) {
+                                signInMutation.mutate();
+                                return;
+                              }
                               if (connecting) {
                                 connectAbortController.current?.abort();
                                 cancelConnectMutation.mutate(provider.id);
@@ -395,14 +417,35 @@ export function MeetingImportScreen({
                               connectMutation.mutate(provider);
                             }}
                           >
-                            {credentialsQuery?.isPending ||
-                            connecting ||
-                            cancellingConnection ? (
+                            {!signedIn ? (
+                              signInMutation.isPending ? (
+                                <>
+                                  <CircleNotch className="size-3.5 animate-spin" />
+                                  <Trans>Opening…</Trans>
+                                </>
+                              ) : (
+                                <span className="grid items-center overflow-hidden">
+                                  <span className="invisible col-start-1 row-start-1">
+                                    <Trans>Sign in to connect</Trans>
+                                  </span>
+                                  <span className="col-start-1 row-start-1 flex items-center justify-center gap-2 transition-transform duration-200 group-hover/sign-in:translate-y-full group-focus-visible/sign-in:translate-y-full">
+                                    <PlugsConnected className="size-3.5" />
+                                    <Trans>Connect & import</Trans>
+                                  </span>
+                                  <span className="col-start-1 row-start-1 flex -translate-y-full items-center justify-center transition-transform duration-200 group-hover/sign-in:translate-y-0 group-focus-visible/sign-in:translate-y-0">
+                                    <Trans>Sign in to connect</Trans>
+                                  </span>
+                                </span>
+                              )
+                            ) : credentialsQuery?.isPending ||
+                              connecting ||
+                              cancellingConnection ? (
                               <CircleNotch className="size-3.5 animate-spin" />
                             ) : (
                               <PlugsConnected className="size-3.5" />
                             )}
-                            {connecting || cancellingConnection ? (
+                            {!signedIn ? null : connecting ||
+                              cancellingConnection ? (
                               <Trans>Cancel</Trans>
                             ) : credentialsQuery?.isPending ? (
                               <Trans>Checking connection</Trans>
@@ -415,9 +458,15 @@ export function MeetingImportScreen({
                               <Button
                                 type="button"
                                 size="sm"
+                                variant={signedIn ? "default" : "outline"}
                                 aria-label={t`Use files`}
                                 disabled={fileImportMutation.isPending}
-                                className="before:bg-primary-foreground/20 relative w-6 px-0 before:absolute before:inset-y-1.5 before:left-0 before:w-px"
+                                className={cn([
+                                  "relative w-6 px-0 before:absolute before:inset-y-1.5 before:left-0 before:w-px",
+                                  signedIn
+                                    ? "before:bg-primary-foreground/20"
+                                    : "before:bg-border",
+                                ])}
                               >
                                 <CaretDown className="size-3.5" />
                               </Button>

--- a/apps/desktop/src/services/meeting-import-sync.test.tsx
+++ b/apps/desktop/src/services/meeting-import-sync.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  signedIn: false,
+  connectedImportSyncQueryOptions: vi.fn(),
+}));
+
+vi.mock("~/auth", () => ({
+  useAuth: () => ({ session: mocks.signedIn ? {} : null }),
+}));
+
+vi.mock("~/imports/connected-import", () => ({
+  connectedImportCredentialsQueryOptions: (providerId: string) => ({
+    queryKey: ["credentials", providerId],
+  }),
+  connectedImportSyncQueryOptions: (
+    provider: { id: string },
+    enabled: boolean,
+  ) => mocks.connectedImportSyncQueryOptions(provider, enabled),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueries: ({ queries }: { queries: { queryKey: string[] }[] }) =>
+    queries[0]?.queryKey[0] === "credentials"
+      ? queries.map(() => ({ data: {} }))
+      : queries.map(() => ({})),
+}));
+
+import { MeetingImportSync } from "./meeting-import-sync";
+
+describe("MeetingImportSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.signedIn = false;
+    mocks.connectedImportSyncQueryOptions.mockImplementation(
+      (provider: { id: string }, enabled: boolean) => ({
+        queryKey: ["sync", provider.id, String(enabled)],
+      }),
+    );
+  });
+
+  afterEach(cleanup);
+
+  it("pauses connected imports while signed out", () => {
+    render(<MeetingImportSync />);
+
+    expect(mocks.connectedImportSyncQueryOptions).toHaveBeenCalled();
+    expect(
+      mocks.connectedImportSyncQueryOptions.mock.calls.every(
+        ([, enabled]) => enabled === false,
+      ),
+    ).toBe(true);
+  });
+
+  it("enables connected imports after sign-in", () => {
+    mocks.signedIn = true;
+
+    render(<MeetingImportSync />);
+
+    expect(mocks.connectedImportSyncQueryOptions).toHaveBeenCalled();
+    expect(
+      mocks.connectedImportSyncQueryOptions.mock.calls.every(
+        ([, enabled]) => enabled === true,
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/services/meeting-import-sync.tsx
+++ b/apps/desktop/src/services/meeting-import-sync.tsx
@@ -1,5 +1,6 @@
 import { useQueries } from "@tanstack/react-query";
 
+import { useAuth } from "~/auth";
 import {
   connectedImportCredentialsQueryOptions,
   connectedImportSyncQueryOptions,
@@ -11,6 +12,8 @@ const CONNECTED_PROVIDERS = MEETING_IMPORT_PROVIDERS.filter(
 );
 
 export function MeetingImportSync() {
+  const auth = useAuth();
+  const signedIn = Boolean(auth.session);
   const credentialQueries = useQueries({
     queries: CONNECTED_PROVIDERS.map((provider) =>
       connectedImportCredentialsQueryOptions(provider.id),
@@ -20,7 +23,7 @@ export function MeetingImportSync() {
     queries: CONNECTED_PROVIDERS.map((provider, index) =>
       connectedImportSyncQueryOptions(
         provider,
-        Boolean(credentialQueries[index]?.data),
+        signedIn && Boolean(credentialQueries[index]?.data),
       ),
     ),
   });


### PR DESCRIPTION
Route signed-out connector actions to account sign-in while keeping file imports available, and pause background connector sync until authenticated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-gated import/connect flows and background sync; scope is limited to import UI and sync enablement with tests, but wrong gating could block imports or leak sync while signed out.
> 
> **Overview**
> **Connected meeting imports (OAuth/MCP) now require an authenticated session**; file-based imports are unchanged and stay available while signed out.
> 
> On `MeetingImportScreen`, the primary connector control checks `useAuth()` session state. Without a session, **Connect & import** becomes a sign-in affordance (hover reveals **Sign in to connect**, click runs `signIn()`), and providers are not treated as connected until signed in. Background sync queries on the screen only run when `signedIn &&` credentials exist.
> 
> `MeetingImportSync` applies the same gate so **background connector sync does not run** until the user is signed in. Tests cover the signed-out sign-in flow on the import screen and sync enable/disable in the background service. Locale catalogs pick up new string references from `imports/screen.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1455789ab09787fa13131cb0965bee974eef5155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->