### PR TITLE
Make right chat header draggable

### DIFF
--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -166,6 +166,9 @@ describe("ChatView", () => {
     expect(root?.className).not.toContain("bg-primary");
     expect(root?.firstElementChild?.className).toContain("h-9");
     expect(root?.firstElementChild?.className).not.toContain("border-b");
+    expect(
+      root?.firstElementChild?.hasAttribute("data-tauri-drag-region"),
+    ).toBe(true);
     expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("light");
     expect(mocks.toolbarControls).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -187,6 +190,9 @@ describe("ChatView", () => {
     expect(root?.className.split(" ")).not.toContain("h-full");
     expect(root?.firstElementChild?.className).toContain("h-11");
     expect(root?.firstElementChild?.className).not.toContain("border-b");
+    expect(
+      root?.firstElementChild?.hasAttribute("data-tauri-drag-region"),
+    ).toBe(false);
     expect(screen.getByTestId("chat-toolbar").dataset.surface).toBe("light");
   });
 });

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -134,6 +134,7 @@ export function ChatPanelFrame({
     >
       {chat.scope === "automations" ? null : (
         <div
+          data-tauri-drag-region={!isFloating || undefined}
           className={cn([
             "flex shrink-0 pr-0 pl-0",
             isFloating ? "h-11 items-center" : "h-9 items-start pt-[9px]",

--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -250,13 +250,19 @@ describe("ChatToolbarControls", () => {
     );
 
     const historyButton = screen.getByRole("button", { name: "Chat history" });
+    const toolbar = container.firstElementChild;
 
-    expect(container.firstElementChild?.className).toContain("pl-3");
-    expect(container.firstElementChild?.className).toContain("pr-1");
-    expect(container.firstElementChild?.className).not.toContain("px-5");
-    expect(container.firstElementChild?.className).not.toContain("px-3");
-    expect(container.firstElementChild?.className).not.toContain("pr-0");
+    expect(toolbar?.className).toContain("pl-3");
+    expect(toolbar?.className).toContain("pr-1");
+    expect(toolbar?.className).not.toContain("px-5");
+    expect(toolbar?.className).not.toContain("px-3");
+    expect(toolbar?.className).not.toContain("pr-0");
+    expect(toolbar?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(
+      toolbar?.firstElementChild?.hasAttribute("data-tauri-drag-region"),
+    ).toBe(true);
     const actions = container.querySelector("[data-chat-toolbar-actions]");
+    expect(actions?.hasAttribute("data-tauri-drag-region")).toBe(true);
     expect(actions?.className).toContain("gap-0");
     expect(actions?.className).not.toContain("gap-1");
     expect(historyButton.className).toContain("-ml-2");
@@ -265,6 +271,9 @@ describe("ChatToolbarControls", () => {
     expect(screen.queryByText("Ask Anarlog AI anything")).toBeNull();
     const floatButton = screen.getByRole("button", { name: "Float chat" });
     const closeButton = screen.getByRole("button", { name: "Close chat" });
+    expect(historyButton.getAttribute("data-tauri-drag-region")).toBe("false");
+    expect(floatButton.getAttribute("data-tauri-drag-region")).toBe("false");
+    expect(closeButton.getAttribute("data-tauri-drag-region")).toBe("false");
     expect(floatButton.className).toContain("hover:!bg-muted/80");
     expect(floatButton.className).toContain("hover:!text-foreground");
     expect(floatButton.className).not.toContain("mr-1");

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -56,12 +56,16 @@ export function ChatToolbarControls({
 
   return (
     <div
+      data-tauri-drag-region={isRightPanel || undefined}
       className={cn([
         "flex h-full w-full min-w-0 items-center gap-2",
         isRightPanel ? "pr-1 pl-3" : "px-3",
       ])}
     >
-      <div className="flex min-w-0 flex-1 items-center gap-1">
+      <div
+        data-tauri-drag-region={isRightPanel || undefined}
+        className="flex min-w-0 flex-1 items-center gap-1"
+      >
         <ChatGroups
           chatScope={chatScope}
           currentChatGroupId={currentChatGroupId}
@@ -71,6 +75,7 @@ export function ChatToolbarControls({
         />
       </div>
       <div
+        data-tauri-drag-region={isRightPanel || undefined}
         data-chat-toolbar-actions
         className="flex shrink-0 items-center gap-0"
       >
@@ -130,6 +135,7 @@ function ChatActionButton({
   return (
     <Button
       aria-label={label}
+      data-tauri-drag-region="false"
       onClick={onClick}
       size="icon"
       variant="ghost"
@@ -164,6 +170,7 @@ function ChatGroups({
       <DropdownMenuTrigger asChild>
         <Button
           aria-label={t`Chat history`}
+          data-tauri-drag-region="false"
           variant="ghost"
           size="sm"
           className={cn([


### PR DESCRIPTION
Mark the docked chat toolbar as a Tauri drag region while preserving button interactions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Tauri window-drag attributes scoped to right-panel layout; floating chat unchanged and buttons explicitly opt out of drag.
> 
> **Overview**
> **Docked (right-panel) chat** can now be moved by dragging the header area, matching other Tauri chrome (e.g. calendar/changelog).
> 
> The chat panel header wrapper and `ChatToolbarControls` get `data-tauri-drag-region` only when `layout === "right-panel"` (floating layout leaves the attribute off). Toolbar **buttons** (new chat, float, close, chat history) set `data-tauri-drag-region="false"` so clicks still work inside the drag region.
> 
> Tests in `chat-panel.test.tsx` and `toolbar-controls.test.tsx` assert drag-region presence on the header/toolbar and `false` on interactive controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b2dcbba9675aa42db4c601bd313bb0ec0b5c6b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->