### PR TITLE
Fix outdated documentation paths

### DIFF
--- a/docs/automatic-capture.mdx
+++ b/docs/automatic-capture.mdx
@@ -7,7 +7,7 @@ Anarlog can start an event-backed note at its scheduled time, remind you when an
 
 ## Start scheduled meetings automatically
 
-Open **Settings → App → Meetings** and enable **Start when meeting begins**.
+Open **Settings → Meetings** and enable **Start when meeting begins**.
 
 When a calendar-backed note reaches its scheduled start time, Anarlog starts listening. This setting does not apply to ordinary notes without a calendar event.
 
@@ -23,12 +23,12 @@ Accessibility permission is required to detect meeting apps and synchronize mute
 
 ## Stop when the call ends
 
-Under **Settings → App → Meetings**, enable **Stop when meeting ends**. Anarlog stops listening when the meeting app releases the microphone.
+Under **Settings → Meetings**, enable **Stop when meeting ends**. Anarlog stops listening when the meeting app releases the microphone.
 
 If you switch audio devices or use an app with unusual microphone behavior, check that the recording is still active before closing the meeting.
 
 ## Keep controls nearby
 
-Enable **Show floating bar** under **Settings → App → Meetings** to keep compact recording controls visible while Anarlog listens.
+Enable **Show floating bar** under **Settings → Meetings** to keep compact recording controls visible while Anarlog listens.
 
 Event and microphone notifications can also respect your system's Do Not Disturb mode from **Settings → Notifications**.

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -35,7 +35,7 @@ See [Use Anarlog offline](/offline) for the full setup.
 
 ## Choose how long audio is kept
 
-Open **Settings → App → Storage → Audio file retention**. Choose:
+Open **Settings → Meetings** and find **Audio file retention** under **Audio**. Choose:
 
 - **Don't save**
 - **1 day**
@@ -48,7 +48,7 @@ Deleting retained audio does not remove the meeting note or transcript. If you n
 
 ## Turn off usage analytics
 
-Open **Settings → App** and disable **Share usage data**. This controls product analytics and desktop session replay, not the meeting content sent to a provider you selected.
+Open **Settings → Privacy** and disable **Share usage data (PostHog)**. This controls product analytics and desktop session replay, not the meeting content sent to a provider you selected.
 
 <Warning>
   Recording-consent rules depend on where you and the other participants are located. Make sure you have permission before recording.

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -11,7 +11,7 @@ No. Anarlog captures your microphone and computer audio from the desktop without
 
 ### Can recording start automatically?
 
-Yes. Anarlog can start calendar-backed meetings on schedule and prompt you when it detects an unscheduled call. You control both behaviors under **Settings → App → Automatic recording**. See [Automatic capture](/automatic-capture).
+Yes. Anarlog can start calendar-backed meetings on schedule and prompt you when it detects an unscheduled call. Manage scheduled meeting controls under **Settings → Meetings** and microphone detection under **Settings → Notifications**. See [Automatic capture](/automatic-capture).
 
 ### Can I edit a transcript or fix a speaker?
 

--- a/docs/languages.mdx
+++ b/docs/languages.mdx
@@ -7,7 +7,7 @@ Anarlog separates the language used for summaries and chat from the languages it
 
 ## Choose the main language
 
-Open **Settings → App → Language & Region** and choose **Main language**.
+Open **Settings → General** and choose **Main language** under **Language & Region**.
 
 Anarlog uses the main language for summaries, chat, and other AI-generated responses. It is also always included as a transcription language.
 

--- a/docs/meetings.mdx
+++ b/docs/meetings.mdx
@@ -23,7 +23,7 @@ Use **Memos** for your own notes. You can keep them rough: the generated summary
 
 Open **Transcript** to follow live text when your selected transcription model supports it. Models marked **After recording** process the audio when you stop.
 
-If you enabled **Show floating bar** in **Settings → App**, you can control recording without keeping the full Anarlog window open.
+If you enabled **Show floating bar** in **Settings → Meetings**, you can control recording without keeping the full Anarlog window open.
 
 ## Finish the meeting
 

--- a/docs/sync.mdx
+++ b/docs/sync.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Cloud sync"
-description: "Keep notes end-to-end encrypted across devices, and avoid conflicts with iCloud Drive or Dropbox."
+description: "Keep notes end-to-end encrypted across devices, and avoid conflicts with cloud-storage folders."
 ---
 
 Cloud sync keeps your notes up to date across your signed-in devices. It is part of Anarlog Pro.
@@ -43,7 +43,7 @@ See [Data, privacy, and retention](/data-and-privacy) for what stays on your com
 
 Cloud API & Connectors is a separate, optional feature. If you enable it under **Settings → Developers**, Anarlog uploads a server-readable copy for remote agents; it does not decrypt or weaken your end-to-end encrypted sync data. See [Cloud API and connectors](/reference/api-cloud).
 
-## Don't combine sync with iCloud Drive or Dropbox
+## Don't combine sync with a cloud-storage folder
 
 Keep your Anarlog storage location out of folders managed by a file-syncing service such as iCloud Drive, Dropbox, Google Drive, or OneDrive. Two sync systems changing the same files can cause:
 
@@ -51,9 +51,17 @@ Keep your Anarlog storage location out of folders managed by a file-syncing serv
 - Incomplete audio files when a service uploads a recording while Anarlog is still writing it
 - Files that are offloaded to the cloud and unavailable offline
 
-This includes Obsidian vaults stored in iCloud Drive. If you selected one as your storage location, choose a local folder instead.
+This includes Obsidian vaults stored in iCloud Drive.
 
 Anarlog shows a warning in **Settings → Sync** when your storage location is inside a known cloud-storage folder. Backup tools that snapshot files without continuously syncing them back are fine.
+
+Anarlog does not currently expose a control for changing a storage location selected in an older version. If you see this warning:
+
+1. Turn off Cloud sync so changes remain on this device.
+2. Leave the existing folder in place. Do not move or delete it manually.
+3. Email [founders@anarlog.so](mailto:founders@anarlog.so) with your operating system and the cloud-storage service named in the warning.
+
+Notes and transcripts migrated to the local SQLite database, but saved recordings and attachments may still depend on the existing folder.
 
 ## Fix a blocked sync
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -34,7 +34,7 @@ For Apple Calendar, also check **Settings → Permissions → Calendar**.
 
 ## A recording disappeared
 
-Open **Settings → App → Storage** and check **Audio file retention**. Anarlog can delete audio immediately or after a selected period while keeping the note and transcript.
+Open **Settings → Meetings** and check **Audio file retention** under **Audio**. Anarlog can delete audio immediately or after a selected period while keeping the note and transcript.
 
 See [Data, privacy, and retention](/data-and-privacy#choose-how-long-audio-is-kept) for every retention option.
 


### PR DESCRIPTION
Correct storage guidance and align Settings references with the current desktop UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code or behavior impact.
> 
> **Overview**
> User-facing docs no longer point at removed **Settings → App** paths. Meeting-related controls (auto-start/stop, floating bar, audio retention) now reference **Settings → Meetings**; main language lives under **Settings → General**; usage analytics under **Settings → Privacy** with the PostHog label; automatic capture help splits scheduled controls vs **Settings → Notifications** for microphone detection.
> 
> **Cloud sync** copy is broadened from iCloud/Dropbox-specific wording to generic cloud-storage folders, and adds steps when Sync warns about a legacy storage location (turn off sync, don’t move the folder, contact support), noting that recordings/attachments may still depend on that folder even after notes moved to SQLite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8254b80e87f097b537881d4b34911001afd67f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->