### PR TITLE
Keep live speaker changes applied

### DIFF
--- a/apps/desktop/src/stt/render-transcript.test.ts
+++ b/apps/desktop/src/stt/render-transcript.test.ts
@@ -238,6 +238,45 @@ describe("buildRenderTranscriptRequestFromRows", () => {
     ]);
   });
 
+  it("applies a live speaker assignment before its anchor word is persisted", () => {
+    const request = buildRenderTranscriptRequestFromRows([
+      {
+        words: [
+          {
+            id: "persisted-word",
+            text: " hello",
+            start_ms: 0,
+            end_ms: 100,
+            channel: 1,
+          },
+        ],
+        speaker_hints: [
+          {
+            word_id: "live-word",
+            type: "user_speaker_assignment",
+            value: {
+              human_id: "remote",
+              scope: "speaker",
+              channel: 1,
+              speaker_index: 2,
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(request?.transcripts[0]?.assignments).toEqual([
+      {
+        human_id: "remote",
+        scope: {
+          kind: "channel_speaker",
+          channel: "RemoteParty",
+          speaker_index: 2,
+        },
+      },
+    ]);
+  });
+
   it("turns segment speaker assignments into word-scoped render assignments", () => {
     const request = createRequest(["segmentOnly"]);
 

--- a/apps/desktop/src/stt/render-transcript.ts
+++ b/apps/desktop/src/stt/render-transcript.ts
@@ -286,6 +286,39 @@ function normalizeSpeakerHint(
     return null;
   }
 
+  const isSpeakerAssignment =
+    hint.type === "automatic_speaker_assignment" ||
+    hint.type === "user_speaker_assignment";
+  const humanId = (value as { human_id?: unknown }).human_id;
+  if (isSpeakerAssignment && typeof humanId === "string") {
+    const explicitSpeakerScope = getExplicitSpeakerScope(value);
+    if (explicitSpeakerScope) {
+      return {
+        human_id: humanId,
+        scope: explicitSpeakerScope,
+      };
+    }
+
+    if (
+      (value as { scope?: unknown }).scope === "segment" &&
+      Array.isArray((value as { word_ids?: unknown }).word_ids)
+    ) {
+      const wordIds = (value as { word_ids: unknown[] }).word_ids.filter(
+        (wordId): wordId is string =>
+          typeof wordId === "string" && wordId.length > 0,
+      );
+      if (wordIds.length > 0) {
+        return {
+          human_id: humanId,
+          scope: {
+            kind: "words",
+            word_ids: wordIds,
+          },
+        };
+      }
+    }
+  }
+
   const wordIndex = wordIndexById.get(hint.word_id);
   if (typeof wordIndex !== "number") {
     return null;
@@ -307,38 +340,7 @@ function normalizeSpeakerHint(
     return null;
   }
 
-  if (
-    (hint.type === "automatic_speaker_assignment" ||
-      hint.type === "user_speaker_assignment") &&
-    typeof (value as { human_id?: unknown }).human_id === "string"
-  ) {
-    const humanId = (value as { human_id: string }).human_id;
-    const explicitSpeakerScope = getExplicitSpeakerScope(value);
-    if (explicitSpeakerScope) {
-      return {
-        human_id: humanId,
-        scope: explicitSpeakerScope,
-      };
-    }
-    if (
-      (value as { scope?: unknown }).scope === "segment" &&
-      Array.isArray((value as { word_ids?: unknown }).word_ids)
-    ) {
-      const wordIds = (value as { word_ids: unknown[] }).word_ids.filter(
-        (wordId): wordId is string =>
-          typeof wordId === "string" && wordId.length > 0,
-      );
-      if (wordIds.length > 0) {
-        return {
-          human_id: humanId,
-          scope: {
-            kind: "words",
-            word_ids: wordIds,
-          },
-        };
-      }
-    }
-
+  if (isSpeakerAssignment && typeof humanId === "string") {
     return word.speaker_index == null
       ? {
           human_id: humanId,

--- a/apps/desktop/src/stt/utils.test.ts
+++ b/apps/desktop/src/stt/utils.test.ts
@@ -567,6 +567,49 @@ describe("TranscriptAccumulator", () => {
     ]);
   });
 
+  it("preserves a live speaker assignment while its anchor word is persisted", () => {
+    const assignment = {
+      id: "word-1:user_speaker_assignment",
+      word_id: "word-1",
+      type: "user_speaker_assignment" as const,
+      value: JSON.stringify({
+        human_id: "human-1",
+        scope: "speaker",
+        channel: 1,
+        speaker_index: 2,
+      }),
+    };
+    const store = createStore({
+      speaker_hints: JSON.stringify([assignment]),
+    });
+    const accumulator = createTranscriptAccumulator(store, "transcript-1");
+
+    accumulator.applyLiveDelta(
+      liveDelta([
+        {
+          id: "word-1",
+          text: "hello",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 1,
+          state: "final",
+          speaker_index: 2,
+        },
+      ]),
+    );
+    accumulator.dispose();
+
+    expect(JSON.parse(store.readCell("speaker_hints"))).toEqual([
+      assignment,
+      {
+        id: "word-1:provider_speaker_index",
+        word_id: "word-1",
+        type: "provider_speaker_index",
+        value: JSON.stringify({ channel: 1, speaker_index: 2 }),
+      },
+    ]);
+  });
+
   it("does not restore externally removed speaker assignments from the accumulator cache", () => {
     const store = createStore({});
     const accumulator = createTranscriptAccumulator(store, "transcript-1", {

--- a/apps/desktop/src/stt/utils.ts
+++ b/apps/desktop/src/stt/utils.ts
@@ -156,7 +156,10 @@ export class TranscriptAccumulator {
       });
 
       for (const reconciledHint of reconciledHints) {
-        if (isSegmentSpeakerAssignmentHint(reconciledHint)) {
+        if (
+          isSegmentSpeakerAssignmentHint(reconciledHint) ||
+          isSpeakerScopedAssignmentHint(reconciledHint)
+        ) {
           nextHints.push(reconciledHint);
           continue;
         }
@@ -715,6 +718,31 @@ function isWithinSegmentRange(
 
 function isSegmentSpeakerAssignmentHint(hint: SpeakerHintWithId): boolean {
   return getSegmentSpeakerAssignment(hint) !== null;
+}
+
+function isSpeakerScopedAssignmentHint(hint: SpeakerHintWithId): boolean {
+  if (
+    hint.type !== "automatic_speaker_assignment" &&
+    hint.type !== "user_speaker_assignment"
+  ) {
+    return false;
+  }
+
+  const value = parseHintValue(hint.value);
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const scope = value as {
+    scope?: unknown;
+    channel?: unknown;
+    speaker_index?: unknown;
+  };
+  return (
+    scope.scope === "speaker" &&
+    (scope.channel === 0 || scope.channel === 1 || scope.channel === 2) &&
+    (scope.speaker_index === null || typeof scope.speaker_index === "number")
+  );
 }
 
 function getSegmentSpeakerAssignment(


### PR DESCRIPTION
Preserve scoped assignments across live persistence and render them before anchor words land.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live transcript hint reconciliation and speaker assignment rendering; wrong logic could mislabel speakers or drop user assignments during streaming updates.
> 
> **Overview**
> Fixes a race where **live speaker relabeling** could disappear or fail to show until the anchor transcript word was saved.
> 
> **Transcript accumulator** (`utils.ts`): hints with `scope: "speaker"` are now retained across live word persistence the same way segment-scoped assignments are—they are no longer dropped when the hint’s `word_id` is replaced or appears in an incoming delta.
> 
> **Render path** (`render-transcript.ts`): `normalizeSpeakerHint` resolves explicit `speaker` and `segment` assignments **before** requiring the anchor word in the word list, so render requests can emit `channel_speaker` assignments even when the hint still points at a not-yet-persisted live word id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d31a1c16d4d17a099dc37abb403b0a1884e70ef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->