### PR TITLE
Constrain Apple speaker attribution output

### DIFF
--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -330,6 +330,11 @@ describe("inferAutomaticSpeakerAssignments", () => {
     });
 
     expect(mocks.generateText).toHaveBeenCalledTimes(2);
+    expect(mocks.generateText.mock.calls[0]![0]).toMatchObject({
+      temperature: 0,
+      maxOutputTokens: 200,
+      output: expect.anything(),
+    });
     expect(automaticHumanIds(updates[0]!)).toEqual([
       "human-lex",
       "human-george",

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -1,4 +1,4 @@
-import { generateText, type LanguageModel } from "ai";
+import { generateText, type LanguageModel, Output } from "ai";
 import { z } from "zod";
 
 import type { TranscriptSpeakerHintsUpdate } from "~/session/content-mutations";
@@ -157,16 +157,23 @@ Do not use elimination, participant or cluster order, generic conversational rol
 Return a mapping only with at least 0.9 confidence and the supplied evidence ID. Otherwise return null.
 Return only JSON with this shape: {"mapping":{"cluster_id":"...","confidence":0.9,"evidence_id":"..."}} or {"mapping":null}.`,
               prompt: formatSpeakerAttributionPrompt(model, payload),
+              output: Output.object({
+                schema: candidateSpeakerAttributionOutputSchema,
+              }),
+              temperature: 0,
               maxRetries: 2,
-              maxOutputTokens: 600,
+              maxOutputTokens: 200,
               abortSignal: signal,
               timeout: { totalMs: 45_000 },
             });
 
-            const mapping = parseCandidateSpeakerAttributionJson(result.text, {
-              finishReason: result.finishReason,
-              outputTokens: result.usage?.outputTokens,
-            }).mapping;
+            const attribution =
+              result.output ??
+              parseCandidateSpeakerAttributionJson(result.text, {
+                finishReason: result.finishReason,
+                outputTokens: result.usage?.outputTokens,
+              });
+            const mapping = attribution.mapping;
 
             if (mapping) {
               directMappings.push({


### PR DESCRIPTION
Use deterministic schema-guided Apple Intelligence responses so automatic transcript speaker mappings persist reliably.

Validated with the real 3-minute Lex Fridman / George Hotz fixture using Apple Intelligence: exactly two 0.9-confidence mappings persisted and rendered under the correct speakers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how automatic transcript speaker hints are inferred from LLM output; mis-parsing or provider incompatibility with structured output could drop assignments, though text fallback limits regression risk.
> 
> **Overview**
> Automatic speaker attribution now uses the AI SDK’s **schema-guided** `Output.object` (with `candidateSpeakerAttributionOutputSchema`), **`temperature: 0`**, and a lower **`maxOutputTokens` (200 vs 600)** on each per-candidate `generateText` call so responses stay small and structurally valid.
> 
> Parsed mappings prefer **`result.output`** when present and **fall back** to the existing free-text JSON parser on `result.text`, so Apple Intelligence and other providers can still recover if structured output is missing.
> 
> The Apple public-evidence test now asserts those generation options are passed for **`apple_foundation`** models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 491afcca9bcb141d8f44c63c3cb5e9be0bb6355f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->