### PR TITLE
Fix Linux package PR authentication

### DIFF
--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -749,7 +749,7 @@ jobs:
           gpg --batch --verify "$release_dir/Release.gpg" "$release_dir/Release"
       - name: Open the Linux package bump pull request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }}
           VERSION: ${{ needs.parse.outputs.version }}
         run: |
           if git diff --quiet -- packaging/aur/anarlog-bin apps/web/public/apt; then


### PR DESCRIPTION
Use the existing repository token for automated Linux packaging pull requests because organization policy blocks the default Actions token from creating them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow env change reusing an existing org secret already used elsewhere; no release or packaging logic changes.
> 
> **Overview**
> The **Open the Linux package bump pull request** step in `desktop_publish.yaml` now authenticates `gh` with `secrets.YUJONGLEE_GITHUB_TOKEN_REPO` instead of the default `GITHUB_TOKEN`.
> 
> That matches other workflows that need to open or push branches when org policy blocks the built-in Actions token from creating pull requests, so automated AUR/APT metadata PRs after a Linux desktop release can succeed again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4a2311c6c5b6e42f07882a2c13aabdd0020d09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->