### PR TITLE
Surface cloud sync Keychain repair

### DIFF
--- a/apps/desktop/src/auth/cloudsync-credentials.ts
+++ b/apps/desktop/src/auth/cloudsync-credentials.ts
@@ -37,6 +37,7 @@ export const DEVICE_LIMIT_TOAST_ID = "cloudsync-device-limit";
 export type CloudsyncCredentialBlock =
   | "device_limit"
   | "identity_mismatch"
+  | "keychain_access"
   | "not_entitled"
   | "reauth_required"
   | "setup_required"

--- a/apps/desktop/src/auth/cloudsync-keychain-repair.test.tsx
+++ b/apps/desktop/src/auth/cloudsync-keychain-repair.test.tsx
@@ -1,0 +1,117 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  applyCloudsyncPreference: vi.fn(),
+  repairKeychainAccess: vi.fn(),
+  setCredentialBlock: vi.fn(),
+  signOut: vi.fn(),
+  credentialBlock: "keychain_access" as string | null,
+  session: { user: { id: "user-1" } },
+}));
+
+vi.mock("./auth-context", () => ({
+  useAuth: () => ({ session: mocks.session, signOut: mocks.signOut }),
+}));
+
+vi.mock("./cloudsync", () => ({
+  applyCloudsyncPreference: mocks.applyCloudsyncPreference,
+  getCloudsyncCredentialBlock: () => mocks.credentialBlock,
+  subscribeCloudsyncCredentialBlock: () => () => {},
+}));
+
+vi.mock("./cloudsync-credentials", () => ({
+  setCredentialBlock: mocks.setCredentialBlock,
+}));
+
+vi.mock("~/shared/keychain", () => ({
+  repairKeychainAccess: mocks.repairKeychainAccess,
+}));
+
+vi.mock("~/shared/ui/settings-alert", () => ({
+  SettingsAlertToast: ({
+    description,
+    action,
+    lifecycle,
+  }: {
+    description?: string;
+    action?: { label: string; onClick: () => void };
+    lifecycle: string;
+  }) =>
+    description ? (
+      <div data-testid="keychain-toast" data-lifecycle={lifecycle}>
+        <span>{description}</span>
+        {action ? (
+          <button type="button" onClick={action.onClick}>
+            {action.label}
+          </button>
+        ) : null}
+      </div>
+    ) : null,
+}));
+
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    t: (strings: TemplateStringsArray, ...values: unknown[]) =>
+      strings.reduce(
+        (message, part, index) =>
+          `${message}${part}${index < values.length ? String(values[index]) : ""}`,
+        "",
+      ),
+  }),
+}));
+
+import { CloudsyncKeychainRepairToast } from "./cloudsync-keychain-repair";
+
+function renderToast() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CloudsyncKeychainRepairToast />
+    </QueryClientProvider>,
+  );
+}
+
+describe("CloudsyncKeychainRepairToast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.credentialBlock = "keychain_access";
+    mocks.repairKeychainAccess.mockResolvedValue(undefined);
+    mocks.applyCloudsyncPreference.mockResolvedValue("ok");
+  });
+
+  afterEach(cleanup);
+
+  it("offers persistent Keychain repair and retries cloud sync", async () => {
+    renderToast();
+
+    expect(screen.getByTestId("keychain-toast").dataset.lifecycle).toBe(
+      "condition-bound",
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Repair Keychain Access" }),
+    );
+
+    await vi.waitFor(() =>
+      expect(mocks.repairKeychainAccess).toHaveBeenCalledOnce(),
+    );
+    await vi.waitFor(() =>
+      expect(mocks.applyCloudsyncPreference).toHaveBeenCalledWith(
+        mocks.session,
+        mocks.signOut,
+      ),
+    );
+    expect(mocks.setCredentialBlock).toHaveBeenCalledWith(null);
+  });
+
+  it("stays hidden for unrelated sync failures", () => {
+    mocks.credentialBlock = "unavailable";
+
+    renderToast();
+
+    expect(screen.queryByTestId("keychain-toast")).toBeNull();
+  });
+});

--- a/apps/desktop/src/auth/cloudsync-keychain-repair.test.tsx
+++ b/apps/desktop/src/auth/cloudsync-keychain-repair.test.tsx
@@ -101,9 +101,9 @@ describe("CloudsyncKeychainRepairToast", () => {
     await vi.waitFor(() =>
       expect(mocks.applyCloudsyncPreference).toHaveBeenCalledWith(
         mocks.session,
-        mocks.signOut,
       ),
     );
+    expect(mocks.signOut).not.toHaveBeenCalled();
     expect(mocks.setCredentialBlock).toHaveBeenCalledWith(null);
   });
 

