### PR TITLE
Restore floating panel top border

### DIFF
--- a/apps/desktop/src/chat/surface.test.ts
+++ b/apps/desktop/src/chat/surface.test.ts
@@ -51,6 +51,9 @@ describe("chat surface tokens", () => {
     expect(chatFloatingPanelShellClassNames()).toContain("border");
     expect(chatFloatingPanelShellClassNames()).toContain("border-border/70");
     expect(chatFloatingPanelShellClassNames()).toContain(
+      "border-t-app-floating-border",
+    );
+    expect(chatFloatingPanelShellClassNames()).toContain(
       "dark:border-white/10",
     );
     expect(chatFloatingPanelShellClassNames()).toContain("dark:bg-[#202020]");

--- a/apps/desktop/src/chat/surface.ts
+++ b/apps/desktop/src/chat/surface.ts
@@ -17,7 +17,7 @@ export function chatPanelBorderClassNames(): string {
 }
 
 export function chatFloatingPanelShellClassNames(): string {
-  return "bg-[#f4f4f5] text-card-foreground rounded-[24px] border border-border/70 shadow-[0_32px_84px_rgba(0,0,0,0.32)] dark:border-white/10 dark:bg-[#202020] dark:shadow-[0_36px_96px_rgba(0,0,0,0.72)]";
+  return "bg-[#f4f4f5] text-card-foreground rounded-[24px] border border-border/70 border-t-app-floating-border shadow-[0_32px_84px_rgba(0,0,0,0.32)] dark:border-white/10 dark:border-t-app-floating-border dark:bg-[#202020] dark:shadow-[0_36px_96px_rgba(0,0,0,0.72)]";
 }
 
 export function chatElevatedSurfaceClassNames(): string {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class changes on the chat floating panel with matching unit test updates only.
> 
> **Overview**
> Restores a distinct **top edge** on the floating chat panel shell by adding `border-t-app-floating-border` to `chatFloatingPanelShellClassNames()` in light and dark modes, alongside the existing `border-border/70` and `dark:border-white/10` styling.
> 
> Tests now assert the shell class list includes `border-t-app-floating-border`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28cb4d48fb88495e01e76fb3792c752e567ab211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->