### PR TITLE
Simplify Developers settings

### DIFF
--- a/apps/desktop/src/settings/developers/cli.tsx
+++ b/apps/desktop/src/settings/developers/cli.tsx
@@ -1,12 +1,6 @@
-import {
-  ArrowSquareOut,
-  CheckCircle,
-  CircleNotch,
-  Copy,
-} from "@phosphor-icons/react";
+import { CheckCircle, CircleNotch, Copy } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { Button } from "@anlg/ui/components/ui/button";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 import { cn } from "@anlg/utils";
@@ -14,8 +8,6 @@ import { cn } from "@anlg/utils";
 import { commands, type EmbeddedCliStatus } from "~/types/tauri.gen";
 
 const CLI_STATUS_QUERY_KEY = ["embedded-cli-status"] as const;
-const CLI_GUIDE_URL = "https://docs.anarlog.so/agents/cli";
-const MCP_GUIDE_URL = "https://docs.anarlog.so/agents/mcp";
 
 async function loadStatus() {
   const result = await commands.checkEmbeddedCli();
@@ -121,7 +113,6 @@ function CliSection({
   isInstalling: boolean;
   onInstall: () => void;
 }) {
-  const commandName = status?.commandName ?? "anarlog";
   const canInstall =
     status?.supported === true &&
     status.state !== "resource_missing" &&
@@ -134,20 +125,18 @@ function CliSection({
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="min-w-0">
-            <h3 className="text-sm font-medium">Anarlog CLI</h3>
-            <CopyableCommand command={`${commandName} --json meetings list`} />
+            <h3 className="flex items-center gap-1.5 text-sm font-medium">
+              Anarlog CLI
+              {isInstalled && (
+                <CheckCircle
+                  aria-label="Installed"
+                  className="size-3.5 text-emerald-600"
+                />
+              )}
+            </h3>
             <CliStatus status={status} isLoading={isLoading} error={error} />
           </div>
           <div className="flex shrink-0 gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => void openerCommands.openUrl(CLI_GUIDE_URL, null)}
-            >
-              Guide
-              <ArrowSquareOut className="size-3.5" />
-            </Button>
             <Button
               type="button"
               size="sm"
@@ -200,54 +189,27 @@ function CliStatus({
     return null;
   }
 
-  const isInstalled = status.state === "installed";
+  if (status.state === "installed") {
+    return null;
+  }
+
   const showDetails = ["conflict", "unsupported", "resource_missing"].includes(
     status.state,
   );
 
   return (
     <div className="mt-1 flex items-start gap-1.5 text-xs">
-      {isInstalled ? (
-        <CheckCircle className="mt-0.5 size-3.5 shrink-0 text-emerald-600" />
-      ) : (
-        <span
-          className={cn([
-            "mt-1 size-2 shrink-0 rounded-full",
-            status.state === "conflict"
-              ? "bg-amber-500"
-              : "bg-muted-foreground/50",
-          ])}
-        />
-      )}
+      <span
+        className={cn([
+          "mt-1 size-2 shrink-0 rounded-full",
+          status.state === "conflict"
+            ? "bg-amber-500"
+            : "bg-muted-foreground/50",
+        ])}
+      />
       <span className="text-muted-foreground break-all">
-        {isInstalled
-          ? "Installed"
-          : showDetails
-            ? (status.details ?? "Unavailable")
-            : "Not installed"}
+        {showDetails ? (status.details ?? "Unavailable") : "Not installed"}
       </span>
-    </div>
-  );
-}
-
-function CopyableCommand({ command }: { command: string }) {
-  return (
-    <div className="mt-1 flex min-w-0 items-center gap-1">
-      <code className="bg-muted scrollbar-hide min-w-0 overflow-x-auto rounded-md px-1.5 py-0.5 text-xs font-medium">
-        {command}
-      </code>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="size-6 shrink-0"
-        aria-label={`Copy ${command}`}
-        onClick={() =>
-          void copyText(command, "Command copied", "Could not copy the command")
-        }
-      >
-        <Copy className="size-3.5" />
-      </Button>
     </div>
   );
 }
@@ -263,18 +225,8 @@ function McpRow({ status }: { status: EmbeddedCliStatus | undefined }) {
     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">
         <h3 className="text-sm font-medium">MCP server</h3>
-        <CopyableCommand command={`${commandName} mcp`} />
       </div>
       <div className="flex shrink-0 gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => void openerCommands.openUrl(MCP_GUIDE_URL, null)}
-        >
-          Guide
-          <ArrowSquareOut className="size-3.5" />
-        </Button>
         <Button
           type="button"
           variant="outline"

--- a/apps/desktop/src/settings/developers/cloud-api.tsx
+++ b/apps/desktop/src/settings/developers/cloud-api.tsx
@@ -1,8 +1,7 @@
-import { ArrowSquareOut, Copy, Key } from "@phosphor-icons/react";
+import { Copy, Key } from "@phosphor-icons/react";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { Button } from "@anlg/ui/components/ui/button";
 import { Input } from "@anlg/ui/components/ui/input";
 import { Switch } from "@anlg/ui/components/ui/switch";
@@ -23,7 +22,6 @@ import {
 } from "~/cloud-api/client";
 import { env } from "~/env";
 
-const CLOUD_API_GUIDE_URL = "https://docs.anarlog.so/reference/api-cloud";
 const CLOUD_API_BASE_URL = new URL("/v1", env.VITE_API_URL).toString();
 const CLOUD_MCP_URL = new URL("/mcp", env.VITE_API_URL).toString();
 const CLOUD_API_SETTINGS_QUERY_KEY = ["cloud-api", "settings"] as const;
@@ -72,71 +70,49 @@ export function CloudApiSection() {
 
   return (
     <section className="flex flex-col gap-4">
-      <h2 className="font-sans text-lg font-semibold">
-        Cloud API & Connectors
-      </h2>
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0">
-            <h3 className="text-sm font-medium">Hosted access for agents</h3>
-            <p className="text-muted-foreground mt-1 text-sm leading-5">
-              Give remote agents meeting context while Anarlog is closed.
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h2 className="font-sans text-lg font-semibold">
+            Cloud API & Connectors
+          </h2>
+          <p className="text-muted-foreground mt-1 text-xs">
+            Uploads meeting content for remote access while Anarlog is closed.
+          </p>
+          {settingsQuery.error && (
+            <p className="text-destructive mt-2 text-xs">
+              {settingsQuery.error.message}
             </p>
-            <p className="text-muted-foreground mt-2 text-xs leading-5">
-              Enabling this uploads a separate server-readable copy of meeting
-              titles, notes, summaries, participants, action items, and
-              transcripts. Encrypted sync stays end-to-end encrypted. Turning
-              this off deletes every readable copy from the server.
-            </p>
-            {settingsQuery.error && (
-              <p className="text-destructive mt-2 text-xs">
-                {settingsQuery.error.message}
-              </p>
-            )}
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                void openerCommands.openUrl(CLOUD_API_GUIDE_URL, null)
-              }
-            >
-              Guide
-              <ArrowSquareOut className="size-3.5" />
-            </Button>
-            <Switch
-              checked={enabled}
-              aria-label="Enable Cloud API & Connectors"
-              disabled={
-                settingsQuery.isPending ||
-                settingsQuery.isError ||
-                toggleMutation.isPending
-              }
-              onCheckedChange={(checked) => toggleMutation.mutate(checked)}
+          )}
+        </div>
+        <Switch
+          checked={enabled}
+          aria-label="Enable Cloud API & Connectors"
+          disabled={
+            settingsQuery.isPending ||
+            settingsQuery.isError ||
+            toggleMutation.isPending
+          }
+          onCheckedChange={(checked) => toggleMutation.mutate(checked)}
+        />
+      </div>
+
+      {enabled && (
+        <>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <CloudEndpoint
+              label="REST API"
+              value={CLOUD_API_BASE_URL}
+              copyMessage="Cloud API URL copied"
+            />
+            <CloudEndpoint
+              label="Remote MCP"
+              value={CLOUD_MCP_URL}
+              copyMessage="Remote MCP URL copied"
             />
           </div>
-        </div>
-
-        {enabled && (
-          <>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <CloudEndpoint
-                label="REST API"
-                value={CLOUD_API_BASE_URL}
-                copyMessage="Cloud API URL copied"
-              />
-              <CloudEndpoint
-                label="Remote MCP"
-                value={CLOUD_MCP_URL}
-                copyMessage="Remote MCP URL copied"
-              />
-            </div>
-            <CloudApiKeys />
-          </>
-        )}
-      </div>
+          <CloudApiKeys />
+        </>
+      )}
     </section>
   );
 }
@@ -198,6 +174,7 @@ function CloudApiKeys() {
     },
   });
   const createdKey = createMutation.data;
+  const keys = keysQuery.data ?? [];
 
   return (
     <div>
@@ -260,20 +237,17 @@ function CloudApiKeys() {
         </div>
       )}
 
-      <ul className="mt-3 flex flex-col gap-1.5">
-        {(keysQuery.data ?? []).map((key) => (
-          <CloudApiKeyRow
-            key={key.id}
-            apiKey={key}
-            onRevoke={() => revokeMutation.mutate(key.id)}
-          />
-        ))}
-        {keysQuery.data?.length === 0 && !createdKey && (
-          <li className="text-muted-foreground text-xs">
-            No cloud keys yet. Create one for a connector or remote agent.
-          </li>
-        )}
-      </ul>
+      {keys.length > 0 && (
+        <ul className="mt-3 flex flex-col gap-1.5">
+          {keys.map((key) => (
+            <CloudApiKeyRow
+              key={key.id}
+              apiKey={key}
+              onRevoke={() => revokeMutation.mutate(key.id)}
+            />
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/settings/developers/index.test.tsx
+++ b/apps/desktop/src/settings/developers/index.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   devtoolsPanelShow: vi.fn(),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
+  openUrl: vi.fn(),
   getCloudApiSettings: vi.fn(),
   setCloudApiEnabled: vi.fn(),
   backfillCloudApiSnapshots: vi.fn(),
@@ -37,7 +38,7 @@ vi.mock("@anlg/plugin-windows", () => ({
 }));
 
 vi.mock("@anlg/plugin-opener2", () => ({
-  commands: { openUrl: vi.fn() },
+  commands: { openUrl: mocks.openUrl },
 }));
 
 vi.mock("@anlg/plugin-local-api", () => ({
@@ -125,6 +126,7 @@ describe("SettingsDevelopers", () => {
     mocks.devtoolsPanelShow.mockResolvedValue({ status: "ok" });
     mocks.toastError.mockReset();
     mocks.toastSuccess.mockReset();
+    mocks.openUrl.mockReset();
     mocks.createCloudApiKey.mockReset();
     mocks.getCloudApiSettings.mockResolvedValue({
       enabled: false,
@@ -136,6 +138,42 @@ describe("SettingsDevelopers", () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  it("shows one guide button in the page header", () => {
+    mocks.checkEmbeddedCli.mockResolvedValue({
+      status: "ok",
+      data: {
+        supported: true,
+        commandName: "anarlog",
+        installPath: "/Users/test/.local/bin/anarlog",
+        state: "installed",
+        details: "Installed.",
+      },
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SettingsDevelopers />
+      </QueryClientProvider>,
+    );
+
+    const heading = screen.getByRole("heading", { name: "Developers" });
+    const guideButton = within(heading.parentElement as HTMLElement).getByRole(
+      "button",
+      { name: "Guide" },
+    );
+    expect(screen.getAllByRole("button", { name: "Guide" })).toHaveLength(1);
+
+    fireEvent.click(guideButton);
+
+    expect(mocks.openUrl).toHaveBeenCalledWith(
+      "https://docs.anarlog.so/agents/overview",
+      null,
+    );
   });
 
   it("uses the installed CLI path when copying the MCP configuration", async () => {
@@ -166,9 +204,13 @@ describe("SettingsDevelopers", () => {
     );
 
     expect(await screen.findByText("Reinstall")).toBeTruthy();
+    expect(screen.getByLabelText("Installed")).toBeTruthy();
+    expect(screen.queryByText("Installed")).toBeNull();
     expect(
       screen.queryByText(/\/Users\/test\/\.local\/bin\/anarlog/),
     ).toBeNull();
+    expect(screen.queryByText("anarlog --json meetings list")).toBeNull();
+    expect(screen.queryByText("anarlog mcp")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Copy config" }));
 
@@ -181,50 +223,6 @@ describe("SettingsDevelopers", () => {
         },
       },
     });
-  });
-
-  it("copies each CLI command", async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText },
-    });
-    mocks.checkEmbeddedCli.mockResolvedValue({
-      status: "ok",
-      data: {
-        supported: true,
-        commandName: "anarlog",
-        installPath: "/Users/test/.local/bin/anarlog",
-        state: "installed",
-        details: "Installed.",
-      },
-    });
-
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    render(
-      <QueryClientProvider client={queryClient}>
-        <SettingsDevelopers />
-      </QueryClientProvider>,
-    );
-
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: "Copy anarlog --json meetings list",
-      }),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Copy anarlog mcp" }));
-
-    await waitFor(() => {
-      expect(writeText).toHaveBeenNthCalledWith(
-        1,
-        "anarlog --json meetings list",
-      );
-      expect(writeText).toHaveBeenNthCalledWith(2, "anarlog mcp");
-    });
-    expect(mocks.toastSuccess).toHaveBeenCalledTimes(2);
-    expect(mocks.toastSuccess).toHaveBeenCalledWith("Command copied");
   });
 
   it("does not expose a nonexistent MCP path when the CLI is unsupported", async () => {
@@ -343,9 +341,7 @@ describe("SettingsDevelopers", () => {
       </QueryClientProvider>,
     );
 
-    expect(
-      await screen.findByText(/separate server-readable copy/),
-    ).toBeTruthy();
+    expect(await screen.findByText(/Uploads meeting content/)).toBeTruthy();
     const toggle = await screen.findByRole("switch", {
       name: "Enable Cloud API & Connectors",
     });

--- a/apps/desktop/src/settings/developers/index.tsx
+++ b/apps/desktop/src/settings/developers/index.tsx
@@ -1,3 +1,8 @@
+import { ArrowSquareOut } from "@phosphor-icons/react";
+
+import { commands as openerCommands } from "@anlg/plugin-opener2";
+import { Button } from "@anlg/ui/components/ui/button";
+
 import { CliSettingsSections } from "./cli";
 import { CloudApiSection } from "./cloud-api";
 import { DevtoolsSection } from "./devtools";
@@ -7,10 +12,25 @@ import { SettingsPageTitle } from "~/settings/page-title";
 
 export { buildMcpConfiguration, getCliInstallNotification } from "./cli";
 
+const DEVELOPERS_GUIDE_URL = "https://docs.anarlog.so/agents/overview";
+
 export function SettingsDevelopers() {
   return (
     <div className="flex flex-col gap-8">
-      <SettingsPageTitle title="Developers" />
+      <div className="flex items-center justify-between gap-4">
+        <SettingsPageTitle title="Developers" />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            void openerCommands.openUrl(DEVELOPERS_GUIDE_URL, null)
+          }
+        >
+          Guide
+          <ArrowSquareOut className="size-3.5" />
+        </Button>
+      </div>
       <CliSettingsSections />
       <CloudApiSection />
       <WebhooksSection />

--- a/apps/desktop/src/settings/developers/webhooks.tsx
+++ b/apps/desktop/src/settings/developers/webhooks.tsx
@@ -1,4 +1,4 @@
-import { ArrowSquareOut, Copy, Trash } from "@phosphor-icons/react";
+import { Copy, Trash } from "@phosphor-icons/react";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -6,7 +6,6 @@ import {
   commands as webhookCommands,
   type WebhookInfo,
 } from "@anlg/plugin-local-api";
-import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { Button } from "@anlg/ui/components/ui/button";
 import { Input } from "@anlg/ui/components/ui/input";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
@@ -14,7 +13,6 @@ import { cn } from "@anlg/utils";
 
 import { copyText } from "./clipboard";
 
-const WEBHOOKS_GUIDE_URL = "https://docs.anarlog.so/reference/webhooks";
 const WEBHOOKS_QUERY_KEY = ["webhooks"] as const;
 
 async function unwrap<T>(
@@ -80,98 +78,75 @@ export function WebhooksSection() {
   });
 
   const createdWebhook = createMutation.data;
+  const webhooks = webhooksQuery.data ?? [];
 
   return (
     <section className="flex flex-col gap-4">
       <h2 className="font-sans text-lg font-semibold">Webhooks</h2>
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0">
-            <h3 className="text-sm font-medium">Meeting events</h3>
-            <p className="text-muted-foreground mt-1 text-sm leading-5">
-              Receive signed events when meetings end or summaries are ready.
-              Deliveries include meeting content, so only add an endpoint you
-              trust.
-            </p>
-          </div>
+      <div>
+        <form
+          className="flex gap-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void form.handleSubmit();
+          }}
+        >
+          <form.Field name="url">
+            {(field) => (
+              <Input
+                className="h-8 max-w-md text-sm"
+                placeholder="https://example.com/webhooks/anarlog"
+                value={field.state.value}
+                onChange={(event) => field.handleChange(event.target.value)}
+              />
+            )}
+          </form.Field>
           <Button
-            type="button"
-            variant="outline"
+            type="submit"
             size="sm"
-            className="shrink-0"
-            onClick={() =>
-              void openerCommands.openUrl(WEBHOOKS_GUIDE_URL, null)
-            }
+            variant="outline"
+            disabled={createMutation.isPending}
           >
-            Guide
-            <ArrowSquareOut className="size-3.5" />
+            Add webhook
           </Button>
-        </div>
+        </form>
 
-        <div>
-          <form
-            className="flex gap-2"
-            onSubmit={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              void form.handleSubmit();
-            }}
-          >
-            <form.Field name="url">
-              {(field) => (
-                <Input
-                  className="h-8 max-w-md text-sm"
-                  placeholder="https://example.com/webhooks/anarlog"
-                  value={field.state.value}
-                  onChange={(event) => field.handleChange(event.target.value)}
-                />
-              )}
-            </form.Field>
-            <Button
-              type="submit"
-              size="sm"
-              variant="outline"
-              disabled={createMutation.isPending}
-            >
-              Add webhook
-            </Button>
-          </form>
-
-          {createdWebhook && (
-            <div className="border-border bg-muted/30 mt-3 rounded-xl border p-3">
-              <p className="text-muted-foreground text-xs">
-                Signing secret — copy it now, it is only shown once. Use it to
-                verify the <code>x-anarlog-signature</code> header.
-              </p>
-              <div className="mt-2 flex items-center gap-2">
-                <code className="bg-muted scrollbar-hide overflow-x-auto rounded-md px-1.5 py-0.5 text-xs">
-                  {createdWebhook.secret}
-                </code>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 shrink-0"
-                  onClick={async () => {
-                    if (
-                      await copyText(
-                        createdWebhook.secret,
-                        "Signing secret copied",
-                      )
-                    ) {
-                      createMutation.reset();
-                    }
-                  }}
-                >
-                  <Copy className="size-3.5" />
-                  Copy
-                </Button>
-              </div>
+        {createdWebhook && (
+          <div className="border-border bg-muted/30 mt-3 rounded-xl border p-3">
+            <p className="text-muted-foreground text-xs">
+              Copy this signing secret now — it is only shown once.
+            </p>
+            <div className="mt-2 flex items-center gap-2">
+              <code className="bg-muted scrollbar-hide overflow-x-auto rounded-md px-1.5 py-0.5 text-xs">
+                {createdWebhook.secret}
+              </code>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 shrink-0"
+                onClick={async () => {
+                  if (
+                    await copyText(
+                      createdWebhook.secret,
+                      "Signing secret copied",
+                    )
+                  ) {
+                    createMutation.reset();
+                  }
+                }}
+              >
+                <Copy className="size-3.5" />
+                Copy
+              </Button>
             </div>
-          )}
+          </div>
+        )}
 
+        {webhooks.length > 0 && (
           <ul className="mt-3 flex flex-col gap-1.5">
-            {(webhooksQuery.data ?? []).map((webhook) => (
+            {webhooks.map((webhook) => (
               <WebhookRow
                 key={webhook.id}
                 webhook={webhook}
@@ -186,13 +161,8 @@ export function WebhooksSection() {
                 isTesting={testMutation.isPending}
               />
             ))}
-            {webhooksQuery.data?.length === 0 && !createdWebhook && (
-              <li className="text-muted-foreground text-xs">
-                No webhooks yet. Add an endpoint to receive events.
-              </li>
-            )}
           </ul>
-        </div>
+        )}
       </div>
     </section>
   );

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -36,6 +36,10 @@ Local CLI and MCP access stays on your computer. Cloud access uploads a separate
   <Card title="MCP for agents" icon="plug" href="/agents/mcp">
     Configure the stdio server and use bounded transcript pages.
   </Card>
+  <Card title="Cloud API and remote MCP" icon="cloud" href="/reference/api-cloud">
+    Enable hosted access and create a connector key.
+  </Card>
+  <Card title="Webhooks" icon="webhook" href="/reference/webhooks">
+    Receive signed meeting events at your endpoint.
+  </Card>
 </CardGroup>
-
-For hosted REST and remote MCP setup, see [Cloud API and connectors](/reference/api-cloud).


### PR DESCRIPTION
Keep setup controls in the app, move usage guidance to docs, show installed CLI status in the heading, and use one page-level Guide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to Developers settings and docs navigation; install/toggle/MCP copy behavior is unchanged aside from removed inline command copy UI.
> 
> **Overview**
> **Developers settings** is trimmed so setup stays in-app and usage guidance lives in docs. A single **Guide** button in the page header opens `https://docs.anarlog.so/agents/overview`, replacing separate Guide links on CLI, MCP, Cloud API, and Webhooks.
> 
> **CLI & MCP:** Example commands (`anarlog --json meetings list`, `anarlog mcp`) and their copy controls are removed. When the CLI is installed, a green check appears on the **Anarlog CLI** heading (`aria-label="Installed"`) and the status line is hidden; problems still show as before. **Copy config** for MCP is unchanged.
> 
> **Cloud API & Webhooks:** Long explanatory copy and per-section guides are removed in favor of short subtitles. Cloud API uses a compact header with the enable switch on the right. Empty-state lines (“No cloud keys yet”, “No webhooks yet”) are dropped; lists render only when there is at least one item.
> 
> **Docs:** The agents overview page adds cards linking to Cloud API / remote MCP and Webhooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2cc181d7e0427b49ba635b8ad62cd8e60dba6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->