### PR TITLE
Define meeting capture contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11140,6 +11140,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "meeting-capture"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "futures-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ anlg-local-stt-server = { path = "crates/local-stt-server", package = "local-stt
 anlg-loops = { path = "crates/loops", package = "loops" }
 anlg-mac = { path = "crates/mac", package = "mac" }
 anlg-mcp = { path = "crates/mcp", package = "mcp" }
+anlg-meeting-capture = { path = "crates/meeting-capture", package = "meeting-capture" }
 anlg-mobile-bridge = { path = "crates/mobile-bridge", package = "mobile-bridge" }
 anlg-model-downloader = { path = "crates/model-downloader", package = "model-downloader" }
 anlg-model-manager = { path = "crates/model-manager", package = "model-manager" }

--- a/crates/meeting-capture/Cargo.toml
+++ b/crates/meeting-capture/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "meeting-capture"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+chrono = { workspace = true, features = ["serde"] }
+futures-core = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/meeting-capture/src/lib.rs
+++ b/crates/meeting-capture/src/lib.rs
@@ -1,0 +1,9 @@
+mod lifecycle;
+mod metadata;
+mod model;
+mod provider;
+
+pub use lifecycle::*;
+pub use metadata::*;
+pub use model::*;
+pub use provider::*;

--- a/crates/meeting-capture/src/lifecycle.rs
+++ b/crates/meeting-capture/src/lifecycle.rs
@@ -1,0 +1,182 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BotState {
+    Queued,
+    Launching,
+    WaitingForAdmission,
+    Joined,
+    Capturing,
+    Stopping,
+    Completed,
+    Failed,
+    Canceled,
+}
+
+impl BotState {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Canceled)
+    }
+
+    pub fn transition_to(
+        self,
+        next: Self,
+        reason: Option<TerminalReason>,
+    ) -> Result<LifecycleTransition, TransitionError> {
+        if !self.allows(next) {
+            return Err(TransitionError::Invalid {
+                from: self,
+                to: next,
+            });
+        }
+        if next.is_terminal() && reason.is_none() {
+            return Err(TransitionError::MissingTerminalReason { state: next });
+        }
+        if !next.is_terminal() && reason.is_some() {
+            return Err(TransitionError::UnexpectedTerminalReason { state: next });
+        }
+
+        Ok(LifecycleTransition {
+            from: self,
+            to: next,
+            reason,
+        })
+    }
+
+    fn allows(self, next: Self) -> bool {
+        match self {
+            Self::Queued => matches!(next, Self::Launching | Self::Canceled | Self::Failed),
+            Self::Launching => matches!(
+                next,
+                Self::WaitingForAdmission
+                    | Self::Joined
+                    | Self::Stopping
+                    | Self::Canceled
+                    | Self::Failed
+            ),
+            Self::WaitingForAdmission => matches!(
+                next,
+                Self::Joined | Self::Stopping | Self::Canceled | Self::Failed
+            ),
+            Self::Joined => matches!(
+                next,
+                Self::Capturing | Self::Stopping | Self::Completed | Self::Failed
+            ),
+            Self::Capturing => {
+                matches!(next, Self::Stopping | Self::Completed | Self::Failed)
+            }
+            Self::Stopping => matches!(next, Self::Completed | Self::Failed | Self::Canceled),
+            Self::Completed | Self::Failed | Self::Canceled => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifecycleTransition {
+    pub from: BotState,
+    pub to: BotState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<TerminalReason>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalReason {
+    pub kind: TerminalReasonKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    pub retryable: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalReasonKind {
+    MeetingEnded,
+    StoppedByRequest,
+    AdmissionDenied,
+    AdmissionTimeout,
+    NoOneJoined,
+    EveryoneLeft,
+    RemovedFromMeeting,
+    RecordingPermissionDenied,
+    InvalidMeeting,
+    AuthenticationFailed,
+    CapacityExceeded,
+    NetworkLost,
+    ProviderError,
+    WorkerExited,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TransitionError {
+    #[error("invalid meeting bot state transition from {from:?} to {to:?}")]
+    Invalid { from: BotState, to: BotState },
+    #[error("terminal state {state:?} requires a terminal reason")]
+    MissingTerminalReason { state: BotState },
+    #[error("non-terminal state {state:?} cannot carry a terminal reason")]
+    UnexpectedTerminalReason { state: BotState },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meeting_ended() -> TerminalReason {
+        TerminalReason {
+            kind: TerminalReasonKind::MeetingEnded,
+            message: None,
+            retryable: false,
+        }
+    }
+
+    #[test]
+    fn accepts_the_capture_happy_path() {
+        let states = [
+            BotState::Queued,
+            BotState::Launching,
+            BotState::WaitingForAdmission,
+            BotState::Joined,
+            BotState::Capturing,
+            BotState::Completed,
+        ];
+
+        for pair in states.windows(2) {
+            let reason = pair[1].is_terminal().then(meeting_ended);
+            pair[0].transition_to(pair[1], reason).unwrap();
+        }
+    }
+
+    #[test]
+    fn rejects_skipping_from_queued_to_capturing() {
+        assert_eq!(
+            BotState::Queued
+                .transition_to(BotState::Capturing, None)
+                .unwrap_err(),
+            TransitionError::Invalid {
+                from: BotState::Queued,
+                to: BotState::Capturing,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_terminal_state_without_reason() {
+        assert_eq!(
+            BotState::Capturing
+                .transition_to(BotState::Completed, None)
+                .unwrap_err(),
+            TransitionError::MissingTerminalReason {
+                state: BotState::Completed,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_transitions_out_of_terminal_states() {
+        assert!(matches!(
+            BotState::Failed.transition_to(BotState::Launching, None),
+            Err(TransitionError::Invalid { .. })
+        ));
+    }
+}

--- a/crates/meeting-capture/src/metadata.rs
+++ b/crates/meeting-capture/src/metadata.rs
@@ -1,0 +1,111 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+pub const MAX_PROVIDER_METADATA_ENTRIES: usize = 32;
+pub const MAX_PROVIDER_METADATA_BYTES: usize = 16 * 1024;
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct ProviderMetadata(BTreeMap<String, Value>);
+
+impl ProviderMetadata {
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.0.get(key)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Value)> {
+        self.0.iter()
+    }
+
+    pub fn into_inner(self) -> BTreeMap<String, Value> {
+        self.0
+    }
+}
+
+impl TryFrom<BTreeMap<String, Value>> for ProviderMetadata {
+    type Error = MetadataError;
+
+    fn try_from(value: BTreeMap<String, Value>) -> Result<Self, Self::Error> {
+        if value.len() > MAX_PROVIDER_METADATA_ENTRIES {
+            return Err(MetadataError::TooManyEntries {
+                count: value.len(),
+                max: MAX_PROVIDER_METADATA_ENTRIES,
+            });
+        }
+
+        let bytes = serde_json::to_vec(&value)
+            .map_err(|error| MetadataError::Serialization(error.to_string()))?
+            .len();
+        if bytes > MAX_PROVIDER_METADATA_BYTES {
+            return Err(MetadataError::TooLarge {
+                bytes,
+                max: MAX_PROVIDER_METADATA_BYTES,
+            });
+        }
+
+        Ok(Self(value))
+    }
+}
+
+impl<'de> Deserialize<'de> for ProviderMetadata {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = BTreeMap::<String, Value>::deserialize(deserializer)?;
+        Self::try_from(value).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MetadataError {
+    #[error("provider metadata has {count} entries; maximum is {max}")]
+    TooManyEntries { count: usize, max: usize },
+    #[error("provider metadata is {bytes} bytes; maximum is {max}")]
+    TooLarge { bytes: usize, max: usize },
+    #[error("failed to serialize provider metadata: {0}")]
+    Serialization(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_bounded_metadata() {
+        let metadata = ProviderMetadata::try_from(BTreeMap::from([
+            ("provider_bot_id".into(), Value::String("bot-1".into())),
+            ("attempt".into(), Value::from(2)),
+        ]))
+        .unwrap();
+
+        assert_eq!(metadata.get("attempt"), Some(&Value::from(2)));
+    }
+
+    #[test]
+    fn rejects_too_many_entries() {
+        let values: BTreeMap<String, Value> = (0..=MAX_PROVIDER_METADATA_ENTRIES)
+            .map(|index| (index.to_string(), Value::Null))
+            .collect();
+
+        assert!(matches!(
+            ProviderMetadata::try_from(values),
+            Err(MetadataError::TooManyEntries { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_oversized_metadata_during_deserialization() {
+        let value = serde_json::json!({ "payload": "x".repeat(MAX_PROVIDER_METADATA_BYTES) });
+
+        let error = serde_json::from_value::<ProviderMetadata>(value).unwrap_err();
+
+        assert!(error.to_string().contains("maximum is"));
+    }
+}

--- a/crates/meeting-capture/src/model.rs
+++ b/crates/meeting-capture/src/model.rs
@@ -1,0 +1,171 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{BotState, LifecycleTransition, ProviderMetadata};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MeetingPlatform {
+    GoogleMeet,
+    Zoom,
+    MicrosoftTeams,
+    Webex,
+    Jitsi,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureProviderKind {
+    Anarlog,
+    Recall,
+    ZoomRtms,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MeetingReference {
+    pub platform: MeetingPlatform,
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calendar_event_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StartCaptureRequest {
+    pub meeting: MeetingReference,
+    pub bot_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub metadata: ProviderMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MeetingBot {
+    pub id: String,
+    pub provider: CaptureProviderKind,
+    pub meeting: MeetingReference,
+    pub state: BotState,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub metadata: ProviderMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Speaker {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub participant_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Participant {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TranscriptSegment {
+    pub id: String,
+    pub sequence: u64,
+    pub start_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_ms: Option<u64>,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speaker: Option<Speaker>,
+    pub is_final: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecordingChunk {
+    pub id: String,
+    pub sequence: u64,
+    pub start_ms: u64,
+    pub duration_ms: u64,
+    pub content_type: String,
+    pub uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CaptureEvent {
+    pub id: String,
+    pub bot_id: String,
+    pub sequence: u64,
+    pub occurred_at: DateTime<Utc>,
+    pub payload: CaptureEventPayload,
+    #[serde(default)]
+    pub metadata: ProviderMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+pub enum CaptureEventPayload {
+    Lifecycle(LifecycleTransition),
+    Transcript(TranscriptSegment),
+    SpeakerUpserted(Speaker),
+    ParticipantUpserted(Participant),
+    ParticipantLeft { participant_id: String },
+    RecordingChunkReady(RecordingChunk),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{TerminalReason, TerminalReasonKind};
+
+    #[test]
+    fn serializes_a_normalized_lifecycle_event() {
+        let transition = BotState::Capturing
+            .transition_to(
+                BotState::Completed,
+                Some(TerminalReason {
+                    kind: TerminalReasonKind::MeetingEnded,
+                    message: None,
+                    retryable: false,
+                }),
+            )
+            .unwrap();
+        let event = CaptureEvent {
+            id: "event-1".into(),
+            bot_id: "bot-1".into(),
+            sequence: 4,
+            occurred_at: DateTime::parse_from_rfc3339("2026-08-14T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            payload: CaptureEventPayload::Lifecycle(transition),
+            metadata: ProviderMetadata::default(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(event).unwrap(),
+            serde_json::json!({
+                "id": "event-1",
+                "bot_id": "bot-1",
+                "sequence": 4,
+                "occurred_at": "2026-08-14T00:00:00Z",
+                "payload": {
+                    "type": "lifecycle",
+                    "data": {
+                        "from": "capturing",
+                        "to": "completed",
+                        "reason": {
+                            "kind": "meeting_ended",
+                            "retryable": false
+                        }
+                    }
+                },
+                "metadata": {}
+            })
+        );
+    }
+}

--- a/crates/meeting-capture/src/provider.rs
+++ b/crates/meeting-capture/src/provider.rs
@@ -1,0 +1,79 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_core::Stream;
+use serde::{Deserialize, Serialize};
+
+use crate::{CaptureEvent, CaptureProviderKind, MeetingBot, StartCaptureRequest};
+
+pub type ProviderResult<T> = Result<T, ProviderError>;
+pub type ProviderFuture<'a, T> = Pin<Box<dyn Future<Output = ProviderResult<T>> + Send + 'a>>;
+
+pub struct CaptureEventStream(
+    Pin<Box<dyn Stream<Item = ProviderResult<CaptureEvent>> + Send + 'static>>,
+);
+
+impl CaptureEventStream {
+    pub fn new(stream: impl Stream<Item = ProviderResult<CaptureEvent>> + Send + 'static) -> Self {
+        Self(Box::pin(stream))
+    }
+}
+
+impl Stream for CaptureEventStream {
+    type Item = ProviderResult<CaptureEvent>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.0.as_mut().poll_next(cx)
+    }
+}
+
+pub trait MeetingCaptureProvider: Send + Sync {
+    fn kind(&self) -> CaptureProviderKind;
+
+    fn start(&self, request: StartCaptureRequest) -> ProviderFuture<'_, MeetingBot>;
+
+    fn stop<'a>(&'a self, bot_id: &'a str) -> ProviderFuture<'a, ()>;
+
+    fn status<'a>(&'a self, bot_id: &'a str) -> ProviderFuture<'a, MeetingBot>;
+
+    fn events<'a>(
+        &'a self,
+        bot_id: &'a str,
+        after_sequence: Option<u64>,
+    ) -> ProviderFuture<'a, CaptureEventStream>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[error("{kind:?}: {message}")]
+pub struct ProviderError {
+    pub kind: ProviderErrorKind,
+    pub message: String,
+    pub retryable: bool,
+}
+
+impl ProviderError {
+    pub fn new(kind: ProviderErrorKind, message: impl Into<String>, retryable: bool) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            retryable,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderErrorKind {
+    InvalidRequest,
+    Authentication,
+    Unsupported,
+    RateLimited,
+    Unavailable,
+    Capacity,
+    NotFound,
+    Conflict,
+    Internal,
+}


### PR DESCRIPTION
Add normalized provider events, bounded metadata, and explicit lifecycle validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New library-only contracts and tests; no runtime, API, or auth changes in this diff.
> 
> **Overview**
> Introduces a new **`meeting-capture`** workspace crate that defines shared types and provider boundaries for meeting bots, without wiring it into **`api-bot`** or other services yet.
> 
> **Lifecycle** adds a **`BotState`** machine with **`transition_to`** validation, typed **`TerminalReason`** values, and unit tests for happy path, invalid skips, and terminal-state rules.
> 
> **Metadata** adds **`ProviderMetadata`** with caps (32 entries, 16 KiB serialized) enforced on **`TryFrom`** and **`Deserialize`**.
> 
> **Domain model** covers platforms, **`CaptureProviderKind`** (Anarlog, Recall, Zoom RTMS), start requests, **`MeetingBot`**, and tagged **`CaptureEvent`** payloads (lifecycle, transcript, participants, recording chunks) with serde tests.
> 
> **Provider** defines **`MeetingCaptureProvider`** (start/stop/status/events stream) plus **`ProviderError`** / **`CaptureEventStream`** wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed2a9fee35e9cf58aab6365fd78373d1f47c867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->