### PR TITLE
Add confirmed complete quit

### DIFF
--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -20,7 +20,8 @@ use crate::{
 
 use crate::menu_items::{
     AppInfo, AppNew, HelpReportBug, HelpSuggestFeature, MenuItemHandler, TrayCheckUpdate, TrayOpen,
-    TrayQuit, TraySettings, TrayShowEvents, TrayStart, TrayVersion, build_agenda_item,
+    TrayQuit, TrayQuitCompletely, TraySettings, TrayShowEvents, TrayStart, TrayVersion,
+    build_agenda_item,
 };
 use tauri_plugin_store2::Store2PluginExt;
 
@@ -356,6 +357,7 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
         menu.append(&TrayCheckUpdate::build(app)?)?;
         menu.append(&PredefinedMenuItem::separator(app)?)?;
         menu.append(&TrayQuit::build(app)?)?;
+        menu.append(&TrayQuitCompletely::build(app)?)?;
 
         Ok(menu)
     }

--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -19,8 +19,8 @@ use crate::{
 };
 
 use crate::menu_items::{
-    AppInfo, AppNew, HelpReportBug, HelpSuggestFeature, MenuItemHandler, TrayCheckUpdate, TrayOpen,
-    TrayQuit, TrayQuitCompletely, TraySettings, TrayShowEvents, TrayStart, TrayVersion,
+    AppInfo, AppNew, HelpReportBug, HelpSuggestFeature, MenuItemHandler, TrayCheckUpdate, TrayHide,
+    TrayOpen, TrayQuit, TrayQuitCompletely, TraySettings, TrayShowEvents, TrayStart, TrayVersion,
     build_agenda_item,
 };
 use tauri_plugin_store2::Store2PluginExt;
@@ -356,7 +356,7 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
         menu.append(&TrayVersion::build(app)?)?;
         menu.append(&TrayCheckUpdate::build(app)?)?;
         menu.append(&PredefinedMenuItem::separator(app)?)?;
-        menu.append(&TrayQuit::build(app)?)?;
+        menu.append(&TrayHide::build(app)?)?;
         menu.append(&TrayQuitCompletely::build(app)?)?;
 
         Ok(menu)

--- a/plugins/tray/src/menu_items/mod.rs
+++ b/plugins/tray/src/menu_items/mod.rs
@@ -4,6 +4,7 @@ mod help_report_bug;
 mod help_suggest_feature;
 mod tray_agenda;
 mod tray_check_update;
+mod tray_hide;
 mod tray_open;
 mod tray_quit;
 mod tray_quit_completely;
@@ -18,6 +19,7 @@ pub use help_report_bug::HelpReportBug;
 pub use help_suggest_feature::HelpSuggestFeature;
 pub use tray_agenda::{build_agenda_item, handle_agenda_menu_event};
 pub use tray_check_update::{TrayCheckUpdate, UpdateMenuState};
+pub use tray_hide::TrayHide;
 pub use tray_open::TrayOpen;
 pub use tray_quit::TrayQuit;
 pub use tray_quit_completely::TrayQuitCompletely;
