### PR TITLE
Gate Team behind Pro

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr "Anarlog Pro is required to use cloud sync."
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr "Anarlog Pro required"
 
@@ -3494,6 +3495,7 @@ msgstr "Upgrade to enable"
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr "Upgrade to Pro"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -292,6 +292,7 @@ msgid "Anarlog Pro is required to use cloud sync."
 msgstr ""
 
 #: src/main/sync-status.tsx
+#: src/settings/team/index.tsx
 msgid "Anarlog Pro required"
 msgstr ""
 
@@ -3494,6 +3495,7 @@ msgstr ""
 #: src/calendar/components/sidebar.tsx
 #: src/session-sharing/index.tsx
 #: src/settings/dictionary/index.tsx
+#: src/settings/team/index.tsx
 #: src/sidebar/settings.tsx
 msgid "Upgrade to Pro"
 msgstr ""

--- a/apps/desktop/src/settings/developers/cloud-api.tsx
+++ b/apps/desktop/src/settings/developers/cloud-api.tsx
@@ -1,4 +1,4 @@
-import { Copy, Key } from "@phosphor-icons/react";
+import { CircleNotch, Copy, Key, LockSimple } from "@phosphor-icons/react";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -10,6 +10,7 @@ import { sonnerToast } from "@anlg/ui/components/ui/toast";
 import { ApiKeyRow } from "./api-key-row";
 import { copyText } from "./clipboard";
 
