### PR TITLE
Make encrypted replica sync portable

### DIFF
--- a/apps/api/openapi.gen.json
+++ b/apps/api/openapi.gen.json
@@ -2810,6 +2810,57 @@
         ]
       }
     },
+    "/sync/replica/credentials": {
+      "post": {
+        "tags": [
+          "sync"
+        ],
+        "operationId": "create_replica_credentials",
+        "parameters": [
+          {
+            "name": "x-anarlog-e2ee-key-id",
+            "in": "header",
+            "description": "Local recovery-key identity",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Encrypted replica credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReplicaCredentials"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid E2EE key identity"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Anarlog Pro subscription required"
+          },
+          "409": {
+            "description": "Account already uses a different recovery key"
+          },
+          "502": {
+            "description": "Replica credential service unavailable"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/sync/shares/{share_id}/attachments/finalize": {
       "post": {
         "tags": [
@@ -9234,6 +9285,39 @@
               "boolean",
               "null"
             ]
+          }
+        }
+      },
+      "ReplicaCredentials": {
+        "type": "object",
+        "required": [
+          "transport",
+          "encryptionVersion",
+          "encryptionKeyId",
+          "expiresAt",
+          "workspaceId",
+          "accountUserId"
+        ],
+        "properties": {
+          "accountUserId": {
+            "type": "string"
+          },
+          "encryptionKeyId": {
+            "type": "string"
+          },
+          "encryptionVersion": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "expiresAt": {
+            "type": "string"
+          },
+          "transport": {
+            "type": "string"
+          },
+          "workspaceId": {
+            "type": "string"
           }
         }
       },

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -78,12 +78,39 @@ fn request_client_address(request: &Request<Body>) -> Option<String> {
 }
 
 fn build_sync_routes(
-    state: anlg_api_sync::AppState,
+    state: Option<anlg_api_sync::AppState>,
+    replica_state: anlg_api_sync::ReplicaState,
     cloudsync_rate_limit_state: rate_limit::RateLimitState,
     session_share_rate_limit_state: rate_limit::RateLimitState,
     witness_rate_limit_state: rate_limit::RateLimitState,
     auth_state: AuthState,
 ) -> Router {
+    let replica_routes = anlg_api_sync::replica_router(replica_state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            cloudsync_rate_limit_state.clone(),
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let witness_routes = anlg_api_sync::e2ee_witness_router(replica_state)
+        .route_layer(middleware::from_fn_with_state(
+            witness_rate_limit_state,
+            rate_limit::wait_for_rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let replica_routes = replica_routes.merge(witness_routes);
+
+    let Some(state) = state else {
+        return replica_routes;
+    };
+
     let cloudsync_routes = anlg_api_sync::cloudsync_router(state.clone())
         .route_layer(middleware::from_fn_with_state(
             cloudsync_rate_limit_state,
@@ -104,16 +131,6 @@ fn build_sync_routes(
             auth_state.clone().with_required_entitlement("hyprnote_pro"),
             auth::require_auth,
         ));
-    let witness_routes = anlg_api_sync::e2ee_witness_router(state.clone())
-        .route_layer(middleware::from_fn_with_state(
-            witness_rate_limit_state,
-            rate_limit::wait_for_rate_limit,
-        ))
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state.clone().with_required_entitlement("hyprnote_pro"),
-            auth::require_auth,
-        ));
     let web_edit_routes = anlg_api_sync::web_edit_router(state)
         .route_layer(middleware::from_fn_with_state(
             session_share_rate_limit_state,
@@ -125,9 +142,9 @@ fn build_sync_routes(
             auth::require_auth,
         ));
 
-    cloudsync_routes
+    replica_routes
+        .merge(cloudsync_routes)
         .merge(session_share_routes)
-        .merge(witness_routes)
         .merge(web_edit_routes)
 }
 
@@ -318,16 +335,23 @@ async fn app_with_env(env: &'static Env) -> Router {
             ))
     };
 
-    let sync_routes = match sync_config {
-        Some(config) => build_sync_routes(
-            anlg_api_sync::AppState::new(config),
-            cloudsync_rate_limit,
-            session_share_rate_limit,
-            e2ee_witness_rate_limit,
-            auth_state.clone(),
-        ),
-        None => Router::new(),
-    };
+    let replica_state = anlg_api_sync::ReplicaState::new(
+        anlg_api_sync::ReplicaConfig::new(
+            &env.supabase.supabase_url,
+            &env.supabase.supabase_anon_key,
+            &env.supabase.supabase_service_role_key,
+        )
+        .unwrap_or_else(|error| panic!("Failed to load environment: {error}")),
+    );
+    let sync_state = sync_config.map(anlg_api_sync::AppState::new);
+    let sync_routes = build_sync_routes(
+        sync_state,
+        replica_state,
+        cloudsync_rate_limit,
+        session_share_rate_limit,
+        e2ee_witness_rate_limit,
+        auth_state.clone(),
+    );
     let shared_notes_state = anlg_api_sync::SharedNotesState::new(shared_notes_config);
     let shared_notes_routes = anlg_api_sync::shared_notes_router(shared_notes_state.clone())
         .route_layer(middleware::from_fn_with_state(

--- a/apps/api/src/tests.rs
+++ b/apps/api/src/tests.rs
@@ -73,6 +73,12 @@ fn test_sync_state(server: &MockServer) -> anlg_api_sync::AppState {
     anlg_api_sync::AppState::new(config)
 }
 
+fn test_replica_state(server: &MockServer) -> anlg_api_sync::ReplicaState {
+    anlg_api_sync::ReplicaState::new(
+        anlg_api_sync::ReplicaConfig::new(server.uri(), "anon-key", "service-role-key").unwrap(),
+    )
+}
+
 async fn response_bytes(response: axum::response::Response) -> Vec<u8> {
     to_bytes(response.into_body(), 16 * 1024)
         .await
@@ -144,6 +150,24 @@ async fn boots_with_minimal_self_hosted_configuration() {
     assert_eq!(
         request_status(&app, Method::GET, "/health").await,
         StatusCode::OK
+    );
+    for (method, path) in [
+        (Method::PUT, "/sync/e2ee/identity"),
+        (
+            Method::GET,
+            "/sync/e2ee/witness/11111111-1111-4111-8111-111111111111",
+        ),
+    ] {
+        assert_eq!(
+            request_status(&app, method, path).await,
+            StatusCode::UNAUTHORIZED,
+            "core encrypted replica route should be mounted: {path}"
+        );
+    }
+    assert_eq!(
+        request_status(&app, Method::POST, "/sync/token").await,
+        StatusCode::NOT_FOUND,
+        "SQLiteCloud credential route should remain optional"
     );
     for (method, path) in [
         (Method::POST, "/research/search"),
@@ -267,10 +291,13 @@ async fn sync_composition_allows_non_pro_web_edits_but_keeps_other_routes_pro_on
         .mount(&server)
         .await;
 
+    let sync_state = test_sync_state(&server);
+    let replica_state = test_replica_state(&server);
     let app = Router::new().nest(
         "/sync",
         build_sync_routes(
-            test_sync_state(&server),
+            Some(sync_state),
+            replica_state,
             test_sync_rate_limit(10),
             test_sync_rate_limit(10),
             test_sync_rate_limit(10),
@@ -374,10 +401,13 @@ async fn sync_composition_keeps_sharing_available_when_cloudsync_is_rate_limited
         .mount(&server)
         .await;
 
+    let sync_state = test_sync_state(&server);
+    let replica_state = test_replica_state(&server);
     let app = Router::new().nest(
         "/sync",
         build_sync_routes(
-            test_sync_state(&server),
+            Some(sync_state),
+            replica_state,
             test_sync_rate_limit(1),
             test_sync_rate_limit(1),
             test_sync_rate_limit(1),

--- a/apps/api/src/tests.rs
+++ b/apps/api/src/tests.rs
@@ -152,6 +152,7 @@ async fn boots_with_minimal_self_hosted_configuration() {
         StatusCode::OK
     );
     for (method, path) in [
+        (Method::POST, "/sync/replica/credentials"),
         (Method::PUT, "/sync/e2ee/identity"),
         (
             Method::GET,

--- a/apps/desktop/src/auth/cloudsync-configuration.ts
+++ b/apps/desktop/src/auth/cloudsync-configuration.ts
@@ -1,7 +1,8 @@
-import { configureCloudsyncToken } from "@anlg/plugin-db";
+import { configureCloudsyncToken, configureE2eeReplica } from "@anlg/plugin-db";
 
 import {
   hasWorkspaceProjection,
+  isReplicaCredentials,
   type CloudsyncCredentials,
 } from "./cloudsync-credentials";
 
@@ -22,6 +23,10 @@ export function configureCloudsyncCredentials(
     ).toString(),
     accessToken,
   };
+
+  if (isReplicaCredentials(credentials)) {
+    return configureE2eeReplica(credentials.workspaceId, witness);
+  }
 
   return hasWorkspaceProjection(credentials)
     ? configureCloudsyncToken(

--- a/apps/desktop/src/auth/cloudsync-credentials.ts
+++ b/apps/desktop/src/auth/cloudsync-credentials.ts
@@ -8,13 +8,22 @@ import { commands as miscCommands } from "@anlg/plugin-misc";
 
 import { getStoredSettingValues } from "~/settings/queries";
 
-type CloudsyncCredentialCore = {
+type E2eeCredentialCore = {
   encryptionVersion: 2;
   encryptionKeyId: string;
-  databaseId: string;
-  token: string;
   expiresAt: string;
   workspaceId: string;
+};
+
+type CloudsyncCredentialCore = E2eeCredentialCore & {
+  databaseId: string;
+  token: string;
+  transport?: undefined;
+};
+
+export type ReplicaCredentials = E2eeCredentialCore & {
+  transport: "replica";
+  accountUserId: string;
 };
 
 type LegacyCloudsyncCredentials = CloudsyncCredentialCore & {
@@ -28,7 +37,8 @@ export type ProjectedCloudsyncCredentials = CloudsyncCredentialCore &
 
 export type CloudsyncCredentials =
   | LegacyCloudsyncCredentials
-  | ProjectedCloudsyncCredentials;
+  | ProjectedCloudsyncCredentials
+  | ReplicaCredentials;
 
 export const DEVICE_NAME_HEADER = "x-anarlog-device-name";
 export const DEVICE_LIMIT_ERROR_CODE = "sync_device_limit_reached";
@@ -193,15 +203,27 @@ export function isCredentials(value: unknown): value is CloudsyncCredentials {
     candidate.encryptionVersion === 2 &&
     typeof candidate.encryptionKeyId === "string" &&
     /^[A-Za-z0-9_-]{22}$/.test(candidate.encryptionKeyId) &&
-    typeof candidate.databaseId === "string" &&
-    candidate.databaseId.length > 0 &&
-    typeof candidate.token === "string" &&
-    candidate.token.length > 0 &&
     typeof candidate.expiresAt === "string" &&
     Number.isFinite(Date.parse(candidate.expiresAt)) &&
     typeof candidate.workspaceId === "string" &&
     candidate.workspaceId.length > 0;
   if (!hasCoreCredentials) {
+    return false;
+  }
+
+  if (candidate.transport === "replica") {
+    return (
+      typeof candidate.accountUserId === "string" &&
+      candidate.accountUserId === candidate.workspaceId
+    );
+  }
+
+  if (
+    typeof candidate.databaseId !== "string" ||
+    candidate.databaseId.length === 0 ||
+    typeof candidate.token !== "string" ||
+    candidate.token.length === 0
+  ) {
     return false;
   }
 
@@ -279,5 +301,14 @@ export function isCredentials(value: unknown): value is CloudsyncCredentials {
 export function hasWorkspaceProjection(
   credentials: CloudsyncCredentials,
 ): credentials is ProjectedCloudsyncCredentials {
-  return credentials.accountUserId !== undefined;
+  return (
+    credentials.transport !== "replica" &&
+    credentials.accountUserId !== undefined
+  );
+}
+
+export function isReplicaCredentials(
+  credentials: CloudsyncCredentials,
+): credentials is ReplicaCredentials {
+  return credentials.transport === "replica";
 }

--- a/apps/desktop/src/auth/cloudsync-token-exchange.ts
+++ b/apps/desktop/src/auth/cloudsync-token-exchange.ts
@@ -10,11 +10,13 @@ import { DEVICE_FINGERPRINT_HEADER } from "~/shared/utils";
 
 export async function requestCloudsyncCredentials({
   accessToken,
+  cloudsyncExtensionAvailable,
   encryptionKeyId,
   shouldStop,
   signal,
 }: {
   accessToken: string;
+  cloudsyncExtensionAvailable: boolean;
   encryptionKeyId: string;
   shouldStop: () => boolean;
   signal: AbortSignal;
@@ -38,14 +40,22 @@ export async function requestCloudsyncCredentials({
     }
 
     response = await raceWithAbort(
-      fetch(new URL("/sync/token", env.VITE_API_URL), {
-        method: "POST",
-        headers,
-        signal,
-      }),
+      fetch(
+        new URL(
+          cloudsyncExtensionAvailable
+            ? "/sync/token"
+            : "/sync/replica/credentials",
+          env.VITE_API_URL,
+        ),
+        {
+          method: "POST",
+          headers,
+          signal,
+        },
+      ),
       signal,
     );
-    if (response.status === 404) {
+    if (cloudsyncExtensionAvailable && response.status === 404) {
       response = await raceWithAbort(
         fetch(new URL("/sync/replica/credentials", env.VITE_API_URL), {
           method: "POST",

--- a/apps/desktop/src/auth/cloudsync-token-exchange.ts
+++ b/apps/desktop/src/auth/cloudsync-token-exchange.ts
@@ -45,6 +45,16 @@ export async function requestCloudsyncCredentials({
       }),
       signal,
     );
+    if (response.status === 404) {
+      response = await raceWithAbort(
+        fetch(new URL("/sync/replica/credentials", env.VITE_API_URL), {
+          method: "POST",
+          headers,
+          signal,
+        }),
+        signal,
+      );
+    }
 
     let credentials: unknown;
     let credentialErrorCode: string | null = null;

--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   bindCloudsyncAccount,
   configureCloudsyncToken,
+  configureE2eeReplica,
   execute,
   getCloudsyncStatus,
   getE2eeIdentityStatus,
@@ -119,6 +120,23 @@ function credentialsResponse(
   );
 }
 
+function replicaCredentialsResponse() {
+  return new Response(
+    JSON.stringify({
+      transport: "replica",
+      encryptionVersion: 2,
+      encryptionKeyId: E2EE_KEY_ID,
+      expiresAt: new Date(NOW.getTime() + 15 * 60 * 1000).toISOString(),
+      workspaceId: "user-id",
+      accountUserId: "user-id",
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
 function cloudsyncStatus(activityPaused = false) {
   return {
     cloudsync_enabled: true,
@@ -199,6 +217,7 @@ describe("CloudSync auth lifecycle", () => {
     vi.clearAllMocks();
     vi.mocked(bindCloudsyncAccount).mockResolvedValue(true);
     vi.mocked(configureCloudsyncToken).mockResolvedValue("configured");
+    vi.mocked(configureE2eeReplica).mockResolvedValue("configured");
     vi.mocked(execute).mockResolvedValue([]);
     vi.mocked(getE2eeIdentityStatus).mockResolvedValue({
       configured: true,
@@ -441,6 +460,29 @@ describe("CloudSync auth lifecycle", () => {
     expect(suspendCloudsync).toHaveBeenCalledTimes(1);
   });
 
+  test("falls back to the portable encrypted replica transport", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(replicaCredentialsResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await handleCloudsyncAuthChange("SIGNED_IN", session());
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      new URL("https://api.test/sync/token"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      new URL("https://api.test/sync/replica/credentials"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(configureE2eeReplica).toHaveBeenCalledWith("user-id", witness());
+    expect(configureCloudsyncToken).not.toHaveBeenCalled();
+  });
+
   test("passes server workspace metadata to the native projection", async () => {
     vi.stubGlobal(
       "fetch",
@@ -665,7 +707,7 @@ describe("CloudSync auth lifecycle", () => {
     ).resolves.toBe("ok");
     await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(configureCloudsyncToken).not.toHaveBeenCalled();
     expect(suspendCloudsync).toHaveBeenCalledTimes(1);
   });
@@ -677,13 +719,16 @@ describe("CloudSync auth lifecycle", () => {
         .fn<() => Promise<Response>>()
         .mockResolvedValueOnce(credentialsResponse())
         .mockResolvedValueOnce(new Response(null, { status }));
+      if (status === 404) {
+        fetchMock.mockResolvedValueOnce(new Response(null, { status: 404 }));
+      }
       vi.stubGlobal("fetch", fetchMock);
       vi.spyOn(console, "warn").mockImplementation(() => {});
 
       await handleCloudsyncAuthChange("INITIAL_SESSION", session());
       await vi.advanceTimersByTimeAsync(13 * 60 * 1000);
 
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenCalledTimes(status === 404 ? 3 : 2);
       expect(configureCloudsyncToken).toHaveBeenCalledTimes(1);
       expect(suspendCloudsync).toHaveBeenCalledTimes(2);
       expect(getCloudsyncCredentialBlock()).toBe("unavailable");
@@ -719,8 +764,10 @@ describe("CloudSync auth lifecycle", () => {
     expect(getCloudsyncCredentialBlock()).toBe("not_entitled");
   });
 
-  test("does not retry credential exchange in local-only mode", async () => {
-    const fetchMock = vi.fn();
+  test("checks the portable transport in local-only mode", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(new Response(null, { status: 404 })),
+    );
     vi.stubGlobal("fetch", fetchMock);
     vi.mocked(getCloudsyncStatus).mockResolvedValueOnce({
       cloudsync_enabled: false,
@@ -743,7 +790,7 @@ describe("CloudSync auth lifecycle", () => {
     await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
 
     expect(getCloudsyncStatus).toHaveBeenCalledTimes(1);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(configureCloudsyncToken).not.toHaveBeenCalled();
     expect(getCloudsyncCredentialBlock()).toBe("unavailable");
   });

--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -764,9 +764,9 @@ describe("CloudSync auth lifecycle", () => {
     expect(getCloudsyncCredentialBlock()).toBe("not_entitled");
   });
 
-  test("checks the portable transport in local-only mode", async () => {
+  test("uses the portable transport directly in local-only mode", async () => {
     const fetchMock = vi.fn(() =>
-      Promise.resolve(new Response(null, { status: 404 })),
+      Promise.resolve(replicaCredentialsResponse()),
     );
     vi.stubGlobal("fetch", fetchMock);
     vi.mocked(getCloudsyncStatus).mockResolvedValueOnce({
@@ -787,12 +787,14 @@ describe("CloudSync auth lifecycle", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await handleCloudsyncAuthChange("INITIAL_SESSION", session());
-    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
-
     expect(getCloudsyncStatus).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("https://api.test/sync/replica/credentials"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(configureE2eeReplica).toHaveBeenCalledWith("user-id", witness());
     expect(configureCloudsyncToken).not.toHaveBeenCalled();
-    expect(getCloudsyncCredentialBlock()).toBe("unavailable");
   });
 
   test("does not configure local sync when the session is rejected", async () => {

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -775,14 +775,6 @@ async function activateCloudsync(
     suspendedBeforeCredentialExchange = true;
   }
 
-  if (!status.cloudsync_enabled) {
-    setCredentialBlock("unavailable");
-    console.warn(
-      "[cloudsync] native sync is unavailable; sync remains disabled",
-    );
-    return "ok";
-  }
-
   if (status.activity_paused) {
     scheduleActivityStatusRetry(
       session,

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -911,6 +911,7 @@ async function activateCloudsync(
 
   const exchange = await requestCloudsyncCredentials({
     accessToken: session.access_token,
+    cloudsyncExtensionAvailable: status.extension_loaded,
     encryptionKeyId,
     shouldStop: isCleanupSuspendRequired,
     signal: controller.signal,

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -66,6 +66,7 @@ vi.mock("@anlg/plugin-db", () => ({
   },
   bindCloudsyncAccount: vi.fn().mockResolvedValue(true),
   configureCloudsyncToken: vi.fn().mockResolvedValue("configured"),
+  configureE2eeReplica: vi.fn().mockResolvedValue("configured"),
   execute: vi.fn().mockResolvedValue([]),
   executeProxy: vi.fn().mockResolvedValue({ rows: [] }),
   executeTransaction: vi.fn().mockResolvedValue([]),

--- a/crates/api-sync/src/config.rs
+++ b/crates/api-sync/src/config.rs
@@ -65,6 +65,13 @@ pub struct SyncConfig {
 }
 
 #[derive(Clone)]
+pub struct ReplicaConfig {
+    pub(crate) supabase_url: String,
+    pub(crate) supabase_anon_key: String,
+    pub(crate) supabase_service_role_key: String,
+}
+
+#[derive(Clone)]
 pub struct SharedNotesConfig {
     pub(crate) supabase_url: String,
     pub(crate) supabase_service_role_key: String,
@@ -258,6 +265,39 @@ impl SyncConfig {
             .with_protocol_mode(protocol_mode, legacy_database_id)?
             .with_token_ttl_seconds(token_ttl_seconds)?,
         ))
+    }
+
+    pub(crate) fn replica_config(&self) -> ReplicaConfig {
+        ReplicaConfig {
+            supabase_url: self.supabase_url.clone(),
+            supabase_anon_key: self.supabase_anon_key.clone(),
+            supabase_service_role_key: self.supabase_service_role_key.clone(),
+        }
+    }
+}
+
+impl ReplicaConfig {
+    pub fn new(
+        supabase_url: impl Into<String>,
+        supabase_anon_key: impl Into<String>,
+        supabase_service_role_key: impl Into<String>,
+    ) -> Result<Self, String> {
+        let supabase_anon_key = supabase_anon_key.into();
+        if supabase_anon_key.trim().is_empty() {
+            return Err("SUPABASE_ANON_KEY is required for encrypted replica sync".to_string());
+        }
+        let supabase_service_role_key = supabase_service_role_key.into();
+        if supabase_service_role_key.trim().is_empty() {
+            return Err(
+                "SUPABASE_SERVICE_ROLE_KEY is required for encrypted replica sync".to_string(),
+            );
+        }
+
+        Ok(Self {
+            supabase_url: validate_supabase_url(supabase_url.into())?,
+            supabase_anon_key,
+            supabase_service_role_key,
+        })
     }
 }
 

--- a/crates/api-sync/src/lib.rs
+++ b/crates/api-sync/src/lib.rs
@@ -5,14 +5,15 @@ mod shared_notes;
 mod snapshot;
 mod state;
 
-pub use config::{SharedNotesConfig, SyncConfig, SyncEnv};
+pub use config::{ReplicaConfig, SharedNotesConfig, SyncConfig, SyncEnv};
 pub use error::{Result, SyncError};
 pub use routes::{
-    cloudsync_router, e2ee_witness_router, openapi, session_share_router, web_edit_router,
+    cloudsync_router, e2ee_witness_router, openapi, replica_router, session_share_router,
+    web_edit_router,
 };
 pub use shared_notes::{
     SharedNotesState, authenticated_router as authenticated_shared_notes_router,
     openapi as shared_notes_openapi, recap_openapi as shared_note_recap_openapi,
     router as shared_notes_router,
 };
-pub use state::AppState;
+pub use state::{AppState, ReplicaState};

--- a/crates/api-sync/src/routes/cloudsync_credentials/identity.rs
+++ b/crates/api-sync/src/routes/cloudsync_credentials/identity.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::SUPABASE_REQUEST_TIMEOUT;
 use crate::{
     error::{Result, SyncError},
-    state::AppState,
+    state::ReplicaState,
 };
 
 pub(in crate::routes) const DEVICE_FINGERPRINT_HEADER: &str = "x-device-fingerprint";
@@ -45,7 +45,7 @@ pub(super) struct SyncDeviceRow {
 }
 
 pub(super) async fn list_sync_devices(
-    state: &AppState,
+    state: &ReplicaState,
     account_user_id: &str,
 ) -> Result<Vec<SyncDeviceRow>> {
     let response = state
@@ -75,7 +75,7 @@ pub(super) async fn list_sync_devices(
 }
 
 pub(super) async fn remove_sync_device(
-    state: &AppState,
+    state: &ReplicaState,
     account_user_id: &str,
     fingerprint: &str,
 ) -> Result<()> {
@@ -114,7 +114,7 @@ fn is_valid_device_fingerprint(fingerprint: &str) -> bool {
 }
 
 pub(super) async fn claim_sync_device(
-    state: &AppState,
+    state: &ReplicaState,
     account_user_id: &str,
     headers: &HeaderMap,
 ) -> Result<()> {
@@ -185,7 +185,7 @@ pub(super) async fn claim_sync_device(
 }
 
 pub(super) async fn claim_personal_e2ee_key(
-    state: &AppState,
+    state: &ReplicaState,
     account_user_id: &str,
     requested_key_id: &str,
 ) -> Result<String> {

--- a/crates/api-sync/src/routes/cloudsync_credentials/mod.rs
+++ b/crates/api-sync/src/routes/cloudsync_credentials/mod.rs
@@ -36,6 +36,7 @@ pub(super) use projection::{
 
 const SUPABASE_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const CLOUDSYNC_ENCRYPTION_VERSION: u8 = 2;
+const REPLICA_CREDENTIAL_TTL_SECONDS: u64 = 15 * 60;
 pub(super) const E2EE_KEY_ID_HEADER: &str = "x-anarlog-e2ee-key-id";
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -62,6 +63,17 @@ pub struct LegacyCloudsyncCredentials {
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplicaCredentials {
+    transport: &'static str,
+    encryption_version: u8,
+    encryption_key_id: String,
+    expires_at: String,
+    workspace_id: String,
+    account_user_id: String,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
 #[serde(untagged)]
 pub enum CloudsyncCredentialResponse {
     Legacy(LegacyCloudsyncCredentials),
@@ -82,14 +94,15 @@ pub struct E2eeIdentity {
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(create_credentials, claim_e2ee_identity),
+    paths(create_credentials, create_replica_credentials, claim_e2ee_identity),
     components(schemas(
         CloudsyncCredentialResponse,
         CloudsyncCredentials,
         CloudsyncWorkspace,
         ClaimE2eeIdentityRequest,
         E2eeIdentity,
-        LegacyCloudsyncCredentials
+        LegacyCloudsyncCredentials,
+        ReplicaCredentials
     ))
 )]
 pub struct ApiDoc;
@@ -104,9 +117,59 @@ pub(super) fn router() -> Router<AppState> {
 
 pub(super) fn replica_router() -> Router<ReplicaState> {
     Router::new()
+        .route("/replica/credentials", post(create_replica_credentials))
         .route("/e2ee/identity", put(claim_e2ee_identity))
         .route("/devices", get(get_devices))
         .route("/devices/{fingerprint}", delete(delete_device))
+}
+
+#[utoipa::path(
+    post,
+    path = "/replica/credentials",
+    tag = "sync",
+    params(("x-anarlog-e2ee-key-id" = String, Header, description = "Local recovery-key identity")),
+    responses(
+        (status = 200, description = "Encrypted replica credentials", body = ReplicaCredentials),
+        (status = 400, description = "Invalid E2EE key identity"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Anarlog Pro subscription required"),
+        (status = 409, description = "Account already uses a different recovery key"),
+        (status = 502, description = "Replica credential service unavailable")
+    )
+)]
+async fn create_replica_credentials(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<ReplicaState>,
+    headers: HeaderMap,
+) -> Result<(
+    [(header::HeaderName, HeaderValue); 1],
+    Json<ReplicaCredentials>,
+)> {
+    if !auth.claims.is_pro() {
+        return Err(SyncError::ProPlanRequired);
+    }
+
+    claim_sync_device(&state, &auth.claims.sub, &headers).await?;
+    let requested_key_id = headers
+        .get(E2EE_KEY_ID_HEADER)
+        .ok_or_else(|| SyncError::BadRequest("E2EE key identity is required".to_string()))?
+        .to_str()
+        .map_err(|_| SyncError::BadRequest("E2EE key identity is invalid".to_string()))?;
+    let encryption_key_id =
+        claim_personal_e2ee_key(&state, &auth.claims.sub, requested_key_id).await?;
+    let expires_at = token_expiry(REPLICA_CREDENTIAL_TTL_SECONDS)?;
+
+    Ok((
+        [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
+        Json(ReplicaCredentials {
+            transport: "replica",
+            encryption_version: CLOUDSYNC_ENCRYPTION_VERSION,
+            encryption_key_id,
+            expires_at,
+            workspace_id: auth.claims.sub.clone(),
+            account_user_id: auth.claims.sub,
+        }),
+    ))
 }
 
 #[derive(Serialize)]

--- a/crates/api-sync/src/routes/cloudsync_credentials/mod.rs
+++ b/crates/api-sync/src/routes/cloudsync_credentials/mod.rs
@@ -11,7 +11,7 @@ use utoipa::OpenApi;
 use crate::{
     config::CloudsyncProtocolMode,
     error::{Result, SyncError},
-    state::AppState,
+    state::{AppState, ReplicaState},
 };
 
 mod identity;
@@ -99,8 +99,11 @@ pub(super) fn openapi() -> utoipa::openapi::OpenApi {
 }
 
 pub(super) fn router() -> Router<AppState> {
+    Router::new().route("/token", post(create_credentials))
+}
+
+pub(super) fn replica_router() -> Router<ReplicaState> {
     Router::new()
-        .route("/token", post(create_credentials))
         .route("/e2ee/identity", put(claim_e2ee_identity))
         .route("/devices", get(get_devices))
         .route("/devices/{fingerprint}", delete(delete_device))
@@ -114,7 +117,7 @@ struct SyncDevicesResponse {
 
 async fn get_devices(
     Extension(auth): Extension<AuthContext>,
-    State(state): State<AppState>,
+    State(state): State<ReplicaState>,
 ) -> Result<Json<SyncDevicesResponse>> {
     if !auth.claims.is_pro() {
         return Err(SyncError::ProPlanRequired);
@@ -126,7 +129,7 @@ async fn get_devices(
 
 async fn delete_device(
     Extension(auth): Extension<AuthContext>,
-    State(state): State<AppState>,
+    State(state): State<ReplicaState>,
     Path(fingerprint): Path<String>,
 ) -> Result<axum::http::StatusCode> {
     if !auth.claims.is_pro() {
@@ -152,7 +155,7 @@ async fn delete_device(
 )]
 async fn claim_e2ee_identity(
     Extension(auth): Extension<AuthContext>,
-    State(state): State<AppState>,
+    State(state): State<ReplicaState>,
     Json(request): Json<ClaimE2eeIdentityRequest>,
 ) -> Result<([(header::HeaderName, HeaderValue); 1], Json<E2eeIdentity>)> {
     if !auth.claims.is_pro() {
@@ -191,7 +194,7 @@ async fn create_credentials(
         return Err(SyncError::ProPlanRequired);
     }
 
-    claim_sync_device(&state, &auth.claims.sub, &headers).await?;
+    claim_sync_device(&state.replica, &auth.claims.sub, &headers).await?;
 
     let requested_key_id = headers
         .get(E2EE_KEY_ID_HEADER)
@@ -241,11 +244,11 @@ async fn create_credentials(
     }
     let requested_key_id = requested_key_id.expect("header presence was checked");
 
-    let workspace_rows = fetch_workspace_projection(&state, &auth).await?;
+    let workspace_rows = fetch_workspace_projection(&state.replica, &auth).await?;
     let (personal_workspace_id, workspaces) =
         validate_workspace_projection(workspace_rows, &auth.claims.sub)?;
     let encryption_key_id =
-        claim_personal_e2ee_key(&state, &auth.claims.sub, requested_key_id).await?;
+        claim_personal_e2ee_key(&state.replica, &auth.claims.sub, requested_key_id).await?;
     let token_attributes = encode_workspace_token_attributes(&workspaces)?;
 
     let token = mint_cloudsync_token(

--- a/crates/api-sync/src/routes/cloudsync_credentials/projection.rs
+++ b/crates/api-sync/src/routes/cloudsync_credentials/projection.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use super::SUPABASE_REQUEST_TIMEOUT;
 use crate::{
     error::{Result, SyncError},
-    state::AppState,
+    state::ReplicaState,
 };
 
 pub(in crate::routes) const WORKSPACE_PROJECTION_SELECT: &str = "id,user_id,role,created_at,updated_at,workspace:workspaces!inner(id,owner_user_id,kind,name,created_at,updated_at)";
@@ -49,7 +49,7 @@ pub(super) struct WorkspaceRow {
 }
 
 pub(super) async fn fetch_workspace_projection(
-    state: &AppState,
+    state: &ReplicaState,
     auth: &AuthContext,
 ) -> Result<Vec<WorkspaceMembershipRow>> {
     let user_filter = format!("eq.{}", auth.claims.sub);

--- a/crates/api-sync/src/routes/e2ee_witness.rs
+++ b/crates/api-sync/src/routes/e2ee_witness.rs
@@ -11,7 +11,7 @@ use utoipa::OpenApi;
 use uuid::Uuid;
 
 use crate::error::{Result, SyncError};
-use crate::state::AppState;
+use crate::state::ReplicaState;
 
 const MAX_EVENTS_PER_BATCH: usize = 64;
 const MAX_EVENT_BYTES: usize = 16 * 1024 * 1024;
@@ -164,7 +164,7 @@ pub fn openapi() -> utoipa::openapi::OpenApi {
     ApiDoc::openapi()
 }
 
-pub fn router() -> Router<AppState> {
+pub fn router() -> Router<ReplicaState> {
     Router::new()
         .route(
             "/e2ee/witness/{workspace_id}",
@@ -193,7 +193,7 @@ pub fn router() -> Router<AppState> {
 )]
 async fn read_e2ee_witness(
     Extension(auth): Extension<AuthContext>,
-    State(state): State<AppState>,
+    State(state): State<ReplicaState>,
     Path(workspace_id): Path<String>,
     Query(query): Query<ReadE2eeWitnessQuery>,
 ) -> Result<(
@@ -248,7 +248,7 @@ async fn read_e2ee_witness(
 )]
 async fn wait_e2ee_witness(
     Extension(auth): Extension<AuthContext>,
-    State(state): State<AppState>,
+    State(state): State<ReplicaState>,
     Path(workspace_id): Path<String>,
     Query(query): Query<WaitE2eeWitnessQuery>,
 ) -> Result<(
@@ -280,7 +280,7 @@ async fn wait_e2ee_witness(
 }
 
 async fn read_witness_head(
-    state: &AppState,
+    state: &ReplicaState,
     actor_user_id: &str,
     workspace_id: &str,
 ) -> Result<E2eeWitnessWaitResponse> {
@@ -350,7 +350,7 @@ async fn read_witness_head(
 }
 
 async fn read_witness_page(
-    state: &AppState,
+    state: &ReplicaState,
     actor_user_id: &str,
     workspace_id: &str,
     after_sequence: i64,
@@ -420,7 +420,7 @@ async fn read_witness_page(
 )]
 async fn publish_e2ee_witness(
     Extension(auth): Extension<AuthContext>,
-    State(state): State<AppState>,
+    State(state): State<ReplicaState>,
     Path(workspace_id): Path<String>,
     Json(request): Json<PublishE2eeWitnessRequest>,
 ) -> Result<(
@@ -672,7 +672,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::SyncConfig;
+    use crate::ReplicaConfig;
 
     const OWNER: &str = "11111111-1111-4111-8111-111111111111";
     const OTHER: &str = "22222222-2222-4222-8222-222222222222";
@@ -681,17 +681,9 @@ mod tests {
 
     fn test_router(server: &MockServer) -> Router {
         router()
-            .with_state(AppState::new(SyncConfig {
-                project_url: server.uri(),
-                token_issuer_api_key: "issuer-key".to_string(),
-                database_id: "database-id".to_string(),
-                legacy_database_id: None,
-                protocol_mode: crate::config::CloudsyncProtocolMode::E2eeEnforced,
-                token_ttl_seconds: 60,
-                supabase_url: server.uri(),
-                supabase_anon_key: "anon-key".to_string(),
-                supabase_service_role_key: "service-role-key".to_string(),
-            }))
+            .with_state(ReplicaState::new(
+                ReplicaConfig::new(server.uri(), "anon-key", "service-role-key").unwrap(),
+            ))
             .layer(Extension(AuthContext {
                 token: "user-token".to_string(),
                 claims: Claims {

--- a/crates/api-sync/src/routes/mod.rs
+++ b/crates/api-sync/src/routes/mod.rs
@@ -1,6 +1,6 @@
 use axum::Router;
 
-use crate::state::AppState;
+use crate::state::{AppState, ReplicaState};
 
 mod attachment_backups;
 mod cloudsync_credentials;
@@ -33,13 +33,17 @@ pub fn cloudsync_router(state: AppState) -> Router {
         .with_state(state)
 }
 
+pub fn replica_router(state: ReplicaState) -> Router {
+    cloudsync_credentials::replica_router().with_state(state)
+}
+
 pub fn session_share_router(state: AppState) -> Router {
     session_shares::router()
         .merge(shared_attachments::router())
         .with_state(state)
 }
 
-pub fn e2ee_witness_router(state: AppState) -> Router {
+pub fn e2ee_witness_router(state: ReplicaState) -> Router {
     e2ee_witness::router().with_state(state)
 }
 

--- a/crates/api-sync/src/routes/tests/credentials.rs
+++ b/crates/api-sync/src/routes/tests/credentials.rs
@@ -1,6 +1,40 @@
 use super::*;
 
 #[tokio::test]
+async fn issues_replica_credentials_without_contacting_sqlitecloud() {
+    let server = MockServer::start().await;
+    mock_e2ee_key_claim(&server, TEST_KEY_ID).await;
+
+    let response = test_router(&server, "issuer-key", &["hyprnote_pro"])
+        .oneshot(
+            Request::post("/replica/credentials")
+                .header(E2EE_KEY_ID_HEADER, TEST_KEY_ID)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[http_header::CACHE_CONTROL], "no-store");
+    let body = response_json(response).await;
+    assert_eq!(body["transport"], "replica");
+    assert_eq!(body["encryptionVersion"], 2);
+    assert_eq!(body["encryptionKeyId"], TEST_KEY_ID);
+    assert_eq!(body["workspaceId"], "user-123");
+    assert_eq!(body["accountUserId"], "user-123");
+    assert!(body["expiresAt"].as_str().unwrap().ends_with('Z'));
+    assert!(
+        server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .all(|request| request.url.path() != "/v2/tokens")
+    );
+}
+
+#[tokio::test]
 async fn mints_token_for_verified_supabase_subject() {
     let server = MockServer::start().await;
     mock_workspace_projection(

--- a/crates/api-sync/src/routes/tests/mod.rs
+++ b/crates/api-sync/src/routes/tests/mod.rs
@@ -45,6 +45,7 @@ fn test_router_with_protocol(
         supabase_service_role_key: "service-role-key".to_string(),
     });
     cloudsync_router(state.clone())
+        .merge(replica_router(state.replica.clone()))
         .merge(session_share_router(state.clone()))
         .merge(web_edit_router(state))
         .layer(Extension(AuthContext {

--- a/crates/api-sync/src/state.rs
+++ b/crates/api-sync/src/state.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use tokio::sync::Semaphore;
 
-use crate::config::SyncConfig;
+use crate::config::{ReplicaConfig, SyncConfig};
 
 const UPSTREAM_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const ATTACHMENT_VERIFICATION_CONCURRENCY: usize = 1;
@@ -35,21 +35,41 @@ impl WitnessWakes {
 }
 
 #[derive(Clone)]
-pub struct AppState {
-    pub config: SyncConfig,
-    pub client: reqwest::Client,
-    pub storage: anlg_supabase_storage::SupabaseStorage,
-    pub attachment_verification_slots: Arc<Semaphore>,
-    pub witness_wakes: WitnessWakes,
+pub struct ReplicaState {
+    pub(crate) config: ReplicaConfig,
+    pub(crate) client: reqwest::Client,
+    pub(crate) witness_wakes: WitnessWakes,
 }
 
-impl AppState {
-    pub fn new(config: SyncConfig) -> Self {
+impl ReplicaState {
+    pub fn new(config: ReplicaConfig) -> Self {
         let client = reqwest::Client::builder()
             .timeout(UPSTREAM_REQUEST_TIMEOUT)
             .redirect(reqwest::redirect::Policy::none())
             .build()
-            .expect("CloudSync HTTP client must build");
+            .expect("encrypted replica HTTP client must build");
+
+        Self {
+            config,
+            client,
+            witness_wakes: WitnessWakes::default(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    pub config: SyncConfig,
+    pub(crate) replica: ReplicaState,
+    pub client: reqwest::Client,
+    pub storage: anlg_supabase_storage::SupabaseStorage,
+    pub attachment_verification_slots: Arc<Semaphore>,
+}
+
+impl AppState {
+    pub fn new(config: SyncConfig) -> Self {
+        let replica = ReplicaState::new(config.replica_config());
+        let client = replica.client.clone();
         let storage = anlg_supabase_storage::SupabaseStorage::new(
             client.clone(),
             &config.supabase_url,
@@ -58,12 +78,12 @@ impl AppState {
 
         Self {
             config,
+            replica,
             client,
             storage,
             attachment_verification_slots: Arc::new(Semaphore::new(
                 ATTACHMENT_VERIFICATION_CONCURRENCY,
             )),
-            witness_wakes: WitnessWakes::default(),
         }
     }
 }

--- a/plugins/db/build.rs
+++ b/plugins/db/build.rs
@@ -23,6 +23,7 @@ const COMMANDS: &[&str] = &[
     "configure_cloudsync",
     "bind_cloudsync_account",
     "configure_cloudsync_token",
+    "configure_e2ee_replica",
     "start_cloudsync",
     "stop_cloudsync",
     "suspend_cloudsync",

--- a/plugins/db/js/bindings.gen.ts
+++ b/plugins/db/js/bindings.gen.ts
@@ -198,6 +198,14 @@ async configureCloudsyncToken(databaseId: string, token: string, workspaceId: st
     else return { status: "error", error: e  as any };
 }
 },
+async configureE2eeReplica(workspaceId: string, e2eeWitness: CloudsyncE2eeWitness) : Promise<Result<CloudsyncTokenConfigurationResult, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:db|configure_e2ee_replica", { workspaceId, e2eeWitness }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async startCloudsync() : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:db|start_cloudsync") };

--- a/plugins/db/js/index.ts
+++ b/plugins/db/js/index.ts
@@ -294,6 +294,16 @@ export async function configureCloudsyncToken(
   });
 }
 
+export async function configureE2eeReplica(
+  workspaceId: string,
+  e2eeWitness: CloudsyncE2eeWitness,
+): Promise<CloudsyncTokenConfigurationResult> {
+  return invoke("plugin:db|configure_e2ee_replica", {
+    workspaceId,
+    e2eeWitness,
+  });
+}
+
 export async function bindCloudsyncAccount(
   accountUserId: string,
 ): Promise<boolean> {

--- a/plugins/db/permissions/autogenerated/commands/configure_e2ee_replica.toml
+++ b/plugins/db/permissions/autogenerated/commands/configure_e2ee_replica.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-configure-e2ee-replica"
+description = "Enables the configure_e2ee_replica command without any pre-configured scope."
+commands.allow = ["configure_e2ee_replica"]
+
+[[permission]]
+identifier = "deny-configure-e2ee-replica"
+description = "Denies the configure_e2ee_replica command without any pre-configured scope."
+commands.deny = ["configure_e2ee_replica"]

--- a/plugins/db/permissions/autogenerated/reference.md
+++ b/plugins/db/permissions/autogenerated/reference.md
@@ -27,6 +27,7 @@ Default permissions for the plugin
 - `allow-unsubscribe`
 - `allow-bind-cloudsync-account`
 - `allow-configure-cloudsync-token`
+- `allow-configure-e2ee-replica`
 - `allow-stop-cloudsync`
 - `allow-suspend-cloudsync`
 - `allow-suspend-cloudsync-for-sign-out`
@@ -194,6 +195,32 @@ Enables the configure_cloudsync_token command without any pre-configured scope.
 <td>
 
 Denies the configure_cloudsync_token command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`db:allow-configure-e2ee-replica`
+
+</td>
+<td>
+
+Enables the configure_e2ee_replica command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`db:deny-configure-e2ee-replica`
+
+</td>
+<td>
+
+Denies the configure_e2ee_replica command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/db/permissions/default.toml
+++ b/plugins/db/permissions/default.toml
@@ -24,6 +24,7 @@ permissions = [
   "allow-unsubscribe",
   "allow-bind-cloudsync-account",
   "allow-configure-cloudsync-token",
+  "allow-configure-e2ee-replica",
   "allow-stop-cloudsync",
   "allow-suspend-cloudsync",
   "allow-suspend-cloudsync-for-sign-out",

--- a/plugins/db/permissions/schemas/schema.json
+++ b/plugins/db/permissions/schemas/schema.json
@@ -367,6 +367,18 @@
           "markdownDescription": "Denies the configure_cloudsync_token command without any pre-configured scope."
         },
         {
+          "description": "Enables the configure_e2ee_replica command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-configure-e2ee-replica",
+          "markdownDescription": "Enables the configure_e2ee_replica command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the configure_e2ee_replica command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-configure-e2ee-replica",
+          "markdownDescription": "Denies the configure_e2ee_replica command without any pre-configured scope."
+        },
+        {
           "description": "Enables the create_e2ee_identity command without any pre-configured scope.",
           "type": "string",
           "const": "allow-create-e2ee-identity",
@@ -691,10 +703,10 @@
           "markdownDescription": "Denies the unsubscribe command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-apply-session-ingest`\n- `allow-execute`\n- `allow-execute-proxy`\n- `allow-execute-transaction`\n- `allow-list-meetings`\n- `allow-get-meeting`\n- `allow-get-meeting-transcript`\n- `allow-get-recurring-meeting-history`\n- `allow-get-legacy-cleanup-status`\n- `allow-get-legacy-import-report`\n- `allow-cleanup-legacy-files`\n- `allow-run-legacy-import`\n- `allow-get-e2ee-identity-status`\n- `allow-inspect-e2ee-recovery-key`\n- `allow-create-e2ee-identity`\n- `allow-import-e2ee-identity`\n- `allow-get-or-create-e2ee-device-identity`\n- `allow-seal-e2ee-recovery-key-for-device`\n- `allow-import-e2ee-device-enrollment`\n- `allow-subscribe`\n- `allow-unsubscribe`\n- `allow-bind-cloudsync-account`\n- `allow-configure-cloudsync-token`\n- `allow-stop-cloudsync`\n- `allow-suspend-cloudsync`\n- `allow-suspend-cloudsync-for-sign-out`\n- `allow-suspend-cloudsync-after-auth-loss`\n- `allow-get-cloudsync-status`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-apply-session-ingest`\n- `allow-execute`\n- `allow-execute-proxy`\n- `allow-execute-transaction`\n- `allow-list-meetings`\n- `allow-get-meeting`\n- `allow-get-meeting-transcript`\n- `allow-get-recurring-meeting-history`\n- `allow-get-legacy-cleanup-status`\n- `allow-get-legacy-import-report`\n- `allow-cleanup-legacy-files`\n- `allow-run-legacy-import`\n- `allow-get-e2ee-identity-status`\n- `allow-inspect-e2ee-recovery-key`\n- `allow-create-e2ee-identity`\n- `allow-import-e2ee-identity`\n- `allow-get-or-create-e2ee-device-identity`\n- `allow-seal-e2ee-recovery-key-for-device`\n- `allow-import-e2ee-device-enrollment`\n- `allow-subscribe`\n- `allow-unsubscribe`\n- `allow-bind-cloudsync-account`\n- `allow-configure-cloudsync-token`\n- `allow-configure-e2ee-replica`\n- `allow-stop-cloudsync`\n- `allow-suspend-cloudsync`\n- `allow-suspend-cloudsync-for-sign-out`\n- `allow-suspend-cloudsync-after-auth-loss`\n- `allow-get-cloudsync-status`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-apply-session-ingest`\n- `allow-execute`\n- `allow-execute-proxy`\n- `allow-execute-transaction`\n- `allow-list-meetings`\n- `allow-get-meeting`\n- `allow-get-meeting-transcript`\n- `allow-get-recurring-meeting-history`\n- `allow-get-legacy-cleanup-status`\n- `allow-get-legacy-import-report`\n- `allow-cleanup-legacy-files`\n- `allow-run-legacy-import`\n- `allow-get-e2ee-identity-status`\n- `allow-inspect-e2ee-recovery-key`\n- `allow-create-e2ee-identity`\n- `allow-import-e2ee-identity`\n- `allow-get-or-create-e2ee-device-identity`\n- `allow-seal-e2ee-recovery-key-for-device`\n- `allow-import-e2ee-device-enrollment`\n- `allow-subscribe`\n- `allow-unsubscribe`\n- `allow-bind-cloudsync-account`\n- `allow-configure-cloudsync-token`\n- `allow-stop-cloudsync`\n- `allow-suspend-cloudsync`\n- `allow-suspend-cloudsync-for-sign-out`\n- `allow-suspend-cloudsync-after-auth-loss`\n- `allow-get-cloudsync-status`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-apply-session-ingest`\n- `allow-execute`\n- `allow-execute-proxy`\n- `allow-execute-transaction`\n- `allow-list-meetings`\n- `allow-get-meeting`\n- `allow-get-meeting-transcript`\n- `allow-get-recurring-meeting-history`\n- `allow-get-legacy-cleanup-status`\n- `allow-get-legacy-import-report`\n- `allow-cleanup-legacy-files`\n- `allow-run-legacy-import`\n- `allow-get-e2ee-identity-status`\n- `allow-inspect-e2ee-recovery-key`\n- `allow-create-e2ee-identity`\n- `allow-import-e2ee-identity`\n- `allow-get-or-create-e2ee-device-identity`\n- `allow-seal-e2ee-recovery-key-for-device`\n- `allow-import-e2ee-device-enrollment`\n- `allow-subscribe`\n- `allow-unsubscribe`\n- `allow-bind-cloudsync-account`\n- `allow-configure-cloudsync-token`\n- `allow-configure-e2ee-replica`\n- `allow-stop-cloudsync`\n- `allow-suspend-cloudsync`\n- `allow-suspend-cloudsync-for-sign-out`\n- `allow-suspend-cloudsync-after-auth-loss`\n- `allow-get-cloudsync-status`"
         }
       ]
     }

--- a/plugins/db/src/commands.rs
+++ b/plugins/db/src/commands.rs
@@ -465,6 +465,31 @@ pub(crate) async fn configure_cloudsync_token<R: tauri::Runtime>(
 
 #[tauri::command]
 #[specta::specta]
+pub(crate) async fn configure_e2ee_replica<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: tauri::State<'_, ManagedState>,
+    workspace_id: String,
+    e2ee_witness: crate::CloudsyncE2eeWitness,
+) -> Result<crate::CloudsyncTokenConfigurationResult, String> {
+    let auth_generation = state.begin_cloudsync_auth_configuration();
+    let recovery_key = load_e2ee_recovery_key(app, &workspace_id)
+        .await?
+        .ok_or_else(|| {
+            "end-to-end encryption recovery key setup is required before sync can start".to_string()
+        })?;
+    state
+        .configure_replica_transport_at_generation(
+            workspace_id,
+            e2ee_witness,
+            recovery_key,
+            auth_generation,
+        )
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub(crate) async fn bind_cloudsync_account(
     state: tauri::State<'_, ManagedState>,
     account_user_id: String,

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -265,6 +265,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::configure_cloudsync,
             commands::bind_cloudsync_account,
             commands::configure_cloudsync_token<tauri::Wry>,
+            commands::configure_e2ee_replica<tauri::Wry>,
             commands::start_cloudsync,
             commands::stop_cloudsync,
             commands::suspend_cloudsync,

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -12,6 +12,7 @@ use crate::{QueryEvent, Result, TransactionStatement};
 mod e2ee_sync;
 mod open;
 mod recovery;
+mod replica_sync;
 mod sync_result;
 mod witness_watch;
 
@@ -144,6 +145,7 @@ pub struct PluginDbRuntime {
     cloudsync_auth_generation: std::sync::Arc<std::sync::atomic::AtomicU64>,
     cloudsync_auth_changed: std::sync::Arc<tokio::sync::Notify>,
     cloudsync_focus_nudge_at: std::sync::Mutex<Option<std::time::Instant>>,
+    _replica_sync: replica_sync::ReplicaSyncTask,
     _witness_watch: witness_watch::WitnessWatchTask,
     #[cfg(test)]
     pause_transaction_after_begin: std::sync::atomic::AtomicBool,
@@ -192,6 +194,10 @@ impl PluginDbRuntime {
             std::sync::Arc::clone(&db),
             std::sync::Arc::clone(&e2ee_sync_hook),
         );
+        let replica_sync = replica_sync::spawn_replica_sync(
+            std::sync::Arc::clone(&db),
+            std::sync::Arc::clone(&e2ee_sync_hook),
+        );
         Self {
             db: std::sync::Arc::clone(&db),
             schema_ready: tokio::sync::OnceCell::new(),
@@ -207,6 +213,7 @@ impl PluginDbRuntime {
             cloudsync_auth_generation: Default::default(),
             cloudsync_auth_changed: Default::default(),
             cloudsync_focus_nudge_at: Default::default(),
+            _replica_sync: replica_sync,
             #[cfg(test)]
             pause_transaction_after_begin: Default::default(),
             #[cfg(test)]
@@ -229,6 +236,14 @@ impl PluginDbRuntime {
         self.db.pool()
     }
 
+    fn request_active_sync(&self) {
+        if self.e2ee_sync_hook.replica_transport_configured() {
+            self.e2ee_sync_hook.request_replica_sync();
+        } else {
+            self.db.cloudsync_request_sync();
+        }
+    }
+
     /// Ask CloudSync to pull promptly when the user comes back to the app,
     /// throttled so rapid window switches do not stack sync rounds.
     pub fn nudge_cloudsync_on_focus(&self) {
@@ -240,7 +255,7 @@ impl PluginDbRuntime {
             }
             *last = Some(now);
         }
-        self.db.cloudsync_request_sync();
+        self.request_active_sync();
     }
 
     #[cfg(test)]
@@ -406,7 +421,7 @@ impl PluginDbRuntime {
             .unwrap()
             .mark_activity_resumed();
         self.e2ee_sync_hook.notify_activity_changed();
-        self.db.cloudsync_request_sync();
+        self.request_active_sync();
     }
 
     async fn ensure_app_schema(&self) -> Result<()> {
@@ -543,6 +558,81 @@ impl PluginDbRuntime {
         Ok(())
     }
 
+    pub(crate) async fn configure_replica_transport_at_generation(
+        &self,
+        account_user_id: String,
+        e2ee_witness: crate::CloudsyncE2eeWitness,
+        recovery_key: anlg_e2ee::RecoveryKey,
+        auth_generation: u64,
+    ) -> Result<crate::CloudsyncTokenConfigurationResult> {
+        let _control_operation = self.cloudsync_control_guard().await?;
+        self.ensure_legacy_migration_ready().await?;
+        let cancellation = crate::e2ee_witness::E2eeWitnessCancellation::default();
+        let operation = async {
+            self.ensure_cloudsync_configuration_active(auth_generation, &cancellation)?;
+            self.cancel_cloudsync_full_resync().await;
+            if self.e2ee_sync_hook.replica_transport_configured() {
+                self.e2ee_sync_hook.clear();
+            }
+            if self.db.cloudsync_enabled() {
+                self.db.cloudsync_stop().await?;
+            }
+            self.ensure_cloudsync_configuration_active(auth_generation, &cancellation)?;
+            self.set_e2ee_recovery_key(&account_user_id, &recovery_key)?;
+            if !self
+                .claim_replica_workspace(&account_user_id, &cancellation)
+                .await?
+            {
+                return Ok(crate::CloudsyncTokenConfigurationResult::AccountMismatch);
+            }
+            self.ensure_cloudsync_configuration_active(auth_generation, &cancellation)?;
+            let witness =
+                crate::e2ee_witness::E2eeWitnessClient::new(e2ee_witness, &account_user_id)?;
+            let key = self
+                .e2ee_sync_hook
+                .workspace_key(&account_user_id)
+                .ok_or(crate::Error::E2eeIdentityRequired)?;
+            self.e2ee_sync_hook
+                .prepare_local_snapshot(self.db.pool(), &cancellation)
+                .await
+                .map_err(|error| std::io::Error::other(error.to_string()))?;
+            cancellation.check()?;
+            witness
+                .initialize_cancellable(self.db.pool(), &key, &cancellation)
+                .await?;
+            self.ensure_cloudsync_configuration_active(auth_generation, &cancellation)?;
+            self.e2ee_sync_hook.set_replica_witness(witness);
+            Ok(crate::CloudsyncTokenConfigurationResult::Configured)
+        };
+        tokio::pin!(operation);
+        let result = tokio::select! {
+            biased;
+            _ = self.wait_until_cloudsync_auth_generation_changes(auth_generation) => {
+                cancellation.cancel();
+                let _ = operation.await;
+                Err(crate::Error::CloudsyncConfigurationCancelled)
+            }
+            _ = self.e2ee_sync_hook.wait_until_activity_paused() => {
+                cancellation.cancel();
+                let _ = operation.await;
+                Err(crate::Error::CloudsyncActivityDeferred)
+            }
+            result = &mut operation => result,
+        };
+        if result.is_err()
+            || matches!(
+                result,
+                Ok(crate::CloudsyncTokenConfigurationResult::AccountMismatch)
+            )
+        {
+            if self.db.cloudsync_enabled() {
+                let _ = self.db.cloudsync_suspend().await;
+            }
+            self.e2ee_sync_hook.clear();
+        }
+        result
+    }
+
     pub async fn configure_cloudsync_token(
         &self,
         database_id: String,
@@ -600,6 +690,9 @@ impl PluginDbRuntime {
                 )?;
                 attempt_started = true;
                 self.cancel_cloudsync_full_resync().await;
+                if self.e2ee_sync_hook.replica_transport_configured() {
+                    self.e2ee_sync_hook.clear();
+                }
                 self.ensure_cloudsync_configuration_active(
                     auth_generation,
                     &configuration_cancellation,
@@ -997,6 +1090,38 @@ impl PluginDbRuntime {
         }
     }
 
+    async fn claim_replica_workspace(
+        &self,
+        account_user_id: &str,
+        cancellation: &crate::e2ee_witness::E2eeWitnessCancellation,
+    ) -> Result<bool> {
+        cancellation.check()?;
+        self.ensure_app_schema().await?;
+        cancellation.check()?;
+        match anlg_db_app::cloudsync_workspace_is_claimed_by(self.db.pool(), account_user_id).await
+        {
+            Ok(true) => return Ok(true),
+            Ok(false) => {}
+            Err(error) if is_permanent_cloudsync_workspace_rejection(&error) => return Ok(false),
+            Err(error) => return Err(error.into()),
+        }
+
+        match anlg_db_app::claim_cloudsync_workspace_cancellable(
+            self.db.pool(),
+            account_user_id,
+            || cancellation.is_cancelled(),
+        )
+        .await
+        {
+            Ok(()) => Ok(true),
+            Err(anlg_db_app::CloudsyncWorkspaceError::ClaimCancelled) => {
+                Err(crate::Error::CloudsyncConfigurationCancelled)
+            }
+            Err(error) if is_permanent_cloudsync_workspace_rejection(&error) => Ok(false),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     async fn prepare_cloudsync_config_fail_closed(
         &self,
         config: anlg_db_core::CloudsyncRuntimeConfig,
@@ -1127,25 +1252,36 @@ impl PluginDbRuntime {
         let _control_operation = self.cloudsync_control_guard().await?;
         self.ensure_legacy_migration_ready().await?;
         self.e2ee_sync_hook.request_reconciliation();
+        if self.e2ee_sync_hook.replica_transport_configured() {
+            self.e2ee_sync_hook.request_replica_sync();
+            return Ok(());
+        }
         self.db.cloudsync_start().await?;
         Ok(())
     }
 
     pub async fn stop_cloudsync(&self) -> Result<()> {
+        let replica_transport = self.e2ee_sync_hook.replica_transport_configured();
         self.invalidate_cloudsync_auth_generation();
         self.cancel_cloudsync_full_resync().await;
         let _control_operation = self.cloudsync_control_operation.lock().await;
         self.cancel_cloudsync_full_resync().await;
-        self.db.cloudsync_stop().await?;
+        if !replica_transport {
+            self.db.cloudsync_stop().await?;
+        }
+        self.e2ee_sync_hook.clear();
         Ok(())
     }
 
     pub async fn suspend_cloudsync(&self) -> Result<()> {
+        let replica_transport = self.e2ee_sync_hook.replica_transport_configured();
         self.invalidate_cloudsync_auth_generation();
         self.cancel_cloudsync_full_resync().await;
         let _control_operation = self.cloudsync_control_operation.lock().await;
         self.cancel_cloudsync_full_resync().await;
-        self.db.cloudsync_suspend().await?;
+        if !replica_transport {
+            self.db.cloudsync_suspend().await?;
+        }
         self.e2ee_sync_hook.clear();
         Ok(())
     }
@@ -1168,6 +1304,9 @@ impl PluginDbRuntime {
     }
 
     pub async fn cloudsync_status(&self) -> Result<serde_json::Value> {
+        if self.e2ee_sync_hook.replica_transport_configured() {
+            return self.replica_transport_status().await;
+        }
         let mut status = serde_json::to_value(self.db.cloudsync_status().await?)?;
         let activity_paused = self.e2ee_sync_hook.activity_paused();
         let deferred_for_capture = self.e2ee_sync_hook.has_activity(CLOUDSYNC_CAPTURE_ACTIVITY);
@@ -1262,21 +1401,64 @@ impl PluginDbRuntime {
 
     pub async fn sync_cloudsync_now(&self) -> Result<serde_json::Value> {
         self.ensure_legacy_migration_ready().await?;
+        if self.e2ee_sync_hook.replica_transport_configured() {
+            self.e2ee_sync_hook.request_replica_sync();
+            return Ok(serde_json::json!({}));
+        }
         Ok(serde_json::to_value(
             self.db.cloudsync_trigger_sync().await?,
         )?)
     }
 
     pub async fn logout_cloudsync(&self, discard_unsent_changes: bool) -> Result<()> {
+        let replica_transport = self.e2ee_sync_hook.replica_transport_configured();
         self.invalidate_cloudsync_auth_generation();
         self.cancel_cloudsync_full_resync().await;
         let _control_operation = self.cloudsync_control_operation.lock().await;
         self.cancel_cloudsync_full_resync().await;
         let _write_guard = self.synced_write_barrier.write().await;
-        self.db.cloudsync_logout(discard_unsent_changes).await?;
+        if !replica_transport {
+            self.db.cloudsync_logout(discard_unsent_changes).await?;
+        }
         self.e2ee_sync_hook.clear();
         self.e2ee_sync_hook.clear_activities();
         Ok(())
+    }
+
+    async fn replica_transport_status(&self) -> Result<serde_json::Value> {
+        let keys = self.e2ee_sync_hook.snapshot();
+        let local_work_pending =
+            anlg_db_app::has_pending_e2ee_dirty_rows_deferring_active_captures(
+                self.db.pool(),
+                &keys,
+            )
+            .await
+            .map_err(|error| {
+                std::io::Error::other(format!(
+                    "failed to inspect pending E2EE replica changes: {error}"
+                ))
+            })?;
+        let replica = self.e2ee_sync_hook.replica_status();
+        let activity_paused = self.e2ee_sync_hook.activity_paused();
+        Ok(serde_json::json!({
+            "cloudsync_enabled": true,
+            "extension_loaded": self.db.cloudsync_enabled(),
+            "configured": true,
+            "running": true,
+            "network_initialized": true,
+            "activity_paused": activity_paused,
+            "deferred_for_capture": self.e2ee_sync_hook.has_activity(CLOUDSYNC_CAPTURE_ACTIVITY),
+            "last_sync": null,
+            "last_sync_at_ms": replica.last_sync_at_ms,
+            "has_unsent_changes": local_work_pending || replica.syncing,
+            "last_error": replica.last_error,
+            "last_error_kind": (replica.consecutive_failures > 0).then_some("transient"),
+            "consecutive_failures": replica.consecutive_failures,
+            "recovery_pending": false,
+            "recovery_delayed": false,
+            "recovery_phase": null,
+            "activity_log": [],
+        }))
     }
 }
 

--- a/plugins/db/src/runtime/e2ee_sync.rs
+++ b/plugins/db/src/runtime/e2ee_sync.rs
@@ -3,10 +3,25 @@ use std::collections::{HashMap, HashSet};
 use super::E2EE_CLOUDSYNC_DIRTY_ROW_LIMIT;
 use super::sync_result::{cloudsync_receive_completed, cloudsync_receive_requires_reconciliation};
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum E2eeTransport {
+    None = 0,
+    Cloudsync = 1,
+    Replica = 2,
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct CloudsyncActivity {
     activity: String,
     key: String,
+}
+
+#[derive(Clone, Default)]
+pub(super) struct ReplicaSyncStatus {
+    pub(super) syncing: bool,
+    pub(super) last_sync_at_ms: Option<u64>,
+    pub(super) last_error: Option<String>,
+    pub(super) consecutive_failures: u32,
 }
 
 pub(crate) struct CloudsyncTokenConfiguration {
@@ -39,7 +54,10 @@ impl CloudsyncTokenConfiguration {
 pub(super) struct E2eeSyncHook {
     keys: std::sync::RwLock<HashMap<String, anlg_e2ee::WorkspaceKey>>,
     witness: std::sync::RwLock<Option<crate::e2ee_witness::E2eeWitnessClient>>,
+    transport: std::sync::atomic::AtomicU8,
     pub(super) witness_changed: tokio::sync::Notify,
+    pub(super) replica_sync_requested: tokio::sync::Notify,
+    replica_status: std::sync::Mutex<ReplicaSyncStatus>,
     activities: std::sync::RwLock<HashSet<CloudsyncActivity>>,
     pub(super) activity_changed: tokio::sync::Notify,
     reconciliation_requested_epoch: std::sync::atomic::AtomicU64,
@@ -92,9 +110,16 @@ impl E2eeSyncHook {
     }
 
     pub(super) fn clear(&self) {
+        self.cancel_active_sync();
         self.keys.write().unwrap().clear();
         *self.witness.write().unwrap() = None;
+        self.transport.store(
+            E2eeTransport::None as u8,
+            std::sync::atomic::Ordering::Release,
+        );
         self.witness_changed.notify_waiters();
+        self.replica_sync_requested.notify_waiters();
+        *self.replica_status.lock().unwrap() = ReplicaSyncStatus::default();
         let requested = self
             .reconciliation_requested_epoch
             .load(std::sync::atomic::Ordering::Acquire);
@@ -114,9 +139,59 @@ impl E2eeSyncHook {
     }
 
     pub(super) fn set_witness(&self, witness: crate::e2ee_witness::E2eeWitnessClient) {
+        self.set_witness_for_transport(witness, E2eeTransport::Cloudsync);
+    }
+
+    pub(super) fn set_replica_witness(&self, witness: crate::e2ee_witness::E2eeWitnessClient) {
+        self.set_witness_for_transport(witness, E2eeTransport::Replica);
+        self.replica_sync_requested.notify_one();
+    }
+
+    fn set_witness_for_transport(
+        &self,
+        witness: crate::e2ee_witness::E2eeWitnessClient,
+        transport: E2eeTransport,
+    ) {
+        self.cancel_active_sync();
         *self.witness.write().unwrap() = Some(witness);
+        self.transport
+            .store(transport as u8, std::sync::atomic::Ordering::Release);
         self.witness_changed.notify_waiters();
         self.request_reconciliation();
+    }
+
+    pub(super) fn replica_transport_configured(&self) -> bool {
+        self.transport.load(std::sync::atomic::Ordering::Acquire) == E2eeTransport::Replica as u8
+    }
+
+    pub(super) fn request_replica_sync(&self) {
+        self.replica_sync_requested.notify_one();
+    }
+
+    pub(super) fn replica_sync_started(&self) {
+        self.replica_status.lock().unwrap().syncing = true;
+    }
+
+    pub(super) fn replica_sync_succeeded(&self) {
+        let mut status = self.replica_status.lock().unwrap();
+        status.syncing = false;
+        status.last_sync_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .ok()
+            .and_then(|duration| u64::try_from(duration.as_millis()).ok());
+        status.last_error = None;
+        status.consecutive_failures = 0;
+    }
+
+    pub(super) fn replica_sync_failed(&self, error: &std::io::Error) {
+        let mut status = self.replica_status.lock().unwrap();
+        status.syncing = false;
+        status.last_error = Some(error.to_string());
+        status.consecutive_failures = status.consecutive_failures.saturating_add(1);
+    }
+
+    pub(super) fn replica_status(&self) -> ReplicaSyncStatus {
+        self.replica_status.lock().unwrap().clone()
     }
 
     pub(super) fn witness(&self) -> Option<crate::e2ee_witness::E2eeWitnessClient> {
@@ -264,6 +339,97 @@ impl E2eeSyncHook {
         )
         .await
         .map(|_| ())
+    }
+
+    pub(super) async fn sync_replica_transport(
+        &self,
+        pool: &sqlx::SqlitePool,
+    ) -> std::io::Result<bool> {
+        if !self.replica_transport_configured() {
+            return Ok(false);
+        }
+        let keys = self.snapshot();
+        let witness = self.witness();
+        let active_sync = self.begin_sync();
+        let cancellation = active_sync.cancellation.clone();
+        let operation = async {
+            cancellation.check()?;
+            let witness = witness
+                .ok_or_else(|| std::io::Error::other("E2EE replica service is not configured"))?;
+            let key = keys
+                .get(witness.workspace_id())
+                .ok_or_else(|| std::io::Error::other("E2EE replica identity is not configured"))?;
+            witness
+                .refresh_notifying_cancellable(
+                    pool,
+                    key,
+                    || {
+                        self.request_reconciliation();
+                    },
+                    &cancellation,
+                )
+                .await?;
+            cancellation.check()?;
+            anlg_db_app::encrypt_e2ee_replica_changes_bounded_deferring_active_captures_cancellable(
+                pool,
+                &keys,
+                E2EE_CLOUDSYNC_DIRTY_ROW_LIMIT,
+                || cancellation.is_cancelled(),
+            )
+            .await
+            .map_err(|error| {
+                std::io::Error::other(format!("E2EE replica encryption failed: {error}"))
+            })?;
+            cancellation.check()?;
+            witness
+                .publish_and_refresh_notifying_cancellable(
+                    pool,
+                    key,
+                    || {
+                        self.request_reconciliation();
+                    },
+                    &cancellation,
+                )
+                .await?;
+            cancellation.check()?;
+            let reconciliation_epoch = self.request_reconciliation();
+            let stats = anlg_db_app::apply_received_e2ee_replica_changes_with_witness_cancellable(
+                pool,
+                &keys,
+                true,
+                || self.received_apply_cancelled(&cancellation),
+            )
+            .await
+            .map_err(|error| {
+                std::io::Error::other(format!("E2EE replica application failed: {error}"))
+            })?;
+            cancellation.check()?;
+            if stats.remaining_replica_changes {
+                self.request_reconciliation();
+            }
+            self.complete_reconciliation(reconciliation_epoch);
+            let local_work_remaining = stats.remaining_replica_changes
+                || self.reconciliation_requested()
+                || anlg_db_app::has_pending_e2ee_dirty_rows_deferring_active_captures(pool, &keys)
+                    .await
+                    .map_err(|error| {
+                        std::io::Error::other(format!(
+                            "failed to inspect pending E2EE replica changes: {error}"
+                        ))
+                    })?;
+            cancellation.check()?;
+            Ok(local_work_remaining)
+        };
+        tokio::pin!(operation);
+        tokio::select! {
+            biased;
+            _ = self.wait_until_activity_paused() => {
+                cancellation.cancel();
+                let _ = operation.await;
+                Ok(true)
+            }
+            result = &mut operation => result,
+        }
     }
 }
 

--- a/plugins/db/src/runtime/e2ee_sync.rs
+++ b/plugins/db/src/runtime/e2ee_sync.rs
@@ -24,6 +24,13 @@ pub(super) struct ReplicaSyncStatus {
     pub(super) consecutive_failures: u32,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ReplicaSyncOutcome {
+    Settled,
+    MoreWork,
+    Paused,
+}
+
 pub(crate) struct CloudsyncTokenConfiguration {
     pub(super) database_id: String,
     pub(super) token: String,
@@ -181,6 +188,10 @@ impl E2eeSyncHook {
             .and_then(|duration| u64::try_from(duration.as_millis()).ok());
         status.last_error = None;
         status.consecutive_failures = 0;
+    }
+
+    pub(super) fn replica_sync_paused(&self) {
+        self.replica_status.lock().unwrap().syncing = false;
     }
 
     pub(super) fn replica_sync_failed(&self, error: &std::io::Error) {
@@ -344,9 +355,9 @@ impl E2eeSyncHook {
     pub(super) async fn sync_replica_transport(
         &self,
         pool: &sqlx::SqlitePool,
-    ) -> std::io::Result<bool> {
+    ) -> std::io::Result<ReplicaSyncOutcome> {
         if !self.replica_transport_configured() {
-            return Ok(false);
+            return Ok(ReplicaSyncOutcome::Settled);
         }
         let keys = self.snapshot();
         let witness = self.witness();
@@ -426,9 +437,15 @@ impl E2eeSyncHook {
             _ = self.wait_until_activity_paused() => {
                 cancellation.cancel();
                 let _ = operation.await;
-                Ok(true)
+                Ok(ReplicaSyncOutcome::Paused)
             }
-            result = &mut operation => result,
+            result = &mut operation => result.map(|work_remaining| {
+                if work_remaining {
+                    ReplicaSyncOutcome::MoreWork
+                } else {
+                    ReplicaSyncOutcome::Settled
+                }
+            }),
         }
     }
 }

--- a/plugins/db/src/runtime/replica_sync.rs
+++ b/plugins/db/src/runtime/replica_sync.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use anlg_db_core::Db;
+
+use super::e2ee_sync::E2eeSyncHook;
+
+const REPLICA_SYNC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+const REPLICA_SYNC_RETRY: std::time::Duration = std::time::Duration::from_secs(5);
+const REPLICA_SYNC_PACING: std::time::Duration = std::time::Duration::from_millis(50);
+
+pub(super) struct ReplicaSyncTask {
+    _shutdown_tx: tokio::sync::oneshot::Sender<()>,
+}
+
+pub(super) fn spawn_replica_sync(db: Arc<Db>, hook: Arc<E2eeSyncHook>) -> ReplicaSyncTask {
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    tauri::async_runtime::spawn(async move {
+        loop {
+            let witness_changed = hook.witness_changed.notified();
+            tokio::pin!(witness_changed);
+            witness_changed.as_mut().enable();
+            if !hook.replica_transport_configured() {
+                tokio::select! {
+                    _ = &mut shutdown_rx => return,
+                    () = &mut witness_changed => {}
+                }
+                continue;
+            }
+
+            if hook.activity_paused() {
+                tokio::select! {
+                    _ = &mut shutdown_rx => return,
+                    () = &mut witness_changed => {}
+                    () = hook.wait_until_activity_resumed() => {}
+                }
+                continue;
+            }
+
+            let requested = hook.replica_sync_requested.notified();
+            tokio::pin!(requested);
+            requested.as_mut().enable();
+            tokio::select! {
+                _ = &mut shutdown_rx => return,
+                () = &mut witness_changed => continue,
+                () = &mut requested => {}
+                () = tokio::time::sleep(REPLICA_SYNC_INTERVAL) => {}
+            }
+
+            hook.replica_sync_started();
+            let result = hook.sync_replica_transport(db.pool()).await;
+            if !hook.replica_transport_configured() {
+                continue;
+            }
+            match result {
+                Ok(true) => {
+                    hook.replica_sync_succeeded();
+                    tokio::select! {
+                        _ = &mut shutdown_rx => return,
+                        () = tokio::time::sleep(REPLICA_SYNC_PACING) => {
+                            hook.request_replica_sync();
+                        }
+                    }
+                }
+                Ok(false) => {
+                    hook.replica_sync_succeeded();
+                }
+                Err(error) => {
+                    hook.replica_sync_failed(&error);
+                    tracing::warn!(%error, "encrypted replica sync failed");
+                    tokio::select! {
+                        _ = &mut shutdown_rx => return,
+                        () = tokio::time::sleep(REPLICA_SYNC_RETRY) => {
+                            hook.request_replica_sync();
+                        }
+                        () = &mut witness_changed => {}
+                    }
+                }
+            }
+        }
+    });
+    ReplicaSyncTask {
+        _shutdown_tx: shutdown_tx,
+    }
+}

--- a/plugins/db/src/runtime/replica_sync.rs
+++ b/plugins/db/src/runtime/replica_sync.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anlg_db_core::Db;
 
-use super::e2ee_sync::E2eeSyncHook;
+use super::e2ee_sync::{E2eeSyncHook, ReplicaSyncOutcome};
 
 const REPLICA_SYNC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 const REPLICA_SYNC_RETRY: std::time::Duration = std::time::Duration::from_secs(5);
@@ -52,7 +52,7 @@ pub(super) fn spawn_replica_sync(db: Arc<Db>, hook: Arc<E2eeSyncHook>) -> Replic
                 continue;
             }
             match result {
-                Ok(true) => {
+                Ok(ReplicaSyncOutcome::MoreWork) => {
                     hook.replica_sync_succeeded();
                     tokio::select! {
                         _ = &mut shutdown_rx => return,
@@ -61,9 +61,10 @@ pub(super) fn spawn_replica_sync(db: Arc<Db>, hook: Arc<E2eeSyncHook>) -> Replic
                         }
                     }
                 }
-                Ok(false) => {
+                Ok(ReplicaSyncOutcome::Settled) => {
                     hook.replica_sync_succeeded();
                 }
+                Ok(ReplicaSyncOutcome::Paused) => hook.replica_sync_paused(),
                 Err(error) => {
                     hook.replica_sync_failed(&error);
                     tracing::warn!(%error, "encrypted replica sync failed");

--- a/plugins/db/src/runtime/tests/configuration.rs
+++ b/plugins/db/src/runtime/tests/configuration.rs
@@ -1,5 +1,54 @@
 use super::*;
 
+#[tokio::test]
+async fn configures_replica_transport_without_the_cloudsync_extension() {
+    let db = std::sync::Arc::new(Db::connect_memory_plain().await.unwrap());
+    anlg_db_app::prepare_schema(db.as_ref()).await.unwrap();
+    sqlx::query(
+        "UPDATE storage_migration_state
+         SET importer_version = ?, parity_verified = 1
+         WHERE id = 'legacy_v1'",
+    )
+    .bind(anlg_db_app::LEGACY_IMPORTER_VERSION)
+    .execute(db.pool())
+    .await
+    .unwrap();
+    let runtime = PluginDbRuntime::new(db);
+    let witness_state = InitiallyUninitializedWitness::default();
+    witness_state.initialized.store(true, Ordering::SeqCst);
+    let witness_server = MockServer::start().await;
+    Mock::given(path("/sync/e2ee/witness/user-a"))
+        .respond_with(witness_state)
+        .mount(&witness_server)
+        .await;
+    let recovery_key = anlg_e2ee::RecoveryKey::parse(
+        "anarlog-e2ee-v1:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc",
+    )
+    .unwrap();
+    let generation = runtime.begin_cloudsync_auth_configuration();
+
+    assert_eq!(
+        runtime
+            .configure_replica_transport_at_generation(
+                "user-a".to_string(),
+                crate::CloudsyncE2eeWitness {
+                    endpoint: format!("{}/sync/e2ee/witness/user-a", witness_server.uri()),
+                    access_token: "access-token".to_string(),
+                },
+                recovery_key,
+                generation,
+            )
+            .await
+            .unwrap(),
+        crate::CloudsyncTokenConfigurationResult::Configured
+    );
+    assert!(runtime.e2ee_sync_hook.replica_transport_configured());
+    assert_eq!(
+        runtime.cloudsync_status().await.unwrap()["configured"],
+        true
+    );
+}
+
 fn test_full_resync_config(token: &str) -> anlg_db_core::CloudsyncRuntimeConfig {
     anlg_db_core::CloudsyncRuntimeConfig {
         connection_string: "test-database".to_string(),

--- a/plugins/db/src/runtime/tests/sync_hook.rs
+++ b/plugins/db/src/runtime/tests/sync_hook.rs
@@ -1,6 +1,118 @@
 use super::*;
 
 #[tokio::test]
+async fn replica_transport_syncs_without_the_cloudsync_extension() {
+    let db = Db::connect_memory_plain().await.unwrap();
+    anlg_db_app::prepare_schema(&db).await.unwrap();
+    let hook = E2eeSyncHook::default();
+    let recovery_key = anlg_e2ee::RecoveryKey::parse(
+        "anarlog-e2ee-v1:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc",
+    )
+    .unwrap();
+    hook.set_personal_workspace("workspace-1", &recovery_key)
+        .unwrap();
+    let witness_state = InitiallyUninitializedWitness::default();
+    witness_state.initialized.store(true, Ordering::SeqCst);
+    let witness_server = MockServer::start().await;
+    Mock::given(path("/sync/e2ee/witness/workspace-1"))
+        .respond_with(witness_state)
+        .mount(&witness_server)
+        .await;
+    hook.set_replica_witness(
+        crate::e2ee_witness::E2eeWitnessClient::new(
+            crate::CloudsyncE2eeWitness {
+                endpoint: format!("{}/sync/e2ee/witness/workspace-1", witness_server.uri()),
+                access_token: "access-token".to_string(),
+            },
+            "workspace-1",
+        )
+        .unwrap(),
+    );
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, title)
+         VALUES ('session-1', 'workspace-1', 'Portable sync')",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    assert!(!hook.sync_replica_transport(db.pool()).await.unwrap());
+    assert!(
+        witness_server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .any(|request| request.method == wiremock::http::Method::POST)
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM e2ee_dirty_rows")
+            .fetch_one(db.pool())
+            .await
+            .unwrap(),
+        0
+    );
+    assert!(
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM e2ee_witness_records")
+            .fetch_one(db.pool())
+            .await
+            .unwrap()
+            > 0
+    );
+}
+
+#[tokio::test]
+async fn replica_transport_hydrates_a_fresh_local_database() {
+    let source = Db::connect_memory_plain().await.unwrap();
+    let target = Db::connect_memory_plain().await.unwrap();
+    anlg_db_app::prepare_schema(&source).await.unwrap();
+    anlg_db_app::prepare_schema(&target).await.unwrap();
+    let recovery_key = anlg_e2ee::RecoveryKey::parse(
+        "anarlog-e2ee-v1:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc",
+    )
+    .unwrap();
+    let (witness_server, witness_config) =
+        crate::tests::support::setup_witness("workspace-1").await;
+    let configure = |hook: &E2eeSyncHook| {
+        hook.set_personal_workspace("workspace-1", &recovery_key)
+            .unwrap();
+        hook.set_replica_witness(
+            crate::e2ee_witness::E2eeWitnessClient::new(witness_config.clone(), "workspace-1")
+                .unwrap(),
+        );
+    };
+    let source_hook = E2eeSyncHook::default();
+    let target_hook = E2eeSyncHook::default();
+    configure(&source_hook);
+    configure(&target_hook);
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, title)
+         VALUES ('session-1', 'workspace-1', 'Portable hydration')",
+    )
+    .execute(source.pool())
+    .await
+    .unwrap();
+
+    source_hook
+        .sync_replica_transport(source.pool())
+        .await
+        .unwrap();
+    target_hook
+        .sync_replica_transport(target.pool())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        sqlx::query_scalar::<_, String>("SELECT title FROM sessions WHERE id = 'session-1'")
+            .fetch_one(target.pool())
+            .await
+            .unwrap(),
+        "Portable hydration"
+    );
+    assert!(!witness_server.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn capture_lifecycle_marker_defers_only_its_transcript() {
     let db = Db::connect_memory_plain().await.unwrap();
     anlg_db_app::prepare_schema(&db).await.unwrap();

--- a/plugins/db/src/runtime/tests/sync_hook.rs
+++ b/plugins/db/src/runtime/tests/sync_hook.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runtime::e2ee_sync::ReplicaSyncOutcome;
 
 #[tokio::test]
 async fn replica_transport_syncs_without_the_cloudsync_extension() {
@@ -36,7 +37,10 @@ async fn replica_transport_syncs_without_the_cloudsync_extension() {
     .await
     .unwrap();
 
-    assert!(!hook.sync_replica_transport(db.pool()).await.unwrap());
+    assert_eq!(
+        hook.sync_replica_transport(db.pool()).await.unwrap(),
+        ReplicaSyncOutcome::Settled
+    );
     assert!(
         witness_server
             .received_requests()
@@ -59,6 +63,23 @@ async fn replica_transport_syncs_without_the_cloudsync_extension() {
             .unwrap()
             > 0
     );
+}
+
+#[test]
+fn paused_replica_sync_preserves_the_last_completed_result() {
+    let hook = E2eeSyncHook::default();
+    hook.replica_sync_succeeded();
+    hook.replica_sync_failed(&std::io::Error::other("temporary failure"));
+    let before = hook.replica_status();
+
+    hook.replica_sync_started();
+    hook.replica_sync_paused();
+
+    let after = hook.replica_status();
+    assert!(!after.syncing);
+    assert_eq!(after.last_sync_at_ms, before.last_sync_at_ms);
+    assert_eq!(after.last_error, before.last_error);
+    assert_eq!(after.consecutive_failures, before.consecutive_failures);
 }
 
 #[tokio::test]

--- a/plugins/db/src/runtime/witness_watch.rs
+++ b/plugins/db/src/runtime/witness_watch.rs
@@ -75,7 +75,11 @@ pub(super) fn spawn_witness_watch(db: Arc<Db>, hook: Arc<E2eeSyncHook>) -> Witne
                 Ok(Some(head)) => {
                     last_triggered = head;
                     error_backoff = WATCH_ERROR_BACKOFF_MIN;
-                    db.cloudsync_request_sync();
+                    if hook.replica_transport_configured() {
+                        hook.request_replica_sync();
+                    } else {
+                        db.cloudsync_request_sync();
+                    }
                 }
                 Ok(None) => {
                     error_backoff = WATCH_ERROR_BACKOFF_MIN;

--- a/plugins/db/src/tests/bindings.rs
+++ b/plugins/db/src/tests/bindings.rs
@@ -22,6 +22,7 @@ fn default_permissions_exclude_generic_cloudsync_control() {
     let permissions = include_str!("../../permissions/default.toml");
 
     assert!(permissions.contains("allow-configure-cloudsync-token"));
+    assert!(permissions.contains("allow-configure-e2ee-replica"));
     assert!(permissions.contains("allow-suspend-cloudsync-for-sign-out"));
     assert!(!permissions.contains("allow-begin-cloudsync-activity"));
     assert!(!permissions.contains("allow-end-cloudsync-activity"));

--- a/plugins/db/src/tests/mod.rs
+++ b/plugins/db/src/tests/mod.rs
@@ -2,5 +2,5 @@ mod bindings;
 mod cloudsync_credentials;
 mod cloudsync_lifecycle;
 mod queries;
-mod support;
+pub(crate) mod support;
 mod transactions;

--- a/plugins/db/src/tests/support.rs
+++ b/plugins/db/src/tests/support.rs
@@ -148,7 +148,7 @@ impl Respond for WitnessResponder {
     }
 }
 
-pub(super) async fn setup_witness(workspace_id: &str) -> (MockServer, CloudsyncE2eeWitness) {
+pub(crate) async fn setup_witness(workspace_id: &str) -> (MockServer, CloudsyncE2eeWitness) {
     let server = MockServer::start().await;
     Mock::given(path(format!("/sync/e2ee/witness/{workspace_id}")))
         .respond_with(WitnessResponder::default())


### PR DESCRIPTION
## Summary

- mount the encrypted replica API independently from SQLiteCloud
- add provider-neutral replica credentials and a direct desktop replica transport
- fall back to the portable transport only when the hosted `/sync/token` route is absent
- cover minimal API boot, credential issuance, direct upload, and fresh-device hydration

## Scope

This is the public, personal-workspace slice of ANLG-219. It does not add generic MySQL/Postgres domain adapters, Compose, offline licensing, runtime URL settings, collaborative-document CRDTs, or enterprise-private code. Hosted production behavior remains first-choice and unchanged.

## Validation

- `cargo check`
- `cargo check -p api`
- `cargo test -p api-sync` (99 passed)
- `cargo test -p tauri-plugin-db` (144 passed)
- `cargo test -p desktop` (31 passed)
- `pnpm -F desktop typecheck`
- `pnpm -F @anlg/plugin-db typecheck`
- `pnpm -F desktop exec vitest run src/auth/cloudsync.test.ts` (74 passed)
- `pnpm exec dprint fmt`
- `pnpm fmt:check`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/` (0 errors)

The full desktop Vitest command is locally obscured by an unrelated uncommitted sidebar test change on another GitButler stack. A strict plugin Clippy run also encounters the existing `too_many_arguments` lint in `crates/e2ee/src/lib.rs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-gated sync credential issuance, E2EE witness routing, and desktop sync lifecycle; mistakes could break Pro sync or mis-route transports, but hosted `/sync/token` behavior is preserved and coverage is broad.
> 
> **Overview**
> **Encrypted replica sync no longer depends on SQLiteCloud.** The API always mounts replica routes (credentials, E2EE identity, devices, witness) from a new `ReplicaState` backed only by Supabase; full CloudSync token minting stays optional when hosted SQLiteCloud config is present.
> 
> **New `POST /sync/replica/credentials`** returns `transport: "replica"` metadata (E2EE key id, workspace/account ids, expiry) after the same device and recovery-key checks as hosted sync, without calling SQLiteCloud.
> 
> **Desktop** chooses `/sync/replica/credentials` when the native CloudSync extension is absent, or retries that route after `/sync/token` 404; replica responses wire through **`configureE2eeReplica`** instead of `configureCloudsyncToken`. Local-only mode no longer blocks credential exchange entirely.
> 
> **Native db plugin** adds replica transport configuration, a background replica sync loop (witness refresh/publish/apply), and status/lifecycle paths that bypass CloudSync extension start/stop when replica mode is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc502be5bfeddc5f393a9411b62874eb592b567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->