### PR TITLE
Refresh 1.4.9 release changelog

### DIFF
--- a/packages/changelog/content/1.4.9.md
+++ b/packages/changelog/content/1.4.9.md
@@ -43,6 +43,7 @@ summary: "Anarlog 1.4.9 adds Team workspace management, relationship briefs, exa
 - Improve the Auto summary format from one to three past summaries by pasting
   text or attaching Markdown files; examples are used only for that request and
   are not saved or reused
+- Get started from a welcome note that offers to open a complete demo meeting
 - Keep template suggestions out of the way after adding an empty checkbox or
   other note structure, and turn the first task item back into a paragraph with
   Backspace instead of swallowing the keypress
@@ -53,6 +54,8 @@ summary: "Anarlog 1.4.9 adds Team workspace management, relationship briefs, exa
 
 - See only meeting assistants installed on your computer during onboarding and
   in Import settings
+- Sign in before connecting meeting assistants, while keeping local file import
+  available without an account
 - Cancel an abandoned browser connection and retry immediately, with file
   import kept as a secondary option beside the main connect action
 - Share private notes with shorter links and get accurate title, summary, and
@@ -65,11 +68,13 @@ summary: "Anarlog 1.4.9 adds Team workspace management, relationship briefs, exa
 - Follow a guided macOS Accessibility setup that opens System Settings and lets
   you drag Anarlog into the permission list after the one-time system prompt is
   gone
+- Get clear recovery steps when Apple Calendar access is denied or the notes on
+  your device belong to a different signed-in account
 - Prevent sync reconciliation from repeatedly scanning the full encrypted
   workspace or exhausting app resources, while keeping live views current
 - Show local AI providers only while their server is reachable, keep toasts
-  readable in narrow windows, and preserve rounded note tabs and the floating
-  meeting panel on Windows
+  and session controls readable in narrow windows and dark mode, and preserve
+  rounded note tabs and the floating meeting panel on Windows
 
 <banner title="Local REST API removed" variant="warning">
 The desktop server at `127.0.0.1:33443` and its local API keys have been


### PR DESCRIPTION
Add the user-facing onboarding, connected-import, permission recovery, account mismatch, and responsive UI improvements that landed after the original changelog PR.

Validated with dprint, repository formatting checks, and the changelog typecheck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no application or infrastructure changes.
> 
> **Overview**
> Updates **`packages/changelog/content/1.4.9.md`** so the 1.4.9 release notes match user-facing work that landed after the original changelog draft.
> 
> **Auto formats and notes** now mention a welcome note that can open a full demo meeting. **Imports and sharing** add that meeting-assistant connections require sign-in while local file import stays available without an account. **Privacy, permissions, and reliability** document recovery guidance when Apple Calendar access is denied or on-device notes belong to another signed-in account, and broaden the narrow-window UI bullet to call out **session controls** and **dark mode** readability alongside toasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c4fdb0cdb8ea7fbe0560ebcd08d89ee2faebb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->