### PR TITLE
Fix mobile checkout handoff

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,6 +7,7 @@
     "start": "dotenvx run --ignore MISSING_ENV_FILE -f ../../.env.supabase -f .env -- expo start",
     "android": "dotenvx run --ignore MISSING_ENV_FILE -f ../../.env.supabase -f .env -- expo start --android",
     "ios": "dotenvx run --ignore MISSING_ENV_FILE -f ../../.env.supabase -f .env -- expo start --ios",
+    "test:billing-handoff": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test --experimental-strip-types src/auth/billing-handoff.test.mjs",
     "test:error-reporting": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test --experimental-strip-types src/lib/error-sanitization.test.mjs",
     "test:transcription-limits": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test --experimental-strip-types src/data/transcription-limits.test.mjs",
     "typecheck": "tsc --noEmit"

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -107,6 +107,7 @@ function Gate() {
       <PaywallScreen
         billing={auth.billing}
         email={auth.session?.user.email ?? ""}
+        onRefreshBilling={auth.refreshBilling}
         onSignOut={auth.signOut}
       />
     );

--- a/apps/mobile/src/auth/billing-handoff.test.mjs
+++ b/apps/mobile/src/auth/billing-handoff.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseBillingCallbackUrl,
+  refreshBillingEntitlement,
+} from "./billing-handoff.ts";
+
+test("parses the mobile checkout return without accepting other deep links", () => {
+  assert.deepEqual(
+    parseBillingCallbackUrl(
+      "anarlog://billing/refresh?checkout=paid&source=mobile",
+    ),
+    { checkout: "paid", checkoutType: null, source: "mobile" },
+  );
+  assert.deepEqual(
+    parseBillingCallbackUrl(
+      "anarlog://billing/refresh?checkout=canceled&checkout_type=trial&source=mobile",
+    ),
+    { checkout: "canceled", checkoutType: "trial", source: "mobile" },
+  );
+  assert.equal(parseBillingCallbackUrl("anarlog://auth/callback"), null);
+  assert.equal(
+    parseBillingCallbackUrl("attacker://billing/refresh?checkout=paid"),
+    null,
+  );
+});
+
+test("retries bounded entitlement refresh until Pro is visible", async () => {
+  const waits = [];
+  let attempts = 0;
+  const unlocked = await refreshBillingEntitlement({
+    delaysMs: [0, 10, 20, 30],
+    wait: async (delayMs) => {
+      waits.push(delayMs);
+    },
+    refresh: async () => {
+      attempts += 1;
+      return attempts === 3;
+    },
+  });
+
+  assert.equal(unlocked, true);
+  assert.equal(attempts, 3);
+  assert.deepEqual(waits, [10, 20]);
+});
+
+test("stops after the bounded refresh window", async () => {
+  let attempts = 0;
+  const unlocked = await refreshBillingEntitlement({
+    delaysMs: [0, 1, 2],
+    wait: async () => {},
+    refresh: async () => {
+      attempts += 1;
+      return false;
+    },
+  });
+
+  assert.equal(unlocked, false);
+  assert.equal(attempts, 3);
+});

