### PR TITLE
Deliver enterprise capture sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18337,6 +18337,7 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "session-ingest",
  "sha2 0.11.0",
  "specta",
  "specta-typescript",

--- a/apps/desktop/src/enterprise-capture/client.test.ts
+++ b/apps/desktop/src/enterprise-capture/client.test.ts
@@ -1,0 +1,172 @@
+import { fetch } from "@tauri-apps/plugin-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  acknowledgeSessionDelivery,
+  EnterpriseCaptureClientError,
+  listSessionDeliveries,
+} from "./client";
+
+vi.mock("@tauri-apps/plugin-http", () => ({ fetch: vi.fn() }));
+
+function delivery() {
+  return {
+    cursor: 7,
+    jobId: "11111111-1111-4111-8111-111111111111",
+    revision: 2,
+    finalized: true,
+    contentHash: "a".repeat(64),
+    acknowledged: false,
+    createdAt: "2026-08-14T08:00:00Z",
+    envelope: {
+      schema_version: 1,
+      source_id: "11111111-1111-4111-8111-111111111111",
+      revision: 2,
+      finalized: true,
+      workspace_id: "workspace-1",
+      session: { id: "session-1", status: "completed" },
+    },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("enterprise capture client", () => {
+  beforeEach(() => vi.mocked(fetch).mockReset());
+
+  it("requests a bounded authenticated cursor page", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ items: [delivery()], nextCursor: 7, hasMore: false }),
+    );
+
+    const page = await listSessionDeliveries({
+      serverUrl: "https://capture.example.test/control/",
+      accessToken: "access-token",
+      workspaceId: "workspace 1",
+      consumerId: "device-1",
+      after: 4,
+    });
+
+    expect(page.items[0]?.envelope.session.id).toBe("session-1");
+    const [url, init] = vi.mocked(fetch).mock.calls[0]!;
+    expect(url).toBe(
+      "https://capture.example.test/control/v1/workspaces/workspace%201/session-envelopes?consumerId=device-1&after=4&limit=10",
+    );
+    expect(new Headers(init?.headers).get("Authorization")).toBe(
+      "Bearer access-token",
+    );
+  });
+
+  it("rejects an envelope whose revision disagrees with its delivery", async () => {
+    const invalid = delivery();
+    invalid.envelope.revision = 3;
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ items: [invalid], nextCursor: 7, hasMore: false }),
+    );
+
+    await expect(
+      listSessionDeliveries({
+        serverUrl: "https://capture.example.test",
+        accessToken: "access-token",
+        workspaceId: "workspace-1",
+        consumerId: "device-1",
+        after: 0,
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_response",
+    } satisfies Partial<EnterpriseCaptureClientError>);
+  });
+
+  it("acknowledges the exact stored revision and content hash", async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ acknowledged: true }));
+
+    await acknowledgeSessionDelivery({
+      serverUrl: "https://capture.example.test",
+      accessToken: "access-token",
+      workspaceId: "workspace-1",
+      consumerId: "device-1",
+      jobId: "job-1",
+      revision: 2,
+      contentHash: "a".repeat(64),
+    });
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0]!;
+    expect(url).toContain("/session-envelopes/job-1/ack");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      consumerId: "device-1",
+      revision: 2,
+      contentHash: "a".repeat(64),
+    });
+  });
+
+  it("rejects an oversized response without a declared content length", async () => {
+    const chunk = new Uint8Array(1024 * 1024);
+    let chunksRead = 0;
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          pull(controller) {
+            chunksRead += 1;
+            controller.enqueue(chunk);
+          },
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(
+      listSessionDeliveries({
+        serverUrl: "https://capture.example.test",
+        accessToken: "access-token",
+        workspaceId: "workspace-1",
+        consumerId: "device-1",
+        after: 0,
+      }),
+    ).rejects.toMatchObject({
+      code: "response_too_large",
+    } satisfies Partial<EnterpriseCaptureClientError>);
+    expect(chunksRead).toBeGreaterThanOrEqual(25);
+    expect(chunksRead).toBeLessThanOrEqual(26);
+  });
+
+  it("keeps the request timeout active while reading the response body", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(fetch).mockImplementation(async (_url, init) => {
+        const signal = init?.signal;
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              signal?.addEventListener("abort", () => {
+                controller.error(new DOMException("aborted", "AbortError"));
+              });
+            },
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      });
+      const result = expect(
+        listSessionDeliveries({
+          serverUrl: "https://capture.example.test",
+          accessToken: "access-token",
+          workspaceId: "workspace-1",
+          consumerId: "device-1",
+          after: 0,
+        }),
+      ).rejects.toMatchObject({
+        code: "request_timeout",
+      } satisfies Partial<EnterpriseCaptureClientError>);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await result;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/desktop/src/enterprise-capture/client.ts
+++ b/apps/desktop/src/enterprise-capture/client.ts
@@ -1,0 +1,244 @@
+import { fetch } from "@tauri-apps/plugin-http";
+
+import type { DeliveryItem, DeliveryPage } from "./types";
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_PAGE_BYTES = 24 * 1024 * 1024;
+
+export class EnterpriseCaptureClientError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "EnterpriseCaptureClientError";
+  }
+}
+
+export async function listSessionDeliveries(input: {
+  serverUrl: string;
+  accessToken: string;
+  workspaceId: string;
+  consumerId: string;
+  after: number;
+  limit?: number;
+}): Promise<DeliveryPage> {
+  const url = endpoint(
+    input.serverUrl,
+    `v1/workspaces/${encodeURIComponent(input.workspaceId)}/session-envelopes`,
+  );
+  url.searchParams.set("consumerId", input.consumerId);
+  url.searchParams.set("after", String(input.after));
+  url.searchParams.set("limit", String(input.limit ?? 10));
+  return parseDeliveryPage(await request(url, input.accessToken));
+}
+
+export async function acknowledgeSessionDelivery(input: {
+  serverUrl: string;
+  accessToken: string;
+  workspaceId: string;
+  consumerId: string;
+  jobId: string;
+  revision: number;
+  contentHash: string;
+}): Promise<void> {
+  const body = await request(
+    endpoint(
+      input.serverUrl,
+      `v1/workspaces/${encodeURIComponent(input.workspaceId)}/session-envelopes/${encodeURIComponent(input.jobId)}/ack`,
+    ),
+    input.accessToken,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        consumerId: input.consumerId,
+        revision: input.revision,
+        contentHash: input.contentHash,
+      }),
+    },
+  );
+  if (!isObject(body) || body.acknowledged !== true) {
+    throw new EnterpriseCaptureClientError(
+      "invalid_response",
+      "The capture server returned an invalid acknowledgement.",
+    );
+  }
+}
+
+async function request(
+  url: URL,
+  accessToken: string,
+  init: RequestInit = {},
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${accessToken}`);
+    const response = await fetch(url.toString(), {
+      ...init,
+      headers,
+      signal: controller.signal,
+    });
+    const body = await boundedJson(response).catch((error) => {
+      if (
+        !response.ok &&
+        error instanceof EnterpriseCaptureClientError &&
+        error.code === "invalid_response"
+      ) {
+        return null;
+      }
+      throw error;
+    });
+    if (!response.ok) {
+      const serverError =
+        isObject(body) && isObject(body.error) ? body.error : null;
+      throw new EnterpriseCaptureClientError(
+        typeof serverError?.code === "string"
+          ? serverError.code
+          : `http_${response.status}`,
+        typeof serverError?.message === "string"
+          ? serverError.message
+          : `Capture server request failed (${response.status}).`,
+      );
+    }
+    return body;
+  } catch (error) {
+    if (error instanceof EnterpriseCaptureClientError) throw error;
+    if (controller.signal.aborted) {
+      throw new EnterpriseCaptureClientError(
+        "request_timeout",
+        "The capture server request timed out.",
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function boundedJson(response: Response): Promise<unknown> {
+  const body = await boundedText(response);
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    throw new EnterpriseCaptureClientError(
+      "invalid_response",
+      "The capture server returned invalid JSON.",
+    );
+  }
+}
+
+async function boundedText(response: Response): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (declaredLength > MAX_PAGE_BYTES) responseTooLarge();
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let body = "";
+  let bytesRead = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesRead += value.byteLength;
+      if (bytesRead > MAX_PAGE_BYTES) {
+        await reader.cancel();
+        responseTooLarge();
+      }
+      body += decoder.decode(value, { stream: true });
+    }
+    return body + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function responseTooLarge(): never {
+  throw new EnterpriseCaptureClientError(
+    "response_too_large",
+    "The capture server response is too large.",
+  );
+}
+
+function parseDeliveryPage(value: unknown): DeliveryPage {
+  if (!isObject(value) || !Array.isArray(value.items)) invalidResponse();
+  const items = value.items.map(parseDeliveryItem);
+  const nextCursor = integer(value.nextCursor, "next cursor", true);
+  if (typeof value.hasMore !== "boolean") invalidResponse();
+  return { items, nextCursor, hasMore: value.hasMore };
+}
+
+function parseDeliveryItem(value: unknown): DeliveryItem {
+  if (!isObject(value) || !isObject(value.envelope)) invalidResponse();
+  const envelope = value.envelope;
+  if (
+    integer(envelope.schema_version, "schema version") < 1 ||
+    typeof envelope.source_id !== "string" ||
+    envelope.source_id.length === 0 ||
+    typeof envelope.finalized !== "boolean" ||
+    typeof envelope.workspace_id !== "string" ||
+    !isObject(envelope.session) ||
+    typeof envelope.session.id !== "string" ||
+    typeof envelope.session.status !== "string"
+  ) {
+    invalidResponse();
+  }
+  const revision = integer(value.revision, "revision");
+  if (integer(envelope.revision, "envelope revision") !== revision) {
+    invalidResponse();
+  }
+  if (
+    typeof value.jobId !== "string" ||
+    value.jobId.length === 0 ||
+    typeof value.contentHash !== "string" ||
+    !/^[0-9a-f]{64}$/.test(value.contentHash) ||
+    typeof value.acknowledged !== "boolean" ||
+    typeof value.finalized !== "boolean" ||
+    value.finalized !== envelope.finalized ||
+    typeof value.createdAt !== "string" ||
+    !Number.isFinite(Date.parse(value.createdAt))
+  ) {
+    invalidResponse();
+  }
+  return {
+    cursor: integer(value.cursor, "cursor"),
+    jobId: value.jobId,
+    revision,
+    finalized: value.finalized,
+    contentHash: value.contentHash,
+    acknowledged: value.acknowledged,
+    createdAt: value.createdAt,
+    envelope: envelope as DeliveryItem["envelope"],
+  };
+}
+
+function integer(value: unknown, _field: string, allowZero = false): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    (allowZero ? value < 0 : value < 1)
+  ) {
+    invalidResponse();
+  }
+  return value;
+}
+
+function invalidResponse(): never {
+  throw new EnterpriseCaptureClientError(
+    "invalid_response",
+    "The capture server returned an invalid delivery envelope.",
+  );
+}
+
+function endpoint(serverUrl: string, path: string): URL {
+  const base = new URL(serverUrl);
+  if (!base.pathname.endsWith("/")) base.pathname += "/";
+  return new URL(path, base);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/desktop/src/enterprise-capture/lifecycle.test.tsx
+++ b/apps/desktop/src/enterprise-capture/lifecycle.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  dispatchPendingEnterpriseCompletions: vi.fn(),
+  getFingerprint: vi.fn(),
+  syncEnterpriseWorkspace: vi.fn(),
+  useQuery: vi.fn(),
+  workspaces: [{ workspaceId: "workspace-1" }],
+}));
+
+vi.mock("@tanstack/react-query", () => ({ useQuery: mocks.useQuery }));
+vi.mock("@anlg/plugin-misc", () => ({
+  commands: { getFingerprint: mocks.getFingerprint },
+}));
+vi.mock("./sync", () => ({
+  dispatchPendingEnterpriseCompletions:
+    mocks.dispatchPendingEnterpriseCompletions,
+  syncEnterpriseWorkspace: mocks.syncEnterpriseWorkspace,
+}));
+vi.mock("~/auth", () => ({
+  useAuth: () => ({
+    session: { access_token: "access-token", user: { id: "user-1" } },
+  }),
+}));
+vi.mock("~/env", () => ({
+  env: { VITE_ENTERPRISE_API_URL: "https://capture.example.test" },
+}));
+vi.mock("~/settings/team/mirror", () => ({
+  useMyWorkspacesWithMirror: () => ({ data: mocks.workspaces }),
+}));
+
+import { EnterpriseCaptureSync } from "./lifecycle";
+
+function getQueryFn() {
+  return vi.mocked(mocks.useQuery).mock.lastCall?.[0]
+    .queryFn as () => Promise<unknown>;
+}
+
+describe("EnterpriseCaptureSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.workspaces = [{ workspaceId: "workspace-1" }];
+    mocks.dispatchPendingEnterpriseCompletions.mockResolvedValue(undefined);
+    mocks.syncEnterpriseWorkspace.mockResolvedValue(undefined);
+    mocks.useQuery.mockReturnValue({});
+  });
+
+  afterEach(cleanup);
+
+  it("keeps delivery polling active while the window is hidden", () => {
+    render(<EnterpriseCaptureSync />);
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ refetchIntervalInBackground: true }),
+    );
+  });
+
+  it("retries fingerprint lookup after a transient failure", async () => {
+    mocks.getFingerprint
+      .mockRejectedValueOnce(new Error("fingerprint unavailable"))
+      .mockResolvedValueOnce({ status: "ok", data: "device-1" });
+    render(<EnterpriseCaptureSync />);
+    const queryFn = getQueryFn();
+
+    await expect(queryFn()).rejects.toThrow("fingerprint unavailable");
+    await expect(queryFn()).resolves.toBeNull();
+
+    expect(mocks.getFingerprint).toHaveBeenCalledTimes(2);
+    expect(mocks.syncEnterpriseWorkspace).toHaveBeenCalledOnce();
+  });
+
+  it("continues other workspaces and completion dispatch after a sync failure", async () => {
+    mocks.workspaces = [
+      { workspaceId: "workspace-1" },
+      { workspaceId: "workspace-2" },
+    ];
+    mocks.getFingerprint.mockResolvedValue({
+      status: "ok",
+      data: "device-1",
+    });
+    mocks.syncEnterpriseWorkspace.mockImplementation(
+      async ({ workspaceId }: { workspaceId: string }) => {
+        if (workspaceId === "workspace-1") {
+          throw new Error("workspace unavailable");
+        }
+      },
+    );
+    render(<EnterpriseCaptureSync />);
+
+    await expect(getQueryFn()()).rejects.toThrow("workspace unavailable");
+
+    expect(
+      mocks.syncEnterpriseWorkspace.mock.calls.map(
+        ([input]) => input.workspaceId,
+      ),
+    ).toEqual(["workspace-1", "workspace-2"]);
+    expect(mocks.dispatchPendingEnterpriseCompletions).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/enterprise-capture/lifecycle.tsx
+++ b/apps/desktop/src/enterprise-capture/lifecycle.tsx
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query";
+import { useRef } from "react";
+
+import { commands as miscCommands } from "@anlg/plugin-misc";
+
+import {
+  dispatchPendingEnterpriseCompletions,
+  syncEnterpriseWorkspace,
+} from "./sync";
+
+import { useAuth } from "~/auth";
+import { env } from "~/env";
+import { useMyWorkspacesWithMirror } from "~/settings/team/mirror";
+
+const POLL_INTERVAL_MS = 15_000;
+
+export function EnterpriseCaptureSync() {
+  const auth = useAuth();
+  const workspaces = useMyWorkspacesWithMirror();
+  const serverUrl = env.VITE_ENTERPRISE_API_URL;
+  const session = auth.session;
+  const deviceFingerprint = useRef<Promise<string> | null>(null);
+
+  useQuery({
+    queryKey: [
+      "enterprise-capture-delivery",
+      serverUrl,
+      session?.user.id,
+      workspaces.data?.map((workspace) => workspace.workspaceId).sort(),
+    ],
+    enabled: Boolean(serverUrl && session && workspaces.data),
+    queryFn: async () => {
+      if (!serverUrl || !session || !workspaces.data) return null;
+      const consumerId = await getDeviceFingerprint(deviceFingerprint);
+      let workspaceError: unknown;
+      for (const workspace of workspaces.data) {
+        try {
+          await syncEnterpriseWorkspace({
+            serverUrl,
+            accessToken: session.access_token,
+            workspaceId: workspace.workspaceId,
+            consumerId,
+          });
+        } catch (error) {
+          workspaceError ??= error;
+        }
+      }
+      await dispatchPendingEnterpriseCompletions();
+      if (workspaceError) throw workspaceError;
+      return null;
+    },
+    refetchInterval: POLL_INTERVAL_MS,
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: true,
+    retry: 2,
+  });
+
+  return null;
+}
+
+async function getDeviceFingerprint(cache: {
+  current: Promise<string> | null;
+}): Promise<string> {
+  cache.current ??= (async () => {
+    const result = await miscCommands.getFingerprint();
+    if (result.status === "error") throw new Error(result.error);
+    if (!result.data) throw new Error("device fingerprint is unavailable");
+    return result.data;
+  })();
+  try {
+    return await cache.current;
+  } catch (error) {
+    cache.current = null;
+    throw error;
+  }
+}

--- a/apps/desktop/src/enterprise-capture/store.test.ts
+++ b/apps/desktop/src/enterprise-capture/store.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { recordRejectedDelivery } from "./store";
+
+const mocks = vi.hoisted(() => ({ executeTransaction: vi.fn() }));
+
+vi.mock("~/db", () => ({
+  executeTransaction: mocks.executeTransaction,
+  liveQueryClient: { execute: vi.fn() },
+}));
+
+describe("enterprise capture store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.executeTransaction.mockResolvedValue(undefined);
+  });
+
+  it("advances rejected deliveries without enqueueing completion", async () => {
+    await recordRejectedDelivery({
+      serverUrl: "https://capture.example.test",
+      workspaceId: "workspace-1",
+      consumerId: "device-1",
+      item: {
+        cursor: 5,
+        jobId: "job-1",
+        revision: 2,
+        finalized: true,
+        contentHash: "a".repeat(64),
+        acknowledged: false,
+        createdAt: "2026-08-14T08:00:00Z",
+        envelope: {
+          schema_version: 1,
+          source_id: "job-1",
+          revision: 2,
+          finalized: true,
+          workspace_id: "workspace-1",
+          session: { id: "session-1", status: "completed" },
+        },
+      },
+    });
+
+    const statements = mocks.executeTransaction.mock.calls[0]?.[0];
+    expect(statements).toHaveLength(2);
+    expect(
+      statements.some(({ sql }: { sql: string }) =>
+        sql.includes("enterprise_session_completion_outbox"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/enterprise-capture/store.ts
+++ b/apps/desktop/src/enterprise-capture/store.ts
@@ -1,0 +1,204 @@
+import type {
+  DeliveryItem,
+  PendingAcknowledgement,
+  PendingCompletion,
+} from "./types";
+
+import { executeTransaction, liveQueryClient } from "~/db";
+
+export async function loadDeliveryCursor(input: {
+  serverUrl: string;
+  workspaceId: string;
+  consumerId: string;
+}): Promise<number> {
+  const rows = await liveQueryClient.execute<{ cursor: number }>(
+    `
+      SELECT cursor
+      FROM enterprise_session_delivery_state
+      WHERE server_url = ? AND workspace_id = ? AND consumer_id = ?
+    `,
+    [input.serverUrl, input.workspaceId, input.consumerId],
+  );
+  return rows[0]?.cursor ?? 0;
+}
+
+export async function recordAppliedDelivery(input: {
+  serverUrl: string;
+  workspaceId: string;
+  consumerId: string;
+  item: DeliveryItem;
+}): Promise<void> {
+  await recordDelivery(input, true);
+}
+
+export async function recordRejectedDelivery(input: {
+  serverUrl: string;
+  workspaceId: string;
+  consumerId: string;
+  item: DeliveryItem;
+}): Promise<void> {
+  await recordDelivery(input, false);
+}
+
+async function recordDelivery(
+  input: {
+    serverUrl: string;
+    workspaceId: string;
+    consumerId: string;
+    item: DeliveryItem;
+  },
+  enqueueCompletion: boolean,
+): Promise<void> {
+  const now = new Date().toISOString();
+  const statements = [
+    {
+      sql: `
+        INSERT INTO enterprise_session_delivery_state (
+          server_url, workspace_id, consumer_id, cursor, updated_at
+        ) VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(server_url, workspace_id, consumer_id) DO UPDATE SET
+          cursor = MAX(cursor, excluded.cursor),
+          updated_at = excluded.updated_at
+      `,
+      params: [
+        input.serverUrl,
+        input.workspaceId,
+        input.consumerId,
+        input.item.cursor,
+        now,
+      ],
+    },
+    {
+      sql: `
+        INSERT INTO enterprise_session_delivery_receipts (
+          server_url, workspace_id, consumer_id, job_id, revision,
+          content_hash, acknowledged_at, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
+        ON CONFLICT(server_url, workspace_id, consumer_id, job_id, revision)
+        DO UPDATE SET updated_at = excluded.updated_at
+      `,
+      params: [
+        input.serverUrl,
+        input.workspaceId,
+        input.consumerId,
+        input.item.jobId,
+        input.item.revision,
+        input.item.contentHash,
+        now,
+        now,
+      ],
+    },
+  ];
+  if (enqueueCompletion && input.item.finalized) {
+    statements.push({
+      sql: `
+        INSERT INTO enterprise_session_completion_outbox (
+          source_id, workspace_id, session_id, revision, created_at, dispatched_at
+        ) VALUES (?, ?, ?, ?, ?, NULL)
+        ON CONFLICT(source_id) DO NOTHING
+      `,
+      params: [
+        input.item.envelope.source_id,
+        input.workspaceId,
+        input.item.envelope.session.id,
+        input.item.revision,
+        now,
+      ],
+    });
+  }
+  await executeTransaction(statements);
+}
+
+export async function listPendingAcknowledgements(input: {
+  serverUrl: string;
+  workspaceId: string;
+  consumerId: string;
+}): Promise<PendingAcknowledgement[]> {
+  return liveQueryClient
+    .execute<{
+      job_id: string;
+      revision: number;
+      content_hash: string;
+    }>(
+      `
+      SELECT job_id, revision, content_hash
+      FROM enterprise_session_delivery_receipts
+      WHERE server_url = ? AND workspace_id = ? AND consumer_id = ?
+        AND acknowledged_at IS NULL
+      ORDER BY revision, job_id
+    `,
+      [input.serverUrl, input.workspaceId, input.consumerId],
+    )
+    .then((rows) =>
+      rows.map((row) => ({
+        jobId: row.job_id,
+        revision: row.revision,
+        contentHash: row.content_hash,
+      })),
+    );
+}
+
+export async function markDeliveryAcknowledged(input: {
+  serverUrl: string;
+  workspaceId: string;
+  consumerId: string;
+  jobId: string;
+  revision: number;
+}): Promise<void> {
+  const now = new Date().toISOString();
+  await liveQueryClient.execute(
+    `
+      UPDATE enterprise_session_delivery_receipts
+      SET acknowledged_at = ?, updated_at = ?
+      WHERE server_url = ? AND workspace_id = ? AND consumer_id = ?
+        AND job_id = ? AND revision = ?
+    `,
+    [
+      now,
+      now,
+      input.serverUrl,
+      input.workspaceId,
+      input.consumerId,
+      input.jobId,
+      input.revision,
+    ],
+  );
+}
+
+export async function listPendingCompletions(): Promise<PendingCompletion[]> {
+  return liveQueryClient
+    .execute<{
+      source_id: string;
+      workspace_id: string;
+      session_id: string;
+      revision: number;
+    }>(
+      `
+      SELECT source_id, workspace_id, session_id, revision
+      FROM enterprise_session_completion_outbox
+      WHERE dispatched_at IS NULL
+      ORDER BY created_at, source_id
+    `,
+    )
+    .then((rows) =>
+      rows.map((row) => ({
+        sourceId: row.source_id,
+        workspaceId: row.workspace_id,
+        sessionId: row.session_id,
+        revision: row.revision,
+      })),
+    );
+}
+
+export async function markCompletionDispatched(
+  sourceId: string,
+): Promise<void> {
+  await liveQueryClient.execute(
+    `
+      UPDATE enterprise_session_completion_outbox
+      SET dispatched_at = ?
+      WHERE source_id = ? AND dispatched_at IS NULL
+    `,
+    [new Date().toISOString(), sourceId],
+  );
+}

--- a/apps/desktop/src/enterprise-capture/sync.test.ts
+++ b/apps/desktop/src/enterprise-capture/sync.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { applySessionIngest } from "@anlg/plugin-db";
+import { commands as localApiCommands } from "@anlg/plugin-local-api";
+
+import { acknowledgeSessionDelivery, listSessionDeliveries } from "./client";
+import {
+  listPendingAcknowledgements,
+  listPendingCompletions,
+  loadDeliveryCursor,
+  markCompletionDispatched,
+  markDeliveryAcknowledged,
+  recordAppliedDelivery,
+  recordRejectedDelivery,
+} from "./store";
+import {
+  dispatchPendingEnterpriseCompletions,
+  syncEnterpriseWorkspace,
+} from "./sync";
+
+import { runMeetingCompletedAutomations } from "~/automations/engine";
+
+vi.mock("@anlg/plugin-db", () => ({ applySessionIngest: vi.fn() }));
+vi.mock("@anlg/plugin-local-api", () => ({
+  commands: { dispatchEvent: vi.fn() },
+}));
+vi.mock("./client", () => ({
+  acknowledgeSessionDelivery: vi.fn(),
+  listSessionDeliveries: vi.fn(),
+}));
+vi.mock("./store", () => ({
+  listPendingAcknowledgements: vi.fn(),
+  listPendingCompletions: vi.fn(),
+  loadDeliveryCursor: vi.fn(),
+  markCompletionDispatched: vi.fn(),
+  markDeliveryAcknowledged: vi.fn(),
+  recordAppliedDelivery: vi.fn(),
+  recordRejectedDelivery: vi.fn(),
+}));
+vi.mock("~/automations/engine", () => ({
+  runMeetingCompletedAutomations: vi.fn(),
+}));
+
+const input = {
+  serverUrl: "https://capture.example.test",
+  accessToken: "access-token",
+  workspaceId: "workspace-1",
+  consumerId: "device-1",
+};
+
+const item = {
+  cursor: 5,
+  jobId: "job-1",
+  revision: 2,
+  finalized: true,
+  contentHash: "a".repeat(64),
+  acknowledged: false,
+  createdAt: "2026-08-14T08:00:00Z",
+  envelope: {
+    schema_version: 1,
+    source_id: "job-1",
+    revision: 2,
+    finalized: true,
+    workspace_id: "workspace-1",
+    session: { id: "session-1", status: "completed" },
+  },
+};
+
+describe("enterprise capture sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listPendingAcknowledgements).mockResolvedValue([]);
+    vi.mocked(loadDeliveryCursor).mockResolvedValue(0);
+    vi.mocked(listSessionDeliveries).mockResolvedValue({
+      items: [item],
+      nextCursor: 5,
+      hasMore: false,
+    });
+    vi.mocked(applySessionIngest).mockResolvedValue("applied");
+    vi.mocked(acknowledgeSessionDelivery).mockResolvedValue(undefined);
+    vi.mocked(recordAppliedDelivery).mockResolvedValue(undefined);
+    vi.mocked(recordRejectedDelivery).mockResolvedValue(undefined);
+    vi.mocked(markDeliveryAcknowledged).mockResolvedValue(undefined);
+  });
+
+  it("acknowledges a permanent rejection and continues with later deliveries", async () => {
+    const laterItem = {
+      ...item,
+      cursor: 6,
+      jobId: "job-2",
+      contentHash: "b".repeat(64),
+      envelope: {
+        ...item.envelope,
+        source_id: "job-2",
+        session: { id: "session-2", status: "completed" },
+      },
+    };
+    vi.mocked(listSessionDeliveries).mockResolvedValue({
+      items: [item, laterItem],
+      nextCursor: 6,
+      hasMore: false,
+    });
+    vi.mocked(applySessionIngest)
+      .mockResolvedValueOnce("rejected")
+      .mockResolvedValueOnce("applied");
+
+    await syncEnterpriseWorkspace(input);
+
+    expect(recordRejectedDelivery).toHaveBeenCalledWith({ ...input, item });
+    expect(recordAppliedDelivery).toHaveBeenCalledWith({
+      ...input,
+      item: laterItem,
+    });
+    expect(acknowledgeSessionDelivery).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies and persists before acknowledging a revision", async () => {
+    await syncEnterpriseWorkspace(input);
+
+    expect(applySessionIngest).toHaveBeenCalledWith(
+      "workspace-1",
+      item.envelope,
+    );
+    expect(recordAppliedDelivery).toHaveBeenCalledWith({ ...input, item });
+    expect(acknowledgeSessionDelivery).toHaveBeenCalledWith({
+      ...input,
+      jobId: "job-1",
+      revision: 2,
+      contentHash: "a".repeat(64),
+    });
+    expect(
+      vi.mocked(recordAppliedDelivery).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(acknowledgeSessionDelivery).mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("retries a durable acknowledgement before requesting later pages", async () => {
+    vi.mocked(listPendingAcknowledgements).mockResolvedValue([
+      { jobId: "job-old", revision: 1, contentHash: "b".repeat(64) },
+    ]);
+
+    await syncEnterpriseWorkspace(input);
+
+    expect(vi.mocked(acknowledgeSessionDelivery).mock.calls[0]?.[0]).toEqual({
+      ...input,
+      jobId: "job-old",
+      revision: 1,
+      contentHash: "b".repeat(64),
+    });
+    expect(
+      vi.mocked(acknowledgeSessionDelivery).mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(listSessionDeliveries).mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("dispatches each durable completion once after successful processing", async () => {
+    vi.mocked(listPendingCompletions)
+      .mockResolvedValueOnce([
+        {
+          sourceId: "job-1",
+          workspaceId: "workspace-1",
+          sessionId: "session-1",
+          revision: 2,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    vi.mocked(localApiCommands.dispatchEvent).mockResolvedValue({
+      status: "ok",
+      data: 0,
+    });
+    vi.mocked(runMeetingCompletedAutomations).mockResolvedValue(undefined);
+    vi.mocked(markCompletionDispatched).mockResolvedValue(undefined);
+
+    await dispatchPendingEnterpriseCompletions();
+    await dispatchPendingEnterpriseCompletions();
+
+    expect(localApiCommands.dispatchEvent).toHaveBeenCalledOnce();
+    expect(runMeetingCompletedAutomations).toHaveBeenCalledOnce();
+    expect(markCompletionDispatched).toHaveBeenCalledWith("job-1");
+  });
+});

--- a/apps/desktop/src/enterprise-capture/sync.ts
+++ b/apps/desktop/src/enterprise-capture/sync.ts
@@ -1,0 +1,101 @@
+import { applySessionIngest } from "@anlg/plugin-db";
+import { commands as localApiCommands } from "@anlg/plugin-local-api";
+
+import { acknowledgeSessionDelivery, listSessionDeliveries } from "./client";
+import {
+  listPendingAcknowledgements,
+  listPendingCompletions,
+  loadDeliveryCursor,
+  markCompletionDispatched,
+  markDeliveryAcknowledged,
+  recordAppliedDelivery,
+  recordRejectedDelivery,
+} from "./store";
+
+import { runMeetingCompletedAutomations } from "~/automations/engine";
+
+const MAX_PAGES_PER_SYNC = 100;
+
+export async function syncEnterpriseWorkspace(input: {
+  serverUrl: string;
+  accessToken: string;
+  workspaceId: string;
+  consumerId: string;
+}): Promise<void> {
+  await flushAcknowledgements(input);
+  let cursor = await loadDeliveryCursor(input);
+
+  for (let pageIndex = 0; pageIndex < MAX_PAGES_PER_SYNC; pageIndex += 1) {
+    const page = await listSessionDeliveries({ ...input, after: cursor });
+    if (page.items.length === 0) {
+      if (page.hasMore)
+        throw new Error("capture delivery cursor did not advance");
+      return;
+    }
+
+    for (const item of page.items) {
+      if (
+        item.cursor <= cursor ||
+        item.envelope.workspace_id !== input.workspaceId
+      ) {
+        throw new Error(
+          "capture delivery is outside the requested cursor or workspace",
+        );
+      }
+      const result = await applySessionIngest(input.workspaceId, item.envelope);
+      if (result === "rejected") {
+        await recordRejectedDelivery({ ...input, item });
+      } else {
+        await recordAppliedDelivery({ ...input, item });
+      }
+      await acknowledgeSessionDelivery({
+        ...input,
+        jobId: item.jobId,
+        revision: item.revision,
+        contentHash: item.contentHash,
+      });
+      await markDeliveryAcknowledged({
+        ...input,
+        jobId: item.jobId,
+        revision: item.revision,
+      });
+      cursor = item.cursor;
+    }
+
+    if (page.nextCursor !== cursor) {
+      throw new Error("capture delivery response has an inconsistent cursor");
+    }
+    if (!page.hasMore) return;
+  }
+  throw new Error("capture delivery exceeded the bounded page limit");
+}
+
+async function flushAcknowledgements(input: {
+  serverUrl: string;
+  accessToken: string;
+  workspaceId: string;
+  consumerId: string;
+}): Promise<void> {
+  const pending = await listPendingAcknowledgements(input);
+  for (const acknowledgement of pending) {
+    await acknowledgeSessionDelivery({ ...input, ...acknowledgement });
+    await markDeliveryAcknowledged({
+      ...input,
+      jobId: acknowledgement.jobId,
+      revision: acknowledgement.revision,
+    });
+  }
+}
+
+export async function dispatchPendingEnterpriseCompletions(): Promise<void> {
+  const pending = await listPendingCompletions();
+  for (const completion of pending) {
+    const result = await localApiCommands.dispatchEvent(
+      "meeting.completed",
+      completion.sessionId,
+    );
+    if (result.status === "error") throw new Error(result.error);
+    await runMeetingCompletedAutomations(completion.sessionId);
+    await markCompletionDispatched(completion.sourceId);
+  }
+}

--- a/apps/desktop/src/enterprise-capture/types.ts
+++ b/apps/desktop/src/enterprise-capture/types.ts
@@ -1,0 +1,38 @@
+export type SessionIngestEnvelope = Record<string, unknown> & {
+  schema_version: number;
+  source_id: string;
+  revision: number;
+  finalized: boolean;
+  workspace_id: string;
+  session: Record<string, unknown> & { id: string; status: string };
+};
+
+export type DeliveryItem = {
+  cursor: number;
+  jobId: string;
+  revision: number;
+  finalized: boolean;
+  contentHash: string;
+  acknowledged: boolean;
+  createdAt: string;
+  envelope: SessionIngestEnvelope;
+};
+
+export type DeliveryPage = {
+  items: DeliveryItem[];
+  nextCursor: number;
+  hasMore: boolean;
+};
+
+export type PendingAcknowledgement = {
+  jobId: string;
+  revision: number;
+  contentHash: string;
+};
+
+export type PendingCompletion = {
+  sourceId: string;
+  workspaceId: string;
+  sessionId: string;
+  revision: number;
+};

--- a/apps/desktop/src/env.ts
+++ b/apps/desktop/src/env.ts
@@ -6,6 +6,7 @@ export const env = createEnv({
   client: {
     VITE_APP_URL: z.string().min(1).default("http://localhost:3000"),
     VITE_API_URL: z.string().min(1).default("http://localhost:3001"),
+    VITE_ENTERPRISE_API_URL: z.string().url().optional(),
     VITE_SUPABASE_URL: z.string().min(1).optional(),
     VITE_SUPABASE_ANON_KEY: z.string().min(1).optional(),
     VITE_PRO_PRODUCT_ID: z.string().min(1).optional(),

--- a/apps/desktop/src/shared/main-app-layout.test.tsx
+++ b/apps/desktop/src/shared/main-app-layout.test.tsx
@@ -39,6 +39,10 @@ vi.mock("~/devtools-panel/host", () => ({
   DevtoolsFloatingPanelHost: () => null,
 }));
 
+vi.mock("~/enterprise-capture/lifecycle", () => ({
+  EnterpriseCaptureSync: () => <div data-testid="enterprise-capture-sync" />,
+}));
+
 vi.mock("~/session/queries", () => ({
   getOrCreateSessionForEventId: vi.fn(),
 }));
@@ -73,13 +77,15 @@ describe("MainAppLayout", () => {
 
   afterEach(cleanup);
 
-  it("mounts connected import sync inside the auth provider", () => {
+  it("mounts main-window sync services inside the auth provider", () => {
     render(<MainAppLayout />);
 
+    const authProvider = screen.getByTestId("auth-provider");
     expect(
-      screen
-        .getByTestId("auth-provider")
-        .contains(screen.getByTestId("meeting-import-sync")),
+      authProvider.contains(screen.getByTestId("meeting-import-sync")),
+    ).toBe(true);
+    expect(
+      authProvider.contains(screen.getByTestId("enterprise-capture-sync")),
     ).toBe(true);
   });
 
@@ -89,5 +95,6 @@ describe("MainAppLayout", () => {
     render(<MainAppLayout />);
 
     expect(screen.queryByTestId("meeting-import-sync")).toBeNull();
+    expect(screen.queryByTestId("enterprise-capture-sync")).toBeNull();
   });
 });

--- a/apps/desktop/src/shared/main-app-layout.tsx
+++ b/apps/desktop/src/shared/main-app-layout.tsx
@@ -15,6 +15,7 @@ import {
 import { AuthProvider } from "~/auth";
 import { BillingProvider } from "~/auth/billing";
 import { DevtoolsFloatingPanelHost } from "~/devtools-panel/host";
+import { EnterpriseCaptureSync } from "~/enterprise-capture/lifecycle";
 import { MeetingImportSync } from "~/services/meeting-import-sync";
 import { getOrCreateSessionForEventId } from "~/session/queries";
 import { useMyWorkspacesWithMirror } from "~/settings/team/mirror";
@@ -42,6 +43,7 @@ function MainAppContent() {
     <>
       <Outlet />
       {isMainWindow ? <MeetingImportSync /> : null}
+      {isMainWindow ? <EnterpriseCaptureSync /> : null}
       <UndoDeleteToast />
       <DevtoolsFloatingPanelHost />
     </>

--- a/crates/db-app/migrations/20260814090000_enterprise_session_delivery.sql
+++ b/crates/db-app/migrations/20260814090000_enterprise_session_delivery.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS enterprise_session_delivery_state (
+  server_url TEXT NOT NULL CHECK (server_url <> ''),
+  workspace_id TEXT NOT NULL CHECK (workspace_id <> ''),
+  consumer_id TEXT NOT NULL CHECK (consumer_id <> ''),
+  cursor INTEGER NOT NULL DEFAULT 0 CHECK (cursor >= 0),
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (server_url, workspace_id, consumer_id)
+);
+
+CREATE TABLE IF NOT EXISTS enterprise_session_delivery_receipts (
+  server_url TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  consumer_id TEXT NOT NULL,
+  job_id TEXT NOT NULL CHECK (job_id <> ''),
+  revision INTEGER NOT NULL CHECK (revision > 0),
+  content_hash TEXT NOT NULL CHECK (length(content_hash) = 64),
+  acknowledged_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (server_url, workspace_id, consumer_id, job_id, revision),
+  FOREIGN KEY (server_url, workspace_id, consumer_id)
+    REFERENCES enterprise_session_delivery_state (server_url, workspace_id, consumer_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_enterprise_session_delivery_pending_acks
+ON enterprise_session_delivery_receipts (
+  server_url,
+  workspace_id,
+  consumer_id,
+  acknowledged_at,
+  revision
+);
+
+CREATE TABLE IF NOT EXISTS enterprise_session_completion_outbox (
+  source_id TEXT PRIMARY KEY CHECK (source_id <> ''),
+  workspace_id TEXT NOT NULL CHECK (workspace_id <> ''),
+  session_id TEXT NOT NULL CHECK (session_id <> ''),
+  revision INTEGER NOT NULL CHECK (revision > 0),
+  created_at TEXT NOT NULL,
+  dispatched_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_enterprise_session_completion_pending
+ON enterprise_session_completion_outbox (dispatched_at, created_at, source_id);

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -329,6 +329,11 @@ pub const APP_MIGRATION_STEPS: &[anlg_db_migrate::MigrationStep] = &[
         },
         sql: include_str!("../migrations/20260812100100_e2ee_replica_reconciliation_triggers.sql"),
     },
+    anlg_db_migrate::MigrationStep {
+        id: "20260814090000_enterprise_session_delivery",
+        scope: anlg_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260814090000_enterprise_session_delivery.sql"),
+    },
 ];
 
 pub fn schema() -> anlg_db_migrate::DbSchema {

--- a/crates/db-app/src/schema_tests/migrations.rs
+++ b/crates/db-app/src/schema_tests/migrations.rs
@@ -55,6 +55,9 @@ async fn migrations_apply_cleanly() {
             "e2ee_witness_records",
             "e2ee_witness_repair_pending",
             "e2ee_witness_state",
+            "enterprise_session_completion_outbox",
+            "enterprise_session_delivery_receipts",
+            "enterprise_session_delivery_state",
             "entity_mentions",
             "events",
             "humans",
@@ -468,4 +471,38 @@ async fn prepare_schema_seeds_templates_when_repair_migration_creates_missing_ta
         .await
         .unwrap();
     assert!(row_count > 0);
+}
+
+#[tokio::test]
+async fn enterprise_session_delivery_tables_are_registered() {
+    let migration = APP_MIGRATION_STEPS
+        .iter()
+        .find(|step| step.id == "20260814090000_enterprise_session_delivery")
+        .unwrap();
+    assert_eq!(migration.scope, anlg_db_migrate::MigrationScope::Plain);
+
+    let db = test_db().await;
+    let tables: Vec<String> = sqlx::query_scalar(
+        r#"SELECT name
+           FROM sqlite_master
+           WHERE type = 'table'
+             AND name IN (
+               'enterprise_session_delivery_state',
+               'enterprise_session_delivery_receipts',
+               'enterprise_session_completion_outbox'
+             )
+           ORDER BY name"#,
+    )
+    .fetch_all(db.pool())
+    .await
+    .unwrap();
+
+    assert_eq!(
+        tables,
+        vec![
+            "enterprise_session_completion_outbox",
+            "enterprise_session_delivery_receipts",
+            "enterprise_session_delivery_state",
+        ]
+    );
 }

--- a/crates/session-ingest/src/apply.rs
+++ b/crates/session-ingest/src/apply.rs
@@ -54,6 +54,12 @@ pub enum Error {
     Database(#[from] sqlx::Error),
 }
 
+impl Error {
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, Self::Database(_))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct IngestMarker {
     source_id: String,

--- a/crates/session-ingest/src/lib.rs
+++ b/crates/session-ingest/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 mod model;
+mod protocol;
 
 #[cfg(feature = "apply")]
 mod apply;
@@ -12,6 +13,10 @@ pub use apply::{ApplyOutcome, Error, apply_session_envelope};
 pub use model::{
     DocumentFormat, DocumentKind, IngestAttachment, IngestDocument, IngestParticipant,
     IngestSession, IngestSpeakerHint, IngestTranscript, IngestWord, SessionIngestEnvelope,
+};
+pub use protocol::{
+    AcknowledgeRequest, AcknowledgeResponse, DeliveryItem, DeliveryPage, RecordingDownload,
+    SessionRead,
 };
 
 pub const SESSION_INGEST_SCHEMA_VERSION: u32 = 1;

--- a/crates/session-ingest/src/protocol.rs
+++ b/crates/session-ingest/src/protocol.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+use crate::SessionIngestEnvelope;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DeliveryItem {
+    pub cursor: u64,
+    pub job_id: String,
+    pub revision: u64,
+    pub finalized: bool,
+    pub content_hash: String,
+    pub acknowledged: bool,
+    pub created_at: String,
+    pub envelope: SessionIngestEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DeliveryPage {
+    pub items: Vec<DeliveryItem>,
+    pub next_cursor: u64,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AcknowledgeRequest {
+    pub consumer_id: String,
+    pub revision: u64,
+    pub content_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AcknowledgeResponse {
+    pub acknowledged: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SessionRead {
+    pub job_id: String,
+    pub revision: u64,
+    pub finalized: bool,
+    pub content_hash: String,
+    pub envelope: SessionIngestEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RecordingDownload {
+    pub url: String,
+    pub expires_at: String,
+}

--- a/crates/session-ingest/src/tests.rs
+++ b/crates/session-ingest/src/tests.rs
@@ -122,6 +122,17 @@ fn envelope(finalized: bool) -> SessionIngestEnvelope {
     }
 }
 
+#[test]
+fn only_database_failures_are_retryable() {
+    assert!(
+        !Error::DeletedSession {
+            session_id: "session-1".to_string(),
+        }
+        .is_retryable()
+    );
+    assert!(Error::Database(sqlx::Error::RowNotFound).is_retryable());
+}
+
 #[tokio::test]
 async fn applies_canonical_graph_idempotently_and_marks_rows_for_e2ee() {
     let db = test_db().await;

--- a/plugins/db/Cargo.toml
+++ b/plugins/db/Cargo.toml
@@ -16,6 +16,7 @@ anlg-db-migrate = { workspace = true }
 anlg-db-reactive = { workspace = true, features = ["specta"] }
 anlg-e2ee = { workspace = true }
 anlg-fs-sync-core = { workspace = true }
+anlg-session-ingest = { workspace = true }
 anlg-storage = { workspace = true }
 anlg-tauri-utils = { workspace = true }
 

--- a/plugins/db/build.rs
+++ b/plugins/db/build.rs
@@ -10,6 +10,7 @@ const COMMANDS: &[&str] = &[
     "list_meetings",
     "cleanup_legacy_files",
     "run_legacy_import",
+    "apply_session_ingest",
     "get_e2ee_identity_status",
     "inspect_e2ee_recovery_key",
     "create_e2ee_identity",

--- a/plugins/db/js/bindings.gen.ts
+++ b/plugins/db/js/bindings.gen.ts
@@ -94,6 +94,14 @@ async runLegacyImport(dryRun: boolean) : Promise<Result<string, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async applySessionIngest(workspaceId: string, envelope: JsonValue) : Promise<Result<SessionIngestApplyResult, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:db|apply_session_ingest", { workspaceId, envelope }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async getE2eeIdentityStatus(accountUserId: string) : Promise<Result<E2eeIdentityStatus, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:db|get_e2ee_identity_status", { accountUserId }) };
@@ -304,6 +312,7 @@ export type MeetingPage = { meetings: MeetingListItem[]; pagination: Pagination 
 export type Pagination = { offset: number; limit: number; returned: number; total: number | null; next_offset: number | null }
 export type Participant = { human_id: string; display_name: string; email: string; role: string; job_title: string; organization_id: string; organization_name: string }
 export type QueryEvent = { event: "result"; data: JsonValue[] } | { event: "error"; data: string }
+export type SessionIngestApplyResult = "applied" | "already_applied" | "rejected"
 export type StorageMigrationState = { phase: string; latestRunId: string; parityVerified: boolean; cutoverAt: string | null; rollbackUntil: string | null; lastError: string; updatedAt: string }
 export type SubscriptionRegistration = { id: string; analysis: DependencyAnalysis }
 export type TAURI_CHANNEL<TSend> = null

--- a/plugins/db/js/index.ts
+++ b/plugins/db/js/index.ts
@@ -17,6 +17,7 @@ import type {
   ListMeetingsInput as GeneratedListMeetingsInput,
   Meeting,
   MeetingPage,
+  SessionIngestApplyResult,
   SubscriptionRegistration,
   TranscriptPage,
 } from "./bindings.gen";
@@ -35,6 +36,7 @@ export type {
   LegacyImportReport,
   Meeting,
   MeetingPage,
+  SessionIngestApplyResult,
   TranscriptPage,
 } from "./bindings.gen";
 
@@ -199,6 +201,13 @@ export async function cleanupLegacyFiles(): Promise<LegacyCleanupResult> {
 
 export async function runLegacyImport(dryRun = false): Promise<string> {
   return invoke("plugin:db|run_legacy_import", { dryRun });
+}
+
+export async function applySessionIngest(
+  workspaceId: string,
+  envelope: Record<string, unknown>,
+): Promise<SessionIngestApplyResult> {
+  return invoke("plugin:db|apply_session_ingest", { workspaceId, envelope });
 }
 
 export async function getE2eeIdentityStatus(

--- a/plugins/db/permissions/autogenerated/commands/apply_session_ingest.toml
+++ b/plugins/db/permissions/autogenerated/commands/apply_session_ingest.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-apply-session-ingest"
+description = "Enables the apply_session_ingest command without any pre-configured scope."
+commands.allow = ["apply_session_ingest"]
+
+[[permission]]
+identifier = "deny-apply-session-ingest"
+description = "Denies the apply_session_ingest command without any pre-configured scope."
+commands.deny = ["apply_session_ingest"]

--- a/plugins/db/permissions/autogenerated/reference.md
+++ b/plugins/db/permissions/autogenerated/reference.md
@@ -4,6 +4,7 @@ Default permissions for the plugin
 
 #### This default permission set includes the following:
 
+- `allow-apply-session-ingest`
 - `allow-execute`
 - `allow-execute-proxy`
 - `allow-execute-transaction`
@@ -40,6 +41,32 @@ Default permissions for the plugin
 <th>Description</th>
 </tr>
 
+
+<tr>
+<td>
+
+`db:allow-apply-session-ingest`
+
+</td>
+<td>
+
+Enables the apply_session_ingest command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`db:deny-apply-session-ingest`
+
+</td>
+<td>
+
+Denies the apply_session_ingest command without any pre-configured scope.
+
+</td>
+</tr>
 
 <tr>
 <td>

--- a/plugins/db/permissions/default.toml
+++ b/plugins/db/permissions/default.toml
@@ -1,6 +1,7 @@
 [default]
 description = "Default permissions for the plugin"
 permissions = [
+    "allow-apply-session-ingest",
   "allow-execute",
   "allow-execute-proxy",
   "allow-execute-transaction",

--- a/plugins/db/permissions/schemas/schema.json
+++ b/plugins/db/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the apply_session_ingest command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-apply-session-ingest",
+          "markdownDescription": "Enables the apply_session_ingest command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the apply_session_ingest command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-apply-session-ingest",
+          "markdownDescription": "Denies the apply_session_ingest command without any pre-configured scope."
+        },
+        {
           "description": "Enables the begin_cloudsync_activity command without any pre-configured scope.",
           "type": "string",
           "const": "allow-begin-cloudsync-activity",
@@ -679,10 +691,10 @@
           "markdownDescription": "Denies the unsubscribe command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-execute`\n- `allow-execute-proxy`\n- `allow-execute-transaction`\n- `allow-list-meetings`\n- `allow-get-meeting`\n- `allow-get-meeting-transcript`\n- `allow-get-recurring-meeting-history`\n- `allow-get-legacy-cleanup-status`\n- `allow-get-legacy-import-report`\n- `allow-cleanup-legacy-files`\n- `allow-run-legacy-import`\n- `allow-get-e2ee-identity-status`\n- `allow-inspect-e2ee-recovery-key`\n- `allow-create-e2ee-identity`\n- `allow-import-e2ee-identity`\n- `allow-get-or-create-e2ee-device-identity`\n- `allow-seal-e2ee-recovery-key-for-device`\n- `allow-import-e2ee-device-enrollment`\n- `allow-subscribe`\n- `allow-unsubscribe`\n- `allow-bind-cloudsync-account`\n- `allow-configure-cloudsync-token`\n- `allow-stop-cloudsync`\n- `allow-suspend-cloudsync`\n- `allow-suspend-cloudsync-for-sign-out`\n- `allow-suspend-cloudsync-after-auth-loss`\n- `allow-get-cloudsync-status`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-apply-session-ingest`\n- `allow-execute`\n- `allow-execute-proxy`\n- `allow-execute-transaction`\n- `allow-list-meetings`\n- `allow-get-meeting`\n- `allow-get-meeting-transcript`\n- `allow-get-recurring-meeting-history`\n- `allow-get-legacy-cleanup-status`\n- `allow-get-legacy-import-report`\n- `allow-cleanup-legacy-files`\n- `allow-run-legacy-import`\n- `allow-get-e2ee-identity-status`\n- `allow-inspect-e2ee-recovery-key`\n- `allow-create-e2ee-identity`\n- `allow-import-e2ee-identity`\n- `allow-get-or-create-e2ee-device-identity`\n- `allow-seal-e2ee-recovery-key-for-device`\n- `allow-import-e2ee-device-enrollment`\n- `allow-subscribe`\n- `allow-unsubscribe`\n- `allow-bind-cloudsync-account`\n- `allow-configure-cloudsync-token`\n- `allow-stop-cloudsync`\n- `allow-suspend-cloudsync`\n- `allow-suspend-cloudsync-for-sign-out`\n- `allow-suspend-cloudsync-after-auth-loss`\n- `allow-get-cloudsync-status`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-execute`\n- `allow-execute-proxy`\n- `allow-execute-transaction`\n- `allow-list-meetings`\n- `allow-get-meeting`\n- `allow-get-meeting-transcript`\n- `allow-get-recurring-meeting-history`\n- `allow-get-legacy-cleanup-status`\n- `allow-get-legacy-import-report`\n- `allow-cleanup-legacy-files`\n- `allow-run-legacy-import`\n- `allow-get-e2ee-identity-status`\n- `allow-inspect-e2ee-recovery-key`\n- `allow-create-e2ee-identity`\n- `allow-import-e2ee-identity`\n- `allow-get-or-create-e2ee-device-identity`\n- `allow-seal-e2ee-recovery-key-for-device`\n- `allow-import-e2ee-device-enrollment`\n- `allow-subscribe`\n- `allow-unsubscribe`\n- `allow-bind-cloudsync-account`\n- `allow-configure-cloudsync-token`\n- `allow-stop-cloudsync`\n- `allow-suspend-cloudsync`\n- `allow-suspend-cloudsync-for-sign-out`\n- `allow-suspend-cloudsync-after-auth-loss`\n- `allow-get-cloudsync-status`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-apply-session-ingest`\n- `allow-execute`\n- `allow-execute-proxy`\n- `allow-execute-transaction`\n- `allow-list-meetings`\n- `allow-get-meeting`\n- `allow-get-meeting-transcript`\n- `allow-get-recurring-meeting-history`\n- `allow-get-legacy-cleanup-status`\n- `allow-get-legacy-import-report`\n- `allow-cleanup-legacy-files`\n- `allow-run-legacy-import`\n- `allow-get-e2ee-identity-status`\n- `allow-inspect-e2ee-recovery-key`\n- `allow-create-e2ee-identity`\n- `allow-import-e2ee-identity`\n- `allow-get-or-create-e2ee-device-identity`\n- `allow-seal-e2ee-recovery-key-for-device`\n- `allow-import-e2ee-device-enrollment`\n- `allow-subscribe`\n- `allow-unsubscribe`\n- `allow-bind-cloudsync-account`\n- `allow-configure-cloudsync-token`\n- `allow-stop-cloudsync`\n- `allow-suspend-cloudsync`\n- `allow-suspend-cloudsync-for-sign-out`\n- `allow-suspend-cloudsync-after-auth-loss`\n- `allow-get-cloudsync-status`"
         }
       ]
     }

--- a/plugins/db/src/commands.rs
+++ b/plugins/db/src/commands.rs
@@ -184,6 +184,36 @@ pub(crate) async fn run_legacy_import(
 
 #[tauri::command]
 #[specta::specta]
+pub(crate) async fn apply_session_ingest(
+    state: tauri::State<'_, ManagedState>,
+    workspace_id: String,
+    envelope: serde_json::Value,
+) -> Result<crate::SessionIngestApplyResult, String> {
+    let envelope = match serde_json::from_value(envelope) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            tracing::warn!(%workspace_id, %error, "rejected malformed session ingest envelope");
+            return Ok(crate::SessionIngestApplyResult::Rejected);
+        }
+    };
+    match anlg_session_ingest::apply_session_envelope(state.pool(), &workspace_id, &envelope).await
+    {
+        Ok(outcome) => Ok(match outcome {
+            anlg_session_ingest::ApplyOutcome::Applied => crate::SessionIngestApplyResult::Applied,
+            anlg_session_ingest::ApplyOutcome::AlreadyApplied => {
+                crate::SessionIngestApplyResult::AlreadyApplied
+            }
+        }),
+        Err(error) if error.is_retryable() => Err(error.to_string()),
+        Err(error) => {
+            tracing::warn!(%workspace_id, %error, "rejected permanent session ingest envelope");
+            Ok(crate::SessionIngestApplyResult::Rejected)
+        }
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
 pub(crate) async fn get_e2ee_identity_status<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     account_user_id: String,

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -106,6 +106,14 @@ pub struct LegacyCleanupResult {
     pub deleted_bytes: u64,
 }
 
+#[derive(Debug, Clone, Copy, serde::Serialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionIngestApplyResult {
+    Applied,
+    AlreadyApplied,
+    Rejected,
+}
+
 #[derive(Debug, Clone, serde::Serialize, specta::Type, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct E2eeIdentityStatus {
@@ -244,6 +252,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::get_legacy_cleanup_status,
             commands::cleanup_legacy_files,
             commands::run_legacy_import,
+            commands::apply_session_ingest,
             commands::get_e2ee_identity_status<tauri::Wry>,
             commands::inspect_e2ee_recovery_key,
             commands::create_e2ee_identity<tauri::Wry>,

--- a/plugins/db/src/tests/bindings.rs
+++ b/plugins/db/src/tests/bindings.rs
@@ -56,3 +56,10 @@ fn default_permissions_include_device_enrollment_workflow() {
         assert!(permissions.contains(permission), "missing {permission}");
     }
 }
+
+#[test]
+fn default_permissions_include_session_ingest() {
+    let permissions = include_str!("../../permissions/default.toml");
+
+    assert!(permissions.contains("allow-apply-session-ingest"));
+}


### PR DESCRIPTION
Pull authenticated workspace envelopes into local E2EE-safe storage with durable cursors, acknowledgements, and completion dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session ingest, local SQLite durability, and meeting-completion side effects; ordering (persist before ack) is intentional but bugs could duplicate or skip automations or advance cursors incorrectly.
> 
> **Overview**
> Adds **enterprise capture delivery** on the desktop: when `VITE_ENTERPRISE_API_URL` is set, the main window polls the capture API, applies session envelopes into the local DB, and drives downstream completion behavior.
> 
> A new **`enterprise-capture`** module implements an authenticated HTTP client (cursor paging, strict response validation, size/time limits), SQLite-backed **delivery state** (cursor, receipts, completion outbox), and sync that **ingests before ack**, retries pending acks, advances the cursor on permanent rejects without enqueueing completions, and dispatches **`meeting.completed`** plus automations once from the outbox. **`EnterpriseCaptureSync`** runs on a 15s interval (including in background) per workspace using the device fingerprint as `consumerId`.
> 
> **Rust/DB:** migration for the three enterprise delivery tables; **`apply_session_ingest`** Tauri command wrapping `session-ingest` with `applied` / `already_applied` / `rejected` and retryable DB errors only; shared **delivery protocol** types in `session-ingest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7acb910d2b275397d06779452e20c6007253205d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->