### PR TITLE
Cover shared workspace key lifecycle

### DIFF
--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -543,6 +543,43 @@ describe("CloudSync auth lifecycle", () => {
     );
   });
 
+  test("removes a revoked shared workspace on credential refresh", async () => {
+    const revokedCredentials = projectedCredentialsResponse((payload) => {
+      payload.workspaces.splice(1);
+      payload.workspaceKeyGrants = [];
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<() => Promise<Response>>()
+        .mockResolvedValueOnce(projectedCredentialsResponse())
+        .mockResolvedValueOnce(revokedCredentials),
+    );
+
+    await handleCloudsyncAuthChange("SIGNED_IN", session());
+    await handleCloudsyncAuthChange("TOKEN_REFRESHED", session());
+
+    expect(configureCloudsyncToken).toHaveBeenCalledTimes(2);
+    expect(configureCloudsyncToken).toHaveBeenLastCalledWith(
+      "database-id",
+      "sqlite-token",
+      "user-id",
+      witness(),
+      {
+        accountUserId: "user-id",
+        personalWorkspaceId: "user-id",
+        workspaces: [
+          expect.objectContaining({
+            id: "user-id",
+            membershipId: "membership-personal",
+            role: "owner",
+          }),
+        ],
+      },
+      [],
+    );
+  });
+
   test("rejects shared workspace credentials without an active key grant", async () => {
     vi.stubGlobal(
       "fetch",

--- a/crates/db-app/src/e2ee/tests/snapshots.rs
+++ b/crates/db-app/src/e2ee/tests/snapshots.rs
@@ -63,6 +63,88 @@ async fn rotated_keyring_applies_new_writes_over_an_old_snapshot() {
 }
 
 #[tokio::test]
+async fn shared_replicas_collaborate_then_fail_closed_after_member_revocation() {
+    let old_key = anlg_e2ee::WorkspaceKey::generate().unwrap();
+    let shared_keys = HashMap::from([(
+        "workspace-a".to_string(),
+        anlg_e2ee::WorkspaceKeyring::new(old_key.clone()),
+    )]);
+    let owner = test_db().await;
+    let member = test_db().await;
+
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('session-1', 'workspace-a', 'user-owner', 'Owner draft')",
+    )
+    .execute(owner.pool())
+    .await
+    .unwrap();
+    encrypt_e2ee_replica_changes(owner.pool(), &shared_keys)
+        .await
+        .unwrap();
+    copy_replica(owner.pool(), member.pool()).await;
+    apply_e2ee_replica_changes(member.pool(), &shared_keys)
+        .await
+        .unwrap();
+
+    sqlx::query("UPDATE sessions SET title = 'Member edit' WHERE id = 'session-1'")
+        .execute(member.pool())
+        .await
+        .unwrap();
+    encrypt_e2ee_replica_changes(member.pool(), &shared_keys)
+        .await
+        .unwrap();
+    copy_replica(member.pool(), owner.pool()).await;
+    apply_e2ee_replica_changes(owner.pool(), &shared_keys)
+        .await
+        .unwrap();
+
+    let owner_title: String =
+        sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+            .fetch_one(owner.pool())
+            .await
+            .unwrap();
+    assert_eq!(owner_title, "Member edit");
+
+    let new_key = anlg_e2ee::WorkspaceKey::generate().unwrap();
+    let mut rotated_keyring = anlg_e2ee::WorkspaceKeyring::new(new_key);
+    rotated_keyring.insert_retired(old_key);
+    let rotated_keys = HashMap::from([("workspace-a".to_string(), rotated_keyring)]);
+
+    sqlx::query("UPDATE sessions SET title = 'After revocation' WHERE id = 'session-1'")
+        .execute(owner.pool())
+        .await
+        .unwrap();
+    encrypt_e2ee_replica_changes(owner.pool(), &rotated_keys)
+        .await
+        .unwrap();
+    copy_replica(owner.pool(), member.pool()).await;
+
+    assert!(matches!(
+        apply_e2ee_replica_changes(member.pool(), &shared_keys).await,
+        Err(E2eeReplicaError::Crypto(anlg_e2ee::Error::UnknownKey))
+    ));
+    let member_title: String =
+        sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+            .fetch_one(member.pool())
+            .await
+            .unwrap();
+    assert_eq!(member_title, "Member edit");
+
+    let restarted_owner = test_db().await;
+    copy_replica(owner.pool(), restarted_owner.pool()).await;
+    apply_e2ee_replica_changes(restarted_owner.pool(), &rotated_keys)
+        .await
+        .unwrap();
+    let restarted_title: String =
+        sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+            .fetch_one(restarted_owner.pool())
+            .await
+            .unwrap();
+    assert_eq!(restarted_title, "After revocation");
+}
+
+#[tokio::test]
 async fn rotated_keyring_authenticates_witness_history_from_a_retired_generation() {
     let db = test_db().await;
     let recovery =

--- a/plugins/db/src/runtime/tests/configuration.rs
+++ b/plugins/db/src/runtime/tests/configuration.rs
@@ -49,6 +49,59 @@ async fn configures_replica_transport_without_the_cloudsync_extension() {
     );
 }
 
+#[tokio::test]
+async fn refreshed_workspace_keys_forget_revoked_memberships() {
+    let db = std::sync::Arc::new(Db::connect_memory_plain().await.unwrap());
+    let runtime = PluginDbRuntime::new(db);
+    let recovery_key = anlg_e2ee::RecoveryKey::parse(
+        "anarlog-e2ee-v1:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc",
+    )
+    .unwrap();
+    let revoked_key = anlg_e2ee::WorkspaceKey::generate().unwrap();
+    let retained_key = anlg_e2ee::WorkspaceKey::generate().unwrap();
+
+    runtime
+        .set_e2ee_workspace_keys(E2eeWorkspaceKeyConfiguration::new(
+            "user-a".to_string(),
+            recovery_key.clone(),
+            std::collections::HashMap::from([
+                (
+                    "workspace-revoked".to_string(),
+                    anlg_e2ee::WorkspaceKeyring::new(revoked_key),
+                ),
+                (
+                    "workspace-retained".to_string(),
+                    anlg_e2ee::WorkspaceKeyring::new(retained_key),
+                ),
+            ]),
+        ))
+        .unwrap();
+    assert!(runtime.workspace_key("workspace-revoked").is_some());
+
+    let rotated_key = anlg_e2ee::WorkspaceKey::generate().unwrap();
+    let rotated_key_id = rotated_key.key_id().to_string();
+    runtime
+        .set_e2ee_workspace_keys(E2eeWorkspaceKeyConfiguration::new(
+            "user-a".to_string(),
+            recovery_key,
+            std::collections::HashMap::from([(
+                "workspace-retained".to_string(),
+                anlg_e2ee::WorkspaceKeyring::new(rotated_key),
+            )]),
+        ))
+        .unwrap();
+
+    assert!(runtime.workspace_key("user-a").is_some());
+    assert!(runtime.workspace_key("workspace-revoked").is_none());
+    assert_eq!(
+        runtime
+            .workspace_key("workspace-retained")
+            .unwrap()
+            .key_id(),
+        rotated_key_id
+    );
+}
+
 fn test_full_resync_config(token: &str) -> anlg_db_core::CloudsyncRuntimeConfig {
     anlg_db_core::CloudsyncRuntimeConfig {
         connection_string: "test-database".to_string(),


### PR DESCRIPTION
## Summary
- exercise bidirectional shared-replica edits across key rotation and authorized restart
- prove revoked workspace keys are evicted from the native runtime cache
- prove credential refresh removes revoked workspaces before native reconfiguration

## Validation
- cargo test -p db-app -p tauri-plugin-db
- cargo test --locked -p db-app --lib
- cargo clippy --locked -p agent-access -p anarlog-cli -p db-app -p db-core -p db-migrate -p tiptap --all-targets --no-deps -- -D warnings
- cargo check
- pnpm -F desktop typecheck
- pnpm exec oxlint --quiet --format=github apps/desktop/src/
- pnpm -F desktop exec vitest run src/auth/cloudsync.test.ts -t "removes a revoked shared workspace on credential refresh"
- pnpm dlx supabase@2.114.0 test db --local supabase/tests/032-shared-workspace-e2ee-grants.sql
- pnpm exec dprint fmt && pnpm fmt:check

## Known unrelated local failures
- full desktop suite: user-owned uncommitted sidebar Discord test cannot find its button (3115 other tests pass)
- broad Rust workspace suite: crates/codex large-stderr timeout under load; the exact test passes in isolation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes across desktop, db-app, and tauri-plugin-db; no runtime behavior modified in this PR.
> 
> **Overview**
> Adds **regression tests** for shared-workspace E2EE when membership or keys are revoked—no production logic changes in this diff.
> 
> **Desktop (`cloudsync.test.ts`):** On `TOKEN_REFRESHED`, when refreshed credentials drop a shared workspace and clear `workspaceKeyGrants`, the last `configureCloudsyncToken` call must include only the personal workspace and an empty grants list.
> 
> **Native plugin (`configuration.rs`):** After `set_e2ee_workspace_keys` is called again without a revoked workspace, `workspace_key` for that id is gone while retained workspaces keep the new key id.
> 
> **Replica sync (`snapshots.rs`):** Owner and member can exchange edits under a shared key; after owner rotates keys (revocation), the member’s stale keyring gets `UnknownKey` on apply and local data stays unchanged; an owner restart with the rotated keyring still applies post-revocation writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1bd63bad92ac69ba7d58c2f7b5028b341f284ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->