### PR TITLE
chore(packaging): bump anarlog-bin to 1.4.9

### DIFF
--- a/packaging/aur/anarlog-bin/.SRCINFO
+++ b/packaging/aur/anarlog-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = anarlog-bin
 	pkgdesc = AI notepad for meetings — local-first, E2EE desktop note-taking app
-	pkgver = 1.4.8
+	pkgver = 1.4.9
 	pkgrel = 1
 	url = https://anarlog.so
 	arch = x86_64
@@ -22,11 +22,11 @@ pkgbase = anarlog-bin
 	provides = anarlog
 	conflicts = anarlog
 	options = !strip
-	source = LICENSE-1.4.8::https://raw.githubusercontent.com/fastrepl/anarlog/desktop_v1.4.8/LICENSE
+	source = LICENSE-1.4.9::https://raw.githubusercontent.com/fastrepl/anarlog/desktop_v1.4.9/LICENSE
 	sha256sums = ba9cc3a7e074c5cfe3985d6956f24c9f7575592a0483e314c9fcb4f72ee1b615
-	source_x86_64 = anarlog-1.4.8-x86_64.deb::https://github.com/fastrepl/anarlog/releases/download/desktop_v1.4.8/anarlog-linux-x86_64.deb
-	sha256sums_x86_64 = 10c0c170f19b8d46c2acccb9ff70a917c9a6c0ce55481b0815f21255048537ee
-	source_aarch64 = anarlog-1.4.8-aarch64.deb::https://github.com/fastrepl/anarlog/releases/download/desktop_v1.4.8/anarlog-linux-aarch64.deb
-	sha256sums_aarch64 = 74e06ae01e838e8e972fbcdd1034fcb9e6c45869b04573fa3b7c3405d1b0f128
+	source_x86_64 = anarlog-1.4.9-x86_64.deb::https://github.com/fastrepl/anarlog/releases/download/desktop_v1.4.9/anarlog-linux-x86_64.deb
+	sha256sums_x86_64 = 317258132a02b7b4d9a91b322e6bea67edd590fa27e767c00b0af884f5dd148d
+	source_aarch64 = anarlog-1.4.9-aarch64.deb::https://github.com/fastrepl/anarlog/releases/download/desktop_v1.4.9/anarlog-linux-aarch64.deb
+	sha256sums_aarch64 = c7e7383dbd98219c9efb234678213634807d586411794d3605f0e28f68490c05
 
 pkgname = anarlog-bin

--- a/packaging/aur/anarlog-bin/PKGBUILD
+++ b/packaging/aur/anarlog-bin/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Anarlog <support@anarlog.so>
 pkgname=anarlog-bin
-pkgver=1.4.8
+pkgver=1.4.9
 pkgrel=1
 pkgdesc="AI notepad for meetings — local-first, E2EE desktop note-taking app"
 arch=('x86_64' 'aarch64')
@@ -31,8 +31,8 @@ source=("LICENSE-${pkgver}::https://raw.githubusercontent.com/fastrepl/anarlog/$
 source_x86_64=("anarlog-${pkgver}-x86_64.deb::https://github.com/fastrepl/anarlog/releases/download/${_release}/anarlog-linux-x86_64.deb")
 source_aarch64=("anarlog-${pkgver}-aarch64.deb::https://github.com/fastrepl/anarlog/releases/download/${_release}/anarlog-linux-aarch64.deb")
 sha256sums=('ba9cc3a7e074c5cfe3985d6956f24c9f7575592a0483e314c9fcb4f72ee1b615')
-sha256sums_x86_64=('10c0c170f19b8d46c2acccb9ff70a917c9a6c0ce55481b0815f21255048537ee')
-sha256sums_aarch64=('74e06ae01e838e8e972fbcdd1034fcb9e6c45869b04573fa3b7c3405d1b0f128')
+sha256sums_x86_64=('317258132a02b7b4d9a91b322e6bea67edd590fa27e767c00b0af884f5dd148d')
+sha256sums_aarch64=('c7e7383dbd98219c9efb234678213634807d586411794d3605f0e28f68490c05')
 
 package() {
   tar -xzf data.tar.gz -C "$pkgdir"


### PR DESCRIPTION
Automated follow-up from the `desktop_v1.4.9` publish run.

Updates the AUR `anarlog-bin` package version and Debian package checksums to 1.4.9.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only version and checksum updates with no application or runtime logic changes.
> 
> **Overview**
> Bumps the AUR **`anarlog-bin`** package from **1.4.8** to **1.4.9** to track the **`desktop_v1.4.9`** desktop release.
> 
> **`PKGBUILD`** and **`.SRCINFO`** now point at the `desktop_v1.4.9` LICENSE URL and GitHub release `.deb` artifacts for **x86_64** and **aarch64**, with updated **SHA256** checksums for those binaries. The shared LICENSE checksum is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f32eb4ed00e43f01aca6c4979562a578e0a82ef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->