### PR TITLE
Preserve transcript position during speaker edits

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -442,7 +442,6 @@ msgstr "Automations"
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -442,7 +442,6 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
-#: src/session/components/note-input/transcript/renderer/selection-menu.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
@@ -6,12 +6,14 @@ import { useRenderedTranscriptData } from "./data-hooks";
 
 const mocks = vi.hoisted(() => ({
   getRenderTranscriptRequestKey: vi.fn((_request: unknown) => "request-key"),
+  keepPreviousData: vi.fn((previous: unknown) => previous),
   renderTranscriptSegments: vi.fn(),
   useQuery: vi.fn(),
   useTranscriptRenderData: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-query", () => ({
+  keepPreviousData: mocks.keepPreviousData,
   useQuery: mocks.useQuery,
 }));
 
@@ -55,6 +57,7 @@ describe("useRenderedTranscriptData", () => {
           "request-key",
         ],
         enabled: true,
+        placeholderData: mocks.keepPreviousData,
         staleTime: Number.POSITIVE_INFINITY,
         gcTime: TRANSCRIPT_RENDER_CACHE_TIME_MS,
       }),

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useMemo, useRef } from "react";
 
 import type { RenderTranscriptRequest } from "@anlg/plugin-transcription";
@@ -77,6 +77,7 @@ export function useRenderedTranscriptData(
       return renderTranscriptSegments(activeBaselineRequest);
     },
     enabled: !!activeBaselineRequest,