@@ -78,6 +80,7 @@ menu_items! {
     TraySettings => TraySettings,
     TrayShowEvents => TrayShowEvents,
     TrayCheckUpdate => TrayCheckUpdate,
+    TrayHide => TrayHide,
     TrayQuit => TrayQuit,
     TrayQuitCompletely => TrayQuitCompletely,
     TrayVersion => TrayVersion,

--- a/plugins/tray/src/menu_items/mod.rs
+++ b/plugins/tray/src/menu_items/mod.rs
@@ -6,6 +6,7 @@ mod tray_agenda;
 mod tray_check_update;
 mod tray_open;
 mod tray_quit;
+mod tray_quit_completely;
 mod tray_settings;
 mod tray_show_events;
 mod tray_start;
@@ -19,6 +20,7 @@ pub use tray_agenda::{build_agenda_item, handle_agenda_menu_event};
 pub use tray_check_update::{TrayCheckUpdate, UpdateMenuState};
 pub use tray_open::TrayOpen;
 pub use tray_quit::TrayQuit;
+pub use tray_quit_completely::TrayQuitCompletely;
 pub use tray_settings::TraySettings;
 pub use tray_show_events::TrayShowEvents;
 pub use tray_start::TrayStart;
@@ -77,6 +79,7 @@ menu_items! {
     TrayShowEvents => TrayShowEvents,
     TrayCheckUpdate => TrayCheckUpdate,
     TrayQuit => TrayQuit,
+    TrayQuitCompletely => TrayQuitCompletely,
     TrayVersion => TrayVersion,
     AppInfo => AppInfo,
     AppNew => AppNew,

--- a/plugins/tray/src/menu_items/tray_hide.rs
+++ b/plugins/tray/src/menu_items/tray_hide.rs
@@ -2,20 +2,21 @@ use tauri::{
     AppHandle, Result,
     menu::{MenuItem, MenuItemKind},
 };
+use tauri_plugin_windows::AppWindow;
 
 use super::MenuItemHandler;
 
-pub struct TrayQuit;
+pub struct TrayHide;
 
-impl MenuItemHandler for TrayQuit {
-    const ID: &'static str = "anlg_tray_quit";
+impl MenuItemHandler for TrayHide {
+    const ID: &'static str = "anlg_tray_hide";
 
     fn build(app: &AppHandle<tauri::Wry>) -> Result<MenuItemKind<tauri::Wry>> {
-        let item = MenuItem::with_id(app, Self::ID, "Quit", true, Some("cmd+q"))?;
+        let item = MenuItem::with_id(app, Self::ID, "Hide", true, None::<&str>)?;
         Ok(MenuItemKind::MenuItem(item))
     }
 
     fn handle(app: &AppHandle<tauri::Wry>) {
-        app.exit(0);
+        let _ = AppWindow::Main.hide(app);
     }
 }

--- a/plugins/tray/src/menu_items/tray_quit.rs
+++ b/plugins/tray/src/menu_items/tray_quit.rs
@@ -11,11 +11,12 @@ impl MenuItemHandler for TrayQuit {
     const ID: &'static str = "anlg_tray_quit";
 
     fn build(app: &AppHandle<tauri::Wry>) -> Result<MenuItemKind<tauri::Wry>> {
-        let item = MenuItem::with_id(app, Self::ID, "Quit", true, Some("cmd+q"))?;
+        let item = MenuItem::with_id(app, Self::ID, "Quit", true, Some("cmd+w"))?;
         Ok(MenuItemKind::MenuItem(item))
     }
 
     fn handle(app: &AppHandle<tauri::Wry>) {
-        app.exit(0);
+        use tauri_plugin_windows::AppWindow;
+        let _ = AppWindow::Main.hide(app);
     }
 }

--- a/plugins/tray/src/menu_items/tray_quit_completely.rs
+++ b/plugins/tray/src/menu_items/tray_quit_completely.rs
@@ -1,0 +1,36 @@
+use tauri::{
+    AppHandle, Result,
+    menu::{MenuItem, MenuItemKind},
+};
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+
+use super::MenuItemHandler;
+
+pub struct TrayQuitCompletely;
+
+impl MenuItemHandler for TrayQuitCompletely {
+    const ID: &'static str = "anlg_tray_quit_completely";
+
+    fn build(app: &AppHandle<tauri::Wry>) -> Result<MenuItemKind<tauri::Wry>> {
+        let item = MenuItem::with_id(app, Self::ID, "Quit Completely…", true, None::<&str>)?;
+        Ok(MenuItemKind::MenuItem(item))
+    }
+
+    fn handle(app: &AppHandle<tauri::Wry>) {
+        let app_name = app.package_info().name.clone();
+        let app = app.clone();
+
+        app.dialog()
+            .message(format!("{} will stop running in the background.", app_name))
+            .title(format!("Quit {} Completely?", app_name))
+            .buttons(MessageDialogButtons::OkCancelCustom(
+                "Quit Completely".to_string(),
+                "Cancel".to_string(),
+            ))
+            .show(move |confirmed| {
+                if confirmed {
+                    app.exit(0);
+                }
+            });
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized tray menu UX change; only full exit path adds a confirmation dialog before `app.exit(0)`.
> 
> **Overview**
> The **tray menu** no longer offers a single **Quit** item. It now has **Hide** (closes the main window via `AppWindow::Main.hide`) and **Quit Completely…**, which shows a confirmation dialog explaining that the app will stop running in the background before calling `app.exit(0)`.
> 
> **TrayQuit** remains registered for the macOS app menu (e.g. Cmd+Q) and still quits immediately without the new dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc64cd6e9ec6fd7de11a6c081390a931dc43f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->