### PR TITLE
Add headless CLI cloud login

### DIFF
--- a/.github/workflows/cli_ci.yaml
+++ b/.github/workflows/cli_ci.yaml
@@ -125,8 +125,7 @@ jobs:
           headless_logout="$(env -u DBUS_SESSION_BUS_ADDRESS XDG_DATA_HOME="$headless_auth_root" target/release/anarlog --json auth logout)"
           grep -q '"command": "auth.logout"' <<<"$headless_logout"
           headless_fallback="$headless_auth_root/com.hyprnote.stable/auth.cli.json"
-          test "$(cat "$headless_fallback")" = '{}'
-          test "$(stat -c '%a' "$headless_fallback")" = '600'
+          test ! -e "$headless_fallback"
       - run: |
           test -s skills/anarlog/SKILL.md
           test "$(sed -n '1p' skills/anarlog/SKILL.md)" = "---"

--- a/.github/workflows/cli_ci.yaml
+++ b/.github/workflows/cli_ci.yaml
@@ -108,6 +108,25 @@ jobs:
             exit 1
           fi
           grep -q '"code": "invalid_arguments"' <<<"$invalid_output"
+          auth_path="$RUNNER_TEMP/anarlog-auth-smoke.json"
+          auth_status="$(ANARLOG_AUTH_PATH="$auth_path" target/release/anarlog --json auth status)"
+          grep -q '"command": "auth.status"' <<<"$auth_status"
+          grep -q '"signed_in": false' <<<"$auth_status"
+          auth_logout="$(ANARLOG_AUTH_PATH="$auth_path" target/release/anarlog --json auth logout)"
+          grep -q '"command": "auth.logout"' <<<"$auth_logout"
+          grep -q '"signed_in": false' <<<"$auth_logout"
+          if auth_error="$(printf '%s\n' 'anarlog://auth/callback?access_token=cli-auth-secret-sentinel' | ANARLOG_AUTH_PATH="$auth_path" target/release/anarlog --json auth login 2>&1)"; then
+            echo "incomplete auth callback unexpectedly succeeded"
+            exit 1
+          fi
+          grep -q '"code": "operation_failed"' <<<"$auth_error"
+          ! grep -q 'cli-auth-secret-sentinel' <<<"$auth_error"
+          headless_auth_root="$RUNNER_TEMP/anarlog-auth-headless"
+          headless_logout="$(env -u DBUS_SESSION_BUS_ADDRESS XDG_DATA_HOME="$headless_auth_root" target/release/anarlog --json auth logout)"
+          grep -q '"command": "auth.logout"' <<<"$headless_logout"
+          headless_fallback="$headless_auth_root/com.hyprnote.stable/auth.cli.json"
+          test "$(cat "$headless_fallback")" = '{}'
+          test "$(stat -c '%a' "$headless_fallback")" = '600'
       - run: |
           test -s skills/anarlog/SKILL.md
           test "$(sed -n '1p' skills/anarlog/SKILL.md)" = "---"
@@ -163,4 +182,17 @@ jobs:
             exit 1
           fi
           grep -q '"code": "invalid_arguments"' <<<"$invalid_output"
+          auth_path="$RUNNER_TEMP/anarlog-auth-smoke.json"
+          auth_status="$(ANARLOG_AUTH_PATH="$auth_path" target/release/anarlog.exe --json auth status)"
+          grep -q '"command": "auth.status"' <<<"$auth_status"
+          grep -q '"signed_in": false' <<<"$auth_status"
+          auth_logout="$(ANARLOG_AUTH_PATH="$auth_path" target/release/anarlog.exe --json auth logout)"
+          grep -q '"command": "auth.logout"' <<<"$auth_logout"
+          grep -q '"signed_in": false' <<<"$auth_logout"
+          if auth_error="$(printf '%s\n' 'anarlog://auth/callback?access_token=cli-auth-secret-sentinel' | ANARLOG_AUTH_PATH="$auth_path" target/release/anarlog.exe --json auth login 2>&1)"; then
+            echo "incomplete auth callback unexpectedly succeeded"
+            exit 1
+          fi
+          grep -q '"code": "operation_failed"' <<<"$auth_error"
+          ! grep -q 'cli-auth-secret-sentinel' <<<"$auth_error"
         shell: bash

--- a/.github/workflows/cli_ci.yaml
+++ b/.github/workflows/cli_ci.yaml
@@ -95,6 +95,7 @@ jobs:
       - run: |
           target/release/anarlog --help
           target/release/anarlog --version
+          target/release/anarlog auth --help
           target/release/anarlog meetings --help
           target/release/anarlog mcp --help
           if doctor_output="$(target/release/anarlog --json --db-path "$RUNNER_TEMP/missing.db" doctor)"; then
@@ -149,6 +150,7 @@ jobs:
       - run: |
           target/release/anarlog.exe --help
           target/release/anarlog.exe --version
+          target/release/anarlog.exe auth --help
           target/release/anarlog.exe meetings --help
           target/release/anarlog.exe mcp --help
           if doctor_output="$(target/release/anarlog.exe --json --db-path "$RUNNER_TEMP/missing.db" doctor)"; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16991,6 +16991,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "storage"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "dirs 6.0.0",
  "serde",
  "serde_json",
