### PR TITLE
Keep sync indicator inside note area

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -194,6 +194,10 @@ vi.mock("./tab-content", () => ({
   },
 }));
 
+vi.mock("./sync-status", () => ({
+  SyncStatusIndicator: () => <div data-testid="sync-status-indicator" />,
+}));
+
 vi.mock("~/sidebar/note-filter-menu", () => ({
   SidebarNoteFilterMenu: () => <button type="button">Filter notes</button>,
 }));
@@ -335,6 +339,19 @@ describe("ClassicMainBody", () => {
     );
     expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-width")).toBe(
       "24%",
+    );
+  });
+
+  it("anchors sync status inside the main note area", () => {
+    render(<ClassicMainBody showSyncStatus />);
+
+    const mainContentPanel = document.querySelector(
+      "[data-main-content-panel]",
+    );
+
+    expect(mainContentPanel?.className).toContain("relative");
+    expect(screen.getByTestId("sync-status-indicator").parentElement).toBe(
+      mainContentPanel,
     );
   });
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -29,6 +29,7 @@ import {
 import { useMainAreaTopWindowDrag } from "./main-area-window-drag";
 import { ClassicMainSidebar } from "./shell-sidebar";
 import { SidebarTimelineChromeWithUpcomingMeeting } from "./sidebar-timeline-chrome";
+import { SyncStatusIndicator } from "./sync-status";
 import { ClassicMainTabContent } from "./tab-content";
 import { useClassicMainShortcuts } from "./useShortcuts";
 
@@ -52,7 +53,11 @@ type LeftSidebarSizeStyle = CSSProperties & {
   "--left-sidebar-panel-width": string;
 };
 
-export function ClassicMainBody() {
+export function ClassicMainBody({
+  showSyncStatus = false,
+}: {
+  showSyncStatus?: boolean;
+}) {
   const { leftsidebar } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
   useClassicMainShortcuts();
@@ -542,7 +547,7 @@ export function ClassicMainBody() {
         >
           <div
             data-main-content-panel
-            className="h-full min-h-0 min-w-0 flex-1 overflow-auto"
+            className="relative h-full min-h-0 min-w-0 flex-1 overflow-auto"
             onClickCapture={mainAreaTopDrag.onClickCapture}
             onDoubleClickCapture={mainAreaTopDrag.onDoubleClickCapture}
             onPointerCancel={mainAreaTopDrag.onPointerEnd}
@@ -556,6 +561,7 @@ export function ClassicMainBody() {
                 tab={currentTab as Tab}
               />
             ) : null}
+            {showSyncStatus ? <SyncStatusIndicator /> : null}
           </div>
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/apps/desktop/src/main/shell-frame.test.tsx
+++ b/apps/desktop/src/main/shell-frame.test.tsx
@@ -9,7 +9,11 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./body", () => ({
-  ClassicMainBody: () => <div data-testid="classic-main-body" />,
+  ClassicMainBody: ({ showSyncStatus }: { showSyncStatus?: boolean }) => (
+    <div data-testid="classic-main-body">
+      {showSyncStatus ? <div data-testid="sync-status-indicator" /> : null}
+    </div>
+  ),
 }));
 
 vi.mock("~/shared/main", () => ({
@@ -43,10 +47,6 @@ vi.mock("~/contexts/shell", () => ({
 
 vi.mock("~/sidebar/toast", () => ({
   ToastNotifications: () => <div data-testid="toast-notifications" />,
-}));
-
-vi.mock("./sync-status", () => ({
-  SyncStatusIndicator: () => <div data-testid="sync-status-indicator" />,
 }));
 
 vi.mock("~/store/zustand/tabs", () => ({

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -2,7 +2,6 @@ import { memo } from "react";
 
 import { ClassicMainBody } from "./body";
 import { resolveMainSurfaceChrome } from "./main-surface-chrome";
-import { SyncStatusIndicator } from "./sync-status";
 
 import { useShell } from "~/contexts/shell";
 import { MainShellBodyFrame, MainShellScaffold } from "~/shared/main";
@@ -39,17 +38,20 @@ export function ClassicMainShellFrame() {
       edgeToEdge={isOnboarding}
       mainSurfaceChrome={isOnboarding ? undefined : mainSurfaceChrome}
     >
-      <ClassicMainBodyHost />
-      {showSyncStatus && <SyncStatusIndicator />}
+      <ClassicMainBodyHost showSyncStatus={showSyncStatus} />
       <ToastNotifications />
     </MainShellScaffold>
   );
 }
 
-const ClassicMainBodyHost = memo(function ClassicMainBodyHost() {
+const ClassicMainBodyHost = memo(function ClassicMainBodyHost({
+  showSyncStatus,
+}: {
+  showSyncStatus: boolean;
+}) {
   return (
     <MainShellBodyFrame>
-      <ClassicMainBody />
+      <ClassicMainBody showSyncStatus={showSyncStatus} />
     </MainShellBodyFrame>
   );
 });

--- a/apps/desktop/src/main/sync-status.tsx
+++ b/apps/desktop/src/main/sync-status.tsx
@@ -258,7 +258,7 @@ export function SyncStatusIndicator() {
           aria-label={t`Cloud sync status: ${view.label}`}
           data-testid="sync-status-indicator"
           className={cn([
-            "fixed right-2 bottom-2 z-40",
+            "absolute right-2 bottom-2 z-40",
             "border-border/60 bg-background/90 flex size-7 items-center justify-center rounded-lg border shadow-sm backdrop-blur",
             "text-muted-foreground hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground outline-hidden transition-colors",
           ])}


### PR DESCRIPTION
Anchor cloud sync status to the note pane so docked chat controls stay unobstructed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change to where the sync badge is mounted and how it is positioned; sync behavior and visibility rules are unchanged.
> 
> **Overview**
> **Moves the cloud sync status control from the shell overlay into the main note/content pane** so it no longer sits over docked chat UI at the window corner.
> 
> `ClassicMainShellFrame` stops rendering `SyncStatusIndicator` as a sibling of the body and instead passes the existing `showSyncStatus` flag (empty + sessions tabs) into `ClassicMainBody`, which renders the indicator inside `[data-main-content-panel]`. That panel gains `relative` positioning; the indicator switches from `fixed` to `absolute` bottom-right within that pane.
> 
> Tests cover the new DOM parent and update shell-frame mocks to reflect the prop-driven placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26f8a25fb3c237bc6cee0581eeca31e439dcf848. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->