### PR TITLE
Keep chat progress visible and context chips scrollable

### DIFF
--- a/apps/desktop/src/chat/components/body/non-empty.test.tsx
+++ b/apps/desktop/src/chat/components/body/non-empty.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/chat/components/message/normal", () => ({
+  NormalMessage: () => <div data-testid="normal-message" />,
+}));
+
+import { ChatBodyNonEmpty } from "./non-empty";
+
+import type { AnlgUIMessage } from "~/chat/types";
+
+afterEach(cleanup);
+
+describe("ChatBodyNonEmpty", () => {
+  it("shows thinking while waiting for content after a completed tool call", () => {
+    render(
+      <ChatBodyNonEmpty
+        messages={[
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-search_meetings",
+                toolCallId: "search-1",
+                state: "output-available",
+                input: { query: "defcon" },
+                output: { results: [] },
+              },
+            ],
+          } as AnlgUIMessage,
+        ]}
+        status="streaming"
+      />,
+    );
+
+    expect(screen.getByText("Thinking...")).not.toBeNull();
+  });
+
+  it("shows thinking when the next model step has started", () => {
+    render(
+      <ChatBodyNonEmpty
+        messages={[
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              { type: "text", text: "Earlier response", state: "done" },
+              { type: "step-start" },
+            ],
+          } as AnlgUIMessage,
+        ]}
+        status="streaming"
+      />,
+    );
+
+    expect(screen.getByText("Thinking...")).not.toBeNull();
+  });
+
+  it("does not add a thinking row while response text is streaming", () => {
+    render(
+      <ChatBodyNonEmpty
+        messages={[
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "text",
+                text: "Here is what I found",
+                state: "streaming",
+              },
+            ],
+          } as AnlgUIMessage,
+        ]}
+        status="streaming"
+      />,
+    );
+
+    expect(screen.queryByText("Thinking...")).toBeNull();
+  });
+});

--- a/apps/desktop/src/chat/components/body/non-empty.tsx
+++ b/apps/desktop/src/chat/components/body/non-empty.tsx
@@ -6,6 +6,27 @@ import { NormalMessage } from "~/chat/components/message/normal";
 import { hasRenderableContent } from "~/chat/components/shared";
 import type { AnlgUIMessage } from "~/chat/types";
 
