### PR TITLE
Make participant selector footer spacing even

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
@@ -219,6 +219,11 @@ describe("SpeakerAssignPopover", () => {
     expect(searchInput.parentElement?.parentElement?.className).toContain(
       "py-1",
     );
+    const footer = screen.getByRole("button", {
+      name: "Confirm",
+    }).parentElement;
+    expect(footer?.className).toContain("py-1");
+    expect(footer?.className).not.toContain("pb-3");
     const aliceOption = screen.getByRole("button", { name: "Alice" });
     expect(aliceOption.querySelector("img")?.getAttribute("src")).toBe(
       "data:image/jpeg;base64,alice",

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -557,7 +557,7 @@ export function SpeakerParticipantPicker({
           )}
         </div>
       </AppFloatingPanel>
-      <div className="flex items-center justify-end gap-3 pt-1 pb-3 pl-2">
+      <div className="flex items-center justify-end gap-3 py-1 pl-2">
         {showAssignmentScope && (
           <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
             <Checkbox


### PR DESCRIPTION
Use equal vertical footer padding and cover it with a regression assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change and test-only assertions; no behavior or data-path impact.
> 
> **Overview**
> The **speaker/participant selector** popover footer (Confirm + “Apply to all”) now uses **symmetric vertical padding** (`py-1`) instead of `pt-1` with a larger `pb-3`, so spacing matches the search area above.
> 
> A **regression test** asserts the Confirm button’s parent has `py-1` and no longer uses `pb-3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd7dc420a922a0d52f4e8f61767f39251650658f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->