### PR TITLE
Align Pro pricing with gated customization

### DIFF
--- a/packages/pricing/src/tiers.ts
+++ b/packages/pricing/src/tiers.ts
@@ -84,6 +84,9 @@ export const MARKETING_PLAN_TIERS: MarketingPlanData[] = [
       { label: "Cloud Transcription", included: true },
       { label: "Cloud LLM", included: true },
       { label: "Better Speaker Identification", included: true },
+      { label: "Custom Transcription Dictionary", included: true },
+      { label: "Custom Auto Summary Format", included: true },
+      { label: "Custom App Icons (macOS)", included: true },
       {
         label: "Integrations",
         included: true,


### PR DESCRIPTION
List the custom transcription dictionary, Auto summary format, and macOS app icons on the shared web and desktop Pro cards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to marketing tier metadata; no billing, gating, or runtime behavior is modified.
> 
> **Overview**
> Updates the shared **Pro** plan feature list in `packages/pricing` so marketing and in-app pricing cards match Pro-gated customization.
> 
> Three included features are added to `MARKETING_PLAN_TIERS` for Pro: **Custom Transcription Dictionary**, **Custom Auto Summary Format**, and **Custom App Icons (macOS)**. Because `PLAN_TIERS` is derived from that data, web and desktop Pro cards pick up the same bullets without further UI changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc92c04b8c8d5750f2a50fe7cafa2bb6b343afea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->