### PR TITLE
ANLG-212: Make API integrations optional

### DIFF
--- a/apps/api/src/env.rs
+++ b/apps/api/src/env.rs
@@ -8,6 +8,40 @@ fn default_port() -> u16 {
     3001
 }
 
+#[derive(Default, Deserialize)]
+struct OptionalNangoEnv {
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    nango_api_base: Option<String>,
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    nango_api_key: Option<String>,
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    nango_webhook_signing_key: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+struct OptionalStripeEnv {
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    stripe_secret_key: Option<String>,
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    stripe_monthly_price_id: Option<String>,
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    stripe_yearly_price_id: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+struct OptionalPyannoteEnv {
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    pyannote_api_key: Option<String>,
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    pyannote_api_base: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+struct OptionalLoopsEnv {
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    loops_key: Option<String>,
+}
+
 #[derive(Deserialize)]
 pub struct Env {
     #[serde(default = "default_port")]
@@ -29,17 +63,17 @@ pub struct Env {
     #[serde(flatten)]
     pub sync: anlg_api_sync::SyncEnv,
     #[serde(flatten)]
-    pub nango: anlg_api_env::NangoEnv,
+    nango: OptionalNangoEnv,
     #[serde(flatten)]
-    pub stripe: anlg_api_env::StripeEnv,
+    stripe: OptionalStripeEnv,
     #[serde(flatten)]
-    pub pyannote: anlg_api_env::PyannoteEnv,
-
-    pub exa_api_key: String,
-    pub jina_api_key: String,
-
+    pyannote: OptionalPyannoteEnv,
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    pub exa_api_key: Option<String>,
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    pub jina_api_key: Option<String>,
     #[serde(flatten)]
-    pub loops: anlg_api_env::LoopsEnv,
+    loops: OptionalLoopsEnv,
 
     #[serde(flatten)]
     pub resend: anlg_api_env::ResendEnv,
@@ -48,6 +82,127 @@ pub struct Env {
     pub llm: anlg_llm_proxy::Env,
     #[serde(flatten)]
     pub stt: anlg_transcribe_proxy::Env,
+}
+
+impl Env {
+    pub(crate) fn nango(&self) -> Result<Option<anlg_api_env::NangoEnv>, String> {
+        let configured = self.nango.nango_api_base.is_some()
+            || self.nango.nango_api_key.is_some()
+            || self.nango.nango_webhook_signing_key.is_some();
+        if !configured {
+            return Ok(None);
+        }
+
+        Ok(Some(anlg_api_env::NangoEnv {
+            nango_api_base: self.nango.nango_api_base.clone(),
+            nango_api_key: required_integration_value(
+                &self.nango.nango_api_key,
+                "NANGO_API_KEY",
+                "Nango is configured",
+            )?,
+            nango_webhook_signing_key: required_integration_value(
+                &self.nango.nango_webhook_signing_key,
+                "NANGO_WEBHOOK_SIGNING_KEY",
+                "Nango is configured",
+            )?,
+        }))
+    }
+
+    pub(crate) fn subscription(
+        &self,
+    ) -> Result<Option<(anlg_api_env::StripeEnv, anlg_api_env::LoopsEnv)>, String> {
+        let stripe_configured = self.stripe.stripe_secret_key.is_some()
+            || self.stripe.stripe_monthly_price_id.is_some()
+            || self.stripe.stripe_yearly_price_id.is_some();
+        let stripe = stripe_configured
+            .then(|| -> Result<_, String> {
+                Ok(anlg_api_env::StripeEnv {
+                    stripe_secret_key: required_integration_value(
+                        &self.stripe.stripe_secret_key,
+                        "STRIPE_SECRET_KEY",
+                        "subscriptions are configured",
+                    )?,
+                    stripe_monthly_price_id: required_integration_value(
+                        &self.stripe.stripe_monthly_price_id,
+                        "STRIPE_MONTHLY_PRICE_ID",
+                        "subscriptions are configured",
+                    )?,
+                    stripe_yearly_price_id: required_integration_value(
+                        &self.stripe.stripe_yearly_price_id,
+                        "STRIPE_YEARLY_PRICE_ID",
+                        "subscriptions are configured",
+                    )?,
+                })
+            })
+            .transpose()?;
+        let loops = self
+            .loops
+            .loops_key
+            .as_ref()
+            .map(|loops_key| anlg_api_env::LoopsEnv {
+                loops_key: loops_key.clone(),
+            });
+
+        match (stripe, loops) {
+            (None, None) => Ok(None),
+            (Some(stripe), Some(loops)) => Ok(Some((stripe, loops))),
+            (Some(_), None) => {
+                Err("LOOPS_KEY is required when subscriptions are configured".to_string())
+            }
+            (None, Some(_)) => Err(
+                "Stripe configuration is required when subscriptions are configured".to_string(),
+            ),
+        }
+    }
+
+    pub(crate) fn pyannote(&self) -> Result<Option<anlg_api_env::PyannoteEnv>, String> {
+        let configured =
+            self.pyannote.pyannote_api_key.is_some() || self.pyannote.pyannote_api_base.is_some();
+        if !configured {
+            return Ok(None);
+        }
+
+        Ok(Some(anlg_api_env::PyannoteEnv {
+            pyannote_api_key: required_integration_value(
+                &self.pyannote.pyannote_api_key,
+                "PYANNOTE_API_KEY",
+                "pyannote is configured",
+            )?,
+            pyannote_api_base: self
+                .pyannote
+                .pyannote_api_base
+                .clone()
+                .unwrap_or_else(|| "https://api.pyannote.ai".to_string()),
+        }))
+    }
+
+    pub(crate) fn research(&self) -> Result<Option<anlg_api_research::ResearchConfig>, String> {
+        match (&self.exa_api_key, &self.jina_api_key) {
+            (None, None) => Ok(None),
+            (Some(exa_api_key), Some(jina_api_key)) => {
+                Ok(Some(anlg_api_research::ResearchConfig {
+                    exa_api_key: exa_api_key.clone(),
+                    jina_api_key: jina_api_key.clone(),
+                }))
+            }
+            (Some(_), None) => {
+                Err("JINA_API_KEY is required when research is configured".to_string())
+            }
+            (None, Some(_)) => {
+                Err("EXA_API_KEY is required when research is configured".to_string())
+            }
+        }
+    }
+}
+
+fn required_integration_value(
+    value: &Option<String>,
+    variable: &str,
+    condition: &str,
+) -> Result<String, String> {
+    value
+        .clone()
+        .ok_or_else(|| format!("{variable} is required when {condition}"))
 }
 
 static ENV: OnceLock<Env> = OnceLock::new();
@@ -64,15 +219,47 @@ pub fn env() -> &'static Env {
         let _ = dotenvy::from_path(manifest_dir.join(".env"));
         let env: Env =
             envy::from_env().unwrap_or_else(|error| panic!("{}", format_env_error(error)));
-        validate_env(&env);
+        validate_env(&env).unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
         env
     })
 }
 
-fn validate_env(env: &Env) {
-    if !cfg!(debug_assertions) && is_stripe_test_key(&env.stripe.stripe_secret_key) {
-        panic!("Failed to load environment: STRIPE_SECRET_KEY must be a live key in production");
+pub(crate) fn validate_env(env: &Env) -> Result<(), String> {
+    validate_supabase_env(&env.supabase)?;
+    env.nango()?;
+    let subscription = env.subscription()?;
+    env.pyannote()?;
+    env.research()?;
+
+    if !cfg!(debug_assertions)
+        && subscription
+            .as_ref()
+            .is_some_and(|(stripe, _)| is_stripe_test_key(&stripe.stripe_secret_key))
+    {
+        return Err("STRIPE_SECRET_KEY must be a live key in production".to_string());
     }
+    if env.anarlog_attachment_backup_gc_enabled && subscription.is_none() {
+        return Err(
+            "Stripe and Loops configuration is required when ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED is true"
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_supabase_env(env: &anlg_api_env::SupabaseEnv) -> Result<(), String> {
+    for (value, variable) in [
+        (&env.supabase_url, "SUPABASE_URL"),
+        (&env.supabase_anon_key, "SUPABASE_ANON_KEY"),
+        (&env.supabase_service_role_key, "SUPABASE_SERVICE_ROLE_KEY"),
+    ] {
+        if value.trim().is_empty() {
+            return Err(format!("{variable} must not be empty"));
+        }
+    }
+
+    Ok(())
 }
 
 fn is_stripe_test_key(key: &str) -> bool {
@@ -82,7 +269,7 @@ fn is_stripe_test_key(key: &str) -> bool {
 fn format_env_error(error: EnvyError) -> String {
     match error {
         EnvyError::MissingValue(field) => {
-            let env_var = field_name_to_env_var(&field);
+            let env_var = field_name_to_env_var(field);
             format!("Failed to load environment: missing {env_var} (field: {field})")
         }
         other => format!("Failed to load environment: {other}"),
@@ -134,5 +321,64 @@ mod tests {
 
         assert!(!disabled.anarlog_attachment_backup_gc_enabled);
         assert!(enabled.anarlog_attachment_backup_gc_enabled);
+    }
+
+    #[test]
+    fn core_supabase_configuration_remains_required() {
+        #[derive(Deserialize)]
+        struct SupabaseOnlyEnv {
+            #[serde(flatten)]
+            _supabase: anlg_api_env::SupabaseEnv,
+        }
+
+        for missing in [
+            "SUPABASE_URL",
+            "SUPABASE_ANON_KEY",
+            "SUPABASE_SERVICE_ROLE_KEY",
+        ] {
+            let values = [
+                ("SUPABASE_URL", "http://127.0.0.1:54321"),
+                ("SUPABASE_ANON_KEY", "anon-key"),
+                ("SUPABASE_SERVICE_ROLE_KEY", "service-role-key"),
+            ]
+            .into_iter()
+            .filter(|(key, _)| *key != missing)
+            .map(|(key, value)| (key.to_string(), value.to_string()));
+            let error = match envy::from_iter::<_, SupabaseOnlyEnv>(values) {
+                Ok(_) => panic!("{missing} should remain required"),
+                Err(error) => error,
+            };
+
+            assert!(matches!(
+                error,
+                EnvyError::MissingValue(field) if field == missing.to_lowercase()
+            ));
+        }
+    }
+
+    #[test]
+    fn core_supabase_configuration_rejects_empty_values() {
+        for (field, expected) in [
+            ("url", "SUPABASE_URL must not be empty"),
+            ("anon", "SUPABASE_ANON_KEY must not be empty"),
+            (
+                "service_role",
+                "SUPABASE_SERVICE_ROLE_KEY must not be empty",
+            ),
+        ] {
+            let mut env = anlg_api_env::SupabaseEnv {
+                supabase_url: "http://127.0.0.1:54321".to_string(),
+                supabase_anon_key: "anon-key".to_string(),
+                supabase_service_role_key: "service-role-key".to_string(),
+            };
+            match field {
+                "url" => env.supabase_url.clear(),
+                "anon" => env.supabase_anon_key.clear(),
+                "service_role" => env.supabase_service_role_key.clear(),
+                _ => unreachable!(),
+            }
+
+            assert_eq!(validate_supabase_env(&env), Err(expected.to_string()));
+        }
     }
 }

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -133,7 +133,10 @@ fn build_sync_routes(
 
 async fn app() -> Router {
     let env = env();
+    app_with_env(env).await
+}
 
+async fn app_with_env(env: &'static Env) -> Router {
     let analytics = build_analytics_client(env);
 
     let llm_config =
@@ -218,21 +221,32 @@ async fn app() -> Router {
     );
     let auth_state_basic = auth_state.clone();
 
-    let nango_config = anlg_api_nango::NangoConfig::new(
-        &env.nango,
-        &env.supabase,
-        Some(env.supabase.supabase_service_role_key.clone()),
-    );
-    let nango_connection_state = anlg_api_nango::NangoConnectionState::from_config(&nango_config);
-    let subscription_config =
-        anlg_api_subscription::SubscriptionConfig::new(&env.supabase, &env.stripe, &env.loops)
-            .with_analytics(analytics.clone())
-            .with_durable_cleanup_enabled(env.anarlog_attachment_backup_gc_enabled);
-    let research_config = anlg_api_research::ResearchConfig {
-        exa_api_key: env.exa_api_key.clone(),
-        jina_api_key: env.jina_api_key.clone(),
-    };
-    let pyannote_config = anlg_api_pyannote::PyannoteConfig::new(&env.pyannote);
+    let nango_config = env
+        .nango()
+        .expect("environment integrations were validated")
+        .map(|nango| {
+            anlg_api_nango::NangoConfig::new(
+                &nango,
+                &env.supabase,
+                Some(env.supabase.supabase_service_role_key.clone()),
+            )
+        });
+    let subscription_config = env
+        .subscription()
+        .expect("environment integrations were validated")
+        .map(|(stripe, loops)| {
+            anlg_api_subscription::SubscriptionConfig::new(&env.supabase, &stripe, &loops)
+                .with_analytics(analytics.clone())
+                .with_durable_cleanup_enabled(env.anarlog_attachment_backup_gc_enabled)
+        });
+    let research_config = env
+        .research()
+        .expect("environment integrations were validated");
+    let pyannote_config = env
+        .pyannote()
+        .expect("environment integrations were validated")
+        .as_ref()
+        .map(anlg_api_pyannote::PyannoteConfig::new);
     let sync_config = anlg_api_sync::SyncConfig::from_env(
         &env.sync,
         &env.supabase.supabase_url,
@@ -266,32 +280,43 @@ async fn app() -> Router {
 
     use anlg_api_nango::NangoIntegrationId;
 
-    let mut forward_handlers = anlg_api_nango::ForwardHandlerRegistry::new();
-    forward_handlers.insert(
-        anlg_api_nango::Linear::ID.to_string(),
-        anlg_api_nango::forward_handler(anlg_linear::webhook::handle),
+    let nango_webhook_routes = match nango_config.clone() {
+        Some(config) => {
+            let mut forward_handlers = anlg_api_nango::ForwardHandlerRegistry::new();
+            forward_handlers.insert(
+                anlg_api_nango::Linear::ID.to_string(),
+                anlg_api_nango::forward_handler(anlg_linear::webhook::handle),
+            );
+            Router::new().nest(
+                "/nango",
+                anlg_api_nango::webhook_router(config, forward_handlers),
+            )
+        }
+        None => Router::new(),
+    };
+
+    let webhook_routes = Router::new().merge(nango_webhook_routes).nest(
+        "/stt",
+        anlg_transcribe_proxy::callback_router(stt_config.clone()),
     );
 
-    let webhook_routes = Router::new()
-        .nest(
-            "/nango",
-            anlg_api_nango::webhook_router(nango_config.clone(), forward_handlers),
-        )
-        .nest(
-            "/stt",
-            anlg_transcribe_proxy::callback_router(stt_config.clone()),
-        );
-
-    let auth_state_integration = auth_state_paid.clone();
-
-    let paid_routes = Router::new()
-        .merge(anlg_api_research::router(research_config))
-        .nest("/pyannote", anlg_api_pyannote::router(pyannote_config))
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state_paid,
-            auth::require_auth,
-        ));
+    let paid_routes = if research_config.is_none() && pyannote_config.is_none() {
+        Router::new()
+    } else {
+        let mut routes = Router::new();
+        if let Some(config) = research_config {
+            routes = routes.merge(anlg_api_research::router(config));
+        }
+        if let Some(config) = pyannote_config {
+            routes = routes.nest("/pyannote", anlg_api_pyannote::router(config));
+        }
+        routes
+            .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+            .route_layer(middleware::from_fn_with_state(
+                auth_state_paid.clone(),
+                auth::require_auth,
+            ))
+    };
 
     let sync_routes = match sync_config {
         Some(config) => build_sync_routes(
@@ -337,33 +362,36 @@ async fn app() -> Router {
             anlg_api_cloud::require_cloud_api_key,
         ));
 
-    let integration_routes = Router::new()
-        .nest("/calendar", anlg_api_calendar::router())
-        .nest("/mail", anlg_api_mail::router())
-        .nest("/messenger", anlg_api_messenger::router())
-        .nest("/notion", anlg_api_notion::router())
-        .nest("/ticket", anlg_api_ticket::router())
-        .nest(
-            "/nango",
-            anlg_api_nango::session_router(nango_config.clone()),
-        )
-        .layer(axum::Extension(nango_connection_state))
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state_integration,
-            auth::require_auth,
-        ));
+    let integration_routes = match nango_config.clone() {
+        Some(config) => {
+            let nango_connection_state = anlg_api_nango::NangoConnectionState::from_config(&config);
+            Router::new()
+                .nest("/calendar", anlg_api_calendar::router())
+                .nest("/mail", anlg_api_mail::router())
+                .nest("/messenger", anlg_api_messenger::router())
+                .nest("/notion", anlg_api_notion::router())
+                .nest("/ticket", anlg_api_ticket::router())
+                .nest("/nango", anlg_api_nango::session_router(config))
+                .layer(axum::Extension(nango_connection_state))
+                .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+                .route_layer(middleware::from_fn_with_state(
+                    auth_state_paid,
+                    auth::require_auth,
+                ))
+        }
+        None => Router::new(),
+    };
 
-    let integration_management_routes = Router::new()
-        .nest(
-            "/nango",
-            anlg_api_nango::management_router(nango_config.clone()),
-        )
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state_basic.clone(),
-            auth::require_auth,
-        ));
+    let integration_management_routes = match nango_config {
+        Some(config) => Router::new()
+            .nest("/nango", anlg_api_nango::management_router(config))
+            .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+            .route_layer(middleware::from_fn_with_state(
+                auth_state_basic.clone(),
+                auth::require_auth,
+            )),
+        None => Router::new(),
+    };
 
     let stt_routes = Router::new()
         .merge(anlg_transcribe_proxy::listen_router(stt_config.clone()))
@@ -381,13 +409,20 @@ async fn app() -> Router {
             rate_limit::rate_limit,
         ));
 
-    let subscription_router = anlg_api_subscription::router(subscription_config);
+    let subscription_routes = match subscription_config {
+        Some(config) => {
+            let router = anlg_api_subscription::router(config);
+            Router::new()
+                .nest("/subscription", router.clone())
+                .nest("/rpc", router.clone())
+                .nest("/billing", router)
+        }
+        None => Router::new(),
+    };
     let auth_routes = Router::new()
         .merge(stt_routes)
         .merge(llm_routes)
-        .nest("/subscription", subscription_router.clone())
-        .nest("/rpc", subscription_router.clone())
-        .nest("/billing", subscription_router)
+        .merge(subscription_routes)
         .route_layer(middleware::from_fn(auth::sentry_and_analytics))
         .route_layer(middleware::from_fn_with_state(
             auth_state_basic,
@@ -631,6 +666,10 @@ fn main() -> std::io::Result<()> {
             let app = app().await;
             let cancellation = CancellationToken::new();
             let worker_task = env.anarlog_attachment_backup_gc_enabled.then(|| {
+                let (stripe, loops) = env
+                    .subscription()
+                    .expect("environment integrations were validated")
+                    .expect("cleanup requires Stripe and Loops configuration");
                 let cloudsync_cleanup = anlg_api_subscription::CloudsyncCleanupConfig::new(
                     env.sync
                         .sqlitecloud_project_url
@@ -649,12 +688,9 @@ fn main() -> std::io::Result<()> {
                         .unwrap_or_default(),
                 )
                 .unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
-                let config = anlg_api_subscription::SubscriptionConfig::new(
-                    &env.supabase,
-                    &env.stripe,
-                    &env.loops,
-                )
-                .with_cloudsync_cleanup(cloudsync_cleanup);
+                let config =
+                    anlg_api_subscription::SubscriptionConfig::new(&env.supabase, &stripe, &loops)
+                        .with_cloudsync_cleanup(cloudsync_cleanup);
                 let worker = anlg_api_subscription::CleanupWorker::new(&config);
                 let worker_cancellation = cancellation.clone();
                 tokio::spawn(worker.run(worker_cancellation))

--- a/apps/api/src/tests.rs
+++ b/apps/api/src/tests.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::{Body, to_bytes},
-    http::{Request, StatusCode, header},
+    http::{Method, Request, StatusCode, header},
 };
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde_json::{Value, json};
@@ -78,6 +78,164 @@ async fn response_bytes(response: axum::response::Response) -> Vec<u8> {
         .await
         .unwrap()
         .to_vec()
+}
+
+fn deserialize_api_env(
+    additional_values: impl IntoIterator<Item = (&'static str, &'static str)>,
+) -> Env {
+    let mut values = vec![
+        ("SUPABASE_URL", "http://127.0.0.1:54321"),
+        ("SUPABASE_ANON_KEY", "anon-key"),
+        ("SUPABASE_SERVICE_ROLE_KEY", "service-role-key"),
+        ("OPENROUTER_API_KEY", "openrouter-key"),
+        ("API_BASE_URL", "http://127.0.0.1:3001"),
+        ("RESEND_API_KEY", "resend-key"),
+        ("RESEND_FROM_EMAIL", "test@example.com"),
+    ];
+    values.extend(additional_values);
+
+    envy::from_iter(
+        values
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value.to_string())),
+    )
+    .unwrap()
+}
+
+fn api_env(with_hosted_integrations: bool) -> &'static Env {
+    let mut integration_values = Vec::new();
+    if with_hosted_integrations {
+        integration_values.extend([
+            ("NANGO_API_KEY", "nango-key"),
+            ("NANGO_WEBHOOK_SIGNING_KEY", "nango-signing-key"),
+            ("STRIPE_SECRET_KEY", "sk_test_hosted"),
+            ("STRIPE_MONTHLY_PRICE_ID", "price_monthly"),
+            ("STRIPE_YEARLY_PRICE_ID", "price_yearly"),
+            ("LOOPS_KEY", "loops-key"),
+            ("PYANNOTE_API_KEY", "pyannote-key"),
+            ("EXA_API_KEY", "exa-key"),
+            ("JINA_API_KEY", "jina-key"),
+        ]);
+    }
+
+    let env = deserialize_api_env(integration_values);
+    crate::env::validate_env(&env).unwrap();
+    Box::leak(Box::new(env))
+}
+
+async fn request_status(app: &Router, method: Method, path: &str) -> StatusCode {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(path)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status()
+}
+
+#[tokio::test]
+async fn boots_with_minimal_self_hosted_configuration() {
+    let app = app_with_env(api_env(false)).await;
+
+    assert_eq!(
+        request_status(&app, Method::GET, "/health").await,
+        StatusCode::OK
+    );
+    for (method, path) in [
+        (Method::POST, "/research/search"),
+        (Method::POST, "/pyannote/v1/diarize"),
+        (Method::POST, "/nango/session"),
+        (Method::POST, "/nango/webhook"),
+        (Method::POST, "/calendar/google/list-calendars"),
+        (Method::GET, "/subscription/can-start-trial"),
+    ] {
+        assert_eq!(
+            request_status(&app, method, path).await,
+            StatusCode::NOT_FOUND,
+            "optional route should not be mounted: {path}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn hosted_configuration_keeps_optional_routes_mounted() {
+    let app = app_with_env(api_env(true)).await;
+
+    for (method, path) in [
+        (Method::POST, "/research/search"),
+        (Method::POST, "/pyannote/v1/diarize"),
+        (Method::POST, "/nango/session"),
+        (Method::POST, "/calendar/google/list-calendars"),
+        (Method::GET, "/subscription/can-start-trial"),
+    ] {
+        assert_eq!(
+            request_status(&app, method, path).await,
+            StatusCode::UNAUTHORIZED,
+            "hosted route should remain mounted: {path}"
+        );
+    }
+    assert_ne!(
+        request_status(&app, Method::POST, "/nango/webhook").await,
+        StatusCode::NOT_FOUND
+    );
+}
+
+#[test]
+fn partial_optional_integration_configuration_fails_closed() {
+    for (values, expected) in [
+        (
+            vec![("NANGO_API_KEY", "nango-key")],
+            "NANGO_WEBHOOK_SIGNING_KEY is required when Nango is configured",
+        ),
+        (
+            vec![("NANGO_WEBHOOK_SIGNING_KEY", "nango-signing-key")],
+            "NANGO_API_KEY is required when Nango is configured",
+        ),
+        (
+            vec![("NANGO_API_BASE", "https://nango.example.com")],
+            "NANGO_API_KEY is required when Nango is configured",
+        ),
+        (
+            vec![("STRIPE_SECRET_KEY", "sk_test_partial")],
+            "STRIPE_MONTHLY_PRICE_ID is required when subscriptions are configured",
+        ),
+        (
+            vec![("STRIPE_MONTHLY_PRICE_ID", "price_monthly")],
+            "STRIPE_SECRET_KEY is required when subscriptions are configured",
+        ),
+        (
+            vec![("LOOPS_KEY", "loops-key")],
+            "Stripe configuration is required when subscriptions are configured",
+        ),
+        (
+            vec![
+                ("STRIPE_SECRET_KEY", "sk_test_partial"),
+                ("STRIPE_MONTHLY_PRICE_ID", "price_monthly"),
+                ("STRIPE_YEARLY_PRICE_ID", "price_yearly"),
+            ],
+            "LOOPS_KEY is required when subscriptions are configured",
+        ),
+        (
+            vec![("PYANNOTE_API_BASE", "https://pyannote.example.com")],
+            "PYANNOTE_API_KEY is required when pyannote is configured",
+        ),
+        (
+            vec![("EXA_API_KEY", "exa-key")],
+            "JINA_API_KEY is required when research is configured",
+        ),
+        (
+            vec![("JINA_API_KEY", "jina-key")],
+            "EXA_API_KEY is required when research is configured",
+        ),
+    ] {
+        let env = deserialize_api_env(values);
+
+        assert_eq!(crate::env::validate_env(&env), Err(expected.to_string()));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- make Stripe and Loops, Nango, pyannote, Exa, and Jina configuration optional
- mount subscription, Nango-dependent, pyannote, and research routes only when configured
- keep Supabase and workspace-related configuration fail-closed
- add minimal self-hosted startup and hosted-route preservation coverage

## Why

The API previously required every hosted integration secret during environment deserialization, preventing a minimal self-hosted deployment from starting even when those integrations were unused.

## Impact

Minimal self-hosted installations can start without the optional hosted integrations. Hosted deployments with the complete configuration retain the existing route surface and authentication behavior.

## Validation

- cargo test -p api (18 passed)
- cargo check -p api
- cargo test -p api-sync (94 passed)
- python3 .github/scripts/test_verify_cloudsync_e2ee.py (10 passed)
- cargo test -p api gen_openapi_json
- pnpm fmt:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup and route surface for billing, Nango, and paid features; misconfiguration now fails at validate time instead of always requiring secrets, but partial env could surprise operators who expect routes to exist.
> 
> **Overview**
> **Optional integration env** — Nango, Stripe/Loops, pyannote, and Exa/Jina are no longer required at deserialize time. `Env` exposes `nango()`, `subscription()`, `pyannote()`, and `research()` that return `None` when unset, or **fail closed** when only part of a bundle is present (e.g. Stripe without Loops).
> 
> **Conditional routing** — `app_with_env` mounts subscription, Nango (webhooks, calendar/mail/etc., management), research, and pyannote routes only when the corresponding config resolves. Minimal installs get **404** on those paths; full hosted config still mounts them (tests expect **401** where auth applies).
> 
> **Validation** — `validate_env` is now `Result`-based: Supabase keys must be present and non-empty; production still rejects Stripe test keys; `ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED` requires full subscription config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16002ac7a1a354b2bd817eb956ea8d8e9cc0eba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->