### PR TITLE
Collapse session toolbar labels in narrow layouts

### DIFF
--- a/apps/desktop/src/session/components/note-input/header-enhanced.tsx
+++ b/apps/desktop/src/session/components/note-input/header-enhanced.tsx
@@ -242,7 +242,7 @@ function HeaderViewEnhancedActive({
         true,
         "tray",
         cn([
-          "max-w-56 min-w-[62px] gap-1.5 px-2",
+          "max-w-56 min-w-[62px] gap-1.5 px-2 @max-[480px]:max-w-10 @max-[480px]:min-w-10 @max-[480px]:gap-0",
           isGenerating ? "cursor-not-allowed opacity-70" : "cursor-pointer",
           isError
             ? [
@@ -261,8 +261,10 @@ function HeaderViewEnhancedActive({
       ) : (
         <Sparkle className="size-4" />
       )}
-      <span className="min-w-0 truncate text-xs font-medium">{viewTitle}</span>
-      <CaretDown className="size-3.5" />
+      <span className="min-w-0 truncate text-xs font-medium @max-[480px]:sr-only">
+        {viewTitle}
+      </span>
+      <CaretDown className="size-3.5 @max-[480px]:hidden" />
     </button>
   );
 

--- a/apps/desktop/src/session/components/note-input/header-shared.tsx
+++ b/apps/desktop/src/session/components/note-input/header-shared.tsx
@@ -57,7 +57,9 @@ export function IconHeaderView({
         size,
         cn([
           "px-2",
-          isActive ? "max-w-40 min-w-10 gap-1.5" : null,
+          isActive
+            ? "max-w-40 min-w-10 gap-1.5 @max-[480px]:max-w-10 @max-[480px]:gap-0"
+            : null,
           hoverLabel
             ? "after:hidden after:min-w-0 after:truncate after:text-xs after:font-medium after:content-[attr(data-hover-label)] hover:after:block"
             : null,
@@ -69,7 +71,7 @@ export function IconHeaderView({
       {isActive && (
         <span
           className={cn([
-            "min-w-0 truncate text-xs font-medium",
+            "min-w-0 truncate text-xs font-medium @max-[480px]:sr-only",
             hoverLabel ? "group-hover/header-view:hidden" : null,
           ])}
         >

--- a/apps/desktop/src/session/components/note-input/header-transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/header-transcript.tsx
@@ -102,7 +102,9 @@ function HeaderViewTranscriptButton({
         live
           ? [
               "group/transcript-live",
-              isActive ? "w-[98px] min-w-[98px] gap-1.5 px-2" : null,
+              isActive
+                ? "w-[98px] min-w-[98px] gap-1.5 px-2 @max-[480px]:w-10 @max-[480px]:min-w-10 @max-[480px]:gap-0"
+                : null,
               isActive
                 ? live.degraded
                   ? [

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -389,6 +389,10 @@ describe("Header", () => {
     expect(memoTab.className).toContain("dark:text-foreground");
     expect(memoTab.className).toContain("dark:bg-accent");
     expect(memoTab.className).toContain("dark:shadow-none");
+    expect(memoTab.className).toContain("@max-[480px]:max-w-10");
+    expect(memoTab.querySelector("span")?.className).toContain(
+      "@max-[480px]:sr-only",
+    );
     expect(summaryTab.className).toContain("h-[26px]");
     expect(summaryTab.className).toContain("px-2");
     expect(summaryTab.className).not.toContain("min-w-10");
@@ -427,6 +431,10 @@ describe("Header", () => {
     expect(activeSummaryTab.className).toContain("text-foreground");
     expect(activeSummaryTab.className).toContain("dark:text-foreground");
     expect(activeSummaryTab.className).toContain("dark:bg-accent");
+    expect(activeSummaryTab.className).toContain("@max-[480px]:max-w-10");
+    expect(activeSummaryTab.querySelector("span")?.className).toContain(
+      "@max-[480px]:sr-only",
+    );
     expect(activeSummaryTab.querySelectorAll("svg")).toHaveLength(2);
 
     fireEvent.click(activeSummaryTab);
@@ -1014,6 +1022,7 @@ describe("Header", () => {
 
     expect(screen.getByTestId("dancing-sticks")).not.toBeNull();
     expect(transcriptTab.className).toContain("bg-red-50");
+    expect(transcriptTab.className).toContain("@max-[480px]:w-10");
     expect(transcriptTab.getAttribute("title")).toBeNull();
     expect(transcriptTab.getAttribute("data-hover-label")).toBeNull();
 

--- a/apps/desktop/src/session/components/note-input/transcript/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/index.tsx
@@ -30,7 +30,7 @@ export function TranscriptEditButton({
         aria-pressed={editMode}
         onClick={() => onEditModeChange(!editMode)}
         className={cn([
-          "border-border bg-card text-foreground flex h-7 items-center gap-1.5 rounded-full border px-2 text-sm font-medium",
+          "border-border bg-card text-foreground flex h-7 items-center gap-1.5 rounded-full border px-2 text-sm font-medium @max-[480px]:w-7 @max-[480px]:justify-center @max-[480px]:gap-0 @max-[480px]:px-0",
           "hover:bg-accent focus-visible:ring-ring transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
           editMode ? "border-primary/30 bg-primary/10 text-primary" : null,
         ])}
@@ -40,7 +40,9 @@ export function TranscriptEditButton({
         ) : (
           <PencilSimple aria-hidden className="size-3.5" />
         )}
-        {editMode ? <Trans>Done writing</Trans> : <Trans>Write</Trans>}
+        <span className="@max-[480px]:sr-only">
+          {editMode ? <Trans>Done writing</Trans> : <Trans>Write</Trans>}
+        </span>
       </button>
     </div>
   );

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -816,6 +816,9 @@ describe("OuterHeader", () => {
 
     expect(recordButton.parentElement?.className).toContain("bg-card");
     expect(recordButton.parentElement?.className).not.toContain("bg-primary");
+    expect(recordButton.querySelector("span")?.className).toContain(
+      "@max-[480px]:sr-only",
+    );
     fireEvent.click(recordButton);
 
     expect(mocks.startListening).toHaveBeenCalledTimes(1);
@@ -983,7 +986,12 @@ describe("OuterHeader", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Write" }));
+    const writeButton = screen.getByRole("button", { name: "Write" });
+    expect(writeButton.className).toContain("@max-[480px]:w-7");
+    expect(writeButton.querySelector("span")?.className).toContain(
+      "@max-[480px]:sr-only",
+    );
+    fireEvent.click(writeButton);
     expect(onTranscriptEditModeChange).toHaveBeenCalledWith(true);
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
     expect(

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -377,7 +377,7 @@ function HeaderMeetingActionPill({
           ])}
         >
           {action.icon}
-          <span className="truncate">{action.label}</span>
+          <span className="truncate @max-[480px]:sr-only">{action.label}</span>
         </button>
         <MetadataButton
           sessionId={sessionId}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Responsive Tailwind-only changes; behavior and aria-labels are preserved via sr-only text.
> 
> **Overview**
> On viewports at or below **480px** (via `@max-[480px]` container queries), session chrome switches from icon+text controls to **compact icon-only** buttons so the toolbar fits narrow windows.
> 
> **Note-input header:** Active tab labels (Memos, summary title, Transcript) and the enhanced summary template trigger shrink to fixed **40px** width; text is **`sr-only`** and the template picker **caret** is hidden on narrow widths. Live transcript tabs drop their wider fixed width in the same breakpoint.
> 
> **Outer header:** Record / Join & record / Stop / Resume labels in the meeting-action pill are **`sr-only`** on narrow layouts (icons and **`aria-label`** unchanged).
> 
> **Transcript:** The Write / Done writing control becomes a square icon button with label **`sr-only`**.
> 
> Tests assert the new responsive class names on memo, summary, live transcript, Record, and Write buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af4789f1bda0ef5e7f42a8e12abb12e215deb17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->