### PR TITLE
Only notify for batch transcription

### DIFF
--- a/apps/desktop/src/store/zustand/listener/general-batch.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.test.ts
@@ -500,99 +500,111 @@ describe("runBatchSession", () => {
     consoleError.mockRestore();
   });
 
-  test("shows a completion notification when the window is not focused", async () => {
-    isFocusedMock.mockResolvedValue(false);
+  test.each([
+    { notifyOnCompletion: undefined, expectedNotifications: 1 },
+    { notifyOnCompletion: false, expectedNotifications: 0 },
+  ])(
+    "shows $expectedNotifications completion notifications when notifyOnCompletion is $notifyOnCompletion",
+    async ({ notifyOnCompletion, expectedNotifications }) => {
+      isFocusedMock.mockResolvedValue(false);
 
-    const handleBatchStarted = vi.fn();
-    const handleBatchResponse = vi.fn();
-    const handleBatchCompleted = vi.fn();
-    const clearBatchPersist = vi.fn();
-    const clearBatchSession = vi.fn();
-    const handleBatchResponseStreamed = vi.fn();
-    const handleBatchFailed = vi.fn();
-    const handleBatchStopped = vi.fn();
-    const updateBatchProgress = vi.fn();
-    const setBatchPersist = vi.fn();
+      const handleBatchStarted = vi.fn();
+      const handleBatchResponse = vi.fn();
+      const handleBatchCompleted = vi.fn();
+      const clearBatchPersist = vi.fn();
+      const clearBatchSession = vi.fn();
+      const handleBatchResponseStreamed = vi.fn();
+      const handleBatchFailed = vi.fn();
+      const handleBatchStopped = vi.fn();
+      const updateBatchProgress = vi.fn();
+      const setBatchPersist = vi.fn();
 
-    let handler:
-      | ((event: {
-          payload: {
-            type: string;
-            session_id: string;
-            response?: unknown;
-            mode?: "direct" | "streamed";
-          };
-        }) => void)
-      | undefined;
+      let handler:
+        | ((event: {
+            payload: {
+              type: string;
+              session_id: string;
+              response?: unknown;
+              mode?: "direct" | "streamed";
+            };
+          }) => void)
+        | undefined;
 
-    listenMock.mockImplementation(async (cb) => {
-      handler = cb;
-      return vi.fn();
-    });
+      listenMock.mockImplementation(async (cb) => {
+        handler = cb;
+        return vi.fn();
+      });
 
-    startTranscriptionMock.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          queueMicrotask(() => {
-            handler?.({
-              payload: {
-                type: "completed",
-                session_id: "session-1",
-                mode: "streamed",
-                response: {
-                  metadata: null,
-                  results: { channels: [] },
+      startTranscriptionMock.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            queueMicrotask(() => {
+              handler?.({
+                payload: {
+                  type: "completed",
+                  session_id: "session-1",
+                  mode: "streamed",
+                  response: {
+                    metadata: null,
+                    results: { channels: [] },
+                  },
                 },
-              },
+              });
+              resolve({
+                status: "ok",
+                data: null,
+              });
             });
-            resolve({
-              status: "ok",
-              data: null,
-            });
-          });
+          }),
+      );
+
+      await runBatchSession(
+        () => ({
+          batch: {},
+          batchPreview: {},
+          batchPersist: {},
+          handleBatchStarted,
+          handleBatchResponse,
+          handleBatchCompleted,
+          clearBatchPersist,
+          clearBatchSession,
+          handleBatchResponseStreamed,
+          handleBatchFailed,
+          handleBatchStopped,
+          updateBatchProgress,
+          setBatchPersist,
         }),
-    );
+        "session-1",
+        {
+          session_id: "session-1",
+          provider: "anarlog",
+          file_path: "/tmp/session.wav",
+          base_url: "",
+          api_key: "",
+        },
+        { notifyOnCompletion },
+      );
 
-    await runBatchSession(
-      () => ({
-        batch: {},
-        batchPreview: {},
-        batchPersist: {},
-        handleBatchStarted,
-        handleBatchResponse,
-        handleBatchCompleted,
-        clearBatchPersist,
-        clearBatchSession,
-        handleBatchResponseStreamed,
-        handleBatchFailed,
-        handleBatchStopped,
-        updateBatchProgress,
-        setBatchPersist,
-      }),
-      "session-1",
-      {
-        session_id: "session-1",
-        provider: "anarlog",
-        file_path: "/tmp/session.wav",
-        base_url: "",
-        api_key: "",
-      },
-    );
+      expect(showNotificationMock).toHaveBeenCalledTimes(expectedNotifications);
+      if (expectedNotifications === 0) {
+        return;
+      }
 
-    const notification = showNotificationMock.mock.calls[0]?.[0];
-    expect(notification).toEqual(
-      expect.objectContaining({
-        title: "Transcription complete",
-        message: "Your transcript is ready.",
-        timeout: { secs: 15, nanos: 0 },
-        action_label: "Open Anarlog",
-        source: { type: "session", session_id: "session-1" },
-      }),
-    );
-    expect(parseBatchCompletedNotificationKey(notification.key)).toBe(
-      "session-1",
-    );
-  });
+      const notification = showNotificationMock.mock.calls[0]?.[0];
+      expect(notification).toEqual(
+        expect.objectContaining({
+          title: "Transcription complete",
+          message: "Your transcript is ready.",
+          timeout: { secs: 15, nanos: 0 },
+          action_label: "Open Anarlog",
+          source: { type: "session", session_id: "session-1" },
+        }),
+      );
+      expect(parseBatchCompletedNotificationKey(notification.key)).toBe(
+        "session-1",
+      );
+    },
+  );
 
   test("uses a fresh notification key for each batch completion", async () => {
     await showBatchCompletedNotification("session-1", { force: true });

--- a/apps/desktop/src/store/zustand/listener/general-batch.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.ts
@@ -77,6 +77,7 @@ export const runBatchSession = async <T extends BatchStore>(
   get: StoreApi<T>["getState"],
   sessionId: string,
   params: TranscriptionParams,
+  options?: { notifyOnCompletion?: boolean },
 ) => {
   get().handleBatchStarted(sessionId);
 
@@ -271,8 +272,10 @@ export const runBatchSession = async <T extends BatchStore>(
       });
   });
 
