### PR TITLE
Fix calendar OAuth and add Microsoft login

### DIFF
--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -244,7 +244,7 @@ async function mintDesktopSessionFromEmail(email: string) {
 export const doAuth = createServerFn({ method: "POST" })
   .inputValidator(
     shared.extend({
-      provider: z.enum(["google", "github"]),
+      provider: z.enum(["azure", "google", "github"]),
       rra: z.boolean().optional(),
     }),
   )
@@ -252,12 +252,19 @@ export const doAuth = createServerFn({ method: "POST" })
     const supabase = getSupabaseServerClient();
     const params = buildAuthCallbackParams(data);
 
-    const scopes = data.provider === "github" && data.rra ? "repo" : undefined;
+    const scopes =
+      data.provider === "github" && data.rra
+        ? "repo"
+        : data.provider === "azure"
+          ? "email"
+          : undefined;
 
     const { data: authData, error } = await supabase.auth.signInWithOAuth({
       provider: data.provider,
       options: {
         redirectTo: buildAuthCallbackUrl(params),
+        queryParams:
+          data.provider === "azure" ? { prompt: "select_account" } : undefined,
         scopes,
       },
     });

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -1,4 +1,4 @@
-import Nango, { type ConnectUI } from "@nangohq/frontend";
+import Nango, { type AuthErrorType, type ConnectUI } from "@nangohq/frontend";
 import { useNavigate } from "@tanstack/react-router";
 import { useRef, useState } from "react";
 
@@ -13,6 +13,22 @@ import { captureOperationalError } from "@/lib/error-reporting";
 
 import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
 import { getIntegrationDisplay, Route } from "./integration";
+
+function getConnectionErrorMessage(
+  errorType: AuthErrorType,
+  providerName: string,
+) {
+  if (errorType === "blocked_by_browser") {
+    return `Your browser blocked the ${providerName} sign-in window. Allow pop-ups for Anarlog and try again.`;
+  }
+  if (errorType === "window_closed") {
+    return `The ${providerName} sign-in window closed before the connection finished. Please try again.`;
+  }
+  if (errorType === "resource_capped") {
+    return "This integration has reached its connection limit. Contact support to connect another account.";
+  }
+  return `${providerName} rejected the connection. Please try again or contact support if it keeps happening.`;
+}
 
 export function ConnectFlow() {
   const search = Route.useSearch();
@@ -31,6 +47,7 @@ export function ConnectFlow() {
   const inFlightRef = useRef(false);
   const connectUIRef = useRef<ConnectUI | null>(null);
   const disposedRef = useRef(false);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
 
   const display = getIntegrationDisplay(search.integration_id);
 
@@ -44,6 +61,7 @@ export function ConnectFlow() {
   const handleConnect = async () => {
     if (inFlightRef.current) return;
     inFlightRef.current = true;
+    setConnectionError(null);
     updateStatus("loading");
     track("integration_connection_started", {
       integration: search.integration_id,
@@ -114,6 +132,7 @@ export function ConnectFlow() {
     updateStatus("connecting");
 
     const connect = nango.openConnectUI({
+      detectClosedAuthWindow: true,
       onEvent: (event) => {
         if (event.type === "close") {
           if (
@@ -129,6 +148,35 @@ export function ConnectFlow() {
               failure_stage: "cancelled",
             });
           }
+        } else if (event.type === "error") {
+          const { errorType } = event.payload;
+          captureOperationalError(
+            new Error("Integration authorization failed"),
+            {
+              operation: "integration_connection_authorization",
+              tags: {
+                integration: search.integration_id,
+                mode: search.action,
+                error_type: errorType,
+              },
+            },
+          );
+          inFlightRef.current = false;
+          setConnectionError(
+            getConnectionErrorMessage(
+              errorType,
+              isGoogleCalendar ? "Google" : "Microsoft",
+            ),
+          );
+          updateStatus("error");
+          connectUIRef.current?.close();
+          track("integration_connection_failed", {
+            integration: search.integration_id,
+            mode: search.action,
+            flow: search.flow,
+            failure_stage: "authorization",
+            error_type: errorType,
+          });
         } else if (event.type === "connect") {
           inFlightRef.current = false;
           updateStatus("success");
@@ -263,7 +311,7 @@ export function ConnectFlow() {
       {status === "error" && (
         <div className="flex flex-col gap-4">
           <p className="text-red-600">
-            Something went wrong. Please try again.
+            {connectionError ?? "Something went wrong. Please try again."}
           </p>
           <IntegrationButton onClick={handleConnect}>
             Try again

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -163,10 +163,7 @@ export function ConnectFlow() {
           );
           inFlightRef.current = false;
           setConnectionError(
-            getConnectionErrorMessage(
-              errorType,
-              isGoogleCalendar ? "Google" : "Microsoft",
-            ),
+            getConnectionErrorMessage(errorType, display.name),
           );
           updateStatus("error");
           connectUIRef.current?.close();

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -2,7 +2,7 @@ import { Icon } from "@iconify-icon/react";
 import { ArrowLeft, Envelope } from "@phosphor-icons/react";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { z } from "zod";
 
 import { cn } from "@anlg/utils";
@@ -27,6 +27,7 @@ import {
   type DesktopScheme,
   flowSearchSchema,
 } from "@/functions/desktop-flow";
+import { useMountEffect } from "@/hooks/useMountEffect";
 import { toAuthFlowSearch } from "@/lib/auth-flow-context";
 import {
   buildPostAuthDestination,
@@ -39,7 +40,7 @@ import {
 
 const commonSearch = {
   redirect: z.string().optional(),
-  provider: z.enum(["github", "google"]).optional(),
+  provider: z.enum(["azure", "github", "google"]).optional(),
   rra: z.boolean().optional(),
 };
 
@@ -86,6 +87,13 @@ export const Route = createFileRoute("/auth")({
 });
 
 type AuthView = "main" | "email";
+type OAuthProvider = "azure" | "github" | "google";
+
+function getOAuthProviderName(provider: OAuthProvider) {
+  return provider === "azure"
+    ? "Microsoft"
+    : provider.charAt(0).toUpperCase() + provider.slice(1);
+}
 
 function Component() {
   const { flow, scheme, redirect, provider, rra } = Route.useSearch();
@@ -107,10 +115,12 @@ function Component() {
   }
 
   if (existingUser && flow === "web" && provider) {
+    const providerName = getOAuthProviderName(provider);
+
     return (
       <AuthShell
-        title={`Reconnect ${provider.charAt(0).toUpperCase() + provider.slice(1)}`}
-        description={`Refresh your ${provider} access to continue with admin actions.`}
+        title={`Reconnect ${providerName}`}
+        description={`Refresh your ${providerName} access to continue with admin actions.`}
       >
         <div className="flex flex-col gap-4">
           <OAuthButton
@@ -127,6 +137,7 @@ function Component() {
   }
 
   const showGoogle = !provider || provider === "google";
+  const showMicrosoft = !provider || provider === "azure";
   const showGithub = !provider || provider === "github";
   const showEmail = !provider;
 
@@ -141,6 +152,14 @@ function Component() {
                 scheme={scheme}
                 redirect={redirect}
                 provider="google"
+              />
+            )}
+            {showMicrosoft && (
+              <OAuthButton
+                flow={flow}
+                scheme={scheme}
+                redirect={redirect}
+                provider="azure"
               />
             )}
             {showGithub && (
@@ -211,9 +230,9 @@ function DesktopReauthView({
     },
   });
 
-  useEffect(() => {
+  useMountEffect(() => {
     retryMutation.mutate();
-  }, []);
+  });
 
   const hasRetryFailed =
     retryMutation.isError || (retryMutation.isSuccess && !retryMutation.data);
@@ -239,6 +258,7 @@ function DesktopReauthView({
           </div>
           <div className="flex flex-col gap-3">
             <OAuthButton flow="desktop" scheme={scheme} provider="google" />
+            <OAuthButton flow="desktop" scheme={scheme} provider="azure" />
             <OAuthButton flow="desktop" scheme={scheme} provider="github" />
           </div>
         </>
@@ -714,12 +734,12 @@ function OAuthButton({
   flow: "desktop" | "web";
   scheme?: DesktopScheme;
   redirect?: string;
-  provider: "google" | "github";
+  provider: OAuthProvider;
   rra?: boolean;
   autoStart?: boolean;
 }) {
   const oauthMutation = useMutation({
-    mutationFn: (provider: "google" | "github") => {
+    mutationFn: (provider: OAuthProvider) => {
       capturePrivateRouteEvent("auth_started", {
         method: "oauth",
         provider,
@@ -759,12 +779,12 @@ function OAuthButton({
   const { mutate, isPending } = oauthMutation;
   const hasAutoStartedRef = useRef(false);
 
-  useEffect(() => {
+  useMountEffect(() => {
     if (autoStart && !hasAutoStartedRef.current) {
       hasAutoStartedRef.current = true;
       mutate(provider);
     }
-  }, [autoStart, mutate, provider]);
+  });
 
   return (
     <button
@@ -778,7 +798,10 @@ function OAuthButton({
       {provider === "github" && (
         <Icon icon="logos:github-icon" width="18" height="18" />
       )}
-      Sign in with {provider.charAt(0).toUpperCase() + provider.slice(1)}
+      {provider === "azure" && (
+        <Icon icon="logos:microsoft-icon" width="18" height="18" />
+      )}
+      Sign in with {getOAuthProviderName(provider)}
     </button>
   );
 }


### PR DESCRIPTION
Add Azure login support and surface provider authorization failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication provider configuration and OAuth entry points; integration changes are mostly UX and error handling around existing Nango flows.
> 
> **Overview**
> Adds **Microsoft (Azure) sign-in** alongside Google and GitHub on web and desktop auth, including reconnect flows and Supabase OAuth with `email` scope and `select_account` prompting.
> 
> The **integration connect flow** now handles Nango authorization failures explicitly: closed/blocked pop-ups, connection limits, and provider rejections show targeted copy instead of a generic error, with operational logging and analytics on the `authorization` failure stage.
> 
> Minor auth UI cleanup swaps some `useEffect` auto-start hooks for `useMountEffect`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66fb2ee65c7484491d2683e32a55871468aa1a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->