### PR TITLE
Expose email change from account settings

### DIFF
--- a/apps/desktop/src/settings/general/account.test.tsx
+++ b/apps/desktop/src/settings/general/account.test.tsx
@@ -11,9 +11,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   analyticsEvent: vi.fn(() => Promise.resolve()),
   analyticsSetProperties: vi.fn(() => Promise.resolve()),
+  openUrl: vi.fn(() => Promise.resolve()),
   signIn: vi.fn(() => Promise.resolve()),
   signOut: vi.fn(() => Promise.resolve()),
-  buildWebAppUrl: vi.fn(() => Promise.resolve("https://anarlog.so/app/portal")),
+  buildWebAppUrl: vi.fn((path: string) =>
+    Promise.resolve(`https://anarlog.so${path}`),
+  ),
   billing: {
     canStartTrial: { data: false, isPending: false },
     hasPaymentMethod: false,
@@ -32,7 +35,7 @@ vi.mock("@anlg/plugin-analytics", () => ({
 }));
 
 vi.mock("@anlg/plugin-opener2", () => ({
-  commands: { openUrl: vi.fn() },
+  commands: { openUrl: mocks.openUrl },
 }));
 
 vi.mock("@anlg/plugin-windows", () => ({
@@ -118,6 +121,20 @@ describe("SettingsAccount", () => {
     expect(mocks.analyticsEvent).toHaveBeenCalledWith({
       event: "user_signed_out",
     });
+  });
+
+  it("opens the account page to change the signed-in email", async () => {
+    renderAccount();
+
+    fireEvent.click(screen.getByRole("button", { name: "john@example.com" }));
+
+    await waitFor(() =>
+      expect(mocks.buildWebAppUrl).toHaveBeenCalledWith("/app/account"),
+    );
+    expect(mocks.openUrl).toHaveBeenCalledWith(
+      "https://anarlog.so/app/account",
+      null,
+    );
   });
 
   it("offers to add a payment method during a cardless trial", async () => {

--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import { ArrowsClockwise } from "@phosphor-icons/react";
+import { ArrowsClockwise, PencilSimple } from "@phosphor-icons/react";
 import { useMutation } from "@tanstack/react-query";
 import {
   type ReactNode,
@@ -75,6 +75,12 @@ export function SettingsAccount() {
       sonnerToast.error(message);
     },
   });
+  const openAccountMutation = useMutation({
+    mutationFn: async () => {
+      const url = await buildWebAppUrl("/app/account");
+      await openerCommands.openUrl(url, null);
+    },
+  });
 
   if (!isAuthenticated) {
     if (isPending) {
@@ -141,7 +147,21 @@ export function SettingsAccount() {
       <SettingsPageTitle title={<Trans>Account</Trans>} />
       <Container
         title={<Trans>Your Account</Trans>}
-        description={auth.session?.user.email ?? t`Signed in`}
+        description={
+          auth.session?.user.email ? (
+            <button
+              type="button"
+              onClick={() => openAccountMutation.mutate()}
+              disabled={openAccountMutation.isPending}
+              className="hover:text-foreground focus-visible:ring-ring inline-flex items-center gap-1.5 rounded-sm transition-colors focus-visible:ring-1 focus-visible:outline-hidden disabled:opacity-50"
+            >
+              <span>{auth.session.user.email}</span>
+              <PencilSimple className="size-3" aria-hidden="true" />
+            </button>
+          ) : (
+            t`Signed in`
+          )
+        }
         action={
           <Button
             variant="destructive"

--- a/apps/desktop/src/shared/utils.ts
+++ b/apps/desktop/src/shared/utils.ts
@@ -27,6 +27,7 @@ export const getScheme = async (): Promise<DesktopScheme> => {
 
 type DesktopFlowPath =
   | "/auth"
+  | "/app/account"
   | "/app/integration"
   | "/app/checkout"
   | "/app/switch-plan"


### PR DESCRIPTION
Link the signed-in email to the existing authenticated account editor and cover the desktop handoff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI and deep-link addition in settings; no auth or billing logic changes beyond opening an existing web flow.
> 
> **Overview**
> **Account settings** now treats the signed-in email as an actionable control (with a pencil icon) instead of plain text. Clicking it opens the authenticated web **account** page via the existing desktop URL handoff (`buildWebAppUrl` + `openUrl`).
> 
> `DesktopFlowPath` gains **`/app/account`** so that handoff is type-safe. Tests assert the click builds that URL and opens it in the browser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed59873532fbb95303a51f6facad44c62bffe608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->