### PR TITLE
Fail closed on stale CloudSync E2EE schema

### DIFF
--- a/.github/scripts/test_verify_cloudsync_e2ee.py
+++ b/.github/scripts/test_verify_cloudsync_e2ee.py
@@ -12,6 +12,59 @@ SPEC.loader.exec_module(verify)
 
 
 class VerifyCloudSyncE2eeTests(unittest.TestCase):
+    def e2ee_record_columns(self) -> list[dict[str, object]]:
+        timestamp_default = "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        return [
+            {
+                "name": "id",
+                "type": "TEXT",
+                "notnull": 1,
+                "pk": 1,
+                "hidden": 0,
+                "dflt_value": None,
+            },
+            {
+                "name": "workspace_id",
+                "type": "TEXT",
+                "notnull": 1,
+                "pk": 0,
+                "hidden": 0,
+                "dflt_value": "''",
+            },
+            {
+                "name": "payload",
+                "type": "TEXT",
+                "notnull": 1,
+                "pk": 0,
+                "hidden": 0,
+                "dflt_value": "''",
+            },
+            {
+                "name": "created_at",
+                "type": "TEXT",
+                "notnull": 1,
+                "pk": 0,
+                "hidden": 0,
+                "dflt_value": timestamp_default,
+            },
+            {
+                "name": "updated_at",
+                "type": "TEXT",
+                "notnull": 1,
+                "pk": 0,
+                "hidden": 0,
+                "dflt_value": timestamp_default,
+            },
+            {
+                "name": "payload_hash",
+                "type": "TEXT",
+                "notnull": 1,
+                "pk": 0,
+                "hidden": 0,
+                "dflt_value": "''",
+            },
+        ]
+
     def test_accepts_only_known_protocol_modes(self) -> None:
         for mode in verify.PROTOCOL_MODES:
             self.assertEqual(
@@ -132,6 +185,20 @@ class VerifyCloudSyncE2eeTests(unittest.TestCase):
         query = run_sql.call_args.args[3]
         for table in verify.LEGACY_PLAINTEXT_TABLES:
             self.assertIn(f"'{table}'", query)
+
+    def test_accepts_the_current_encrypted_replica_columns(self) -> None:
+        verify.verify_e2ee_record_columns(self.e2ee_record_columns())
+
+    def test_rejects_the_pre_payload_hash_column_contract(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unexpected column contract"):
+            verify.verify_e2ee_record_columns(self.e2ee_record_columns()[:-1])
+
+    def test_requires_the_payload_hash_default(self) -> None:
+        columns = self.e2ee_record_columns()
+        columns[-1]["dflt_value"] = None
+
+        with self.assertRaisesRegex(ValueError, "unexpected column defaults"):
+            verify.verify_e2ee_record_columns(columns)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/verify_cloudsync_e2ee.py
+++ b/.github/scripts/verify_cloudsync_e2ee.py
@@ -225,6 +225,42 @@ def verify_no_plaintext_tables(
         )
 
 
+def verify_e2ee_record_columns(columns: list[dict[str, object]]) -> None:
+    column_shape = [
+        (
+            str(column.get("name", "")),
+            str(column.get("type", "")).upper(),
+            int(column.get("notnull", 0)),
+            int(column.get("pk", 0)),
+            int(column.get("hidden", 0)),
+        )
+        for column in columns
+    ]
+    expected_columns = [
+        ("id", "TEXT", 1, 1, 0),
+        ("workspace_id", "TEXT", 1, 0, 0),
+        ("payload", "TEXT", 1, 0, 0),
+        ("created_at", "TEXT", 1, 0, 0),
+        ("updated_at", "TEXT", 1, 0, 0),
+        ("payload_hash", "TEXT", 1, 0, 0),
+    ]
+    if column_shape != expected_columns:
+        raise ValueError("e2ee_records has an unexpected column contract")
+
+    defaults = [column.get("dflt_value") for column in columns]
+    timestamp_default = "strftime('%y-%m-%dt%h:%m:%fz','now')"
+    if (
+        defaults[0] is not None
+        or defaults[1:3] != ["''", "''"]
+        or any(
+            timestamp_default not in "".join(str(value).lower().split())
+            for value in defaults[3:5]
+        )
+        or defaults[5] != "''"
+    ):
+        raise ValueError("e2ee_records has unexpected column defaults")
+
+
 def run_sql(
     project_url: str,
     issuer_key: str,
@@ -323,36 +359,7 @@ def verify_remote_database(values: dict[str, str]) -> None:
         "PRAGMA table_xinfo(e2ee_records)",
         "E2EE table column check",
     )
-    column_shape = [
-        (
-            str(column.get("name", "")),
-            str(column.get("type", "")).upper(),
-            int(column.get("notnull", 0)),
-            int(column.get("pk", 0)),
-            int(column.get("hidden", 0)),
-        )
-        for column in columns
-    ]
-    expected_columns = [
-        ("id", "TEXT", 1, 1, 0),
-        ("workspace_id", "TEXT", 1, 0, 0),
-        ("payload", "TEXT", 1, 0, 0),
-        ("created_at", "TEXT", 1, 0, 0),
-        ("updated_at", "TEXT", 1, 0, 0),
-    ]
-    if column_shape != expected_columns:
-        raise ValueError("e2ee_records has an unexpected column contract")
-    defaults = [column.get("dflt_value") for column in columns]
-    timestamp_default = "strftime('%y-%m-%dt%h:%m:%fz','now')"
-    if (
-        defaults[0] is not None
-        or defaults[1:3] != ["''", "''"]
-        or any(
-            timestamp_default not in "".join(str(value).lower().split())
-            for value in defaults[3:]
-        )
-    ):
-        raise ValueError("e2ee_records has unexpected column defaults")
+    verify_e2ee_record_columns(columns)
 
     indexes = run_sql(
         project_url,


### PR DESCRIPTION
## Summary
- require the payload_hash column in the production e2ee_records contract
- validate its non-null empty-string default
- cover the current six-column shape and reject the pre-migration five-column shape

## Validation
- python3 .github/scripts/test_verify_cloudsync_e2ee.py (13 passed)
- cargo check -p api
- cargo test -p api-sync (106 passed)
- cargo test -p api gen_openapi_json
- git diff --exit-code -- apps/api/openapi.gen.json
- pnpm exec dprint fmt
- pnpm fmt:check

## Live evidence
The Infisical-backed production preflight now stops before token minting or workspace creation with: e2ee_records has an unexpected column contract.

Production still has the five-column table used by desktop 1.4.9. Migrating it to payload_hash must be coordinated with a compatible desktop rollout; this PR does not mutate production.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Blocks deploy/preflight until production schema is migrated, but only validates schema in CI/preflight and does not change live databases.
> 
> **Overview**
> **Tightens CloudSync E2EE deployment preflight** so it no longer passes when production `e2ee_records` is still on the pre-migration five-column contract.
> 
> Column checks are moved into **`verify_e2ee_record_columns`**, which now expects six columns (`id`, `workspace_id`, `payload`, `created_at`, `updated_at`, **`payload_hash`**) and asserts **`payload_hash`** defaults to `''` alongside the existing timestamp default rules. **`verify_remote_database`** calls that helper instead of inlined logic.
> 
> Unit tests add a six-column fixture and cover acceptance of the current shape, rejection of the five-column pre-`payload_hash` contract, and failure when **`payload_hash`** lacks the required default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01dbfd9131536f5490131f777806ecff7338d5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->