### PR TITLE
Polish Team settings layout

### DIFF
--- a/apps/desktop/src/settings/team/index.tsx
+++ b/apps/desktop/src/settings/team/index.tsx
@@ -72,7 +72,7 @@ export function SettingsTeam() {
 
   if (!signedIn) {
     return (
-      <div className="space-y-6">
+      <div className="flex flex-col gap-8">
         <SettingsPageTitle title={<Trans>Team</Trans>} />
         <p className="text-muted-foreground text-sm">
           <Trans>Sign in to create a shared workspace for your team.</Trans>
@@ -82,7 +82,7 @@ export function SettingsTeam() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col gap-8">
       <SettingsPageTitle title={<Trans>Team</Trans>} />
 
       {workspaces.isPending ? (
@@ -129,7 +129,7 @@ export function SettingsTeam() {
           )}
         </>
       ) : (
-        <CreateWorkspaceCard
+        <CreateWorkspaceForm
           onCreate={(name) => create.mutate(name)}
           pending={create.isPending}
           error={create.error?.message}
@@ -140,7 +140,7 @@ export function SettingsTeam() {
   );
 }
 
-function CreateWorkspaceCard({
+function CreateWorkspaceForm({
   onCreate,
   pending,
   error,
@@ -155,7 +155,7 @@ function CreateWorkspaceCard({
   const trimmed = name.trim();
 
   return (
-    <div className="border-border rounded-lg border p-4">
+    <div>
       <h3 className="text-sm font-medium">
         <Trans>Create a shared workspace</Trans>
       </h3>


### PR DESCRIPTION
Remove the empty-state card treatment and add consistent space below the Team title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and styling-only changes on the Team settings screen with no logic or API impact.
> 
> **Overview**
> Team settings pages use **`flex flex-col gap-8`** instead of **`space-y-6`**, so content below the **Team** title has more consistent vertical spacing (signed-out and signed-in views).
> 
> The no-workspace empty state drops the bordered card wrapper on the create flow; **`CreateWorkspaceCard`** is renamed **`CreateWorkspaceForm`** with the same behavior and copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a24e57b8444af3b147931acc65b5edfcb8f1113f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->