### PR TITLE
Recover dead webviews when reopening

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -252,6 +252,7 @@ pub async fn main() {
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.show();
                 let _ = window.set_focus();
+                AppWindow::Main.request_webview_health_check(app, &window);
             }
         }));
     }

--- a/plugins/windows/build.rs
+++ b/plugins/windows/build.rs
@@ -6,6 +6,8 @@ const COMMANDS: &[&str] = &[
     "window_emit_navigate",
     "window_is_exists",
     "window_is_occluded",
+    "webview_health_ack",
+    "webview_health_ready",
     "window_set_frame_animated",
     "window_save_frame",
     "window_restore_frame_animated",

--- a/plugins/windows/js/bindings.gen.ts
+++ b/plugins/windows/js/bindings.gen.ts
@@ -95,6 +95,30 @@ export const commands = {
       else return { status: "error", error: e as any };
     }
   },
+  async webviewHealthAck(requestId: string): Promise<Result<null, string>> {
+    try {
+      return {
+        status: "ok",
+        data: await TAURI_INVOKE("plugin:windows|webview_health_ack", {
+          requestId,
+        }),
+      };
+    } catch (e) {
+      if (e instanceof Error) throw e;
+      else return { status: "error", error: e as any };
+    }
+  },
+  async webviewHealthReady(): Promise<Result<null, string>> {
+    try {
+      return {
+        status: "ok",
+        data: await TAURI_INVOKE("plugin:windows|webview_health_ready"),
+      };
+    } catch (e) {
+      if (e instanceof Error) throw e;
+      else return { status: "error", error: e as any };
+    }
+  },
   async windowSetFrameAnimated(
     window: AppWindow,
     anchor: Anchor,
@@ -300,6 +324,7 @@ export const events = __makeEvents__<{
   navigate: Navigate;
   openTab: OpenTab;
   visibilityEvent: VisibilityEvent;
+  webviewHealthCheck: WebviewHealthCheck;
   windowDestroyed: WindowDestroyed;
 }>({
   devtoolsPanelAction: "plugin:windows:devtools-panel-action",
@@ -309,6 +334,7 @@ export const events = __makeEvents__<{
   navigate: "plugin:windows:navigate",
   openTab: "plugin:windows:open-tab",
   visibilityEvent: "plugin:windows:visibility-event",
+  webviewHealthCheck: "plugin:windows:webview-health-check",
   windowDestroyed: "plugin:windows:window-destroyed",
 });
 
@@ -433,6 +459,7 @@ export type TemplatesState = {
   selectedWebIndex: number | null;
 };
 export type VisibilityEvent = { window: AppWindow; visible: boolean };
+export type WebviewHealthCheck = { requestId: string };
 export type WindowDestroyed = { window: AppWindow };
 
 /** tauri-specta globals **/

--- a/plugins/windows/js/index.ts
+++ b/plugins/windows/js/index.ts
@@ -1,7 +1,7 @@
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 
 export * from "./bindings.gen";
-import { commands } from "./bindings.gen";
+import { commands, events } from "./bindings.gen";
 
 export type WindowLabel =
   | "main"
@@ -62,12 +62,15 @@ export async function dismissInstruction() {
 
 const DROP_PREVENTION_CLEANUP_KEY =
   "__ANARLOG_WINDOWS_DROP_PREVENTION_CLEANUP__";
+const HEALTH_CHECK_CLEANUP_KEY = "__ANARLOG_WINDOWS_HEALTH_CHECK_CLEANUP__";
 
 export const init = () => {
   const host = window as typeof window & {
     [DROP_PREVENTION_CLEANUP_KEY]?: () => void;
+    [HEALTH_CHECK_CLEANUP_KEY]?: () => void;
   };
   host[DROP_PREVENTION_CLEANUP_KEY]?.();
+  host[HEALTH_CHECK_CLEANUP_KEY]?.();
 
   const allowDropAttribute = "[data-allow-file-drop='true']";
   const shouldAllow = (event: DragEvent) => {
@@ -105,15 +108,48 @@ export const init = () => {
   document.addEventListener("dragenter", preventUnlessAllowed);
   document.addEventListener("dragleave", preventUnlessAllowed);
 
-  const cleanup = () => {
+  const cleanupDropPrevention = () => {
     document.removeEventListener("dragover", preventUnlessAllowed);
     document.removeEventListener("drop", preventUnlessAllowed);
     document.removeEventListener("dragenter", preventUnlessAllowed);
     document.removeEventListener("dragleave", preventUnlessAllowed);
-    if (host[DROP_PREVENTION_CLEANUP_KEY] === cleanup) {
+    if (host[DROP_PREVENTION_CLEANUP_KEY] === cleanupDropPrevention) {
       delete host[DROP_PREVENTION_CLEANUP_KEY];
     }
   };
-  host[DROP_PREVENTION_CLEANUP_KEY] = cleanup;
-  return cleanup;
+  host[DROP_PREVENTION_CLEANUP_KEY] = cleanupDropPrevention;
+
+  let healthCheckUnlisten: (() => void) | null = null;
+  let healthCheckCancelled = false;
+  void events.webviewHealthCheck
+    .listen(({ payload }) => {
+      void commands.webviewHealthAck(payload.requestId);
+    })
+    .then((unlisten) => {
+      if (healthCheckCancelled) {
+        unlisten();
+      } else {
+        healthCheckUnlisten = unlisten;
+        void commands.webviewHealthReady().catch((error) => {
+          console.error("Failed to mark webview health checks ready", error);
+        });
+      }
+    })
+    .catch((error) => {
+      console.error("Failed to listen for webview health checks", error);
+    });
+
+  const cleanupHealthCheck = () => {
+    healthCheckCancelled = true;
+    healthCheckUnlisten?.();
+    if (host[HEALTH_CHECK_CLEANUP_KEY] === cleanupHealthCheck) {
+      delete host[HEALTH_CHECK_CLEANUP_KEY];
+    }
+  };
+  host[HEALTH_CHECK_CLEANUP_KEY] = cleanupHealthCheck;
+
+  return () => {
+    cleanupDropPrevention();
+    cleanupHealthCheck();
+  };
 };

--- a/plugins/windows/permissions/autogenerated/commands/webview_health_ack.toml
+++ b/plugins/windows/permissions/autogenerated/commands/webview_health_ack.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-webview-health-ack"
+description = "Enables the webview_health_ack command without any pre-configured scope."
+commands.allow = ["webview_health_ack"]
+
+[[permission]]
+identifier = "deny-webview-health-ack"
+description = "Denies the webview_health_ack command without any pre-configured scope."
+commands.deny = ["webview_health_ack"]

--- a/plugins/windows/permissions/autogenerated/commands/webview_health_ready.toml
+++ b/plugins/windows/permissions/autogenerated/commands/webview_health_ready.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-webview-health-ready"
+description = "Enables the webview_health_ready command without any pre-configured scope."
+commands.allow = ["webview_health_ready"]
+
+[[permission]]
+identifier = "deny-webview-health-ready"
+description = "Denies the webview_health_ready command without any pre-configured scope."
+commands.deny = ["webview_health_ready"]

--- a/plugins/windows/permissions/autogenerated/reference.md
+++ b/plugins/windows/permissions/autogenerated/reference.md
@@ -11,6 +11,8 @@ Default permissions for the plugin
 - `allow-window-emit-navigate`
 - `allow-window-is-exists`
 - `allow-window-is-occluded`
+- `allow-webview-health-ack`
+- `allow-webview-health-ready`
 - `allow-window-set-frame-animated`
 - `allow-window-save-frame`
 - `allow-window-restore-frame-animated`
@@ -317,6 +319,58 @@ Enables the set_show_app_in_dock command without any pre-configured scope.
 <td>
 
 Denies the set_show_app_in_dock command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:allow-webview-health-ack`
+
+</td>
+<td>
+
+Enables the webview_health_ack command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:deny-webview-health-ack`
+
+</td>
+<td>
+
+Denies the webview_health_ack command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:allow-webview-health-ready`
+
+</td>
+<td>
+
+Enables the webview_health_ready command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:deny-webview-health-ready`
+
+</td>
+<td>
+
+Denies the webview_health_ready command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/windows/permissions/default.toml
+++ b/plugins/windows/permissions/default.toml
@@ -8,6 +8,8 @@ permissions = [
     "allow-window-emit-navigate",
     "allow-window-is-exists",
     "allow-window-is-occluded",
+    "allow-webview-health-ack",
+    "allow-webview-health-ready",
     "allow-window-set-frame-animated",
     "allow-window-save-frame",
     "allow-window-restore-frame-animated",

--- a/plugins/windows/permissions/schemas/schema.json
+++ b/plugins/windows/permissions/schemas/schema.json
@@ -427,6 +427,30 @@
           "markdownDescription": "Denies the set_show_app_in_dock command without any pre-configured scope."
         },
         {
+          "description": "Enables the webview_health_ack command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-webview-health-ack",
+          "markdownDescription": "Enables the webview_health_ack command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_health_ack command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-webview-health-ack",
+          "markdownDescription": "Denies the webview_health_ack command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the webview_health_ready command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-webview-health-ready",
+          "markdownDescription": "Enables the webview_health_ready command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the webview_health_ready command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-webview-health-ready",
+          "markdownDescription": "Denies the webview_health_ready command without any pre-configured scope."
+        },
+        {
           "description": "Enables the window_destroy command without any pre-configured scope.",
           "type": "string",
           "const": "allow-window-destroy",
@@ -571,10 +595,10 @@
           "markdownDescription": "Denies the window_show command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-window-show`\n- `allow-window-hide`\n- `allow-window-destroy`\n- `allow-window-navigate`\n- `allow-window-emit-navigate`\n- `allow-window-is-exists`\n- `allow-window-is-occluded`\n- `allow-window-set-frame-animated`\n- `allow-window-save-frame`\n- `allow-window-restore-frame-animated`\n- `allow-window-expand-width`\n- `allow-window-restore-width`\n- `allow-set-show-app-in-dock`\n- `allow-floating-bar-show`\n- `allow-floating-bar-hide`\n- `allow-floating-bar-update`\n- `allow-live-caption-show`\n- `allow-live-caption-hide`\n- `allow-live-caption-update`\n- `allow-devtools-panel-show`\n- `allow-devtools-panel-hide`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-window-show`\n- `allow-window-hide`\n- `allow-window-destroy`\n- `allow-window-navigate`\n- `allow-window-emit-navigate`\n- `allow-window-is-exists`\n- `allow-window-is-occluded`\n- `allow-webview-health-ack`\n- `allow-webview-health-ready`\n- `allow-window-set-frame-animated`\n- `allow-window-save-frame`\n- `allow-window-restore-frame-animated`\n- `allow-window-expand-width`\n- `allow-window-restore-width`\n- `allow-set-show-app-in-dock`\n- `allow-floating-bar-show`\n- `allow-floating-bar-hide`\n- `allow-floating-bar-update`\n- `allow-live-caption-show`\n- `allow-live-caption-hide`\n- `allow-live-caption-update`\n- `allow-devtools-panel-show`\n- `allow-devtools-panel-hide`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-window-show`\n- `allow-window-hide`\n- `allow-window-destroy`\n- `allow-window-navigate`\n- `allow-window-emit-navigate`\n- `allow-window-is-exists`\n- `allow-window-is-occluded`\n- `allow-window-set-frame-animated`\n- `allow-window-save-frame`\n- `allow-window-restore-frame-animated`\n- `allow-window-expand-width`\n- `allow-window-restore-width`\n- `allow-set-show-app-in-dock`\n- `allow-floating-bar-show`\n- `allow-floating-bar-hide`\n- `allow-floating-bar-update`\n- `allow-live-caption-show`\n- `allow-live-caption-hide`\n- `allow-live-caption-update`\n- `allow-devtools-panel-show`\n- `allow-devtools-panel-hide`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-window-show`\n- `allow-window-hide`\n- `allow-window-destroy`\n- `allow-window-navigate`\n- `allow-window-emit-navigate`\n- `allow-window-is-exists`\n- `allow-window-is-occluded`\n- `allow-webview-health-ack`\n- `allow-webview-health-ready`\n- `allow-window-set-frame-animated`\n- `allow-window-save-frame`\n- `allow-window-restore-frame-animated`\n- `allow-window-expand-width`\n- `allow-window-restore-width`\n- `allow-set-show-app-in-dock`\n- `allow-floating-bar-show`\n- `allow-floating-bar-hide`\n- `allow-floating-bar-update`\n- `allow-live-caption-show`\n- `allow-live-caption-hide`\n- `allow-live-caption-update`\n- `allow-devtools-panel-show`\n- `allow-devtools-panel-hide`"
         }
       ]
     }

--- a/plugins/windows/src/commands.rs
+++ b/plugins/windows/src/commands.rs
@@ -1,4 +1,4 @@
-use crate::{AppWindow, SavedFrames, WindowImpl, WindowsPluginExt, events};
+use crate::{AppWindow, SavedFrames, WebviewHealthState, WindowImpl, WindowsPluginExt, events};
 
 use tauri::Manager;
 
@@ -22,6 +22,27 @@ pub async fn window_hide(
     window: AppWindow,
 ) -> Result<(), String> {
     app.windows().hide(window).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn webview_health_ack(
+    window: tauri::Window<tauri::Wry>,
+    request_id: String,
+) -> Result<(), String> {
+    if let Some(state) = window.try_state::<WebviewHealthState>() {
+        state.acknowledge(window.label(), &request_id);
+    }
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn webview_health_ready(window: tauri::Window<tauri::Wry>) -> Result<(), String> {
+    if let Some(state) = window.try_state::<WebviewHealthState>() {
+        state.ready(window.label());
+    }
     Ok(())
 }
 

--- a/plugins/windows/src/events.rs
+++ b/plugins/windows/src/events.rs
@@ -91,6 +91,12 @@ common_event_derives! {
     }
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, specta::Type, tauri_specta::Event)]
+#[serde(rename_all = "camelCase")]
+pub struct WebviewHealthCheck {
+    pub request_id: String,
+}
+
 common_event_derives! {
     pub struct FloatingBarStop {}
 }

--- a/plugins/windows/src/ext.rs
+++ b/plugins/windows/src/ext.rs
@@ -1,7 +1,10 @@
 use tauri::{AppHandle, Manager, WebviewWindow};
 use tauri_specta::Event;
 
-use crate::{AppWindow, SavedFrame, WindowImpl, WindowReadyState, events};
+use crate::{AppWindow, SavedFrame, WebviewHealthState, WindowImpl, WindowReadyState, events};
+
+#[cfg(target_os = "macos")]
+const WEBVIEW_HEALTH_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 #[cfg(target_os = "macos")]
 pub(crate) fn run_on_main_thread<R: Send + 'static>(
@@ -18,6 +21,92 @@ pub(crate) fn run_on_main_thread<R: Send + 'static>(
 }
 
 impl AppWindow {
+    #[cfg(target_os = "macos")]
+    fn reload_unresponsive_webview(app: &AppHandle<tauri::Wry>, label: &str, request_id: &str) {
+        let Some(window) = app.get_webview_window(label) else {
+            return;
+        };
+        if !window.is_visible().unwrap_or(false) {
+            return;
+        }
+
+        let Some(state) = app.try_state::<WebviewHealthState>() else {
+            return;
+        };
+        state.begin_recovery(label);
+
+        match window.reload() {
+            Ok(()) => tracing::warn!(
+                request_id,
+                "reloaded unresponsive main webview after reopen"
+            ),
+            Err(error) => {
+                state.ready(label);
+                tracing::error!(
+                    %error,
+                    request_id,
+                    "failed to reload unresponsive main webview after reopen"
+                );
+            }
+        }
+    }
+
+    pub fn request_webview_health_check(
+        &self,
+        app: &AppHandle<tauri::Wry>,
+        window: &WebviewWindow,
+    ) {
+        #[cfg(target_os = "macos")]
+        {
+            if !matches!(self, Self::Main) {
+                return;
+            }
+
+            let Some(state) = app.try_state::<WebviewHealthState>() else {
+                return;
+            };
+            let label = window.label().to_string();
+            let Some((registration_id, request_id, rx)) = state.register(label.clone()) else {
+                return;
+            };
+
+            let health_check = events::WebviewHealthCheck {
+                request_id: request_id.clone(),
+            };
+            if let Err(error) = health_check.emit_to(app, &label) {
+                let should_reload = state.unregister(&label, registration_id);
+                tracing::warn!(%error, "failed to request main webview health check");
+                if should_reload {
+                    Self::reload_unresponsive_webview(app, &label, &request_id);
+                }
+                return;
+            }
+
+            let app = app.clone();
+            tauri::async_runtime::spawn(async move {
+                match tokio::time::timeout(WEBVIEW_HEALTH_CHECK_TIMEOUT, rx).await {
+                    Ok(Ok(())) | Ok(Err(_)) => return,
+                    Err(_) => {}
+                }
+
+                let Some(state) = app.try_state::<WebviewHealthState>() else {
+                    return;
+                };
+                if !state.unregister(&label, registration_id) {
+                    return;
+                }
+
+                Self::reload_unresponsive_webview(&app, &label, &request_id);
+            });
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = app;
+            let _ = window;
+        }
+    }
+
     #[cfg(target_os = "macos")]
     fn with_ns_window<R: Send + 'static>(
         &self,
@@ -279,6 +368,7 @@ impl AppWindow {
             self.ensure_visible(app, &window);
             window.show()?;
             window.set_focus()?;
+            self.request_webview_health_check(app, &window);
             return Ok(Some(window));
         }
         Ok(None)

--- a/plugins/windows/src/lib.rs
+++ b/plugins/windows/src/lib.rs
@@ -18,6 +18,9 @@ use std::sync::{
     Mutex,
     atomic::{AtomicBool, AtomicU64, Ordering},
 };
+use std::time::{Duration, Instant};
+
+const WEBVIEW_RECOVERY_GRACE_PERIOD: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Copy)]
 pub struct SavedFrame {
@@ -91,6 +94,81 @@ pub struct WindowReadyState {
     pending: Mutex<HashMap<String, (u64, oneshot::Sender<()>)>>,
 }
 
+#[derive(Default)]
+struct WebviewHealthState {
+    next_registration_id: AtomicU64,
+    pending: Mutex<HashMap<String, (u64, String, oneshot::Sender<()>)>>,
+    recovering_since: Mutex<HashMap<String, Instant>>,
+}
+
+impl WebviewHealthState {
+    fn register(&self, label: String) -> Option<(u64, String, oneshot::Receiver<()>)> {
+        let mut recovering_since = self.recovering_since.lock().unwrap();
+        if recovering_since
+            .get(&label)
+            .is_some_and(|started_at| started_at.elapsed() < WEBVIEW_RECOVERY_GRACE_PERIOD)
+        {
+            return None;
+        }
+        recovering_since.remove(&label);
+
+        let (tx, rx) = oneshot::channel();
+        let registration_id = self.next_registration_id.fetch_add(1, Ordering::Relaxed);
+        let request_id = uuid::Uuid::new_v4().to_string();
+        self.pending
+            .lock()
+            .unwrap()
+            .insert(label, (registration_id, request_id.clone(), tx));
+        drop(recovering_since);
+
+        Some((registration_id, request_id, rx))
+    }
+
+    fn acknowledge(&self, label: &str, request_id: &str) -> bool {
+        let mut pending = self.pending.lock().unwrap();
+        let is_match = pending
+            .get(label)
+            .is_some_and(|(_, current_request_id, _)| current_request_id == request_id);
+
+        if !is_match {
+            return false;
+        }
+
+        if let Some((_, _, tx)) = pending.remove(label) {
+            let _ = tx.send(());
+        }
+        true
+    }
+
+    fn unregister(&self, label: &str, registration_id: u64) -> bool {
+        let mut pending = self.pending.lock().unwrap();
+        let is_match = pending
+            .get(label)
+            .is_some_and(|(current_id, _, _)| *current_id == registration_id);
+
+        if is_match {
+            pending.remove(label);
+        }
+        is_match
+    }
+
+    fn begin_recovery(&self, label: &str) {
+        let mut recovering_since = self.recovering_since.lock().unwrap();
+        recovering_since.insert(label.to_string(), Instant::now());
+        self.pending.lock().unwrap().remove(label);
+    }
+
+    fn ready(&self, label: &str) {
+        self.recovering_since.lock().unwrap().remove(label);
+    }
+
+    fn remove(&self, label: &str) {
+        let mut recovering_since = self.recovering_since.lock().unwrap();
+        recovering_since.remove(label);
+        self.pending.lock().unwrap().remove(label);
+    }
+}
+
 impl WindowReadyState {
     pub fn register(&self, label: String) -> (u64, oneshot::Receiver<()>) {
         let (tx, rx) = oneshot::channel();
@@ -127,6 +205,9 @@ pub(crate) fn clear_window_state(app: &tauri::AppHandle<tauri::Wry>, label: &str
     if let Some(state) = app.try_state::<WindowReadyState>() {
         state.remove(label);
     }
+    if let Some(state) = app.try_state::<WebviewHealthState>() {
+        state.remove(label);
+    }
     if let Some(state) = app.try_state::<SavedFrames>() {
         state.remove(label);
     }
@@ -143,6 +224,7 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             events::WindowDestroyed,
             events::OpenTab,
             events::VisibilityEvent,
+            events::WebviewHealthCheck,
             events::FloatingBarStop,
             events::FloatingBarOpenMain,
             events::FloatingBarSettingsChange,
@@ -156,6 +238,8 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::window_emit_navigate,
             commands::window_is_exists,
             commands::window_is_occluded,
+            commands::webview_health_ack,
+            commands::webview_health_ready,
             commands::window_set_frame_animated,
             commands::window_save_frame,
             commands::window_restore_frame_animated,
@@ -191,6 +275,11 @@ pub fn init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
             {
                 let ready_state = WindowReadyState::default();
                 app.manage(ready_state);
+            }
+
+            {
+                let health_state = WebviewHealthState::default();
+                app.manage(health_state);
             }
 
             {
@@ -253,6 +342,42 @@ mod test {
         assert!(second_rx.await.is_ok());
         state.unregister("note-1", second_id);
         assert!(state.pending.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn webview_health_acknowledges_only_the_current_request() {
+        let state = WebviewHealthState::default();
+        let (first_id, first_request_id, first_rx) = state.register("main".into()).unwrap();
+        let (second_id, second_request_id, second_rx) = state.register("main".into()).unwrap();
+
+        assert!(first_rx.await.is_err());
+        assert!(!state.acknowledge("main", &first_request_id));
+        assert!(!state.unregister("main", first_id));
+        assert!(state.acknowledge("main", &second_request_id));
+        assert!(second_rx.await.is_ok());
+        assert!(!state.unregister("main", second_id));
+        assert!(state.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn webview_health_timeout_unregisters_only_the_current_request() {
+        let state = WebviewHealthState::default();
+        let (first_id, _, _) = state.register("main".into()).unwrap();
+        let (second_id, _, _) = state.register("main".into()).unwrap();
+
+        assert!(!state.unregister("main", first_id));
+        assert!(state.unregister("main", second_id));
+        assert!(state.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn webview_health_waits_for_reloaded_frontend() {
+        let state = WebviewHealthState::default();
+        state.begin_recovery("main");
+
+        assert!(state.register("main".into()).is_none());
+        state.ready("main");
+        assert!(state.register("main".into()).is_some());
     }
 
     #[test]


### PR DESCRIPTION
Reload the main macOS webview when its frontend no longer responds after an existing window is shown.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reloading the main webview on timeout can discard in-memory UI state if a check misfires, though scope is limited to macOS main window with a post-reload grace period.
> 
> **Overview**
> Adds a **macOS-only webview health check** when the main window is shown again (including second-instance activation), so a frozen frontend can be detected and recovered instead of staying dead behind a visible window.
> 
> On show/reopen, the native side emits a `webviewHealthCheck` event with a `requestId` and waits **2 seconds** for an ack. The windows plugin JS `init()` listens and calls `webviewHealthAck`; after the listener is up it signals `webviewHealthReady` to clear post-reload recovery state. If the event cannot be delivered or the ack never arrives, and the main window is visible, the webview is **reloaded** once, with a **10s grace period** to avoid reload loops while the page boots.
> 
> Wiring includes new Tauri commands and permissions, specta/TS bindings, and unit tests around request matching, timeouts, and recovery gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b775513ddf0bcbe7daade09aec6368eec3d8f75e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->