### PR TITLE
Keep calendar contact enhancement local

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
@@ -1,23 +1,10 @@
-import { generateText, type LanguageModel } from "ai";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import {
   buildEventContactExtractionContextFromRecords,
   extractEventContacts,
   planExtractedContactToHuman,
 } from "./event-contact-extraction";
-
-const mocks = vi.hoisted(() => ({
-  renderTemplate: vi.fn(),
-}));
-
-vi.mock("ai", () => ({
-  generateText: vi.fn(),
-}));
-
-vi.mock("@anlg/plugin-template", () => ({
-  commands: { render: mocks.renderTemplate },
-}));
 
 const sessionEvent = {
   tracking_id: "event-1",
@@ -31,20 +18,6 @@ const sessionEvent = {
 };
 
 describe("event contact extraction", () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-    mocks.renderTemplate.mockImplementation(async (template: unknown) => {
-      if (
-        template &&
-        typeof template === "object" &&
-        ("eventContactSystem" in template || "eventContactUser" in template)
-      ) {
-        return { status: "success", data: "Prompt" };
-      }
-      return { status: "error", error: "Unexpected template" };
-    });
-  });
-
   test("builds context from canonical participants and event attendees", () => {
     const context = buildEventContactExtractionContextFromRecords({
       sessionEvent,
@@ -154,19 +127,7 @@ describe("event contact extraction", () => {
     expect(changes).toEqual({});
   });
 
-  test("normalizes model output against canonical candidates", async () => {
-    vi.mocked(generateText).mockResolvedValue({
-      text: JSON.stringify({
-        contacts: [
-          {
-            name: "Alice Kim",
-            email: "ALICE@example.com",
-            companyName: "Example",
-          },
-        ],
-      }),
-    } as never);
-
+  test("extracts contacts locally from event text and canonical candidates", () => {
     const context = buildEventContactExtractionContextFromRecords({
       sessionEvent,
       currentUserId: "user-1",
@@ -186,18 +147,14 @@ describe("event contact extraction", () => {
       ],
       eventParticipants: [],
     });
-    const result = await extractEventContacts({
-      model: {} as LanguageModel,
-      context,
-    });
+    const result = extractEventContacts({ context });
 
     expect(result).toEqual({
-      source: "model",
+      source: "local",
       contacts: [
         {
           name: "Alice Kim",
           email: "alice@example.com",
-          companyName: "Example",
         },
       ],
     });

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
@@ -1,10 +1,3 @@
-import { generateText, type LanguageModel } from "ai";
-import { z } from "zod";
-
-import {
-  commands as templateCommands,
-  type EventContactCandidate as TemplateEventContactCandidate,
-} from "@anlg/plugin-template";
 import type { EventParticipant, SessionEvent } from "@anlg/store";
 
 const MAX_EVENT_TEXT_CHARS = 6000;
@@ -32,7 +25,7 @@ export type ExtractedEventContact = {
 
 export type ExtractEventContactsResult = {
   contacts: ExtractedEventContact[];
-  source: "model";
+  source: "local";
 };
 
 export type ApplyExtractedContactsResult = {
@@ -52,18 +45,6 @@ export type ContactEnhancementChanges = {
   email?: string;
   companyName?: string;
 };
-
-const aiExtractionSchema = z.object({
-  contacts: z
-    .array(
-      z.object({
-        name: z.string(),
-        email: z.union([z.string(), z.null()]).optional(),
-        companyName: z.union([z.string(), z.null()]).optional(),
-      }),
-    )
-    .max(MAX_CONTACTS_TO_EXTRACT),
-});
 
 export function buildEventContactExtractionContextFromRecords({
   sessionEvent,
@@ -173,39 +154,24 @@ export function planExtractedContactToHuman({
   return { result, changes };
 }
 
-export async function extractEventContacts({
-  model,
+export function extractEventContacts({
   context,
 }: {
-  model: LanguageModel | null;
   context: EventContactExtractionContext;
-}): Promise<ExtractEventContactsResult> {
-  if (!model) {
-    throw new Error("Language model needed");
-  }
-
-  const [system, prompt] = await Promise.all([
-    getSystemPrompt(),
-    getUserPrompt(context),
-  ]);
-
-  const result = await generateText({
-    model,
-    maxRetries: 2,
-    maxOutputTokens: 384,
-    system,
-    prompt,
-  });
-
+}): ExtractEventContactsResult {
   const contacts = normalizeExtractedContacts(
     [
       ...inferContactsFromEventText(context),
-      ...parseExtractionJson(result.text).contacts,
+      ...context.candidates.flatMap((candidate) =>
+        candidate.isCurrentUser || candidate.isOrganizer
+          ? []
+          : [{ name: candidate.name, email: candidate.email }],
+      ),
     ],
     context.candidates,
   );
 
-  return { contacts, source: "model" };
+  return { contacts, source: "local" };
 }
 
 function dedupeCandidates(
@@ -241,57 +207,6 @@ function dedupeCandidates(
   }
 
   return Array.from(byKey.values());
-}
-
-async function getSystemPrompt(): Promise<string> {
-  const result = await templateCommands.render({ eventContactSystem: {} });
-  if (result.status === "error") {
-    throw new Error(result.error);
-  }
-
-  return result.data;
-}
-
-function parseExtractionJson(text: string): z.infer<typeof aiExtractionSchema> {
-  try {
-    return aiExtractionSchema.parse(JSON.parse(stripJsonFence(text)));
-  } catch {
-    throw new Error("Invalid contact extraction JSON");
-  }
-}
-
-function stripJsonFence(text: string): string {
-  const trimmed = text.trim();
-  const match = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-  return match ? match[1].trim() : trimmed;
-}
-
-async function getUserPrompt(
-  context: EventContactExtractionContext,
-): Promise<string> {
-  const result = await templateCommands.render({
-    eventContactUser: {
-      title: context.title?.trim() || null,
-      description: trimEventText(context.description) || null,
-      candidates: context.candidates.map(toTemplateCandidate),
-    },
-  });
-  if (result.status === "error") {
-    throw new Error(result.error);
-  }
-
-  return result.data;
-}
-
-function toTemplateCandidate(
-  candidate: EventContactCandidate,
-): TemplateEventContactCandidate {
-  return {
-    name: candidate.name?.trim() || null,
-    email: candidate.email?.trim() || null,
-    isCurrentUser: !!candidate.isCurrentUser,
-    isOrganizer: !!candidate.isOrganizer,
-  };
 }
 
 function trimEventText(value: string | undefined): string {

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
@@ -22,7 +22,6 @@ import {
   planExtractedContactToHuman,
 } from "./event-contact-extraction";
 
-import { useLanguageModel } from "~/ai/hooks";
 import { useSessionEventParticipants } from "~/calendar/queries";
 import {
   applyContactEnhancement,
@@ -410,8 +409,6 @@ function useEventContactEnhancement(sessionId: string) {
   const participants = useSessionParticipants(sessionId);
   const humans = useHumans();
   const eventParticipants = useSessionEventParticipants(sessionId);
-  const model = useLanguageModel("title");
-
   const showEnhancementButtons = Boolean(
     sessionEvent?.title?.trim() || sessionEvent?.description?.trim(),
   );
@@ -429,7 +426,7 @@ function useEventContactEnhancement(sessionId: string) {
         participants,
         eventParticipants,
       });
-      const extraction = await extractEventContacts({ model, context });
+      const extraction = extractEventContacts({ context });
       const participant = participants.find(
         (candidate) => candidate.humanId === humanId,
       );

--- a/apps/web/content/legal/privacy.mdx
+++ b/apps/web/content/legal/privacy.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2026-08-01"
+date: "2026-08-14"
 title: "Privacy Policy"
 summary: "What we collect, what stays on your device, and the choices you have."
 ---
@@ -44,7 +44,9 @@ If you connect Google Calendar or Microsoft Outlook Calendar, we use the Google 
 - **Event information:** Event IDs, titles, descriptions, locations, meeting links, start and end times, time zones, recurrence metadata, organizer details, and attendee details such as names, email addresses, and RSVP status
 - **Connection information:** Provider connection IDs, connection status, and the Google or Microsoft account identity associated with the connection
 
-We use connected calendar data to display calendars and upcoming events and to support the personal notes and memos you create for those events. Calendar API responses pass through Nango's encrypted API proxy before reaching Anarlog. We do not use connected calendar data for advertising, marketing personalization, sale to data brokers, or training generalized AI models. The use of information received from Google Workspace APIs adheres to the [Google Workspace API User Data and Developer Policy](https://developers.google.com/workspace/workspace-api-user-data-developer-policy), including the Limited Use requirements.
+We use connected calendar data to display calendars and upcoming events and to support the personal notes and memos you create for those events. Contact enhancement from event details is performed locally on your device. If you deliberately use AI on an event-linked note, the note context needed for that request — such as the event title and participant names — may be processed by the language model you selected. Local models keep that processing on your device. For a cloud model, the context goes through our AI gateway or directly to the provider when you use your own API key, as described in Sections 4 and 8.2.
+
+Calendar API responses pass through Nango's encrypted API proxy before reaching Anarlog. We do not use connected calendar data for advertising, marketing personalization, sale to data brokers, or training generalized AI models. The use of information received from Google Workspace APIs adheres to the [Google Workspace API User Data and Developer Policy](https://developers.google.com/workspace/workspace-api-user-data-developer-policy), including the Limited Use requirements.
 
 ### 3.4 Other connected accounts
 
@@ -55,7 +57,7 @@ If you connect an issue tracker like Linear or GitHub, we access the issues, pul
 - **Recording happens on your device.** Anarlog captures microphone and system audio locally, without adding a bot to your call. Recordings can include other people's voices — you're responsible for giving any notice and getting any consent the law requires for your meetings.
 - **Local options.** Use on-device transcription and a local language model, and meeting content never leaves your device.
 - **Cloud transcription.** If you use it, the audio needed for the transcript travels through our servers to our speech-to-text providers, and a request may fail over between the providers listed in Section 8.2. We delete uploaded audio from our storage once the job completes. The transcript result is stored so your devices can fetch it, and deleted with your account.
-- **Cloud AI.** If you use cloud summaries or chat, the text and instructions needed for the request go through our AI gateway to the model providers listed in Section 8.2. If you use AI chat with web search, your search queries go to our search providers. We never use your notes, transcripts, or audio to train AI models.
+- **Cloud AI.** If you use cloud summaries or chat, the text and instructions needed for the request go through our AI gateway to the model providers listed in Section 8.2. This can include event context associated with a note when you deliberately invoke AI on that note. If you use AI chat with web search, your search queries go to our search providers. We never use your notes, transcripts, audio, or connected calendar data to train AI models.
 - **Your own providers.** If you bring your own API key or a local endpoint, content goes directly to the provider you chose, under your agreement with them.
 
 ## 5. Cloud Sync, sharing, and the Cloud API
@@ -120,6 +122,7 @@ We share information with providers who do work on our behalf:
 When you connect Google Calendar or Microsoft Outlook Calendar, we may share connected calendar data only:
 
 - With service providers directly involved in authenticating the connection, syncing calendars and events, and delivering the calendar features you enable
+- With the language-model provider you select, only when you deliberately invoke AI on a note that includes event context; local models process that context on your device
 - Through encrypted Cloud Sync or content you choose to share when event context has been associated with a note and you enable that user-facing feature
 - For security purposes, such as investigating abuse, preventing fraud, or fixing integration failures
 - To comply with applicable law, regulation, legal process, or enforceable governmental request

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -257,6 +257,13 @@ export function ConnectFlow() {
             may be included.
           </p>
           <p>
+            Contact enhancement from event details is processed locally on your
+            device. If you choose to use AI on an event-linked note, relevant
+            note context such as the event title and participants may go to the
+            language model you selected. Local models keep that processing on
+            your device.
+          </p>
+          <p>
             Read our{" "}
             <a className="underline" href="/privacy">
               Privacy Policy


### PR DESCRIPTION
Remove model-based contact extraction and disclose optional AI processing for event-linked notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible contact enrichment (no cloud/LLM inference) and legal/consent text; behavior may differ from prior model-based extraction (e.g. company names from descriptions).
> 
> **Overview**
> **Event contact enhancement no longer calls a language model.** `extractEventContacts` is synchronous and builds contacts from on-device event text heuristics plus non–current-user / non-organizer candidates, with result `source: "local"`. The participant UI drops `useLanguageModel` and no longer needs a configured model for enhancement.
> 
> **Disclosures align with the new behavior.** The privacy policy and calendar connect consent copy state that contact enhancement from event details stays on the device, while deliberate AI on an event-linked note may send limited event context to the model the user chose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ddea0d55efd1e1ef83642aadce389fe5e1531f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->