-  await showBatchCompletedNotification(sessionId);
-  void requestAppAttention("transcript_ready");
+  if (options?.notifyOnCompletion !== false) {
+    await showBatchCompletedNotification(sessionId);
+    void requestAppAttention("transcript_ready");
+  }
 };
 
 export function shouldUseSyntheticBatchProgress(params: TranscriptionParams) {

--- a/apps/desktop/src/store/zustand/listener/general.ts
+++ b/apps/desktop/src/store/zustand/listener/general.ts
@@ -64,7 +64,10 @@ export type GeneralActions = {
   ) => Promise<void>;
   startTranscription: (
     params: TranscriptionParams,
-    options?: { handlePersist?: BatchPersistCallback },
+    options?: {
+      handlePersist?: BatchPersistCallback;
+      notifyOnCompletion?: boolean;
+    },
   ) => Promise<void>;
   stopTranscription: (sessionId: string) => Promise<void>;
   canStartLiveSession: (sessionId: string) => boolean;
@@ -221,7 +224,9 @@ export const createGeneralSlice = <
       get().setBatchPersist(sessionId, options.handlePersist);
     }
 
-    await runBatchSession(get, sessionId, params);
+    await runBatchSession(get, sessionId, params, {
+      notifyOnCompletion: options?.notifyOnCompletion,
+    });
   },
   stopTranscription: async (sessionId) => {
     if (!sessionId) {

--- a/apps/desktop/src/stt/capture-lifecycle.ts
+++ b/apps/desktop/src/stt/capture-lifecycle.ts
@@ -433,6 +433,7 @@ export function useCaptureLifecycle(sessionId: string) {
                 : 0;
             await runBatchRef.current(details.audioPath!, {
               deferAudioFinalization: true,
+              notifyOnCompletion: !details.liveTranscriptionActive,
               ...(useLocalBatchForSpeakerDiarization
                 ? {
                     provider: "soniqo",

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -1217,6 +1217,7 @@ describe("useRunBatch", () => {
         model: "soniqo-parakeet-batch",
         baseUrl: "soniqo://local",
         apiKey: "",
+        notifyOnCompletion: false,
       });
     });
 
@@ -1227,7 +1228,7 @@ describe("useRunBatch", () => {
         base_url: "soniqo://local",
         api_key: "",
       }),
-      expect.any(Object),
+      expect.objectContaining({ notifyOnCompletion: false }),
     );
     expect(sonnerToastWarningMock).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -40,6 +40,7 @@ import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
 type RunOptions = {
   deferAudioFinalization?: boolean;
   handlePersist?: BatchPersistCallback;
+  notifyOnCompletion?: boolean;
   provider?: string;
   model?: string;
   baseUrl?: string;
@@ -903,7 +904,10 @@ export const useRunBatch = (sessionId: string) => {
           };
 
           try {
-            await startTranscription(params, { handlePersist: persist });
+            await startTranscription(params, {
+              handlePersist: persist,
+              notifyOnCompletion: options?.notifyOnCompletion,
+            });
           } catch (error) {
             if (
               target.provider !== "anarlog" ||
@@ -923,7 +927,10 @@ export const useRunBatch = (sessionId: string) => {
             }
             await startTranscription(
               { ...params, api_key: refreshedSession.access_token },
-              { handlePersist: persist },
+              {
+                handlePersist: persist,
+                notifyOnCompletion: options?.notifyOnCompletion,
+              },
             );
           }
 

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -845,6 +845,7 @@ describe("useStartListening", () => {
 
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav", {
       deferAudioFinalization: true,
+      notifyOnCompletion: true,
       promotion: { scope: "whole_session" },
     });
     expect(setBatchTranscriptionPendingMock.mock.calls).toEqual([
@@ -929,6 +930,7 @@ describe("useStartListening", () => {
 
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav", {
       deferAudioFinalization: true,
+      notifyOnCompletion: false,
       promotion: {
         scope: "current_capture",
         audioOffsetMs: 0,
@@ -993,6 +995,7 @@ describe("useStartListening", () => {
 
       expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav", {
         deferAudioFinalization: true,
+        notifyOnCompletion: false,
         provider: "soniqo",
         model: "soniqo-parakeet-batch",
         baseUrl: "soniqo://local",
@@ -1455,6 +1458,7 @@ describe("useStartListening", () => {
 
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav", {
       deferAudioFinalization: true,
+      notifyOnCompletion: true,
       promotion: {
         scope: "current_capture",
         audioOffsetMs: 10_000,
@@ -1526,6 +1530,7 @@ describe("useStartListening", () => {
     );
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav", {
       deferAudioFinalization: true,
+      notifyOnCompletion: false,
       promotion: {
         scope: "current_capture",
         audioOffsetMs: 10_000,
@@ -1785,6 +1790,7 @@ describe("useStartListening", () => {
 
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/existing-session.mp3", {
       deferAudioFinalization: true,
+      notifyOnCompletion: true,
       promotion: {
         scope: "current_capture",
         audioOffsetMs: 10_000,
@@ -2462,6 +2468,7 @@ describe("useStartListening", () => {
     expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith("session-1");
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav", {
       deferAudioFinalization: true,
+      notifyOnCompletion: false,
       promotion: { scope: "whole_session" },
     });
     expect(sonnerToastErrorMock).not.toHaveBeenCalled();
@@ -3020,6 +3027,7 @@ describe("useStartListening", () => {
 
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav", {
       deferAudioFinalization: true,
+      notifyOnCompletion: true,
       promotion: {
         scope: "current_capture",
         audioOffsetMs: 60_000,
@@ -3071,6 +3079,7 @@ describe("useStartListening", () => {
 
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav", {
       deferAudioFinalization: true,
+      notifyOnCompletion: false,
       promotion: {
         scope: "current_capture",
         audioOffsetMs: 60_000,


### PR DESCRIPTION
Suppress completion alerts for live transcript refinement while preserving notifications for batch-only jobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX change to notification gating with explicit defaults and broad test updates; no auth or data-path changes.
> 
> **Overview**
> Adds an optional **`notifyOnCompletion`** flag on the batch transcription path (`useRunBatch` → `startTranscription` → `runBatchSession`). When it is **`false`**, the desktop skips the **“Transcription complete”** notification and **`requestAppAttention("transcript_ready")`** after batch finishes.
> 
> **Post-capture batch repair** now sets **`notifyOnCompletion: !liveTranscriptionActive`**: batch-only recordings still get alerts; sessions that already had **live transcription** (repair, diarization refinement, etc.) no longer get a second completion ping when background batch work finishes.
> 
> Default behavior is unchanged (**notify** unless explicitly disabled). Tests cover the flag through **`general-batch`**, **`useRunBatch`**, and **`useStartListening`** lifecycle expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f22dbd04b49863a2afd91ba232a641d1a44052b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->