### PR TITLE
Fix stale billing claims before integration gates

### DIFF
--- a/.github/workflows/web_cd.yaml
+++ b/.github/workflows/web_cd.yaml
@@ -41,7 +41,6 @@ jobs:
         run: |
           netlify build \
             --context production \
-            --site "$NETLIFY_SITE_ID" \
             --filter @anlg/web
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/apps/web/src/hooks/use-billing.ts
+++ b/apps/web/src/hooks/use-billing.ts
@@ -16,6 +16,10 @@ import { getSupabaseBrowserClient } from "@/functions/supabase";
 
 const DEFAULT_BILLING = deriveBillingInfo(null);
 
+function deriveBillingFromAccessToken(accessToken: string) {
+  return deriveBillingInfo(jwtDecode<SupabaseJwtPayload>(accessToken));
+}
+
 export function useBilling() {
   const queryClient = useQueryClient();
   const [accessToken, setAccessToken] = useState<string | null | undefined>(
@@ -47,7 +51,7 @@ export function useBilling() {
         return DEFAULT_BILLING;
       }
 
-      return deriveBillingInfo(jwtDecode<SupabaseJwtPayload>(accessToken));
+      return deriveBillingFromAccessToken(accessToken);
     },
     enabled: accessToken !== undefined,
     // Keep isReady stable across token refreshes so consumers gating on it
@@ -62,9 +66,23 @@ export function useBilling() {
 
   const refreshBilling = useCallback(async () => {
     const supabase = getSupabaseBrowserClient();
-    const { data } = await supabase.auth.refreshSession();
-    setAccessToken(data.session?.access_token ?? null);
-    await queryClient.invalidateQueries({ queryKey: ["billing"] });
+    const { data, error } = await supabase.auth.refreshSession();
+
+    if (error) {
+      throw error;
+    }
+
+    const refreshedAccessToken = data.session?.access_token;
+
+    if (!refreshedAccessToken) {
+      throw new Error("Billing refresh returned no authenticated session");
+    }
+
+    const refreshedBilling = deriveBillingFromAccessToken(refreshedAccessToken);
+    setAccessToken(refreshedAccessToken);
+    await queryClient.invalidateQueries({ queryKey: ["billing", "jwt"] });
+
+    return refreshedBilling;
   }, [queryClient]);
 
   return {

--- a/apps/web/src/lib/integration-billing-gate.test.ts
+++ b/apps/web/src/lib/integration-billing-gate.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getIntegrationBillingGate } from "./integration-billing-gate.ts";
+
+const verifiedGate = {
+  action: "connect" as const,
+  isBillingReady: true,
+  isVerifying: false,
+  verificationFailed: false,
+};
+
+test("uses refreshed paid claims before connecting", () => {
+  assert.equal(
+    getIntegrationBillingGate({
+      ...verifiedGate,
+      verifiedIsPaid: true,
+    }),
+    "connect",
+  );
+});
+
+test("shows upgrade only after refreshed claims confirm a free plan", () => {
+  assert.equal(
+    getIntegrationBillingGate({
+      ...verifiedGate,
+      verifiedIsPaid: false,
+    }),
+    "upgrade",
+  );
+});
+
+test("keeps the gate closed while billing claims refresh", () => {
+  assert.equal(
+    getIntegrationBillingGate({
+      ...verifiedGate,
+      isVerifying: true,
+      verifiedIsPaid: undefined,
+    }),
+    "loading",
+  );
+});
+
+test("offers a retry instead of showing a false paywall after refresh failure", () => {
+  assert.equal(
+    getIntegrationBillingGate({
+      ...verifiedGate,
+      verificationFailed: true,
+      verifiedIsPaid: undefined,
+    }),
+    "retry",
+  );
+});
+
+test("disconnect does not wait for billing verification", () => {
+  assert.equal(
+    getIntegrationBillingGate({
+      action: "disconnect",
+      isBillingReady: false,
+      isVerifying: false,
+      verificationFailed: false,
+      verifiedIsPaid: undefined,
+    }),
+    "disconnect",
+  );
+});

--- a/apps/web/src/lib/integration-billing-gate.ts
+++ b/apps/web/src/lib/integration-billing-gate.ts
@@ -1,0 +1,31 @@
+export function getIntegrationBillingGate({
+  action,
+  isBillingReady,
+  isVerifying,
+  verificationFailed,
+  verifiedIsPaid,
+}: {
+  action: "connect" | "reconnect" | "disconnect";
+  isBillingReady: boolean;
+  isVerifying: boolean;
+  verificationFailed: boolean;
+  verifiedIsPaid: boolean | undefined;
+}) {
+  if (action === "disconnect") {
+    return "disconnect";
+  }
+
+  if (!isBillingReady || isVerifying) {
+    return "loading";
+  }
+
+  if (verificationFailed) {
+    return "retry";
+  }
+
+  if (verifiedIsPaid === undefined) {
+    return "loading";
+  }
+
+  return verifiedIsPaid ? "connect" : "upgrade";
+}

--- a/apps/web/src/routes/_view/app/integration.tsx
+++ b/apps/web/src/routes/_view/app/integration.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 
@@ -6,8 +7,9 @@ import {
   flowSearchSchema,
 } from "@/functions/desktop-flow";
 import { useBilling } from "@/hooks/use-billing";
+import { getIntegrationBillingGate } from "@/lib/integration-billing-gate";
 
-import { IntegrationPageLayout } from "./-integration-ui";
+import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
 import { ConnectFlow } from "./-integrations-connect-flow";
 import { DisconnectFlow } from "./-integrations-disconnect-flow";
 import { UpgradePrompt } from "./-integrations-upgrade-prompt";
@@ -81,12 +83,35 @@ export const Route = createFileRoute("/_view/app/integration")({
 function Component() {
   const search = Route.useSearch();
   const billing = useBilling();
+  const billingVerification = useQuery({
+    queryKey: [
+      "billing",
+      "integration-verification",
+      search.flow,
+      search.integration_id,
+      search.action,
+      search.connection_id ?? "",
+    ],
+    queryFn: billing.refreshBilling,
+    enabled: search.action !== "disconnect" && billing.isReady,
+    refetchOnMount: "always",
+    staleTime: Infinity,
+    retry: 1,
+  });
+  const gate = getIntegrationBillingGate({
+    action: search.action,
+    isBillingReady: billing.isReady,
+    isVerifying:
+      billingVerification.isPending || billingVerification.isFetching,
+    verificationFailed: billingVerification.isError,
+    verifiedIsPaid: billingVerification.data?.isPaid,
+  });
 
-  if (search.action === "disconnect") {
+  if (gate === "disconnect") {
     return <DisconnectFlow />;
   }
 
-  if (!billing.isReady) {
+  if (gate === "loading") {
     return (
       <IntegrationPageLayout>
         <p className="text-neutral-500">Loading...</p>
@@ -94,7 +119,22 @@ function Component() {
     );
   }
 
-  if (!billing.isPaid) {
+  if (gate === "retry") {
+    return (
+      <IntegrationPageLayout>
+        <div className="flex flex-col gap-4">
+          <p className="text-neutral-600">
+            We couldn’t verify your plan. Please try again.
+          </p>
+          <IntegrationButton onClick={() => void billingVerification.refetch()}>
+            Try again
+          </IntegrationButton>
+        </div>
+      </IntegrationPageLayout>
+    );
+  }
+
+  if (gate === "upgrade") {
     return (
       <UpgradePrompt
         integrationId={search.integration_id}


### PR DESCRIPTION
- Refresh the browser Supabase session before integration entitlement checks.
- Show a retry state when billing verification fails.
- Remove the unsupported Netlify build --site flag.

Validation: web typecheck, 221 web tests, 15 Supabase billing tests, formatting, media figure check, and Netlify CLI dry-run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes entitlement gating and session refresh behavior for paid integrations; incorrect refresh or gate logic could block connects or show wrong paywalls, though logic is isolated and tested.
> 
> **Overview**
> Integration **connect/reconnect** no longer trusts cached JWT billing claims alone. On mount it runs **`refreshBilling`** (Supabase session refresh) and only then decides between connect, upgrade, loading, or a **retry** UI if verification fails; **disconnect** skips that check.
> 
> **`useBilling.refreshBilling`** now surfaces refresh errors, requires a session token, returns the derived **`BillingInfo`**, and narrows query invalidation to `["billing", "jwt"]`. Gate logic lives in new **`getIntegrationBillingGate`** with unit tests.
> 
> CI: **`netlify build`** drops the unsupported **`--site`** flag (site id remains via env on deploy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72401fcaabd542a703a6ed0479691b8ef4abb056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->