### PR TITLE
Keep summary review actions in chat

### DIFF
--- a/apps/desktop/src/chat/components/message/tool/define-tool.tsx
+++ b/apps/desktop/src/chat/components/message/tool/define-tool.tsx
@@ -9,6 +9,7 @@ import {
 } from "./shared";
 
 type ToolPart = {
+  toolCallId: string;
   state: string;
   output?: unknown;
   // deno-lint-ignore no-explicit-any
@@ -36,6 +37,7 @@ type ToolConfig<TParsed> = {
     errorText: unknown;
     rawText: string | null;
     parsed: TParsed | null;
+    toolCallId: string;
   }) => ReactNode;
 };
 
@@ -66,6 +68,7 @@ export function defineTool<TParsed>(config: ToolConfig<TParsed>) {
             errorText: part.errorText,
             rawText,
             parsed,
+            toolCallId: part.toolCallId,
           })
         ) : (
           <ToolCardFooters

--- a/apps/desktop/src/chat/components/message/tool/edit-summary.test.tsx
+++ b/apps/desktop/src/chat/components/message/tool/edit-summary.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tabState = vi.hoisted(() => ({
+  close: vi.fn(),
+  tabs: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: {
+    getState: () => tabState,
+  },
+}));
+
+import { ToolEditSummary } from "./edit-summary";
+
+import { usePendingEditStore } from "~/chat/tools/pending-edit-store";
+
+const part = {
+  type: "tool-edit_summary",
+  toolCallId: "tool-call-1",
+  state: "input-available",
+  input: { content: "Updated summary" },
+} as const;
+
+describe("ToolEditSummary", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    usePendingEditStore.setState({ edits: new Map() });
+    tabState.tabs = [
+      {
+        active: true,
+        pinned: false,
+        requestId: "tool-call-1",
+        slotId: "review-slot",
+        type: "edit",
+      },
+    ];
+  });
+
+  it.each([
+    ["Decline", false],
+    ["Apply to summary", true],
+  ])("resolves %s from the chat card", (label, approved) => {
+    const resolve = vi.fn();
+    usePendingEditStore.getState().addEdit({
+      requestId: "tool-call-1",
+      sessionId: "session-1",
+      enhancedNoteId: "summary-1",
+      currentContent: "Current summary",
+      proposedContent: "Updated summary",
+      resolve,
+    });
+
+    render(<ToolEditSummary part={part} />);
+    fireEvent.click(screen.getByRole("button", { name: label }));
+
+    expect(resolve).toHaveBeenCalledWith(approved);
+    expect(tabState.close).toHaveBeenCalledWith(tabState.tabs[0]);
+    expect(usePendingEditStore.getState().edits.has("tool-call-1")).toBe(false);
+  });
+
+  it("hides review actions when the edit is no longer pending", () => {
+    render(<ToolEditSummary part={part} />);
+
+    expect(screen.queryByRole("button", { name: "Decline" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Apply to summary" }),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/chat/components/message/tool/edit-summary.tsx
+++ b/apps/desktop/src/chat/components/message/tool/edit-summary.tsx
@@ -1,5 +1,7 @@
 import { Pencil } from "@phosphor-icons/react";
 
+import { Button } from "@anlg/ui/components/ui/button";
+
 import { defineTool } from "./define-tool";
 import {
   MarkdownPreview,
@@ -9,6 +11,8 @@ import {
 } from "./shared";
 
 import { parseMcpObjectOutput } from "~/chat/mcp/mcp-output-parser";
+import { usePendingEditStore } from "~/chat/tools/pending-edit-store";
+import { useTabs } from "~/store/zustand/tabs";
 
 type EditSummaryOutput = {
   status?: string;
@@ -23,6 +27,45 @@ type EditSummaryOutput = {
 
 function parseEditSummaryOutput(output: unknown): EditSummaryOutput | null {
   return parseMcpObjectOutput<EditSummaryOutput>(output);
+}
+
+function EditSummaryActions({ toolCallId }: { toolCallId: string }) {
+  const editPending = usePendingEditStore((state) =>
+    state.edits.has(toolCallId),
+  );
+  const resolveEdit = usePendingEditStore((state) => state.resolveEdit);
+
+  if (!editPending) {
+    return null;
+  }
+
+  const resolve = (approved: boolean) => {
+    resolveEdit(toolCallId, approved);
+
+    const tabs = useTabs.getState();
+    const reviewTab = tabs.tabs.find(
+      (tab) => tab.type === "edit" && tab.requestId === toolCallId,
+    );
+    if (reviewTab) {
+      tabs.close(reviewTab);
+    }
+  };
+
+  return (
+    <div className="border-border/80 flex justify-end gap-2 border-t px-3.5 py-2.5">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        onClick={() => resolve(false)}
+      >
+        Decline
+      </Button>
+      <Button type="button" size="sm" onClick={() => resolve(true)}>
+        Apply to summary
+      </Button>
+    </div>
+  );
 }
 
 export const ToolEditSummary = defineTool({
@@ -42,22 +85,25 @@ export const ToolEditSummary = defineTool({
         <MarkdownPreview>{input.content}</MarkdownPreview>
       </ToolCardBody>
     ) : null,
-  renderFooter: ({ failed, errorText, parsed }) => (
-    <ToolCardFooters failed={failed} errorText={errorText} rawText={null}>
-      {parsed?.status === "error" ? (
-        <div className="space-y-2">
-          <ToolCardFooterError text={parsed.message ?? "Unknown error"} />
-          {parsed.candidates && parsed.candidates.length > 0 ? (
-            <div className="border-border bg-muted text-muted-foreground space-y-1 rounded-md border p-2 text-[12px]">
-              {parsed.candidates.map((candidate) => (
-                <div key={candidate.enhancedNoteId}>
-                  {candidate.title} ({candidate.enhancedNoteId})
-                </div>
-              ))}
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-    </ToolCardFooters>
+  renderFooter: ({ failed, errorText, parsed, toolCallId }) => (
+    <>
+      <ToolCardFooters failed={failed} errorText={errorText} rawText={null}>
+        {parsed?.status === "error" ? (
+          <div className="space-y-2">
+            <ToolCardFooterError text={parsed.message ?? "Unknown error"} />
+            {parsed.candidates && parsed.candidates.length > 0 ? (
+              <div className="border-border bg-muted text-muted-foreground space-y-1 rounded-md border p-2 text-[12px]">
+                {parsed.candidates.map((candidate) => (
+                  <div key={candidate.enhancedNoteId}>
+                    {candidate.title} ({candidate.enhancedNoteId})
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </ToolCardFooters>
+      <EditSummaryActions toolCallId={toolCallId} />
+    </>
   ),
 });

--- a/apps/desktop/src/chat/tools/edit-summary.test.ts
+++ b/apps/desktop/src/chat/tools/edit-summary.test.ts
@@ -13,10 +13,6 @@ vi.mock("~/session/queries", () => ({
   updateEnhancedNoteContent: mocks.updateEnhancedNoteContent,
 }));
 
-vi.mock("~/shared/utils", () => ({
-  id: () => "request-1",
-}));
-
 import { buildEditSummaryTool } from "./edit-summary";
 
 import { usePendingEditStore } from "~/chat/tools/pending-edit-store";
@@ -57,7 +53,10 @@ describe("edit summary chat tool", () => {
     });
 
     await expect(
-      (editTool as any).execute({ content: "Updated summary" }),
+      (editTool as any).execute(
+        { content: "Updated summary" },
+        { toolCallId: "request-1", messages: [] },
+      ),
     ).resolves.toEqual({ status: "applied" });
 
     expect(openEditTab).toHaveBeenCalledWith("request-1");
@@ -76,10 +75,13 @@ describe("edit summary chat tool", () => {
     });
 
     await expect(
-      (editTool as any).execute({
-        enhancedNoteId: "summary-other",
-        content: "Updated summary",
-      }),
+      (editTool as any).execute(
+        {
+          enhancedNoteId: "summary-other",
+          content: "Updated summary",
+        },
+        { toolCallId: "request-1", messages: [] },
+      ),
     ).resolves.toEqual({
       status: "error",
       message: "That summary does not belong to the target session.",

--- a/apps/desktop/src/chat/tools/edit-summary.ts
+++ b/apps/desktop/src/chat/tools/edit-summary.ts
@@ -8,7 +8,6 @@ import type { ToolDependencies } from "./types";
 import { usePendingEditStore } from "~/chat/tools/pending-edit-store";
 import { loadSessionContentSnapshot } from "~/session/content-queries";
 import { updateEnhancedNoteContent } from "~/session/queries";
-import { id } from "~/shared/utils";
 
 type SummaryCandidate = {
   enhancedNoteId: string;
@@ -54,11 +53,14 @@ export const buildEditSummaryTool = (
         .string()
         .describe("The complete replacement summary in markdown format"),
     }),
-    execute: async (params: {
-      sessionId?: string;
-      enhancedNoteId?: string;
-      content: string;
-    }) => {
+    execute: async (
+      params: {
+        sessionId?: string;
+        enhancedNoteId?: string;
+        content: string;
+      },
+      { toolCallId },
+    ) => {
       const activeSessionId = deps.getSessionId();
       const sessionId = params.sessionId ?? activeSessionId;
 
@@ -120,17 +122,16 @@ export const buildEditSummaryTool = (
       const currentContent =
         notes.find((note) => note.id === enhancedNoteId)?.markdown ?? "";
 
-      const requestId = id();
       const approved = await new Promise<boolean>((resolve) => {
         usePendingEditStore.getState().addEdit({
-          requestId,
+          requestId: toolCallId,
           sessionId,
           enhancedNoteId,
           currentContent,
           proposedContent: params.content,
           resolve,
         });
-        deps.openEditTab(requestId);
+        deps.openEditTab(toolCallId);
       });
 
       if (!approved) {

--- a/apps/desktop/src/edit/tab-content.tsx
+++ b/apps/desktop/src/edit/tab-content.tsx
@@ -6,13 +6,12 @@ import { useStrictModeUnmount } from "./hooks";
 import { usePendingEditStore } from "~/chat/tools/pending-edit-store";
 import { useEnhancedNote, useSessionSummary } from "~/session/queries";
 import { StandardContentWrapper } from "~/shared/main";
-import { type Tab, useTabs } from "~/store/zustand/tabs";
+import type { Tab } from "~/store/zustand/tabs";
 
 type EditTab = Extract<Tab, { type: "edit" }>;
 
 export function TabContentEdit({ tab }: { tab: EditTab }) {
   const edit = usePendingEditStore((s) => s.edits.get(tab.requestId));
-  const resolveEdit = usePendingEditStore((s) => s.resolveEdit);
 
   const session = useSessionSummary(edit?.sessionId ?? "");
   const summary = useEnhancedNote(edit?.enhancedNoteId ?? "");
@@ -51,7 +50,7 @@ export function TabContentEdit({ tab }: { tab: EditTab }) {
   return (
     <StandardContentWrapper>
       <div className="flex h-full flex-col">
-        <div className="border-border flex items-start justify-between gap-3 border-b px-4 py-3">
+        <div className="border-border border-b px-4 py-3">
           <div className="min-w-0 flex-1">
             <div className="text-foreground text-[13px] font-medium">
               {sessionTitle ?? "Untitled session"}
@@ -59,27 +58,6 @@ export function TabContentEdit({ tab }: { tab: EditTab }) {
             <div className="text-muted-foreground text-[12px]">
               {summaryTitle ?? "Summary"}
             </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <button
-              className="border-border bg-card text-muted-foreground hover:bg-accent rounded-md border px-4 py-1.5 text-[13px] transition-colors"
-              onClick={() => {
-                resolveEdit(tab.requestId, false);
-                useTabs.getState().close(tab);
-              }}
-            >
-              Cancel
-            </button>
-            <button
-              className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-1.5 text-[13px] transition-colors"
-              onClick={() => {
-                resolveEdit(tab.requestId, true);
-                useTabs.getState().close(tab);
-              }}
-              autoFocus
-            >
-              Apply to summary
-            </button>
           </div>
         </div>
         <div className="flex-1 overflow-auto">


### PR DESCRIPTION
Move summary edit decisions into the originating chat tool card and keep the review tab focused on the diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the user approval path for summary writes and correlates pending edits by tool call id; mistakes could block or mis-apply edits, but behavior is covered by new/updated tests.
> 
> **Overview**
> **Summary edit approve/decline** now lives on the originating `edit_summary` chat tool card instead of the review tab. The review tab shows only session context and the unified diff.
> 
> `defineTool` passes **`toolCallId`** into custom `renderFooter` hooks so the card can tie into pending edits. **`buildEditSummaryTool`** uses the runtime **`toolCallId`** (not a locally generated id) as the pending-edit `requestId` and when opening the review tab, keeping chat UI and tool execution aligned.
> 
> **Decline** / **Apply to summary** resolve the pending edit via `usePendingEditStore` and close the matching edit tab when present. The edit tab no longer renders those buttons; unmount still auto-declines if the edit is still pending.
> 
> Component tests cover resolving from the card and hiding actions when nothing is pending; tool tests were updated for the new `execute` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fba8be4f79a07b30586adb23e46653599bf1c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->