### PR TITLE
Define E2EE-safe bot session ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16187,6 +16187,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "session-ingest"
+version = "0.1.0"
+dependencies = [
+ "agent-access",
+ "db-app",
+ "db-core",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ anlg-resampler = { path = "crates/resampler", package = "resampler" }
 anlg-s3 = { path = "crates/s3", package = "s3" }
 anlg-screen-core = { path = "crates/screen-core", package = "screen-core" }
 anlg-segmentation = { path = "crates/segmentation", package = "segmentation" }
+anlg-session-ingest = { path = "crates/session-ingest", package = "session-ingest" }
 anlg-shortcut-macos = { path = "crates/shortcut-macos", package = "shortcut-macos" }
 anlg-slack-web = { path = "crates/slack-web", package = "slack-web" }
 anlg-storage = { path = "crates/storage", package = "storage" }

--- a/crates/session-ingest/Cargo.toml
+++ b/crates/session-ingest/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "session-ingest"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha2 = { workspace = true, optional = true }
+sqlx = { workspace = true, features = ["runtime-tokio", "sqlite"], optional = true }
+thiserror = { workspace = true, optional = true }
+
+[features]
+default = ["apply"]
+apply = ["dep:sha2", "dep:sqlx", "dep:thiserror"]
+
+[dev-dependencies]
+anlg-agent-access = { workspace = true }
+anlg-db-app = { workspace = true }
+anlg-db-core = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/session-ingest/src/apply.rs
+++ b/crates/session-ingest/src/apply.rs
@@ -1,0 +1,797 @@
+use std::{collections::HashSet, fmt::Write};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+use sqlx::{Sqlite, SqlitePool, Transaction};
+
+use crate::{SessionIngestEnvelope, validate};
+
+const SOURCE_TYPE: &str = "meeting_bot";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyOutcome {
+    Applied,
+    AlreadyApplied,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid session ingest envelope: {0}")]
+    InvalidEnvelope(String),
+    #[error("session ingest schema {actual} is unsupported; supported version is {supported}")]
+    UnsupportedSchema { actual: u32, supported: u32 },
+    #[error("session ingest envelope is {actual} bytes; maximum is {maximum}")]
+    EnvelopeTooLarge { actual: usize, maximum: usize },
+    #[error("workspace mismatch: expected '{expected}', received '{actual}'")]
+    WorkspaceMismatch { expected: String, actual: String },
+    #[error("{entity} '{id}' belongs to a different session, workspace, or owner")]
+    OwnershipConflict { entity: &'static str, id: String },
+    #[error("session '{session_id}' is not owned by capture source '{source_id}'")]
+    SourceConflict {
+        session_id: String,
+        source_id: String,
+    },
+    #[error("{entity} '{id}' is not owned by capture source '{source_id}'")]
+    ChildSourceConflict {
+        entity: &'static str,
+        id: String,
+        source_id: String,
+    },
+    #[error("session '{session_id}' already finalized at revision {revision}")]
+    Finalized { session_id: String, revision: u64 },
+    #[error("session '{session_id}' was deleted")]
+    DeletedSession { session_id: String },
+    #[error("revision {actual} is older than applied revision {applied}")]
+    StaleRevision { actual: u64, applied: u64 },
+    #[error("revision {revision} was already applied with different content")]
+    RevisionConflict { revision: u64 },
+    #[error("existing metadata for {entity} '{id}' is invalid")]
+    InvalidExistingMetadata { entity: &'static str, id: String },
+    #[error("could not serialize session ingest data: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("could not apply session ingest envelope: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IngestMarker {
+    source_id: String,
+    revision: u64,
+    content_hash: String,
+    finalized: bool,
+}
+
+struct ExistingSession {
+    workspace_id: String,
+    owner_user_id: String,
+    metadata_json: String,
+    deleted_at: Option<String>,
+}
+
+pub async fn apply_session_envelope(
+    pool: &SqlitePool,
+    expected_workspace_id: &str,
+    envelope: &SessionIngestEnvelope,
+) -> Result<ApplyOutcome, Error> {
+    let serialized = serde_json::to_vec(envelope)?;
+    validate::validate(expected_workspace_id, envelope, &serialized)?;
+    let marker = IngestMarker {
+        source_id: envelope.source_id.clone(),
+        revision: envelope.revision,
+        content_hash: content_hash(envelope)?,
+        finalized: envelope.finalized,
+    };
+
+    let mut tx = pool.begin().await?;
+    let existing = load_session(&mut tx, &envelope.session.id).await?;
+    let attached_existing = match existing.as_ref() {
+        Some(existing) => {
+            ensure_session_scope(existing, envelope)?;
+            if existing.deleted_at.is_some() {
+                return Err(Error::DeletedSession {
+                    session_id: envelope.session.id.clone(),
+                });
+            }
+            match read_marker("session", &envelope.session.id, &existing.metadata_json)? {
+                Some(applied) => {
+                    if applied.source_id != envelope.source_id {
+                        return Err(Error::SourceConflict {
+                            session_id: envelope.session.id.clone(),
+                            source_id: envelope.source_id.clone(),
+                        });
+                    }
+                    if envelope.revision < applied.revision {
+                        return Err(Error::StaleRevision {
+                            actual: envelope.revision,
+                            applied: applied.revision,
+                        });
+                    }
+                    if envelope.revision == applied.revision {
+                        if marker.content_hash == applied.content_hash {
+                            return Ok(ApplyOutcome::AlreadyApplied);
+                        }
+                        return Err(Error::RevisionConflict {
+                            revision: envelope.revision,
+                        });
+                    }
+                    if applied.finalized {
+                        return Err(Error::Finalized {
+                            session_id: envelope.session.id.clone(),
+                            revision: applied.revision,
+                        });
+                    }
+                    envelope.attach_to_existing
+                }
+                None if envelope.attach_to_existing => true,
+                None => {
+                    return Err(Error::SourceConflict {
+                        session_id: envelope.session.id.clone(),
+                        source_id: envelope.source_id.clone(),
+                    });
+                }
+            }
+        }
+        None => false,
+    };
+
+    ensure_child_scopes(&mut tx, envelope).await?;
+    write_session(&mut tx, envelope, &marker, existing, attached_existing).await?;
+    write_documents(&mut tx, envelope, &marker).await?;
+    write_attachments(&mut tx, envelope, &marker).await?;
+    write_transcripts(&mut tx, envelope, &marker).await?;
+    write_participants(&mut tx, envelope, &marker).await?;
+    reconcile_children(&mut tx, envelope, &marker).await?;
+    tx.commit().await?;
+
+    Ok(ApplyOutcome::Applied)
+}
+
+async fn load_session(
+    tx: &mut Transaction<'_, Sqlite>,
+    session_id: &str,
+) -> Result<Option<ExistingSession>, sqlx::Error> {
+    sqlx::query_as::<_, (String, String, String, Option<String>)>(
+        "SELECT workspace_id, owner_user_id, metadata_json, deleted_at FROM sessions WHERE id = ?",
+    )
+    .bind(session_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map(|row| {
+        row.map(
+            |(workspace_id, owner_user_id, metadata_json, deleted_at)| ExistingSession {
+                workspace_id,
+                owner_user_id,
+                metadata_json,
+                deleted_at,
+            },
+        )
+    })
+}
+
+fn ensure_session_scope(
+    existing: &ExistingSession,
+    envelope: &SessionIngestEnvelope,
+) -> Result<(), Error> {
+    if existing.workspace_id != envelope.workspace_id
+        || existing.owner_user_id != envelope.owner_user_id
+    {
+        return Err(Error::OwnershipConflict {
+            entity: "session",
+            id: envelope.session.id.clone(),
+        });
+    }
+    Ok(())
+}
+
+async fn ensure_child_scopes(
+    tx: &mut Transaction<'_, Sqlite>,
+    envelope: &SessionIngestEnvelope,
+) -> Result<(), Error> {
+    for document in &envelope.documents {
+        ensure_session_child_scope(tx, "session_documents", "document", &document.id, envelope)
+            .await?;
+    }
+    for transcript in &envelope.transcripts {
+        ensure_session_child_scope(tx, "transcripts", "transcript", &transcript.id, envelope)
+            .await?;
+    }
+    for participant in &envelope.participants {
+        ensure_session_child_scope(
+            tx,
+            "session_participants",
+            "participant",
+            &participant.id,
+            envelope,
+        )
+        .await?;
+        if !participant.human_id.is_empty() {
+            let row = sqlx::query_as::<_, (String, String)>(
+                "SELECT workspace_id, owner_user_id FROM humans WHERE id = ?",
+            )
+            .bind(&participant.human_id)
+            .fetch_optional(&mut **tx)
+            .await?;
+            if row.is_some_and(|(workspace_id, owner_user_id)| {
+                workspace_id != envelope.workspace_id || owner_user_id != envelope.owner_user_id
+            }) {
+                return Err(Error::OwnershipConflict {
+                    entity: "human",
+                    id: participant.human_id.clone(),
+                });
+            }
+        }
+    }
+    for attachment in &envelope.attachments {
+        ensure_session_child_scope(
+            tx,
+            "session_attachments",
+            "attachment",
+            &attachment.id,
+            envelope,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn ensure_session_child_scope(
+    tx: &mut Transaction<'_, Sqlite>,
+    table: &'static str,
+    entity: &'static str,
+    id: &str,
+    envelope: &SessionIngestEnvelope,
+) -> Result<(), Error> {
+    let statement = match table {
+        "session_documents" => {
+            "SELECT workspace_id, session_id, generation_metadata_json
+             FROM session_documents WHERE id = ?"
+        }
+        "transcripts" => {
+            "SELECT workspace_id, session_id, metadata_json FROM transcripts WHERE id = ?"
+        }
+        "session_participants" => {
+            "SELECT workspace_id, session_id, metadata_json
+             FROM session_participants WHERE id = ?"
+        }
+        "session_attachments" => {
+            "SELECT workspace_id, session_id, metadata_json
+             FROM session_attachments WHERE id = ?"
+        }
+        _ => unreachable!(),
+    };
+    let row = sqlx::query_as::<_, (String, String, String)>(statement)
+        .bind(id)
+        .fetch_optional(&mut **tx)
+        .await?;
+    if let Some((workspace_id, session_id, metadata_json)) = row {
+        if workspace_id != envelope.workspace_id || session_id != envelope.session.id {
+            return Err(Error::OwnershipConflict {
+                entity,
+                id: id.to_string(),
+            });
+        }
+        let source_matches = read_marker(entity, id, &metadata_json)?
+            .is_some_and(|marker| marker.source_id == envelope.source_id);
+        if !source_matches {
+            return Err(Error::ChildSourceConflict {
+                entity,
+                id: id.to_string(),
+                source_id: envelope.source_id.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+async fn write_session(
+    tx: &mut Transaction<'_, Sqlite>,
+    envelope: &SessionIngestEnvelope,
+    marker: &IngestMarker,
+    existing: Option<ExistingSession>,
+    attached_existing: bool,
+) -> Result<(), Error> {
+    let metadata_json = merge_metadata(
+        "session",
+        &envelope.session.id,
+        existing
+            .as_ref()
+            .map(|session| session.metadata_json.as_str()),
+        &envelope.session.metadata,
+        marker,
+    )?;
+    let source_apps_json = serde_json::to_string(&[json!({ "app": SOURCE_TYPE })])?;
+    let event_json = if envelope.session.event.is_null() {
+        String::new()
+    } else {
+        serde_json::to_string(&envelope.session.event)?
+    };
+
+    if existing.is_none() {
+        sqlx::query(
+            "INSERT INTO sessions (
+                id, workspace_id, owner_user_id, title, kind, status, created_at, updated_at,
+                started_at, ended_at, timezone, language, event_id, external_event_id,
+                external_provider, series_id, source_apps_json, event_json, metadata_json
+             ) VALUES (?, ?, ?, ?, 'meeting', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&envelope.session.id)
+        .bind(&envelope.workspace_id)
+        .bind(&envelope.owner_user_id)
+        .bind(&envelope.session.title)
+        .bind(&envelope.session.status)
+        .bind(&envelope.session.created_at)
+        .bind(&envelope.session.updated_at)
+        .bind(&envelope.session.started_at)
+        .bind(&envelope.session.ended_at)
+        .bind(&envelope.session.timezone)
+        .bind(&envelope.session.language)
+        .bind(&envelope.session.event_id)
+        .bind(&envelope.session.external_event_id)
+        .bind(&envelope.session.external_provider)
+        .bind(&envelope.session.series_id)
+        .bind(source_apps_json)
+        .bind(event_json)
+        .bind(metadata_json)
+        .execute(&mut **tx)
+        .await?;
+    } else if attached_existing {
+        sqlx::query(
+            "UPDATE sessions SET
+                status = ?,
+                updated_at = ?,
+                started_at = COALESCE(NULLIF(?, ''), started_at),
+                ended_at = COALESCE(NULLIF(?, ''), ended_at),
+                timezone = COALESCE(NULLIF(timezone, ''), ?),
+                language = COALESCE(NULLIF(language, ''), ?),
+                event_id = COALESCE(NULLIF(event_id, ''), ?),
+                external_event_id = COALESCE(NULLIF(external_event_id, ''), ?),
+                external_provider = COALESCE(NULLIF(external_provider, ''), ?),
+                series_id = COALESCE(NULLIF(series_id, ''), ?),
+                metadata_json = ?
+             WHERE id = ?",
+        )
+        .bind(&envelope.session.status)
+        .bind(&envelope.session.updated_at)
+        .bind(&envelope.session.started_at)
+        .bind(&envelope.session.ended_at)
+        .bind(&envelope.session.timezone)
+        .bind(&envelope.session.language)
+        .bind(&envelope.session.event_id)
+        .bind(&envelope.session.external_event_id)
+        .bind(&envelope.session.external_provider)
+        .bind(&envelope.session.series_id)
+        .bind(metadata_json)
+        .bind(&envelope.session.id)
+        .execute(&mut **tx)
+        .await?;
+    } else {
+        sqlx::query(
+            "UPDATE sessions SET
+                title = ?, status = ?, updated_at = ?, started_at = ?, ended_at = ?,
+                timezone = ?, language = ?, event_id = ?, external_event_id = ?,
+                external_provider = ?, series_id = ?, source_apps_json = ?, event_json = ?,
+                metadata_json = ?
+             WHERE id = ?",
+        )
+        .bind(&envelope.session.title)
+        .bind(&envelope.session.status)
+        .bind(&envelope.session.updated_at)
+        .bind(&envelope.session.started_at)
+        .bind(&envelope.session.ended_at)
+        .bind(&envelope.session.timezone)
+        .bind(&envelope.session.language)
+        .bind(&envelope.session.event_id)
+        .bind(&envelope.session.external_event_id)
+        .bind(&envelope.session.external_provider)
+        .bind(&envelope.session.series_id)
+        .bind(source_apps_json)
+        .bind(event_json)
+        .bind(metadata_json)
+        .bind(&envelope.session.id)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+async fn write_documents(
+    tx: &mut Transaction<'_, Sqlite>,
+    envelope: &SessionIngestEnvelope,
+    marker: &IngestMarker,
+) -> Result<(), Error> {
+    for document in &envelope.documents {
+        let existing = load_metadata(tx, "session_documents", &document.id).await?;
+        let generation_metadata = merge_metadata(
+            "document",
+            &document.id,
+            existing.as_deref(),
+            &document.generation_metadata,
+            marker,
+        )?;
+        sqlx::query(
+            "INSERT INTO session_documents (
+                id, workspace_id, session_id, kind, template_id, title, body_format, body,
+                source_hash, generation_metadata_json, sort_order, created_by, updated_by,
+                created_at, updated_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+                kind = excluded.kind, template_id = excluded.template_id, title = excluded.title,
+                body_format = excluded.body_format, body = excluded.body,
+                source_hash = excluded.source_hash,
+                generation_metadata_json = excluded.generation_metadata_json,
+                sort_order = excluded.sort_order, updated_by = excluded.updated_by,
+                updated_at = excluded.updated_at, deleted_at = NULL",
+        )
+        .bind(&document.id)
+        .bind(&envelope.workspace_id)
+        .bind(&envelope.session.id)
+        .bind(document.kind.as_str())
+        .bind(&document.template_id)
+        .bind(&document.title)
+        .bind(document.format.as_str())
+        .bind(&document.body)
+        .bind(&document.source_hash)
+        .bind(generation_metadata)
+        .bind(document.sort_order)
+        .bind(SOURCE_TYPE)
+        .bind(SOURCE_TYPE)
+        .bind(&document.created_at)
+        .bind(&document.updated_at)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+async fn write_attachments(
+    tx: &mut Transaction<'_, Sqlite>,
+    envelope: &SessionIngestEnvelope,
+    marker: &IngestMarker,
+) -> Result<(), Error> {
+    for attachment in &envelope.attachments {
+        let existing = load_metadata(tx, "session_attachments", &attachment.id).await?;
+        let metadata = merge_metadata(
+            "attachment",
+            &attachment.id,
+            existing.as_deref(),
+            &attachment.metadata,
+            marker,
+        )?;
+        sqlx::query(
+            "INSERT INTO session_attachments (
+                id, workspace_id, session_id, filename, content_type, size_bytes, sha256,
+                storage_kind, cloud_object_key, source_type, source_id, metadata_json,
+                created_at, updated_at, cloud_sync_enabled
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, 'remote_object', ?, ?, ?, ?, ?, ?, 0)
+             ON CONFLICT(id) DO UPDATE SET
+                filename = excluded.filename, content_type = excluded.content_type,
+                size_bytes = excluded.size_bytes, sha256 = excluded.sha256,
+                storage_kind = excluded.storage_kind, cloud_object_key = excluded.cloud_object_key,
+                source_type = excluded.source_type, source_id = excluded.source_id,
+                metadata_json = excluded.metadata_json, updated_at = excluded.updated_at,
+                cloud_sync_enabled = 0, deleted_at = NULL",
+        )
+        .bind(&attachment.id)
+        .bind(&envelope.workspace_id)
+        .bind(&envelope.session.id)
+        .bind(&attachment.filename)
+        .bind(&attachment.content_type)
+        .bind(i64::try_from(attachment.size_bytes).expect("attachment size was validated"))
+        .bind(&attachment.sha256)
+        .bind(&attachment.object_key)
+        .bind(SOURCE_TYPE)
+        .bind(&envelope.source_id)
+        .bind(metadata)
+        .bind(&attachment.created_at)
+        .bind(&attachment.updated_at)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+async fn write_transcripts(
+    tx: &mut Transaction<'_, Sqlite>,
+    envelope: &SessionIngestEnvelope,
+    marker: &IngestMarker,
+) -> Result<(), Error> {
+    for transcript in &envelope.transcripts {
+        let existing = load_metadata(tx, "transcripts", &transcript.id).await?;
+        let metadata = merge_metadata(
+            "transcript",
+            &transcript.id,
+            existing.as_deref(),
+            &transcript.metadata,
+            marker,
+        )?;
+        sqlx::query(
+            "INSERT INTO transcripts (
+                id, workspace_id, owner_user_id, session_id, source, provider, model, language,
+                started_at_ms, ended_at_ms, audio_attachment_id, memo, words_json,
+                speaker_hints_json, metadata_json, created_at, updated_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+                source = excluded.source, provider = excluded.provider, model = excluded.model,
+                language = excluded.language, started_at_ms = excluded.started_at_ms,
+                ended_at_ms = excluded.ended_at_ms,
+                audio_attachment_id = excluded.audio_attachment_id, memo = excluded.memo,
+                words_json = excluded.words_json,
+                speaker_hints_json = excluded.speaker_hints_json,
+                metadata_json = excluded.metadata_json, updated_at = excluded.updated_at,
+                deleted_at = NULL",
+        )
+        .bind(&transcript.id)
+        .bind(&envelope.workspace_id)
+        .bind(&envelope.owner_user_id)
+        .bind(&envelope.session.id)
+        .bind(SOURCE_TYPE)
+        .bind(&transcript.provider)
+        .bind(&transcript.model)
+        .bind(&transcript.language)
+        .bind(transcript.started_at_ms)
+        .bind(transcript.ended_at_ms)
+        .bind(&transcript.audio_attachment_id)
+        .bind(&transcript.memo)
+        .bind(serde_json::to_string(&transcript.words)?)
+        .bind(serde_json::to_string(&transcript.speaker_hints)?)
+        .bind(metadata)
+        .bind(&transcript.created_at)
+        .bind(&transcript.updated_at)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+async fn write_participants(
+    tx: &mut Transaction<'_, Sqlite>,
+    envelope: &SessionIngestEnvelope,
+    marker: &IngestMarker,
+) -> Result<(), Error> {
+    for participant in &envelope.participants {
+        if !participant.human_id.is_empty() {
+            sqlx::query(
+                "INSERT OR IGNORE INTO humans (
+                    id, workspace_id, owner_user_id, name, email, created_at, updated_at
+                 ) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&participant.human_id)
+            .bind(&envelope.workspace_id)
+            .bind(&envelope.owner_user_id)
+            .bind(&participant.display_name)
+            .bind(&participant.email)
+            .bind(&participant.created_at)
+            .bind(&participant.updated_at)
+            .execute(&mut **tx)
+            .await?;
+        }
+        let existing = load_metadata(tx, "session_participants", &participant.id).await?;
+        let metadata = merge_metadata(
+            "participant",
+            &participant.id,
+            existing.as_deref(),
+            &participant.metadata,
+            marker,
+        )?;
+        sqlx::query(
+            "INSERT INTO session_participants (
+                id, workspace_id, owner_user_id, session_id, human_id, display_name, email,
+                role, source, metadata_json, created_at, updated_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+                human_id = excluded.human_id, display_name = excluded.display_name,
+                email = excluded.email, role = excluded.role, source = excluded.source,
+                metadata_json = excluded.metadata_json, updated_at = excluded.updated_at,
+                deleted_at = NULL",
+        )
+        .bind(&participant.id)
+        .bind(&envelope.workspace_id)
+        .bind(&envelope.owner_user_id)
+        .bind(&envelope.session.id)
+        .bind(&participant.human_id)
+        .bind(&participant.display_name)
+        .bind(&participant.email)
+        .bind(&participant.role)
+        .bind(SOURCE_TYPE)
+        .bind(metadata)
+        .bind(&participant.created_at)
+        .bind(&participant.updated_at)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+async fn reconcile_children(
+    tx: &mut Transaction<'_, Sqlite>,
+    envelope: &SessionIngestEnvelope,
+    marker: &IngestMarker,
+) -> Result<(), Error> {
+    reconcile_table(
+        tx,
+        "session_documents",
+        "document",
+        envelope,
+        marker,
+        envelope.documents.iter().map(|value| value.id.as_str()),
+    )
+    .await?;
+    reconcile_table(
+        tx,
+        "transcripts",
+        "transcript",
+        envelope,
+        marker,
+        envelope.transcripts.iter().map(|value| value.id.as_str()),
+    )
+    .await?;
+    reconcile_table(
+        tx,
+        "session_participants",
+        "participant",
+        envelope,
+        marker,
+        envelope.participants.iter().map(|value| value.id.as_str()),
+    )
+    .await?;
+    reconcile_table(
+        tx,
+        "session_attachments",
+        "attachment",
+        envelope,
+        marker,
+        envelope.attachments.iter().map(|value| value.id.as_str()),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn reconcile_table<'a>(
+    tx: &mut Transaction<'_, Sqlite>,
+    table: &'static str,
+    entity: &'static str,
+    envelope: &SessionIngestEnvelope,
+    marker: &IngestMarker,
+    retained_ids: impl Iterator<Item = &'a str>,
+) -> Result<(), Error> {
+    let select = match table {
+        "session_documents" => {
+            "SELECT id, generation_metadata_json FROM session_documents WHERE session_id = ? AND deleted_at IS NULL"
+        }
+        "transcripts" => {
+            "SELECT id, metadata_json FROM transcripts WHERE session_id = ? AND deleted_at IS NULL"
+        }
+        "session_participants" => {
+            "SELECT id, metadata_json FROM session_participants WHERE session_id = ? AND deleted_at IS NULL"
+        }
+        "session_attachments" => {
+            "SELECT id, metadata_json FROM session_attachments WHERE session_id = ? AND deleted_at IS NULL"
+        }
+        _ => unreachable!(),
+    };
+    let rows = sqlx::query_as::<_, (String, String)>(select)
+        .bind(&envelope.session.id)
+        .fetch_all(&mut **tx)
+        .await?;
+    let retained_ids = retained_ids.collect::<HashSet<_>>();
+    for (id, metadata_json) in rows {
+        if retained_ids.contains(id.as_str()) {
+            continue;
+        }
+        let Some(applied) = read_marker(entity, &id, &metadata_json)? else {
+            continue;
+        };
+        if applied.source_id != marker.source_id {
+            continue;
+        }
+        let update = match table {
+            "session_documents" => {
+                "UPDATE session_documents SET deleted_at = ?, updated_at = ? WHERE id = ?"
+            }
+            "transcripts" => "UPDATE transcripts SET deleted_at = ?, updated_at = ? WHERE id = ?",
+            "session_participants" => {
+                "UPDATE session_participants SET deleted_at = ?, updated_at = ? WHERE id = ?"
+            }
+            "session_attachments" => {
+                "UPDATE session_attachments SET deleted_at = ?, updated_at = ? WHERE id = ?"
+            }
+            _ => unreachable!(),
+        };
+        sqlx::query(update)
+            .bind(&envelope.session.updated_at)
+            .bind(&envelope.session.updated_at)
+            .bind(&id)
+            .execute(&mut **tx)
+            .await?;
+    }
+    Ok(())
+}
+
+async fn load_metadata(
+    tx: &mut Transaction<'_, Sqlite>,
+    table: &'static str,
+    id: &str,
+) -> Result<Option<String>, sqlx::Error> {
+    let statement = match table {
+        "session_documents" => {
+            "SELECT generation_metadata_json FROM session_documents WHERE id = ?"
+        }
+        "transcripts" => "SELECT metadata_json FROM transcripts WHERE id = ?",
+        "session_participants" => "SELECT metadata_json FROM session_participants WHERE id = ?",
+        "session_attachments" => "SELECT metadata_json FROM session_attachments WHERE id = ?",
+        _ => unreachable!(),
+    };
+    sqlx::query_scalar(statement)
+        .bind(id)
+        .fetch_optional(&mut **tx)
+        .await
+}
+
+fn merge_metadata(
+    entity: &'static str,
+    id: &str,
+    existing: Option<&str>,
+    incoming: &Map<String, Value>,
+    marker: &IngestMarker,
+) -> Result<String, Error> {
+    let mut metadata = match existing {
+        Some(existing) => serde_json::from_str::<Map<String, Value>>(existing).map_err(|_| {
+            Error::InvalidExistingMetadata {
+                entity,
+                id: id.to_string(),
+            }
+        })?,
+        None => Map::new(),
+    };
+    metadata.extend(incoming.clone());
+    metadata.insert(
+        validate::reserved_metadata_key().to_string(),
+        serde_json::to_value(marker)?,
+    );
+    serde_json::to_string(&metadata).map_err(Error::from)
+}
+
+fn read_marker(
+    entity: &'static str,
+    id: &str,
+    metadata_json: &str,
+) -> Result<Option<IngestMarker>, Error> {
+    let metadata = serde_json::from_str::<Map<String, Value>>(metadata_json).map_err(|_| {
+        Error::InvalidExistingMetadata {
+            entity,
+            id: id.to_string(),
+        }
+    })?;
+    metadata
+        .get(validate::reserved_metadata_key())
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(Error::from)
+}
+
+fn content_hash(envelope: &SessionIngestEnvelope) -> Result<String, serde_json::Error> {
+    let mut canonical = serde_json::to_value(envelope)?;
+    sort_json_keys(&mut canonical);
+    Ok(sha256_hex(&serde_json::to_vec(&canonical)?))
+}
+
+fn sort_json_keys(value: &mut Value) {
+    match value {
+        Value::Array(values) => values.iter_mut().for_each(sort_json_keys),
+        Value::Object(values) => {
+            values.values_mut().for_each(sort_json_keys);
+            values.sort_keys();
+        }
+        _ => {}
+    }
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    let mut output = String::with_capacity(64);
+    for byte in Sha256::digest(value) {
+        write!(output, "{byte:02x}").expect("writing to a string cannot fail");
+    }
+    output
+}

--- a/crates/session-ingest/src/lib.rs
+++ b/crates/session-ingest/src/lib.rs
@@ -1,0 +1,21 @@
+#![forbid(unsafe_code)]
+
+mod model;
+
+#[cfg(feature = "apply")]
+mod apply;
+#[cfg(feature = "apply")]
+mod validate;
+
+#[cfg(feature = "apply")]
+pub use apply::{ApplyOutcome, Error, apply_session_envelope};
+pub use model::{
+    DocumentFormat, DocumentKind, IngestAttachment, IngestDocument, IngestParticipant,
+    IngestSession, IngestSpeakerHint, IngestTranscript, IngestWord, SessionIngestEnvelope,
+};
+
+pub const SESSION_INGEST_SCHEMA_VERSION: u32 = 1;
+pub const MAX_SESSION_INGEST_BYTES: usize = 2 * 1024 * 1024;
+
+#[cfg(test)]
+mod tests;

--- a/crates/session-ingest/src/model.rs
+++ b/crates/session-ingest/src/model.rs
@@ -1,0 +1,195 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SessionIngestEnvelope {
+    pub schema_version: u32,
+    pub source_id: String,
+    pub revision: u64,
+    pub finalized: bool,
+    #[serde(default)]
+    pub attach_to_existing: bool,
+    pub workspace_id: String,
+    pub owner_user_id: String,
+    pub session: IngestSession,
+    #[serde(default)]
+    pub documents: Vec<IngestDocument>,
+    #[serde(default)]
+    pub transcripts: Vec<IngestTranscript>,
+    #[serde(default)]
+    pub participants: Vec<IngestParticipant>,
+    #[serde(default)]
+    pub attachments: Vec<IngestAttachment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IngestSession {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default)]
+    pub started_at: String,
+    #[serde(default)]
+    pub ended_at: String,
+    #[serde(default)]
+    pub timezone: String,
+    #[serde(default)]
+    pub language: String,
+    #[serde(default)]
+    pub event_id: String,
+    #[serde(default)]
+    pub external_event_id: String,
+    #[serde(default)]
+    pub external_provider: String,
+    #[serde(default)]
+    pub series_id: String,
+    #[serde(default)]
+    pub event: Value,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DocumentKind {
+    Note,
+    Summary,
+    TemplateOutput,
+}
+
+#[cfg(feature = "apply")]
+impl DocumentKind {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Note => "note",
+            Self::Summary => "summary",
+            Self::TemplateOutput => "template_output",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DocumentFormat {
+    Markdown,
+    ProsemirrorJson,
+}
+
+#[cfg(feature = "apply")]
+impl DocumentFormat {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Markdown => "markdown",
+            Self::ProsemirrorJson => "prosemirror_json",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IngestDocument {
+    pub id: String,
+    pub kind: DocumentKind,
+    pub format: DocumentFormat,
+    #[serde(default)]
+    pub template_id: String,
+    #[serde(default)]
+    pub title: String,
+    pub body: String,
+    #[serde(default)]
+    pub source_hash: String,
+    #[serde(default)]
+    pub generation_metadata: Map<String, Value>,
+    #[serde(default)]
+    pub sort_order: i64,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IngestTranscript {
+    pub id: String,
+    #[serde(default)]
+    pub provider: String,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub language: String,
+    #[serde(default)]
+    pub started_at_ms: i64,
+    pub ended_at_ms: Option<i64>,
+    #[serde(default)]
+    pub audio_attachment_id: String,
+    #[serde(default)]
+    pub memo: String,
+    #[serde(default)]
+    pub words: Vec<IngestWord>,
+    #[serde(default)]
+    pub speaker_hints: Vec<IngestSpeakerHint>,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IngestWord {
+    pub id: String,
+    pub text: String,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    #[serde(default)]
+    pub channel: i64,
+    pub speaker: Option<String>,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IngestSpeakerHint {
+    pub id: String,
+    pub word_id: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IngestParticipant {
+    pub id: String,
+    #[serde(default)]
+    pub human_id: String,
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub email: String,
+    #[serde(default)]
+    pub role: String,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IngestAttachment {
+    pub id: String,
+    pub filename: String,
+    pub content_type: String,
+    pub size_bytes: u64,
+    pub sha256: String,
+    pub object_key: String,
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+    pub created_at: String,
+    pub updated_at: String,
+}

--- a/crates/session-ingest/src/tests.rs
+++ b/crates/session-ingest/src/tests.rs
@@ -1,0 +1,443 @@
+use std::collections::BTreeSet;
+
+use anlg_agent_access::{GetMeetingInput, get_meeting, get_meeting_export};
+use anlg_db_core::Db;
+use serde_json::{Map, json};
+
+use crate::{
+    ApplyOutcome, DocumentFormat, DocumentKind, Error, IngestAttachment, IngestDocument,
+    IngestParticipant, IngestSession, IngestSpeakerHint, IngestTranscript, IngestWord,
+    SESSION_INGEST_SCHEMA_VERSION, SessionIngestEnvelope, apply_session_envelope,
+};
+
+async fn test_db() -> Db {
+    let db = Db::connect_memory_plain().await.unwrap();
+    anlg_db_app::prepare_schema(&db).await.unwrap();
+    db
+}
+
+fn envelope(finalized: bool) -> SessionIngestEnvelope {
+    SessionIngestEnvelope {
+        schema_version: SESSION_INGEST_SCHEMA_VERSION,
+        source_id: "capture-job-1".to_string(),
+        revision: 1,
+        finalized,
+        attach_to_existing: false,
+        workspace_id: "workspace-1".to_string(),
+        owner_user_id: "user-1".to_string(),
+        session: IngestSession {
+            id: "session-1".to_string(),
+            title: "Weekly planning".to_string(),
+            status: if finalized { "completed" } else { "active" }.to_string(),
+            created_at: "2026-08-14T08:00:00.000Z".to_string(),
+            updated_at: "2026-08-14T09:00:00.000Z".to_string(),
+            started_at: "2026-08-14T08:00:00.000Z".to_string(),
+            ended_at: if finalized {
+                "2026-08-14T09:00:00.000Z".to_string()
+            } else {
+                String::new()
+            },
+            timezone: "Asia/Seoul".to_string(),
+            language: "en".to_string(),
+            event_id: "event-1".to_string(),
+            external_event_id: "calendar-event-1".to_string(),
+            external_provider: "calendar".to_string(),
+            series_id: "series-1".to_string(),
+            event: json!({ "summary": "Weekly planning" }),
+            metadata: Map::from_iter([("room".to_string(), json!("planning"))]),
+        },
+        documents: vec![IngestDocument {
+            id: "summary-1".to_string(),
+            kind: DocumentKind::Summary,
+            format: DocumentFormat::Markdown,
+            template_id: String::new(),
+            title: "Summary".to_string(),
+            body: "We agreed on the launch plan.".to_string(),
+            source_hash: "summary-hash".to_string(),
+            generation_metadata: Map::new(),
+            sort_order: 1,
+            created_at: "2026-08-14T09:00:00.000Z".to_string(),
+            updated_at: "2026-08-14T09:00:00.000Z".to_string(),
+        }],
+        transcripts: vec![IngestTranscript {
+            id: "transcript-1".to_string(),
+            provider: "customer_stt".to_string(),
+            model: "model-1".to_string(),
+            language: "en".to_string(),
+            started_at_ms: 0,
+            ended_at_ms: Some(1_000),
+            audio_attachment_id: "audio-1".to_string(),
+            memo: String::new(),
+            words: vec![
+                IngestWord {
+                    id: "word-1".to_string(),
+                    text: "Launch".to_string(),
+                    start_ms: 0,
+                    end_ms: 400,
+                    channel: 0,
+                    speaker: Some("Alice".to_string()),
+                    metadata: Map::new(),
+                },
+                IngestWord {
+                    id: "word-2".to_string(),
+                    text: "Friday".to_string(),
+                    start_ms: 500,
+                    end_ms: 1_000,
+                    channel: 0,
+                    speaker: Some("Alice".to_string()),
+                    metadata: Map::new(),
+                },
+            ],
+            speaker_hints: vec![IngestSpeakerHint {
+                id: "hint-1".to_string(),
+                word_id: "word-1".to_string(),
+                kind: "human_id".to_string(),
+                value: "human-1".to_string(),
+            }],
+            metadata: Map::new(),
+            created_at: "2026-08-14T08:00:00.000Z".to_string(),
+            updated_at: "2026-08-14T09:00:00.000Z".to_string(),
+        }],
+        participants: vec![IngestParticipant {
+            id: "participant-1".to_string(),
+            human_id: "human-1".to_string(),
+            display_name: "Alice".to_string(),
+            email: "alice@example.com".to_string(),
+            role: "host".to_string(),
+            metadata: Map::new(),
+            created_at: "2026-08-14T08:00:00.000Z".to_string(),
+            updated_at: "2026-08-14T09:00:00.000Z".to_string(),
+        }],
+        attachments: vec![IngestAttachment {
+            id: "audio-1".to_string(),
+            filename: "meeting.webm".to_string(),
+            content_type: "audio/webm".to_string(),
+            size_bytes: 1_024,
+            sha256: "audio-hash".to_string(),
+            object_key: "workspace-1/capture-job-1/audio.webm".to_string(),
+            metadata: Map::new(),
+            created_at: "2026-08-14T08:00:00.000Z".to_string(),
+            updated_at: "2026-08-14T09:00:00.000Z".to_string(),
+        }],
+    }
+}
+
+#[tokio::test]
+async fn applies_canonical_graph_idempotently_and_marks_rows_for_e2ee() {
+    let db = test_db().await;
+    let mut envelope = envelope(true);
+    envelope
+        .session
+        .metadata
+        .insert("alpha".to_string(), json!(1));
+    envelope
+        .session
+        .metadata
+        .insert("omega".to_string(), json!(2));
+
+    assert_eq!(
+        apply_session_envelope(db.pool(), "workspace-1", &envelope)
+            .await
+            .unwrap(),
+        ApplyOutcome::Applied
+    );
+    let mut retry = envelope.clone();
+    retry.session.metadata.clear();
+    retry.session.metadata.insert("omega".to_string(), json!(2));
+    retry
+        .session
+        .metadata
+        .insert("room".to_string(), json!("planning"));
+    retry.session.metadata.insert("alpha".to_string(), json!(1));
+    assert_eq!(
+        apply_session_envelope(db.pool(), "workspace-1", &retry)
+            .await
+            .unwrap(),
+        ApplyOutcome::AlreadyApplied
+    );
+
+    let export = get_meeting_export(db.pool(), "session-1".to_string())
+        .await
+        .unwrap();
+    assert_eq!(export.meeting.title, "Weekly planning");
+    assert_eq!(
+        export.meeting.summaries[0].markdown,
+        "We agreed on the launch plan."
+    );
+    assert_eq!(export.meeting.participants[0].display_name, "Alice");
+    assert_eq!(export.transcripts[0].text, "Launch Friday");
+
+    let attachment = sqlx::query_as::<_, (String, String, i64)>(
+        "SELECT storage_kind, cloud_object_key, cloud_sync_enabled
+         FROM session_attachments WHERE id = 'audio-1'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        attachment,
+        (
+            "remote_object".to_string(),
+            "workspace-1/capture-job-1/audio.webm".to_string(),
+            0,
+        )
+    );
+
+    let dirty_rows = sqlx::query_as::<_, (String, String)>(
+        "SELECT table_name, row_id FROM e2ee_dirty_rows WHERE workspace_id = 'workspace-1'",
+    )
+    .fetch_all(db.pool())
+    .await
+    .unwrap()
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    assert!(dirty_rows.contains(&("sessions".to_string(), "session-1".to_string())));
+    assert!(dirty_rows.contains(&("session_documents".to_string(), "summary-1".to_string())));
+    assert!(dirty_rows.contains(&("transcripts".to_string(), "transcript-1".to_string())));
+    assert!(dirty_rows.contains(&(
+        "session_participants".to_string(),
+        "participant-1".to_string()
+    )));
+    assert!(dirty_rows.contains(&("session_attachments".to_string(), "audio-1".to_string())));
+    assert!(dirty_rows.contains(&("humans".to_string(), "human-1".to_string())));
+}
+
+#[tokio::test]
+async fn rejects_cross_workspace_and_cross_owner_writes() {
+    let db = test_db().await;
+    let envelope = envelope(false);
+
+    let error = apply_session_envelope(db.pool(), "workspace-other", &envelope)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::WorkspaceMismatch { .. }));
+
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('session-1', 'workspace-1', 'user-other', 'Private')",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    let error = apply_session_envelope(db.pool(), "workspace-1", &envelope)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::OwnershipConflict {
+            entity: "session",
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn enforces_revision_and_finalization_rules() {
+    let db = test_db().await;
+    let first = envelope(false);
+    apply_session_envelope(db.pool(), "workspace-1", &first)
+        .await
+        .unwrap();
+
+    let mut conflicting = first.clone();
+    conflicting.session.title = "Changed without a revision".to_string();
+    let error = apply_session_envelope(db.pool(), "workspace-1", &conflicting)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::RevisionConflict { revision: 1 }));
+
+    let mut final_revision = first.clone();
+    final_revision.revision = 2;
+    final_revision.finalized = true;
+    final_revision.session.status = "completed".to_string();
+    final_revision.session.ended_at = "2026-08-14T09:00:00.000Z".to_string();
+    apply_session_envelope(db.pool(), "workspace-1", &final_revision)
+        .await
+        .unwrap();
+
+    let error = apply_session_envelope(db.pool(), "workspace-1", &first)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::StaleRevision {
+            actual: 1,
+            applied: 2
+        }
+    ));
+
+    let mut after_final = final_revision;
+    after_final.revision = 3;
+    let error = apply_session_envelope(db.pool(), "workspace-1", &after_final)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::Finalized { revision: 2, .. }));
+}
+
+#[tokio::test]
+async fn attaches_explicitly_without_overwriting_user_title() {
+    let db = test_db().await;
+    sqlx::query(
+        "INSERT INTO sessions (
+            id, workspace_id, owner_user_id, title, status, created_at, updated_at, metadata_json
+         ) VALUES (
+            'session-1', 'workspace-1', 'user-1', 'My title', 'active',
+            '2026-08-14T07:00:00.000Z', '2026-08-14T07:00:00.000Z', '{\"pinned\":true}'
+         )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    let mut envelope = envelope(false);
+
+    let error = apply_session_envelope(db.pool(), "workspace-1", &envelope)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::SourceConflict { .. }));
+
+    envelope.attach_to_existing = true;
+    apply_session_envelope(db.pool(), "workspace-1", &envelope)
+        .await
+        .unwrap();
+    envelope.revision = 2;
+    envelope.session.title = "Capture title".to_string();
+    envelope.session.updated_at = "2026-08-14T09:30:00.000Z".to_string();
+    apply_session_envelope(db.pool(), "workspace-1", &envelope)
+        .await
+        .unwrap();
+    let meeting = get_meeting(
+        db.pool(),
+        GetMeetingInput {
+            meeting_id: "session-1".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(meeting.title, "My title");
+    let metadata: serde_json::Value =
+        sqlx::query_scalar("SELECT metadata_json FROM sessions WHERE id = 'session-1'")
+            .fetch_one(db.pool())
+            .await
+            .map(|value: String| serde_json::from_str(&value).unwrap())
+            .unwrap();
+    assert_eq!(metadata["pinned"], true);
+    assert_eq!(
+        metadata["anarlog_capture_ingest"]["source_id"],
+        "capture-job-1"
+    );
+}
+
+#[tokio::test]
+async fn refuses_to_resurrect_deleted_sessions() {
+    let db = test_db().await;
+    let first = envelope(false);
+    apply_session_envelope(db.pool(), "workspace-1", &first)
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE sessions SET deleted_at = '2026-08-14T09:15:00.000Z' WHERE id = 'session-1'",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let mut second = first;
+    second.revision = 2;
+    second.session.title = "Must stay deleted".to_string();
+    let error = apply_session_envelope(db.pool(), "workspace-1", &second)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, Error::DeletedSession { .. }));
+    let row = sqlx::query_as::<_, (String, Option<String>)>(
+        "SELECT title, deleted_at FROM sessions WHERE id = 'session-1'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(row.0, "Weekly planning");
+    assert!(row.1.is_some());
+}
+
+#[tokio::test]
+async fn reconciles_only_children_owned_by_the_capture_source() {
+    let db = test_db().await;
+    let first = envelope(false);
+    apply_session_envelope(db.pool(), "workspace-1", &first)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO session_documents (
+            id, workspace_id, session_id, kind, body_format, body, generation_metadata_json
+         ) VALUES (
+            'user-note', 'workspace-1', 'session-1', 'note', 'markdown', 'Keep me', '{}'
+         )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let mut second = first;
+    second.revision = 2;
+    second.documents.clear();
+    apply_session_envelope(db.pool(), "workspace-1", &second)
+        .await
+        .unwrap();
+
+    let rows = sqlx::query_as::<_, (String, Option<String>)>(
+        "SELECT id, deleted_at FROM session_documents
+         WHERE session_id = 'session-1' ORDER BY id",
+    )
+    .fetch_all(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(rows[0].0, "summary-1");
+    assert!(rows[0].1.is_some());
+    assert_eq!(rows[1], ("user-note".to_string(), None));
+}
+
+#[tokio::test]
+async fn refuses_to_overwrite_an_unowned_child_row() {
+    let db = test_db().await;
+    let first = envelope(false);
+    apply_session_envelope(db.pool(), "workspace-1", &first)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO session_documents (
+            id, workspace_id, session_id, kind, body_format, body, generation_metadata_json
+         ) VALUES (
+            'user-note', 'workspace-1', 'session-1', 'note', 'markdown', 'Keep me', '{}'
+         )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let mut second = first;
+    second.revision = 2;
+    second.session.title = "Must roll back".to_string();
+    second.documents[0].id = "user-note".to_string();
+    let error = apply_session_envelope(db.pool(), "workspace-1", &second)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::ChildSourceConflict {
+            entity: "document",
+            ..
+        }
+    ));
+
+    let title: String = sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(title, "Weekly planning");
+    let body: String =
+        sqlx::query_scalar("SELECT body FROM session_documents WHERE id = 'user-note'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(body, "Keep me");
+}

--- a/crates/session-ingest/src/validate.rs
+++ b/crates/session-ingest/src/validate.rs
@@ -1,0 +1,224 @@
+use std::collections::HashSet;
+
+use crate::{
+    MAX_SESSION_INGEST_BYTES, SESSION_INGEST_SCHEMA_VERSION, SessionIngestEnvelope, apply::Error,
+};
+
+const MAX_ID_BYTES: usize = 255;
+const MAX_TIMESTAMP_BYTES: usize = 64;
+const RESERVED_METADATA_KEY: &str = "anarlog_capture_ingest";
+
+pub(crate) fn validate(
+    expected_workspace_id: &str,
+    envelope: &SessionIngestEnvelope,
+    serialized: &[u8],
+) -> Result<(), Error> {
+    if serialized.len() > MAX_SESSION_INGEST_BYTES {
+        return Err(Error::EnvelopeTooLarge {
+            actual: serialized.len(),
+            maximum: MAX_SESSION_INGEST_BYTES,
+        });
+    }
+    if envelope.schema_version != SESSION_INGEST_SCHEMA_VERSION {
+        return Err(Error::UnsupportedSchema {
+            actual: envelope.schema_version,
+            supported: SESSION_INGEST_SCHEMA_VERSION,
+        });
+    }
+    if envelope.revision == 0 {
+        return invalid("revision must be greater than zero");
+    }
+    validate_id("expected workspace id", expected_workspace_id)?;
+    validate_id("workspace id", &envelope.workspace_id)?;
+    if expected_workspace_id != envelope.workspace_id {
+        return Err(Error::WorkspaceMismatch {
+            expected: expected_workspace_id.to_string(),
+            actual: envelope.workspace_id.clone(),
+        });
+    }
+    validate_id("owner user id", &envelope.owner_user_id)?;
+    validate_id("source id", &envelope.source_id)?;
+    validate_id("session id", &envelope.session.id)?;
+    validate_text("session title", &envelope.session.title, 1024)?;
+    validate_text("session status", &envelope.session.status, 64)?;
+    validate_timestamp("session created_at", &envelope.session.created_at, false)?;
+    validate_timestamp("session updated_at", &envelope.session.updated_at, false)?;
+    validate_timestamp("session started_at", &envelope.session.started_at, true)?;
+    validate_timestamp("session ended_at", &envelope.session.ended_at, true)?;
+    validate_metadata(&envelope.session.metadata)?;
+
+    validate_unique_ids(
+        "document",
+        envelope
+            .documents
+            .iter()
+            .map(|document| document.id.as_str()),
+    )?;
+    for document in &envelope.documents {
+        validate_id("document id", &document.id)?;
+        validate_timestamp("document created_at", &document.created_at, false)?;
+        validate_timestamp("document updated_at", &document.updated_at, false)?;
+        validate_metadata(&document.generation_metadata)?;
+        if matches!(document.format, crate::DocumentFormat::ProsemirrorJson) {
+            serde_json::from_str::<serde_json::Value>(&document.body).map_err(|error| {
+                Error::InvalidEnvelope(format!(
+                    "document '{}' contains invalid ProseMirror JSON: {error}",
+                    document.id
+                ))
+            })?;
+        }
+    }
+
+    validate_unique_ids(
+        "transcript",
+        envelope
+            .transcripts
+            .iter()
+            .map(|transcript| transcript.id.as_str()),
+    )?;
+    for transcript in &envelope.transcripts {
+        validate_id("transcript id", &transcript.id)?;
+        validate_timestamp("transcript created_at", &transcript.created_at, false)?;
+        validate_timestamp("transcript updated_at", &transcript.updated_at, false)?;
+        validate_metadata(&transcript.metadata)?;
+        if transcript.started_at_ms < 0
+            || transcript
+                .ended_at_ms
+                .is_some_and(|ended| ended < transcript.started_at_ms)
+        {
+            return invalid(format!(
+                "transcript '{}' has an invalid time range",
+                transcript.id
+            ));
+        }
+        validate_unique_ids("word", transcript.words.iter().map(|word| word.id.as_str()))?;
+        for word in &transcript.words {
+            validate_id("word id", &word.id)?;
+            if word.start_ms < 0 || word.end_ms < word.start_ms {
+                return invalid(format!("word '{}' has an invalid time range", word.id));
+            }
+        }
+        validate_unique_ids(
+            "speaker hint",
+            transcript.speaker_hints.iter().map(|hint| hint.id.as_str()),
+        )?;
+        let word_ids = transcript
+            .words
+            .iter()
+            .map(|word| word.id.as_str())
+            .collect::<HashSet<_>>();
+        for hint in &transcript.speaker_hints {
+            validate_id("speaker hint id", &hint.id)?;
+            if !word_ids.contains(hint.word_id.as_str()) {
+                return invalid(format!(
+                    "speaker hint '{}' references unknown word '{}'",
+                    hint.id, hint.word_id
+                ));
+            }
+        }
+    }
+
+    validate_unique_ids(
+        "participant",
+        envelope
+            .participants
+            .iter()
+            .map(|participant| participant.id.as_str()),
+    )?;
+    for participant in &envelope.participants {
+        validate_id("participant id", &participant.id)?;
+        if !participant.human_id.is_empty() {
+            validate_id("participant human id", &participant.human_id)?;
+        }
+        validate_timestamp("participant created_at", &participant.created_at, false)?;
+        validate_timestamp("participant updated_at", &participant.updated_at, false)?;
+        validate_metadata(&participant.metadata)?;
+    }
+
+    validate_unique_ids(
+        "attachment",
+        envelope
+            .attachments
+            .iter()
+            .map(|attachment| attachment.id.as_str()),
+    )?;
+    let attachment_ids = envelope
+        .attachments
+        .iter()
+        .map(|attachment| attachment.id.as_str())
+        .collect::<HashSet<_>>();
+    for attachment in &envelope.attachments {
+        validate_id("attachment id", &attachment.id)?;
+        validate_text("attachment filename", &attachment.filename, 1024)?;
+        validate_text("attachment object key", &attachment.object_key, 2048)?;
+        i64::try_from(attachment.size_bytes).map_err(|_| {
+            Error::InvalidEnvelope(format!(
+                "attachment '{}' exceeds the supported size",
+                attachment.id
+            ))
+        })?;
+        validate_timestamp("attachment created_at", &attachment.created_at, false)?;
+        validate_timestamp("attachment updated_at", &attachment.updated_at, false)?;
+        validate_metadata(&attachment.metadata)?;
+    }
+    for transcript in &envelope.transcripts {
+        if !transcript.audio_attachment_id.is_empty()
+            && !attachment_ids.contains(transcript.audio_attachment_id.as_str())
+        {
+            return invalid(format!(
+                "transcript '{}' references unknown attachment '{}'",
+                transcript.id, transcript.audio_attachment_id
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_unique_ids<'a>(entity: &str, ids: impl Iterator<Item = &'a str>) -> Result<(), Error> {
+    let mut seen = HashSet::new();
+    for id in ids {
+        if !seen.insert(id) {
+            return invalid(format!("duplicate {entity} id '{id}'"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_id(field: &str, value: &str) -> Result<(), Error> {
+    validate_text(field, value, MAX_ID_BYTES)
+}
+
+fn validate_timestamp(field: &str, value: &str, allow_empty: bool) -> Result<(), Error> {
+    if allow_empty && value.is_empty() {
+        return Ok(());
+    }
+    validate_text(field, value, MAX_TIMESTAMP_BYTES)
+}
+
+fn validate_text(field: &str, value: &str, maximum: usize) -> Result<(), Error> {
+    if value.trim().is_empty() {
+        return invalid(format!("{field} must not be empty"));
+    }
+    if value.len() > maximum {
+        return invalid(format!("{field} exceeds {maximum} bytes"));
+    }
+    Ok(())
+}
+
+fn validate_metadata(metadata: &serde_json::Map<String, serde_json::Value>) -> Result<(), Error> {
+    if metadata.contains_key(RESERVED_METADATA_KEY) {
+        return invalid(format!(
+            "metadata key '{RESERVED_METADATA_KEY}' is reserved"
+        ));
+    }
+    Ok(())
+}
+
+fn invalid<T>(message: impl Into<String>) -> Result<T, Error> {
+    Err(Error::InvalidEnvelope(message.into()))
+}
+
+pub(crate) const fn reserved_metadata_key() -> &'static str {
+    RESERVED_METADATA_KEY
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Writes directly to core session/transcript tables with merge, attach, and soft-delete reconciliation; mistakes could corrupt user data or cross tenant boundaries despite guards.
> 
> **Overview**
> Adds a new **`session-ingest`** workspace crate that defines a versioned **`SessionIngestEnvelope`** (session, documents, transcripts, participants, attachments) and **`apply_session_envelope`** to upsert that graph into the app SQLite schema for **`meeting_bot`** capture sources.
> 
> **Validation** enforces schema v1, a 2 MB cap, workspace match, unique IDs, transcript/attachment references, and blocks clients from setting the reserved **`anarlog_capture_ingest`** metadata key.
> 
> **Apply** runs in a transaction with revision + canonical content-hash idempotency, source/session ownership checks, no writes to deleted sessions, optional **`attach_to_existing`** (preserves user title and merges metadata), child reconciliation that soft-deletes only rows owned by the same **`source_id`**, and bot attachments stored as **`remote_object`** with **`cloud_sync_enabled = 0`**. Ingest state is stored under **`anarlog_capture_ingest`** on affected rows. Integration tests cover idempotent apply, E2EE dirty-row marking, cross-workspace rejection, finalization, and attach/reconcile safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc4eeb4d3f42bb0fe82b6ce423a36b633faa435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->