### PR TITLE
Recognize generic speaker summaries

### DIFF
--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -369,7 +369,7 @@ describe("inferAutomaticSpeakerAssignments", () => {
 
     const updates = await inferAutomaticSpeakerAssignments({
       generatedSummary:
-        "Speaker 1 asked about Llama. Speaker 2 supported open source AI.",
+        "One speaker asked about Llama. Another speaker supported open source AI.",
       model: {} as LanguageModel,
       snapshot: createSnapshot(),
       signal: new AbortController().signal,

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -115,7 +115,7 @@ export async function inferAutomaticSpeakerAssignments({
             (candidate) => candidate.summaryMentions.length === 0,
           ) &&
           (isAppleFoundationModel(model) ||
-            hasTwoGenericSpeakerLabels(generatedSummary));
+            hasGenericSpeakerReferences(generatedSummary));
 
         for (const candidate of candidates) {
           if (
@@ -219,11 +219,14 @@ function formatSpeakerAttributionPrompt(
     : json;
 }
 
-function hasTwoGenericSpeakerLabels(summary: string): boolean {
+function hasGenericSpeakerReferences(summary: string): boolean {
+  const numberedSpeakerCount = new Set(
+    [...summary.matchAll(/\bspeaker\s+(\d+)\b/giu)].map((match) => match[1]),
+  ).size;
+
   return (
-    new Set(
-      [...summary.matchAll(/\bspeaker\s+(\d+)\b/giu)].map((match) => match[1]),
-    ).size === 2
+    numberedSpeakerCount === 2 ||
+    [...summary.matchAll(/\bspeaker\b/giu)].length >= 2
   );
 }
 


### PR DESCRIPTION
Enable public-evidence speaker attribution when generated notes use unnumbered speaker references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small heuristic change in enhance-time speaker attribution with an updated unit test; gated on two participants, two clusters, and empty name-based summary mentions.
> 
> **Overview**
> **Cloud automatic speaker attribution** can now use the **public-evidence fallback** when enhanced notes never name participants but still read like a two-person dialogue with generic wording (e.g. “one speaker … another speaker”), not only when the summary uses **“Speaker 1” / “Speaker 2”** labels.
> 
> The gate helper is renamed to `hasGenericSpeakerReferences` and its logic is broadened: it still matches two distinct numbered speakers, and also matches when the word **speaker** appears at least twice. The existing test for cloud models without participant names is updated to use unnumbered phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a5f0b13c53368d268b415d7e36c1dc1b5bfdd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->