### PR TITLE
Restrict snapshot read service grants

### DIFF
--- a/supabase/migrations/20260815140635_restrict_snapshot_read_service_role.sql
+++ b/supabase/migrations/20260815140635_restrict_snapshot_read_service_role.sql
@@ -1,0 +1,12 @@
+REVOKE EXECUTE ON FUNCTION
+  public.read_my_session_share_snapshot(uuid),
+  public.read_my_session_share_snapshot_v2(uuid),
+  public.read_my_session_share_snapshot_with_attachments(uuid),
+  public.list_my_session_share_snapshots(),
+  public.list_my_session_share_snapshots_with_attachments(),
+  public.list_my_session_share_snapshot_page(uuid, integer),
+  public.list_my_session_share_snapshot_page_v2(uuid, integer),
+  public.list_my_session_share_snapshot_page_with_attachments(uuid, integer),
+  public.read_session_share_link_snapshot(uuid, text),
+  public.read_public_session_share_snapshot(text)
+FROM service_role;

--- a/supabase/tests/010-session-share-snapshots.sql
+++ b/supabase/tests/010-session-share-snapshots.sql
@@ -161,7 +161,7 @@ select ok(
 
 select ok(
   (
-    select count(*) = 6
+    select count(*) = 11
       and bool_and(
         has_function_privilege('service_role', proc.oid, 'EXECUTE')
           = (proc.proname = 'publish_session_share_snapshot')
@@ -170,8 +170,13 @@ select ok(
         has_function_privilege('authenticated', proc.oid, 'EXECUTE')
           = (proc.proname in (
             'read_my_session_share_snapshot',
+            'read_my_session_share_snapshot_v2',
+            'read_my_session_share_snapshot_with_attachments',
             'list_my_session_share_snapshots',
-            'list_my_session_share_snapshot_page'
+            'list_my_session_share_snapshots_with_attachments',
+            'list_my_session_share_snapshot_page',
+            'list_my_session_share_snapshot_page_v2',
+            'list_my_session_share_snapshot_page_with_attachments'
           ))
       )
       and bool_and(
@@ -184,10 +189,15 @@ select ok(
       and proc.proname in (
         'publish_session_share_snapshot',
         'read_my_session_share_snapshot',
+        'read_my_session_share_snapshot_v2',
+        'read_my_session_share_snapshot_with_attachments',
         'read_session_share_link_snapshot',
         'read_public_session_share_snapshot',
         'list_my_session_share_snapshots',
-        'list_my_session_share_snapshot_page'
+        'list_my_session_share_snapshots_with_attachments',
+        'list_my_session_share_snapshot_page',
+        'list_my_session_share_snapshot_page_v2',
+        'list_my_session_share_snapshot_page_with_attachments'
       )
   ),
   'Snapshot RPC grants keep general-access reads behind the service gateway'


### PR DESCRIPTION
## Summary
- revoke service-role execution from all client-facing snapshot read wrappers
- preserve authenticated reads and service-only gateway and publish RPCs
- cover original, v2, and attachment-aware functions

## Validation
- clean local database reset applied every migration
- full pgTAP suite: 1,070/1,070 passed
- database advisors: no errors
- formatting checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production DB privileges for `service_role` on session-share snapshot reads; callers that relied on direct read RPCs under the service key must use gateway paths instead.
> 
> **Overview**
> **Tightens snapshot read permissions** so `service_role` can no longer execute the public client-facing snapshot read/list wrappers (original, v2, and attachment-aware variants, plus link and public slug readers).
> 
> Trusted server code is expected to use the dedicated **gateway** RPCs for link/public reads; **`publish_session_share_snapshot`** stays the only snapshot-related function `service_role` may execute among the audited set. **`authenticated`** grants on the “my snapshot” read/list functions are unchanged.
> 
> pgTAP in `010-session-share-snapshots.sql` now asserts this grant matrix across all eleven named functions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d121aeca2ad1b60ead0dfa4a35d07ca2a73a549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->