### PR TITLE
Fix Netlify no-build deploy

### DIFF
--- a/.github/workflows/web_cd.yaml
+++ b/.github/workflows/web_cd.yaml
@@ -81,7 +81,6 @@ jobs:
           netlify deploy \
             --prod \
             --no-build \
-            --context production \
             --site "$NETLIFY_SITE_ID" \
             --filter @anlg/web \
             --message "web v${{ needs.compute-version.outputs.version }} ($GITHUB_SHA)"


### PR DESCRIPTION
Remove the deploy-only --context flag because Netlify CLI 26 rejects it when --no-build is enabled. The production build and source-map upload already pass with this CLI version.

Validation: Netlify CLI 26.2.0 deploy help, dprint fmt, and pnpm fmt:check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow flag change with no application or security impact; production build context remains on the separate build step.
> 
> **Overview**
> Fixes **web CD** failing on Netlify CLI **26.x** by dropping `--context production` from the deploy-only `netlify deploy` step when `--no-build` is set—the CLI no longer allows that flag in that combination.
> 
> Production context is unchanged for the earlier **`netlify build`** step; deploy still uses **`--prod`** to publish the prebuilt artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b73133215fa128d3b8bd16080d0b610300548d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->