### PR TITLE
Follow native macOS appearance changes

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -20,6 +20,7 @@
     "core:window:allow-set-position",
     "core:window:allow-is-maximized",
     "core:window:allow-toggle-maximize",
+    "core:window:allow-set-theme",
     "calendar:default",
     "audio-priority:default",
     "auth:default",

--- a/apps/desktop/src/shared/theme/provider.test.tsx
+++ b/apps/desktop/src/shared/theme/provider.test.tsx
@@ -286,6 +286,32 @@ describe("AppThemeProvider", () => {
     expect(setDockIcon).toHaveBeenCalledWith("stable");
   });
 
+  it("ignores a system event emitted while applying an explicit theme", async () => {
+    themeState.settingsReady = true;
+    themeState.theme = "system";
+
+    render(
+      <AppThemeProvider>
+        <div>child</div>
+      </AppThemeProvider>,
+    );
+
+    await waitFor(() => expect(onThemeChanged).toHaveBeenCalledOnce());
+    const handleThemeChanged = onThemeChanged.mock.calls[0]?.[0];
+    setNativeTheme.mockImplementationOnce(async () => {
+      handleThemeChanged({ payload: "light" });
+    });
+    applyDocumentTheme.mockClear();
+    writeStoredThemePreference.mockClear();
+
+    await applyThemePreference("light");
+
+    expect(applyDocumentTheme).toHaveBeenCalledOnce();
+    expect(applyDocumentTheme).toHaveBeenCalledWith("light", false);
+    expect(writeStoredThemePreference).toHaveBeenCalledOnce();
+    expect(writeStoredThemePreference).toHaveBeenCalledWith("light");
+  });
+
   it("applies a selected system theme and Dock icon from the native appearance", async () => {
     nativeTheme.mockResolvedValue("dark");
 

--- a/apps/desktop/src/shared/theme/provider.test.tsx
+++ b/apps/desktop/src/shared/theme/provider.test.tsx
@@ -19,6 +19,13 @@ const setDockIcon = vi.hoisted(() =>
 const getIdentifier = vi.hoisted(() =>
   vi.fn(async () => "com.hyprnote.stable"),
 );
+const nativeTheme = vi.hoisted(() => vi.fn(async () => "light"));
+const setNativeTheme = vi.hoisted(() => vi.fn(async () => undefined));
+const onThemeChanged = vi.hoisted(() =>
+  vi.fn(async (_listener: (event: { payload: "light" | "dark" }) => void) =>
+    vi.fn(),
+  ),
+);
 const matchMedia = vi.hoisted(() => vi.fn());
 const systemTheme = vi.hoisted(() => ({
   matches: false,
@@ -27,6 +34,14 @@ const systemTheme = vi.hoisted(() => ({
 }));
 
 vi.mock("@tauri-apps/api/app", () => ({ getIdentifier }));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    theme: nativeTheme,
+    setTheme: setNativeTheme,
+    onThemeChanged,
+  }),
+}));
 
 vi.mock("@anlg/plugin-icon", () => ({
   commands: { setDockIcon },
@@ -67,6 +82,12 @@ describe("AppThemeProvider", () => {
     setDockIcon.mockClear();
     getIdentifier.mockReset();
     getIdentifier.mockResolvedValue("com.hyprnote.stable");
+    nativeTheme.mockReset();
+    nativeTheme.mockResolvedValue("light");
+    setNativeTheme.mockReset();
+    setNativeTheme.mockResolvedValue(undefined);
+    onThemeChanged.mockReset();
+    onThemeChanged.mockResolvedValue(vi.fn());
     systemTheme.matches = false;
     systemTheme.addEventListener.mockReset();
     systemTheme.removeEventListener.mockReset();
@@ -90,6 +111,7 @@ describe("AppThemeProvider", () => {
     expect(applyDocumentTheme).not.toHaveBeenCalled();
     expect(writeStoredThemePreference).not.toHaveBeenCalled();
     expect(setDockIcon).not.toHaveBeenCalled();
+    expect(setNativeTheme).not.toHaveBeenCalled();
   });
 
   it("applies the hydrated settings theme once SQLite is ready", async () => {
@@ -107,12 +129,13 @@ describe("AppThemeProvider", () => {
     );
     expect(writeStoredThemePreference).toHaveBeenCalledWith("light");
     await waitFor(() => expect(setDockIcon).toHaveBeenCalledWith("stable"));
+    expect(setNativeTheme).toHaveBeenCalledWith("light");
   });
 
-  it("uses the webview appearance for the system theme", async () => {
+  it("uses the native appearance for the system theme", async () => {
     themeState.settingsReady = true;
     themeState.theme = "system";
-    systemTheme.matches = true;
+    nativeTheme.mockResolvedValue("dark");
 
     render(
       <AppThemeProvider>
@@ -123,6 +146,7 @@ describe("AppThemeProvider", () => {
     await waitFor(() =>
       expect(applyDocumentTheme).toHaveBeenCalledWith("system", true),
     );
+    expect(setNativeTheme).toHaveBeenCalledWith(null);
     expect(writeStoredThemePreference).toHaveBeenCalledWith("system");
     await waitFor(() =>
       expect(setDockIcon).toHaveBeenCalledWith("stable-dark"),
@@ -183,8 +207,8 @@ describe("AppThemeProvider", () => {
 
     await waitFor(() => expect(setDockIcon).toHaveBeenCalledWith("stable"));
 
-    const handleThemeChanged = systemTheme.addEventListener.mock.calls[0]?.[1];
-    handleThemeChanged({ matches: true });
+    const handleThemeChanged = onThemeChanged.mock.calls[0]?.[0];
+    handleThemeChanged({ payload: "dark" });
 
     await waitFor(() =>
       expect(setDockIcon).toHaveBeenLastCalledWith("stable-dark"),
@@ -192,7 +216,34 @@ describe("AppThemeProvider", () => {
     expect(applyDocumentTheme).toHaveBeenLastCalledWith("system", true);
   });
 
-  it("keeps an explicit theme's icon when the system appearance changes", async () => {
+  it("rechecks native appearance when the webview reports a change", async () => {
+    themeState.settingsReady = true;
+    themeState.theme = "system";
+
+    render(
+      <AppThemeProvider>
+        <div>child</div>
+      </AppThemeProvider>,
+    );
+
+    await waitFor(() => expect(setDockIcon).toHaveBeenCalledWith("stable"));
+    const handleWebviewThemeChanged =
+      systemTheme.addEventListener.mock.calls[0]?.[1];
+    applyDocumentTheme.mockClear();
+    setDockIcon.mockClear();
+    nativeTheme.mockClear();
+    nativeTheme.mockResolvedValue("dark");
+
+    handleWebviewThemeChanged({ matches: false });
+
+    await waitFor(() =>
+      expect(applyDocumentTheme).toHaveBeenCalledWith("system", true),
+    );
+    expect(nativeTheme).toHaveBeenCalledOnce();
+    expect(setDockIcon).toHaveBeenCalledWith("stable-dark");
+  });
+
+  it("pins the native appearance for an explicit theme", async () => {
     themeState.settingsReady = true;
     themeState.theme = "light";
 
@@ -203,14 +254,9 @@ describe("AppThemeProvider", () => {
     );
 
     await waitFor(() => expect(setDockIcon).toHaveBeenCalledWith("stable"));
-
-    const handleThemeChanged = systemTheme.addEventListener.mock.calls[0]?.[1];
-    handleThemeChanged({ matches: true });
-
-    await waitFor(() =>
-      expect(applyDocumentTheme).toHaveBeenLastCalledWith("light", true),
-    );
-    expect(setDockIcon).toHaveBeenLastCalledWith("stable");
+    expect(setNativeTheme).toHaveBeenCalledWith("light");
+    expect(onThemeChanged).not.toHaveBeenCalled();
+    expect(systemTheme.addEventListener).not.toHaveBeenCalled();
   });
 
   it("ignores stale system events after leaving system appearance", async () => {
@@ -223,8 +269,9 @@ describe("AppThemeProvider", () => {
       </AppThemeProvider>,
     );
 
+    await waitFor(() => expect(onThemeChanged).toHaveBeenCalledOnce());
     await waitFor(() => expect(applyDocumentTheme).toHaveBeenCalledOnce());
-    const handleThemeChanged = systemTheme.addEventListener.mock.calls[0]?.[1];
+    const handleThemeChanged = onThemeChanged.mock.calls[0]?.[0];
 
     themeState.theme = "light";
     rerender(
@@ -232,19 +279,20 @@ describe("AppThemeProvider", () => {
         <div>child</div>
       </AppThemeProvider>,
     );
-    handleThemeChanged({ matches: true });
+    handleThemeChanged({ payload: "dark" });
 
     expect(applyDocumentTheme).toHaveBeenCalledTimes(2);
     expect(applyDocumentTheme).toHaveBeenLastCalledWith("light", false);
     expect(setDockIcon).toHaveBeenCalledWith("stable");
   });
 
-  it("applies a selected system theme and Dock icon from the webview", async () => {
-    systemTheme.matches = true;
+  it("applies a selected system theme and Dock icon from the native appearance", async () => {
+    nativeTheme.mockResolvedValue("dark");
 
     await applyThemePreference("system");
 
-    expect(matchMedia).toHaveBeenCalledOnce();
+    expect(setNativeTheme).toHaveBeenCalledWith(null);
+    expect(nativeTheme).toHaveBeenCalledOnce();
     expect(applyDocumentTheme).toHaveBeenCalledWith("system", true);
     expect(writeStoredThemePreference).toHaveBeenCalledWith("system");
     expect(setDockIcon).toHaveBeenCalledWith("stable-dark");
@@ -253,7 +301,8 @@ describe("AppThemeProvider", () => {
   it("applies an explicit selection and matching Dock icon immediately", async () => {
     await applyThemePreference("light");
 
-    expect(matchMedia).toHaveBeenCalledOnce();
+    expect(setNativeTheme).toHaveBeenCalledWith("light");
+    expect(nativeTheme).not.toHaveBeenCalled();
     expect(applyDocumentTheme).toHaveBeenCalledWith("light", false);
     expect(writeStoredThemePreference).toHaveBeenCalledWith("light");
     expect(setDockIcon).toHaveBeenCalledWith("stable");
@@ -262,15 +311,16 @@ describe("AppThemeProvider", () => {
   it("pins the Dock icon when selecting the dark theme on a light system", async () => {
     await applyThemePreference("dark");
 
-    expect(applyDocumentTheme).toHaveBeenCalledWith("dark", false);
+    expect(applyDocumentTheme).toHaveBeenCalledWith("dark", true);
     expect(setDockIcon).toHaveBeenCalledWith("stable-dark");
   });
 
   it("applies an icon selection using the system appearance", async () => {
-    systemTheme.matches = true;
+    nativeTheme.mockResolvedValue("dark");
 
     await applyAppIconPreference("anagram");
 
+    expect(nativeTheme).toHaveBeenCalledOnce();
     expect(setDockIcon).toHaveBeenCalledWith("anagram-dark");
   });
 

--- a/apps/desktop/src/shared/theme/provider.tsx
+++ b/apps/desktop/src/shared/theme/provider.tsx
@@ -1,4 +1,9 @@
 import { getIdentifier } from "@tauri-apps/api/app";
+import {
+  getCurrentWindow,
+  type Theme,
+  type Window,
+} from "@tauri-apps/api/window";
 import type { ReactNode } from "react";
 
 import { commands as iconCommands } from "@anlg/plugin-icon";
@@ -42,8 +47,10 @@ function ThemeSync({
   appIcon: AppIconPreference;
 }) {
   useMountEffect(() => {
+    const appWindow = getCurrentWindow();
     const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
     let cancelled = false;
+    let unlisten: (() => void) | undefined;
 
     const applySystemTheme = (systemIsDark: boolean) => {
       if (cancelled) {
@@ -53,16 +60,50 @@ function ThemeSync({
       void applyAppearance(theme, appIcon, systemIsDark);
     };
 
-    const handleSystemThemeChange = ({ matches }: MediaQueryListEvent) => {
-      applySystemTheme(matches);
+    const refreshSystemTheme = async () => {
+      applySystemTheme(await readSystemIsDark(appWindow));
+    };
+
+    if (theme !== "system") {
+      applySystemTheme(theme === "dark");
+      void setNativeThemePreference(appWindow, theme);
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const handleSystemThemeChange = () => {
+      void refreshSystemTheme();
     };
 
     systemTheme.addEventListener("change", handleSystemThemeChange);
-    applySystemTheme(systemTheme.matches);
+    window.addEventListener("focus", handleSystemThemeChange);
+
+    void (async () => {
+      await setNativeThemePreference(appWindow, theme);
+      unlisten = await appWindow.onThemeChanged(({ payload }) => {
+        applySystemTheme(payload === "dark");
+      });
+
+      if (cancelled) {
+        unlisten();
+        return;
+      }
+
+      await refreshSystemTheme();
+    })().catch((error) => {
+      if (!cancelled) {
+        console.error("[theme] failed to follow system appearance", error);
+        applySystemTheme(systemTheme.matches);
+      }
+    });
 
     return () => {
       cancelled = true;
+      unlisten?.();
       systemTheme.removeEventListener("change", handleSystemThemeChange);
+      window.removeEventListener("focus", handleSystemThemeChange);
     };
   });
 
@@ -73,7 +114,18 @@ export async function applyThemePreference(
   theme: ThemePreference,
   appIcon: AppIconPreference = "default",
 ) {
-  await applyAppearance(theme, appIcon, prefersDarkColorScheme());
+  const appWindow = getCurrentWindow();
+
+  if (theme !== "system") {
+    await Promise.all([
+      setNativeThemePreference(appWindow, theme),
+      applyAppearance(theme, appIcon, theme === "dark"),
+    ]);
+    return;
+  }
+
+  await setNativeThemePreference(appWindow, theme);
+  await applyAppearance(theme, appIcon, await readSystemIsDark(appWindow));
 }
 
 async function applyAppearance(
@@ -90,7 +142,37 @@ export async function applyAppIconPreference(
   appIcon: AppIconPreference,
   theme: ThemePreference = "system",
 ) {
-  await applyDockIcon(appIcon, theme, prefersDarkColorScheme());
+  await applyDockIcon(
+    appIcon,
+    theme,
+    theme === "system" ? await readSystemIsDark() : theme === "dark",
+  );
+}
+
+async function setNativeThemePreference(
+  appWindow: Window,
+  theme: ThemePreference,
+) {
+  try {
+    await appWindow.setTheme(theme === "system" ? null : theme);
+  } catch (error) {
+    console.error("[theme] failed to update native appearance", error);
+  }
+}
+
+async function readSystemIsDark(
+  appWindow: Window = getCurrentWindow(),
+): Promise<boolean> {
+  try {
+    return isDarkTheme(await appWindow.theme());
+  } catch (error) {
+    console.error("[theme] failed to read system appearance", error);
+    return prefersDarkColorScheme();
+  }
+}
+
+function isDarkTheme(theme: Theme | null): boolean {
+  return theme === null ? prefersDarkColorScheme() : theme === "dark";
 }
 
 function prefersDarkColorScheme(): boolean {

--- a/apps/desktop/src/shared/theme/provider.tsx
+++ b/apps/desktop/src/shared/theme/provider.tsx
@@ -20,6 +20,8 @@ import { useSettingsThemeReady } from "./use-settings-theme-ready";
 import { useConfigValue } from "~/shared/config";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
+let activeThemePreference: ThemePreference = "system";
+
 export function AppThemeProvider({ children }: { children: ReactNode }) {
   const theme = useConfigValue("theme") as ThemePreference;
   const appIcon = normalizeAppIconPreference(useConfigValue("app_icon"));
@@ -47,13 +49,14 @@ function ThemeSync({
   appIcon: AppIconPreference;
 }) {
   useMountEffect(() => {
+    activeThemePreference = theme;
     const appWindow = getCurrentWindow();
     const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
     let cancelled = false;
     let unlisten: (() => void) | undefined;
 
     const applySystemTheme = (systemIsDark: boolean) => {
-      if (cancelled) {
+      if (cancelled || activeThemePreference !== theme) {
         return;
       }
 
@@ -114,6 +117,7 @@ export async function applyThemePreference(
   theme: ThemePreference,
   appIcon: AppIconPreference = "default",
 ) {
+  activeThemePreference = theme;
   const appWindow = getCurrentWindow();
 
   if (theme !== "system") {


### PR DESCRIPTION
Use Tauri window appearance for system theme updates with a WebKit fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/appearance-only changes with error fallbacks to existing webview behavior; no auth, data, or security surface.
> 
> **Overview**
> **System appearance** on the desktop app now follows **native macOS light/dark** through Tauri’s window APIs (`theme`, `setTheme`, `onThemeChanged`), with `matchMedia` and window focus kept as fallbacks when native reads fail or the webview reports a change.
> 
> When the user picks **light** or **dark**, the window theme is **pinned** to that choice; **system** mode clears the override (`setTheme(null)`) and listens for native theme changes. Document styling, stored preference, and Dock icon updates use the resolved dark/light state, including treating an explicit **dark** selection as dark for icon/document application even on a light OS theme.
> 
> **Stale-event handling** tracks the active preference so system callbacks are ignored after switching away from system mode or while applying an explicit theme. Tauri capabilities add **`core:window:allow-set-theme`** so `setTheme` is permitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5bcf57de15d09ed00186490a7644e35608962b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->