+function isWaitingForAssistantContent(message: AnlgUIMessage | undefined) {
+  if (message?.role !== "assistant") {
+    return false;
+  }
+
+  const lastPart = message.parts[message.parts.length - 1];
+  if (!lastPart) {
+    return false;
+  }
+
+  if (lastPart.type === "step-start") {
+    return true;
+  }
+
+  const state = "state" in lastPart ? lastPart.state : undefined;
+  return (
+    lastPart.type.startsWith("tool-") &&
+    (state === "output-available" || state === "output-error")
+  );
+}
+
 export function ChatBodyNonEmpty({
   messages,
   status,
@@ -21,7 +42,9 @@ export function ChatBodyNonEmpty({
   const lastMessage = messages[messages.length - 1];
   const showLoadingState =
     (status === "submitted" || status === "streaming") &&
-    (lastMessage?.role !== "assistant" || !hasRenderableContent(lastMessage));
+    (lastMessage?.role !== "assistant" ||
+      !hasRenderableContent(lastMessage) ||
+      isWaitingForAssistantContent(lastMessage));
 
   let lastAssistantIndex = -1;
   for (let i = messages.length - 1; i >= 0; i--) {

--- a/apps/desktop/src/chat/components/context-bar.test.tsx
+++ b/apps/desktop/src/chat/components/context-bar.test.tsx
@@ -67,7 +67,7 @@ describe("ContextBar", () => {
     expect(screen.queryByText(/artem@example.com/)).toBeNull();
   });
 
-  it("centers the squircle chip strip above the input surface", () => {
+  it("keeps the squircle chip strip above the input surface", () => {
     const { container } = render(
       <ContextBar
         entities={[
@@ -160,9 +160,11 @@ describe("ContextBar", () => {
     );
 
     const chipList = container.querySelector("[data-chat-context-chip-list]");
+    const chipStrip = container.querySelector("[data-chat-context-chip-strip]");
 
-    expect(chipList?.className).toContain("overflow-hidden");
-    expect(chipList?.className).not.toContain("flex-wrap");
+    expect(chipList?.className).toContain("overflow-x-auto");
+    expect(chipList?.className).not.toContain("overflow-hidden");
+    expect(chipList?.className).not.toContain("flex-1");
     expect(container.querySelectorAll("[data-chat-context-chip]")).toHaveLength(
       4,
     );
@@ -180,7 +182,8 @@ describe("ContextBar", () => {
     expect(container.querySelectorAll("[data-chat-context-chip]")).toHaveLength(
       6,
     );
-    expect(chipList?.className).toContain("flex-wrap");
+    expect(chipStrip?.className).toContain("flex-wrap");
+    expect(chipList?.className).not.toContain("overflow-x-auto");
     expect(screen.queryByText("+2 more")).toBeNull();
 
     fireEvent.click(
@@ -193,10 +196,10 @@ describe("ContextBar", () => {
       4,
     );
     expect(screen.getByText("+2 more")).not.toBeNull();
-    expect(chipList?.className).toContain("overflow-hidden");
+    expect(chipList?.className).toContain("overflow-x-auto");
   });
 
-  it("wraps four-or-fewer chips instead of clipping them", () => {
+  it("scrolls four-or-fewer chips horizontally instead of clipping them", () => {
     const { container } = render(
       <ContextBar
         entities={[
@@ -241,10 +244,13 @@ describe("ContextBar", () => {
     );
 
     const chipList = container.querySelector("[data-chat-context-chip-list]");
+    const chipStrip = container.querySelector("[data-chat-context-chip-strip]");
     const chip = container.querySelector("[data-chat-context-chip]");
 
-    expect(chipList?.className).toContain("flex-wrap");
+    expect(chipList?.className).toContain("overflow-x-auto");
     expect(chipList?.className).not.toContain("overflow-hidden");
+    expect(chipStrip?.className).toContain("w-max");
+    expect(chipStrip?.className).toContain("min-w-full");
     expect(chip?.className).toContain("shrink-0");
     expect(screen.queryByRole("button", { name: /more/ })).toBeNull();
   });

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -99,18 +99,28 @@ function ChipList({
       <div
         data-chat-context-chip-list
         className={cn([
-          "flex max-w-full min-w-0 items-center justify-center gap-1.5",
-          canExpand && !isExpanded ? "overflow-hidden" : "flex-wrap",
+          "min-w-0",
+          !isExpanded && "overflow-x-auto overscroll-x-contain",
         ])}
       >
-        {visibleChips.map(({ chip, pending }) => (
-          <ContextChip
-            key={chip.key}
-            chip={chip}
-            onRemove={onRemove}
-            pending={pending}
-          />
-        ))}
+        <div
+          data-chat-context-chip-strip
+          className={cn([
+            "flex items-center gap-1.5",
+            isExpanded
+              ? "w-full flex-wrap justify-center"
+              : "w-max min-w-full justify-center",
+          ])}
+        >
+          {visibleChips.map(({ chip, pending }) => (
+            <ContextChip
+              key={chip.key}
+              chip={chip}
+              onRemove={onRemove}
+              pending={pending}
+            />
+          ))}
+        </div>
       </div>
 
       {canExpand && (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Desktop chat UI and layout only; no auth, data, or API changes.
> 
> **Overview**
> **Chat progress:** `ChatBodyNonEmpty` now treats the assistant as still in progress when the last message part is a `step-start` or a tool part with `output-available` / `output-error`, so the existing **Thinking...** loading row stays visible while the model continues after a tool call or new step. It still hides that row when the latest part is streaming text.
> 
> **Context chips:** The context bar splits chips into a scrollable list wrapper and an inner strip. When collapsed, chips use **horizontal scroll** (`overflow-x-auto`) with a `w-max` strip instead of `overflow-hidden` clipping; expanding still uses **flex-wrap** on the strip. Tests were updated for the new DOM/classes and behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed155ea7641b6c3889fe288a9b1a393abb03286b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->