### PR TITLE
Prevent duplicate desktop auth prompts

### DIFF
--- a/apps/web/src/lib/desktop-auth-handoff.test.ts
+++ b/apps/web/src/lib/desktop-auth-handoff.test.ts
@@ -64,7 +64,7 @@ test("attempts the external protocol through an anchor navigation", () => {
   assert.deepEqual(events, ["create:a", "append", "click", "remove"]);
 });
 
-test("attempts automatic opening once under StrictMode", async () => {
+test("attempts automatic opening once under StrictMode and remounts", async () => {
   const dom = new JSDOM('<div id="root"></div>', {
     url: "https://anarlog.so",
   });
@@ -114,9 +114,21 @@ test("attempts automatic opening once under StrictMode", async () => {
 
   const rootElement = document.getElementById("root");
   assert.ok(rootElement);
-  const root = createRoot(rootElement);
+  let root = createRoot(rootElement);
 
   try {
+    await act(async () => {
+      root.render(
+        createElement(StrictMode, null, createElement(AutoOpenProbe)),
+      );
+    });
+
+    assert.deepEqual(attempts, [deeplink]);
+
+    await act(async () => {
+      root.unmount();
+    });
+    root = createRoot(rootElement);
     await act(async () => {
       root.render(
         createElement(StrictMode, null, createElement(AutoOpenProbe)),

--- a/apps/web/src/lib/desktop-auth-handoff.ts
+++ b/apps/web/src/lib/desktop-auth-handoff.ts
@@ -1,8 +1,8 @@
-import { useRef } from "react";
-
 import type { DesktopScheme } from "@/functions/desktop-flow";
 
 import { useMountEffect } from "../hooks/useMountEffect.ts";
+
+const autoOpenAttempts = new WeakMap<Document, Set<string>>();
 
 export function buildDesktopAuthDeeplink(
   scheme: DesktopScheme,
@@ -35,14 +35,15 @@ export function attemptDesktopAppOpen(
 }
 
 export function useDesktopAppAutoOpen(deeplink: string) {
-  const attemptedRef = useRef(false);
-
   useMountEffect(() => {
-    if (attemptedRef.current) {
+    const attempts = autoOpenAttempts.get(document) ?? new Set<string>();
+    autoOpenAttempts.set(document, attempts);
+
+    if (attempts.has(deeplink)) {
       return;
     }
 
-    attemptedRef.current = true;
+    attempts.add(deeplink);
     attemptDesktopAppOpen(deeplink);
   });
 }


### PR DESCRIPTION
Keep automatic desktop auth handoff idempotent across callback route remounts and cover it with a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX guard around when `attemptDesktopAppOpen` runs; token/deeplink building and manual open paths are untouched.
> 
> **Overview**
> **Desktop auth callback auto-open** now fires at most once per deeplink per browser document, instead of once per component mount via `useRef`.
> 
> `useDesktopAppAutoOpen` tracks attempted deeplinks in a module-level `WeakMap<Document, Set<string>>`, so React StrictMode double effects and unmount/remount of the callback route no longer trigger duplicate protocol opens. Manual “open app” link behavior is unchanged.
> 
> The StrictMode integration test now unmounts and remounts the tree and asserts the deeplink is still only attempted once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 971d310181abe8696471bd23b4bde595ee4c0687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->