--- a/apps/desktop/src/auth/cloudsync-keychain-repair.test.tsx
+++ b/apps/desktop/src/auth/cloudsync-keychain-repair.test.tsx
@@ -107,6 +107,17 @@ describe("CloudsyncKeychainRepairToast", () => {
     expect(mocks.setCredentialBlock).toHaveBeenCalledWith(null);
   });
 
+  it("signs out when repair finds an account mismatch", async () => {
+    mocks.applyCloudsyncPreference.mockResolvedValue("account_mismatch");
+    renderToast();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Repair Keychain Access" }),
+    );
+
+    await vi.waitFor(() => expect(mocks.signOut).toHaveBeenCalledOnce());
+  });
+
   it("stays hidden for unrelated sync failures", () => {
     mocks.credentialBlock = "unavailable";
 

--- a/apps/desktop/src/auth/cloudsync-keychain-repair.tsx
+++ b/apps/desktop/src/auth/cloudsync-keychain-repair.tsx
@@ -29,7 +29,7 @@ export function CloudsyncKeychainRepairToast() {
     mutationFn: async () => {
       await repairKeychainAccess();
       setCredentialBlock(null);
-      const result = await applyCloudsyncPreference(auth.session, auth.signOut);
+      const result = await applyCloudsyncPreference(auth.session);
       if (result === "account_mismatch") {
         await auth.signOut();
       }

--- a/apps/desktop/src/auth/cloudsync-keychain-repair.tsx
+++ b/apps/desktop/src/auth/cloudsync-keychain-repair.tsx
@@ -1,0 +1,70 @@
+import { useLingui } from "@lingui/react/macro";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useSyncExternalStore } from "react";
+
+import { useAuth } from "./auth-context";
+import {
+  applyCloudsyncPreference,
+  getCloudsyncCredentialBlock,
+  subscribeCloudsyncCredentialBlock,
+} from "./cloudsync";
+import { setCredentialBlock } from "./cloudsync-credentials";
+
+import { repairKeychainAccess } from "~/shared/keychain";
+import { SettingsAlertToast } from "~/shared/ui/settings-alert";
+
+const TOAST_ID = "cloudsync-keychain-access";
+
+export function CloudsyncKeychainRepairToast() {
+  const { t } = useLingui();
+  const auth = useAuth();
+  const queryClient = useQueryClient();
+  const credentialBlock = useSyncExternalStore(
+    subscribeCloudsyncCredentialBlock,
+    getCloudsyncCredentialBlock,
+    getCloudsyncCredentialBlock,
+  );
+  const repairMutation = useMutation({
+    mutationKey: ["repair-keychain-access", "cloudsync-toast"],
+    mutationFn: async () => {
+      await repairKeychainAccess();
+      setCredentialBlock(null);
+      await applyCloudsyncPreference(auth.session, auth.signOut);
+    },
+    onSettled: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["e2ee-identity", auth.session?.user.id],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["cloudsync-status-indicator"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["cloudsync-status-settings"],
+        }),
+      ]);
+    },
+  });
+  const description =
+    repairMutation.error?.message ??
+    t`macOS could not access your recovery key. Repair Keychain access, then resume sync.`;
+  const needsRepair =
+    Boolean(auth.session) && credentialBlock === "keychain_access";
+
+  return (
+    <SettingsAlertToast
+      id={TOAST_ID}
+      description={needsRepair ? description : undefined}
+      variant="error"
+      lifecycle="condition-bound"
+      action={
+        repairMutation.isPending
+          ? undefined
+          : {
+              label: t`Repair Keychain Access`,
+              onClick: () => repairMutation.mutate(),
+            }
+      }
+    />
+  );
+}

