### PR TITLE
Reduce idle CPU and memory usage

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -116,7 +116,6 @@
     "retext-pos": "^5.0.0",
     "retext-stringify": "^4.0.0",
     "streamdown": "^2.5.0",
-    "tinytick": "^1.2.8",
     "unified": "^11.0.5",
     "usehooks-ts": "^3.1.1",
     "vfile": "^6.0.3",

--- a/apps/desktop/src/attachment-sync/runner.test.ts
+++ b/apps/desktop/src/attachment-sync/runner.test.ts
@@ -36,6 +36,9 @@ const job: AttachmentTransferJob = {
 
 function dependencies() {
   const store = {
+    subscribeToNextAttempt: vi
+      .fn()
+      .mockResolvedValue(vi.fn(async () => undefined)),
     resetProcessLocalAttempts: vi.fn(),
     recoverInterrupted: vi.fn(),
     reconcile: vi.fn(),
@@ -124,6 +127,41 @@ function dependencies() {
 }
 
 describe("attachment transfer runner", () => {
+  it("sleeps on an empty queue and wakes at the database retry deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-15T12:00:00.000Z"));
+    const deps = dependencies();
+    deps.store.claimNext.mockResolvedValue(undefined);
+    let onChange: ((value: string | null) => void) | undefined;
+    const unsubscribe = vi.fn(async () => undefined);
+    deps.store.subscribeToNextAttempt.mockImplementationOnce(
+      (listener: (value: string | null) => void) => {
+        onChange = listener;
+        return Promise.resolve(unsubscribe);
+      },
+    );
+
+    try {
+      const stop = startAttachmentTransferRunner({
+        ...deps,
+        supabaseUrl: "https://project.supabase.co",
+      } as any);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(deps.store.claimNext).toHaveBeenCalledOnce();
+
+      onChange?.(new Date(Date.now() + 30_000).toISOString());
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(deps.store.claimNext).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(deps.store.claimNext).toHaveBeenCalledTimes(2);
+      stop();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(unsubscribe).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uploads, finalizes, promotes, and commits the private backup", async () => {
     const deps = dependencies();
 

--- a/apps/desktop/src/attachment-sync/runner.ts
+++ b/apps/desktop/src/attachment-sync/runner.ts
@@ -102,33 +102,126 @@ export function startAttachmentTransferRunner(
   externalSignal?: AbortSignal,
 ): () => void {
   const controller = new AbortController();
+  const store = dependencies.store ?? attachmentTransferStore;
   let timeout: ReturnType<typeof setTimeout> | undefined;
+  let nextAttemptAt: number | null = null;
+  let nextMaintenanceAt = Date.now();
+  let fallbackAt: number | null = null;
+  let running = false;
+  let runAgain = false;
+  let stopRequested = false;
+  let unsubscribeStarted = false;
+  let unsubscribePromise: Promise<() => Promise<void>> | undefined;
+
+  const reschedule = () => {
+    clearTimeout(timeout);
+    timeout = undefined;
+    if (controller.signal.aborted || running) return;
+
+    const deadline = [nextAttemptAt, nextMaintenanceAt, fallbackAt]
+      .filter((value): value is number => value !== null)
+      .reduce(
+        (earliest, value) => Math.min(earliest, value),
+        Number.POSITIVE_INFINITY,
+      );
+    if (Number.isFinite(deadline)) {
+      timeout = setTimeout(
+        () => void tick(),
+        Math.max(0, deadline - Date.now()),
+      );
+    }
+  };
+
+  const requestUnsubscribe = () => {
+    stopRequested = true;
+    if (!unsubscribePromise || unsubscribeStarted) return;
+    unsubscribeStarted = true;
+    void unsubscribePromise
+      .then((unsubscribe) => unsubscribe())
+      .catch((error) =>
+        console.error("[attachment-sync] queue unsubscribe failed", error),
+      );
+  };
   const stop = () => {
     controller.abort();
-    if (timeout) clearTimeout(timeout);
+    clearTimeout(timeout);
+    requestUnsubscribe();
   };
   const stopFromExternalSignal = () => stop();
   externalSignal?.addEventListener("abort", stopFromExternalSignal, {
     once: true,
   });
+  if (externalSignal?.aborted) stop();
 
   const tick = async () => {
     if (controller.signal.aborted) return;
+    if (running) {
+      runAgain = true;
+      return;
+    }
+    running = true;
+    clearTimeout(timeout);
+    timeout = undefined;
+    const now = Date.now();
+    if (nextAttemptAt !== null && nextAttemptAt <= now) nextAttemptAt = null;
+    if (fallbackAt !== null && fallbackAt <= now) {
+      fallbackAt = now + PASS_INTERVAL_MS;
+    }
+
     try {
-      const store = dependencies.store ?? attachmentTransferStore;
       const native = dependencies.native ?? attachmentTransferNative;
       await ensureProcessLocalAttemptsReset(store);
       await ensureDeleteGuardsReconciled(native);
-      await runAttachmentTransferPass(dependencies, controller.signal);
+      nextMaintenanceAt = Date.now() + DELETE_GUARD_RECONCILE_INTERVAL_MS;
+      const processed = await runAttachmentTransferPass(
+        dependencies,
+        controller.signal,
+      );
+      if (processed === MAX_JOBS_PER_PASS) runAgain = true;
     } catch (error) {
       if (!controller.signal.aborted) {
         console.error("[attachment-sync] transfer pass failed", error);
+        fallbackAt = Date.now() + PASS_INTERVAL_MS;
       }
+    } finally {
+      running = false;
     }
-    if (!controller.signal.aborted) {
-      timeout = setTimeout(() => void tick(), PASS_INTERVAL_MS);
+
+    if (runAgain && !controller.signal.aborted) {
+      runAgain = false;
+      void tick();
+    } else {
+      reschedule();
     }
   };
+
+  const subscribeToNextAttempt = store.subscribeToNextAttempt?.bind(store);
+  if (!subscribeToNextAttempt) fallbackAt = Date.now() + PASS_INTERVAL_MS;
+  unsubscribePromise = subscribeToNextAttempt?.(
+    (value) => {
+      const timestamp = value ? Date.parse(value) : Number.NaN;
+      nextAttemptAt = Number.isFinite(timestamp) ? timestamp : null;
+      fallbackAt = null;
+      if (running && nextAttemptAt !== null && nextAttemptAt <= Date.now()) {
+        runAgain = true;
+      } else {
+        reschedule();
+      }
+    },
+    (error) => {
+      console.error("[attachment-sync] queue subscription failed", error);
+      fallbackAt = Date.now() + PASS_INTERVAL_MS;
+      reschedule();
+    },
+  ).catch((error) => {
+    if (!controller.signal.aborted) {
+      console.error("[attachment-sync] queue subscription failed", error);
+      fallbackAt = Date.now() + PASS_INTERVAL_MS;
+      reschedule();
+    }
+    return async () => {};
+  });
+  if (stopRequested) requestUnsubscribe();
   void tick();
 
   return () => {

--- a/apps/desktop/src/attachment-sync/store.ts
+++ b/apps/desktop/src/attachment-sync/store.ts
@@ -13,6 +13,7 @@ import {
   retryAttachmentTransfersForAttachment,
   setDownloadGrant,
   setUploadReservation,
+  subscribeToNextAttachmentTransferAttempt,
 } from "./store/jobs";
 import {
   reconcileAttachmentTransferJobs,
@@ -41,6 +42,7 @@ export {
   retryAttachmentTransfersForAttachment,
   setDownloadGrant,
   setUploadReservation,
+  subscribeToNextAttachmentTransferAttempt,
 };
 
 export const attachmentTransferStore = {
@@ -48,6 +50,7 @@ export const attachmentTransferStore = {
   resetProcessLocalAttempts: resetProcessLocalAttachmentTransferAttempts,
   recoverInterrupted: recoverInterruptedAttachmentTransfers,
   claimNext: claimNextAttachmentTransferJob,
+  subscribeToNextAttempt: subscribeToNextAttachmentTransferAttempt,
   setUploadReservation,
   setDownloadGrant,
   markPhase,

--- a/apps/desktop/src/attachment-sync/store/jobs.ts
+++ b/apps/desktop/src/attachment-sync/store/jobs.ts
@@ -8,6 +8,26 @@ import {
 import { executeTransaction, liveQueryClient } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
 
+type NextAttemptRow = { next_attempt_at: string | null };
+
+export function subscribeToNextAttachmentTransferAttempt(
+  onChange: (nextAttemptAt: string | null) => void,
+  onError?: (error: string) => void,
+) {
+  return liveQueryClient.subscribe<NextAttemptRow>(
+    `
+      SELECT MIN(next_attempt_at) AS next_attempt_at
+      FROM attachment_transfer_jobs
+      WHERE phase IN ('queued', 'retry_wait')
+    `,
+    [],
+    {
+      onData: (rows) => onChange(rows[0]?.next_attempt_at ?? null),
+      onError,
+    },
+  );
+}
+
 export async function claimNextAttachmentTransferJob(): Promise<
   AttachmentTransferJob | undefined
 > {

--- a/apps/desktop/src/calendar/components/context.test.tsx
+++ b/apps/desktop/src/calendar/components/context.test.tsx
@@ -5,47 +5,62 @@ import {
   render,
   screen,
 } from "@testing-library/react";
-import { createManager } from "tinytick";
-import { Provider as TinyTickProvider } from "tinytick/ui-react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { SyncProvider, useSync } from "./context";
 
 import { CALENDAR_SYNC_TASK_ID } from "~/services/calendar";
+import {
+  createTaskScheduler,
+  TaskSchedulerProvider,
+} from "~/services/task-scheduler";
 
 function StatusHarness() {
-  const { scheduleSync, status } = useSync();
+  const { canSync, scheduleSync, status } = useSync();
 
   return (
-    <button type="button" onClick={scheduleSync}>
+    <button type="button" disabled={!canSync} onClick={scheduleSync}>
       {status}
     </button>
   );
 }
 
 describe("SyncProvider", () => {
-  const managers: ReturnType<typeof createManager>[] = [];
+  const managers: ReturnType<typeof createTaskScheduler>[] = [];
 
   afterEach(() => {
     cleanup();
     for (const manager of managers) {
-      manager.stop(true);
+      manager.stop();
     }
     managers.length = 0;
     vi.useRealTimers();
   });
 
+  test("disables sync without a scheduler", () => {
+    render(
+      <SyncProvider>
+        <StatusHarness />
+      </SyncProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: "idle" })).toHaveProperty(
+      "disabled",
+      true,
+    );
+  });
+
   test("keeps a newly scheduled sync in the scheduled state", () => {
-    const manager = createManager();
+    const manager = createTaskScheduler();
     managers.push(manager);
     manager.setTask(CALENDAR_SYNC_TASK_ID, async () => undefined);
 
     render(
-      <TinyTickProvider manager={manager}>
+      <TaskSchedulerProvider scheduler={manager}>
         <SyncProvider>
           <StatusHarness />
         </SyncProvider>
-      </TinyTickProvider>,
+      </TaskSchedulerProvider>,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "idle" }));
@@ -54,17 +69,17 @@ describe("SyncProvider", () => {
   });
 
   test("reflects a calendar sync scheduled outside the provider", () => {
-    const manager = createManager();
+    const manager = createTaskScheduler();
     managers.push(manager);
     manager.setTask(CALENDAR_SYNC_TASK_ID, async () => undefined);
     manager.scheduleTaskRun(CALENDAR_SYNC_TASK_ID);
 
     render(
-      <TinyTickProvider manager={manager}>
+      <TaskSchedulerProvider scheduler={manager}>
         <SyncProvider>
           <StatusHarness />
         </SyncProvider>
-      </TinyTickProvider>,
+      </TaskSchedulerProvider>,
     );
 
     expect(screen.getByRole("button", { name: "scheduled" })).toBeDefined();
@@ -72,7 +87,7 @@ describe("SyncProvider", () => {
 
   test("moves from scheduled to syncing to idle", async () => {
     vi.useFakeTimers();
-    const manager = createManager();
+    const manager = createTaskScheduler();
     managers.push(manager);
     let finishTask = () => {};
     manager.setTask(
@@ -84,11 +99,11 @@ describe("SyncProvider", () => {
     );
 
     render(
-      <TinyTickProvider manager={manager}>
+      <TaskSchedulerProvider scheduler={manager}>
         <SyncProvider>
           <StatusHarness />
         </SyncProvider>
-      </TinyTickProvider>,
+      </TaskSchedulerProvider>,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "idle" }));

--- a/apps/desktop/src/calendar/components/context.tsx
+++ b/apps/desktop/src/calendar/components/context.tsx
@@ -5,11 +5,6 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  useManager,
-  useRunningTaskRunIds,
-  useScheduledTaskRunIds,
-} from "tinytick/ui-react";
 
 import {
   type CalendarSyncRange,
@@ -17,6 +12,11 @@ import {
   scheduleCalendarSync,
   syncCalendarEventsForRange,
 } from "~/services/calendar";
+import {
+  useRunningTaskRunIds,
+  useScheduledTaskRunIds,
+  useTaskScheduler,
+} from "~/services/task-scheduler";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 export const TOGGLE_SYNC_DEBOUNCE_MS = 5000;
@@ -35,9 +35,9 @@ interface SyncContextValue {
 const SyncContext = createContext<SyncContextValue | null>(null);
 
 export function SyncProvider({ children }: { children: React.ReactNode }) {
-  const manager = useManager();
-  const scheduledTaskRunIds = useScheduledTaskRunIds() ?? [];
-  const runningTaskRunIds = useRunningTaskRunIds() ?? [];
+  const manager = useTaskScheduler();
+  const scheduledTaskRunIds = useScheduledTaskRunIds();
+  const runningTaskRunIds = useRunningTaskRunIds();
   const toggleSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -49,7 +49,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
   const isScheduled = scheduledTaskRunIds.some(isCalendarTaskRun);
   const isSyncing = runningTaskRunIds.some(isCalendarTaskRun);
   const isRangeSyncing = rangeSyncCount > 0;
-  const canSync = manager !== undefined;
+  const canSync = manager !== null;
 
   const status: SyncStatus =
     isSyncing || isRangeSyncing

--- a/apps/desktop/src/calendar/hooks.ts
+++ b/apps/desktop/src/calendar/hooks.ts
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 
 import { safeParseDate } from "@anlg/utils";
 import { TZDate } from "@anlg/utils";
@@ -28,16 +28,72 @@ export function toTz(date: Date | string, tz?: string): Date {
 
 export function useNow() {
   const tz = useTimezone();
-  const [now, setNow] = useState(() => toTz(new Date(), tz));
+  const store = useMemo(() => getNowStore(tz), [tz]);
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  );
+}
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setNow(toTz(new Date(), tz));
-    }, 60000);
-    return () => clearInterval(interval);
-  }, [tz]);
+const nowStores = new Map<string, ReturnType<typeof createNowStore>>();
 
-  return now;
+function getNowStore(timezone: string | undefined) {
+  const key = timezone ?? "";
+  let store = nowStores.get(key);
+  if (!store) {
+    store = createNowStore(timezone);
+    nowStores.set(key, store);
+  }
+  return store;
+}
+
+function createNowStore(timezone: string | undefined) {
+  let now = toTz(new Date(), timezone);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const listeners = new Set<() => void>();
+
+  const scheduleRefresh = () => {
+    clearTimeout(timeout);
+    timeout = undefined;
+    if (listeners.size === 0 || document.visibilityState === "hidden") return;
+    const remainder = Date.now() % 60_000;
+    timeout = setTimeout(
+      refresh,
+      remainder === 0 ? 60_000 : 60_000 - remainder,
+    );
+  };
+  const refresh = () => {
+    now = toTz(new Date(), timezone);
+    listeners.forEach((listener) => listener());
+    scheduleRefresh();
+  };
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") refresh();
+    else scheduleRefresh();
+  };
+  const subscribe = (listener: () => void) => {
+    if (listeners.size === 0) {
+      window.addEventListener("focus", refresh);
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+    }
+    listeners.add(listener);
+    refresh();
+
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        scheduleRefresh();
+        window.removeEventListener("focus", refresh);
+        document.removeEventListener(
+          "visibilitychange",
+          handleVisibilityChange,
+        );
+      }
+    };
+  };
+
+  return { getSnapshot: () => now, subscribe };
 }
 
 function getSystemWeekStart(): 0 | 1 {

--- a/apps/desktop/src/contexts/notifications.tsx
+++ b/apps/desktop/src/contexts/notifications.tsx
@@ -71,7 +71,7 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
   const localSttQuery = useQuery({
     enabled: isLocalSttModel,
     queryKey: ["local-stt-status", sttModel],
-    refetchInterval: 1000,
+    refetchInterval: (query) => (query.state.data === "loading" ? 1000 : false),
     queryFn: async () => {
       if (!sttModel) return null;
 

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -5,11 +5,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { StrictMode, useMemo } from "react";
 import ReactDOM from "react-dom/client";
-import { createManager } from "tinytick";
-import {
-  Provider as TinyTickProvider,
-  useCreateManager,
-} from "tinytick/ui-react";
 
 import "@anlg/ui/globals.css";
 import { commands as analyticsCommands } from "@anlg/plugin-analytics";
@@ -31,6 +26,10 @@ import { FloatingMeetingWindowHost } from "./meeting-float/host";
 import { routeTree } from "./routeTree.gen";
 import { EventListeners } from "./services/event-listeners";
 import { TaskManager } from "./services/task-manager";
+import {
+  createTaskScheduler,
+  TaskSchedulerProvider,
+} from "./services/task-scheduler";
 import { TrayRecordingSync } from "./services/tray-recording";
 import { TrayScheduleSync } from "./services/tray-schedule";
 import { UpdaterMeetingSync } from "./services/updater-meeting";
@@ -87,15 +86,13 @@ function App() {
 initializeErrorReporting();
 
 function AppRoot() {
-  const manager = useCreateManager(() => {
-    return createManager().start();
-  });
+  const scheduler = useMemo(() => createTaskScheduler().start(), []);
   const theme = useConfigValue("theme") as ThemePreference;
   useRemoteSessionDeletionUndoListener(isMainWindow);
 
   return (
     <QueryClientProvider client={queryClient}>
-      <TinyTickProvider manager={manager}>
+      <TaskSchedulerProvider scheduler={scheduler}>
         <App />
         {isMainWindow ? <TaskManager /> : null}
         {isMainWindow ? <FloatingMeetingWindowHost /> : null}
@@ -104,7 +101,7 @@ function AppRoot() {
         {isMainWindow ? <TrayRecordingSync /> : null}
         {isMainWindow ? <UpdaterMeetingSync /> : null}
         <Toaster position="bottom-right" theme={theme} />
-      </TinyTickProvider>
+      </TaskSchedulerProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/desktop/src/services/calendar/index.test.ts
+++ b/apps/desktop/src/services/calendar/index.test.ts
@@ -1,4 +1,3 @@
-import { createManager } from "tinytick";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const ctxMocks = vi.hoisted(() => ({
@@ -50,6 +49,8 @@ import {
   syncCalendarEventsForRange,
 } from ".";
 
+import { createTaskScheduler } from "~/services/task-scheduler";
+
 const ctx = {
   provider: "google" as const,
   connectionId: "conn-1",
@@ -59,7 +60,7 @@ const ctx = {
   calendarTrackingIdToId: new Map([["primary", "cal-1"]]),
 };
 
-const managers: ReturnType<typeof createManager>[] = [];
+const managers: ReturnType<typeof createTaskScheduler>[] = [];
 
 describe("syncCalendarEventsForRange", () => {
   beforeEach(() => {
@@ -100,7 +101,7 @@ describe("syncCalendarEventsForRange", () => {
 
   afterEach(() => {
     for (const manager of managers) {
-      manager.stop(true);
+      manager.stop();
     }
     managers.length = 0;
     vi.useRealTimers();
@@ -347,7 +348,7 @@ describe("syncCalendarEventsForRange", () => {
   });
 
   test("reuses an active scheduled calendar sync", () => {
-    const manager = createManager();
+    const manager = createTaskScheduler();
     managers.push(manager);
     manager.setTask(CALENDAR_SYNC_TASK_ID, async () => undefined);
 
@@ -360,7 +361,7 @@ describe("syncCalendarEventsForRange", () => {
 
   test("reuses a running calendar sync", async () => {
     vi.useFakeTimers();
-    const manager = createManager();
+    const manager = createTaskScheduler();
     managers.push(manager);
     manager.setTask(
       CALENDAR_SYNC_TASK_ID,
@@ -380,7 +381,7 @@ describe("syncCalendarEventsForRange", () => {
   });
 
   test("can schedule a new calendar sync after a timeout", async () => {
-    const manager = createManager();
+    const manager = createTaskScheduler();
     managers.push(manager);
     manager.setTask(
       CALENDAR_SYNC_TASK_ID,
@@ -388,7 +389,6 @@ describe("syncCalendarEventsForRange", () => {
         await new Promise<void>((resolve) => {
           signal.addEventListener("abort", () => resolve(), { once: true });
         }),
-      undefined,
       { maxDuration: 50 },
     );
     manager.start();

--- a/apps/desktop/src/services/calendar/index.ts
+++ b/apps/desktop/src/services/calendar/index.ts
@@ -1,5 +1,3 @@
-import type { Manager } from "tinytick";
-
 import type { CalendarProviderType } from "@anlg/plugin-calendar";
 
 import {
@@ -26,6 +24,7 @@ import {
 } from "./storage";
 
 import { enqueueDatabaseWrite } from "~/db/write-queue";
+import type { TaskScheduler } from "~/services/task-scheduler";
 
 export const CALENDAR_SYNC_TASK_ID = "calendarSync";
 export type { CalendarSyncRange };
@@ -56,7 +55,9 @@ export function syncCalendarEvents(
   });
 }
 
-export function scheduleCalendarSync(manager: Manager): string | undefined {
+export function scheduleCalendarSync(
+  manager: TaskScheduler,
+): string | undefined {
   const activeTaskRunId = [
     ...manager.getScheduledTaskRunIds(),
     ...manager.getRunningTaskRunIds(),

--- a/apps/desktop/src/services/task-manager.tsx
+++ b/apps/desktop/src/services/task-manager.tsx
@@ -1,6 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useRef } from "react";
-import { useManager, useScheduleTaskRun, useSetTask } from "tinytick/ui-react";
 
 import { events as appleCalendarEvents } from "@anlg/plugin-calendar";
 
@@ -23,23 +22,26 @@ import {
 } from "./event-notification";
 import { cleanupExpiredVoiceprintCandidates } from "./voiceprint";
 
+import {
+  useRegisterTask,
+  useScheduleTaskRun,
+  useTaskScheduler,
+} from "~/services/task-scheduler";
 import { useConfigValue } from "~/shared/config";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 const CALENDAR_SYNC_INTERVAL = 60 * 1000; // 60 sec
 const CALENDAR_SYNC_MAX_DURATION = 120 * 1000; // 2 min
 
-// tinytick aborts runs after a default maxDuration of 1s and never re-schedules
-// the repeatDelay of a timed-out run, which permanently kills the repeating
-// task. Long-running tasks must set an explicit maxDuration, and retries keep
-// the repeat loop alive if a run still exceeds it.
+// Long-running tasks need explicit deadlines so a hung provider cannot block
+// later deadline-driven work indefinitely.
 const AUDIO_RETENTION_MAX_DURATION = 10 * 60 * 1000; // 10 min
 const EVENT_NOTIFICATION_MAX_DURATION = 60 * 1000; // 60 sec
 const REPEATING_TASK_MAX_RETRIES = 3;
 
 export function TaskManager() {
   const queryClient = useQueryClient();
-  const manager = useManager();
+  const manager = useTaskScheduler();
 
   const notificationEvent = useConfigValue("notification_event");
   const audioRetention = normalizeAudioRetention(
@@ -47,13 +49,11 @@ export function TaskManager() {
   );
   const notifiedEventsRef = useRef<NotifiedEventsMap>(new Map());
 
-  useSetTask(
+  useRegisterTask(
     CALENDAR_SYNC_TASK_ID,
     async (_arg, signal) => {
       await syncCalendarEvents({ signal });
     },
-    [],
-    undefined,
     { maxDuration: CALENDAR_SYNC_MAX_DURATION },
   );
 
@@ -97,7 +97,7 @@ export function TaskManager() {
     };
   });
 
-  useSetTask(
+  useRegisterTask(
     EVENT_NOTIFICATION_TASK_ID,
     async () => {
       await checkEventNotifications(
@@ -105,8 +105,6 @@ export function TaskManager() {
         notifiedEventsRef.current,
       );
     },
-    [notificationEvent],
-    undefined,
     {
       maxDuration: EVENT_NOTIFICATION_MAX_DURATION,
       maxRetries: REPEATING_TASK_MAX_RETRIES,
@@ -118,7 +116,7 @@ export function TaskManager() {
     repeatDelay: EVENT_NOTIFICATION_INTERVAL,
   });
 
-  useSetTask(
+  useRegisterTask(
     AUDIO_RETENTION_TASK_ID,
     async () => {
       const deletedSessionIds = await cleanupExpiredAudio(audioRetention);
@@ -132,8 +130,6 @@ export function TaskManager() {
       }
       void cleanupExpiredVoiceprintCandidates();
     },
-    [audioRetention, queryClient],
-    undefined,
     {
       maxDuration: AUDIO_RETENTION_MAX_DURATION,
       maxRetries: REPEATING_TASK_MAX_RETRIES,

--- a/apps/desktop/src/services/task-scheduler.test.ts
+++ b/apps/desktop/src/services/task-scheduler.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createTaskScheduler } from "./task-scheduler";
+
+describe("TaskScheduler", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("has no idle heartbeat", () => {
+    vi.useFakeTimers();
+    const scheduler = createTaskScheduler().start();
+
+    expect(vi.getTimerCount()).toBe(0);
+
+    scheduler.stop();
+  });
+
+  test("uses one timer for the exact next deadline", async () => {
+    vi.useFakeTimers();
+    const task = vi.fn(async () => undefined);
+    const scheduler = createTaskScheduler();
+    scheduler.setTask("scheduled", task);
+    scheduler.scheduleTaskRun("scheduled", undefined, 60_000);
+    scheduler.start();
+
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(task).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(task).toHaveBeenCalledOnce();
+
+    scheduler.stop();
+  });
+
+  test("reschedules repeating work from its completion time", async () => {
+    vi.useFakeTimers();
+    const task = vi.fn(async () => undefined);
+    const scheduler = createTaskScheduler();
+    scheduler.setTask("repeating", task);
+    scheduler.scheduleTaskRun("repeating", undefined, 0, {
+      repeatDelay: 30_000,
+    });
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(task).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(task).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(task).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+  });
+
+  test("releases queued runs when their task is removed", () => {
+    vi.useFakeTimers();
+    const scheduler = createTaskScheduler().start();
+    scheduler.setTask("removed", vi.fn());
+    scheduler.scheduleTaskRun("removed", undefined, 60_000);
+
+    scheduler.delTask("removed");
+
+    expect(scheduler.getScheduledTaskRunIds()).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+    scheduler.stop();
+  });
+});

--- a/apps/desktop/src/services/task-scheduler.tsx
+++ b/apps/desktop/src/services/task-scheduler.tsx
@@ -1,0 +1,481 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useSyncExternalStore,
+} from "react";
+
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+export type TaskRunConfig = {
+  maxDuration?: number;
+  maxRetries?: number;
+  repeatDelay?: number | null;
+  retryDelay?: number | string;
+};
+
+export type TaskRunInfo = {
+  manager: TaskScheduler;
+  taskId: string;
+  taskRunId: string;
+  arg: unknown;
+  retry: number;
+  running: boolean;
+  nextTimestamp: number;
+};
+
+type Task = (
+  arg: unknown,
+  signal: AbortSignal,
+  info: TaskRunInfo,
+) => Promise<void> | void;
+
+type TaskDefinition = {
+  task: Task;
+  config: TaskRunConfig;
+};
+
+type TaskRun = {
+  id: string;
+  taskId: string;
+  arg: unknown;
+  config: TaskRunConfig;
+  nextTimestamp: number;
+  retry: number;
+  running: boolean;
+  retriesRemaining?: number;
+  retryDelays?: number[];
+  repeatDelay?: number | null;
+  timeout?: number;
+  controller?: AbortController;
+};
+
+type TaskRunListener = (
+  scheduler: TaskScheduler,
+  taskId: string,
+  taskRunId: string,
+  running: boolean | undefined,
+) => void;
+
+export class TaskScheduler {
+  private readonly tasks = new Map<string, TaskDefinition>();
+  private readonly runs = new Map<string, TaskRun>();
+  private readonly stateListeners = new Set<() => void>();
+  private readonly taskRunListeners = new Map<
+    number,
+    { taskId: string; taskRunId: string | null; listener: TaskRunListener }
+  >();
+  private nextListenerId = 0;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private timerDeadline: number | null = null;
+  private started = false;
+  private scheduledSnapshot: readonly string[] = [];
+  private runningSnapshot: readonly string[] = [];
+
+  start(): this {
+    this.started = true;
+    this.scheduleNextWake();
+    return this;
+  }
+
+  stop(): this {
+    this.started = false;
+    this.clearTimer();
+    return this;
+  }
+
+  setTask(
+    taskId: string,
+    task: Task,
+    config: TaskRunConfig = EMPTY_TASK_RUN_CONFIG,
+  ): void {
+    this.tasks.set(taskId, { task, config });
+    this.scheduleNextWake();
+  }
+
+  delTask(taskId: string): void {
+    this.tasks.delete(taskId);
+    for (const run of this.runs.values()) {
+      if (run.taskId !== taskId) continue;
+      run.controller?.abort();
+      this.runs.delete(run.id);
+      this.publishTaskRun(run, undefined);
+    }
+    this.publishState();
+    this.scheduleNextWake();
+  }
+
+  scheduleTaskRun(
+    taskId: string,
+    arg?: unknown,
+    startAfter = 0,
+    config: TaskRunConfig = EMPTY_TASK_RUN_CONFIG,
+  ): string {
+    const taskRunId = crypto.randomUUID();
+    this.runs.set(taskRunId, {
+      id: taskRunId,
+      taskId,
+      arg,
+      config,
+      nextTimestamp: Date.now() + Math.max(0, startAfter),
+      retry: 0,
+      running: false,
+    });
+    this.publishState();
+    this.scheduleNextWake();
+    return taskRunId;
+  }
+
+  delTaskRun(taskRunId: string): void {
+    const run = this.runs.get(taskRunId);
+    if (!run) return;
+    run.controller?.abort();
+    this.runs.delete(taskRunId);
+    this.publishTaskRun(run, undefined);
+    this.publishState();
+    this.scheduleNextWake();
+  }
+
+  getTaskRunInfo(taskRunId: string): TaskRunInfo | undefined {
+    const run = this.runs.get(taskRunId);
+    return run ? this.toTaskRunInfo(run) : undefined;
+  }
+
+  getScheduledTaskRunIds(): readonly string[] {
+    return this.scheduledSnapshot;
+  }
+
+  getRunningTaskRunIds(): readonly string[] {
+    return this.runningSnapshot;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.stateListeners.add(listener);
+    return () => this.stateListeners.delete(listener);
+  }
+
+  addTaskRunRunningListener(
+    taskId: string,
+    taskRunId: string | null,
+    listener: TaskRunListener,
+  ): number {
+    const id = this.nextListenerId++;
+    this.taskRunListeners.set(id, { taskId, taskRunId, listener });
+    return id;
+  }
+
+  delListener(listenerId: number): void {
+    this.taskRunListeners.delete(listenerId);
+  }
+
+  untilTaskRunDone(taskRunId: string): Promise<void> {
+    const run = this.runs.get(taskRunId);
+    if (!run) return Promise.resolve();
+    return new Promise((resolve) => {
+      const listenerId = this.addTaskRunRunningListener(
+        run.taskId,
+        taskRunId,
+        (_scheduler, _taskId, _runId, running) => {
+          if (running !== undefined) return;
+          this.delListener(listenerId);
+          resolve();
+        },
+      );
+    });
+  }
+
+  private scheduleNextWake(): void {
+    if (!this.started) return;
+    const nextDeadline = this.getNextDeadline();
+    if (nextDeadline === null) {
+      this.clearTimer();
+      return;
+    }
+    if (this.timer && this.timerDeadline === nextDeadline) return;
+
+    this.clearTimer();
+    this.timerDeadline = nextDeadline;
+    this.timer = setTimeout(
+      () => {
+        this.timer = null;
+        this.timerDeadline = null;
+        this.tick();
+      },
+      Math.min(MAX_TIMEOUT_MS, Math.max(0, nextDeadline - Date.now())),
+    );
+  }
+
+  private clearTimer(): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+    this.timerDeadline = null;
+  }
+
+  private getNextDeadline(): number | null {
+    let deadline = Number.POSITIVE_INFINITY;
+    for (const run of this.runs.values()) {
+      deadline = Math.min(deadline, run.nextTimestamp);
+    }
+    return Number.isFinite(deadline) ? deadline : null;
+  }
+
+  private tick(): void {
+    const now = Date.now();
+    const due = [...this.runs.values()].filter(
+      (run) => run.nextTimestamp <= now,
+    );
+    for (const run of due) {
+      if (run.running) {
+        this.timeoutRun(run);
+      } else {
+        this.startRun(run);
+      }
+    }
+    this.scheduleNextWake();
+  }
+
+  private startRun(run: TaskRun): void {
+    const definition = this.tasks.get(run.taskId);
+    if (!definition) {
+      this.runs.delete(run.id);
+      this.publishTaskRun(run, undefined);
+      this.publishState();
+      return;
+    }
+
+    const config = { ...definition.config, ...run.config };
+    run.retriesRemaining ??= Math.max(0, config.maxRetries ?? 0);
+    run.retryDelays ??= parseRetryDelays(config.retryDelay ?? 1_000);
+    run.repeatDelay ??= config.repeatDelay ?? null;
+    run.timeout = Math.max(1, config.maxDuration ?? 1_000);
+    run.running = true;
+    const controller = new AbortController();
+    run.controller = controller;
+    run.nextTimestamp = Date.now() + run.timeout;
+    this.publishTaskRun(run, true);
+    this.publishState();
+    this.scheduleNextWake();
+
+    void Promise.resolve()
+      .then(() =>
+        definition.task(run.arg, controller.signal, this.toTaskRunInfo(run)),
+      )
+      .then(
+        () => this.finishRun(run.id),
+        () => this.failRun(run.id),
+      );
+  }
+
+  private finishRun(taskRunId: string): void {
+    const run = this.runs.get(taskRunId);
+    if (!run || !run.running || run.controller?.signal.aborted) return;
+    const repeatDelay = run.repeatDelay;
+    if (repeatDelay !== null && repeatDelay !== undefined) {
+      run.running = false;
+      run.controller = undefined;
+      run.nextTimestamp = Date.now() + Math.max(0, repeatDelay);
+      run.retry = 0;
+      run.retriesRemaining = undefined;
+      run.retryDelays = undefined;
+      run.repeatDelay = undefined;
+      run.timeout = undefined;
+      this.publishTaskRun(run, false);
+    } else {
+      this.runs.delete(taskRunId);
+      this.publishTaskRun(run, undefined);
+    }
+    this.publishState();
+    this.scheduleNextWake();
+  }
+
+  private failRun(taskRunId: string): void {
+    const run = this.runs.get(taskRunId);
+    if (!run || !run.running || run.controller?.signal.aborted) return;
+    this.retryOrDelete(run);
+  }
+
+  private timeoutRun(run: TaskRun): void {
+    run.controller?.abort();
+    this.retryOrDelete(run);
+  }
+
+  private retryOrDelete(run: TaskRun): void {
+    const retriesRemaining = run.retriesRemaining ?? 0;
+    if (retriesRemaining > 0) {
+      const retryDelays = run.retryDelays ?? [1_000];
+      const retryDelay =
+        retryDelays[Math.min(run.retry, retryDelays.length - 1)]!;
+      run.retriesRemaining = retriesRemaining - 1;
+      run.retry += 1;
+      run.running = false;
+      run.controller = undefined;
+      run.nextTimestamp = Date.now() + retryDelay;
+      this.publishTaskRun(run, false);
+    } else {
+      this.runs.delete(run.id);
+      this.publishTaskRun(run, undefined);
+    }
+    this.publishState();
+    this.scheduleNextWake();
+  }
+
+  private publishState(): void {
+    this.scheduledSnapshot = [...this.runs.values()]
+      .filter((run) => !run.running)
+      .sort((left, right) => left.nextTimestamp - right.nextTimestamp)
+      .map((run) => run.id);
+    this.runningSnapshot = [...this.runs.values()]
+      .filter((run) => run.running)
+      .sort((left, right) => left.nextTimestamp - right.nextTimestamp)
+      .map((run) => run.id);
+    this.stateListeners.forEach((listener) => listener());
+  }
+
+  private publishTaskRun(run: TaskRun, running: boolean | undefined): void {
+    for (const entry of this.taskRunListeners.values()) {
+      if (
+        entry.taskId === run.taskId &&
+        (entry.taskRunId === null || entry.taskRunId === run.id)
+      ) {
+        entry.listener(this, run.taskId, run.id, running);
+      }
+    }
+  }
+
+  private toTaskRunInfo(run: TaskRun): TaskRunInfo {
+    return {
+      manager: this,
+      taskId: run.taskId,
+      taskRunId: run.id,
+      arg: run.arg,
+      retry: run.retry,
+      running: run.running,
+      nextTimestamp: run.nextTimestamp,
+    };
+  }
+}
+
+const TaskSchedulerContext = createContext<TaskScheduler | null>(null);
+
+export function TaskSchedulerProvider({
+  scheduler,
+  children,
+}: {
+  scheduler: TaskScheduler;
+  children: React.ReactNode;
+}) {
+  return (
+    <TaskSchedulerContext.Provider value={scheduler}>
+      {children}
+    </TaskSchedulerContext.Provider>
+  );
+}
+
+export function useTaskScheduler(): TaskScheduler | null {
+  return useContext(TaskSchedulerContext);
+}
+
+export function useScheduledTaskRunIds(): readonly string[] {
+  const scheduler = useTaskScheduler();
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      scheduler?.subscribe(listener) ?? emptySubscribe(),
+    [scheduler],
+  );
+  const getSnapshot = useCallback(
+    () => scheduler?.getScheduledTaskRunIds() ?? EMPTY_TASK_RUN_IDS,
+    [scheduler],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, emptySnapshot);
+}
+
+export function useRunningTaskRunIds(): readonly string[] {
+  const scheduler = useTaskScheduler();
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      scheduler?.subscribe(listener) ?? emptySubscribe(),
+    [scheduler],
+  );
+  const getSnapshot = useCallback(
+    () => scheduler?.getRunningTaskRunIds() ?? EMPTY_TASK_RUN_IDS,
+    [scheduler],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, emptySnapshot);
+}
+
+export function useRegisterTask(
+  taskId: string,
+  task: Task,
+  config: TaskRunConfig = EMPTY_TASK_RUN_CONFIG,
+): void {
+  const scheduler = useTaskScheduler();
+  const taskRef = useRef(task);
+  taskRef.current = task;
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  useMountEffect(() => {
+    if (!scheduler) return;
+    scheduler.setTask(
+      taskId,
+      (arg, signal, info) => taskRef.current(arg, signal, info),
+      configRef.current,
+    );
+    return () => scheduler.delTask(taskId);
+  });
+}
+
+export function useScheduleTaskRun(
+  taskId: string,
+  arg?: unknown,
+  startAfter = 0,
+  config: TaskRunConfig = EMPTY_TASK_RUN_CONFIG,
+): void {
+  const scheduler = useTaskScheduler();
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  useMountEffect(() => {
+    if (!scheduler) return;
+    const taskRunId = scheduler.scheduleTaskRun(
+      taskId,
+      arg,
+      startAfter,
+      configRef.current,
+    );
+    return () => scheduler.delTaskRun(taskRunId);
+  });
+}
+
+export function useScheduleTaskRunCallback(
+  taskId: string,
+  arg?: unknown,
+  startAfter = 0,
+  config: TaskRunConfig = EMPTY_TASK_RUN_CONFIG,
+): () => string | undefined {
+  const scheduler = useTaskScheduler();
+  return useCallback(
+    () => scheduler?.scheduleTaskRun(taskId, arg, startAfter, config),
+    [arg, config, scheduler, startAfter, taskId],
+  );
+}
+
+function parseRetryDelays(value: number | string): number[] {
+  const values = typeof value === "string" ? value.split(",") : [value];
+  const delays = values
+    .map(Number)
+    .filter((delay) => Number.isFinite(delay) && delay >= 0);
+  return delays.length > 0 ? delays : [1_000];
+}
+
+const EMPTY_TASK_RUN_IDS: readonly string[] = [];
+const EMPTY_TASK_RUN_CONFIG: TaskRunConfig = {};
+const emptySnapshot = () => EMPTY_TASK_RUN_IDS;
+const emptySubscribe = () => () => {};
+
+export function createTaskScheduler(): TaskScheduler {
+  return new TaskScheduler();
+}

--- a/apps/desktop/src/session/components/note-input/search/matching.ts
+++ b/apps/desktop/src/session/components/note-input/search/matching.ts
@@ -18,6 +18,19 @@ export type TranscriptSearchSource = (
   opts: SearchOptions,
 ) => MatchResult[];
 
+export type TranscriptSearchWord = {
+  id: string | null;
+  text: string;
+  scrollIntoView: () => void;
+};
+
+export type TranscriptSearchIndex = {
+  entries: { element: HTMLElement; id: string | null }[];
+  spanPositions: { start: number; end: number }[];
+  normalizedText: string;
+  foldedText: string;
+};
+
 const transcriptSearchSources = new WeakMap<
   HTMLElement,
   Map<symbol, TranscriptSearchSource>
@@ -126,18 +139,26 @@ export function getTranscriptMatches(
 }
 
 export function getTranscriptWordMatches(
-  words: { id: string | null; text: string; scrollIntoView: () => void }[],
+  words: TranscriptSearchWord[],
   prepared: string,
   opts: SearchOptions,
 ): MatchResult[] {
-  return getTranscriptEntryMatches(
+  return getTranscriptSearchIndexMatches(
+    createTranscriptSearchIndex(words),
+    prepared,
+    opts,
+  );
+}
+
+export function createTranscriptSearchIndex(
+  words: TranscriptSearchWord[],
+): TranscriptSearchIndex {
+  return createTranscriptEntryIndex(
     words.map((word) => ({
       element: { scrollIntoView: word.scrollIntoView } as HTMLElement,
       id: word.id,
       text: word.text,
     })),
-    prepared,
-    opts,
   );
 }
 
@@ -146,6 +167,16 @@ function getTranscriptEntryMatches(
   prepared: string,
   opts: SearchOptions,
 ): MatchResult[] {
+  return getTranscriptSearchIndexMatches(
+    createTranscriptEntryIndex(entries),
+    prepared,
+    opts,
+  );
+}
+
+function createTranscriptEntryIndex(
+  entries: { element: HTMLElement; id: string | null; text: string }[],
+): TranscriptSearchIndex {
   const spanPositions: { start: number; end: number }[] = [];
   let fullText = "";
 
@@ -157,35 +188,53 @@ function getTranscriptEntryMatches(
     spanPositions.push({ start, end: fullText.length });
   }
 
-  const searchText = prepareText(fullText, opts.caseSensitive);
+  const normalizedText = fullText.normalize("NFC");
+  return {
+    entries: entries.map(({ element, id }) => ({ element, id })),
+    spanPositions,
+    normalizedText,
+    foldedText: normalizedText.toLowerCase(),
+  };
+}
+
+export function getTranscriptSearchIndexMatches(
+  index: TranscriptSearchIndex,
+  prepared: string,
+  opts: SearchOptions,
+): MatchResult[] {
+  const searchText = opts.caseSensitive
+    ? index.normalizedText
+    : index.foldedText;
   const indices = findOccurrences(searchText, prepared, opts.wholeWord);
   const result: MatchResult[] = [];
   let spanIndex = 0;
 
   for (const idx of indices) {
     while (
-      spanIndex < spanPositions.length - 1 &&
-      idx >= spanPositions[spanIndex].end &&
-      idx >= spanPositions[spanIndex + 1].start
+      spanIndex < index.spanPositions.length - 1 &&
+      idx >= index.spanPositions[spanIndex].end &&
+      idx >= index.spanPositions[spanIndex + 1].start
     ) {
       spanIndex += 1;
     }
 
-    const { start, end } = spanPositions[spanIndex];
+    const position = index.spanPositions[spanIndex];
+    if (!position) continue;
+    const { start, end } = position;
     if (idx >= start && idx < end) {
       result.push({
-        element: entries[spanIndex].element,
-        id: entries[spanIndex].id,
+        element: index.entries[spanIndex].element,
+        id: index.entries[spanIndex].id,
       });
       continue;
     }
 
     if (
-      spanIndex < spanPositions.length - 1 &&
+      spanIndex < index.spanPositions.length - 1 &&
       idx >= end &&
-      idx < spanPositions[spanIndex + 1].start
+      idx < index.spanPositions[spanIndex + 1].start
     ) {
-      const nextSpan = entries[spanIndex + 1];
+      const nextSpan = index.entries[spanIndex + 1];
       result.push({
         element: nextSpan.element,
         id: nextSpan.id,

--- a/apps/desktop/src/session/components/note-input/transcript/render-request-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/render-request-hooks.test.tsx
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   humanIds: [] as string[],
   humans: [{ human_id: "human-1", name: "Alice" }],
   participantHumanIds: ["human-1"],
+  transcriptQueryArgs: [] as unknown[],
   transcript: {
     id: "transcript-1",
     ownerUserId: "user-1",
@@ -27,7 +28,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock("~/stt/queries", () => ({
   useSessionParticipantHumanIds: () => mocks.participantHumanIds,
   useSessionTranscripts: () => [mocks.transcript],
-  useTranscript: () => mocks.transcript,
+  useTranscript: (...args: unknown[]) => {
+    mocks.transcriptQueryArgs = args;
+    return mocks.transcript;
+  },
   useTranscriptHumans: (humanIds: string[]) => {
     mocks.humanIds = humanIds;
     return mocks.humans;
@@ -42,6 +46,13 @@ import {
 describe("SQLite transcript render data", () => {
   beforeEach(() => {
     mocks.humanIds = [];
+    mocks.transcriptQueryArgs = [];
+  });
+
+  it("can read only the compacted base for an active transcript", () => {
+    renderHook(() => useTranscriptRenderData("transcript-1", false));
+
+    expect(mocks.transcriptQueryArgs).toEqual(["transcript-1", false]);
   });
 
   it("builds a renderer request from one canonical transcript", () => {

--- a/apps/desktop/src/session/components/note-input/transcript/render-request-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/render-request-hooks.ts
@@ -20,11 +20,14 @@ export type TranscriptRowWithId = {
   row: TranscriptRow;
 };
 
-export function useTranscriptRenderData(transcriptId: string): {
+export function useTranscriptRenderData(
+  transcriptId: string,
+  includePendingDeltas = true,
+): {
   request: RenderTranscriptRequest | null;
   transcriptRows: TranscriptRowWithId[];
 } {
-  const transcript = useTranscript(transcriptId);
+  const transcript = useTranscript(transcriptId, includePendingDeltas);
   const transcripts = useMemo(
     () => (transcript ? [transcript] : emptyTranscripts),
     [transcript],

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
@@ -48,6 +48,11 @@ describe("useRenderedTranscriptData", () => {
   it("keeps settled transcript data cached across short tab remounts", () => {
     renderHook(() => useRenderedTranscriptData("transcript-1"));
 
+    expect(mocks.useTranscriptRenderData).toHaveBeenCalledWith(
+      "transcript-1",
+      true,
+    );
+
     expect(mocks.useQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: [
@@ -66,6 +71,11 @@ describe("useRenderedTranscriptData", () => {
 
   it("keeps one reusable render baseline while the transcript is active", () => {
     renderHook(() => useRenderedTranscriptData("transcript-1", true));
+
+    expect(mocks.useTranscriptRenderData).toHaveBeenCalledWith(
+      "transcript-1",
+      false,
+    );
 
     expect(mocks.useQuery).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -32,7 +32,7 @@ export function useRenderedTranscriptData(
   request: RenderTranscriptRequest | null;
   segments: Segment[];
 } {
-  const { request } = useTranscriptRenderData(transcriptId);
+  const { request } = useTranscriptRenderData(transcriptId, !currentActive);
   // Recovery needs the persisted prefix. The active key stays stable across
   // word and assignment writes so tab remounts reuse the same native render.
   const activeBaselineRef = useRef<{

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/virtual-segments.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/virtual-segments.tsx
@@ -11,7 +11,8 @@ import {
 } from "react";
 
 import {
-  getTranscriptWordMatches,
+  createTranscriptSearchIndex,
+  getTranscriptSearchIndexMatches,
   registerTranscriptSearchSource,
   type TranscriptSearchSource,
 } from "../../search/matching";
@@ -86,14 +87,14 @@ export function useVirtualSegments({
   }, [estimatedHeights, measuredHeights, segmentKeys]);
   const totalHeight = offsets[offsets.length - 1] ?? 0;
   const viewport = useVirtualViewport(scrollElement, listElement);
+  const segmentIndex = useMemo(() => createSegmentIndex(segments), [segments]);
 
-  const activeMatchIndex = useMemo(
-    () => findWordSegmentIndex(segments, activeMatchId),
-    [activeMatchId, segments],
-  );
+  const activeMatchIndex = activeMatchId
+    ? (segmentIndex.wordIndexes.get(activeMatchId) ?? null)
+    : null;
   const playbackIndex = useMemo(
-    () => findPlaybackSegmentIndex(segments, currentMs, offsetMs),
-    [currentMs, offsetMs, segments],
+    () => findPlaybackSegmentIndex(segmentIndex, currentMs, offsetMs),
+    [currentMs, offsetMs, segmentIndex],
   );
   const selectedIndexes = useSelectedSegmentIndexes(listElement);
   const virtualItems = useMemo(() => {
@@ -215,18 +216,21 @@ export function useVirtualSegments({
     scrollToIndex,
   ]);
 
-  searchSourceRef.current = (preparedQuery, options) =>
-    getTranscriptWordMatches(
-      segments.flatMap((segment, index) =>
-        segment.words.map((word) => ({
-          id: word.id ?? null,
-          text: word.text.trim(),
-          scrollIntoView: () => scrollToIndexRef.current(index, "smooth"),
-        })),
+  const searchIndex = useMemo(
+    () =>
+      createTranscriptSearchIndex(
+        segments.flatMap((segment, index) =>
+          segment.words.map((word) => ({
+            id: word.id ?? null,
+            text: word.text.trim(),
+            scrollIntoView: () => scrollToIndexRef.current(index, "smooth"),
+          })),
+        ),
       ),
-      preparedQuery,
-      options,
-    );
+    [segments],
+  );
+  searchSourceRef.current = (preparedQuery, options) =>
+    getTranscriptSearchIndexMatches(searchIndex, preparedQuery, options);
 
   const listRef = useCallback(
     (node: HTMLDivElement | null) => {
@@ -355,40 +359,98 @@ function useVirtualViewport(
   scrollElement: HTMLDivElement | null,
   listElement: HTMLDivElement | null,
 ) {
-  const subscribe = useCallback(
-    (notify: () => void) => {
-      if (!scrollElement) return () => {};
-      scrollElement.addEventListener("scroll", notify, { passive: true });
-      window.addEventListener("resize", notify);
-      const observer =
-        typeof ResizeObserver === "undefined"
-          ? null
-          : new ResizeObserver(notify);
-      observer?.observe(scrollElement);
-      if (listElement) observer?.observe(listElement);
-
-      return () => {
-        scrollElement.removeEventListener("scroll", notify);
-        window.removeEventListener("resize", notify);
-        observer?.disconnect();
-      };
-    },
+  const store = useMemo(
+    () => createVirtualViewportStore(scrollElement, listElement),
     [listElement, scrollElement],
   );
-  const getSnapshot = useCallback(() => {
-    if (!scrollElement) {
-      return `0|${FALLBACK_VIEWPORT_HEIGHT}|0`;
-    }
-    const scrollRect = scrollElement.getBoundingClientRect();
-    const listRect = listElement?.getBoundingClientRect();
-    const listTop = listRect
-      ? scrollElement.scrollTop + listRect.top - scrollRect.top
-      : scrollElement.scrollTop;
-    return `${scrollElement.scrollTop}|${scrollElement.clientHeight || FALLBACK_VIEWPORT_HEIGHT}|${listTop}`;
-  }, [listElement, scrollElement]);
-  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const snapshot = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  );
   const [scrollTop, height, listTop] = snapshot.split("|").map(Number);
   return { scrollTop, height, listTop };
+}
+
+function createVirtualViewportStore(
+  scrollElement: HTMLDivElement | null,
+  listElement: HTMLDivElement | null,
+) {
+  let listTop: number | null = null;
+  let snapshot = "0|800|0";
+  let animationFrame: number | null = null;
+  let shouldMeasureList = true;
+  const listeners = new Set<() => void>();
+
+  const refresh = (measureList: boolean) => {
+    if (!scrollElement) {
+      snapshot = `0|${FALLBACK_VIEWPORT_HEIGHT}|0`;
+      return;
+    }
+
+    if (measureList || listTop === null) {
+      const scrollRect = scrollElement.getBoundingClientRect();
+      const listRect = listElement?.getBoundingClientRect();
+      listTop = listRect
+        ? scrollElement.scrollTop + listRect.top - scrollRect.top
+        : scrollElement.scrollTop;
+    }
+    const next = `${scrollElement.scrollTop}|${scrollElement.clientHeight || FALLBACK_VIEWPORT_HEIGHT}|${listTop}`;
+    if (next !== snapshot) {
+      snapshot = next;
+      listeners.forEach((listener) => listener());
+    }
+  };
+
+  const scheduleRefresh = (measureList = false) => {
+    shouldMeasureList ||= measureList;
+    if (animationFrame !== null) return;
+    animationFrame = requestAnimationFrame(() => {
+      animationFrame = null;
+      const measure = shouldMeasureList;
+      shouldMeasureList = false;
+      refresh(measure);
+    });
+  };
+
+  refresh(true);
+  const subscribe = (listener: () => void) => {
+    if (!scrollElement) return () => {};
+    listeners.add(listener);
+    const handleScroll = () => scheduleRefresh();
+    const handleLayout = () => scheduleRefresh(true);
+    scrollElement.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleLayout);
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(handleLayout);
+    resizeObserver?.observe(scrollElement);
+    if (listElement) resizeObserver?.observe(listElement);
+    const mutationObserver =
+      typeof MutationObserver === "undefined"
+        ? null
+        : new MutationObserver(handleLayout);
+    mutationObserver?.observe(scrollElement, {
+      childList: true,
+      subtree: true,
+    });
+    scheduleRefresh(true);
+
+    return () => {
+      listeners.delete(listener);
+      scrollElement.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleLayout);
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame);
+        animationFrame = null;
+      }
+    };
+  };
+
+  return { getSnapshot: () => snapshot, subscribe };
 }
 
 function findRowIndex(offsets: number[], target: number): number {
@@ -406,31 +468,70 @@ function findRowIndex(offsets: number[], target: number): number {
   return low;
 }
 
-function findWordSegmentIndex(
-  segments: Segment[],
-  wordId: string | null,
-): number | null {
-  if (!wordId) return null;
-  const index = segments.findIndex((segment) =>
-    segment.words.some((word) => word.id === wordId),
-  );
-  return index < 0 ? null : index;
+function createSegmentIndex(segments: Segment[]) {
+  const wordIndexes = new Map<string, number>();
+  const playbackStarts: number[] = [];
+  const playbackEnds: number[] = [];
+  const playbackSegmentIndexes: number[] = [];
+  const playbackPrefixMaxEnds: number[] = [];
+
+  segments.forEach((segment, segmentIndex) => {
+    for (const word of segment.words) {
+      if (word.id && !wordIndexes.has(word.id)) {
+        wordIndexes.set(word.id, segmentIndex);
+      }
+    }
+    const first = segment.words[0];
+    const last = segment.words[segment.words.length - 1];
+    if (!first || !last) return;
+    const start = first.start_ms ?? 0;
+    const end = last.end_ms ?? 0;
+    playbackStarts.push(start);
+    playbackEnds.push(end);
+    playbackSegmentIndexes.push(segmentIndex);
+    playbackPrefixMaxEnds.push(
+      Math.max(
+        playbackPrefixMaxEnds[playbackPrefixMaxEnds.length - 1] ??
+          Number.NEGATIVE_INFINITY,
+        end,
+      ),
+    );
+  });
+
+  return {
+    wordIndexes,
+    playbackStarts,
+    playbackEnds,
+    playbackSegmentIndexes,
+    playbackPrefixMaxEnds,
+  };
 }
 
 function findPlaybackSegmentIndex(
-  segments: Segment[],
+  index: ReturnType<typeof createSegmentIndex>,
   currentMs: number,
   offsetMs: number,
 ): number | null {
   if (currentMs <= 0) return null;
-  const index = segments.findIndex((segment) => {
-    const first = segment.words[0];
-    const last = segment.words[segment.words.length - 1];
-    if (!first || !last) return false;
-    return (
-      currentMs >= offsetMs + (first.start_ms ?? 0) &&
-      currentMs <= offsetMs + (last.end_ms ?? 0)
-    );
-  });
-  return index < 0 ? null : index;
+  const target = currentMs - offsetMs;
+  let low = 0;
+  let high = index.playbackStarts.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (index.playbackStarts[middle]! <= target) low = middle + 1;
+    else high = middle;
+  }
+  const lastStarted = low - 1;
+  if (lastStarted < 0) return null;
+
+  low = 0;
+  high = lastStarted;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (index.playbackPrefixMaxEnds[middle]! < target) low = middle + 1;
+    else high = middle;
+  }
+  return index.playbackEnds[low]! >= target
+    ? index.playbackSegmentIndexes[low]!
+    : null;
 }

--- a/apps/desktop/src/session/hooks/useEventCountdown.ts
+++ b/apps/desktop/src/session/hooks/useEventCountdown.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 
 import { useSessionEvent } from "~/session/hooks/useSessionEvent";
 
@@ -7,43 +7,84 @@ const FIVE_MINUTES = 5 * 60 * 1000;
 export function useEventCountdown(sessionId: string) {
   const sessionEvent = useSessionEvent(sessionId);
   const startedAt = sessionEvent?.started_at;
+  const store = useMemo(() => createCountdownStore(startedAt), [startedAt]);
+  const label = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  );
 
-  const [label, setLabel] = useState<string | null>(null);
+  return { label };
+}
 
-  useEffect(() => {
-    if (!startedAt) {
-      setLabel(null);
+function getCountdownLabel(startedAt: string | undefined, nowMs: number) {
+  if (!startedAt) return null;
+  const diff = new Date(startedAt).getTime() - nowMs;
+  if (diff <= 0 || diff > FIVE_MINUTES) return null;
+
+  const totalSeconds = Math.floor(diff / 1000);
+  const mins = Math.floor(totalSeconds / 60);
+  const secs = totalSeconds % 60;
+  return mins > 0 ? `starts in ${mins}m ${secs}s` : `starts in ${secs}s`;
+}
+
+function createCountdownStore(startedAt: string | undefined) {
+  const eventStart = startedAt ? new Date(startedAt).getTime() : Number.NaN;
+  let label = getCountdownLabel(startedAt, Date.now());
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const listeners = new Set<() => void>();
+
+  const scheduleRefresh = () => {
+    clearTimeout(timeout);
+    timeout = undefined;
+    if (
+      listeners.size === 0 ||
+      !Number.isFinite(eventStart) ||
+      document.visibilityState === "hidden"
+    ) {
       return;
     }
 
-    const eventStart = new Date(startedAt).getTime();
+    const diff = eventStart - Date.now();
+    if (diff <= 0) return;
+    if (diff > FIVE_MINUTES) {
+      timeout = setTimeout(refresh, Math.ceil(diff - FIVE_MINUTES));
+      return;
+    }
 
-    let interval: ReturnType<typeof setInterval>;
+    const remainder = diff % 1000;
+    timeout = setTimeout(
+      refresh,
+      remainder === 0 ? 1000 : Math.max(1, Math.floor(remainder) + 1),
+    );
+  };
 
-    const update = () => {
-      const diff = eventStart - Date.now();
+  const refresh = () => {
+    const nextLabel = getCountdownLabel(startedAt, Date.now());
+    if (nextLabel !== label) {
+      label = nextLabel;
+      listeners.forEach((listener) => listener());
+    }
+    scheduleRefresh();
+  };
 
-      if (diff <= 0) {
-        setLabel(null);
-        clearInterval(interval);
-        return;
-      }
-
-      if (diff > FIVE_MINUTES) {
-        setLabel(null);
-        return;
-      }
-
-      const totalSeconds = Math.floor(diff / 1000);
-      const mins = Math.floor(totalSeconds / 60);
-      const secs = totalSeconds % 60;
-      setLabel(mins > 0 ? `starts in ${mins}m ${secs}s` : `starts in ${secs}s`);
+  const subscribe = (listener: () => void) => {
+    listeners.add(listener);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") refresh();
+      else scheduleRefresh();
     };
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    refresh();
 
-    update();
-    interval = setInterval(update, 1000);
-    return () => clearInterval(interval);
-  }, [startedAt]);
+    return () => {
+      listeners.delete(listener);
+      scheduleRefresh();
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  };
 
-  return { label };
+  return { getSnapshot: () => label, subscribe };
 }

--- a/apps/desktop/src/settings/sync/index.tsx
+++ b/apps/desktop/src/settings/sync/index.tsx
@@ -295,7 +295,7 @@ export function SettingsSync() {
     queryKey: statusQueryKey,
     queryFn: getCloudsyncStatus,
     refetchInterval: STATUS_POLL_INTERVAL_MS,
-    refetchIntervalInBackground: true,
+    refetchIntervalInBackground: false,
     enabled: Boolean(session) && isPro && syncEnabled,
   });
   const syncNowMutation = useMutation({

--- a/apps/desktop/src/shared-notes/attachment-cache-runner.test.ts
+++ b/apps/desktop/src/shared-notes/attachment-cache-runner.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   runSharedAttachmentCacheJob,
   runSharedAttachmentCachePass,
+  startSharedAttachmentCacheRunner,
 } from "./attachment-cache-runner";
 import { SharedAttachmentGatewayError } from "./attachment-client";
 
@@ -47,6 +48,9 @@ function dependencies() {
       clearSharedAttachmentScope: vi.fn().mockResolvedValue(0),
     },
     store: {
+      subscribeToNextAttempt: vi
+        .fn()
+        .mockResolvedValue(vi.fn(async () => undefined)),
       recoverInterrupted: vi.fn().mockResolvedValue(undefined),
       claimNext: vi.fn().mockResolvedValue(null),
       completeDownload: vi.fn().mockResolvedValue(true),
@@ -58,6 +62,27 @@ function dependencies() {
 }
 
 describe("shared attachment cache runner", () => {
+  it("does not poll an empty cache queue", async () => {
+    vi.useFakeTimers();
+    const deps = dependencies();
+    const unsubscribe = vi.fn(async () => undefined);
+    deps.store.subscribeToNextAttempt.mockResolvedValueOnce(unsubscribe);
+
+    try {
+      const stop = startSharedAttachmentCacheRunner(deps as never);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(deps.store.claimNext).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(deps.store.claimNext).toHaveBeenCalledOnce();
+      stop();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(unsubscribe).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("downloads only a grant that exactly matches the cached manifest", async () => {
     const deps = dependencies();
 

--- a/apps/desktop/src/shared-notes/attachment-cache-runner.ts
+++ b/apps/desktop/src/shared-notes/attachment-cache-runner.ts
@@ -143,11 +143,50 @@ export function startSharedAttachmentCacheRunner(
   dependencies: SharedAttachmentCacheRunnerDependencies,
 ) {
   const controller = new AbortController();
+  const store = dependencies.store ?? sharedAttachmentCacheStore;
   let timeout: ReturnType<typeof setTimeout> | undefined;
   let initialized = false;
+  let nextAttemptAt: number | null = null;
+  let fallbackAt: number | null = null;
+  let running = false;
+  let runAgain = false;
+  let unsubscribeStarted = false;
+  let unsubscribePromise: Promise<() => Promise<void>> | undefined;
+
+  const reschedule = () => {
+    clearTimeout(timeout);
+    timeout = undefined;
+    if (controller.signal.aborted || running) return;
+
+    const deadline = [nextAttemptAt, fallbackAt]
+      .filter((value): value is number => value !== null)
+      .reduce(
+        (earliest, value) => Math.min(earliest, value),
+        Number.POSITIVE_INFINITY,
+      );
+    if (Number.isFinite(deadline)) {
+      timeout = setTimeout(
+        () => void tick(),
+        Math.max(0, deadline - Date.now()),
+      );
+    }
+  };
 
   const tick = async () => {
     if (controller.signal.aborted) return;
+    if (running) {
+      runAgain = true;
+      return;
+    }
+    running = true;
+    clearTimeout(timeout);
+    timeout = undefined;
+    const now = Date.now();
+    if (nextAttemptAt !== null && nextAttemptAt <= now) nextAttemptAt = null;
+    if (fallbackAt !== null && fallbackAt <= now) {
+      fallbackAt = now + PASS_INTERVAL_MS;
+    }
+
     try {
       if (!initialized) {
         const native = dependencies.native ?? attachmentTransferNative;
@@ -158,21 +197,67 @@ export function startSharedAttachmentCacheRunner(
         );
         initialized = true;
       }
-      await runSharedAttachmentCachePass(dependencies, controller.signal);
+      const processed = await runSharedAttachmentCachePass(
+        dependencies,
+        controller.signal,
+      );
+      if (processed === MAX_JOBS_PER_PASS) runAgain = true;
     } catch (error) {
       if (!controller.signal.aborted) {
         console.error("[shared-attachments] cache pass failed", error);
+        fallbackAt = Date.now() + PASS_INTERVAL_MS;
       }
+    } finally {
+      running = false;
     }
-    if (!controller.signal.aborted) {
-      timeout = setTimeout(() => void tick(), PASS_INTERVAL_MS);
+
+    if (runAgain && !controller.signal.aborted) {
+      runAgain = false;
+      void tick();
+    } else {
+      reschedule();
     }
   };
+
+  const subscribeToNextAttempt = store.subscribeToNextAttempt?.bind(store);
+  if (!subscribeToNextAttempt) fallbackAt = Date.now() + PASS_INTERVAL_MS;
+  unsubscribePromise = subscribeToNextAttempt?.(
+    dependencies.viewerUserId,
+    (value) => {
+      const timestamp = value ? Date.parse(value) : Number.NaN;
+      nextAttemptAt = Number.isFinite(timestamp) ? timestamp : null;
+      fallbackAt = null;
+      if (running && nextAttemptAt !== null && nextAttemptAt <= Date.now()) {
+        runAgain = true;
+      } else {
+        reschedule();
+      }
+    },
+    (error) => {
+      console.error("[shared-attachments] queue subscription failed", error);
+      fallbackAt = Date.now() + PASS_INTERVAL_MS;
+      reschedule();
+    },
+  ).catch((error) => {
+    if (!controller.signal.aborted) {
+      console.error("[shared-attachments] queue subscription failed", error);
+      fallbackAt = Date.now() + PASS_INTERVAL_MS;
+      reschedule();
+    }
+    return async () => {};
+  });
   void tick();
 
   return () => {
     controller.abort();
-    if (timeout) clearTimeout(timeout);
+    clearTimeout(timeout);
+    if (!unsubscribePromise || unsubscribeStarted) return;
+    unsubscribeStarted = true;
+    void unsubscribePromise
+      .then((unsubscribe) => unsubscribe())
+      .catch((error) =>
+        console.error("[shared-attachments] queue unsubscribe failed", error),
+      );
   };
 }
 

--- a/apps/desktop/src/shared-notes/attachment-cache-store.ts
+++ b/apps/desktop/src/shared-notes/attachment-cache-store.ts
@@ -42,6 +42,26 @@ type CacheSqlRow = {
 const WRITE_KEY = "shared-attachment-cache-runner";
 
 export const sharedAttachmentCacheStore = {
+  subscribeToNextAttempt(
+    viewerUserId: string,
+    onChange: (nextAttemptAt: string | null) => void,
+    onError?: (error: string) => void,
+  ) {
+    return liveQueryClient.subscribe<{ next_attempt_at: string | null }>(
+      `
+        SELECT MIN(next_attempt_at) AS next_attempt_at
+        FROM shared_session_attachment_cache
+        WHERE viewer_user_id = ?
+          AND availability IN ('pending', 'delete_pending', 'failed')
+      `,
+      [viewerUserId],
+      {
+        onData: (rows) => onChange(rows[0]?.next_attempt_at ?? null),
+        onError,
+      },
+    );
+  },
+
   async recoverInterrupted(viewerUserId: string) {
     await enqueueDatabaseWrite(WRITE_KEY, () =>
       executeTransaction([

--- a/apps/desktop/src/shared/hooks/useCurrentDay.ts
+++ b/apps/desktop/src/shared/hooks/useCurrentDay.ts
@@ -1,7 +1,7 @@
 import { useMemo, useSyncExternalStore } from "react";
 
 export function useCurrentDay(timezone?: string) {
-  const store = useMemo(() => createCurrentDayStore(timezone), [timezone]);
+  const store = useMemo(() => getCurrentDayStore(timezone), [timezone]);
   return useSyncExternalStore(
     store.subscribe,
     store.getSnapshot,
@@ -9,36 +9,87 @@ export function useCurrentDay(timezone?: string) {
   );
 }
 
+const currentDayStores = new Map<
+  string,
+  ReturnType<typeof createCurrentDayStore>
+>();
+
+function getCurrentDayStore(timezone: string | undefined) {
+  const key = timezone ?? "";
+  let store = currentDayStores.get(key);
+  if (!store) {
+    store = createCurrentDayStore(timezone);
+    currentDayStores.set(key, store);
+  }
+  return store;
+}
+
 function createCurrentDayStore(timezone?: string) {
-  const getCurrentDay = () =>
-    new Intl.DateTimeFormat("en-CA", {
-      day: "2-digit",
-      month: "2-digit",
-      timeZone: timezone,
-      year: "numeric",
-    }).format(new Date());
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    day: "2-digit",
+    month: "2-digit",
+    timeZone: timezone,
+    year: "numeric",
+  });
+  const getCurrentDay = (timestamp = Date.now()) =>
+    formatter.format(new Date(timestamp));
   let currentDay = getCurrentDay();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const listeners = new Set<() => void>();
+
+  const getNextDayDelay = () => {
+    const now = Date.now();
+    const today = getCurrentDay(now);
+    let low = now + 1;
+    let high = now + 36 * 60 * 60 * 1000;
+    while (getCurrentDay(high) === today) high += 12 * 60 * 60 * 1000;
+
+    while (low < high) {
+      const middle = Math.floor((low + high) / 2);
+      if (getCurrentDay(middle) === today) low = middle + 1;
+      else high = middle;
+    }
+    return Math.max(1, low - now);
+  };
+
+  const scheduleRefresh = () => {
+    clearTimeout(timeout);
+    timeout = undefined;
+    if (listeners.size === 0 || document.visibilityState === "hidden") return;
+    timeout = setTimeout(refresh, getNextDayDelay());
+  };
+
+  const refresh = () => {
+    const nextDay = getCurrentDay();
+    if (nextDay !== currentDay) {
+      currentDay = nextDay;
+      listeners.forEach((listener) => listener());
+    }
+    scheduleRefresh();
+  };
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") refresh();
+    else scheduleRefresh();
+  };
 
   const subscribe = (listener: () => void) => {
-    const refresh = () => {
-      const nextDay = getCurrentDay();
-      if (nextDay === currentDay) return;
-      currentDay = nextDay;
-      listener();
-    };
-    const interval = setInterval(refresh, 60_000);
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") refresh();
-    };
-
-    window.addEventListener("focus", refresh);
-    document.addEventListener("visibilitychange", handleVisibilityChange);
+    if (listeners.size === 0) {
+      window.addEventListener("focus", refresh);
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+    }
+    listeners.add(listener);
     refresh();
 
     return () => {
-      clearInterval(interval);
-      window.removeEventListener("focus", refresh);
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        scheduleRefresh();
+        window.removeEventListener("focus", refresh);
+        document.removeEventListener(
+          "visibilitychange",
+          handleVisibilityChange,
+        );
+      }
     };
   };
 

--- a/apps/desktop/src/shared/hooks/useDeeplinkHandler.ts
+++ b/apps/desktop/src/shared/hooks/useDeeplinkHandler.ts
@@ -1,7 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { isTauri } from "@tauri-apps/api/core";
 import { useRef } from "react";
-import { useScheduleTaskRunCallback } from "tinytick/ui-react";
 
 import {
   type DeepLink,
@@ -19,6 +18,7 @@ import {
   removeDisconnectedCalendarConnection,
   syncCalendarEvents,
 } from "~/services/calendar";
+import { useScheduleTaskRunCallback } from "~/services/task-scheduler";
 import {
   createShareOpenProcessor,
   subscribeThenDrainShareOpens,

--- a/apps/desktop/src/sidebar/timeline/upcoming-meeting.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/upcoming-meeting.test.tsx
@@ -139,9 +139,8 @@ describe("useSidebarUpcomingMeetingStatus", () => {
       title: "Team standup",
     });
 
-    vi.setSystemTime(new Date("2024-01-15T12:30:01.000Z"));
     act(() => {
-      vi.advanceTimersByTime(1_000);
+      vi.advanceTimersByTime(30 * 60_000 + 1);
     });
 
     expect(active.result.current).toBeNull();

--- a/apps/desktop/src/sidebar/timeline/upcoming-meeting.ts
+++ b/apps/desktop/src/sidebar/timeline/upcoming-meeting.ts
@@ -84,32 +84,44 @@ function createUpcomingMeetingStatusStore(
   activeLabel: string,
 ) {
   const getCurrentStatus = () =>
-    getUpcomingMeetingStatus(
-      buckets,
-      Math.floor(Date.now() / UPCOMING_MEETING_STATUS_TICK_MS) *
-        UPCOMING_MEETING_STATUS_TICK_MS,
-      formatLabel,
-      activeLabel,
-    );
+    getUpcomingMeetingStatus(buckets, Date.now(), formatLabel, activeLabel);
   let status = getCurrentStatus();
   const listeners = new Set<() => void>();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
 
-  const refresh = () => {
-    const nextStatus = getCurrentStatus();
-    if (upcomingMeetingStatusesAreEqual(status, nextStatus)) {
+  const scheduleRefresh = () => {
+    clearTimeout(timeout);
+    timeout = undefined;
+    if (listeners.size === 0 || document.visibilityState === "hidden") {
       return;
     }
 
-    status = nextStatus;
-    listeners.forEach((listener) => listener());
+    const delayMs = getNextUpcomingMeetingStatusRefreshMs(
+      buckets,
+      Date.now(),
+      status,
+    );
+    if (delayMs !== null) {
+      timeout = setTimeout(refresh, delayMs);
+    }
+  };
+
+  const refresh = () => {
+    const nextStatus = getCurrentStatus();
+    if (!upcomingMeetingStatusesAreEqual(status, nextStatus)) {
+      status = nextStatus;
+      listeners.forEach((listener) => listener());
+    }
+    scheduleRefresh();
   };
 
   const subscribe = (listener: () => void) => {
     listeners.add(listener);
-    const interval = setInterval(refresh, UPCOMING_MEETING_STATUS_TICK_MS);
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         refresh();
+      } else {
+        scheduleRefresh();
       }
     };
 
@@ -119,7 +131,7 @@ function createUpcomingMeetingStatusStore(
 
     return () => {
       listeners.delete(listener);
-      clearInterval(interval);
+      scheduleRefresh();
       window.removeEventListener("focus", refresh);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
@@ -129,6 +141,43 @@ function createUpcomingMeetingStatusStore(
     getSnapshot: () => status,
     subscribe,
   };
+}
+
+export function getNextUpcomingMeetingStatusRefreshMs(
+  buckets: TimelineBucket[],
+  currentTimeMs: number,
+  status: SidebarUpcomingMeetingStatus | null,
+): number | null {
+  if (status?.progress !== undefined && status.progress < 1) {
+    const remainder = currentTimeMs % UPCOMING_MEETING_STATUS_TICK_MS;
+    return Math.max(1, UPCOMING_MEETING_STATUS_TICK_MS - remainder);
+  }
+
+  let nextDeadlineMs = Number.POSITIVE_INFINITY;
+  for (const bucket of buckets) {
+    for (const item of bucket.items) {
+      if (item.type === "event" && item.data.is_all_day) continue;
+
+      const { start, end } = getItemTimeRange(item);
+      const startsAtMs = start?.getTime();
+      if (startsAtMs === undefined) continue;
+
+      const deadlines = [
+        startsAtMs - UPCOMING_MEETING_VISIBLE_WINDOW_MS,
+        startsAtMs,
+        end ? end.getTime() + 1 : Number.NaN,
+      ];
+      for (const deadlineMs of deadlines) {
+        if (deadlineMs > currentTimeMs && deadlineMs < nextDeadlineMs) {
+          nextDeadlineMs = deadlineMs;
+        }
+      }
+    }
+  }
+
+  return Number.isFinite(nextDeadlineMs)
+    ? Math.max(1, Math.ceil(nextDeadlineMs - currentTimeMs))
+    : null;
 }
 
 export function getUpcomingMeetingStatus(

--- a/apps/desktop/src/stt/queries.test.tsx
+++ b/apps/desktop/src/stt/queries.test.tsx
@@ -168,6 +168,37 @@ describe("transcript SQLite queries", () => {
     ]);
   });
 
+  it("skips live journal replay for an active renderer baseline", () => {
+    mocks.transcriptRows = [
+      {
+        id: "transcript-1",
+        owner_user_id: "user-1",
+        session_id: "session-1",
+        started_at_ms: 1000,
+        ended_at_ms: null,
+        words_json: JSON.stringify([
+          {
+            id: "word-base",
+            text: "Base",
+            start_ms: 0,
+            end_ms: 100,
+            channel: 0,
+          },
+        ]),
+        speaker_hints_json: "[]",
+        content_revision: 0,
+        pending_deltas_json: "[]",
+      },
+    ];
+
+    const { result } = renderHook(() => useTranscript("transcript-1", false));
+
+    expect(result.current?.words.map((word) => word.id)).toEqual(["word-base"]);
+    expect(mocks.queryOptions[0]?.sql).not.toContain(
+      "FROM transcript_live_deltas AS delta",
+    );
+  });
+
   it("projects transcript metadata without transferring content blobs", () => {
     mocks.transcriptRows = [
       {

--- a/apps/desktop/src/stt/queries.ts
+++ b/apps/desktop/src/stt/queries.ts
@@ -7,6 +7,7 @@ import { commands as transcriptionCommands } from "@anlg/plugin-transcription";
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
 import type { SegmentKey } from "~/stt/live-segment";
+import { coalesceLiveTranscriptDeltas } from "~/stt/transcript-persistence-worker";
 import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
 import {
   applyLiveTranscriptDelta,
@@ -108,6 +109,18 @@ const TRANSCRIPT_COLUMNS = `
   ), '[]') AS pending_deltas_json
 `;
 
+const TRANSCRIPT_BASE_COLUMNS = `
+  transcript.id,
+  transcript.owner_user_id,
+  transcript.session_id,
+  transcript.started_at_ms,
+  transcript.ended_at_ms,
+  transcript.words_json,
+  transcript.speaker_hints_json,
+  transcript.content_revision,
+  '[]' AS pending_deltas_json
+`;
+
 const TRANSCRIPT_METADATA_COLUMNS = `
   transcript.id,
   transcript.session_id,
@@ -147,13 +160,16 @@ export function useSessionTranscripts(sessionId: string): TranscriptRecord[] {
   return sessionId ? data : EMPTY_TRANSCRIPTS;
 }
 
-export function useTranscript(transcriptId: string): TranscriptRecord | null {
+export function useTranscript(
+  transcriptId: string,
+  includePendingDeltas = true,
+): TranscriptRecord | null {
   const { data = null } = useLiveQuery<
     TranscriptSqlRow,
     TranscriptRecord | null
   >({
     sql: `
-      SELECT ${TRANSCRIPT_COLUMNS}
+      SELECT ${includePendingDeltas ? TRANSCRIPT_COLUMNS : TRANSCRIPT_BASE_COLUMNS}
       FROM transcripts AS transcript
       WHERE transcript.id = ? AND transcript.deleted_at IS NULL
       LIMIT 1
@@ -707,19 +723,16 @@ function materializeTranscriptSnapshot(
   transcriptId: string,
   pendingDeltasJson: string,
 ) {
-  let snapshot = { wordsJson, hintsJson };
-  for (const delta of parseLiveTranscriptDeltas(
-    pendingDeltasJson,
-    transcriptId,
-  )) {
-    snapshot = mutateTranscriptSnapshot(
-      snapshot.wordsJson,
-      snapshot.hintsJson,
+  const deltas = parseLiveTranscriptDeltas(pendingDeltasJson, transcriptId);
+  if (deltas.length === 0) return { wordsJson, hintsJson };
+
+  return mutateTranscriptSnapshot(wordsJson, hintsJson, transcriptId, (store) =>
+    applyLiveTranscriptDelta(
+      store,
       transcriptId,
-      (store) => applyLiveTranscriptDelta(store, transcriptId, delta),
-    );
-  }
-  return snapshot;
+      coalesceLiveTranscriptDeltas(deltas),
+    ),
+  );
 }
 
 function parseLiveTranscriptDeltas(

--- a/apps/desktop/src/stt/scheduled-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-auto-start.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useRef } from "react";
+
 import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { getCurrentWebviewWindowLabel } from "@anlg/plugin-windows";
 import { safeParseDate } from "@anlg/utils";
@@ -126,6 +128,13 @@ export function ScheduledMeetingAutoStart() {
   ] as const);
   const autoStartRef = useLatestRef(autoStart);
   const autoJoinRef = useLatestRef(autoJoin);
+  const configChangedRef = useRef<() => void>(() => {});
+  const configChangeNodeRef = useCallback(
+    (node: HTMLSpanElement | null) => {
+      if (node) configChangedRef.current();
+    },
+    [autoJoin, autoStart],
+  );
 
   useMountEffect(() => {
     if (getCurrentWebviewWindowLabel() !== "main") {
@@ -136,16 +145,47 @@ export function ScheduledMeetingAutoStart() {
     let rows: ScheduledMeetingRow[] = [];
     let unsubscribe: (() => Promise<void>) | null = null;
     let starting = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     const firedEventIds = new Set<string>();
 
+    const scheduleTick = (delayMs: number) => {
+      clearTimeout(timeout);
+      timeout = setTimeout(
+        () => {
+          timeout = undefined;
+          tick();
+        },
+        Math.max(1, delayMs),
+      );
+    };
+
+    const scheduleNextStart = () => {
+      clearTimeout(timeout);
+      timeout = undefined;
+      if (!autoStartRef.current) return;
+
+      const now = Date.now();
+      const nextStart = rows.reduce((earliest, row) => {
+        if (firedEventIds.has(row.id)) return earliest;
+        const start = safeParseDate(row.started_at)?.getTime();
+        return start !== undefined && start > now
+          ? Math.min(earliest, start)
+          : earliest;
+      }, Number.POSITIVE_INFINITY);
+      if (Number.isFinite(nextStart)) {
+        scheduleTick(nextStart - now);
+      }
+    };
+
     const tick = () => {
-      // Ticks come from both the interval and calendar updates; without this a
-      // second tick could open another meeting mid-start.
+      // Deadlines and state updates can coincide; without this a second tick
+      // could open another meeting mid-start.
       if (starting) {
         return;
       }
 
       if (!autoStartRef.current) {
+        scheduleNextStart();
         return;
       }
 
@@ -161,24 +201,32 @@ export function ScheduledMeetingAutoStart() {
         });
       }
 
-      if (
-        hasScheduledAutoStartInFlight() ||
-        hasPendingAutoStart(useTabs.getState().tabs)
-      ) {
-        return;
-      }
-
-      if (listenerStore.getState().live.status !== "inactive") {
-        return;
-      }
-
       const due = selectDueMeetings({
         rows,
         nowMs: Date.now(),
         firedEventIds,
       });
       const next = due[0];
+      const scheduleAfterTransientBlock = () => {
+        if (next) scheduleTick(TICK_MS);
+        else scheduleNextStart();
+      };
+
+      if (
+        hasScheduledAutoStartInFlight() ||
+        hasPendingAutoStart(useTabs.getState().tabs)
+      ) {
+        scheduleAfterTransientBlock();
+        return;
+      }
+
+      if (listenerStore.getState().live.status !== "inactive") {
+        scheduleAfterTransientBlock();
+        return;
+      }
+
       if (!next) {
+        scheduleNextStart();
         return;
       }
 
@@ -188,6 +236,7 @@ export function ScheduledMeetingAutoStart() {
           // A blocked start is transient (another session finalizing, a start
           // already in flight), so leave it eligible for the next tick.
           if (outcome === "blocked") {
+            scheduleTick(TICK_MS);
             return;
           }
 
@@ -207,13 +256,18 @@ export function ScheduledMeetingAutoStart() {
             "[listener] failed to auto-start scheduled meeting",
             error,
           );
+          scheduleTick(TICK_MS);
         })
         .finally(() => {
           starting = false;
+          if (!timeout) tick();
         });
     };
-
-    const interval = setInterval(tick, TICK_MS);
+    configChangedRef.current = tick;
+    const unsubscribeTabs = useTabs.subscribe(tick);
+    const unsubscribeListener = listenerStore.subscribe((state, previous) => {
+      if (state.live.status !== previous.live.status) tick();
+    });
 
     void liveQueryClient
       .subscribe<ScheduledMeetingRow>(SCHEDULED_MEETINGS_SQL, [], {
@@ -241,10 +295,13 @@ export function ScheduledMeetingAutoStart() {
 
     return () => {
       cancelled = true;
-      clearInterval(interval);
+      configChangedRef.current = () => {};
+      clearTimeout(timeout);
+      unsubscribeTabs();
+      unsubscribeListener();
       void unsubscribe?.();
     };
   });
 
-  return null;
+  return <span ref={configChangeNodeRef} hidden aria-hidden="true" />;
 }

--- a/apps/desktop/src/stt/transcript-persistence-worker.ts
+++ b/apps/desktop/src/stt/transcript-persistence-worker.ts
@@ -315,6 +315,14 @@ function toDelta(pendingWrite: PendingTranscriptWrite): LiveTranscriptDelta {
   };
 }
 
+export function coalesceLiveTranscriptDeltas(
+  deltas: readonly LiveTranscriptDelta[],
+): LiveTranscriptDelta {
+  const pendingWrite = createPendingWrite();
+  for (const delta of deltas) mergeDelta(pendingWrite, delta);
+  return toDelta(pendingWrite);
+}
+
 function removePendingWords(
   pendingWrite: PendingTranscriptWrite,
   wordId: string,

--- a/apps/desktop/src/stt/useLocalSttModel.ts
+++ b/apps/desktop/src/stt/useLocalSttModel.ts
@@ -33,7 +33,6 @@ export const localSttQueries = {
     }),
   isDownloaded: (model: LocalModel) =>
     queryOptions({
-      refetchInterval: 1000,
       queryKey: localSttKeys.modelDownloaded(model),
       queryFn: () => localSttCommands.isModelDownloaded(model),
       select: (result) => {
@@ -45,7 +44,6 @@ export const localSttQueries = {
     }),
   isDownloading: (model: LocalModel) =>
     queryOptions({
-      refetchInterval: 1000,
       queryKey: localSttKeys.modelDownloading(model),
       queryFn: () => localSttCommands.isModelDownloading(model),
       select: (result) => {
@@ -68,6 +66,7 @@ export function useLocalModelDownload(
   const isDownloaded = useQuery(localSttQueries.isDownloaded(model));
   const isDownloading = useQuery(localSttQueries.isDownloading(model));
   const refetchDownloaded = isDownloaded.refetch;
+  const refetchDownloading = isDownloading.refetch;
 
   const showProgress =
     !isDownloaded.data && (isStarting || (isDownloading.data ?? false));
@@ -86,11 +85,16 @@ export function useLocalModelDownload(
           setErrorMessage(status.failed);
           setIsStarting(false);
           setProgress(0);
+          void refetchDownloading();
         } else if (status === "completed") {
           setErrorMessage(null);
           setProgress(100);
+          setIsStarting(false);
+          void refetchDownloaded();
+          void refetchDownloading();
         } else if (typeof status === "object" && "downloading" in status) {
           setErrorMessage(null);
+          setIsStarting(true);
           setProgress(Math.max(0, Math.min(100, status.downloading)));
         }
       }
@@ -99,7 +103,7 @@ export function useLocalModelDownload(
     return () => {
       void unlisten.then((fn) => fn());
     };
-  }, [model]);
+  }, [model, refetchDownloaded, refetchDownloading]);
 
   useEffect(() => {
     if (isDownloaded.data && progress > 0) {
@@ -124,10 +128,12 @@ export function useLocalModelDownload(
   }, [isDownloaded.data, isDownloading.data, isStarting, model]);
 
   const handleCancel = useCallback(() => {
-    void localSttCommands.cancelDownload(model);
+    void localSttCommands
+      .cancelDownload(model)
+      .then(() => refetchDownloading());
     setIsStarting(false);
     setProgress(0);
-  }, [model]);
+  }, [model, refetchDownloading]);
 
   const handleDelete = useCallback(() => {
     void localSttCommands.deleteModel(model).then((result) => {

--- a/apps/desktop/src/stt/useSTTConnection.ts
+++ b/apps/desktop/src/stt/useSTTConnection.ts
@@ -49,7 +49,8 @@ export const useSTTConnection = () => {
   const local = useQuery({
     enabled: isLocalModel,
     queryKey: ["stt-connection", current_stt_provider, localModel],
-    refetchInterval: 1000,
+    refetchInterval: (query) =>
+      query.state.data?.status === "loading" ? 1000 : false,
     queryFn: async () => {
       if (!localModel) {
         return null;

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(() => ({
   plugins: [
     relayShim(),
     changelog(),
-    tanstackRouter({ target: "react", autoCodeSplitting: false }),
+    tanstackRouter({ target: "react", autoCodeSplitting: true }),
     react(),
     lingui(),
     babel({

--- a/crates/detect/src/lib.rs
+++ b/crates/detect/src/lib.rs
@@ -91,10 +91,25 @@ pub struct Detector {
 #[cfg(feature = "mic")]
 impl Detector {
     pub fn start(&mut self, f: DetectCallback) {
-        self.mic_detector.start(f.clone());
+        #[cfg(all(target_os = "macos", feature = "zoom", feature = "list"))]
+        let zoom_mic_usage = ZoomMicUsage::default();
+        #[cfg(all(target_os = "macos", feature = "zoom", feature = "list"))]
+        let mic_callback = {
+            let f = f.clone();
+            let zoom_mic_usage = zoom_mic_usage.clone();
+            new_callback(move |event| {
+                zoom_mic_usage.update_from_mic_event(&event);
+                f(event);
+            })
+        };
+        #[cfg(not(all(target_os = "macos", feature = "zoom", feature = "list")))]
+        let mic_callback = f.clone();
+
+        self.mic_detector.start(mic_callback);
 
         #[cfg(all(target_os = "macos", feature = "zoom", feature = "list"))]
-        self.zoom_watcher.start(f.clone());
+        self.zoom_watcher
+            .start_with_mic_usage(f.clone(), zoom_mic_usage);
 
         #[cfg(all(target_os = "macos", feature = "sleep"))]
         self.sleep_detector.start(f);

--- a/crates/detect/src/mic/macos/mod.rs
+++ b/crates/detect/src/mic/macos/mod.rs
@@ -3,7 +3,7 @@ mod device;
 mod state;
 
 use cidre::core_audio as ca;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::mpsc;
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -19,7 +19,6 @@ const DEVICE_IS_RUNNING_SOMEWHERE: ca::PropAddr = ca::PropAddr {
 };
 
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
-const DEBOUNCE_TICK_INTERVAL: Duration = Duration::from_millis(50);
 const LISTENER_GENERATION_IDLE: u8 = 0;
 const LISTENER_GENERATION_ACTIVE: u8 = 1;
 const LISTENER_GENERATION_DISABLED: u8 = 2;
@@ -273,13 +272,19 @@ impl Drop for CoreAudioListeners {
 }
 
 struct Worker {
-    shutdown_tx: mpsc::Sender<()>,
+    shutdown: std::sync::Arc<AtomicBool>,
+    signal_tx: mpsc::SyncSender<WorkerSignal>,
     thread: JoinHandle<()>,
+}
+
+pub(super) enum WorkerSignal {
+    Wake,
 }
 
 impl Worker {
     fn stop(self) {
-        let _ = self.shutdown_tx.send(());
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.signal_tx.try_send(WorkerSignal::Wake);
 
         if self.thread.thread().id() == std::thread::current().id() {
             return;
@@ -332,22 +337,49 @@ impl crate::Observer for Detector {
             }
         }
 
-        let (shutdown_tx, shutdown_rx) = mpsc::channel();
+        let shutdown = std::sync::Arc::new(AtomicBool::new(false));
+        let thread_shutdown = shutdown.clone();
+        let (signal_tx, signal_rx) = mpsc::sync_channel(1);
+        let context_signal_tx = signal_tx.clone();
         let thread = match std::thread::Builder::new()
             .name("coreaudio-mic-detector".to_string())
             .spawn(move || {
                 let generation = ListenerGeneration::new();
-                let ctx = SharedContext::new(f);
+                let ctx = SharedContext::with_worker_signal(f, context_signal_tx);
                 let _listeners = CoreAudioListeners::new(ctx.clone_shared(), generation);
                 let mut last_app_poll = std::time::Instant::now();
 
-                while let Err(mpsc::RecvTimeoutError::Timeout) =
-                    shutdown_rx.recv_timeout(DEBOUNCE_TICK_INTERVAL)
-                {
+                loop {
+                    if thread_shutdown.load(Ordering::SeqCst) {
+                        break;
+                    }
                     ctx.flush_pending_mic_change();
-                    if last_app_poll.elapsed() >= POLL_INTERVAL {
+                    if ctx.app_polling_active() && last_app_poll.elapsed() >= POLL_INTERVAL {
                         poll_apps(&ctx);
                         last_app_poll = std::time::Instant::now();
+                    }
+
+                    let now = std::time::Instant::now();
+                    let debounce_wait = ctx.next_pending_delay(now);
+                    let app_poll_wait = ctx.app_polling_active().then(|| {
+                        POLL_INTERVAL.saturating_sub(now.saturating_duration_since(last_app_poll))
+                    });
+                    let wait = match (debounce_wait, app_poll_wait) {
+                        (Some(debounce), Some(app_poll)) => Some(debounce.min(app_poll)),
+                        (Some(debounce), None) => Some(debounce),
+                        (None, Some(app_poll)) => Some(app_poll),
+                        (None, None) => None,
+                    };
+
+                    match wait {
+                        Some(wait) => match signal_rx.recv_timeout(wait) {
+                            Ok(WorkerSignal::Wake) | Err(mpsc::RecvTimeoutError::Timeout) => {}
+                            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                        },
+                        None => match signal_rx.recv() {
+                            Ok(WorkerSignal::Wake) => {}
+                            Err(_) => break,
+                        },
                     }
                 }
             }) {
@@ -360,7 +392,8 @@ impl crate::Observer for Detector {
         };
 
         self.worker = Some(Worker {
-            shutdown_tx,
+            shutdown,
+            signal_tx,
             thread,
         });
     }

--- a/crates/detect/src/mic/macos/state.rs
+++ b/crates/detect/src/mic/macos/state.rs
@@ -1,8 +1,10 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
 use crate::{DetectEvent, InstalledApp};
+
+use super::WorkerSignal;
 
 pub(super) struct DetectorState {
     /// Latest physical state reported by CoreAudio.
@@ -96,10 +98,26 @@ pub(super) struct SharedContext {
     polling_fallback_required: Arc<AtomicBool>,
     device_listener_context_retention_required: Arc<AtomicBool>,
     listener_callbacks_active: Arc<AtomicBool>,
+    worker_signal: Option<mpsc::SyncSender<WorkerSignal>>,
 }
 
 impl SharedContext {
+    #[cfg(test)]
     pub(super) fn new(callback: crate::DetectCallback) -> Self {
+        Self::new_inner(callback, None)
+    }
+
+    pub(super) fn with_worker_signal(
+        callback: crate::DetectCallback,
+        worker_signal: mpsc::SyncSender<WorkerSignal>,
+    ) -> Self {
+        Self::new_inner(callback, Some(worker_signal))
+    }
+
+    fn new_inner(
+        callback: crate::DetectCallback,
+        worker_signal: Option<mpsc::SyncSender<WorkerSignal>>,
+    ) -> Self {
         Self {
             callback: Arc::new(Mutex::new(callback)),
             current_device: Arc::new(Mutex::new(None)),
@@ -109,6 +127,7 @@ impl SharedContext {
             polling_fallback_required: Arc::new(AtomicBool::new(false)),
             device_listener_context_retention_required: Arc::new(AtomicBool::new(false)),
             listener_callbacks_active: Arc::new(AtomicBool::new(true)),
+            worker_signal,
         }
     }
 
@@ -124,6 +143,13 @@ impl SharedContext {
                 .device_listener_context_retention_required
                 .clone(),
             listener_callbacks_active: self.listener_callbacks_active.clone(),
+            worker_signal: self.worker_signal.clone(),
+        }
+    }
+
+    fn wake_worker(&self) {
+        if let Some(worker_signal) = &self.worker_signal {
+            let _ = worker_signal.try_send(WorkerSignal::Wake);
         }
     }
 
@@ -142,6 +168,7 @@ impl SharedContext {
 
     pub(super) fn enable_polling_fallback(&self) {
         self.polling_fallback_active.store(true, Ordering::SeqCst);
+        self.wake_worker();
     }
 
     pub(super) fn require_polling_fallback(&self) {
@@ -152,6 +179,7 @@ impl SharedContext {
     pub(super) fn disable_polling_fallback(&self) {
         if !self.polling_fallback_required.load(Ordering::SeqCst) {
             self.polling_fallback_active.store(false, Ordering::SeqCst);
+            self.wake_worker();
         }
     }
 
@@ -213,6 +241,15 @@ impl SharedContext {
         self.flush_pending_mic_change_at(Instant::now());
     }
 
+    pub(super) fn next_pending_delay(&self, now: Instant) -> Option<Duration> {
+        self.state.lock().ok().and_then(|state| {
+            state
+                .pending_change
+                .as_ref()
+                .map(|pending| pending.emit_at.saturating_duration_since(now))
+        })
+    }
+
     pub(super) fn seed_running_state(&self, mic_in_use: bool) {
         let app_snapshot = if mic_in_use {
             crate::list_mic_using_apps()
@@ -233,6 +270,7 @@ impl SharedContext {
 
         state_guard.seed(mic_in_use, Instant::now());
         self.polling_active.store(mic_in_use, Ordering::SeqCst);
+        self.wake_worker();
 
         if !mic_in_use {
             state_guard.active_apps.clear();
@@ -296,6 +334,7 @@ impl SharedContext {
 
         let event = state_guard.record_edge(mic_in_use, event, now);
         drop(state_guard);
+        self.wake_worker();
         if let Some(event) = event {
             self.emit(event);
         }

--- a/crates/detect/src/sleep.rs
+++ b/crates/detect/src/sleep.rs
@@ -1,7 +1,5 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::thread::JoinHandle;
-use std::time::Duration;
 
 use block2::RcBlock;
 use objc2::{msg_send, rc::Retained};
@@ -26,14 +24,14 @@ impl Drop for SleepObserver {
 }
 
 pub struct SleepDetector {
-    running: Arc<AtomicBool>,
+    shutdown_tx: Option<mpsc::Sender<()>>,
     thread_handle: Option<JoinHandle<()>>,
 }
 
 impl Default for SleepDetector {
     fn default() -> Self {
         Self {
-            running: Arc::new(AtomicBool::new(false)),
+            shutdown_tx: None,
             thread_handle: None,
         }
     }
@@ -41,12 +39,12 @@ impl Default for SleepDetector {
 
 impl crate::Observer for SleepDetector {
     fn start(&mut self, f: DetectCallback) {
-        if self.running.load(Ordering::SeqCst) {
+        if self.thread_handle.is_some() {
             return;
         }
 
-        self.running.store(true, Ordering::SeqCst);
-        let running = self.running.clone();
+        let (shutdown_tx, shutdown_rx) = mpsc::channel();
+        self.shutdown_tx = Some(shutdown_tx);
 
         self.thread_handle = Some(std::thread::spawn(move || {
             let will_sleep_callback = f.clone();
@@ -89,18 +87,18 @@ impl crate::Observer for SleepDetector {
                 }
             };
 
-            while running.load(Ordering::SeqCst) {
-                std::thread::sleep(Duration::from_millis(500));
-            }
+            let _ = shutdown_rx.recv();
         }));
     }
 
     fn stop(&mut self) {
-        if !self.running.load(Ordering::SeqCst) {
+        if self.thread_handle.is_none() {
             return;
         }
 
-        self.running.store(false, Ordering::SeqCst);
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
 
         if let Some(handle) = self.thread_handle.take() {
             let _ = handle.join();

--- a/crates/detect/src/zoom.rs
+++ b/crates/detect/src/zoom.rs
@@ -1,10 +1,43 @@
-use std::time::{Duration, Instant};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use cidre::{ax, ns};
 
 use crate::{BackgroundTask, DetectCallback, DetectEvent};
 
 const ZOOM_BUNDLE_ID: &str = "us.zoom.xos";
+const ACTIVE_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Default)]
+pub(crate) struct ZoomMicUsage {
+    active: Arc<AtomicBool>,
+    changed: Arc<tokio::sync::Notify>,
+}
+
+impl ZoomMicUsage {
+    pub(crate) fn set(&self, active: bool) {
+        if self.active.swap(active, Ordering::SeqCst) != active {
+            self.changed.notify_one();
+        }
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn update_from_mic_event(&self, event: &DetectEvent) {
+        match event {
+            DetectEvent::MicStarted(apps) if apps.iter().any(|app| app.id == ZOOM_BUNDLE_ID) => {
+                self.set(true);
+            }
+            DetectEvent::MicStopped(apps) if apps.iter().any(|app| app.id == ZOOM_BUNDLE_ID) => {
+                self.set(false);
+            }
+            _ => {}
+        }
+    }
+}
 
 #[derive(Default)]
 pub struct ZoomMuteWatcher {
@@ -13,16 +46,12 @@ pub struct ZoomMuteWatcher {
 
 struct WatcherState {
     last_mute_state: Option<bool>,
-    last_check: Instant,
-    poll_interval: Duration,
 }
 
 impl WatcherState {
     fn new() -> Self {
         Self {
             last_mute_state: None,
-            last_check: Instant::now(),
-            poll_interval: Duration::from_millis(1000),
         }
     }
 }
@@ -115,6 +144,20 @@ fn reconcile_zoom_mute_state(
 
 impl crate::Observer for ZoomMuteWatcher {
     fn start(&mut self, f: DetectCallback) {
+        self.start_inner(f, None);
+    }
+
+    fn stop(&mut self) {
+        self.background.stop();
+    }
+}
+
+impl ZoomMuteWatcher {
+    pub(crate) fn start_with_mic_usage(&mut self, f: DetectCallback, mic_usage: ZoomMicUsage) {
+        self.start_inner(f, Some(mic_usage));
+    }
+
+    fn start_inner(&mut self, f: DetectCallback, mic_usage: Option<ZoomMicUsage>) {
         if self.background.is_running() {
             return;
         }
@@ -123,40 +166,60 @@ impl crate::Observer for ZoomMuteWatcher {
             return;
         }
 
-        self.background.start(|running, mut rx| async move {
+        self.background.start(move |running, mut rx| async move {
             let mut state = WatcherState::new();
+            if let Some(mic_usage) = &mic_usage {
+                mic_usage.set(is_zoom_using_mic().unwrap_or(false));
+            }
 
             loop {
+                if let Some(mic_usage) = &mic_usage
+                    && !mic_usage.is_active()
+                {
+                    if state.last_mute_state.is_some() {
+                        let _ = reconcile_zoom_mute_state(&mut state, Ok(false), None);
+                    }
+                    tokio::select! {
+                        _ = &mut rx => break,
+                        _ = mic_usage.changed.notified() => continue,
+                    }
+                }
+
                 tokio::select! {
                     _ = &mut rx => {
                         break;
                     }
-                    _ = tokio::time::sleep(state.poll_interval) => {
+                    _ = async {
+                        if let Some(mic_usage) = &mic_usage {
+                            mic_usage.changed.notified().await;
+                        } else {
+                            std::future::pending::<()>().await;
+                        }
+                    } => {
+                        continue;
+                    }
+                    _ = tokio::time::sleep(ACTIVE_POLL_INTERVAL) => {
                         if !running.load(std::sync::atomic::Ordering::SeqCst) {
                             break;
                         }
 
-                        let mic_usage = is_zoom_using_mic();
-                        let mute_state = match mic_usage {
+                        let current_mic_usage = mic_usage
+                            .as_ref()
+                            .map_or_else(is_zoom_using_mic, |usage| Ok(usage.is_active()));
+                        let mute_state = match current_mic_usage {
                             Ok(true) => check_zoom_mute_state(),
                             Ok(false) | Err(_) => None,
                         };
 
-                        if let Some(event) = reconcile_zoom_mute_state(&mut state, mic_usage, mute_state) {
+                        if let Some(event) = reconcile_zoom_mute_state(&mut state, current_mic_usage, mute_state) {
                             f(event);
                         }
-
-                        state.last_check = Instant::now();
                     }
                 }
             }
 
             tracing::info!("zoom mute watcher stopped");
         });
-    }
-
-    fn stop(&mut self) {
-        self.background.stop();
     }
 }
 
@@ -203,6 +266,24 @@ mod tests {
 
         assert!(event.is_none());
         assert_eq!(state.last_mute_state, None);
+    }
+
+    #[test]
+    fn test_zoom_mic_usage_ignores_other_app_deltas() {
+        let usage = ZoomMicUsage::default();
+        usage.set(true);
+
+        usage.update_from_mic_event(&DetectEvent::MicStarted(vec![crate::InstalledApp {
+            id: "com.example.recorder".to_string(),
+            name: "Recorder".to_string(),
+        }]));
+        assert!(usage.is_active());
+
+        usage.update_from_mic_event(&DetectEvent::MicStopped(vec![crate::InstalledApp {
+            id: "com.example.recorder".to_string(),
+            name: "Recorder".to_string(),
+        }]));
+        assert!(usage.is_active());
     }
 
     // cargo test --package detect --lib --features mic,list,zoom -- zoom::tests::test_watcher --exact --nocapture --ignored

--- a/plugins/detect/src/competitor_monitor.rs
+++ b/plugins/detect/src/competitor_monitor.rs
@@ -4,24 +4,32 @@ use std::time::Duration;
 
 const TERMINATION_INTERVAL: Duration = Duration::from_secs(5);
 
+#[derive(Default)]
+struct CompetitorTerminationInner {
+    pause_count: AtomicUsize,
+    changed: tokio::sync::Notify,
+}
+
 #[derive(Clone, Default)]
-pub(crate) struct CompetitorTerminationState(Arc<AtomicUsize>);
+pub(crate) struct CompetitorTerminationState(Arc<CompetitorTerminationInner>);
 
 impl CompetitorTerminationState {
     pub fn set_paused(&self, paused: bool) {
         if paused {
-            self.0.fetch_add(1, Ordering::SeqCst);
+            self.0.pause_count.fetch_add(1, Ordering::SeqCst);
         } else {
             let _ = self
                 .0
+                .pause_count
                 .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
                     count.checked_sub(1)
                 });
         }
+        self.0.changed.notify_one();
     }
 
     pub fn is_paused(&self) -> bool {
-        self.0.load(Ordering::SeqCst) > 0
+        self.0.pause_count.load(Ordering::SeqCst) > 0
     }
 }
 
@@ -35,16 +43,21 @@ async fn run(
     terminate: impl Fn() -> Vec<anlg_detect::InstalledApp> + Send + 'static,
 ) {
     loop {
-        if !state.is_paused() {
-            let terminated = terminate();
-            if !terminated.is_empty() {
-                tracing::info!(
-                    apps = ?terminated.iter().map(|app| &app.name).collect::<Vec<_>>(),
-                    "terminated competing meeting assistants"
-                );
-            }
+        while state.is_paused() {
+            state.0.changed.notified().await;
         }
-        tokio::time::sleep(TERMINATION_INTERVAL).await;
+
+        let terminated = terminate();
+        if !terminated.is_empty() {
+            tracing::info!(
+                apps = ?terminated.iter().map(|app| &app.name).collect::<Vec<_>>(),
+                "terminated competing meeting assistants"
+            );
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(TERMINATION_INTERVAL) => {}
+            _ = state.0.changed.notified() => {}
+        }
     }
 }
 

--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -14,7 +14,10 @@ use tauri::{
 };
 
 use crate::{
-    schedule::{TrayAgendaSection, TrayScheduleEvent, agenda_sections, menu_bar_title},
+    schedule::{
+        TrayAgendaSection, TrayScheduleEvent, agenda_sections, menu_bar_title,
+        next_schedule_refresh_ms,
+    },
     tray_icon::{RECORDING_FRAMES, TrayIconState},
 };
 
@@ -222,22 +225,7 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
         Self::refresh_menu_bar_title(app)?;
         Self::refresh_menu_if_agenda_changed(app)?;
 
-        let mut task = SCHEDULE_TASK.lock().unwrap();
-        if task.is_none() {
-            let app = app.clone();
-            *task = Some(tauri::async_runtime::spawn(async move {
-                let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
-                loop {
-                    interval.tick().await;
-                    if let Err(error) = Self::refresh_menu_bar_title(&app) {
-                        tracing::warn!(%error, "failed to refresh menu bar title");
-                    }
-                    if let Err(error) = Self::refresh_menu_if_agenda_changed(&app) {
-                        tracing::warn!(%error, "failed to refresh tray agenda");
-                    }
-                }
-            }));
-        }
+        Self::restart_schedule_task(app);
 
         Ok(())
     }
@@ -252,7 +240,9 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
         let app = self.manager.app_handle();
         Self::persist_show_events(app, show);
         Self::refresh_menu_bar_title(app)?;
-        Self::rebuild_menu(app)
+        Self::rebuild_menu(app)?;
+        Self::restart_schedule_task(app);
+        Ok(())
     }
 
     fn load_show_events(app: &AppHandle<tauri::Wry>) -> bool {
@@ -388,6 +378,47 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
         Ok(())
     }
 
+    fn restart_schedule_task(app: &AppHandle<tauri::Wry>) {
+        let mut task = SCHEDULE_TASK.lock().unwrap();
+        if let Some(handle) = task.take() {
+            handle.abort();
+        }
+
+        let next_delay = || {
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as f64;
+            next_schedule_refresh_ms(
+                &SCHEDULE.lock().unwrap(),
+                now_ms,
+                SHOW_EVENTS.load(Ordering::SeqCst),
+                IS_RECORDING.load(Ordering::SeqCst),
+            )
+        };
+        let Some(initial_delay_ms) = next_delay() else {
+            return;
+        };
+
+        let app = app.clone();
+        *task = Some(tauri::async_runtime::spawn(async move {
+            let mut delay_ms = initial_delay_ms;
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                if let Err(error) = Self::refresh_menu_bar_title(&app) {
+                    tracing::warn!(%error, "failed to refresh menu bar title");
+                }
+                if let Err(error) = Self::refresh_menu_if_agenda_changed(&app) {
+                    tracing::warn!(%error, "failed to refresh tray agenda");
+                }
+                let Some(next_delay_ms) = next_delay() else {
+                    return;
+                };
+                delay_ms = next_delay_ms;
+            }
+        }));
+    }
+
     pub fn set_recording(&self, recording: bool) -> Result<()> {
         IS_RECORDING.store(recording, Ordering::SeqCst);
         if !recording {
@@ -396,7 +427,9 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
 
         let app = self.manager.app_handle();
         Self::refresh_menu_bar_title(app)?;
-        Self::refresh_icon(app)
+        Self::refresh_icon(app)?;
+        Self::restart_schedule_task(app);
+        Ok(())
     }
 
     pub fn set_recording_title(&self, title: Option<String>) -> Result<()> {

--- a/plugins/tray/src/schedule.rs
+++ b/plugins/tray/src/schedule.rs
@@ -100,7 +100,69 @@ pub fn menu_bar_title(
         return None;
     }
 
-    let active = events
+    let active = active_event(events, now_ms);
+
+    if let Some(event) = active {
+        let suffix = format!(
+            " • {} left",
+            duration_label(event.ends_at_ms.unwrap_or(now_ms) - now_ms)
+        );
+        return Some(menu_bar_label(&event.title, &suffix));
+    }
+
+    let event = upcoming_event(events, now_ms)?;
+
+    let suffix = format!(" • in {}", duration_label(event.starts_at_ms - now_ms));
+    Some(menu_bar_label(&event.title, &suffix))
+}
+
+pub fn next_schedule_refresh_ms(
+    events: &[TrayScheduleEvent],
+    now_ms: f64,
+    show_events: bool,
+    is_recording: bool,
+) -> Option<u64> {
+    if !show_events {
+        return None;
+    }
+
+    let mut next_delay_ms = events
+        .iter()
+        .flat_map(|event| {
+            [
+                event.starts_at_ms,
+                event.ends_at_ms.unwrap_or(f64::NAN),
+                event.day_start_ms,
+                event.previous_day_start_ms,
+                event.starts_at_ms - DISPLAY_HORIZON_MS,
+            ]
+        })
+        .filter(|deadline_ms| deadline_ms.is_finite() && *deadline_ms > now_ms)
+        .map(|deadline_ms| deadline_ms - now_ms)
+        .min_by(f64::total_cmp);
+
+    if !is_recording {
+        let displayed_event = active_event(events, now_ms)
+            .map(|event| event.ends_at_ms.unwrap_or(now_ms) - now_ms)
+            .or_else(|| upcoming_event(events, now_ms).map(|event| event.starts_at_ms - now_ms));
+        if let Some(diff_ms) = displayed_event {
+            let total_seconds = (diff_ms / 1000.0).floor().max(1.0) as u64;
+            let quantum_ms = if total_seconds < 60 {
+                1_000.0
+            } else {
+                60_000.0
+            };
+            let label_delay_ms = diff_ms.rem_euclid(quantum_ms).floor() + 1.0;
+            next_delay_ms =
+                Some(next_delay_ms.map_or(label_delay_ms, |delay| delay.min(label_delay_ms)));
+        }
+    }
+
+    next_delay_ms.map(|delay| delay.ceil().max(1.0) as u64)
+}
+
+fn active_event(events: &[TrayScheduleEvent], now_ms: f64) -> Option<&TrayScheduleEvent> {
+    events
         .iter()
         .filter(|event| {
             event.starts_at_ms.is_finite()
@@ -113,17 +175,11 @@ pub fn menu_bar_title(
             left.ends_at_ms
                 .partial_cmp(&right.ends_at_ms)
                 .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        })
+}
 
-    if let Some(event) = active {
-        let suffix = format!(
-            " • {} left",
-            duration_label(event.ends_at_ms.unwrap_or(now_ms) - now_ms)
-        );
-        return Some(menu_bar_label(&event.title, &suffix));
-    }
-
-    let event = events
+fn upcoming_event(events: &[TrayScheduleEvent], now_ms: f64) -> Option<&TrayScheduleEvent> {
+    events
         .iter()
         .filter(|event| {
             event.starts_at_ms.is_finite()
@@ -134,10 +190,7 @@ pub fn menu_bar_title(
             left.starts_at_ms
                 .partial_cmp(&right.starts_at_ms)
                 .unwrap_or(std::cmp::Ordering::Equal)
-        })?;
-
-    let suffix = format!(" • in {}", duration_label(event.starts_at_ms - now_ms));
-    Some(menu_bar_label(&event.title, &suffix))
+        })
 }
 
 fn menu_bar_label(title: &str, suffix: &str) -> String {
@@ -238,6 +291,29 @@ mod tests {
         assert_eq!(
             menu_bar_title(&events, now, true, false, None),
             Some("Standup • in 5m".to_string())
+        );
+    }
+
+    #[test]
+    fn schedules_only_the_next_visible_title_change() {
+        let now = 1_000_000.0;
+        let events = vec![event("Standup", now + 5.0 * 60.0 * 1000.0 + 750.0, None)];
+
+        assert_eq!(
+            next_schedule_refresh_ms(&events, now, true, false),
+            Some(751)
+        );
+        assert_eq!(next_schedule_refresh_ms(&events, now, false, false), None);
+    }
+
+    #[test]
+    fn recording_title_skips_countdown_ticks_but_keeps_event_deadlines() {
+        let now = 1_000_000.0;
+        let events = vec![event("Standup", now + 5.0 * 60.0 * 1000.0 + 750.0, None)];
+
+        assert_eq!(
+            next_schedule_refresh_ms(&events, now, true, true),
+            Some(300_750)
         );
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,9 +345,6 @@ importers:
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      tinytick:
-        specifier: ^1.2.8
-        version: 1.2.8
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -16662,9 +16659,6 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
-
-  tinytick@1.2.8:
-    resolution: {integrity: sha512-tT7/2EIfUcQN4yjREOx7xwL85pooPYg9vahoPcY9/sGdfurR/cp/bgfxlAAKQnIoXjcD8peYhqa6NS3em2PioA==}
 
   tlds@1.261.0:
     resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
@@ -37077,8 +37071,6 @@ snapshots:
   tinyrainbow@1.2.0: {}
 
   tinyrainbow@3.1.0: {}
-
-  tinytick@1.2.8: {}
 
   tlds@1.261.0: {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wide scheduling refactor across calendar sync, attachment queues, and background tasks, but behavior is covered by new/updated tests and mostly changes when work runs, not what it does.
> 
> **Overview**
> This PR cuts idle work by **replacing fixed-interval timers** with scheduling that wakes only when something is actually due.
> 
> **Background jobs:** The **tinytick** dependency is removed in favor of an in-house **`TaskScheduler`** (single timer per next deadline, no idle heartbeat). Calendar sync, `TaskManager`, and related UI now use **`TaskSchedulerProvider`** / **`useRegisterTask`** instead of tinytick’s React bindings.
> 
> **Sync runners:** Attachment transfer and shared-attachment cache runners **stop polling empty queues**; they subscribe to **`MIN(next_attempt_at)`** via live queries and reschedule one timeout, with a fallback interval only when subscription is missing or fails.
> 
> **UI timekeeping:** Clocks and countdowns (`useNow`, `useCurrentDay`, event countdown, sidebar upcoming meeting) move from **`setInterval`** to **`useSyncExternalStore`** stores that compute the next refresh (including pausing when the document is hidden).
> 
> **Other desktop tweaks:** React Query **1s refetch** is limited to loading states (STT, local models, notifications); cloud sync status no longer polls in the background; scheduled meeting auto-start uses DB/subscription deadlines instead of a constant tick; active transcript rendering can **omit live journal replay**; transcript search/virtual list work is **indexed/cached**; Vite **route code splitting** is enabled.
> 
> **Native (Rust):** macOS mic detection uses **worker wake signals** instead of a 50ms debounce loop; Zoom mute watching **idles until Zoom is using the mic**; sleep detector and competitor termination use **blocking wait/notify** instead of spin/sleep loops; tray agenda refresh uses **`next_schedule_refresh_ms`** instead of a 1s interval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d41b330a375f8ca0c91fc9d8912b7406ceb61b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->