+import { useBillingAccess } from "~/auth/billing-context";
 import {
   backfillCloudApiSnapshots,
   createCloudApiKey,
@@ -28,10 +29,12 @@ const CLOUD_API_SETTINGS_QUERY_KEY = ["cloud-api", "settings"] as const;
 const CLOUD_API_KEYS_QUERY_KEY = ["cloud-api", "keys"] as const;
 
 export function CloudApiSection() {
+  const billing = useBillingAccess();
   const queryClient = useQueryClient();
   const settingsQuery = useQuery({
     queryKey: CLOUD_API_SETTINGS_QUERY_KEY,
     queryFn: getCloudApiSettings,
+    enabled: billing.isReady && billing.isPro,
     retry: false,
   });
   const toggleMutation = useMutation({
@@ -68,22 +71,52 @@ export function CloudApiSection() {
   });
   const enabled = settingsQuery.data?.enabled === true;
 
+  if (!billing.isReady) {
+    return (
+      <section className="flex items-start justify-between gap-4">
+        <CloudApiHeading />
+        <CircleNotch
+          aria-label="Loading Cloud API access"
+          className="text-muted-foreground mt-1 size-4 animate-spin"
+        />
+      </section>
+    );
+  }
+
+  if (!billing.isPro) {
+    return (
+      <section className="flex items-start justify-between gap-6">
+        <div className="flex gap-3">
+          <LockSimple className="text-muted-foreground mt-1 size-4 shrink-0" />
+          <div>
+            <h2 className="font-sans text-lg font-semibold">
+              Cloud API & Connectors
+            </h2>
+            <p className="text-muted-foreground mt-1 text-xs leading-5">
+              Access meetings remotely through the REST API and MCP connectors
+              with Anarlog Pro.
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          onClick={billing.upgradeToPro}
+          disabled={billing.isUpgradingToPro}
+        >
+          {billing.isUpgradingToPro ? (
+            <CircleNotch className="size-4 animate-spin" />
+          ) : null}
+          Upgrade to Pro
+        </Button>
+      </section>
+    );
+  }
+
   return (
     <section className="flex flex-col gap-4">
       <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <h2 className="font-sans text-lg font-semibold">
-            Cloud API & Connectors
-          </h2>
-          <p className="text-muted-foreground mt-1 text-xs">
-            Uploads meeting content for remote access while Anarlog is closed.
-          </p>
-          {settingsQuery.error && (
-            <p className="text-destructive mt-2 text-xs">
-              {settingsQuery.error.message}
-            </p>
-          )}
-        </div>
+        <CloudApiHeading error={settingsQuery.error?.message} />
         <Switch
           checked={enabled}
           aria-label="Enable Cloud API & Connectors"
@@ -114,6 +147,20 @@ export function CloudApiSection() {
         </>
       )}
     </section>
+  );
+}
+
+function CloudApiHeading({ error }: { error?: string }) {
+  return (
+    <div className="min-w-0">
+      <h2 className="font-sans text-lg font-semibold">
+        Cloud API & Connectors
+      </h2>
+      <p className="text-muted-foreground mt-1 text-xs">
+        Uploads meeting content for remote access while Anarlog is closed.
+      </p>
+      {error ? <p className="text-destructive mt-2 text-xs">{error}</p> : null}
+    </div>
   );
 }
 

--- a/apps/desktop/src/settings/developers/index.test.tsx
+++ b/apps/desktop/src/settings/developers/index.test.tsx
@@ -21,6 +21,16 @@ const mocks = vi.hoisted(() => ({
   setCloudApiEnabled: vi.fn(),
   backfillCloudApiSnapshots: vi.fn(),
   createCloudApiKey: vi.fn(),
+  billing: {
+    isPro: true,
+    isReady: true,
+    isUpgradingToPro: false,
+    upgradeToPro: vi.fn(),
+  },
+}));
+
+vi.mock("~/auth/billing-context", () => ({
+  useBillingAccess: () => mocks.billing,
 }));
 
 vi.mock("~/types/tauri.gen", () => ({
@@ -128,12 +138,17 @@ describe("SettingsDevelopers", () => {
     mocks.toastSuccess.mockReset();
     mocks.openUrl.mockReset();
     mocks.createCloudApiKey.mockReset();
+    mocks.getCloudApiSettings.mockReset();
     mocks.getCloudApiSettings.mockResolvedValue({
       enabled: false,
       updated_at: null,
     });
     mocks.setCloudApiEnabled.mockReset();
     mocks.backfillCloudApiSnapshots.mockReset();
+    mocks.billing.isPro = true;
+    mocks.billing.isReady = true;
+    mocks.billing.isUpgradingToPro = false;
+    mocks.billing.upgradeToPro.mockReset();
   });
 
   afterEach(() => {
@@ -360,6 +375,40 @@ describe("SettingsDevelopers", () => {
     });
     expect(screen.getByText("REST API")).toBeTruthy();
     expect(screen.getByText("Remote MCP")).toBeTruthy();
+  });
+
+  it("offers an upgrade instead of Cloud API controls on the free plan", () => {
+    mocks.billing.isPro = false;
+    mocks.checkEmbeddedCli.mockResolvedValue({
+      status: "ok",
+      data: {
+        supported: false,
+        commandName: "anarlog",
+        installPath: "/Users/test/.local/bin/anarlog",
+        state: "unsupported",
+        details: "Unavailable.",
+      },
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SettingsDevelopers />
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.queryByRole("switch", {
+        name: "Enable Cloud API & Connectors",
+      }),
+    ).toBeNull();
+    expect(mocks.getCloudApiSettings).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Pro" }));
+
+    expect(mocks.billing.upgradeToPro).toHaveBeenCalledOnce();
   });
 
   it("hides the devtools section when devtools are disabled", async () => {

--- a/apps/desktop/src/settings/team/index.test.tsx
+++ b/apps/desktop/src/settings/team/index.test.tsx
@@ -94,4 +94,24 @@ describe("SettingsTeam", () => {
     expect(screen.getByRole("textbox")).toBeTruthy();
     expect(screen.queryByText("Anarlog Pro required")).toBeNull();
   });
+
+  it("keeps existing workspaces accessible without Pro", () => {
+    mocks.workspaces.data = [
+      {
+        workspaceId: "00000000-0000-4000-8000-000000000001",
+        name: "Existing workspace",
+        ownerUserId: "user-1",
+        role: "owner",
+      },
+    ];
+
+    renderTeam();
+
+    expect(screen.getByText("Existing workspace")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Delete workspace" }),
+    ).toBeTruthy();
+    expect(screen.queryByText("Anarlog Pro required")).toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
 });

--- a/apps/desktop/src/settings/team/index.test.tsx
+++ b/apps/desktop/src/settings/team/index.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  billing: {
+    isPro: false,
+    isReady: true,
+    isUpgradingToPro: false,
+    upgradeToPro: vi.fn(),
+  },
+  session: { user: { id: "user-1" } } as { user: { id: string } } | null,
+  workspaces: {
+    data: [] as Array<{
+      workspaceId: string;
+      name: string;
+      ownerUserId: string;
+      role: "owner" | "admin" | "member";
+    }>,
+    isPending: false,
+  },
+}));
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  useLingui: () => ({
+    t: (strings: TemplateStringsArray, ...values: unknown[]) =>
+      strings.reduce(
+        (message, part, index) =>
+          `${message}${part}${index < values.length ? String(values[index]) : ""}`,
+        "",
+      ),
+  }),
+}));
+
+vi.mock("~/auth", () => ({
+  useAuth: () => ({ session: mocks.session, supabase: {} }),
+}));
+
+vi.mock("~/auth/billing-context", () => ({
+  useBillingAccess: () => mocks.billing,
+}));
+
+vi.mock("./mirror", () => ({
+  MY_WORKSPACES_QUERY_KEY: "team-workspaces",
+  useMyWorkspacesWithMirror: () => mocks.workspaces,
+}));
+
+import { SettingsTeam } from "./index";
+
+function renderTeam() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SettingsTeam />
+    </QueryClientProvider>,
+  );
+}
+
+describe("SettingsTeam", () => {
+  beforeEach(() => {
+    mocks.billing.isPro = false;
+    mocks.billing.isReady = true;
+    mocks.billing.isUpgradingToPro = false;
+    mocks.billing.upgradeToPro.mockClear();
+    mocks.session = { user: { id: "user-1" } };
+    mocks.workspaces.data = [];
+    mocks.workspaces.isPending = false;
+  });
+
+  afterEach(cleanup);
+
+  it("offers an upgrade instead of Team controls on the free plan", () => {
+    renderTeam();
+
+    expect(screen.getByText("Anarlog Pro required")).toBeTruthy();
+    expect(screen.queryByRole("textbox")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Pro" }));
+
+    expect(mocks.billing.upgradeToPro).toHaveBeenCalledOnce();
+  });
+
+  it("shows workspace creation controls on Pro", () => {
+    mocks.billing.isPro = true;
+
+    renderTeam();
+
+    expect(screen.getByText("Create a shared workspace")).toBeTruthy();
+    expect(screen.getByRole("textbox")).toBeTruthy();
+    expect(screen.queryByText("Anarlog Pro required")).toBeNull();
+  });
+});

--- a/apps/desktop/src/settings/team/index.tsx
+++ b/apps/desktop/src/settings/team/index.tsx
@@ -93,7 +93,11 @@ export function SettingsTeam() {
     );
   }
 