--- a/apps/desktop/src/auth/cloudsync-keychain-repair.tsx
+++ b/apps/desktop/src/auth/cloudsync-keychain-repair.tsx
@@ -29,7 +29,10 @@ export function CloudsyncKeychainRepairToast() {
     mutationFn: async () => {
       await repairKeychainAccess();
       setCredentialBlock(null);
-      await applyCloudsyncPreference(auth.session, auth.signOut);
+      const result = await applyCloudsyncPreference(auth.session, auth.signOut);
+      if (result === "account_mismatch") {
+        await auth.signOut();
+      }
     },
     onSettled: async () => {
       await Promise.all([

--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -276,10 +276,12 @@ describe("CloudSync auth lifecycle", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await handleCloudsyncAuthChange("SIGNED_IN", session());
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(configureCloudsyncToken).not.toHaveBeenCalled();
     expect(suspendCloudsync).toHaveBeenCalledTimes(1);
+    expect(getE2eeIdentityStatus).toHaveBeenCalledTimes(1);
     expect(getCloudsyncCredentialBlock()).toBe("keychain_access");
   });
 

--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -267,6 +267,22 @@ describe("CloudSync auth lifecycle", () => {
     expect(getCloudsyncCredentialBlock()).toBe("setup_required");
   });
 
+  test("surfaces macOS Keychain access failures separately", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(getE2eeIdentityStatus).mockRejectedValue(
+      "macOS couldn't access your login Keychain. Use “Repair Keychain Access” below, then try again.",
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await handleCloudsyncAuthChange("SIGNED_IN", session());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(configureCloudsyncToken).not.toHaveBeenCalled();
+    expect(suspendCloudsync).toHaveBeenCalledTimes(1);
+    expect(getCloudsyncCredentialBlock()).toBe("keychain_access");
+  });
+
   test("polls only native status while CloudSync activity is paused", async () => {
     const fetchMock = vi.fn(() => Promise.resolve(credentialsResponse()));
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -32,6 +32,7 @@ import { flushCloudsyncSessionEvictions } from "./cloudsync-session-evictions";
 import { requestCloudsyncCredentials } from "./cloudsync-token-exchange";
 
 import { resolveConfigValue } from "~/shared/config";
+import { isKeychainAccessError } from "~/shared/keychain";
 
 export {
   getCloudsyncCredentialBlock,
@@ -838,14 +839,16 @@ async function activateCloudsync(
       return "ok";
     }
     encryptionKeyId = identity.keyId;
-  } catch {
+  } catch (error) {
     if (isCleanupSuspendRequired()) {
       await suspendCloudsyncPreemptivelyForGeneration(activeGeneration);
       scheduleReactivation();
       return "ok";
     }
     if (activeGeneration === generation) {
-      setCredentialBlock("unavailable");
+      setCredentialBlock(
+        isKeychainAccessError(error) ? "keychain_access" : "unavailable",
+      );
     }
     await suspendCloudsyncAfterCredentialRejection(activeGeneration);
     console.warn(

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -845,16 +845,17 @@ async function activateCloudsync(
       scheduleReactivation();
       return "ok";
     }
+    const keychainAccessError = isKeychainAccessError(error);
     if (activeGeneration === generation) {
       setCredentialBlock(
-        isKeychainAccessError(error) ? "keychain_access" : "unavailable",
+        keychainAccessError ? "keychain_access" : "unavailable",
       );
     }
     await suspendCloudsyncAfterCredentialRejection(activeGeneration);
     console.warn(
       "[cloudsync] E2EE recovery key is unavailable; sync remains disabled",
     );
-    if (activeGeneration === generation) {
+    if (activeGeneration === generation && !keychainAccessError) {
       scheduleExchange(
         session,
         activeGeneration,

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -1755,6 +1755,8 @@ msgstr "Low-light canvas"
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr "macOS could not access your recovery key. Repair Keychain access, then resume sync."
@@ -2485,6 +2487,7 @@ msgstr "Reopen in browser"
 msgid "Reopen sign-in page"
 msgstr "Reopen sign-in page"
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr "Sync issue"
 msgid "Sync log"
 msgstr "Sync log"
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr "Sync needs attention"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -1755,6 +1755,8 @@ msgstr ""
 msgid "macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key."
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "macOS could not access your recovery key. Repair Keychain access, then resume sync."
 msgstr ""
@@ -2485,6 +2487,7 @@ msgstr ""
 msgid "Reopen sign-in page"
 msgstr ""
 
+#: src/auth/cloudsync-keychain-repair.tsx
 #: src/settings/ai/shared/index.tsx
 #: src/settings/sync/index.tsx
 msgid "Repair Keychain Access"
@@ -3191,6 +3194,7 @@ msgstr ""
 msgid "Sync log"
 msgstr ""
 
+#: src/main/sync-status.tsx
 #: src/settings/sync/index.tsx
 msgid "Sync needs attention"
 msgstr ""

--- a/apps/desktop/src/main/lifecycle.tsx
+++ b/apps/desktop/src/main/lifecycle.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useLanguageModel, useLLMConnection } from "~/ai/hooks";
 import { AttachmentTransferLifecycle } from "~/attachment-sync/lifecycle";
 import { useAuth } from "~/auth";
+import { CloudsyncKeychainRepairToast } from "~/auth/cloudsync-keychain-repair";
 import { searchCalendarEvents } from "~/calendar/queries";
 import { useSessionTab } from "~/chat/components/use-session-tab";
 import { buildChatTools } from "~/chat/tools";
@@ -49,6 +50,7 @@ export function ClassicMainServices() {
   return (
     <>
       <AttachmentTransferLifecycle />
+      <CloudsyncKeychainRepairToast />
       <CloudApiBackfillLifecycle />
       <DurableSharedNoteCacheSync />
       <SharedAttachmentCacheLifecycle />

--- a/apps/desktop/src/main/sync-status.test.tsx
+++ b/apps/desktop/src/main/sync-status.test.tsx
@@ -232,6 +232,11 @@ describe("SyncStatusIndicator", () => {
       "Cloud sync could not start on this device. Open Sync settings to try again.",
     ],
     [
+      "keychain_access",
+      "Sync needs attention",
+      "macOS could not access your recovery key. Repair Keychain access, then resume sync.",
+    ],
+    [
       "reauth_required",
       "Sign in again",
       "Sign out and sign in again to resume cloud sync.",

--- a/apps/desktop/src/main/sync-status.tsx
+++ b/apps/desktop/src/main/sync-status.tsx
@@ -130,6 +130,12 @@ export function SyncStatusIndicator() {
           label: t`Cloud sync identity mismatch`,
           description: t`This device's sync identity does not match your account. Sign in again or check Sync settings.`,
         };
+      case "keychain_access":
+        return {
+          kind: "error" as const,
+          label: t`Sync needs attention`,
+          description: t`macOS could not access your recovery key. Repair Keychain access, then resume sync.`,
+        };
       case "not_entitled":
         return {
           kind: "error" as const,

--- a/apps/desktop/src/settings/providers.test.ts
+++ b/apps/desktop/src/settings/providers.test.ts
@@ -308,6 +308,11 @@ describe("SQLite AI providers", () => {
       ),
     ).toBe(true);
     expect(
+      isKeychainAccessError(
+        "macOS couldn't access your login Keychain. Use repair below.",
+      ),
+    ).toBe(true);
+    expect(
       isKeychainAccessError(new Error("Platform failure: missing entitlement")),
     ).toBe(false);
   });

--- a/apps/desktop/src/settings/providers.ts
+++ b/apps/desktop/src/settings/providers.ts
@@ -5,6 +5,8 @@ import { commands as store2Commands } from "@anlg/plugin-store2";
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
 
+export { isKeychainAccessError, repairKeychainAccess } from "~/shared/keychain";
+
 export type AiProviderType = "llm" | "stt";
 
 export type AiProviderConfig = {
@@ -17,8 +19,6 @@ type AppSettingRow = { id: string; value_json: string };
 
 const LEGACY_SETTINGS_ID = "legacy_settings_document";
 const PROVIDER_SECRET_SCOPE = "ai-provider-api-keys";
-const MACOS_KEYCHAIN_ACCESS_ERROR_PREFIX =
-  "macOS couldn't access your login Keychain.";
 const EMPTY_PROVIDER_API_KEYS: Record<string, string> = {};
 const EMPTY_ROWS: AppSettingRow[] = [];
 
@@ -205,20 +205,6 @@ export function useSetAiProvider(type: AiProviderType, providerId: string) {
       ]);
     },
   });
-}
-
-export function isKeychainAccessError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    error.message.startsWith(MACOS_KEYCHAIN_ACCESS_ERROR_PREFIX)
-  );
-}
-
-export async function repairKeychainAccess(): Promise<void> {
-  const result = await store2Commands.repairKeychainAccess();
-  if (result.status === "error") {
-    throw new Error(result.error);
-  }
 }
 
 export async function loadSecureAiProviderApiKeys(

--- a/apps/desktop/src/settings/sync/index.test.tsx
+++ b/apps/desktop/src/settings/sync/index.test.tsx
@@ -247,9 +247,11 @@ describe("SettingsSync", () => {
   });
 
   it("repairs macOS Keychain access and retries cloud sync", async () => {
-    mocks.credentialBlock = "unavailable";
+    mocks.credentialBlock = "keychain_access";
     mocks.getE2eeIdentityStatus
-      .mockRejectedValueOnce("E2EE recovery key read timed out")
+      .mockRejectedValueOnce(
+        "macOS couldn't access your login Keychain. Use “Repair Keychain Access” below, then try again.",
+      )
       .mockResolvedValue({ configured: true });
     renderSettings();
 
@@ -271,6 +273,20 @@ describe("SettingsSync", () => {
         true,
       ),
     );
+  });
+
+  it("does not offer Keychain repair for generic sync failures", async () => {
+    mocks.credentialBlock = "unavailable";
+    mocks.getE2eeIdentityStatus.mockRejectedValue(
+      "E2EE recovery key read timed out",
+    );
+
+    renderSettings();
+
+    expect(await screen.findByText("Sync needs attention")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Repair Keychain Access" }),
+    ).toBeNull();
   });
 
   it("shows native cloud sync preflight errors", async () => {

--- a/apps/desktop/src/settings/sync/index.tsx
+++ b/apps/desktop/src/settings/sync/index.tsx
@@ -24,7 +24,6 @@ import {
 import type { CloudsyncActivityEntry } from "@anlg/plugin-db";
 import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { commands as settingsCommands } from "@anlg/plugin-settings";
-import { commands as store2Commands } from "@anlg/plugin-store2";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   Dialog,
@@ -57,6 +56,7 @@ import {
   useStoredSettingValuesQuery,
 } from "~/settings/queries";
 import { resolveConfigValue } from "~/shared/config";
+import { isKeychainAccessError, repairKeychainAccess } from "~/shared/keychain";
 import { useTabs } from "~/store/zustand/tabs";
 
 const STATUS_POLL_INTERVAL_MS = 10_000;
@@ -82,13 +82,6 @@ async function readE2eeIdentityStatus(accountUserId: string) {
     return await getE2eeIdentityStatus(accountUserId);
   } catch (error) {
     throw error instanceof Error ? error : new Error(String(error));
-  }
-}
-
-async function repairKeychainAccess() {
-  const result = await store2Commands.repairKeychainAccess();
-  if (result.status === "error") {
-    throw new Error(result.error);
   }
 }
 
@@ -551,7 +544,8 @@ export function SettingsSync() {
     syncNowMutation.error;
   const canRepairKeychainAccess =
     platform() === "macos" &&
-    (credentialBlock === "unavailable" || e2eeIdentityQuery.isError);
+    (credentialBlock === "keychain_access" ||
+      isKeychainAccessError(e2eeIdentityQuery.error));
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/desktop/src/shared/keychain.ts
+++ b/apps/desktop/src/shared/keychain.ts
@@ -1,0 +1,16 @@
+import { commands as store2Commands } from "@anlg/plugin-store2";
+
+const MACOS_KEYCHAIN_ACCESS_ERROR_PREFIX =
+  "macOS couldn't access your login Keychain.";
+
+export function isKeychainAccessError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.startsWith(MACOS_KEYCHAIN_ACCESS_ERROR_PREFIX);
+}
+
+export async function repairKeychainAccess(): Promise<void> {
+  const result = await store2Commands.repairKeychainAccess();
+  if (result.status === "error") {
+    throw new Error(result.error);
+  }
+}


### PR DESCRIPTION
Distinguish recoverable Keychain failures, show a persistent repair toast, and retry sync after repair.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how cloud sync handles E2EE recovery key access and credential blocking on macOS; incorrect classification could leave sync disabled or skip needed retries, though behavior is covered by new tests.
> 
> **Overview**
> Adds a dedicated **`keychain_access`** cloud-sync credential block when E2EE recovery key reads fail with a recoverable macOS Keychain error, instead of lumping them into **`unavailable`**. For that case, sync stays suspended and automatic credential-exchange retries are **not** scheduled.
> 
> **`CloudsyncKeychainRepairToast`** is mounted in the main app lifecycle: it shows a condition-bound alert with **Repair Keychain Access**, runs shared **`repairKeychainAccess`**, clears the block, and calls **`applyCloudsyncPreference`** to resume sync (signing out if repair reveals an account mismatch). Sync status UI and Sync settings use the same messaging; settings only offer Keychain repair when the block is **`keychain_access`** or the identity preflight error matches **`isKeychainAccessError`** (not for generic failures).
> 
> Keychain helpers move to **`~/shared/keychain`** (re-exported from AI provider settings); **`isKeychainAccessError`** now also accepts string errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5046d7f3a7b9cebe5581ce4686c43d7b551a23b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->