--- a/apps/mobile/src/auth/billing-handoff.ts
+++ b/apps/mobile/src/auth/billing-handoff.ts
@@ -1,0 +1,61 @@
+export const MOBILE_BILLING_RETURN_URL = "anarlog://billing/refresh";
+
+export type BillingCallback = {
+  checkout: "trial" | "paid" | "canceled" | "failed" | null;
+  checkoutType: "trial" | "paid" | null;
+  source: "mobile" | "unknown";
+};
+
+const isCheckout = (
+  value: string | null,
+): value is NonNullable<BillingCallback["checkout"]> =>
+  value === "trial" ||
+  value === "paid" ||
+  value === "canceled" ||
+  value === "failed";
+
+const isCheckoutType = (
+  value: string | null,
+): value is NonNullable<BillingCallback["checkoutType"]> =>
+  value === "trial" || value === "paid";
+
+export function parseBillingCallbackUrl(url: string): BillingCallback | null {
+  try {
+    const parsed = new URL(url);
+    if (
+      parsed.protocol !== "anarlog:" ||
+      parsed.hostname !== "billing" ||
+      parsed.pathname.replace(/\/+$/, "") !== "/refresh"
+    ) {
+      return null;
+    }
+
+    const checkout = parsed.searchParams.get("checkout");
+    const checkoutType = parsed.searchParams.get("checkout_type");
+    return {
+      checkout: isCheckout(checkout) ? checkout : null,
+      checkoutType: isCheckoutType(checkoutType) ? checkoutType : null,
+      source:
+        parsed.searchParams.get("source") === "mobile" ? "mobile" : "unknown",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function refreshBillingEntitlement({
+  refresh,
+  wait = (delayMs) =>
+    new Promise<void>((resolve) => setTimeout(resolve, delayMs)),
+  delaysMs = [0, 1_500, 3_000, 5_000],
+}: {
+  refresh: () => Promise<boolean>;
+  wait?: (delayMs: number) => Promise<void>;
+  delaysMs?: number[];
+}): Promise<boolean> {
+  for (const delayMs of delaysMs) {
+    if (delayMs > 0) await wait(delayMs);
+    if (await refresh()) return true;
+  }
+  return false;
+}

--- a/apps/mobile/src/auth/context.tsx
+++ b/apps/mobile/src/auth/context.tsx
@@ -23,6 +23,7 @@ import {
   deriveBillingInfo,
   type BillingInfo,
 } from "@/auth/billing";
+import { refreshBillingEntitlement as retryBillingEntitlement } from "@/auth/billing-handoff";
 import { authStorageKey, supabase } from "@/auth/client";
 import {
   captureAnalytics,
@@ -44,6 +45,7 @@ export type AuthState = {
   billing: BillingInfo;
   billingReady: boolean;
   signIn: () => Promise<void>;
+  refreshBilling: () => Promise<boolean>;
   signOut: () => Promise<void>;
 };
 
@@ -200,6 +202,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const sessionRef = useRef<Session | null | undefined>(session);
   const identifiedUserIdRef = useRef<string | null>(null);
   const reportedUndecodableUserIdRef = useRef<string | null>(null);
+  const billingRefreshRef = useRef<Promise<boolean> | null>(null);
   // Prevents double init in React StrictMode (refresh token races)
   const initStartedRef = useRef(false);
 
@@ -362,6 +365,43 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  const refreshBilling = useCallback((): Promise<boolean> => {
+    const client = supabase;
+    if (!client) return Promise.resolve(true);
+    if (billingRefreshRef.current) return billingRefreshRef.current;
+
+    let lastError: unknown;
+    const task = retryBillingEntitlement({
+      refresh: async () => {
+        const { data, error } = await client.auth.refreshSession();
+        if (error) {
+          lastError = error;
+          return false;
+        }
+
+        const nextSession = data.session;
+        if (!nextSession) return false;
+        setSession(nextSession);
+        return deriveBillingInfo(decodeJwtPayload(nextSession.access_token))
+          .isPro;
+      },
+    })
+      .then((unlocked) => {
+        if (!unlocked && lastError) {
+          captureOperationalError(lastError, {
+            operation: "billing_entitlement_refresh",
+            level: "warning",
+          });
+        }
+        return unlocked;
+      })
+      .finally(() => {
+        billingRefreshRef.current = null;
+      });
+    billingRefreshRef.current = task;
+    return task;
+  }, [setSession]);
+
   const signOut = useCallback(async () => {
     if (!supabase) {
       return;
@@ -419,9 +459,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       billing,
       billingReady,
       signIn,
+      refreshBilling,
       signOut,
     }),
-    [status, bypass, session, billing, billingReady, signIn, signOut],
+    [
+      status,
+      bypass,
+      session,
+      billing,
+      billingReady,
+      signIn,
+      refreshBilling,
+      signOut,
+    ],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/mobile/src/auth/screens.tsx
+++ b/apps/mobile/src/auth/screens.tsx
@@ -1,4 +1,5 @@
 import * as WebBrowser from "expo-web-browser";
+import { useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -9,6 +10,10 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import type { BillingInfo } from "@/auth/billing";
+import {
+  MOBILE_BILLING_RETURN_URL,
+  parseBillingCallbackUrl,
+} from "@/auth/billing-handoff";
 import { Colors, CornerCurve, Radius, Spacing } from "@/constants/theme";
 import { captureAnalytics } from "@/lib/analytics";
 import { env } from "@/lib/env";
@@ -31,7 +36,7 @@ export function SignInScreen({
         </View>
         <Text style={styles.subtitle}>Meetings, remembered.</Text>
         <Text style={styles.copy}>
-          Sign in to sync your notes and recordings.
+          Sign in to use the mobile companion with your Pro account.
         </Text>
       </View>
 
@@ -57,12 +62,17 @@ export function SignInScreen({
 export function PaywallScreen({
   billing,
   email,
+  onRefreshBilling,
   onSignOut,
 }: {
   billing: BillingInfo;
   email: string;
+  onRefreshBilling: () => Promise<boolean>;
   onSignOut: () => void;
 }) {
+  const [busy, setBusy] = useState(false);
+  const [accessPending, setAccessPending] = useState(false);
+
   useMountEffect(() => {
     captureAnalytics("paywall_viewed", {
       entry_point: "mobile_gate",
@@ -70,16 +80,67 @@ export function PaywallScreen({
     });
   });
 
-  const handleOpenPlans = async () => {
+  const refreshAccess = async (checkoutType: "trial" | "paid" | "unknown") => {
+    const unlocked = await onRefreshBilling();
+    if (unlocked) {
+      captureAnalytics("mobile_access_unlocked", {
+        entry_point: "mobile_checkout",
+        checkout_type: checkoutType,
+      });
+    } else {
+      setAccessPending(true);
+      captureAnalytics("billing_refresh_pending", {
+        entry_point: "mobile_checkout",
+        checkout_type: checkoutType,
+      });
+    }
+  };
+
+  const handlePrimaryAction = async () => {
+    if (busy) return;
+    setBusy(true);
     try {
-      await WebBrowser.openBrowserAsync(
-        `${env.appUrl}/app/checkout?source=mobile`,
+      if (accessPending) {
+        await refreshAccess("unknown");
+        return;
+      }
+
+      captureAnalytics("upgrade_clicked", {
+        plan: "pro",
+        period: "monthly",
+        source: "mobile",
+      });
+      const result = await WebBrowser.openAuthSessionAsync(
+        `${env.appUrl.replace(/\/+$/, "")}/app/checkout?period=monthly&source=mobile&scheme=anarlog`,
+        MOBILE_BILLING_RETURN_URL,
       );
+      if (result.type !== "success") return;
+
+      const callback = parseBillingCallbackUrl(result.url);
+      if (!callback) {
+        throw new Error("Invalid billing callback URL");
+      }
+      if (callback.checkout === "canceled" || callback.checkout === "failed") {
+        captureAnalytics(`checkout_${callback.checkout}`, {
+          checkout_type: callback.checkoutType ?? "unknown",
+          entry_source: callback.source,
+        });
+        return;
+      }
+
+      const checkoutType = callback.checkout ?? "unknown";
+      captureAnalytics("checkout_returned", {
+        checkout_type: checkoutType,
+        entry_source: callback.source,
+      });
+      await refreshAccess(checkoutType);
     } catch (error) {
       captureOperationalError(error, {
         operation: "billing_checkout_open",
         tags: { entry_point: "mobile_gate" },
       });
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -91,9 +152,14 @@ export function PaywallScreen({
           <View style={styles.accentDot} />
         </View>
         <Text style={styles.copy}>
-          Keep notes end-to-end encrypted and up to date across your signed-in
-          devices.
+          Record in-person meetings and voice notes from your phone. Notes stay
+          on this device while mobile sync is in development.
         </Text>
+        {accessPending && (
+          <Text style={styles.pendingCopy}>
+            Your plan changed, but mobile access is still updating.
+          </Text>
+        )}
         {billing.plan === "trial" && billing.trialDaysRemaining !== null && (
           <Text style={styles.trialLine}>
             Trial: {billing.trialDaysRemaining} days left
@@ -102,10 +168,21 @@ export function PaywallScreen({
       </View>
 
       <Pressable
-        onPress={() => void handleOpenPlans()}
-        style={({ pressed }) => [styles.cta, pressed && styles.ctaPressed]}
+        onPress={() => void handlePrimaryAction()}
+        disabled={busy}
+        style={({ pressed }) => [
+          styles.cta,
+          pressed && styles.ctaPressed,
+          busy && styles.ctaDisabled,
+        ]}
       >
-        <Text style={styles.ctaLabel}>View plans</Text>
+        {busy ? (
+          <ActivityIndicator color={Colors.inkInverse} />
+        ) : (
+          <Text style={styles.ctaLabel}>
+            {accessPending ? "Refresh access" : "View plans"}
+          </Text>
+        )}
       </Pressable>
 
       <View style={styles.footer}>
@@ -169,6 +246,12 @@ const styles = StyleSheet.create({
     marginTop: Spacing.md,
     fontSize: 13,
     color: Colors.muted,
+  },
+  pendingCopy: {
+    marginTop: Spacing.md,
+    fontSize: 13,
+    lineHeight: 19,
+    color: Colors.accent,
   },
   cta: {
     alignItems: "center",

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -25,6 +25,10 @@ import {
   sanitizeInternalReturnPath,
   toAbsoluteInternalReturnUrl,
 } from "@/lib/auth-redirect";
+import {
+  checkoutSourceSchema,
+  type CheckoutSource,
+} from "@/lib/checkout-source";
 import { captureOperationalError } from "@/lib/error-reporting";
 import { captureServerAnalytics } from "@/lib/server-analytics";
 import {
@@ -272,12 +276,7 @@ async function createCheckoutUrl({
   trial?: boolean;
   reservationId?: string;
   trialDays?: number;
-  source?:
-    | "onboarding"
-    | "settings"
-    | "trial_ended"
-    | "feature_gate"
-    | "unknown";
+  source?: CheckoutSource;
   returnTo?: string;
 }) {
   const stripe = getStripeClient();
@@ -389,9 +388,7 @@ const createCheckoutSessionInput = z.object({
   plan: z.enum(["pro"]).default("pro").optional(),
   scheme: desktopSchemeSchema.optional(),
   trial: z.boolean().default(false),
-  source: z
-    .enum(["onboarding", "settings", "trial_ended", "feature_gate", "unknown"])
-    .default("unknown"),
+  source: checkoutSourceSchema.default("unknown"),
   returnTo: z.string().optional(),
 });
 
@@ -452,7 +449,7 @@ export const createCheckoutSession = createServerFn({ method: "POST" })
             await releaseTrialReservation(user.id, reservationId);
           }
           const returnUrl = data.scheme
-            ? getBillingReturnUrl(data.scheme)
+            ? `${getBillingReturnUrl(data.scheme)}&source=${data.source}`
             : toAbsoluteInternalReturnUrl(getRequestAppOrigin(), returnTo);
           const portalSession = await stripe.billingPortal.sessions.create({
             customer: stripeCustomerId,

--- a/apps/web/src/lib/checkout-source.test.ts
+++ b/apps/web/src/lib/checkout-source.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildBillingRefreshDeeplink,
+  checkoutSourceSchema,
+} from "./checkout-source.ts";
+
+test("keeps mobile checkout attribution through validation", () => {
+  assert.equal(checkoutSourceSchema.parse("mobile"), "mobile");
+  assert.equal(
+    checkoutSourceSchema.catch("unknown").parse("invalid"),
+    "unknown",
+  );
+});
+
+test("returns checkout outcome and attribution to the app", () => {
+  assert.equal(
+    buildBillingRefreshDeeplink({
+      scheme: "anarlog",
+      checkout: "paid",
+      source: "mobile",
+    }),
+    "anarlog://billing/refresh?checkout=paid&source=mobile",
+  );
+
+  assert.equal(
+    buildBillingRefreshDeeplink({
+      scheme: "anarlog-staging",
+      checkout: "canceled",
+      checkoutType: "trial",
+      source: "mobile",
+    }),
+    "anarlog-staging://billing/refresh?checkout=canceled&checkout_type=trial&source=mobile",
+  );
+
+  assert.equal(
+    buildBillingRefreshDeeplink({ scheme: "anarlog", source: "mobile" }),
+    "anarlog://billing/refresh?source=mobile",
+  );
+});

--- a/apps/web/src/lib/checkout-source.ts
+++ b/apps/web/src/lib/checkout-source.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const checkoutSourceSchema = z.enum([
+  "onboarding",
+  "settings",
+  "trial_ended",
+  "feature_gate",
+  "mobile",
+  "unknown",
+]);
+
+export type CheckoutSource = z.infer<typeof checkoutSourceSchema>;
+
+export function buildBillingRefreshDeeplink({
+  scheme,
+  checkout,
+  checkoutType,
+  source,
+}: {
+  scheme: string;
+  checkout?: "trial" | "paid" | "canceled" | "failed";
+  checkoutType?: "trial" | "paid";
+  source?: CheckoutSource;
+}) {
+  const search = new URLSearchParams();
+  if (checkout) search.set("checkout", checkout);
+  if (checkoutType) search.set("checkout_type", checkoutType);
+  if (source) search.set("source", source);
+  const query = search.toString();
+  return `${scheme}://billing/refresh${query ? `?${query}` : ""}`;
+}

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -11,6 +11,7 @@ import { AnarlogLogo } from "@/components/anarlog-logo";
 import { desktopSchemeSchema } from "@/functions/desktop-flow";
 import { getSupabaseBrowserClient } from "@/functions/supabase";
 import { useAnalytics } from "@/hooks/use-posthog";
+import { checkoutSourceSchema } from "@/lib/checkout-source";
 
 import { AccountAccessSection } from "./-account-access";
 import { ApiKeysSection } from "./-account-api-keys";
@@ -30,13 +31,7 @@ const validateSearch = z
     scheme: desktopSchemeSchema,
     checkout: z.enum(["trial", "paid", "canceled", "failed"]),
     checkout_type: z.enum(["trial", "paid"]),
-    source: z.enum([
-      "onboarding",
-      "settings",
-      "trial_ended",
-      "feature_gate",
-      "unknown",
-    ]),
+    source: checkoutSourceSchema,
     referral: z.enum(["ineligible"]),
   })
   .partial();

--- a/apps/web/src/routes/_view/app/checkout.tsx
+++ b/apps/web/src/routes/_view/app/checkout.tsx
@@ -7,6 +7,7 @@ import {
   addInternalReturnPathSearch,
   sanitizeInternalReturnPath,
 } from "@/lib/auth-redirect";
+import { checkoutSourceSchema } from "@/lib/checkout-source";
 import { captureOperationalError } from "@/lib/error-reporting";
 
 const validateSearch = z.object({
@@ -17,9 +18,7 @@ const validateSearch = z.object({
     .enum(["true", "false"])
     .catch("false")
     .transform((value) => value === "true"),
-  source: z
-    .enum(["onboarding", "settings", "trial_ended", "feature_gate", "unknown"])
-    .catch("unknown"),
+  source: checkoutSourceSchema.catch("unknown"),
   return_to: z.string().optional(),
 });
 

--- a/apps/web/src/routes/_view/callback/billing.tsx
+++ b/apps/web/src/routes/_view/callback/billing.tsx
@@ -10,14 +10,16 @@ import {
   desktopSchemeSchema,
 } from "@/functions/desktop-flow";
 import { useAnalytics } from "@/hooks/use-posthog";
+import {
+  buildBillingRefreshDeeplink,
+  checkoutSourceSchema,
+} from "@/lib/checkout-source";
 
 const validateSearch = z.object({
   scheme: desktopSchemeSchema.optional(),
   checkout: z.enum(["trial", "paid", "canceled", "failed"]).optional(),
   checkout_type: z.enum(["trial", "paid"]).optional(),
-  source: z
-    .enum(["onboarding", "settings", "trial_ended", "feature_gate", "unknown"])
-    .optional(),
+  source: checkoutSourceSchema.optional(),
 });
 
 export const Route = createFileRoute("/_view/callback/billing")({
@@ -43,7 +45,12 @@ function Component() {
   const { track } = useAnalytics();
   const [copied, setCopied] = useState(false);
 
-  const deeplink = `${scheme}://billing/refresh`;
+  const deeplink = buildBillingRefreshDeeplink({
+    scheme,
+    checkout,
+    checkoutType,
+    source,
+  });
 
   const handleDeeplink = () => {
     window.location.href = deeplink;


### PR DESCRIPTION
Preserve mobile attribution through web billing callbacks, refresh entitlements after return, and keep local-only copy honest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing checkout return URLs and mobile entitlement gating via JWT refresh; deeplink parsing is restricted to `anarlog://billing/refresh`, with bounded retries and tests reducing rollout risk.
> 
> **Overview**
> **Mobile Pro checkout** now uses an auth session that returns through `anarlog://billing/refresh` instead of opening checkout in a plain browser tab. The paywall parses the callback (checkout outcome + `source=mobile`), fires analytics, then **polls session refresh** until the JWT shows Pro or shows a **“Refresh access”** pending state.
> 
> **Web billing** centralizes `checkoutSourceSchema` (adds **`mobile`**) and **`buildBillingRefreshDeeplink`** so `/callback/billing` redirects with `checkout`, `checkout_type`, and `source` on the deeplink—not only `scheme://billing/refresh`. Checkout/portal return URLs for scheme flows also carry **`source`** through billing.
> 
> **Auth** exposes deduped **`refreshBilling`** wired from the gate paywall. Copy on sign-in/paywall reflects **Pro requirement** and **local-only notes** while sync is in development. Unit tests cover deeplink parsing, retry bounds, and web deeplink building.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4393cd41bf52d302f4660d91f1e2bb150fa950e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->