### PR TITLE
Remove unreliable speaker identity claim

### DIFF
--- a/packages/changelog/content/1.4.9.md
+++ b/packages/changelog/content/1.4.9.md
@@ -20,10 +20,6 @@ summary: "Anarlog 1.4.9 adds Team workspace management, relationship briefs, exa
 - Avoid failures from unsupported temperature settings on newer models, and
   stop automatic summary retries after a bounded backoff instead of retrying
   forever
-- Reliably match two speakers to two named participants after recording,
-  including local live transcription when the batch model is installed and
-  summaries that use only generic speaker labels
-
 ## Teams and contacts
 
 - Create and manage shared workspaces from the new **Team** settings page:


### PR DESCRIPTION
Remove the 1.4.9 changelog bullet that overstates automatic speaker identification reliability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to release notes with no runtime or API impact.
> 
> **Overview**
> Updates the **1.4.9** release notes in `packages/changelog/content/1.4.9.md` by deleting the Transcription bullet that claimed reliable matching of two speakers to named participants (including local live transcription and generic speaker labels in summaries).
> 
> No product or code behavior changes—only the public changelog is aligned with actual speaker-identification reliability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebdad712371dcbfdee0401d9333d56efab09ba3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->