@@ -16999,6 +17000,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -18209,7 +18211,6 @@ dependencies = [
 name = "tauri-plugin-auth"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "serde",
  "serde_json",
  "specta",
@@ -18225,7 +18226,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
- "windows 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,17 +390,23 @@ name = "anarlog-cli"
 version = "0.1.0"
 dependencies = [
  "agent-access",
+ "base64 0.22.1",
  "clap",
  "cli-docs",
  "db-app",
  "db-core",
  "dirs 6.0.0",
  "insta",
+ "keyring",
+ "reqwest 0.13.2",
  "rmcp",
+ "rpassword",
  "sentry",
  "serde",
  "serde_json",
  "sqlx",
+ "storage",
+ "supabase-auth",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -15018,6 +15024,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rquickjs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15121,6 +15138,16 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,7 @@ libloading = "0.8"
 moka = { version = "0.12", features = ["future"] }
 open = "5"
 regex = "1.12"
+rpassword = "7.5.4"
 schemars = "1"
 self-replace = "1.5"
 serde = "1"

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -11,17 +11,25 @@ path = "src/main.rs"
 anlg-agent-access = { workspace = true }
 anlg-db-app = { workspace = true }
 anlg-db-core = { workspace = true }
+anlg-storage = { workspace = true }
+anlg-supabase-auth = { workspace = true }
 anlg-user-error = { workspace = true }
 
+base64 = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 dirs = { workspace = true }
+reqwest = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
+rpassword = { workspace = true }
 sentry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-std", "macros", "rt-multi-thread"] }
 url = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { workspace = true }
 
 [dev-dependencies]
 cli-docs = { path = "../../crates/cli-docs" }

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -5,7 +5,11 @@ use clap::{Parser, Subcommand, ValueEnum};
 use anlg_agent_access::{DEFAULT_TRANSCRIPT_LIMIT, MAX_TRANSCRIPT_LIMIT};
 
 #[derive(Debug, Parser)]
-#[command(name = "anarlog", version, about = "Query local Anarlog meeting data")]
+#[command(
+    name = "anarlog",
+    version,
+    about = "Access Anarlog from the command line"
+)]
 pub struct Args {
     #[arg(
         long,
@@ -35,6 +39,11 @@ pub struct Args {
 impl Args {
     pub fn analytics_command_name(&self) -> &'static str {
         match &self.command {
+            Command::Auth { command } => match command {
+                AuthCommand::Login => "auth_login",
+                AuthCommand::Status => "auth_status",
+                AuthCommand::Logout => "auth_logout",
+            },
             Command::Doctor => "doctor",
             Command::Meetings { command } => match command {
                 MeetingCommand::List { .. } => "meetings_list",
@@ -51,6 +60,11 @@ impl Args {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
+    /// Sign in to an Anarlog account from a browser
+    Auth {
+        #[command(subcommand)]
+        command: AuthCommand,
+    },
     /// Check the local CLI and database connection without changing data
     Doctor,
     /// Browse and export meetings
@@ -60,6 +74,16 @@ pub enum Command {
     },
     /// Run the read-only Anarlog MCP server over stdio
     Mcp,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AuthCommand {
+    /// Sign in through a browser on this or another device
+    Login,
+    /// Show the locally stored account session
+    Status,
+    /// Remove the locally stored account session
+    Logout,
 }
 
 #[derive(Debug, Subcommand)]
@@ -151,6 +175,7 @@ mod tests {
     #[test]
     fn help_exposes_mcp_and_export() {
         let help = Args::command().render_long_help().to_string();
+        assert!(help.contains("auth"));
         assert!(help.contains("meetings"));
         assert!(help.contains("mcp"));
         assert!(help.contains("doctor"));
@@ -172,6 +197,28 @@ mod tests {
             MeetingCommand::Export {
                 format: ExportFormat::Json,
                 ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parses_auth_commands() {
+        assert!(matches!(
+            Args::parse_from(["anarlog", "auth", "login"]).command,
+            Command::Auth {
+                command: AuthCommand::Login
+            }
+        ));
+        assert!(matches!(
+            Args::parse_from(["anarlog", "auth", "status"]).command,
+            Command::Auth {
+                command: AuthCommand::Status
+            }
+        ));
+        assert!(matches!(
+            Args::parse_from(["anarlog", "auth", "logout"]).command,
+            Command::Auth {
+                command: AuthCommand::Logout
             }
         ));
     }

--- a/apps/cli/src/commands/auth/mod.rs
+++ b/apps/cli/src/commands/auth/mod.rs
@@ -1,0 +1,514 @@
+mod storage;
+
+use std::io::{IsTerminal, Read};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anlg_supabase_auth::session::{AppMetadata, Session, SessionUser, UserMetadata};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use url::Url;
+
+use crate::cli::AuthCommand;
+use crate::{Error, Result, output};
+
+use self::storage::{AuthStore, Backend};
+
+const WEB_APP_URL: &str = "https://anarlog.so";
+const API_URL: &str = "https://api.anarlog.so";
+const MAX_CALLBACK_BYTES: usize = 32 * 1024;
+
+pub async fn run(command: &AuthCommand, json: bool) -> Result<()> {
+    let environment = Environment::current();
+    let store = AuthStore::new(environment.bundle_id)?;
+
+    match command {
+        AuthCommand::Login => login(&store, environment, json).await,
+        AuthCommand::Status => status(&store, json),
+        AuthCommand::Logout => logout(&store, json),
+    }
+}
+
+async fn login(store: &AuthStore, environment: Environment, json: bool) -> Result<()> {
+    let login_url = login_url(environment.scheme)?;
+    if json {
+        eprintln!("Open this URL in any browser:\n{login_url}\n");
+        eprintln!("After signing in, choose Copy URL and paste the callback link below.");
+    } else {
+        output::emit(&format!(
+            "Open this URL in any browser:\n\n{login_url}\n\nAfter signing in, choose Copy URL and paste the callback link below."
+        ));
+    }
+
+    let callback = read_callback_url()?;
+    let tokens = CallbackTokens::parse(&callback, environment.scheme)?;
+    let session = verify_and_build_session(tokens).await?;
+    let user_id = session
+        .user
+        .as_ref()
+        .map(|user| user.id.clone())
+        .ok_or_else(|| Error::operation("complete login", "account identity is missing"))?;
+    let email = session.user.as_ref().and_then(|user| user.email.clone());
+    let storage_key = storage_key(&session.access_token)?;
+    let mut data = store.load()?.data;
+    data.retain(|key, _| !key.ends_with("-auth-token"));
+    data.insert(
+        storage_key,
+        serde_json::to_string(&session)
+            .map_err(|error| Error::operation("serialize login", error.to_string()))?,
+    );
+    let backend = store.save(&data)?;
+
+    emit_status(
+        "auth.login",
+        AuthStatus::signed_in(user_id, email, session.expires_at, backend, store),
+        json,
+    )
+}
+
+fn status(store: &AuthStore, json: bool) -> Result<()> {
+    let loaded = store.load()?;
+    let Some(session) = storage::find_session(&loaded.data)? else {
+        return emit_status("auth.status", AuthStatus::signed_out(store), json);
+    };
+    let user = session
+        .user
+        .ok_or_else(|| Error::operation("read login", "stored account identity is missing"))?;
+
+    emit_status(
+        "auth.status",
+        AuthStatus::signed_in(
+            user.id,
+            user.email,
+            session.expires_at,
+            loaded.backend,
+            store,
+        ),
+        json,
+    )
+}
+
+fn logout(store: &AuthStore, json: bool) -> Result<()> {
+    store.remove_sessions()?;
+    emit_status("auth.logout", AuthStatus::signed_out(store), json)
+}
+
+fn emit_status(command: &'static str, status: AuthStatus, json: bool) -> Result<()> {
+    if json {
+        output::emit(&output::json(command, &status, None)?);
+        return Ok(());
+    }
+
+    if !status.signed_in {
+        output::emit("Not signed in.");
+        return Ok(());
+    }
+
+    let identity = status.email.as_deref().unwrap_or_else(|| {
+        status
+            .user_id
+            .as_deref()
+            .expect("signed-in status has an identity")
+    });
+    if status.expired {
+        output::emit(&format!(
+            "Signed in as {identity}. The access token has expired; open Anarlog or run the login command again to refresh it."
+        ));
+    } else {
+        output::emit(&format!("Signed in as {identity}."));
+    }
+    Ok(())
+}
+
+fn login_url(scheme: &str) -> Result<Url> {
+    let mut url = Url::parse(WEB_APP_URL)
+        .map_err(|error| Error::operation("build login URL", error.to_string()))?;
+    url.set_path("/auth/");
+    url.query_pairs_mut()
+        .append_pair("flow", "desktop")
+        .append_pair("scheme", scheme);
+    Ok(url)
+}
+
+fn read_callback_url() -> Result<String> {
+    let input = if std::io::stdin().is_terminal() {
+        rpassword::prompt_password("Callback URL (input hidden): ")
+            .map_err(|error| Error::operation("read callback URL", error.to_string()))?
+    } else {
+        let mut input = String::new();
+        std::io::stdin()
+            .lock()
+            .take((MAX_CALLBACK_BYTES + 1) as u64)
+            .read_to_string(&mut input)
+            .map_err(|error| Error::operation("read callback URL", error.to_string()))?;
+        input
+    };
+    let input = input.trim();
+    if input.is_empty() || input.len() > MAX_CALLBACK_BYTES {
+        return Err(Error::operation(
+            "read callback URL",
+            "callback URL is missing or too large",
+        ));
+    }
+    Ok(input.to_string())
+}
+
+struct CallbackTokens {
+    access_token: String,
+    refresh_token: String,
+}
+
+impl CallbackTokens {
+    fn parse(value: &str, expected_scheme: &str) -> Result<Self> {
+        let url = Url::parse(value)
+            .map_err(|_| Error::operation("read callback URL", "callback URL is invalid"))?;
+        if url.scheme() != expected_scheme
+            || url.host_str() != Some("auth")
+            || url.path() != "/callback"
+            || url.fragment().is_some()
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.port().is_some()
+        {
+            return Err(Error::operation(
+                "read callback URL",
+                format!("expected {expected_scheme}://auth/callback"),
+            ));
+        }
+
+        let mut access_token = None;
+        let mut refresh_token = None;
+        for (key, value) in url.query_pairs() {
+            let slot = match key.as_ref() {
+                "access_token" => &mut access_token,
+                "refresh_token" => &mut refresh_token,
+                _ => continue,
+            };
+            if slot.replace(value.into_owned()).is_some() {
+                return Err(Error::operation(
+                    "read callback URL",
+                    "callback URL contains duplicate tokens",
+                ));
+            }
+        }
+
+        let access_token = access_token.filter(|token| !token.is_empty());
+        let refresh_token = refresh_token.filter(|token| !token.is_empty());
+        match (access_token, refresh_token) {
+            (Some(access_token), Some(refresh_token)) => Ok(Self {
+                access_token,
+                refresh_token,
+            }),
+            _ => Err(Error::operation(
+                "read callback URL",
+                "callback URL does not contain a complete session",
+            )),
+        }
+    }
+}
+
+async fn verify_and_build_session(tokens: CallbackTokens) -> Result<Session> {
+    let claims = decode_token_claims(&tokens.access_token)?;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .user_agent(format!("anarlog-cli/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|error| Error::operation("verify login", error.to_string()))?;
+    let response = client
+        .get(format!("{API_URL}/v1/cloud-api/settings"))
+        .bearer_auth(&tokens.access_token)
+        .send()
+        .await
+        .map_err(|error| Error::operation("verify login", error.to_string()))?;
+    if !response.status().is_success() {
+        let reason = if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            "Anarlog rejected the callback session".to_string()
+        } else {
+            format!(
+                "Anarlog could not verify the callback session (HTTP {})",
+                response.status().as_u16()
+            )
+        };
+        return Err(Error::operation("verify login", reason));
+    }
+
+    let now = unix_timestamp();
+    if claims.exp <= now {
+        return Err(Error::operation(
+            "verify login",
+            "callback session has expired",
+        ));
+    }
+    validate_issuer(&claims.iss)?;
+
+    Ok(Session {
+        access_token: tokens.access_token,
+        refresh_token: Some(tokens.refresh_token),
+        token_type: "bearer".to_string(),
+        expires_in: Some(claims.exp - now),
+        expires_at: Some(claims.exp),
+        user: Some(SessionUser {
+            id: claims.sub,
+            aud: claims.aud.as_str().map(str::to_string),
+            role: claims.role,
+            email: claims.email,
+            phone: claims.phone,
+            email_confirmed_at: None,
+            confirmed_at: None,
+            recovery_sent_at: None,
+            last_sign_in_at: None,
+            app_metadata: claims
+                .app_metadata
+                .and_then(|value| serde_json::from_value::<AppMetadata>(value).ok()),
+            user_metadata: claims
+                .user_metadata
+                .and_then(|value| serde_json::from_value::<UserMetadata>(value).ok()),
+            identities: Vec::new(),
+            created_at: None,
+            updated_at: None,
+            is_anonymous: claims.is_anonymous,
+            extra: Map::new(),
+        }),
+        extra: Map::new(),
+    })
+}
+
+#[derive(Deserialize)]
+struct TokenClaims {
+    sub: String,
+    exp: u64,
+    iss: String,
+    #[serde(default)]
+    aud: Value,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    phone: Option<String>,
+    #[serde(default)]
+    app_metadata: Option<Value>,
+    #[serde(default)]
+    user_metadata: Option<Value>,
+    #[serde(default)]
+    is_anonymous: Option<bool>,
+}
+
+fn decode_token_claims(token: &str) -> Result<TokenClaims> {
+    let mut parts = token.split('.');
+    let _header = parts.next();
+    let payload = parts.next();
+    let signature = parts.next();
+    if payload.is_none() || signature.is_none() || parts.next().is_some() {
+        return Err(Error::operation(
+            "verify login",
+            "callback session is invalid",
+        ));
+    }
+    let payload = URL_SAFE_NO_PAD
+        .decode(payload.expect("payload checked above"))
+        .map_err(|_| Error::operation("verify login", "callback session is invalid"))?;
+    let claims: TokenClaims = serde_json::from_slice(&payload)
+        .map_err(|_| Error::operation("verify login", "callback session is invalid"))?;
+    if claims.sub.trim().is_empty() {
+        return Err(Error::operation(
+            "verify login",
+            "callback account identity is missing",
+        ));
+    }
+    Ok(claims)
+}
+
+fn validate_issuer(issuer: &str) -> Result<Url> {
+    let url = Url::parse(issuer)
+        .map_err(|_| Error::operation("verify login", "callback issuer is invalid"))?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || url.path() != "/auth/v1"
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port().is_some()
+    {
+        return Err(Error::operation(
+            "verify login",
+            "callback issuer is invalid",
+        ));
+    }
+    Ok(url)
+}
+
+fn storage_key(access_token: &str) -> Result<String> {
+    let issuer = validate_issuer(&decode_token_claims(access_token)?.iss)?;
+    let project = issuer
+        .host_str()
+        .and_then(|host| host.split('.').next())
+        .filter(|project| !project.is_empty())
+        .ok_or_else(|| Error::operation("complete login", "callback issuer is invalid"))?;
+    Ok(format!("sb-{project}-auth-token"))
+}
+
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+#[derive(Serialize)]
+struct AuthStatus {
+    signed_in: bool,
+    user_id: Option<String>,
+    email: Option<String>,
+    expires_at: Option<u64>,
+    expired: bool,
+    storage: Option<&'static str>,
+    storage_path: String,
+}
+
+impl AuthStatus {
+    fn signed_in(
+        user_id: String,
+        email: Option<String>,
+        expires_at: Option<u64>,
+        backend: Backend,
+        store: &AuthStore,
+    ) -> Self {
+        Self {
+            signed_in: true,
+            user_id: Some(user_id),
+            email,
+            expires_at,
+            expired: expires_at.is_none_or(|expires_at| expires_at <= unix_timestamp()),
+            storage: Some(backend.as_str()),
+            storage_path: store.path().display().to_string(),
+        }
+    }
+
+    fn signed_out(store: &AuthStore) -> Self {
+        Self {
+            signed_in: false,
+            user_id: None,
+            email: None,
+            expires_at: None,
+            expired: false,
+            storage: None,
+            storage_path: store.path().display().to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Environment {
+    scheme: &'static str,
+    bundle_id: &'static str,
+}
+
+impl Environment {
+    fn current() -> Self {
+        let executable = std::env::current_exe()
+            .ok()
+            .and_then(|path| {
+                path.file_stem()
+                    .map(|name| name.to_string_lossy().into_owned())
+            })
+            .unwrap_or_default();
+        if executable.contains("staging") {
+            return Self {
+                scheme: "anarlog-staging",
+                bundle_id: "com.hyprnote.staging",
+            };
+        }
+        if executable.contains("dev") {
+            return Self {
+                scheme: "anarlog-dev",
+                bundle_id: "com.hyprnote.dev",
+            };
+        }
+        Self {
+            scheme: "anarlog",
+            bundle_id: "com.hyprnote.stable",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn token(payload: Value) -> String {
+        format!(
+            "header.{}.signature",
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap())
+        )
+    }
+
+    #[test]
+    fn builds_headless_browser_login_url() {
+        assert_eq!(
+            login_url("anarlog").unwrap().as_str(),
+            "https://anarlog.so/auth/?flow=desktop&scheme=anarlog"
+        );
+    }
+
+    #[test]
+    fn parses_desktop_callback_without_logging_tokens() {
+        let callback = CallbackTokens::parse(
+            "anarlog://auth/callback?access_token=access%2Etoken&refresh_token=refresh-token",
+            "anarlog",
+        )
+        .unwrap();
+
+        assert_eq!(callback.access_token, "access.token");
+        assert_eq!(callback.refresh_token, "refresh-token");
+    }
+
+    #[test]
+    fn rejects_wrong_or_incomplete_callback_urls() {
+        assert!(
+            CallbackTokens::parse(
+                "https://auth/callback?access_token=access&refresh_token=refresh",
+                "anarlog"
+            )
+            .is_err()
+        );
+        assert!(
+            CallbackTokens::parse("anarlog://auth/callback?access_token=access", "anarlog")
+                .is_err()
+        );
+        assert!(
+            CallbackTokens::parse(
+                "anarlog://auth/callback?access_token=one&access_token=two&refresh_token=refresh",
+                "anarlog"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn derives_desktop_storage_key_from_validated_issuer_shape() {
+        let access_token = token(serde_json::json!({
+            "sub": "user-1",
+            "exp": 4_000_000_000_u64,
+            "iss": "https://project-ref.supabase.co/auth/v1"
+        }));
+
+        assert_eq!(
+            storage_key(&access_token).unwrap(),
+            "sb-project-ref-auth-token"
+        );
+    }
+
+    #[test]
+    fn rejects_non_https_or_malformed_issuers() {
+        for issuer in [
+            "http://project.supabase.co/auth/v1",
+            "https://project.supabase.co/other",
+            "https://user:secret@project.supabase.co/auth/v1",
+            "https://project.supabase.co/auth/v1?key=value",
+        ] {
+            assert!(validate_issuer(issuer).is_err(), "accepted {issuer}");
+        }
+    }
+}

--- a/apps/cli/src/commands/auth/mod.rs
+++ b/apps/cli/src/commands/auth/mod.rs
@@ -123,7 +123,7 @@ fn emit_status(command: &'static str, status: AuthStatus, json: bool) -> Result<
 fn login_url(scheme: &str) -> Result<Url> {
     let mut url = Url::parse(WEB_APP_URL)
         .map_err(|error| Error::operation("build login URL", error.to_string()))?;
-    url.set_path("/auth/");
+    url.set_path("/auth");
     url.query_pairs_mut()
         .append_pair("flow", "desktop")
         .append_pair("scheme", scheme);
@@ -448,7 +448,7 @@ mod tests {
     fn builds_headless_browser_login_url() {
         assert_eq!(
             login_url("anarlog").unwrap().as_str(),
-            "https://anarlog.so/auth/?flow=desktop&scheme=anarlog"
+            "https://anarlog.so/auth?flow=desktop&scheme=anarlog"
         );
     }
 

--- a/apps/cli/src/commands/auth/storage.rs
+++ b/apps/cli/src/commands/auth/storage.rs
@@ -9,6 +9,8 @@ use crate::{Error, Result};
 const SECRET_SERVICE: &str = "com.anarlog.stable.secure-store";
 #[cfg(target_os = "linux")]
 const SECRET_ACCOUNT: &str = "auth:supabase-storage";
+#[cfg(target_os = "linux")]
+const CLI_FALLBACK_FILENAME: &str = "auth.cli.json";
 
 #[derive(Clone, Copy)]
 pub(super) enum Backend {
@@ -62,10 +64,18 @@ impl AuthStore {
                 .join(bundle_id)
                 .join("auth.json"),
         };
+        #[cfg(target_os = "linux")]
+        let use_secret_service = override_path.is_none() && bundle_id == "com.hyprnote.stable";
+        #[cfg(target_os = "linux")]
+        let path = if use_secret_service {
+            path.with_file_name(CLI_FALLBACK_FILENAME)
+        } else {
+            path
+        };
         Ok(Self {
             path,
             #[cfg(target_os = "linux")]
-            use_secret_service: override_path.is_none() && bundle_id == "com.hyprnote.stable",
+            use_secret_service,
         })
     }
 
@@ -85,6 +95,20 @@ impl AuthStore {
     pub(super) fn load(&self) -> Result<LoadedAuth> {
         #[cfg(target_os = "linux")]
         if self.use_secret_service {
+            if let Some(data) = self.read_file()? {
+                if save_secret_service(&data).is_ok() {
+                    self.remove_file()?;
+                    return Ok(LoadedAuth {
+                        data,
+                        backend: Backend::SecretService,
+                    });
+                }
+                return Ok(LoadedAuth {
+                    data,
+                    backend: Backend::File,
+                });
+            }
+
             match load_secret_service() {
                 Ok(Some(data)) => {
                     return Ok(LoadedAuth {
@@ -119,17 +143,22 @@ impl AuthStore {
     pub(super) fn remove_sessions(&self) -> Result<()> {
         #[cfg(target_os = "linux")]
         if self.use_secret_service {
-            match load_secret_service() {
-                Ok(Some(mut data)) => {
-                    data.retain(|key, _| !key.ends_with("-auth-token"));
-                    save_secret_service(&data)
+            let mut loaded = self.load()?;
+            loaded.data.retain(|key, _| !key.ends_with("-auth-token"));
+            match loaded.backend {
+                Backend::SecretService => {
+                    save_secret_service(&loaded.data)
                         .map_err(|reason| Error::operation("clear auth storage", reason))?;
+                    self.remove_file()?;
                 }
-                Ok(None) | Err(SecretReadError::Unavailable) => {}
-                Err(SecretReadError::Invalid(reason)) => {
-                    return Err(Error::operation("read auth storage", reason));
+                Backend::File => {
+                    // An empty file is an intentional tombstone. It prevents a session
+                    // hidden by an unavailable keyring from returning when the desktop
+                    // app can read Secret Service again.
+                    self.write_file(&loaded.data)?;
                 }
             }
+            return Ok(());
         }
 
         if let Some(mut data) = self.read_file()? {

--- a/apps/cli/src/commands/auth/storage.rs
+++ b/apps/cli/src/commands/auth/storage.rs
@@ -132,9 +132,9 @@ impl AuthStore {
 
         #[cfg(target_os = "linux")]
         if self.use_secret_service {
-            if let Some(data) = self.read_file()? {
+            if let Some(data) = self.read_fallback() {
                 if save_secret_service(&data).is_ok() {
-                    self.remove_file()?;
+                    let _ = self.remove_file();
                     return Ok(LoadedAuth {
                         data,
                         backend: Backend::SecretService,
@@ -158,6 +158,11 @@ impl AuthStore {
                     return Err(Error::operation("read auth storage", reason));
                 }
             }
+
+            return Ok(LoadedAuth {
+                data: HashMap::new(),
+                backend: Backend::File,
+            });
         }
 
         Ok(LoadedAuth {
@@ -175,9 +180,18 @@ impl AuthStore {
         }
 
         #[cfg(target_os = "linux")]
-        if self.use_secret_service && save_secret_service(data).is_ok() {
-            self.remove_file()?;
-            return Ok(Backend::SecretService);
+        if self.use_secret_service {
+            // Keep an existing fallback current before updating Secret Service so a
+            // cleanup failure cannot restore the previous session later.
+            let fallback_staged = self.stage_fallback(data)?;
+            if save_secret_service(data).is_ok() {
+                let _ = self.remove_file();
+                return Ok(Backend::SecretService);
+            }
+            if !fallback_staged {
+                self.write_file(data)?;
+            }
+            return Ok(Backend::File);
         }
 
         self.write_file(data)?;
@@ -203,19 +217,7 @@ impl AuthStore {
         if self.use_secret_service {
             let mut loaded = self.load()?;
             loaded.data.retain(|key, _| !key.ends_with("-auth-token"));
-            match loaded.backend {
-                Backend::SecretService => {
-                    save_secret_service(&loaded.data)
-                        .map_err(|reason| Error::operation("clear auth storage", reason))?;
-                    self.remove_file()?;
-                }
-                Backend::File => {
-                    // An empty file is an intentional tombstone. It prevents a session
-                    // hidden by an unavailable keyring from returning when the desktop
-                    // app can read Secret Service again.
-                    self.write_file(&loaded.data)?;
-                }
-            }
+            self.save(&loaded.data)?;
             return Ok(());
         }
 
@@ -241,6 +243,28 @@ impl AuthStore {
             .map_err(|error| Error::operation("read auth storage", error.to_string()))
     }
 
+    #[cfg(any(target_os = "linux", test))]
+    fn read_fallback(&self) -> Option<HashMap<String, String>> {
+        match self.read_file() {
+            Ok(data) => data,
+            Err(_) => {
+                // A malformed fallback has no recoverable state and must not hide a
+                // usable Secret Service session.
+                let _ = self.remove_file();
+                None
+            }
+        }
+    }
+
+    #[cfg(any(target_os = "linux", test))]
+    fn stage_fallback(&self, data: &HashMap<String, String>) -> Result<bool> {
+        if !self.path.is_file() {
+            return Ok(false);
+        }
+        self.write_file(data)?;
+        Ok(true)
+    }
+
     fn write_file(&self, data: &HashMap<String, String>) -> Result<()> {
         let content = serde_json::to_string(data)
             .map_err(|error| Error::operation("serialize auth storage", error.to_string()))?;
@@ -257,22 +281,11 @@ impl AuthStore {
     }
 
     fn remove_file(&self) -> Result<()> {
-        let mut file = match std::fs::OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(&self.path)
-        {
-            Ok(file) => file,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-            Err(error) => return Err(Error::operation("clear auth storage", error.to_string())),
-        };
-        use std::io::Write;
-        file.flush()
-            .map_err(|error| Error::operation("clear auth storage", error.to_string()))?;
-        file.sync_all()
-            .map_err(|error| Error::operation("clear auth storage", error.to_string()))?;
-        std::fs::remove_file(&self.path)
-            .map_err(|error| Error::operation("clear auth storage", error.to_string()))
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(Error::operation("clear auth storage", error.to_string())),
+        }
     }
 }
 
@@ -388,6 +401,34 @@ mod tests {
             store.load().unwrap().data,
             HashMap::from([("unrelated".to_string(), "value".to_string())])
         );
+    }
+
+    #[test]
+    fn corrupt_fallback_is_discarded() {
+        let dir = tempdir().unwrap();
+        let store = AuthStore::at(dir.path().join("auth.cli.json"));
+        std::fs::write(store.path(), "{").unwrap();
+
+        assert!(store.read_fallback().is_none());
+        assert!(!store.path().exists());
+    }
+
+    #[test]
+    fn existing_fallback_is_updated_before_secure_storage() {
+        let dir = tempdir().unwrap();
+        let store = AuthStore::at(dir.path().join("auth.cli.json"));
+        let old_data = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            session_json("old", 100),
+        )]);
+        let new_data = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            session_json("new", 200),
+        )]);
+        store.write_file(&old_data).unwrap();
+
+        assert!(store.stage_fallback(&new_data).unwrap());
+        assert_eq!(store.read_file().unwrap(), Some(new_data));
     }
 
     #[test]

--- a/apps/cli/src/commands/auth/storage.rs
+++ b/apps/cli/src/commands/auth/storage.rs
@@ -1,0 +1,317 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anlg_supabase_auth::session::Session;
+
+use crate::{Error, Result};
+
+#[cfg(target_os = "linux")]
+const SECRET_SERVICE: &str = "com.anarlog.stable.secure-store";
+#[cfg(target_os = "linux")]
+const SECRET_ACCOUNT: &str = "auth:supabase-storage";
+
+#[derive(Clone, Copy)]
+pub(super) enum Backend {
+    #[cfg(target_os = "linux")]
+    SecretService,
+    File,
+}
+
+impl Backend {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            #[cfg(target_os = "linux")]
+            Self::SecretService => "secret_service",
+            Self::File => "file",
+        }
+    }
+}
+
+pub(super) struct LoadedAuth {
+    pub(super) data: HashMap<String, String>,
+    pub(super) backend: Backend,
+}
+
+pub(super) struct AuthStore {
+    path: PathBuf,
+    #[cfg(target_os = "linux")]
+    use_secret_service: bool,
+}
+
+impl AuthStore {
+    pub(super) fn new(bundle_id: &str) -> Result<Self> {
+        let override_path = std::env::var_os("ANARLOG_AUTH_PATH").map(PathBuf::from);
+        if override_path
+            .as_ref()
+            .is_some_and(|path| !path.is_absolute())
+        {
+            return Err(Error::operation(
+                "resolve auth storage",
+                "ANARLOG_AUTH_PATH must be an absolute path",
+            ));
+        }
+        let path = match override_path.as_ref() {
+            Some(path) => path.clone(),
+            None => dirs::data_local_dir()
+                .ok_or_else(|| {
+                    Error::operation(
+                        "resolve auth storage",
+                        "local data directory is unavailable",
+                    )
+                })?
+                .join(bundle_id)
+                .join("auth.json"),
+        };
+        Ok(Self {
+            path,
+            #[cfg(target_os = "linux")]
+            use_secret_service: override_path.is_none() && bundle_id == "com.hyprnote.stable",
+        })
+    }
+
+    #[cfg(test)]
+    fn at(path: PathBuf) -> Self {
+        Self {
+            path,
+            #[cfg(target_os = "linux")]
+            use_secret_service: false,
+        }
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(super) fn load(&self) -> Result<LoadedAuth> {
+        #[cfg(target_os = "linux")]
+        if self.use_secret_service {
+            match load_secret_service() {
+                Ok(Some(data)) => {
+                    return Ok(LoadedAuth {
+                        data,
+                        backend: Backend::SecretService,
+                    });
+                }
+                Ok(None) | Err(SecretReadError::Unavailable) => {}
+                Err(SecretReadError::Invalid(reason)) => {
+                    return Err(Error::operation("read auth storage", reason));
+                }
+            }
+        }
+
+        Ok(LoadedAuth {
+            data: self.read_file()?.unwrap_or_default(),
+            backend: Backend::File,
+        })
+    }
+
+    pub(super) fn save(&self, data: &HashMap<String, String>) -> Result<Backend> {
+        #[cfg(target_os = "linux")]
+        if self.use_secret_service && save_secret_service(data).is_ok() {
+            self.remove_file()?;
+            return Ok(Backend::SecretService);
+        }
+
+        self.write_file(data)?;
+        Ok(Backend::File)
+    }
+
+    pub(super) fn remove_sessions(&self) -> Result<()> {
+        #[cfg(target_os = "linux")]
+        if self.use_secret_service {
+            match load_secret_service() {
+                Ok(Some(mut data)) => {
+                    data.retain(|key, _| !key.ends_with("-auth-token"));
+                    save_secret_service(&data)
+                        .map_err(|reason| Error::operation("clear auth storage", reason))?;
+                }
+                Ok(None) | Err(SecretReadError::Unavailable) => {}
+                Err(SecretReadError::Invalid(reason)) => {
+                    return Err(Error::operation("read auth storage", reason));
+                }
+            }
+        }
+
+        if let Some(mut data) = self.read_file()? {
+            data.retain(|key, _| !key.ends_with("-auth-token"));
+            if data.is_empty() {
+                self.remove_file()?;
+            } else {
+                self.write_file(&data)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn read_file(&self) -> Result<Option<HashMap<String, String>>> {
+        let content = match std::fs::read_to_string(&self.path) {
+            Ok(content) => content,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(Error::operation("read auth storage", error.to_string())),
+        };
+        serde_json::from_str(&content)
+            .map(Some)
+            .map_err(|error| Error::operation("read auth storage", error.to_string()))
+    }
+
+    fn write_file(&self, data: &HashMap<String, String>) -> Result<()> {
+        let content = serde_json::to_string(data)
+            .map_err(|error| Error::operation("serialize auth storage", error.to_string()))?;
+        anlg_storage::fs::atomic_write(&self.path, &content)
+            .map_err(|error| Error::operation("write auth storage", error.to_string()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o600))
+                .map_err(|error| Error::operation("protect auth storage", error.to_string()))?;
+        }
+        Ok(())
+    }
+
+    fn remove_file(&self) -> Result<()> {
+        let mut file = match std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&self.path)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(Error::operation("clear auth storage", error.to_string())),
+        };
+        use std::io::Write;
+        file.flush()
+            .map_err(|error| Error::operation("clear auth storage", error.to_string()))?;
+        file.sync_all()
+            .map_err(|error| Error::operation("clear auth storage", error.to_string()))?;
+        std::fs::remove_file(&self.path)
+            .map_err(|error| Error::operation("clear auth storage", error.to_string()))
+    }
+}
+
+pub(super) fn find_session(data: &HashMap<String, String>) -> Result<Option<Session>> {
+    data.iter()
+        .filter(|(key, _)| key.ends_with("-auth-token"))
+        .map(|(_, value)| {
+            serde_json::from_str::<Session>(value)
+                .map_err(|error| Error::operation("read login", error.to_string()))
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(|sessions| {
+            sessions
+                .into_iter()
+                .max_by_key(|session| session.expires_at.unwrap_or(0))
+        })
+}
+
+#[cfg(target_os = "linux")]
+enum SecretReadError {
+    Unavailable,
+    Invalid(String),
+}
+
+#[cfg(target_os = "linux")]
+fn load_secret_service() -> std::result::Result<Option<HashMap<String, String>>, SecretReadError> {
+    let entry = keyring::Entry::new(SECRET_SERVICE, SECRET_ACCOUNT)
+        .map_err(|_| SecretReadError::Unavailable)?;
+    match entry.get_password() {
+        Ok(value) => serde_json::from_str(&value)
+            .map(Some)
+            .map_err(|error| SecretReadError::Invalid(error.to_string())),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(_) => Err(SecretReadError::Unavailable),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn save_secret_service(data: &HashMap<String, String>) -> std::result::Result<(), String> {
+    let entry =
+        keyring::Entry::new(SECRET_SERVICE, SECRET_ACCOUNT).map_err(|error| error.to_string())?;
+    if data.is_empty() {
+        return match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(error.to_string()),
+        };
+    }
+    let value = serde_json::to_string(data).map_err(|error| error.to_string())?;
+    entry
+        .set_password(&value)
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn session_json(id: &str, expires_at: u64) -> String {
+        serde_json::json!({
+            "access_token": "access",
+            "refresh_token": "refresh",
+            "token_type": "bearer",
+            "expires_at": expires_at,
+            "user": { "id": id, "email": format!("{id}@example.com") }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn file_store_round_trips_desktop_auth_shape() {
+        let dir = tempdir().unwrap();
+        let store = AuthStore::at(dir.path().join("com.hyprnote.stable/auth.json"));
+        let data = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            session_json("user-1", 100),
+        )]);
+
+        assert!(matches!(store.save(&data).unwrap(), Backend::File));
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded.data, data);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(store.path())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn logout_removes_only_auth_sessions() {
+        let dir = tempdir().unwrap();
+        let store = AuthStore::at(dir.path().join("auth.json"));
+        let data = HashMap::from([
+            (
+                "sb-project-auth-token".to_string(),
+                session_json("user-1", 100),
+            ),
+            ("unrelated".to_string(), "value".to_string()),
+        ]);
+        store.save(&data).unwrap();
+
+        store.remove_sessions().unwrap();
+
+        assert_eq!(
+            store.load().unwrap().data,
+            HashMap::from([("unrelated".to_string(), "value".to_string())])
+        );
+    }
+
+    #[test]
+    fn finds_the_newest_desktop_session() {
+        let data = HashMap::from([
+            ("sb-old-auth-token".to_string(), session_json("old", 100)),
+            ("sb-new-auth-token".to_string(), session_json("new", 200)),
+        ]);
+
+        let session = find_session(&data).unwrap().unwrap();
+
+        assert_eq!(session.user.unwrap().id, "new");
+    }
+}

--- a/apps/cli/src/commands/auth/storage.rs
+++ b/apps/cli/src/commands/auth/storage.rs
@@ -36,6 +36,8 @@ impl Backend {
 pub(super) struct LoadedAuth {
     pub(super) data: HashMap<String, String>,
     pub(super) backend: Backend,
+    #[cfg(any(target_os = "linux", test))]
+    source_is_authoritative: bool,
 }
 
 pub(super) struct AuthStore {
@@ -127,6 +129,8 @@ impl AuthStore {
             return Ok(LoadedAuth {
                 data,
                 backend: Backend::WindowsDataProtection,
+                #[cfg(any(target_os = "linux", test))]
+                source_is_authoritative: true,
             });
         }
 
@@ -138,36 +142,47 @@ impl AuthStore {
                     return Ok(LoadedAuth {
                         data,
                         backend: Backend::SecretService,
+                        #[cfg(any(target_os = "linux", test))]
+                        source_is_authoritative: true,
                     });
                 }
                 return Ok(LoadedAuth {
                     data,
                     backend: Backend::File,
+                    #[cfg(any(target_os = "linux", test))]
+                    source_is_authoritative: true,
                 });
             }
 
-            match load_secret_service() {
+            let source_is_authoritative = match load_secret_service() {
                 Ok(Some(data)) => {
                     return Ok(LoadedAuth {
                         data,
                         backend: Backend::SecretService,
+                        #[cfg(any(target_os = "linux", test))]
+                        source_is_authoritative: true,
                     });
                 }
-                Ok(None) | Err(SecretReadError::Unavailable) => {}
+                Ok(None) => true,
+                Err(SecretReadError::Unavailable) => false,
                 Err(SecretReadError::Invalid(reason)) => {
                     return Err(Error::operation("read auth storage", reason));
                 }
-            }
+            };
 
             return Ok(LoadedAuth {
                 data: HashMap::new(),
                 backend: Backend::File,
+                #[cfg(any(target_os = "linux", test))]
+                source_is_authoritative,
             });
         }
 
         Ok(LoadedAuth {
             data: self.read_file()?.unwrap_or_default(),
             backend: Backend::File,
+            #[cfg(any(target_os = "linux", test))]
+            source_is_authoritative: true,
         })
     }
 
@@ -215,10 +230,7 @@ impl AuthStore {
 
         #[cfg(target_os = "linux")]
         if self.use_secret_service {
-            let mut loaded = self.load()?;
-            loaded.data.retain(|key, _| !key.ends_with("-auth-token"));
-            self.save(&loaded.data)?;
-            return Ok(());
+            return self.remove_loaded_sessions(self.load()?);
         }
 
         if let Some(mut data) = self.read_file()? {
@@ -229,6 +241,16 @@ impl AuthStore {
                 self.write_file(&data)?;
             }
         }
+        Ok(())
+    }
+
+    #[cfg(any(target_os = "linux", test))]
+    fn remove_loaded_sessions(&self, mut loaded: LoadedAuth) -> Result<()> {
+        if !loaded.source_is_authoritative {
+            return Ok(());
+        }
+        loaded.data.retain(|key, _| !key.ends_with("-auth-token"));
+        self.save(&loaded.data)?;
         Ok(())
     }
 
@@ -429,6 +451,21 @@ mod tests {
 
         assert!(store.stage_fallback(&new_data).unwrap());
         assert_eq!(store.read_file().unwrap(), Some(new_data));
+    }
+
+    #[test]
+    fn logout_without_authoritative_state_does_not_create_fallback() {
+        let dir = tempdir().unwrap();
+        let store = AuthStore::at(dir.path().join("auth.cli.json"));
+        let loaded = LoadedAuth {
+            data: HashMap::new(),
+            backend: Backend::File,
+            source_is_authoritative: false,
+        };
+
+        store.remove_loaded_sessions(loaded).unwrap();
+
+        assert!(!store.path().exists());
     }
 
     #[test]

--- a/apps/cli/src/commands/auth/storage.rs
+++ b/apps/cli/src/commands/auth/storage.rs
@@ -16,6 +16,8 @@ const CLI_FALLBACK_FILENAME: &str = "auth.cli.json";
 pub(super) enum Backend {
     #[cfg(target_os = "linux")]
     SecretService,
+    #[cfg(target_os = "windows")]
+    WindowsDataProtection,
     File,
 }
 
@@ -24,6 +26,8 @@ impl Backend {
         match self {
             #[cfg(target_os = "linux")]
             Self::SecretService => "secret_service",
+            #[cfg(target_os = "windows")]
+            Self::WindowsDataProtection => "windows_data_protection",
             Self::File => "file",
         }
     }
@@ -38,6 +42,8 @@ pub(super) struct AuthStore {
     path: PathBuf,
     #[cfg(target_os = "linux")]
     use_secret_service: bool,
+    #[cfg(target_os = "windows")]
+    use_windows_data_protection: bool,
 }
 
 impl AuthStore {
@@ -72,10 +78,20 @@ impl AuthStore {
         } else {
             path
         };
+        #[cfg(target_os = "windows")]
+        let use_windows_data_protection = override_path.is_none();
+        #[cfg(target_os = "windows")]
+        let path = if use_windows_data_protection {
+            anlg_storage::windows_auth::secure_path(&path)
+        } else {
+            path
+        };
         Ok(Self {
             path,
             #[cfg(target_os = "linux")]
             use_secret_service,
+            #[cfg(target_os = "windows")]
+            use_windows_data_protection,
         })
     }
 
@@ -85,6 +101,8 @@ impl AuthStore {
             path,
             #[cfg(target_os = "linux")]
             use_secret_service: false,
+            #[cfg(target_os = "windows")]
+            use_windows_data_protection: false,
         }
     }
 
@@ -93,6 +111,25 @@ impl AuthStore {
     }
 
     pub(super) fn load(&self) -> Result<LoadedAuth> {
+        #[cfg(target_os = "windows")]
+        if self.use_windows_data_protection {
+            let data = match anlg_storage::windows_auth::load(&self.path) {
+                Ok(data) => data,
+                Err(anlg_storage::Error::Io(error))
+                    if error.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    HashMap::new()
+                }
+                Err(error) => {
+                    return Err(Error::operation("read auth storage", error.to_string()));
+                }
+            };
+            return Ok(LoadedAuth {
+                data,
+                backend: Backend::WindowsDataProtection,
+            });
+        }
+
         #[cfg(target_os = "linux")]
         if self.use_secret_service {
             if let Some(data) = self.read_file()? {
@@ -130,6 +167,13 @@ impl AuthStore {
     }
 
     pub(super) fn save(&self, data: &HashMap<String, String>) -> Result<Backend> {
+        #[cfg(target_os = "windows")]
+        if self.use_windows_data_protection {
+            anlg_storage::windows_auth::persist(&self.path, data)
+                .map_err(|error| Error::operation("write auth storage", error.to_string()))?;
+            return Ok(Backend::WindowsDataProtection);
+        }
+
         #[cfg(target_os = "linux")]
         if self.use_secret_service && save_secret_service(data).is_ok() {
             self.remove_file()?;
@@ -141,6 +185,20 @@ impl AuthStore {
     }
 
     pub(super) fn remove_sessions(&self) -> Result<()> {
+        #[cfg(target_os = "windows")]
+        if self.use_windows_data_protection {
+            let mut loaded = self.load()?;
+            loaded.data.retain(|key, _| !key.ends_with("-auth-token"));
+            if loaded.data.is_empty() {
+                anlg_storage::windows_auth::clear(&self.path)
+                    .map_err(|error| Error::operation("clear auth storage", error.to_string()))?;
+            } else {
+                anlg_storage::windows_auth::persist(&self.path, &loaded.data)
+                    .map_err(|error| Error::operation("clear auth storage", error.to_string()))?;
+            }
+            return Ok(());
+        }
+
         #[cfg(target_os = "linux")]
         if self.use_secret_service {
             let mut loaded = self.load()?;
@@ -342,5 +400,30 @@ mod tests {
         let session = find_session(&data).unwrap().unwrap();
 
         assert_eq!(session.user.unwrap().id, "new");
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_store_round_trips_desktop_dpapi_format() {
+        let dir = tempdir().unwrap();
+        let store = AuthStore {
+            path: dir.path().join("auth.dpapi"),
+            use_windows_data_protection: true,
+        };
+        let data = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            session_json("user-1", 100),
+        )]);
+
+        assert!(matches!(
+            store.save(&data).unwrap(),
+            Backend::WindowsDataProtection
+        ));
+        assert_eq!(store.load().unwrap().data, data);
+        assert!(
+            !std::fs::read_to_string(store.path())
+                .unwrap()
+                .contains("access_token")
+        );
     }
 }

--- a/apps/cli/src/commands/mod.rs
+++ b/apps/cli/src/commands/mod.rs
@@ -1,2 +1,3 @@
+pub mod auth;
 pub mod doctor;
 pub mod meetings;

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -12,6 +12,11 @@ pub use error::{Error, Result};
 pub use output::JSON_SCHEMA_VERSION;
 
 pub async fn run(args: Args) -> Result<u8> {
+    if let cli::Command::Auth { command } = &args.command {
+        commands::auth::run(command, args.json).await?;
+        return Ok(0);
+    }
+
     if matches!(&args.command, cli::Command::Doctor) {
         let ready = commands::doctor::run(&args, args.json).await?;
         return Ok(if ready { 0 } else { 1 });
@@ -20,6 +25,7 @@ pub async fn run(args: Args) -> Result<u8> {
     let db = std::sync::Arc::new(db::open(&args).await?);
 
     match args.command {
+        cli::Command::Auth { .. } => unreachable!("auth returns before opening the database"),
         cli::Command::Doctor => unreachable!("doctor returns before opening the database"),
         cli::Command::Meetings { command } => {
             commands::meetings::run(db.as_ref(), command, args.json).await?

--- a/apps/cli/src/snapshots/anarlog_cli__cli__tests__cli_contract.snap
+++ b/apps/cli/src/snapshots/anarlog_cli__cli__tests__cli_contract.snap
@@ -1,9 +1,9 @@
 ---
 source: apps/cli/src/cli.rs
-expression: contract
+expression: canonicalize_json(contract)
 ---
 {
-  "about": "Query local Anarlog meeting data",
+  "about": "Access Anarlog from the command line",
   "global_options": [
     {
       "flags": "--base",
@@ -39,6 +39,60 @@ expression: contract
     }
   ],
   "subcommands": [
+    {
+      "about": "Sign in to an Anarlog account from a browser",
+      "name": "anarlog auth",
+      "options": [
+        {
+          "flags": "-h, --help",
+          "help": "Print help",
+          "is_flag": false,
+          "required": false
+        }
+      ],
+      "subcommands": [
+        {
+          "about": "Sign in through a browser on this or another device",
+          "name": "anarlog auth login",
+          "options": [
+            {
+              "flags": "-h, --help",
+              "help": "Print help",
+              "is_flag": false,
+              "required": false
+            }
+          ],
+          "synopsis": "anarlog auth login [-h]"
+        },
+        {
+          "about": "Show the locally stored account session",
+          "name": "anarlog auth status",
+          "options": [
+            {
+              "flags": "-h, --help",
+              "help": "Print help",
+              "is_flag": false,
+              "required": false
+            }
+          ],
+          "synopsis": "anarlog auth status [-h]"
+        },
+        {
+          "about": "Remove the locally stored account session",
+          "name": "anarlog auth logout",
+          "options": [
+            {
+              "flags": "-h, --help",
+              "help": "Print help",
+              "is_flag": false,
+              "required": false
+            }
+          ],
+          "synopsis": "anarlog auth logout [-h]"
+        }
+      ],
+      "synopsis": "anarlog auth [-h] <command>"
+    },
     {
       "about": "Check the local CLI and database connection without changing data",
       "name": "anarlog doctor",

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -8,6 +8,7 @@ default = []
 specta = ["dep:specta"]
 
 [dependencies]
+base64 = { workspace = true }
 dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -16,6 +17,9 @@ specta = { workspace = true, optional = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { workspace = true, features = ["Win32_Foundation", "Win32_Security_Cryptography"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -18,4 +18,6 @@ pub enum Error {
     VaultBaseIsSubdirectory,
     #[error("cannot move vault to a parent directory of the current location")]
     VaultBaseIsParent,
+    #[error("{0}")]
+    SecureStorage(String),
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -4,6 +4,7 @@ pub mod global;
 pub mod obsidian;
 mod runtime;
 pub mod vault;
+pub mod windows_auth;
 
 pub use error::*;
 pub use obsidian::ObsidianVault;

--- a/crates/storage/src/windows_auth.rs
+++ b/crates/storage/src/windows_auth.rs
@@ -1,0 +1,281 @@
+use std::path::{Path, PathBuf};
+
+#[cfg(any(target_os = "windows", test))]
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+#[cfg(any(target_os = "windows", test))]
+use std::collections::HashMap;
+
+const FILENAME: &str = "auth.dpapi";
+#[cfg(any(target_os = "windows", test))]
+const FORMAT_PREFIX: &str = "anarlog-auth-dpapi-v1:";
+
+pub fn secure_path(plaintext_path: &Path) -> PathBuf {
+    plaintext_path.with_file_name(FILENAME)
+}
+
+#[cfg(target_os = "windows")]
+pub fn load(path: &Path) -> Result<HashMap<String, String>, crate::Error> {
+    load_with(path, unprotect)
+}
+
+#[cfg(target_os = "windows")]
+pub fn persist(path: &Path, auth: &HashMap<String, String>) -> Result<(), crate::Error> {
+    persist_with(path, auth, protect, unprotect)
+}
+
+#[cfg(target_os = "windows")]
+pub fn clear(path: &Path) -> Result<(), crate::Error> {
+    if !path.is_file() {
+        return Ok(());
+    }
+
+    let overwrite_result = persist(path, &HashMap::new());
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(remove_error) => {
+            overwrite_result?;
+            Err(remove_error.into())
+        }
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn persist_with(
+    path: &Path,
+    auth: &HashMap<String, String>,
+    protect: impl Fn(&[u8]) -> Result<Vec<u8>, crate::Error>,
+    unprotect: impl Fn(&[u8]) -> Result<Vec<u8>, crate::Error>,
+) -> Result<(), crate::Error> {
+    let plaintext = serde_json::to_vec(auth)?;
+    let protected = protect(&plaintext)?;
+    let encoded = format!("{FORMAT_PREFIX}{}", STANDARD.encode(protected));
+    let previous = match std::fs::read_to_string(path) {
+        Ok(previous) => Some(previous),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
+    crate::fs::atomic_write(path, &encoded)?;
+
+    let verified = load_with(path, unprotect)
+        .map(|persisted| persisted == *auth)
+        .unwrap_or(false);
+    if !verified {
+        match previous {
+            Some(previous) => crate::fs::atomic_write(path, &previous)?,
+            None => match std::fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            },
+        }
+        return Err(crate::Error::SecureStorage(
+            "Windows encrypted auth verification failed".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn load_with(
+    path: &Path,
+    unprotect: impl Fn(&[u8]) -> Result<Vec<u8>, crate::Error>,
+) -> Result<HashMap<String, String>, crate::Error> {
+    let encoded = std::fs::read_to_string(path)?;
+    let protected = encoded.strip_prefix(FORMAT_PREFIX).ok_or_else(|| {
+        crate::Error::SecureStorage("unsupported Windows auth format".to_string())
+    })?;
+    let protected = STANDARD
+        .decode(protected)
+        .map_err(|_| crate::Error::SecureStorage("invalid Windows auth encoding".to_string()))?;
+    let plaintext = unprotect(&protected)?;
+    Ok(serde_json::from_slice(&plaintext)?)
+}
+
+#[cfg(target_os = "windows")]
+fn protect(data: &[u8]) -> Result<Vec<u8>, crate::Error> {
+    use windows::Win32::Security::Cryptography::{
+        CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptProtectData,
+    };
+    use windows::core::PCWSTR;
+
+    let input_len = u32::try_from(data.len()).map_err(|_| {
+        crate::Error::SecureStorage("Windows auth payload is too large".to_string())
+    })?;
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: input_len,
+        pbData: data.as_ptr().cast_mut(),
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+
+    unsafe {
+        CryptProtectData(
+            &input,
+            PCWSTR::null(),
+            None,
+            None,
+            None,
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+        .map_err(data_protection_error)?;
+    }
+
+    Ok(copy_and_free(output, false))
+}
+
+#[cfg(target_os = "windows")]
+fn unprotect(data: &[u8]) -> Result<Vec<u8>, crate::Error> {
+    use windows::Win32::Security::Cryptography::{
+        CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptUnprotectData,
+    };
+
+    let input_len = u32::try_from(data.len()).map_err(|_| {
+        crate::Error::SecureStorage("Windows auth payload is too large".to_string())
+    })?;
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: input_len,
+        pbData: data.as_ptr().cast_mut(),
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+
+    unsafe {
+        CryptUnprotectData(
+            &input,
+            None,
+            None,
+            None,
+            None,
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut output,
+        )
+        .map_err(data_protection_error)?;
+    }
+
+    Ok(copy_and_free(output, true))
+}
+
+#[cfg(target_os = "windows")]
+fn copy_and_free(
+    output: windows::Win32::Security::Cryptography::CRYPT_INTEGER_BLOB,
+    clear_source: bool,
+) -> Vec<u8> {
+    use windows::Win32::Foundation::{HLOCAL, LocalFree};
+
+    if output.pbData.is_null() || output.cbData == 0 {
+        if !output.pbData.is_null() {
+            unsafe {
+                LocalFree(Some(HLOCAL(output.pbData.cast())));
+            }
+        }
+        return Vec::new();
+    }
+
+    let bytes =
+        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize) }.to_vec();
+    if clear_source {
+        unsafe {
+            std::ptr::write_bytes(output.pbData, 0, output.cbData as usize);
+        }
+    }
+    unsafe {
+        LocalFree(Some(HLOCAL(output.pbData.cast())));
+    }
+    bytes
+}
+
+#[cfg(target_os = "windows")]
+fn data_protection_error(error: windows::core::Error) -> crate::Error {
+    crate::Error::SecureStorage(format!(
+        "Windows data protection failed ({:#010X})",
+        error.code().0
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn xor(data: &[u8]) -> Result<Vec<u8>, crate::Error> {
+        Ok(data.iter().map(|byte| byte ^ 0xa5).collect())
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn dpapi_protects_and_round_trips_for_current_user() {
+        let plaintext = b"anarlog-windows-dpapi-round-trip";
+
+        let protected = protect(plaintext).unwrap();
+
+        assert_ne!(protected, plaintext);
+        assert_eq!(unprotect(&protected).unwrap(), plaintext);
+    }
+
+    #[test]
+    fn encrypted_auth_round_trips_sessions_larger_than_credential_manager_limit() {
+        let temp = tempdir().unwrap();
+        let secure_path = temp.path().join(FILENAME);
+        let auth = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            format!(r#"{{"access_token":"{}"}}"#, "token".repeat(2_000)),
+        )]);
+
+        persist_with(&secure_path, &auth, xor, xor).unwrap();
+
+        assert_eq!(load_with(&secure_path, xor).unwrap(), auth);
+        assert!(
+            !std::fs::read_to_string(secure_path)
+                .unwrap()
+                .contains("access_token")
+        );
+    }
+
+    #[test]
+    fn failed_verification_does_not_leave_a_new_secure_file() {
+        let temp = tempdir().unwrap();
+        let secure_path = temp.path().join(FILENAME);
+        let auth = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            r#"{"access_token":"secret"}"#.to_string(),
+        )]);
+
+        let result = persist_with(&secure_path, &auth, xor, |_| {
+            Err(crate::Error::SecureStorage("unavailable".to_string()))
+        });
+
+        assert!(result.is_err());
+        assert!(!secure_path.exists());
+    }
+
+    #[test]
+    fn failed_verification_restores_previous_secure_file() {
+        let temp = tempdir().unwrap();
+        let secure_path = temp.path().join(FILENAME);
+        let first = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            r#"{"access_token":"first"}"#.to_string(),
+        )]);
+        let second = HashMap::from([(
+            "sb-project-auth-token".to_string(),
+            r#"{"access_token":"second"}"#.to_string(),
+        )]);
+        persist_with(&secure_path, &first, xor, xor).unwrap();
+
+        let result = persist_with(&secure_path, &second, xor, |_| {
+            Err(crate::Error::SecureStorage("unavailable".to_string()))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(load_with(&secure_path, xor).unwrap(), first);
+    }
+
+    #[test]
+    fn rejects_unversioned_encrypted_auth() {
+        let temp = tempdir().unwrap();
+        let secure_path = temp.path().join(FILENAME);
+        std::fs::write(&secure_path, STANDARD.encode(b"ciphertext")).unwrap();
+
+        assert!(load_with(&secure_path, xor).is_err());
+    }
+}

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -17,6 +17,22 @@ anarlog [--base DIR] [--db-path FILE] [--json] <command>
 
 `--db-path` takes precedence over `--base`. Without either option, the CLI uses Anarlog's platform application-data directory and recognized legacy locations.
 
+The Linux desktop package exposes the bundled command as `anarlog-cli`. Substitute `anarlog-cli` for `anarlog` in the examples below when using that package.
+
+## Account commands
+
+```bash
+anarlog auth login
+anarlog auth status
+anarlog auth logout
+```
+
+`auth login` prints a URL that can be opened in any browser, including one on another device. Sign in, choose **Copy URL** on the completion page, then paste the `anarlog://auth/callback` link into the hidden CLI prompt. The CLI verifies the session with Anarlog before saving it in the same local auth store as the desktop app.
+
+On Linux, the CLI uses Secret Service when it is available. Headless systems without Secret Service fall back to `auth.json` in Anarlog's local application-data directory with permissions limited to the current user. `auth logout` removes the local session; it does not delete the Anarlog account.
+
+`auth status` reports the signed-in account and whether the current access token has expired. The stored refresh token lets the desktop app refresh an expired access token when it starts.
+
 ## Meeting commands
 
 | Command | Options | Result |
@@ -61,6 +77,7 @@ Starts the read-only MCP server over stdio. Do not write other output to the ser
 
 ```bash
 anarlog --help
+anarlog auth --help
 anarlog meetings --help
 anarlog meetings list --help
 anarlog --version

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -29,7 +29,7 @@ anarlog auth logout
 
 `auth login` prints a URL that can be opened in any browser, including one on another device. Sign in, choose **Copy URL** on the completion page, then paste the `anarlog://auth/callback` link into the hidden CLI prompt. The CLI verifies the session with Anarlog before saving it in the same local auth store as the desktop app.
 
-On Linux, the CLI uses Secret Service when it is available. Headless systems without Secret Service fall back to `auth.json` in Anarlog's local application-data directory with permissions limited to the current user. `auth logout` removes the local session; it does not delete the Anarlog account.
+On Linux, the CLI uses Secret Service when it is available. Headless systems without Secret Service fall back to `auth.cli.json` in Anarlog's local application-data directory with permissions limited to the current user. The desktop app reconciles that file into Secret Service when it becomes available. `auth logout` removes the local session; it does not delete the Anarlog account.
 
 `auth status` reports the signed-in account and whether the current access token has expired. The stored refresh token lets the desktop app refresh an expired access token when it starts.
 

--- a/plugins/auth/Cargo.toml
+++ b/plugins/auth/Cargo.toml
@@ -17,7 +17,6 @@ tempfile = { workspace = true }
 [dependencies]
 anlg-storage = { workspace = true }
 anlg-supabase-auth = { workspace = true, features = ["client"] }
-base64 = { workspace = true }
 tauri-plugin-settings = { workspace = true }
 tauri-plugin-store2 = { workspace = true }
 
@@ -31,6 +30,3 @@ strum = { workspace = true, features = ["derive"] }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-windows = { workspace = true, features = ["Win32_Foundation", "Win32_Security_Cryptography"] }

--- a/plugins/auth/src/lib.rs
+++ b/plugins/auth/src/lib.rs
@@ -2,7 +2,7 @@ mod commands;
 mod error;
 mod ext;
 mod migrate;
-#[cfg(any(target_os = "windows", test))]
+#[cfg(target_os = "windows")]
 mod windows;
 
 // Tauri unit tests bypass the application manifest while still importing

--- a/plugins/auth/src/migrate.rs
+++ b/plugins/auth/src/migrate.rs
@@ -6,6 +6,8 @@ use tauri::Manager;
 use crate::PLUGIN_NAME;
 
 const FILENAME: &str = "auth.json";
+#[cfg(any(target_os = "linux", test))]
+const CLI_FALLBACK_FILENAME: &str = "auth.cli.json";
 
 pub(crate) fn auth_path<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> crate::Result<PathBuf> {
     let new_auth_path = new_auth_path(app)?;
@@ -29,6 +31,7 @@ pub(crate) fn load_linux_auth<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
 ) -> crate::Result<HashMap<String, String>> {
     let auth_path = auth_path(app)?;
+    let cli_fallback_path = cli_fallback_auth_path(&auth_path);
 
     // A locked or unavailable keyring must not abort plugin setup, otherwise the app
     // cannot start and the plaintext session can never be migrated. `Ok(None)` means
@@ -43,6 +46,23 @@ pub(crate) fn load_linux_auth<R: tauri::Runtime>(
             None
         }
     };
+
+    if cli_fallback_path.is_file() {
+        match read_auth_file(&cli_fallback_path) {
+            Ok(auth) => {
+                if keyring_readable {
+                    if let Err(error) = persist_linux_auth(app, &auth) {
+                        tracing::warn!(%error, "failed_to_reconcile_cli_auth_with_secret_service");
+                    }
+                }
+                return Ok(auth);
+            }
+            Err(error) => {
+                tracing::warn!(%error, "ignoring_unreadable_cli_auth_fallback");
+                discard_plaintext_auth(&cli_fallback_path);
+            }
+        }
+    }
 
     if let Some(data) = secure_data {
         match serde_json::from_str::<HashMap<String, String>>(&data) {
@@ -61,10 +81,7 @@ pub(crate) fn load_linux_auth<R: tauri::Runtime>(
         return Ok(HashMap::new());
     }
 
-    let auth = match std::fs::read_to_string(&auth_path)
-        .map_err(crate::Error::Io)
-        .and_then(|data| Ok(serde_json::from_str::<HashMap<String, String>>(&data)?))
-    {
+    let auth = match read_auth_file(&auth_path) {
         Ok(auth) => auth,
         Err(error) => {
             // Matches the keyring path: a corrupt or truncated auth.json costs the
@@ -109,9 +126,10 @@ pub(crate) fn persist_linux_auth<R: tauri::Runtime>(
 
 #[cfg(all(target_os = "linux", not(test)))]
 pub(crate) fn clear_linux_auth<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> crate::Result<()> {
-    drop_plaintext_auth_for(app);
     tauri_plugin_store2::delete_secret_blocking(app, AUTH_SCOPE, AUTH_KEY)
-        .map_err(crate::Error::Storage)
+        .map_err(crate::Error::Storage)?;
+    drop_plaintext_auth_for(app);
+    Ok(())
 }
 
 // The keyring is authoritative once it has been written or cleared, so a plaintext
@@ -120,9 +138,23 @@ pub(crate) fn clear_linux_auth<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> 
 #[cfg(all(target_os = "linux", not(test)))]
 fn drop_plaintext_auth_for<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     match auth_path(app) {
-        Ok(path) => discard_plaintext_auth(&path),
+        Ok(path) => {
+            discard_plaintext_auth(&path);
+            discard_plaintext_auth(&cli_fallback_auth_path(&path));
+        }
         Err(error) => tracing::warn!(%error, "failed_to_resolve_auth_path"),
     }
+}
+
+#[cfg(all(target_os = "linux", not(test)))]
+fn read_auth_file(path: &Path) -> crate::Result<HashMap<String, String>> {
+    let data = std::fs::read_to_string(path).map_err(crate::Error::Io)?;
+    Ok(serde_json::from_str(&data)?)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn cli_fallback_auth_path(auth_path: &Path) -> PathBuf {
+    auth_path.with_file_name(CLI_FALLBACK_FILENAME)
 }
 
 // A leftover auth.json is less harmful than refusing a session the secure store
@@ -517,6 +549,16 @@ mod test {
 
         assert!(!auth_path.exists());
         assert_eq!(std::fs::read(&surviving_link).unwrap(), b"");
+    }
+
+    #[test]
+    fn cli_fallback_is_distinct_from_legacy_plaintext_auth() {
+        let auth_path = Path::new("/data/com.hyprnote.stable/auth.json");
+
+        assert_eq!(
+            cli_fallback_auth_path(auth_path),
+            Path::new("/data/com.hyprnote.stable/auth.cli.json")
+        );
     }
 
     #[test]

--- a/plugins/auth/src/migrate.rs
+++ b/plugins/auth/src/migrate.rs
@@ -159,7 +159,7 @@ fn cli_fallback_auth_path(auth_path: &Path) -> PathBuf {
 
 // A leftover auth.json is less harmful than refusing a session the secure store
 // already holds, so cleanup failures are reported rather than propagated.
-#[cfg(any(all(target_os = "linux", not(test)), target_os = "windows", test))]
+#[cfg(any(all(target_os = "linux", not(test)), target_os = "windows"))]
 pub(crate) fn discard_plaintext_auth(path: &Path) {
     if let Err(error) = remove_plaintext_auth(path) {
         tracing::warn!(
@@ -196,7 +196,9 @@ fn new_auth_path<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> std::io::Resul
 pub(crate) fn windows_secure_auth_path<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
 ) -> std::io::Result<PathBuf> {
-    Ok(new_auth_path(app)?.with_file_name("auth.dpapi"))
+    Ok(anlg_storage::windows_auth::secure_path(&new_auth_path(
+        app,
+    )?))
 }
 
 fn legacy_auth_path<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> std::io::Result<PathBuf> {

--- a/plugins/auth/src/windows.rs
+++ b/plugins/auth/src/windows.rs
@@ -1,10 +1,6 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use base64::{Engine as _, engine::general_purpose::STANDARD};
-
-const FORMAT_PREFIX: &str = "anarlog-auth-dpapi-v1:";
-
 #[cfg(target_os = "windows")]
 pub(crate) fn load_auth<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
@@ -13,7 +9,7 @@ pub(crate) fn load_auth<R: tauri::Runtime>(
     let secure_path = crate::migrate::windows_secure_auth_path(app)?;
 
     if secure_path.is_file() {
-        let auth = match load_auth_file(&secure_path, unprotect) {
+        let auth = match anlg_storage::windows_auth::load(&secure_path) {
             Ok(auth) => auth,
             Err(error) => {
                 tracing::warn!(%error, "ignoring_unreadable_windows_auth");
@@ -37,7 +33,7 @@ pub(crate) fn load_auth<R: tauri::Runtime>(
         }
     };
 
-    if let Err(error) = persist_auth_file(&secure_path, &auth, protect, unprotect) {
+    if let Err(error) = anlg_storage::windows_auth::persist(&secure_path, &auth) {
         tracing::warn!(%error, "failed_to_migrate_auth_to_windows_data_protection");
         return Ok(auth);
     }
@@ -52,7 +48,8 @@ pub(crate) fn persist_auth<R: tauri::Runtime>(
     auth: &HashMap<String, String>,
 ) -> crate::Result<()> {
     let secure_path = crate::migrate::windows_secure_auth_path(app)?;
-    persist_auth_file(&secure_path, auth, protect, unprotect)?;
+    anlg_storage::windows_auth::persist(&secure_path, auth)
+        .map_err(|error| crate::Error::Storage(error.to_string()))?;
     crate::migrate::discard_windows_plaintext_auth(app);
     Ok(())
 }
@@ -61,299 +58,10 @@ pub(crate) fn persist_auth<R: tauri::Runtime>(
 pub(crate) fn clear_auth<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> crate::Result<()> {
     let secure_path = crate::migrate::windows_secure_auth_path(app)?;
     crate::migrate::discard_windows_plaintext_auth(app);
-
-    if !secure_path.is_file() {
-        return Ok(());
-    }
-
-    let overwrite_result = persist_auth_file(&secure_path, &HashMap::new(), protect, unprotect);
-    match std::fs::remove_file(&secure_path) {
-        Ok(()) => Ok(()),
-        Err(remove_error) => {
-            overwrite_result?;
-            Err(remove_error.into())
-        }
-    }
+    anlg_storage::windows_auth::clear(&secure_path)
+        .map_err(|error| crate::Error::Storage(error.to_string()))
 }
 
 fn read_plaintext_auth(path: &Path) -> crate::Result<HashMap<String, String>> {
     Ok(serde_json::from_str(&std::fs::read_to_string(path)?)?)
-}
-
-fn persist_auth_file(
-    path: &Path,
-    auth: &HashMap<String, String>,
-    protect: impl Fn(&[u8]) -> crate::Result<Vec<u8>>,
-    unprotect: impl Fn(&[u8]) -> crate::Result<Vec<u8>>,
-) -> crate::Result<()> {
-    let plaintext = serde_json::to_vec(auth)?;
-    let protected = protect(&plaintext)?;
-    let encoded = format!("{FORMAT_PREFIX}{}", STANDARD.encode(protected));
-    let previous = match std::fs::read_to_string(path) {
-        Ok(previous) => Some(previous),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-        Err(error) => return Err(error.into()),
-    };
-    anlg_storage::fs::atomic_write(path, &encoded)?;
-
-    let verified = load_auth_file(path, unprotect)
-        .map(|persisted| persisted == *auth)
-        .unwrap_or(false);
-    if !verified {
-        match previous {
-            Some(previous) => anlg_storage::fs::atomic_write(path, &previous)?,
-            None => match std::fs::remove_file(path) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => return Err(error.into()),
-            },
-        }
-        return Err(crate::Error::Storage(
-            "Windows encrypted auth verification failed".to_string(),
-        ));
-    }
-
-    Ok(())
-}
-
-fn load_auth_file(
-    path: &Path,
-    unprotect: impl Fn(&[u8]) -> crate::Result<Vec<u8>>,
-) -> crate::Result<HashMap<String, String>> {
-    let encoded = std::fs::read_to_string(path)?;
-    let protected = encoded
-        .strip_prefix(FORMAT_PREFIX)
-        .ok_or_else(|| crate::Error::Storage("unsupported Windows auth format".to_string()))?;
-    let protected = STANDARD
-        .decode(protected)
-        .map_err(|_| crate::Error::Storage("invalid Windows auth encoding".to_string()))?;
-    let plaintext = unprotect(&protected)?;
-    Ok(serde_json::from_slice(&plaintext)?)
-}
-
-#[cfg(target_os = "windows")]
-fn protect(data: &[u8]) -> crate::Result<Vec<u8>> {
-    use windows::Win32::Security::Cryptography::{
-        CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptProtectData,
-    };
-    use windows::core::PCWSTR;
-
-    let input_len = u32::try_from(data.len())
-        .map_err(|_| crate::Error::Storage("Windows auth payload is too large".to_string()))?;
-    let input = CRYPT_INTEGER_BLOB {
-        cbData: input_len,
-        pbData: data.as_ptr().cast_mut(),
-    };
-    let mut output = CRYPT_INTEGER_BLOB::default();
-
-    unsafe {
-        CryptProtectData(
-            &input,
-            PCWSTR::null(),
-            None,
-            None,
-            None,
-            CRYPTPROTECT_UI_FORBIDDEN,
-            &mut output,
-        )
-        .map_err(data_protection_error)?;
-    }
-
-    Ok(copy_and_free(output, false))
-}
-
-#[cfg(target_os = "windows")]
-fn unprotect(data: &[u8]) -> crate::Result<Vec<u8>> {
-    use windows::Win32::Security::Cryptography::{
-        CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptUnprotectData,
-    };
-
-    let input_len = u32::try_from(data.len())
-        .map_err(|_| crate::Error::Storage("Windows auth payload is too large".to_string()))?;
-    let input = CRYPT_INTEGER_BLOB {
-        cbData: input_len,
-        pbData: data.as_ptr().cast_mut(),
-    };
-    let mut output = CRYPT_INTEGER_BLOB::default();
-
-    unsafe {
-        CryptUnprotectData(
-            &input,
-            None,
-            None,
-            None,
-            None,
-            CRYPTPROTECT_UI_FORBIDDEN,
-            &mut output,
-        )
-        .map_err(data_protection_error)?;
-    }
-
-    Ok(copy_and_free(output, true))
-}
-
-#[cfg(target_os = "windows")]
-fn copy_and_free(
-    output: windows::Win32::Security::Cryptography::CRYPT_INTEGER_BLOB,
-    clear_source: bool,
-) -> Vec<u8> {
-    use windows::Win32::Foundation::{HLOCAL, LocalFree};
-
-    if output.pbData.is_null() || output.cbData == 0 {
-        if !output.pbData.is_null() {
-            unsafe {
-                LocalFree(Some(HLOCAL(output.pbData.cast())));
-            }
-        }
-        return Vec::new();
-    }
-
-    let bytes =
-        unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize) }.to_vec();
-    if clear_source {
-        unsafe {
-            std::ptr::write_bytes(output.pbData, 0, output.cbData as usize);
-        }
-    }
-    unsafe {
-        LocalFree(Some(HLOCAL(output.pbData.cast())));
-    }
-    bytes
-}
-
-#[cfg(target_os = "windows")]
-fn data_protection_error(error: windows::core::Error) -> crate::Error {
-    crate::Error::Storage(format!(
-        "Windows data protection failed ({:#010X})",
-        error.code().0
-    ))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    fn xor(data: &[u8]) -> crate::Result<Vec<u8>> {
-        Ok(data.iter().map(|byte| byte ^ 0xa5).collect())
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn dpapi_protects_and_round_trips_for_current_user() {
-        let plaintext = b"anarlog-windows-dpapi-round-trip";
-
-        let protected = protect(plaintext).unwrap();
-
-        assert_ne!(protected, plaintext);
-        assert_eq!(unprotect(&protected).unwrap(), plaintext);
-    }
-
-    #[test]
-    fn encrypted_auth_round_trips_sessions_larger_than_credential_manager_limit() {
-        let temp = tempdir().unwrap();
-        let secure_path = temp.path().join("auth.dpapi");
-        let auth = HashMap::from([(
-            "sb-project-auth-token".to_string(),
-            format!(r#"{{"access_token":"{}"}}"#, "token".repeat(2_000)),
-        )]);
-
-        persist_auth_file(&secure_path, &auth, xor, xor).unwrap();
-
-        assert_eq!(load_auth_file(&secure_path, xor).unwrap(), auth);
-        assert!(
-            !std::fs::read_to_string(secure_path)
-                .unwrap()
-                .contains("access_token")
-        );
-    }
-
-    #[test]
-    fn plaintext_migration_writes_verified_ciphertext_before_removal() {
-        let temp = tempdir().unwrap();
-        let plaintext_path = temp.path().join("auth.json");
-        let secure_path = temp.path().join("auth.dpapi");
-        let auth = HashMap::from([(
-            "sb-project-auth-token".to_string(),
-            r#"{"access_token":"secret"}"#.to_string(),
-        )]);
-        std::fs::write(&plaintext_path, serde_json::to_string(&auth).unwrap()).unwrap();
-
-        let loaded = read_plaintext_auth(&plaintext_path).unwrap();
-        persist_auth_file(&secure_path, &loaded, xor, xor).unwrap();
-        crate::migrate::discard_plaintext_auth(&plaintext_path);
-
-        assert!(!plaintext_path.exists());
-        assert_eq!(load_auth_file(&secure_path, xor).unwrap(), auth);
-    }
-
-    #[test]
-    fn failed_secure_write_leaves_plaintext_available_for_retry() {
-        let temp = tempdir().unwrap();
-        let plaintext_path = temp.path().join("auth.json");
-        let secure_path = temp.path().join("missing-parent").join("auth.dpapi");
-        let auth = HashMap::from([(
-            "sb-project-auth-token".to_string(),
-            r#"{"access_token":"secret"}"#.to_string(),
-        )]);
-        std::fs::write(&plaintext_path, serde_json::to_string(&auth).unwrap()).unwrap();
-
-        let result = persist_auth_file(
-            &secure_path,
-            &auth,
-            |_| Err(crate::Error::Storage("unavailable".to_string())),
-            xor,
-        );
-
-        assert!(result.is_err());
-        assert!(plaintext_path.is_file());
-    }
-
-    #[test]
-    fn failed_verification_does_not_leave_a_new_secure_file() {
-        let temp = tempdir().unwrap();
-        let secure_path = temp.path().join("auth.dpapi");
-        let auth = HashMap::from([(
-            "sb-project-auth-token".to_string(),
-            r#"{"access_token":"secret"}"#.to_string(),
-        )]);
-
-        let result = persist_auth_file(&secure_path, &auth, xor, |_| {
-            Err(crate::Error::Storage("unavailable".to_string()))
-        });
-
-        assert!(result.is_err());
-        assert!(!secure_path.exists());
-    }
-
-    #[test]
-    fn failed_verification_restores_previous_secure_file() {
-        let temp = tempdir().unwrap();
-        let secure_path = temp.path().join("auth.dpapi");
-        let first = HashMap::from([(
-            "sb-project-auth-token".to_string(),
-            r#"{"access_token":"first"}"#.to_string(),
-        )]);
-        let second = HashMap::from([(
-            "sb-project-auth-token".to_string(),
-            r#"{"access_token":"second"}"#.to_string(),
-        )]);
-        persist_auth_file(&secure_path, &first, xor, xor).unwrap();
-
-        let result = persist_auth_file(&secure_path, &second, xor, |_| {
-            Err(crate::Error::Storage("unavailable".to_string()))
-        });
-
-        assert!(result.is_err());
-        assert_eq!(load_auth_file(&secure_path, xor).unwrap(), first);
-    }
-
-    #[test]
-    fn rejects_unversioned_encrypted_auth() {
-        let temp = tempdir().unwrap();
-        let secure_path = temp.path().join("auth.dpapi");
-        std::fs::write(&secure_path, STANDARD.encode(b"ciphertext")).unwrap();
-
-        assert!(load_auth_file(&secure_path, xor).is_err());
-    }
 }

--- a/skills/anarlog/references/cli.md
+++ b/skills/anarlog/references/cli.md
@@ -2,6 +2,20 @@
 
 Use `--json` for agent-readable output.
 
+Linux desktop packages install this command as `anarlog-cli`; use that name instead of `anarlog` in the examples when necessary.
+
+Account authentication works on headless systems:
+
+```bash
+anarlog auth login
+anarlog --json auth status
+anarlog auth logout
+```
+
+For `auth login`, give the printed URL to the user. They may open it on another device, sign in, choose **Copy URL**, and paste the resulting `anarlog://auth/callback` link into the hidden prompt. Never ask the user to paste that callback link into chat or expose it in command arguments because it contains account tokens.
+
+On Linux, sessions use Secret Service when available and otherwise use the desktop-compatible local auth file with mode `0600`.
+
 ```bash
 anarlog --json doctor
 anarlog --json meetings list --query "planning" --limit 20 --offset 0

--- a/skills/anarlog/references/setup.md
+++ b/skills/anarlog/references/setup.md
@@ -38,6 +38,10 @@ anarlog --version
 
 Run the Anarlog desktop app once so its local database exists. The CLI and local MCP server work while the app is closed after that.
 
+Cloud sign-in does not require a graphical session on the Anarlog machine. Run `anarlog auth login`, open the printed URL in any browser, and paste the copied callback URL into the CLI prompt. Confirm the session with `anarlog auth status`.
+
+The Linux desktop package names the bundled command `anarlog-cli`, so use `anarlog-cli auth login` and `anarlog-cli auth status` there.
+
 Homebrew, standalone release binaries, Windows package-manager distribution, and bundled CLI installation on platforms other than macOS are not yet available.
 
 Use `--db-path FILE` or `ANARLOG_DB_PATH` only when the database is outside Anarlog's default application-data location.


### PR DESCRIPTION
Add browser handoff auth commands, desktop-compatible secure session storage, and CLI docs and tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces end-to-end CLI authentication, token verification, and cross-platform credential storage that must stay aligned with the desktop app and avoid leaking secrets in errors or logs.
> 
> **Overview**
> Adds **`anarlog auth login`**, **`status`**, and **`logout`** so the CLI can sign in without opening the desktop app. **Login** prints a web URL, accepts a pasted `anarlog://auth/callback` link (hidden prompt), validates tokens against the cloud API, and stores a Supabase session in the **same local auth layout** the desktop app uses.
> 
> **Platform storage** is shared with the app: Linux prefers **Secret Service** with an **`auth.cli.json`** fallback when headless; Windows uses **DPAPI** via a new **`storage::windows_auth`** module. The Tauri auth plugin **delegates** Windows encryption there and **reconciles** CLI fallback files into Secret Service on startup.
> 
> CI adds **release smoke tests** (signed-out status/logout, incomplete callback errors without leaking tokens, headless Linux logout). CLI reference docs and agent skills document the flow and **`anarlog-cli`** naming on Linux packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f1c56ae85253240969d04b8d42112d95d825426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->