### PR TITLE
Prevent connected import startup crash

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -30,7 +30,6 @@ import { AppI18nProvider } from "./i18n/provider";
 import { FloatingMeetingWindowHost } from "./meeting-float/host";
 import { routeTree } from "./routeTree.gen";
 import { EventListeners } from "./services/event-listeners";
-import { MeetingImportSync } from "./services/meeting-import-sync";
 import { TaskManager } from "./services/task-manager";
 import { TrayRecordingSync } from "./services/tray-recording";
 import { TrayScheduleSync } from "./services/tray-schedule";
@@ -101,7 +100,6 @@ function AppRoot() {
         {isMainWindow ? <TaskManager /> : null}
         {isMainWindow ? <FloatingMeetingWindowHost /> : null}
         {isMainWindow ? <EventListeners /> : null}
-        {isMainWindow ? <MeetingImportSync /> : null}
         {isMainWindow ? <TrayScheduleSync /> : null}
         {isMainWindow ? <TrayRecordingSync /> : null}
         {isMainWindow ? <UpdaterMeetingSync /> : null}

--- a/apps/desktop/src/shared/main-app-layout.test.tsx
+++ b/apps/desktop/src/shared/main-app-layout.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  windowLabel: "main",
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Outlet: () => <div data-testid="outlet" />,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/webviewWindow", () => ({
+  getCurrentWebviewWindow: () => ({}),
+}));
+
+vi.mock("@anlg/plugin-windows", () => ({
+  events: {},
+  getCurrentWebviewWindowLabel: () => mocks.windowLabel,
+}));
+
+vi.mock("./useNewNote", () => ({
+  openNewNoteAndListen: vi.fn(),
+  openSessionAndListen: vi.fn(),
+  useNewNote: () => vi.fn(),
+}));
+
+vi.mock("~/auth", () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="auth-provider">{children}</div>
+  ),
+}));
+
+vi.mock("~/auth/billing", () => ({
+  BillingProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("~/devtools-panel/host", () => ({
+  DevtoolsFloatingPanelHost: () => null,
+}));
+
+vi.mock("~/session/queries", () => ({
+  getOrCreateSessionForEventId: vi.fn(),
+}));
+
+vi.mock("~/services/meeting-import-sync", () => ({
+  MeetingImportSync: () => <div data-testid="meeting-import-sync" />,
+}));
+
+vi.mock("~/settings/team/mirror", () => ({
+  useMyWorkspacesWithMirror: vi.fn(),
+}));
+
+vi.mock("~/shared/hooks/useMountEffect", () => ({
+  useMountEffect: vi.fn(),
+}));
+
+vi.mock("~/sidebar/toast/undo-delete-toast", () => ({
+  UndoDeleteToast: () => null,
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  isTabInputSupported: vi.fn(),
+  useTabs: () => vi.fn(),
+}));
+
+import MainAppLayout from "./main-app-layout";
+
+describe("MainAppLayout", () => {
+  beforeEach(() => {
+    mocks.windowLabel = "main";
+  });
+
+  afterEach(cleanup);
+
+  it("mounts connected import sync inside the auth provider", () => {
+    render(<MainAppLayout />);
+
+    expect(
+      screen
+        .getByTestId("auth-provider")
+        .contains(screen.getByTestId("meeting-import-sync")),
+    ).toBe(true);
+  });
+
+  it("does not mount connected import sync in secondary windows", () => {
+    mocks.windowLabel = "note";
+
+    render(<MainAppLayout />);
+
+    expect(screen.queryByTestId("meeting-import-sync")).toBeNull();
+  });
+});

--- a/apps/desktop/src/shared/main-app-layout.tsx
+++ b/apps/desktop/src/shared/main-app-layout.tsx
@@ -1,7 +1,10 @@
 import { Outlet, useNavigate } from "@tanstack/react-router";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 
-import { events as windowsEvents } from "@anlg/plugin-windows";
+import {
+  events as windowsEvents,
+  getCurrentWebviewWindowLabel,
+} from "@anlg/plugin-windows";
 
 import {
   openNewNoteAndListen,
@@ -12,6 +15,7 @@ import {
 import { AuthProvider } from "~/auth";
 import { BillingProvider } from "~/auth/billing";
 import { DevtoolsFloatingPanelHost } from "~/devtools-panel/host";
+import { MeetingImportSync } from "~/services/meeting-import-sync";
 import { getOrCreateSessionForEventId } from "~/session/queries";
 import { useMyWorkspacesWithMirror } from "~/settings/team/mirror";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
@@ -32,9 +36,12 @@ export default function MainAppLayout() {
 }
 
 function MainAppContent() {
+  const isMainWindow = getCurrentWebviewWindowLabel() === "main";
+
   return (
     <>
       <Outlet />
+      {isMainWindow ? <MeetingImportSync /> : null}
       <UndoDeleteToast />
       <DevtoolsFloatingPanelHost />
     </>


### PR DESCRIPTION
Mount connected import sync under AuthProvider so authenticated background sync cannot crash the main window. Preserve the main-window-only behavior and add regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small mount-order fix with no auth or sync logic changes; regression tests cover main vs secondary windows.
> 
> **Overview**
> **Moves `MeetingImportSync` from the root app shell into `MainAppLayout`**, so it renders inside `AuthProvider`. That component calls `useAuth()` for connected-import background sync; mounting it above the auth tree could crash the main window on startup.
> 
> **Main-window-only behavior is unchanged**: sync still mounts only when `getCurrentWebviewWindowLabel() === "main"`, not in secondary windows like note views.
> 
> Adds **`main-app-layout` tests** that assert import sync is nested under the auth provider on the main window and absent elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a9b51f036182d703744a66b7194ec6bbc65790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->