### PR TITLE
Show summary dropdown chevron

### DIFF
--- a/apps/desktop/src/session/components/note-input/header-enhanced.tsx
+++ b/apps/desktop/src/session/components/note-input/header-enhanced.tsx
@@ -242,7 +242,7 @@ function HeaderViewEnhancedActive({
         true,
         "tray",
         cn([
-          "max-w-56 min-w-[62px] gap-1.5 px-2 @max-[480px]:max-w-10 @max-[480px]:min-w-10 @max-[480px]:gap-0",
+          "max-w-56 min-w-[62px] gap-1.5 px-2 @max-[480px]:max-w-12 @max-[480px]:min-w-12 @max-[480px]:gap-0 @max-[480px]:px-1.5",
           isGenerating ? "cursor-not-allowed opacity-70" : "cursor-pointer",
           isError
             ? [
@@ -264,7 +264,7 @@ function HeaderViewEnhancedActive({
       <span className="min-w-0 truncate text-xs font-medium @max-[480px]:sr-only">
         {viewTitle}
       </span>
-      <CaretDown className="size-3.5 @max-[480px]:hidden" />
+      <CaretDown className="size-3.5" />
     </button>
   );
 

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -431,11 +431,15 @@ describe("Header", () => {
     expect(activeSummaryTab.className).toContain("text-foreground");
     expect(activeSummaryTab.className).toContain("dark:text-foreground");
     expect(activeSummaryTab.className).toContain("dark:bg-accent");
-    expect(activeSummaryTab.className).toContain("@max-[480px]:max-w-10");
+    expect(activeSummaryTab.className).toContain("@max-[480px]:max-w-12");
     expect(activeSummaryTab.querySelector("span")?.className).toContain(
       "@max-[480px]:sr-only",
     );
-    expect(activeSummaryTab.querySelectorAll("svg")).toHaveLength(2);
+    const activeSummaryIcons = activeSummaryTab.querySelectorAll("svg");
+    expect(activeSummaryIcons).toHaveLength(2);
+    expect(activeSummaryIcons[1]?.getAttribute("class")).not.toContain(
+      "@max-[480px]:hidden",
+    );
 
     fireEvent.click(activeSummaryTab);
 


### PR DESCRIPTION
Keep the template picker affordance visible in narrow session layouts and cover it with a regression assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session header styling and test-only assertions; no auth, data, or API changes.
> 
> **Overview**
> On viewports ≤480px, the active summary tab’s **template picker** no longer hides the dropdown chevron, so the control still reads as a menu when the title is screen-reader-only.
> 
> Narrow layout sizing is bumped from **40px** (`max-w-10` / `min-w-10`) to **48px** (`max-w-12` / `min-w-12`) with `@max-[480px]:px-1.5` so the sparkle + chevron fit. A **header** test now expects those classes and asserts the second icon (caret) is not hidden at the narrow breakpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1935e13deca473a7bc3bea38ddf12b2f3def0b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->