### PR TITLE
Hide sync status during meetings

### DIFF
--- a/apps/desktop/src/main/sync-status.test.tsx
+++ b/apps/desktop/src/main/sync-status.test.tsx
@@ -158,6 +158,15 @@ describe("SyncStatusIndicator", () => {
     ).toBeTruthy();
   });
 
+  it("renders below the chat FAB layers", async () => {
+    renderIndicator();
+
+    const indicator = await screen.findByTestId("sync-status-indicator");
+
+    expect(indicator.className).toContain("z-10");
+    expect(indicator.className).not.toContain("z-40");
+  });
+
   it("does not render for free users", () => {
     mocks.billing.isPro = false;
 
@@ -356,9 +365,9 @@ describe("SyncStatusIndicator", () => {
       pollStatus?.();
       await Promise.resolve();
     });
-    expect(
-      await screen.findByLabelText("Cloud sync status: Saved locally"),
-    ).toBeTruthy();
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId("sync-status-indicator")).toBeNull();
+    });
 
     await act(async () => {
       pollStatus?.();
@@ -388,7 +397,7 @@ describe("SyncStatusIndicator", () => {
     expect(screen.getByText("token rejected")).toBeTruthy();
   });
 
-  it("shows capture deferral instead of a transient sync issue during recording", async () => {
+  it("hides capture deferral instead of showing a transient sync issue during recording", async () => {
     mocks.getCloudsyncStatus.mockResolvedValue(
       syncedStatus({
         activity_paused: true,
@@ -401,18 +410,9 @@ describe("SyncStatusIndicator", () => {
     );
 
     renderIndicator();
-    await openMenu();
-
-    expect(await screen.findByText("Saved locally")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "Cloud sync resumes after this meeting finishes processing",
-      ),
-    ).toBeTruthy();
-    expect(screen.queryByText("Sync issue")).toBeNull();
-
-    const syncNowItem = screen.getByRole("menuitem", { name: "Sync now" });
-    expect(syncNowItem.getAttribute("data-disabled")).not.toBeNull();
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId("sync-status-indicator")).toBeNull();
+    });
   });
 
   it("uses the last successful sync while native local status is busy", async () => {
@@ -459,7 +459,7 @@ describe("SyncStatusIndicator", () => {
     ).toBeTruthy();
   });
 
-  it("shows capture-deferred work as saved locally without offering a manual sync", async () => {
+  it("hides capture-deferred work", async () => {
     mocks.getCloudsyncStatus.mockResolvedValue(
       syncedStatus({
         activity_paused: true,
@@ -469,24 +469,9 @@ describe("SyncStatusIndicator", () => {
     );
 
     renderIndicator();
-    await openMenu();
-
-    expect(await screen.findByText("Saved locally")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "Cloud sync resumes after this meeting finishes processing",
-      ),
-    ).toBeTruthy();
-    expect(
-      screen
-        .getByLabelText("Cloud sync status: Saved locally")
-        .querySelector(".animate-spin"),
-    ).toBeNull();
-
-    const syncNowItem = screen.getByRole("menuitem", { name: "Sync now" });
-    expect(syncNowItem.getAttribute("data-disabled")).not.toBeNull();
-    fireEvent.click(syncNowItem);
-    expect(mocks.syncCloudsyncNow).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId("sync-status-indicator")).toBeNull();
+    });
   });
 
   it("shows other paused activity as saved locally without capture-specific copy", async () => {
@@ -521,7 +506,7 @@ describe("SyncStatusIndicator", () => {
     expect(mocks.syncCloudsyncNow).not.toHaveBeenCalled();
   });
 
-  it("shows capture deferral while recovery is paused during recording", async () => {
+  it("hides capture deferral while recovery is paused during recording", async () => {
     mocks.getCloudsyncStatus.mockResolvedValue(
       syncedStatus({
         running: false,
@@ -536,21 +521,9 @@ describe("SyncStatusIndicator", () => {
     );
 
     renderIndicator();
-    await openMenu();
-
-    expect(await screen.findByText("Saved locally")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "Cloud sync resumes after this meeting finishes processing",
-      ),
-    ).toBeTruthy();
-    expect(screen.queryByText("Restoring cloud sync...")).toBeNull();
-    expect(screen.queryByText("Cloud sync delayed")).toBeNull();
-    expect(
-      screen
-        .getByLabelText("Cloud sync status: Saved locally")
-        .querySelector(".animate-spin"),
-    ).toBeNull();
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId("sync-status-indicator")).toBeNull();
+    });
   });
 
   it("explains background recovery without implying local notes are blocked", async () => {

--- a/apps/desktop/src/main/sync-status.tsx
+++ b/apps/desktop/src/main/sync-status.tsx
@@ -251,6 +251,11 @@ export function SyncStatusIndicator() {
       )}`,
     };
   })();
+
+  if (deferredForCapture && view.kind === "deferred") {
+    return null;
+  }
+
   const canRetrySync =
     view.kind === "error" && status?.last_error_kind === "transient";
   const canRetryStatus = statusUnavailable;
@@ -264,7 +269,7 @@ export function SyncStatusIndicator() {
           aria-label={t`Cloud sync status: ${view.label}`}
           data-testid="sync-status-indicator"
           className={cn([
-            "absolute right-2 bottom-2 z-40",
+            "absolute right-2 bottom-2 z-10",
             "border-border/60 bg-background/90 flex size-7 items-center justify-center rounded-lg border shadow-sm backdrop-blur",
             "text-muted-foreground hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground outline-hidden transition-colors",
           ])}


### PR DESCRIPTION
Suppress the capture-deferred sync indicator while preserving actionable error states, with regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility and stacking for a known transient state; error paths during capture remain covered by tests.
> 
> **Overview**
> **Hides the cloud sync status control while sync is deferred for meeting capture**, instead of showing “Saved locally” and meeting-specific copy. When `deferred_for_capture` would map to the deferred view, `SyncStatusIndicator` returns `null`; **actionable states (e.g. auth sync issues) still render** when they are not that deferred-only path.
> 
> **Stacks the indicator below the chat FAB** by changing the trigger from `z-40` to `z-10`, with a regression test on class names.
> 
> Tests now expect the indicator absent during capture deferral (including background poll and recovery-paused-during-recording), while non-capture `activity_paused` behavior stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa40feff39d84e71a00ce9bac410eb53a96eaa01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->