### PR TITLE
Remove gaps between header icons

### DIFF
--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -601,6 +601,7 @@ describe("SessionShareButton", () => {
     expect(trigger.textContent).toBe("");
     expect(trigger.querySelectorAll("svg")).toHaveLength(1);
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger.className).not.toContain("mr-1");
 
     await openSharePopover();
 

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -593,7 +593,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
           title="Share note"
           onClick={handleShare}
           className={cn([
-            "text-muted-foreground hover:text-foreground mr-1 rounded-full",
+            "text-muted-foreground hover:text-foreground rounded-full",
             sharePopoverOpen && "bg-accent text-foreground",
           ])}
         >

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -970,6 +970,7 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("button", { name: "Join & record" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
     expect(metadataButton.getAttribute("data-tauri-drag-region")).toBe("false");
+    expect(metadataButton.parentElement?.className).not.toContain("mr-1");
     expect(mocks.startListening).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -154,7 +154,7 @@ function HeaderMeetingControl({
           editMode={transcriptEditMode}
           onEditModeChange={onTranscriptEditModeChange}
         />
-        <div className="mr-1 shrink-0">
+        <div className="shrink-0">
           <MetadataButton sessionId={sessionId} />
         </div>
       </>
@@ -167,7 +167,7 @@ function HeaderMeetingControl({
   if (!sessionEvent && !isRecording) {
     if (hasTranscript || audioExists) {
       return (
-        <div className="mr-1 shrink-0">
+        <div className="shrink-0">
           <MetadataButton sessionId={sessionId} />
         </div>
       );
@@ -190,7 +190,7 @@ function HeaderMeetingControl({
 
   if (ended && !isRecording) {
     return (
-      <div className="mr-1 shrink-0">
+      <div className="shrink-0">
         <MetadataButton sessionId={sessionId} />
       </div>
     );


### PR DESCRIPTION
Pack metadata, sharing, and overflow icon buttons without inter-button margins and cover the compact spacing in tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class removals only; no behavior or data-path changes.
> 
> **Overview**
> **Tightens the session header action strip** by dropping `mr-1` margins that sat between toolbar icons.
> 
> The **Share note** ghost button no longer applies a right margin, and the **metadata** button wrappers in `OuterHeader` (standalone calendar icon paths) likewise lose `mr-1` while keeping `shrink-0`. The parent action row already uses `gap-0`, so metadata, share, and overflow icons sit flush next to each other.
> 
> Tests now assert the share trigger and metadata button parent **do not** include `mr-1`, locking in the compact layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd206a2b555d8407300364674c0f578958914fd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->