### PR TITLE
Define MIT and enterprise product boundary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,7 @@
-https://docs.anarlog.so
+# Contributing
+
+Development documentation is available at [docs.anarlog.so](https://docs.anarlog.so).
+
+By submitting a contribution to this repository, you agree that it may be distributed under the repository's [MIT License](LICENSE). Only submit material you have the right to license this way.
+
+Do not include Fastrepl enterprise source, customer configuration, credentials, or untracked third-party code. Record the immutable upstream revision and license before reusing third-party material. See [Licensing and product boundary](LICENSING.md) for the component-placement and provenance rules.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,55 @@
+# Licensing and product boundary
+
+Anarlog uses a repository boundary, not a source-available license, to separate the open-source application from Fastrepl's commercial enterprise software.
+
+## Open-source repository
+
+Everything in this repository is licensed under the [MIT License](LICENSE) unless a file or bundled third-party component says otherwise. This includes:
+
+- the desktop, web, mobile, and command-line applications;
+- local meeting capture, transcription, storage, export, and sync clients;
+- provider-neutral meeting-capture contracts, normalized events, and behavior fixtures; and
+- public APIs and SDKs required for an MIT client to communicate with a separately deployed service.
+
+Contributions accepted into this repository must be distributable under MIT. A contribution must not contain Fastrepl enterprise source code, credentials, customer configuration, or third-party code whose terms are incompatible with MIT distribution.
+
+## Commercial enterprise software
+
+Fastrepl enterprise software is developed and distributed from a separate private repository under a commercial agreement. It includes:
+
+- customer-hosted meeting-bot workers and their browser automation;
+- scheduling, orchestration, capacity management, and job persistence;
+- enterprise administration, SSO enforcement, audit export, policy, and license enforcement; and
+- Docker, Kubernetes, air-gapped, and regulated-environment deployment packages.
+
+Enterprise software may depend on versioned MIT packages from this repository. Code in this repository must never depend on, import, generate from, or require the enterprise repository.
+
+Enterprise source delivery, binary delivery, evaluation rights, redistribution, support, warranty, and termination terms must come from a counsel-approved Fastrepl Enterprise Software License and the applicable customer agreement. Those terms are intentionally not defined in this MIT repository.
+
+## Self-hosted licensing
+
+Customer-hosted enterprise deployments must support a signed, time-bounded or perpetual license file that can be validated offline. The deployment must not require an outbound licensing request after installation unless the customer explicitly enables one. Activation, enforcement, and signing-key material belong only in the enterprise repository.
+
+## Third-party provenance
+
+Before third-party code or assets are incorporated into either product:
+
+1. Record the upstream repository, immutable revision, file paths, copyright holder, license, and whether the material was copied, modified, or used only as behavioral reference.
+2. Preserve all required license, copyright, patent, trademark, modification, and NOTICE material in the delivered source or binary distribution.
+3. Keep provenance records beside the consuming code and generate the distribution's third-party notices from those records.
+4. Do not incorporate AGPL, GPL, SSPL, source-available, or unknown-license material without written legal approval.
+
+Apache-2.0 material can be used in commercial software when its conditions are satisfied. That does not make untracked copying acceptable: directly reused files must retain the required notices and modifications must be identified.
+
+Behavioral observation is preferred when replacing a third-party implementation. Tests and fixtures should record public API behavior without copying implementation source, confidential data, or trademarks into product identity.
+
+## Component placement test
+
+A component belongs in this MIT repository only when all of the following are true:
+
+- an independent MIT client needs the component;
+- the component is useful without Fastrepl's enterprise control plane;
+- publishing it does not expose enterprise enforcement, orchestration, or deployment logic; and
+- every dependency and incorporated asset is compatible with MIT distribution.
+
+If any condition is false, build it in the enterprise repository or request a licensing review before implementation.

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ Either way, it's yours.
 
 ---
 
-**License:** MIT · **Maintainers:** [fastrepl](https://github.com/fastrepl)
+**License:** [MIT](LICENSE) · [Product boundary](LICENSING.md) · **Maintainers:** [fastrepl](https://github.com/fastrepl)


### PR DESCRIPTION
Document repository ownership, offline commercial licensing, contribution rules, and provenance requirements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-path impact.
> 
> **Overview**
> **Adds formal documentation** for where MIT open source ends and Fastrepl enterprise software begins, plus contributor obligations around licensing and third-party code.
> 
> **`LICENSING.md`** (new) describes the open-source repo scope, what lives in the private enterprise repo, one-way dependency rules (enterprise may use MIT packages; this repo must not depend on enterprise), offline signed license expectations for self-hosted enterprise, third-party provenance steps, and a four-part “component placement test” for deciding what belongs here.
> 
> **`CONTRIBUTING.md`** is expanded from a docs link into a short guide: MIT contribution agreement, bans on enterprise source/credentials/untracked third-party code, and a pointer to `LICENSING.md`.
> 
> **`README.md`** footer now links **`LICENSE`** and **`LICENSING.md`** alongside maintainers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 353da58edbb1d4037385486443ac32c24190f7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->