-  if (!billing.isPro) {
+  if (
+    !billing.isPro &&
+    !workspaces.isPending &&
+    (!workspaces.data || workspaces.data.length === 0)
+  ) {
     return (
       <div className="flex flex-col gap-8">
         <SettingsPageTitle title={<Trans>Team</Trans>} />
@@ -161,6 +165,8 @@ export function SettingsTeam() {
               key={activeId}
               workspaceId={activeId}
               workspaceName={activeWorkspace?.name ?? ""}
+              workspaceRole={activeWorkspace?.role ?? "member"}
+              hasProAccess={billing.isPro}
               onWorkspaceRenamed={() => {
                 void queryClient.invalidateQueries({
                   queryKey: [MY_WORKSPACES_QUERY_KEY],
@@ -243,11 +249,15 @@ function CreateWorkspaceCard({
 function WorkspacePanel({
   workspaceId,
   workspaceName,
+  workspaceRole,
+  hasProAccess,
   onWorkspaceRenamed,
   onWorkspaceLeft,
 }: {
   workspaceId: string;
   workspaceName: string;
+  workspaceRole: WorkspaceRole;
+  hasProAccess: boolean;
   // Renaming keeps the panel where it is; leaving or deleting must drop the
   // selection because the workspace is gone.
   onWorkspaceRenamed: () => void;
@@ -337,10 +347,9 @@ function WorkspacePanel({
   });
 
   const viewerId = auth.session?.user.id;
-  const viewerRole = members.data?.find(
-    (member) => member.userId === viewerId,
-  )?.role;
-  const canManage = viewerRole === "owner" || viewerRole === "admin";
+  const viewerRole = workspaceRole;
+  const canManage =
+    hasProAccess && (viewerRole === "owner" || viewerRole === "admin");
   const trimmedEmail = email.trim();
   const actionError =
     invite.error?.message ??
@@ -433,7 +442,7 @@ function WorkspacePanel({
               key={member.userId}
               member={member}
               isViewer={member.userId === viewerId}
-              viewerRole={viewerRole}
+              viewerRole={canManage ? viewerRole : undefined}
               onRoleChange={(role) =>
                 changeRole.mutate({ userId: member.userId, role })
               }

--- a/apps/desktop/src/settings/team/index.tsx
+++ b/apps/desktop/src/settings/team/index.tsx
@@ -2,6 +2,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import {
   CircleNotch,
   Crown,
+  LockSimple,
   Plus,
   Trash,
   UserPlus,
@@ -40,10 +41,12 @@ import {
 import { MY_WORKSPACES_QUERY_KEY, useMyWorkspacesWithMirror } from "./mirror";
 
 import { useAuth } from "~/auth";
+import { useBillingAccess } from "~/auth/billing-context";
 import { SettingsPageTitle } from "~/settings/page-title";
 
 export function SettingsTeam() {
   const auth = useAuth();
+  const billing = useBillingAccess();
   const { t } = useLingui();
   const queryClient = useQueryClient();
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -77,6 +80,50 @@ export function SettingsTeam() {
         <p className="text-muted-foreground text-sm">
           <Trans>Sign in to create a shared workspace for your team.</Trans>
         </p>
+      </div>
+    );
+  }
+
+  if (!billing.isReady) {
+    return (
+      <div className="flex flex-col gap-8">
+        <SettingsPageTitle title={<Trans>Team</Trans>} />
+        <TeamSkeleton />
+      </div>
+    );
+  }
+
+  if (!billing.isPro) {
+    return (
+      <div className="flex flex-col gap-8">
+        <SettingsPageTitle title={<Trans>Team</Trans>} />
+        <div className="flex max-w-2xl items-start justify-between gap-6">
+          <div className="flex gap-3">
+            <LockSimple className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+            <div>
+              <h3 className="text-sm font-medium">
+                <Trans>Anarlog Pro required</Trans>
+              </h3>
+              <p className="text-muted-foreground mt-1 text-xs leading-5">
+                <Trans>
+                  Invite teammates, share notes across the workspace, and manage
+                  who has access. Your personal notes stay private.
+                </Trans>
+              </p>
+            </div>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            onClick={billing.upgradeToPro}
+            disabled={billing.isUpgradingToPro}
+          >
+            {billing.isUpgradingToPro ? (
+              <CircleNotch className="size-4 animate-spin" />
+            ) : null}
+            <Trans>Upgrade to Pro</Trans>
+          </Button>
+        </div>
       </div>
     );
   }

--- a/apps/desktop/src/sidebar/settings.test.tsx
+++ b/apps/desktop/src/sidebar/settings.test.tsx
@@ -136,6 +136,7 @@ describe("SettingsNav", () => {
       "General",
       "Appearance",
       "Account",
+      "Team",
       "Notifications",
       "Workspace",
       "Meetings",
@@ -283,7 +284,7 @@ describe("SettingsNav", () => {
     expect(mocks.updateSettingsTabState).not.toHaveBeenCalled();
   });
 
-  it.each(["Automations", "Dictionary", "Sync"])(
+  it.each(["Team", "Automations", "Dictionary", "Sync"])(
     "does not open locked %s navigation",
     (label) => {
       mocks.isPro = false;

--- a/apps/desktop/src/sidebar/settings.test.tsx
+++ b/apps/desktop/src/sidebar/settings.test.tsx
@@ -284,7 +284,7 @@ describe("SettingsNav", () => {
     expect(mocks.updateSettingsTabState).not.toHaveBeenCalled();
   });
 
-  it.each(["Team", "Automations", "Dictionary", "Sync"])(
+  it.each(["Automations", "Dictionary", "Sync"])(
     "does not open locked %s navigation",
     (label) => {
       mocks.isPro = false;
@@ -297,6 +297,19 @@ describe("SettingsNav", () => {
       expect(mocks.updateSettingsTabState).not.toHaveBeenCalled();
     },
   );
+
+  it("opens Team navigation for non-Pro members", () => {
+    mocks.isPro = false;
+
+    render(<SettingsNav />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Team" }));
+
+    expect(mocks.updateSettingsTabState).toHaveBeenCalledWith(
+      mocks.currentTab,
+      { tab: "team" },
+    );
+  });
 
   it("opens Imports inside settings", () => {
     render(<SettingsNav />);

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -87,7 +87,6 @@ export function SettingsNav() {
                 id: "team" as const,
                 label: t`Team`,
                 icon: UsersThree,
-                requiresPro: true,
               },
             ]
           : []),

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -82,7 +82,14 @@ export function SettingsNav() {
         { id: "app", label: t`General`, icon: Gear },
         { id: "account", label: t`Account`, icon: User },
         ...(signedIn
-          ? [{ id: "team" as const, label: t`Team`, icon: UsersThree }]
+          ? [
+              {
+                id: "team" as const,
+                label: t`Team`,
+                icon: UsersThree,
+                requiresPro: true,
+              },
+            ]
           : []),
         { id: "appearance", label: t`Appearance`, icon: Sun },
         { id: "notifications", label: t`Notifications`, icon: Bell },

--- a/supabase/migrations/20260814100000_gate_team_by_pro.sql
+++ b/supabase/migrations/20260814100000_gate_team_by_pro.sql
@@ -1,0 +1,251 @@
+CREATE OR REPLACE FUNCTION private.protected_create_workspace(
+  p_name text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  membership_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_hyprnote_pro_entitlement();
+
+  RETURN QUERY
+  SELECT *
+  FROM private.create_workspace(p_name);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.protected_rename_workspace(
+  p_workspace_id uuid,
+  p_name text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  workspace_name text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_hyprnote_pro_entitlement();
+
+  RETURN QUERY
+  SELECT *
+  FROM private.rename_workspace(p_workspace_id, p_name);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.protected_set_workspace_membership_role(
+  p_workspace_id uuid,
+  p_user_id uuid,
+  p_role text
+)
+RETURNS TABLE (
+  membership_id uuid,
+  membership_role text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_hyprnote_pro_entitlement();
+
+  RETURN QUERY
+  SELECT *
+  FROM private.set_workspace_membership_role(
+    p_workspace_id,
+    p_user_id,
+    p_role
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.protected_transfer_workspace_ownership(
+  p_workspace_id uuid,
+  p_user_id uuid
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  owner_user_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_hyprnote_pro_entitlement();
+
+  RETURN QUERY
+  SELECT *
+  FROM private.transfer_workspace_ownership(p_workspace_id, p_user_id);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.protected_create_workspace_invitation(
+  p_workspace_id uuid,
+  p_invitee_email text
+)
+RETURNS TABLE (
+  invitation_id uuid,
+  invite_token text,
+  invitation_expires_at timestamptz,
+  was_created boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_hyprnote_pro_entitlement();
+
+  RETURN QUERY
+  SELECT *
+  FROM private.create_workspace_invitation(p_workspace_id, p_invitee_email);
+END;
+$$;
+
+-- Keep invitation acceptance and access-reducing operations available so
+-- invited users can join and expired subscribers can leave or clean up a Team.
+REVOKE ALL ON FUNCTION private.create_workspace(text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.rename_workspace(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.set_workspace_membership_role(uuid, uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.transfer_workspace_ownership(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.create_workspace_invitation(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION private.protected_create_workspace(text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.protected_rename_workspace(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.protected_set_workspace_membership_role(
+  uuid,
+  uuid,
+  text
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.protected_transfer_workspace_ownership(
+  uuid,
+  uuid
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.protected_create_workspace_invitation(
+  uuid,
+  text
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION private.protected_create_workspace(text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.protected_rename_workspace(uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.protected_set_workspace_membership_role(
+  uuid,
+  uuid,
+  text
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION private.protected_transfer_workspace_ownership(
+  uuid,
+  uuid
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION private.protected_create_workspace_invitation(
+  uuid,
+  text
+) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.create_workspace(
+  p_name text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  membership_id uuid
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.protected_create_workspace(p_name);
+$$;
+
+CREATE OR REPLACE FUNCTION public.rename_workspace(
+  p_workspace_id uuid,
+  p_name text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  workspace_name text
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.protected_rename_workspace(p_workspace_id, p_name);
+$$;
+
+CREATE OR REPLACE FUNCTION public.set_workspace_membership_role(
+  p_workspace_id uuid,
+  p_user_id uuid,
+  p_role text
+)
+RETURNS TABLE (
+  membership_id uuid,
+  membership_role text
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.protected_set_workspace_membership_role(
+    p_workspace_id,
+    p_user_id,
+    p_role
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.transfer_workspace_ownership(
+  p_workspace_id uuid,
+  p_user_id uuid
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  owner_user_id uuid
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.protected_transfer_workspace_ownership(
+    p_workspace_id,
+    p_user_id
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_workspace_invitation(
+  p_workspace_id uuid,
+  p_invitee_email text
+)
+RETURNS TABLE (
+  invitation_id uuid,
+  invite_token text,
+  invitation_expires_at timestamptz,
+  was_created boolean
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.protected_create_workspace_invitation(
+    p_workspace_id,
+    p_invitee_email
+  );
+$$;

--- a/supabase/tests/008-workspace-invitations.sql
+++ b/supabase/tests/008-workspace-invitations.sql
@@ -252,7 +252,7 @@ select ok(
   'Privileged implementations are private and every RPC uses an empty search path'
 );
 
-select tests.authenticate_as('invite_owner');
+select tests.authenticate_as_hyprnote_pro('invite_owner');
 
 select lives_ok(
   $$
@@ -372,7 +372,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('invite_other');
+select tests.authenticate_as_hyprnote_pro('invite_other');
 
 select throws_ok(
   $$
@@ -529,7 +529,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('invite_owner');
+select tests.authenticate_as_hyprnote_pro('invite_owner');
 
 select results_eq(
   $$
@@ -633,7 +633,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('invite_owner');
+select tests.authenticate_as_hyprnote_pro('invite_owner');
 
 select lives_ok(
   $$
@@ -699,7 +699,7 @@ select ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('invite_owner');
+select tests.authenticate_as_hyprnote_pro('invite_owner');
 
 select lives_ok(
   $$
@@ -767,7 +767,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('invite_owner');
+select tests.authenticate_as_hyprnote_pro('invite_owner');
 
 select throws_ok(
   $$

--- a/supabase/tests/031-shared-workspace-lifecycle.sql
+++ b/supabase/tests/031-shared-workspace-lifecycle.sql
@@ -87,7 +87,7 @@ select ok(
   'Privileged lifecycle implementations are private and every RPC uses an empty search path'
 );
 
-select tests.authenticate_as('lifecycle_unconfirmed');
+select tests.authenticate_as_hyprnote_pro('lifecycle_unconfirmed');
 
 select throws_ok(
   $$select * from public.create_workspace('Shadow Org')$$,
@@ -97,7 +97,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('lifecycle_owner');
+select tests.authenticate_as_hyprnote_pro('lifecycle_owner');
 
 select lives_ok(
   $$
@@ -148,7 +148,7 @@ select lives_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('lifecycle_member');
+select tests.authenticate_as_hyprnote_pro('lifecycle_member');
 
 select lives_ok(
   $$
@@ -163,7 +163,7 @@ select lives_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('lifecycle_owner');
+select tests.authenticate_as_hyprnote_pro('lifecycle_owner');
 
 select results_eq(
   $$
@@ -205,7 +205,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('lifecycle_member');
+select tests.authenticate_as_hyprnote_pro('lifecycle_member');
 
 select results_eq(
   $$
@@ -245,7 +245,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('lifecycle_owner');
+select tests.authenticate_as_hyprnote_pro('lifecycle_owner');
 
 select throws_ok(
   $$
@@ -304,7 +304,7 @@ select ok(
   'Transfer swaps the owner column and both membership roles atomically'
 );
 
-select tests.authenticate_as('lifecycle_owner');
+select tests.authenticate_as_hyprnote_pro('lifecycle_owner');
 
 select throws_ok(
   $$
@@ -342,7 +342,7 @@ select results_eq(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('lifecycle_member');
+select tests.authenticate_as_hyprnote_pro('lifecycle_member');
 
 select throws_ok(
   $$
@@ -400,7 +400,7 @@ select ok(
   'Deletion soft deletes the workspace and revokes its pending invitations'
 );
 
-select tests.authenticate_as('lifecycle_outsider');
+select tests.authenticate_as_hyprnote_pro('lifecycle_outsider');
 
 select throws_ok(
   $$
@@ -415,7 +415,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('lifecycle_owner');
+select tests.authenticate_as_hyprnote_pro('lifecycle_owner');
 
 select lives_ok(
   $$

--- a/supabase/tests/032-shared-workspace-e2ee-grants.sql
+++ b/supabase/tests/032-shared-workspace-e2ee-grants.sql
@@ -70,7 +70,7 @@ select ok(
   'Privileged E2EE grant implementations are private and use an empty search path'
 );
 
-select tests.authenticate_as('grant_owner');
+select tests.authenticate_as_hyprnote_pro('grant_owner');
 
 select results_eq(
   $$select public_key from public.publish_e2ee_member_identity(rpad('owner', 43, 'A'))$$,
@@ -141,7 +141,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('grant_owner');
+select tests.authenticate_as_hyprnote_pro('grant_owner');
 
 select results_eq(
   $$
@@ -259,7 +259,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('grant_owner');
+select tests.authenticate_as_hyprnote_pro('grant_owner');
 
 -- Rotation: mint a second generation covering only the remaining member.
 select lives_ok(

--- a/supabase/tests/033-workspace-billing-and-seats.sql
+++ b/supabase/tests/033-workspace-billing-and-seats.sql
@@ -24,7 +24,7 @@ where id in (
   tests.get_supabase_uid('seat_extra')
 );
 
-select tests.authenticate_as('seat_owner');
+select tests.authenticate_as_hyprnote_pro('seat_owner');
 
 select lives_ok(
   $$
@@ -80,7 +80,7 @@ values ('ent_seat_team', 'cus_seat_team', 'hyprnote_pro')
 on conflict (id) do nothing;
 
 select tests.clear_authentication();
-select tests.authenticate_as('seat_owner');
+select tests.authenticate_as_hyprnote_pro('seat_owner');
 
 select results_eq(
   $$
@@ -194,7 +194,7 @@ select results_eq(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('seat_owner');
+select tests.authenticate_as_hyprnote_pro('seat_owner');
 
 select lives_ok(
   $$

--- a/supabase/tests/034-admin-role-promotion.sql
+++ b/supabase/tests/034-admin-role-promotion.sql
@@ -24,7 +24,7 @@ where id in (
   tests.get_supabase_uid('promo_member')
 );
 
-select tests.authenticate_as('promo_owner');
+select tests.authenticate_as_hyprnote_pro('promo_owner');
 
 insert into promo_test_state (name, workspace_id)
 select 'hq', workspace_id from public.create_workspace('Promotion HQ');
@@ -45,7 +45,7 @@ from public.create_workspace_invitation(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('promo_admin');
+select tests.authenticate_as_hyprnote_pro('promo_admin');
 
 select lives_ok(
   $$
@@ -84,7 +84,7 @@ select lives_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('promo_owner');
+select tests.authenticate_as_hyprnote_pro('promo_owner');
 
 select results_eq(
   $$
@@ -100,7 +100,7 @@ select results_eq(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('promo_admin');
+select tests.authenticate_as_hyprnote_pro('promo_admin');
 
 select results_eq(
   $$
@@ -155,7 +155,7 @@ select throws_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('promo_owner');
+select tests.authenticate_as_hyprnote_pro('promo_owner');
 
 select results_eq(
   $$

--- a/supabase/tests/035-seat-usage-new-account-invitee.sql
+++ b/supabase/tests/035-seat-usage-new-account-invitee.sql
@@ -18,7 +18,7 @@ update auth.users
 set email_confirmed_at = now()
 where id = tests.get_supabase_uid('cap_owner');
 
-select tests.authenticate_as('cap_owner');
+select tests.authenticate_as_hyprnote_pro('cap_owner');
 
 insert into cap_test_state (name, workspace_id)
 select 'hq', workspace_id from public.create_workspace('Cap HQ');
@@ -31,7 +31,7 @@ update public.workspaces
 set seat_limit = 2
 where id = (select workspace_id from cap_test_state where name = 'hq');
 
-select tests.authenticate_as('cap_owner');
+select tests.authenticate_as_hyprnote_pro('cap_owner');
 
 select lives_ok(
   $$
@@ -80,7 +80,7 @@ select lives_ok(
 );
 
 select tests.clear_authentication();
-select tests.authenticate_as('cap_owner');
+select tests.authenticate_as_hyprnote_pro('cap_owner');
 
 select results_eq(
   $$

--- a/supabase/tests/037-team-pro-entitlement.sql
+++ b/supabase/tests/037-team-pro-entitlement.sql
@@ -1,0 +1,151 @@
+begin;
+select plan(8);
+
+select tests.create_supabase_user('team_pro_owner', 'team-pro-owner@example.com');
+select tests.create_supabase_user('team_free_member', 'team-free-member@example.com');
+
+create temporary table team_pro_test_state (
+  name text primary key,
+  workspace_id uuid,
+  invitation_id uuid,
+  invite_token text
+);
+
+grant all on team_pro_test_state to authenticated, service_role;
+
+reset role;
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('team_pro_owner'),
+  tests.get_supabase_uid('team_free_member')
+);
+
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    'private.create_workspace(text)',
+    'EXECUTE'
+  )
+    and not has_function_privilege(
+      'authenticated',
+      'private.rename_workspace(uuid,text)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'private.create_workspace_invitation(uuid,text)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'private.set_workspace_membership_role(uuid,uuid,text)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'private.transfer_workspace_ownership(uuid,uuid)',
+      'EXECUTE'
+    ),
+  'Authenticated clients cannot bypass the protected Team RPC wrappers'
+);
+
+select tests.authenticate_as('team_pro_owner');
+
+select throws_ok(
+  $$select * from public.create_workspace('Free Team')$$,
+  '42501',
+  'hyprnote pro entitlement required',
+  'A free account cannot create a Team workspace'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_hyprnote_pro('team_pro_owner');
+
+select lives_ok(
+  $$
+    insert into team_pro_test_state (name, workspace_id)
+    select 'hq', workspace_id
+    from public.create_workspace('Pro Team')
+  $$,
+  'A Pro account can create a Team workspace'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('team_pro_owner');
+
+select throws_ok(
+  $$
+    select *
+    from public.rename_workspace(
+      (select workspace_id from team_pro_test_state where name = 'hq'),
+      'Free Rename'
+    )
+  $$,
+  '42501',
+  'hyprnote pro entitlement required',
+  'A free account cannot manage its existing Team workspace'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_workspace_invitation(
+      (select workspace_id from team_pro_test_state where name = 'hq'),
+      'team-free-member@example.com'
+    )
+  $$,
+  '42501',
+  'hyprnote pro entitlement required',
+  'A free account cannot invite Team members'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_hyprnote_pro('team_pro_owner');
+
+select lives_ok(
+  $$
+    insert into team_pro_test_state (
+      name,
+      invitation_id,
+      invite_token
+    )
+    select 'member_invite', invitation_id, invite_token
+    from public.create_workspace_invitation(
+      (select workspace_id from team_pro_test_state where name = 'hq'),
+      'team-free-member@example.com'
+    )
+  $$,
+  'A Pro account can invite a Team member'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('team_free_member');
+
+select lives_ok(
+  $$
+    select *
+    from public.accept_workspace_invitation(
+      (select invitation_id from team_pro_test_state where name = 'member_invite'),
+      (select invite_token from team_pro_test_state where name = 'member_invite')
+    )
+  $$,
+  'A free invitee can accept a Team invitation'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('team_pro_owner');
+
+select lives_ok(
+  $$
+    select *
+    from public.delete_workspace(
+      (select workspace_id from team_pro_test_state where name = 'hq')
+    )
+  $$,
+  'A lapsed owner can still delete a Team workspace'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
- Renamed or introduced "Gate Team" behindPro" (primary change reflected in message)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Entitlement checks on workspace RPCs and billing-gated UI can block team admins who lapse Pro; migration and test auth changes need careful rollout verification.
> 
> **Overview**
> **Team workspaces** now require **Anarlog Pro** to create or manage shared teams. The desktop **Team** settings page shows an upgrade prompt when the user has no workspaces and is not on Pro; **existing workspaces stay reachable**, but invite/rename/role changes and similar admin actions are disabled without Pro. **Team** remains in settings navigation for signed-in users.
> 
> On the backend, workspace **create, rename, invite, role changes, and ownership transfer** RPCs route through new `protected_*` wrappers that call `require_hyprnote_pro_entitlement()`, with direct access to the old private implementations revoked. **Accepting invitations, leaving, and deleting** stay available so users can join or wind down teams without Pro.
> 
> **Developers** settings are tightened in the same pass: **Cloud API & Connectors** is gated behind Pro on the client (settings are not fetched until Pro), with a single **Guide** link on the Developers page. CLI/MCP and webhooks sections drop per-section guide buttons and some inline command copy UI. Docs add cards for Cloud API and webhooks. Locale `.po` files pick up new Team string references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78a8e1025628ae0c74330d27b8d0be00c758aeec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->