+    placeholderData: keepPreviousData,
     staleTime: Number.POSITIVE_INFINITY,
     gcTime: TRANSCRIPT_RENDER_CACHE_TIME_MS,
   });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -285,8 +285,11 @@ describe("TranscriptViewer", () => {
 
     expect(controls?.className).toContain("right-1");
     expect(controls?.className).toContain("top-1/2");
-    expect(controls?.className).toContain("bg-muted/70");
-    expect(controls?.className).toContain("border-border/60");
+    expect(controls?.className).toContain("bg-transparent");
+    expect(controls?.className).toContain("border-transparent");
+    expect(controls?.className).toContain("hover:bg-background/65");
+    expect(controls?.className).toContain("hover:backdrop-blur-md");
+    expect(controls?.className).toContain("focus-within:backdrop-blur-md");
     expect((topButton as HTMLButtonElement).disabled).toBe(false);
     expect((bottomButton as HTMLButtonElement).disabled).toBe(false);
     expect(topButton.firstElementChild?.tagName.toLowerCase()).toBe("svg");

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -23,6 +23,7 @@ import type { TranscriptContextMenuRequest } from "./selection-menu";
 import { TranscriptSeparator } from "./separator";
 import { RenderTranscript } from "./transcript";
 import {
+  preserveScrollPosition,
   useAutoScroll,
   usePlaybackAutoScroll,
   useScrollDetection,
@@ -142,16 +143,18 @@ export function TranscriptViewer({
   );
   const handleAssignSpeaker = useCallback(
     async (selection: TranscriptWordSelection, humanId: string) => {
-      await Promise.all(
-        selection.groups.map((group) =>
-          assignTranscriptSpeaker({
-            transcriptId: group.transcriptId,
-            segmentKey: group.segmentKey,
-            humanId,
-            anchorWordId: group.wordIds[0]!,
-            mode: "segment",
-            wordIds: group.wordIds,
-          }),
+      await preserveScrollPosition(containerRef.current, () =>
+        Promise.all(
+          selection.groups.map((group) =>
+            assignTranscriptSpeaker({
+              transcriptId: group.transcriptId,
+              segmentKey: group.segmentKey,
+              humanId,
+              anchorWordId: group.wordIds[0]!,
+              mode: "segment",
+              wordIds: group.wordIds,
+            }),
+          ),
         ),
       );
       trackAnalyticsEvent("participant_assigned", {
@@ -321,6 +324,7 @@ export function TranscriptViewer({
         <SelectionMenu
           containerRef={containerRef}
           contextRequest={contextRequest}
+          audioExists={audioExists}
           onContextClose={handleContextClose}
           onAction={handleSelectionAction}
           onAssignSpeaker={handleAssignSpeaker}
@@ -340,8 +344,11 @@ export function TranscriptViewer({
         <div
           data-transcript-scroll-controls
           className={cn([
-            "absolute top-1/2 right-1 z-40 flex -translate-y-1/2 flex-col overflow-hidden",
-            "border-border/60 bg-muted/70 text-foreground rounded-full border",
+            "group/scroll-controls absolute top-1/2 right-1 z-40 flex -translate-y-1/2 flex-col overflow-hidden",
+            "text-muted-foreground/45 rounded-full border border-transparent bg-transparent",
+            "transition-[background-color,border-color,color,box-shadow,backdrop-filter] duration-150",
+            "hover:border-border/50 hover:bg-background/65 hover:text-foreground hover:shadow-sm hover:backdrop-blur-md",
+            "focus-within:border-border/50 focus-within:bg-background/65 focus-within:text-foreground focus-within:shadow-sm focus-within:backdrop-blur-md",
           ])}
         >
           <button
@@ -351,13 +358,13 @@ export function TranscriptViewer({
             disabled={isAtTop}
             className={cn([
               "flex size-8 items-center justify-center",
-              "hover:bg-muted/85 active:bg-muted/85",
+              "hover:bg-muted/55 active:bg-muted/70 focus-visible:bg-muted/55 focus-visible:outline-none",
               "disabled:pointer-events-none disabled:opacity-30",
             ])}
           >
             <ArrowUp aria-hidden="true" className="size-3.5" />
           </button>
-          <div className="bg-border/70 h-px w-full" />
+          <div className="bg-border/20 group-hover/scroll-controls:bg-border/60 group-focus-within/scroll-controls:bg-border/60 h-px w-full transition-colors" />
           <button
             type="button"
             aria-label="Scroll to bottom"
@@ -365,7 +372,7 @@ export function TranscriptViewer({
             disabled={isAtBottom}
             className={cn([
               "flex size-8 items-center justify-center",
-              "hover:bg-muted/85 active:bg-muted/85",
+              "hover:bg-muted/55 active:bg-muted/70 focus-visible:bg-muted/55 focus-visible:outline-none",
               "disabled:pointer-events-none disabled:opacity-30",
             ])}
           >

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/selection-menu.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/selection-menu.test.tsx
@@ -1,0 +1,122 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createRef, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SelectionMenu } from "./selection-menu";
+import type { TranscriptContextMenuRequest } from "./selection-menu";
+
+vi.mock("@floating-ui/react", () => ({
+  autoUpdate: vi.fn(),
+  flip: vi.fn(),
+  FloatingPortal: ({ children }: { children: ReactNode }) => children,
+  offset: vi.fn(),
+  shift: vi.fn(),
+  useFloating: () => ({
+    refs: {
+      setFloating: vi.fn(),
+      setPositionReference: vi.fn(),
+    },
+    floatingStyles: {},
+    update: vi.fn(),
+  }),
+}));
+
+vi.mock("./speaker-assign", () => ({
+  SpeakerParticipantPicker: () => <button type="button">Confirm</button>,
+}));
+
+vi.mock("~/shared/hooks/useAutoCloser", () => ({
+  useAutoCloser: () => ({ current: null }),
+}));
+
+afterEach(cleanup);
+
+describe("SelectionMenu", () => {
+  it("keeps the speaker picker inside the viewport without a back row", () => {
+    const request = {
+      id: "request-1",
+      range: {
+        getBoundingClientRect: () => new DOMRect(20, 700, 100, 20),
+        getClientRects: () => [],
+        startOffset: 0,
+        endOffset: 4,
+      },
+      selection: {
+        sessionId: "session-1",
+        text: "Test",
+        startMs: 0,
+        groups: [],
+      },
+      x: 20,
+      y: 700,
+    } as unknown as TranscriptContextMenuRequest;
+
+    render(
+      <SelectionMenu
+        containerRef={createRef()}
+        contextRequest={request}
+        audioExists={false}
+        onContextClose={vi.fn()}
+        onAssignSpeaker={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Change speaker" }));
+
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
+    const confirm = screen.getByRole("button", { name: "Confirm" });
+    expect(confirm.parentElement?.className).toContain(
+      "max-h-[min(28rem,calc(100vh-1rem))]",
+    );
+  });
+
+  it("hides playback when the transcript has no audio", () => {
+    render(
+      <SelectionMenu
+        containerRef={createRef()}
+        contextRequest={createContextRequest()}
+        audioExists={false}
+        onContextClose={vi.fn()}
+        onAssignSpeaker={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Play from here" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Change speaker" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Copy$/ })).toBeTruthy();
+  });
+
+  it("keeps playback available when the transcript has audio", () => {
+    render(
+      <SelectionMenu
+        containerRef={createRef()}
+        contextRequest={createContextRequest()}
+        audioExists
+        onContextClose={vi.fn()}
+        onAssignSpeaker={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Play from here" })).toBeTruthy();
+  });
+});
+
+function createContextRequest() {
+  return {
+    id: crypto.randomUUID(),
+    range: {
+      getBoundingClientRect: () => new DOMRect(20, 700, 100, 20),
+      getClientRects: () => [],
+      startOffset: 0,
+      endOffset: 4,
+    },
+    selection: {
+      sessionId: "session-1",
+      text: "Test",
+      startMs: 0,
+      groups: [],
+    },
+    x: 20,
+    y: 700,
+  } as unknown as TranscriptContextMenuRequest;
+}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/selection-menu.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/selection-menu.tsx
@@ -1,4 +1,5 @@
 import {
+  autoUpdate,
   flip,
   FloatingPortal,
   offset,
@@ -6,7 +7,7 @@ import {
   useFloating,
 } from "@floating-ui/react";
 import { Trans } from "@lingui/react/macro";
-import { ArrowLeft, Play, UserSwitch, X } from "@phosphor-icons/react";
+import { Play, UserSwitch, X } from "@phosphor-icons/react";
 import { type MouseEvent, useCallback, useMemo, useRef, useState } from "react";
 
 import {
@@ -44,12 +45,14 @@ export type TranscriptContextMenuRequest = {
 export function SelectionMenu({
   containerRef,
   contextRequest,
+  audioExists,
   onContextClose,
   onAction,
   onAssignSpeaker,
 }: {
   containerRef: React.RefObject<HTMLElement | null>;
   contextRequest: TranscriptContextMenuRequest | null;
+  audioExists: boolean;
   onContextClose: () => void;
   onAction?: (
     action: "copy" | "play",
@@ -65,6 +68,7 @@ export function SelectionMenu({
       <TextSelectionMenu
         containerRef={containerRef}
         suspended={contextRequest !== null}
+        audioExists={audioExists}
         onAction={onAction}
         onAssignSpeaker={onAssignSpeaker}
       />
@@ -73,6 +77,7 @@ export function SelectionMenu({
           key={contextRequest.id}
           request={contextRequest}
           containerRef={containerRef}
+          audioExists={audioExists}
           onClose={onContextClose}
           onAction={onAction}
           onAssignSpeaker={onAssignSpeaker}
@@ -155,11 +160,13 @@ export function MultiSelectionBar({
 function TextSelectionMenu({
   containerRef,
   suspended,
+  audioExists,
   onAction,
   onAssignSpeaker,
 }: {
   containerRef: React.RefObject<HTMLElement | null>;
   suspended: boolean;
+  audioExists: boolean;
   onAction?: (
     action: "copy" | "play",
     selection: TranscriptWordSelection,
@@ -198,6 +205,7 @@ function TextSelectionMenu({
       containerRef={containerRef}
       floatingRef={floatingRef}
       floatingStyles={floatingStyles}
+      audioExists={audioExists}
       onClose={handleClose}
       onAction={onAction}
       onAssignSpeaker={onAssignSpeaker}
@@ -208,12 +216,14 @@ function TextSelectionMenu({
 function ContextSelectionMenu({
   request,
   containerRef,
+  audioExists,
   onClose,
   onAction,
   onAssignSpeaker,
 }: {
   request: TranscriptContextMenuRequest;
   containerRef: React.RefObject<HTMLElement | null>;
+  audioExists: boolean;
   onClose: () => void;
   onAction?: (
     action: "copy" | "play",
@@ -234,6 +244,7 @@ function ContextSelectionMenu({
     strategy: "fixed",
     transform: false,
     middleware: [offset(4), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
   });
   const handleClose = useCallback(() => {
     onClose();
@@ -264,6 +275,7 @@ function ContextSelectionMenu({
       containerRef={containerRef}
       floatingRef={floatingRef}
       floatingStyles={floatingStyles}
+      audioExists={audioExists}
       onClose={handleClose}
       onAction={onAction}
       onAssignSpeaker={onAssignSpeaker}
@@ -277,6 +289,7 @@ function SelectionFloatingMenu({
   containerRef,
   floatingRef,
   floatingStyles,
+  audioExists,
   onClose,
   onAction,
   onAssignSpeaker,
@@ -286,6 +299,7 @@ function SelectionFloatingMenu({
   containerRef: React.RefObject<HTMLElement | null>;
   floatingRef: (node: HTMLDivElement | null) => void;
   floatingStyles: React.CSSProperties;
+  audioExists: boolean;
   onClose: () => void;
   onAction?: (
     action: "copy" | "play",
@@ -328,7 +342,9 @@ function SelectionFloatingMenu({
           style={{ ...floatingStyles, zIndex: 50 }}
           className={cn([
             MENU_CONTAINER_CLASSES,
-            view === "speaker" ? "w-80" : "min-w-40",
+            view === "speaker"
+              ? "max-h-[min(28rem,calc(100vh-1rem))] w-80"
+              : "min-w-40",
           ])}
           onMouseDown={view === "actions" ? handleMouseDown : undefined}
         >
@@ -344,14 +360,16 @@ function SelectionFloatingMenu({
                   <Trans>Change speaker</Trans>
                 </button>
               )}
-              <button
-                type="button"
-                className={cn(MENU_BUTTON_CLASSES)}
-                onClick={() => handleAction("play")}
-              >
-                <Play className="size-3.5" />
-                <Trans>Play from here</Trans>
-              </button>
+              {audioExists && (
+                <button
+                  type="button"
+                  className={cn(MENU_BUTTON_CLASSES)}
+                  onClick={() => handleAction("play")}
+                >
+                  <Play className="size-3.5" />
+                  <Trans>Play from here</Trans>
+                </button>
+              )}
               <button
                 type="button"
                 className={cn(MENU_BUTTON_CLASSES)}
@@ -362,21 +380,11 @@ function SelectionFloatingMenu({
               </button>
             </div>
           ) : (
-            <div>
-              <button
-                type="button"
-                className={cn(MENU_BUTTON_CLASSES)}
-                onClick={() => setView("actions")}
-              >
-                <ArrowLeft className="size-3.5" />
-                <Trans>Back</Trans>
-              </button>
-              <SpeakerParticipantPicker
-                sessionId={selection.sessionId}
-                showAssignmentScope={false}
-                onSelect={handleAssign}
-              />
-            </div>
+            <SpeakerParticipantPicker
+              sessionId={selection.sessionId}
+              showAssignmentScope={false}
+              onSelect={handleAssign}
+            />
           )}
         </div>
       </FloatingPortal>
@@ -459,6 +467,7 @@ function useSelectionMenuState({
     strategy: "fixed",
     transform: false,
     middleware: [offset(6), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
   });
   const show = useCallback(
     (nextSelection: TranscriptWordSelection, range: Range) => {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
@@ -142,7 +142,14 @@ beforeEach(() => {
   assignTranscriptSpeakerMock.mockResolvedValue(undefined);
   addSessionParticipantMock.mockResolvedValue(undefined);
   createHumanMock.mockResolvedValue("human-new");
-  useHumansMock.mockReturnValue([{ id: "human-1", name: "Alice", email: "" }]);
+  useHumansMock.mockReturnValue([
+    {
+      id: "human-1",
+      name: "Alice",
+      email: "",
+      avatarDataUrl: "data:image/jpeg;base64,alice",
+    },
+  ]);
   useSessionParticipantsMock.mockReturnValue([]);
 });
 
@@ -205,10 +212,18 @@ describe("SpeakerAssignPopover", () => {
     expect(
       screen.getByRole("button", { name: "Create new speaker" }),
     ).toBeTruthy();
-    expect(
-      screen.getByPlaceholderText("Select or type to add speaker"),
-    ).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Alice" }));
+    const searchInput = screen.getByPlaceholderText(
+      "Select or type to add speaker",
+    );
+    expect(searchInput.parentElement?.className).toContain("h-8");
+    expect(searchInput.parentElement?.parentElement?.className).toContain(
+      "py-1",
+    );
+    const aliceOption = screen.getByRole("button", { name: "Alice" });
+    expect(aliceOption.querySelector("img")?.getAttribute("src")).toBe(
+      "data:image/jpeg;base64,alice",
+    );
+    fireEvent.click(aliceOption);
     expect(assignTranscriptSpeakerMock).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "Confirm" }));

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -12,9 +12,13 @@ import {
 } from "@anlg/ui/components/ui/popover";
 import { cn } from "@anlg/utils";
 
+import { preserveScrollPosition } from "./viewport-hooks";
+
 import { trackAnalyticsEvent } from "~/analytics";
 import { useSessionEventParticipants } from "~/calendar/queries";
+import { ContactImage } from "~/contacts/contact-avatar";
 import { createHuman, useHumans } from "~/contacts/queries";
+import { ContactFacehash } from "~/contacts/shared";
 import {
   addSessionParticipant,
   useSession,
@@ -43,6 +47,7 @@ export function SpeakerAssignPopover({
   onAssigned?: (humanId: string) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -53,14 +58,20 @@ export function SpeakerAssignPopover({
       if (segment.words.length === 0) return;
       const anchorWordId = getAssignmentAnchorWordId(segment);
       if (!anchorWordId) return;
-      void assignTranscriptSpeaker({
-        transcriptId,
-        segmentKey: segment.key,
-        humanId,
-        anchorWordId,
-        mode: assignmentMode,
-        wordIds: getAssignmentWordIds(segment),
-      })
+      const scrollContainer =
+        triggerRef.current?.closest<HTMLElement>(
+          "[data-transcript-container]",
+        ) ?? null;
+      void preserveScrollPosition(scrollContainer, () =>
+        assignTranscriptSpeaker({
+          transcriptId,
+          segmentKey: segment.key,
+          humanId,
+          anchorWordId,
+          mode: assignmentMode,
+          wordIds: getAssignmentWordIds(segment),
+        }),
+      )
         .then(() => {
           trackAnalyticsEvent("participant_assigned", {
             assignment_scope: assignmentMode,
@@ -80,6 +91,7 @@ export function SpeakerAssignPopover({
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button
+          ref={triggerRef}
           type="button"
           className={cn([
             "-my-0.5 cursor-pointer rounded-full py-0.5 pr-2",
@@ -131,6 +143,7 @@ export type SpeakerParticipantOption = {
   id: string;
   name: string;
   email?: string;
+  avatarDataUrl?: string;
   isSessionParticipant: boolean;
   isNew?: boolean;
   isCreateOption?: boolean;
@@ -305,6 +318,13 @@ export function SpeakerParticipantPicker({
   const [assigning, setAssigning] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
+  const avatarByHumanId = useMemo(
+    () =>
+      new Map(
+        humanRecords.map((human) => [human.id, human.avatarDataUrl] as const),
+      ),
+    [humanRecords],
+  );
   const participants = useMemo(
     () =>
       participantRecords
@@ -316,13 +336,15 @@ export function SpeakerParticipantPicker({
             id: participant.humanId,
             name: name || email || t`Unknown`,
             email: email || undefined,
+            avatarDataUrl:
+              avatarByHumanId.get(participant.humanId) ?? undefined,
             isSessionParticipant: true,
           };
         })
         .filter((participant): participant is SpeakerParticipantOption =>
           Boolean(participant),
         ),
-    [participantRecords, t],
+    [avatarByHumanId, participantRecords, t],
   );
 
   const contacts = useMemo(
@@ -337,6 +359,7 @@ export function SpeakerParticipantPicker({
             id: human.id,
             name: name || email,
             email: email || undefined,
+            avatarDataUrl: human.avatarDataUrl ?? undefined,
             isSessionParticipant: false,
           };
         })
@@ -454,10 +477,10 @@ export function SpeakerParticipantPicker({
   ]);
 
   return (
-    <div className="flex max-h-[min(var(--radix-popover-content-available-height),28rem)] flex-col gap-1 overflow-hidden">
+    <div className="flex max-h-[min(var(--radix-popover-content-available-height,calc(100vh-1rem)),28rem)] flex-col gap-1 overflow-hidden">
       <AppFloatingPanel className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="border-border border-b py-2">
-          <div className="flex h-9 items-center gap-2 px-3">
+        <div className="border-border border-b py-1">
+          <div className="flex h-8 items-center gap-2 px-3">
             <MagnifyingGlass
               size={16}
               className="text-muted-foreground shrink-0"
@@ -587,19 +610,33 @@ function ParticipantOptionButton({
       type="button"
       aria-pressed={selected}
       className={cn([
-        "w-full px-3 py-1.5 text-left text-sm",
+        "flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm",
         selected ? "bg-accent text-accent-foreground" : "hover:bg-accent",
       ])}
       onClick={() => onSelect(option)}
     >
-      <span className="block truncate">
-        {option.isCreateOption ? t`Add "${option.name}"` : option.name}
-      </span>
-      {option.email && (
-        <span className="text-muted-foreground block truncate text-xs">
-          {option.email}
+      {option.isCreateOption ? (
+        <span className="bg-muted text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded-full border">
+          <Plus className="size-3.5" aria-hidden="true" />
         </span>
+      ) : option.avatarDataUrl ? (
+        <ContactImage src={option.avatarDataUrl} size={28} />
+      ) : (
+        <ContactFacehash
+          name={option.name || option.email || option.id}
+          size={28}
+        />
       )}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium">
+          {option.isCreateOption ? t`Add "${option.name}"` : option.name}
+        </span>
+        {option.email && (
+          <span className="text-muted-foreground block truncate text-xs">
+            {option.email}
+          </span>
+        )}
+      </span>
     </button>
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
@@ -1,8 +1,8 @@
 import { act, renderHook } from "@testing-library/react";
 import { createRef } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { useScrollDetection } from "./viewport-hooks";
+import { preserveScrollPosition, useScrollDetection } from "./viewport-hooks";
 
 function setScrollMetrics(
   element: HTMLDivElement,
@@ -101,5 +101,40 @@ describe("useScrollDetection", () => {
 
     expect(result.current.autoScrollEnabled).toBe(false);
     expect(result.current.scrollTarget).toBe("bottom");
+  });
+});
+
+describe("preserveScrollPosition", () => {
+  it("restores the viewport after the mutation and follow-up layout frames", async () => {
+    const frames: FrameRequestCallback[] = [];
+    const requestAnimationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        frames.push(callback);
+        return frames.length;
+      });
+    const element = document.createElement("div");
+    element.scrollTop = 420;
+
+    await preserveScrollPosition(element, async () => {
+      element.scrollTop = 0;
+    });
+
+    expect(element.scrollTop).toBe(420);
+
+    element.scrollTop = 0;
+    frames.shift()?.(0);
+    expect(element.scrollTop).toBe(420);
+
+    element.scrollTop = 0;
+    frames.shift()?.(0);
+    expect(element.scrollTop).toBe(420);
+
+    element.scrollTop = 0;
+    element.append("updated transcript");
+    await Promise.resolve();
+    expect(element.scrollTop).toBe(420);
+
+    requestAnimationFrame.mockRestore();
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -7,6 +7,71 @@ import {
   useState,
 } from "react";
 
+export async function preserveScrollPosition<T>(
+  element: HTMLElement | null,
+  action: () => Promise<T>,
+): Promise<T> {
+  if (!element) {
+    return action();
+  }
+
+  const scrollTop = element.scrollTop;
+  let actionSettled = false;
+  let contentChanged = false;
+  let observer: MutationObserver | null = null;
+  let cleanupTimer: number | null = null;
+
+  const restore = () => {
+    element.scrollTop = scrollTop;
+  };
+
+  const stopObserving = () => {
+    observer?.disconnect();
+    observer = null;
+    if (cleanupTimer !== null) {
+      window.clearTimeout(cleanupTimer);
+      cleanupTimer = null;
+    }
+  };
+
+  if (typeof MutationObserver !== "undefined") {
+    observer = new MutationObserver(() => {
+      contentChanged = true;
+      restore();
+      requestAnimationFrame(() => {
+        restore();
+        if (actionSettled) {
+          stopObserving();
+        }
+      });
+    });
+    observer.observe(element, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+  }
+
+  try {
+    return await action();
+  } finally {
+    actionSettled = true;
+    restore();
+    requestAnimationFrame(() => {
+      restore();
+      requestAnimationFrame(() => {
+        restore();
+        if (contentChanged) {
+          stopObserving();
+        }
+      });
+    });
+    if (observer && !contentChanged) {
+      cleanupTimer = window.setTimeout(stopObserving, 5_000);
+    }
+  }
+}
+
 export function useScrollDetection(
   containerRef: RefObject<HTMLDivElement | null>,
   active = true,


### PR DESCRIPTION
Restore the transcript viewport across speaker updates and keep the speaker picker visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core transcript interaction and async scroll restoration; no auth or data-model changes, but layout/observer edge cases could affect long transcripts.
> 
> **Overview**
> Keeps the transcript viewport stable when changing speakers by adding **`preserveScrollPosition`** (mutation observer + rAF restore) around speaker assignment from the selection menu and inline speaker labels, and uses **`keepPreviousData`** on the rendered-segment query so the list does not blank while re-rendering.
> 
> **Selection menu:** drops the speaker sub-view **Back** control, caps picker height for small viewports, wires **`autoUpdate`** on floating menus, and only shows **Play from here** when session audio exists. **Speaker picker** shows contact avatars/facehash and a slightly denser search row.
> 
> **Scroll controls** on the transcript are restyled to stay transparent until hover/focus. Locale **`.po`** files drop a stale **Back** source reference from the removed menu control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfda0400b33492bf7b2cd0b3d047f29b7a21f431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->