### PR TITLE
Pace chat responses line by line

### DIFF
--- a/apps/desktop/src/chat/transport/index.test.ts
+++ b/apps/desktop/src/chat/transport/index.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  agentStream: vi.fn(),
+  smoothStream: vi.fn(),
+  streamTransform: vi.fn(),
+}));
+
+vi.mock("ai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("ai")>()),
+  smoothStream: mocks.smoothStream,
+  ToolLoopAgent: class {
+    stream = mocks.agentStream;
+  },
+}));
+
+import { CustomChatTransport } from "./index";
+
+describe("CustomChatTransport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.smoothStream.mockReturnValue(mocks.streamTransform);
+    mocks.agentStream.mockResolvedValue({
+      toUIMessageStream: vi.fn(
+        () =>
+          new ReadableStream({
+            start(controller) {
+              controller.close();
+            },
+          }),
+      ),
+    });
+  });
+
+  it("paces streamed chat responses line by line like summary generation", async () => {
+    const transport = new CustomChatTransport({} as never, {});
+
+    await transport.sendMessages({
+      abortSignal: new AbortController().signal,
+      chatId: "chat-1",
+      messageId: undefined,
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          parts: [{ type: "text", text: "Summarize this meeting" }],
+        },
+      ],
+      trigger: "submit-message",
+    });
+
+    expect(mocks.smoothStream).toHaveBeenCalledWith({
+      chunking: "line",
+      delayInMs: 250,
+    });
+    expect(mocks.agentStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        experimental_transform: mocks.streamTransform,
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/chat/transport/index.ts
+++ b/apps/desktop/src/chat/transport/index.ts
@@ -253,7 +253,7 @@ export class CustomChatTransport implements ChatTransport<AnlgUIMessage> {
       abortSignal: options.abortSignal,
       experimental_transform: smoothStream({
         chunking: "line",
-        delayInMs: null,
+        delayInMs: 250,
       }),
     });
 


### PR DESCRIPTION
Match chat streaming cadence to summary generation and cover the transport configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only streaming timing in chat transport; no auth, data, or tool-loop behavior changes.
> 
> **Overview**
> Chat streaming no longer emits assistant text as fast as the model returns it. **`CustomChatTransport`** now passes **`delayInMs: 250`** into **`smoothStream`** (with **`chunking: "line"`** unchanged), replacing **`delayInMs: null`**, so replies appear line-by-line on the same cadence as summary generation in **`enhance-workflow`**.
> 
> Adds **`index.test.ts`** for **`CustomChatTransport`**, asserting **`sendMessages`** wires **`smoothStream({ chunking: "line", delayInMs: 250 })`** into **`agent.stream`** via **`experimental_transform`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c44633e13b8d6739fa4423d4447aa0cb4e98879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->