### PR TITLE
Keep CloudSync E2EE schema compatible

### DIFF
--- a/.github/scripts/test_verify_cloudsync_e2ee.py
+++ b/.github/scripts/test_verify_cloudsync_e2ee.py
@@ -55,14 +55,6 @@ class VerifyCloudSyncE2eeTests(unittest.TestCase):
                 "hidden": 0,
                 "dflt_value": timestamp_default,
             },
-            {
-                "name": "payload_hash",
-                "type": "TEXT",
-                "notnull": 1,
-                "pk": 0,
-                "hidden": 0,
-                "dflt_value": "''",
-            },
         ]
 
     def test_accepts_only_known_protocol_modes(self) -> None:
@@ -189,13 +181,24 @@ class VerifyCloudSyncE2eeTests(unittest.TestCase):
     def test_accepts_the_current_encrypted_replica_columns(self) -> None:
         verify.verify_e2ee_record_columns(self.e2ee_record_columns())
 
-    def test_rejects_the_pre_payload_hash_column_contract(self) -> None:
-        with self.assertRaisesRegex(ValueError, "unexpected column contract"):
-            verify.verify_e2ee_record_columns(self.e2ee_record_columns()[:-1])
-
-    def test_requires_the_payload_hash_default(self) -> None:
+    def test_rejects_a_client_only_payload_hash_column(self) -> None:
         columns = self.e2ee_record_columns()
-        columns[-1]["dflt_value"] = None
+        columns.append(
+            {
+                "name": "payload_hash",
+                "type": "TEXT",
+                "notnull": 1,
+                "pk": 0,
+                "hidden": 0,
+                "dflt_value": "''",
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "unexpected column contract"):
+            verify.verify_e2ee_record_columns(columns)
+
+    def test_requires_the_payload_default(self) -> None:
+        columns = self.e2ee_record_columns()
+        columns[2]["dflt_value"] = None
 
         with self.assertRaisesRegex(ValueError, "unexpected column defaults"):
             verify.verify_e2ee_record_columns(columns)

--- a/.github/scripts/verify_cloudsync_e2ee.py
+++ b/.github/scripts/verify_cloudsync_e2ee.py
@@ -242,7 +242,6 @@ def verify_e2ee_record_columns(columns: list[dict[str, object]]) -> None:
         ("payload", "TEXT", 1, 0, 0),
         ("created_at", "TEXT", 1, 0, 0),
         ("updated_at", "TEXT", 1, 0, 0),
-        ("payload_hash", "TEXT", 1, 0, 0),
     ]
     if column_shape != expected_columns:
         raise ValueError("e2ee_records has an unexpected column contract")
@@ -256,7 +255,6 @@ def verify_e2ee_record_columns(columns: list[dict[str, object]]) -> None:
             timestamp_default not in "".join(str(value).lower().split())
             for value in defaults[3:5]
         )
-        or defaults[5] != "''"
     ):
         raise ValueError("e2ee_records has unexpected column defaults")
 

--- a/crates/db-app/migrations/20260816100000_e2ee_replica_payload_hashes.sql
+++ b/crates/db-app/migrations/20260816100000_e2ee_replica_payload_hashes.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS e2ee_replica_payload_hashes (
+  record_id    TEXT PRIMARY KEY NOT NULL,
+  workspace_id TEXT NOT NULL DEFAULT '',
+  payload_hash TEXT NOT NULL DEFAULT '',
+  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+) STRICT;
+
+INSERT INTO e2ee_replica_payload_hashes (record_id, workspace_id, payload_hash)
+SELECT id, workspace_id, payload_hash
+FROM e2ee_records
+WHERE true
+ON CONFLICT(record_id) DO UPDATE SET
+  workspace_id = excluded.workspace_id,
+  payload_hash = excluded.payload_hash,
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now');

--- a/crates/db-app/migrations/20260816100100_e2ee_payload_hash_local_state.sql
+++ b/crates/db-app/migrations/20260816100100_e2ee_payload_hash_local_state.sql
@@ -1,0 +1,350 @@
+DROP VIEW IF EXISTS e2ee_local_state_resolved;
+DROP VIEW IF EXISTS e2ee_witness_records_resolved;
+
+DROP TRIGGER IF EXISTS e2ee_records_archive_before_update;
+DROP TRIGGER IF EXISTS e2ee_records_archive_before_delete;
+DROP TRIGGER IF EXISTS e2ee_records_clear_stale_payload_hash;
+DROP TRIGGER IF EXISTS e2ee_local_state_normalize_payload_insert;
+DROP TRIGGER IF EXISTS e2ee_local_state_normalize_payload_update;
+DROP TRIGGER IF EXISTS e2ee_witness_records_normalize_payload_insert;
+DROP TRIGGER IF EXISTS e2ee_witness_records_normalize_payload_update;
+DROP TRIGGER IF EXISTS e2ee_local_state_prune_archive_delete;
+DROP TRIGGER IF EXISTS e2ee_local_state_prune_archive_update;
+DROP TRIGGER IF EXISTS e2ee_witness_records_prune_archive_delete;
+DROP TRIGGER IF EXISTS e2ee_witness_records_prune_archive_update;
+
+ALTER TABLE e2ee_records DROP COLUMN payload_hash;
+
+CREATE VIEW e2ee_local_state_resolved AS
+SELECT
+  local.record_id,
+  local.workspace_id,
+  local.table_name,
+  local.row_id,
+  local.field_name,
+  local.revision,
+  local.writer_id,
+  local.value_tag,
+  local.payload_hash,
+  CASE
+    WHEN replica.workspace_id = local.workspace_id
+      AND replica_hash.payload_hash = local.payload_hash
+      THEN replica.payload
+    ELSE archive.payload
+  END AS payload,
+  local.updated_at
+FROM e2ee_local_state AS local
+LEFT JOIN e2ee_records AS replica
+  ON replica.id = local.record_id
+LEFT JOIN e2ee_replica_payload_hashes AS replica_hash
+  ON replica_hash.record_id = replica.id
+ AND replica_hash.workspace_id = replica.workspace_id
+LEFT JOIN e2ee_ciphertext_archive AS archive
+  ON archive.workspace_id = local.workspace_id
+ AND archive.record_id = local.record_id
+ AND archive.payload_hash = local.payload_hash;
+
+CREATE VIEW e2ee_witness_records_resolved AS
+SELECT
+  witness.workspace_id,
+  witness.record_id,
+  witness.revision,
+  witness.writer_id,
+  witness.payload_hash,
+  CASE
+    WHEN replica.workspace_id = witness.workspace_id
+      AND replica_hash.payload_hash = witness.payload_hash
+      THEN replica.payload
+    ELSE archive.payload
+  END AS payload,
+  witness.sequence,
+  witness.updated_at
+FROM e2ee_witness_records AS witness
+LEFT JOIN e2ee_records AS replica
+  ON replica.id = witness.record_id
+LEFT JOIN e2ee_replica_payload_hashes AS replica_hash
+  ON replica_hash.record_id = replica.id
+ AND replica_hash.workspace_id = replica.workspace_id
+LEFT JOIN e2ee_ciphertext_archive AS archive
+  ON archive.workspace_id = witness.workspace_id
+ AND archive.record_id = witness.record_id
+ AND archive.payload_hash = witness.payload_hash;
+
+CREATE TRIGGER e2ee_records_archive_before_update
+BEFORE UPDATE OF workspace_id, payload ON e2ee_records
+WHEN OLD.payload <> ''
+  AND (
+    OLD.workspace_id <> NEW.workspace_id
+    OR OLD.payload <> NEW.payload
+  )
+BEGIN
+  INSERT OR IGNORE INTO e2ee_ciphertext_archive (
+    workspace_id, record_id, payload_hash, payload
+  )
+  SELECT OLD.workspace_id, OLD.id, replica_hash.payload_hash, OLD.payload
+  FROM e2ee_replica_payload_hashes AS replica_hash
+  WHERE replica_hash.record_id = OLD.id
+    AND replica_hash.workspace_id = OLD.workspace_id
+    AND replica_hash.payload_hash <> ''
+    AND NOT EXISTS (
+      SELECT 1 FROM e2ee_ciphertext_archive AS archive
+      WHERE archive.workspace_id = OLD.workspace_id
+        AND archive.record_id = OLD.id
+        AND archive.payload_hash = replica_hash.payload_hash
+    )
+    AND (
+      EXISTS(
+        SELECT 1 FROM e2ee_local_state AS local
+        WHERE local.workspace_id = OLD.workspace_id
+          AND local.record_id = OLD.id
+          AND local.payload_hash = replica_hash.payload_hash
+      )
+      OR EXISTS(
+        SELECT 1 FROM e2ee_witness_records AS witness
+        WHERE witness.workspace_id = OLD.workspace_id
+          AND witness.record_id = OLD.id
+          AND witness.payload_hash = replica_hash.payload_hash
+      )
+    );
+END;
+
+CREATE TRIGGER e2ee_records_archive_before_delete
+BEFORE DELETE ON e2ee_records
+WHEN OLD.payload <> ''
+BEGIN
+  INSERT OR IGNORE INTO e2ee_ciphertext_archive (
+    workspace_id, record_id, payload_hash, payload
+  )
+  SELECT OLD.workspace_id, OLD.id, replica_hash.payload_hash, OLD.payload
+  FROM e2ee_replica_payload_hashes AS replica_hash
+  WHERE replica_hash.record_id = OLD.id
+    AND replica_hash.workspace_id = OLD.workspace_id
+    AND replica_hash.payload_hash <> ''
+    AND NOT EXISTS (
+      SELECT 1 FROM e2ee_ciphertext_archive AS archive
+      WHERE archive.workspace_id = OLD.workspace_id
+        AND archive.record_id = OLD.id
+        AND archive.payload_hash = replica_hash.payload_hash
+    )
+    AND (
+      EXISTS(
+        SELECT 1 FROM e2ee_local_state AS local
+        WHERE local.workspace_id = OLD.workspace_id
+          AND local.record_id = OLD.id
+          AND local.payload_hash = replica_hash.payload_hash
+      )
+      OR EXISTS(
+        SELECT 1 FROM e2ee_witness_records AS witness
+        WHERE witness.workspace_id = OLD.workspace_id
+          AND witness.record_id = OLD.id
+          AND witness.payload_hash = replica_hash.payload_hash
+      )
+    );
+END;
+
+CREATE TRIGGER e2ee_replica_payload_hash_insert
+AFTER INSERT ON e2ee_records
+BEGIN
+  INSERT INTO e2ee_replica_payload_hashes (record_id, workspace_id, payload_hash)
+  VALUES (NEW.id, NEW.workspace_id, '')
+  ON CONFLICT(record_id) DO UPDATE SET
+    workspace_id = excluded.workspace_id,
+    payload_hash = '',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+END;
+
+CREATE TRIGGER e2ee_replica_payload_hash_update
+AFTER UPDATE OF workspace_id, payload ON e2ee_records
+WHEN OLD.workspace_id <> NEW.workspace_id OR OLD.payload <> NEW.payload
+BEGIN
+  INSERT INTO e2ee_replica_payload_hashes (record_id, workspace_id, payload_hash)
+  VALUES (NEW.id, NEW.workspace_id, '')
+  ON CONFLICT(record_id) DO UPDATE SET
+    workspace_id = excluded.workspace_id,
+    payload_hash = '',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+END;
+
+CREATE TRIGGER e2ee_replica_payload_hash_delete
+AFTER DELETE ON e2ee_records
+BEGIN
+  DELETE FROM e2ee_replica_payload_hashes WHERE record_id = OLD.id;
+END;
+
+CREATE TRIGGER e2ee_local_state_normalize_payload_insert
+AFTER INSERT ON e2ee_local_state
+WHEN NEW.payload <> ''
+BEGIN
+  INSERT OR IGNORE INTO e2ee_ciphertext_archive (
+    workspace_id, record_id, payload_hash, payload
+  )
+  SELECT NEW.workspace_id, NEW.record_id, NEW.payload_hash, NEW.payload
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM e2ee_records AS replica
+    JOIN e2ee_replica_payload_hashes AS replica_hash
+      ON replica_hash.record_id = replica.id
+     AND replica_hash.workspace_id = replica.workspace_id
+    WHERE replica.id = NEW.record_id
+      AND replica.workspace_id = NEW.workspace_id
+      AND replica.payload = NEW.payload
+      AND replica_hash.payload_hash = NEW.payload_hash
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM e2ee_ciphertext_archive AS archive
+    WHERE archive.workspace_id = NEW.workspace_id
+      AND archive.record_id = NEW.record_id
+      AND archive.payload_hash = NEW.payload_hash
+  );
+  UPDATE e2ee_local_state SET payload = '' WHERE record_id = NEW.record_id;
+END;
+
+CREATE TRIGGER e2ee_local_state_normalize_payload_update
+AFTER UPDATE OF payload ON e2ee_local_state
+WHEN NEW.payload <> ''
+BEGIN
+  INSERT OR IGNORE INTO e2ee_ciphertext_archive (
+    workspace_id, record_id, payload_hash, payload
+  )
+  SELECT NEW.workspace_id, NEW.record_id, NEW.payload_hash, NEW.payload
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM e2ee_records AS replica
+    JOIN e2ee_replica_payload_hashes AS replica_hash
+      ON replica_hash.record_id = replica.id
+     AND replica_hash.workspace_id = replica.workspace_id
+    WHERE replica.id = NEW.record_id
+      AND replica.workspace_id = NEW.workspace_id
+      AND replica.payload = NEW.payload
+      AND replica_hash.payload_hash = NEW.payload_hash
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM e2ee_ciphertext_archive AS archive
+    WHERE archive.workspace_id = NEW.workspace_id
+      AND archive.record_id = NEW.record_id
+      AND archive.payload_hash = NEW.payload_hash
+  );
+  UPDATE e2ee_local_state SET payload = '' WHERE record_id = NEW.record_id;
+END;
+
+CREATE TRIGGER e2ee_witness_records_normalize_payload_insert
+AFTER INSERT ON e2ee_witness_records
+WHEN NEW.payload <> ''
+BEGIN
+  INSERT OR IGNORE INTO e2ee_ciphertext_archive (
+    workspace_id, record_id, payload_hash, payload
+  )
+  SELECT NEW.workspace_id, NEW.record_id, NEW.payload_hash, NEW.payload
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM e2ee_records AS replica
+    JOIN e2ee_replica_payload_hashes AS replica_hash
+      ON replica_hash.record_id = replica.id
+     AND replica_hash.workspace_id = replica.workspace_id
+    WHERE replica.id = NEW.record_id
+      AND replica.workspace_id = NEW.workspace_id
+      AND replica.payload = NEW.payload
+      AND replica_hash.payload_hash = NEW.payload_hash
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM e2ee_ciphertext_archive AS archive
+    WHERE archive.workspace_id = NEW.workspace_id
+      AND archive.record_id = NEW.record_id
+      AND archive.payload_hash = NEW.payload_hash
+  );
+  UPDATE e2ee_witness_records
+  SET payload = ''
+  WHERE workspace_id = NEW.workspace_id AND record_id = NEW.record_id;
+END;
+
+CREATE TRIGGER e2ee_witness_records_normalize_payload_update
+AFTER UPDATE OF payload ON e2ee_witness_records
+WHEN NEW.payload <> ''
+BEGIN
+  INSERT OR IGNORE INTO e2ee_ciphertext_archive (
+    workspace_id, record_id, payload_hash, payload
+  )
+  SELECT NEW.workspace_id, NEW.record_id, NEW.payload_hash, NEW.payload
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM e2ee_records AS replica
+    JOIN e2ee_replica_payload_hashes AS replica_hash
+      ON replica_hash.record_id = replica.id
+     AND replica_hash.workspace_id = replica.workspace_id
+    WHERE replica.id = NEW.record_id
+      AND replica.workspace_id = NEW.workspace_id
+      AND replica.payload = NEW.payload
+      AND replica_hash.payload_hash = NEW.payload_hash
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM e2ee_ciphertext_archive AS archive
+    WHERE archive.workspace_id = NEW.workspace_id
+      AND archive.record_id = NEW.record_id
+      AND archive.payload_hash = NEW.payload_hash
+  );
+  UPDATE e2ee_witness_records
+  SET payload = ''
+  WHERE workspace_id = NEW.workspace_id AND record_id = NEW.record_id;
+END;
+
+CREATE TRIGGER e2ee_local_state_prune_archive_delete
+AFTER DELETE ON e2ee_local_state
+BEGIN
+  DELETE FROM e2ee_ciphertext_archive
+  WHERE workspace_id = OLD.workspace_id
+    AND record_id = OLD.record_id
+    AND payload_hash = OLD.payload_hash
+    AND NOT EXISTS (
+      SELECT 1 FROM e2ee_witness_records AS witness
+      WHERE witness.workspace_id = OLD.workspace_id
+        AND witness.record_id = OLD.record_id
+        AND witness.payload_hash = OLD.payload_hash
+    );
+END;
+
+CREATE TRIGGER e2ee_local_state_prune_archive_update
+AFTER UPDATE OF workspace_id, payload_hash ON e2ee_local_state
+WHEN OLD.workspace_id <> NEW.workspace_id OR OLD.payload_hash <> NEW.payload_hash
+BEGIN
+  DELETE FROM e2ee_ciphertext_archive
+  WHERE workspace_id = OLD.workspace_id
+    AND record_id = OLD.record_id
+    AND payload_hash = OLD.payload_hash
+    AND NOT EXISTS (
+      SELECT 1 FROM e2ee_witness_records AS witness
+      WHERE witness.workspace_id = OLD.workspace_id
+        AND witness.record_id = OLD.record_id
+        AND witness.payload_hash = OLD.payload_hash
+    );
+END;
+
+CREATE TRIGGER e2ee_witness_records_prune_archive_delete
+AFTER DELETE ON e2ee_witness_records
+BEGIN
+  DELETE FROM e2ee_ciphertext_archive
+  WHERE workspace_id = OLD.workspace_id
+    AND record_id = OLD.record_id
+    AND payload_hash = OLD.payload_hash
+    AND NOT EXISTS (
+      SELECT 1 FROM e2ee_local_state AS local
+      WHERE local.workspace_id = OLD.workspace_id
+        AND local.record_id = OLD.record_id
+        AND local.payload_hash = OLD.payload_hash
+    );
+END;
+
+CREATE TRIGGER e2ee_witness_records_prune_archive_update
+AFTER UPDATE OF workspace_id, payload_hash ON e2ee_witness_records
+WHEN OLD.workspace_id <> NEW.workspace_id OR OLD.payload_hash <> NEW.payload_hash
+BEGIN
+  DELETE FROM e2ee_ciphertext_archive
+  WHERE workspace_id = OLD.workspace_id
+    AND record_id = OLD.record_id
+    AND payload_hash = OLD.payload_hash
+    AND NOT EXISTS (
+      SELECT 1 FROM e2ee_local_state AS local
+      WHERE local.workspace_id = OLD.workspace_id
+        AND local.record_id = OLD.record_id
+        AND local.payload_hash = OLD.payload_hash
+    );
+END;

--- a/crates/db-app/src/e2ee/replica_apply.rs
+++ b/crates/db-app/src/e2ee/replica_apply.rs
@@ -188,6 +188,7 @@ pub(super) async fn load_changed_e2ee_record_metadata(
                  AND witness.payload_hash = replica_hash.payload_hash
              ) AS witnessed,
            replica.id IS NOT NULL
+           AND replica.payload != ''
            AND (
              replica_hash.record_id IS NULL
              OR local.record_id IS NULL

--- a/crates/db-app/src/e2ee/replica_apply.rs
+++ b/crates/db-app/src/e2ee/replica_apply.rs
@@ -8,9 +8,9 @@ use sqlx::{QueryBuilder, Sqlite, SqlitePool, Transaction};
 use super::cooperative::yield_once;
 use super::replica_storage::{
     clear_stale_apply_guards, delete_row, insert_apply_guard, insert_row, load_row_local_states,
-    read_field, record_version_order, remove_apply_guard, replica_records_still_current,
-    restore_local_payload, row_changed_since_snapshot, row_exists, table_columns, update_field,
-    upsert_local_state,
+    normalize_replica_payload_hashes, read_field, record_version_order, remove_apply_guard,
+    replica_records_still_current, restore_local_payload, row_changed_since_snapshot, row_exists,
+    table_columns, update_field, upsert_local_state,
 };
 use super::witness::repair_e2ee_replica_from_witness_bounded_cancellable;
 use super::{
@@ -185,18 +185,22 @@ pub(super) async fn load_changed_e2ee_record_metadata(
                FROM e2ee_witness_records AS witness
                WHERE witness.workspace_id = replica.workspace_id
                  AND witness.record_id = replica.id
-                 AND witness.payload_hash = replica.payload_hash
+                 AND witness.payload_hash = replica_hash.payload_hash
              ) AS witnessed,
            replica.id IS NOT NULL
            AND (
-             local.record_id IS NULL
+             replica_hash.record_id IS NULL
+             OR local.record_id IS NULL
              OR local.workspace_id != replica.workspace_id
-             OR local.payload_hash != replica.payload_hash
+             OR local.payload_hash != replica_hash.payload_hash
            ) AS changed
          FROM page
          LEFT JOIN e2ee_records AS replica
            ON replica.id = page.id
           AND replica.workspace_id = page.workspace_id
+         LEFT JOIN e2ee_replica_payload_hashes AS replica_hash
+           ON replica_hash.record_id = replica.id
+          AND replica_hash.workspace_id = replica.workspace_id
          LEFT JOIN e2ee_local_state AS local
            ON local.record_id = replica.id
          ORDER BY page.workspace_id, page.id",
@@ -218,9 +222,12 @@ async fn load_encrypted_records_by_id(
              FROM e2ee_witness_records AS witness
              WHERE witness.workspace_id = replica.workspace_id
                AND witness.record_id = replica.id
-               AND witness.payload_hash = replica.payload_hash
+               AND witness.payload_hash = replica_hash.payload_hash
            ) AS witnessed
          FROM e2ee_records AS replica
+         LEFT JOIN e2ee_replica_payload_hashes AS replica_hash
+           ON replica_hash.record_id = replica.id
+          AND replica_hash.workspace_id = replica.workspace_id
          WHERE replica.id IN (",
     );
     {
@@ -248,7 +255,7 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
     check_e2ee_apply_cancellation(is_cancelled)?;
     clear_stale_apply_guards(pool).await?;
     check_e2ee_apply_cancellation(is_cancelled)?;
-    normalize_e2ee_record_payload_hashes(pool, keys, is_cancelled).await?;
+    normalize_replica_payload_hashes(pool, keys, is_cancelled).await?;
     check_e2ee_apply_cancellation(is_cancelled)?;
     let mut groups = BTreeMap::<(String, String, String), BTreeSet<String>>::new();
     let mut group_pending = BTreeMap::<(String, String, String), Vec<(String, i64)>>::new();
@@ -777,10 +784,13 @@ async fn load_encrypted_row_group(
              FROM e2ee_witness_records AS witness
              WHERE witness.workspace_id = replica.workspace_id
                AND witness.record_id = replica.id
-               AND witness.payload_hash = replica.payload_hash
+               AND witness.payload_hash = replica_hash.payload_hash
            ) AS witnessed,
            1 AS changed
          FROM e2ee_records AS replica
+         LEFT JOIN e2ee_replica_payload_hashes AS replica_hash
+           ON replica_hash.record_id = replica.id
+          AND replica_hash.workspace_id = replica.workspace_id
          WHERE replica.workspace_id = ",
     );
     query.push_bind(workspace_id);
@@ -809,54 +819,4 @@ async fn load_encrypted_row_group(
         .into_iter()
         .filter(|record| record.workspace_id == workspace_id)
         .collect())
-}
-
-async fn normalize_e2ee_record_payload_hashes(
-    pool: &SqlitePool,
-    keys: &HashMap<String, WorkspaceKeyring>,
-    is_cancelled: &(impl Fn() -> bool + Sync),
-) -> E2eeReplicaResult<()> {
-    let mut workspace_ids = keys.keys().collect::<Vec<_>>();
-    workspace_ids.sort_unstable();
-    loop {
-        check_e2ee_apply_cancellation(is_cancelled)?;
-        let mut query = QueryBuilder::<Sqlite>::new(
-            "SELECT id, workspace_id, payload
-             FROM e2ee_records
-             WHERE payload_hash = '' AND workspace_id IN (",
-        );
-        {
-            let mut separated = query.separated(", ");
-            for workspace_id in &workspace_ids {
-                separated.push_bind(workspace_id);
-            }
-        }
-        query.push(") ORDER BY workspace_id, id LIMIT 64");
-        let records: Vec<(String, String, String)> = query.build_query_as().fetch_all(pool).await?;
-        check_e2ee_apply_cancellation(is_cancelled)?;
-        if records.is_empty() {
-            return Ok(());
-        }
-
-        let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
-        for (record_id, workspace_id, payload) in records {
-            if is_cancelled() {
-                return rollback_cancelled_e2ee_apply(transaction).await;
-            }
-            let payload_hash = anlg_e2ee::payload_hash(&payload);
-            sqlx::query(
-                "UPDATE e2ee_records
-                 SET payload_hash = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-                 WHERE id = ? AND workspace_id = ? AND payload = ? AND payload_hash = ''",
-            )
-            .bind(payload_hash)
-            .bind(record_id)
-            .bind(workspace_id)
-            .bind(payload)
-            .execute(&mut *transaction)
-            .await?;
-        }
-        commit_e2ee_apply_transaction(transaction, is_cancelled).await?;
-        yield_once().await;
-    }
 }

--- a/crates/db-app/src/e2ee/replica_encrypt.rs
+++ b/crates/db-app/src/e2ee/replica_encrypt.rs
@@ -678,11 +678,10 @@ pub(super) async fn persist_prepared_dirty_row_cancellable(
             return Err(error);
         }
         let result = sqlx::query(
-            "INSERT INTO e2ee_records (id, workspace_id, payload, payload_hash)
-             VALUES (?, ?, ?, ?)
+            "INSERT INTO e2ee_records (id, workspace_id, payload)
+             VALUES (?, ?, ?)
              ON CONFLICT(id) DO UPDATE SET
                payload = excluded.payload,
-               payload_hash = excluded.payload_hash,
                updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
              WHERE e2ee_records.workspace_id = excluded.workspace_id
                AND e2ee_records.payload != excluded.payload",
@@ -690,7 +689,6 @@ pub(super) async fn persist_prepared_dirty_row_cancellable(
         .bind(&field.state.record_id)
         .bind(&field.state.workspace_id)
         .bind(&field.state.payload)
-        .bind(&field.state.payload_hash)
         .execute(&mut *transaction)
         .await?;
         if let Err(error) = check_e2ee_cancellation(is_cancelled) {

--- a/crates/db-app/src/e2ee/replica_storage.rs
+++ b/crates/db-app/src/e2ee/replica_storage.rs
@@ -10,8 +10,116 @@ use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool, Transaction, TypeInfo, ValueRe
 
 use super::{
     DecryptedRecord, E2EE_DOMAIN_TABLES, E2eeReplicaError, E2eeReplicaResult, LocalState,
-    ROW_MANIFEST_FIELD,
+    ROW_MANIFEST_FIELD, check_e2ee_cancellation, yield_once,
 };
+
+pub(super) async fn normalize_replica_payload_hashes(
+    pool: &SqlitePool,
+    keys: &HashMap<String, WorkspaceKeyring>,
+    is_cancelled: &(impl Fn() -> bool + Sync),
+) -> E2eeReplicaResult<()> {
+    if keys.is_empty() {
+        return Ok(());
+    }
+    let mut workspace_ids = keys.keys().collect::<Vec<_>>();
+    workspace_ids.sort_unstable();
+    loop {
+        check_e2ee_cancellation(is_cancelled)?;
+        let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+        if let Err(error) = check_e2ee_cancellation(is_cancelled) {
+            transaction.rollback().await?;
+            return Err(error);
+        }
+        let mut query = QueryBuilder::<Sqlite>::new(
+            "SELECT replica.id, replica.workspace_id, replica.payload
+             FROM e2ee_records AS replica
+             LEFT JOIN e2ee_replica_payload_hashes AS replica_hash
+               ON replica_hash.record_id = replica.id
+             WHERE replica.workspace_id IN (",
+        );
+        {
+            let mut separated = query.separated(", ");
+            for workspace_id in &workspace_ids {
+                separated.push_bind(workspace_id);
+            }
+        }
+        query.push(
+            ")
+             AND (
+               replica_hash.record_id IS NULL
+               OR replica_hash.workspace_id != replica.workspace_id
+               OR replica_hash.payload_hash = ''
+             )
+             ORDER BY replica.workspace_id, replica.id
+             LIMIT 64",
+        );
+        let records: Vec<(String, String, String)> =
+            query.build_query_as().fetch_all(&mut *transaction).await?;
+        if records.is_empty() {
+            transaction.commit().await?;
+            check_e2ee_cancellation(is_cancelled)?;
+            return Ok(());
+        }
+        for (record_id, workspace_id, payload) in records {
+            if let Err(error) = check_e2ee_cancellation(is_cancelled) {
+                transaction.rollback().await?;
+                return Err(error);
+            }
+            let payload_hash = anlg_e2ee::payload_hash(&payload);
+            upsert_replica_payload_hash(
+                &mut transaction,
+                &workspace_id,
+                &record_id,
+                &payload_hash,
+                &payload,
+            )
+            .await?;
+        }
+        transaction.commit().await?;
+        check_e2ee_cancellation(is_cancelled)?;
+        yield_once().await;
+    }
+}
+
+pub(super) async fn upsert_replica_payload_hash(
+    transaction: &mut Transaction<'_, Sqlite>,
+    workspace_id: &str,
+    record_id: &str,
+    payload_hash: &str,
+    payload: &str,
+) -> E2eeReplicaResult<()> {
+    if workspace_id.is_empty()
+        || record_id.is_empty()
+        || payload.is_empty()
+        || anlg_e2ee::payload_hash(payload) != payload_hash
+    {
+        return Err(E2eeReplicaError::RollbackDetected);
+    }
+    let result = sqlx::query(
+        "INSERT INTO e2ee_replica_payload_hashes (record_id, workspace_id, payload_hash)
+         SELECT ?, ?, ?
+         WHERE EXISTS (
+           SELECT 1 FROM e2ee_records
+           WHERE id = ? AND workspace_id = ? AND payload = ?
+         )
+         ON CONFLICT(record_id) DO UPDATE SET
+           workspace_id = excluded.workspace_id,
+           payload_hash = excluded.payload_hash,
+           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+    )
+    .bind(record_id)
+    .bind(workspace_id)
+    .bind(payload_hash)
+    .bind(record_id)
+    .bind(workspace_id)
+    .bind(payload)
+    .execute(&mut **transaction)
+    .await?;
+    if result.rows_affected() != 1 {
+        return Err(E2eeReplicaError::RollbackDetected);
+    }
+    Ok(())
+}
 
 pub(super) async fn replica_records_still_current(
     transaction: &mut Transaction<'_, Sqlite>,
@@ -190,31 +298,20 @@ pub(super) async fn retain_ciphertext(
         return Err(E2eeReplicaError::RollbackDetected);
     }
 
-    let current: Option<(String, String, String)> = sqlx::query_as(
-        "SELECT workspace_id, payload_hash, payload
+    let current: Option<(String, String)> = sqlx::query_as(
+        "SELECT workspace_id, payload
          FROM e2ee_records
          WHERE id = ?",
     )
     .bind(record_id)
     .fetch_optional(&mut **transaction)
     .await?;
-    if let Some((current_workspace_id, current_payload_hash, current_payload)) = current
+    if let Some((current_workspace_id, current_payload)) = current
         && current_workspace_id == workspace_id
         && current_payload == payload
     {
-        if current_payload_hash != payload_hash {
-            sqlx::query(
-                "UPDATE e2ee_records
-                 SET payload_hash = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-                 WHERE id = ? AND workspace_id = ? AND payload = ?",
-            )
-            .bind(payload_hash)
-            .bind(record_id)
-            .bind(workspace_id)
-            .bind(payload)
-            .execute(&mut **transaction)
+        upsert_replica_payload_hash(transaction, workspace_id, record_id, payload_hash, payload)
             .await?;
-        }
         return Ok(());
     }
 
@@ -246,7 +343,6 @@ pub(super) async fn prune_ciphertext_archive(
                SELECT 1 FROM e2ee_records AS replica
                WHERE replica.workspace_id = archive.workspace_id
                  AND replica.id = archive.record_id
-                 AND replica.payload_hash = archive.payload_hash
                  AND replica.payload = archive.payload
              )
              OR (
@@ -346,15 +442,21 @@ pub(super) async fn restore_local_payload(
     }
     sqlx::query(
         "UPDATE e2ee_records
-         SET payload = ?, payload_hash = ?,
-             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+         SET payload = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
          WHERE id = ? AND workspace_id = ?",
     )
     .bind(&state.payload)
-    .bind(&state.payload_hash)
     .bind(&state.record_id)
     .bind(&state.workspace_id)
     .execute(&mut **transaction)
+    .await?;
+    upsert_replica_payload_hash(
+        transaction,
+        &state.workspace_id,
+        &state.record_id,
+        &state.payload_hash,
+        &state.payload,
+    )
     .await?;
     Ok(())
 }

--- a/crates/db-app/src/e2ee/replica_storage.rs
+++ b/crates/db-app/src/e2ee/replica_storage.rs
@@ -50,6 +50,7 @@ pub(super) async fn normalize_replica_payload_hashes(
                OR replica_hash.workspace_id != replica.workspace_id
                OR replica_hash.payload_hash = ''
              )
+             AND replica.payload != ''
              ORDER BY replica.workspace_id, replica.id
              LIMIT 64",
         );

--- a/crates/db-app/src/e2ee/tests/replica_apply.rs
+++ b/crates/db-app/src/e2ee/tests/replica_apply.rs
@@ -1,6 +1,69 @@
 use super::*;
 
 #[tokio::test]
+async fn empty_replica_placeholders_wait_for_ciphertext() {
+    let workspace_keys = keys("workspace-a");
+    let source = test_db().await;
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('session-1', 'workspace-a', 'user-a', 'Ready')",
+    )
+    .execute(source.pool())
+    .await
+    .unwrap();
+    encrypt_e2ee_replica_changes(source.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    let record_id = workspace_keys["workspace-a"].blind_field_id("sessions", "session-1", "title");
+    let payload: String = sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
+        .bind(&record_id)
+        .fetch_one(source.pool())
+        .await
+        .unwrap();
+
+    let target = test_db().await;
+    sqlx::query("INSERT INTO e2ee_records (id, workspace_id) VALUES (?, 'workspace-a')")
+        .bind(&record_id)
+        .execute(target.pool())
+        .await
+        .unwrap();
+
+    let stats = apply_e2ee_replica_changes(target.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    assert_eq!(stats, E2eeReplicaStats::default());
+    let repair = repair_e2ee_replica_from_witness_bounded(
+        target.pool(),
+        &workspace_keys,
+        true,
+        64,
+        usize::MAX,
+    )
+    .await
+    .unwrap();
+    assert_eq!(repair.repaired_records, 0);
+    assert!(!repair.remaining);
+
+    sqlx::query("UPDATE e2ee_records SET payload = ? WHERE id = ?")
+        .bind(&payload)
+        .bind(&record_id)
+        .execute(target.pool())
+        .await
+        .unwrap();
+    apply_e2ee_replica_changes(target.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    let payload_hash: String = sqlx::query_scalar(
+        "SELECT payload_hash FROM e2ee_replica_payload_hashes WHERE record_id = ?",
+    )
+    .bind(&record_id)
+    .fetch_one(target.pool())
+    .await
+    .unwrap();
+    assert_eq!(payload_hash, anlg_e2ee::payload_hash(&payload));
+}
+
+#[tokio::test]
 async fn field_chunk_before_manifest_waits_then_applies_without_echo() {
     let workspace_keys = keys("workspace-a");
     let source = test_db().await;

--- a/crates/db-app/src/e2ee/tests/replica_apply.rs
+++ b/crates/db-app/src/e2ee/tests/replica_apply.rs
@@ -35,13 +35,38 @@ async fn field_chunk_before_manifest_waits_then_applies_without_echo() {
              VALUES (?, 'workspace-a', ?)",
     )
     .bind(&title_id)
-    .bind(title_payload)
+    .bind(&title_payload)
     .execute(target.pool())
     .await
     .unwrap();
+    let before_apply: (String, String) = sqlx::query_as(
+        "SELECT replica_hash.payload_hash, replica.updated_at
+         FROM e2ee_records AS replica
+         JOIN e2ee_replica_payload_hashes AS replica_hash
+           ON replica_hash.record_id = replica.id
+         WHERE replica.id = ?",
+    )
+    .bind(&title_id)
+    .fetch_one(target.pool())
+    .await
+    .unwrap();
+    assert!(before_apply.0.is_empty());
     apply_e2ee_replica_changes(target.pool(), &workspace_keys)
         .await
         .unwrap();
+    let after_apply: (String, String) = sqlx::query_as(
+        "SELECT replica_hash.payload_hash, replica.updated_at
+         FROM e2ee_records AS replica
+         JOIN e2ee_replica_payload_hashes AS replica_hash
+           ON replica_hash.record_id = replica.id
+         WHERE replica.id = ?",
+    )
+    .bind(&title_id)
+    .fetch_one(target.pool())
+    .await
+    .unwrap();
+    assert_eq!(after_apply.0, anlg_e2ee::payload_hash(&title_payload));
+    assert_eq!(after_apply.1, before_apply.1);
     let before_manifest: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM sessions WHERE id = 'session-1'")
             .fetch_one(target.pool())
@@ -838,15 +863,26 @@ async fn replica_apply_scan_bounds_payload_comparisons_before_filtering() {
     .await
     .unwrap();
     sqlx::query(
-        "INSERT INTO e2ee_records (id, workspace_id, payload_hash, payload)
-         SELECT record_id, workspace_id, payload_hash, payload FROM e2ee_witness_records",
+        "INSERT INTO e2ee_records (id, workspace_id, payload)
+         SELECT record_id, workspace_id, payload FROM e2ee_witness_records",
+    )
+    .execute(target.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE e2ee_replica_payload_hashes
+         SET payload_hash = (
+           SELECT witness.payload_hash
+           FROM e2ee_witness_records AS witness
+           WHERE witness.record_id = e2ee_replica_payload_hashes.record_id
+         )",
     )
     .execute(target.pool())
     .await
     .unwrap();
     sqlx::query(
         "INSERT INTO e2ee_local_state (record_id, workspace_id, payload_hash, payload)
-         SELECT id, workspace_id, payload_hash, payload FROM e2ee_records",
+         SELECT record_id, workspace_id, payload_hash, payload FROM e2ee_witness_records",
     )
     .execute(target.pool())
     .await
@@ -854,8 +890,16 @@ async fn replica_apply_scan_bounds_payload_comparisons_before_filtering() {
 
     sqlx::query(
         "UPDATE e2ee_records
-         SET payload_hash = 'changed-hash', payload = 'changed'
+         SET payload = 'changed'
          WHERE id = 'record-255'",
+    )
+    .execute(target.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE e2ee_replica_payload_hashes
+         SET payload_hash = 'changed-hash'
+         WHERE record_id = 'record-255'",
     )
     .execute(target.pool())
     .await

--- a/crates/db-app/src/e2ee/witness.rs
+++ b/crates/db-app/src/e2ee/witness.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 use anlg_e2ee::{OpenedField, WorkspaceKey, WorkspaceKeyring};
 use sqlx::{QueryBuilder, Sqlite, SqlitePool, Transaction};
 
-use super::replica_storage::{prune_ciphertext_archive, retain_ciphertext};
+use super::replica_storage::{
+    normalize_replica_payload_hashes, prune_ciphertext_archive, retain_ciphertext,
+    upsert_replica_payload_hash,
+};
 use super::{
     E2EE_DOMAIN_TABLES, E2eeReplicaError, E2eeReplicaResult, LocalState, check_e2ee_cancellation,
     reconcile_e2ee_witness_pending, yield_once,
@@ -508,6 +511,8 @@ async fn repair_e2ee_replica_from_witness_bounded_inner(
         return Ok(outcome);
     }
 
+    normalize_replica_payload_hashes(pool, keys, is_cancelled).await?;
+    check_e2ee_cancellation(is_cancelled)?;
     let records = load_bounded_e2ee_witness_repairs(
         pool,
         keys,
@@ -650,7 +655,8 @@ async fn load_bounded_e2ee_witness_repairs(
                  replica.id IS NOT NULL
                  AND (
                    replica.workspace_id != witness.workspace_id
-                   OR replica.payload_hash != witness.payload_hash
+                   OR replica_hash.record_id IS NULL
+                   OR replica_hash.payload_hash != witness.payload_hash
                  )
                )
              ) AS needs_repair
@@ -660,6 +666,9 @@ async fn load_bounded_e2ee_witness_repairs(
           AND witness.record_id = page.record_id
          LEFT JOIN e2ee_records AS replica
            ON replica.id = page.record_id
+         LEFT JOIN e2ee_replica_payload_hashes AS replica_hash
+           ON replica_hash.record_id = replica.id
+          AND replica_hash.workspace_id = replica.workspace_id
          ORDER BY page.workspace_id, page.record_id",
         );
     let metadata: Vec<(String, String, i64, i64, bool)> =
@@ -812,11 +821,10 @@ async fn persist_e2ee_witness_repairs(
             continue;
         }
         let result = sqlx::query(
-            "INSERT INTO e2ee_records (id, workspace_id, payload, payload_hash)
-             VALUES (?, ?, ?, ?)
+            "INSERT INTO e2ee_records (id, workspace_id, payload)
+             VALUES (?, ?, ?)
              ON CONFLICT(id) DO UPDATE SET
                payload = excluded.payload,
-               payload_hash = excluded.payload_hash,
                updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
              WHERE e2ee_records.workspace_id = excluded.workspace_id
                AND e2ee_records.payload != excluded.payload",
@@ -824,7 +832,6 @@ async fn persist_e2ee_witness_repairs(
         .bind(&record.record_id)
         .bind(&record.workspace_id)
         .bind(&record.payload)
-        .bind(&record.payload_hash)
         .execute(&mut *transaction)
         .await?;
         if let Err(error) = check_e2ee_cancellation(is_cancelled) {
@@ -852,6 +859,14 @@ async fn persist_e2ee_witness_repairs(
         } else {
             repaired_records += 1;
         }
+        upsert_replica_payload_hash(
+            &mut transaction,
+            &record.workspace_id,
+            &record.record_id,
+            &record.payload_hash,
+            &record.payload,
+        )
+        .await?;
         sqlx::query("DELETE FROM e2ee_witness_repair_pending WHERE record_id = ?")
             .bind(&record.record_id)
             .execute(&mut *transaction)

--- a/crates/db-app/src/e2ee/witness/witness_cancellation_tests.rs
+++ b/crates/db-app/src/e2ee/witness/witness_cancellation_tests.rs
@@ -352,8 +352,19 @@ async fn witness_scan_selects_only_records_that_need_repair() {
     .await
     .unwrap();
     sqlx::query(
-        "INSERT INTO e2ee_records (id, workspace_id, payload_hash, payload)
-         SELECT record_id, workspace_id, payload_hash, payload FROM e2ee_witness_records",
+        "INSERT INTO e2ee_records (id, workspace_id, payload)
+         SELECT record_id, workspace_id, payload FROM e2ee_witness_records",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE e2ee_replica_payload_hashes
+         SET payload_hash = (
+           SELECT witness.payload_hash
+           FROM e2ee_witness_records AS witness
+           WHERE witness.record_id = e2ee_replica_payload_hashes.record_id
+         )",
     )
     .execute(db.pool())
     .await
@@ -372,8 +383,16 @@ async fn witness_scan_selects_only_records_that_need_repair() {
 
     sqlx::query(
         "UPDATE e2ee_records
-         SET payload_hash = 'changed-hash', payload = 'changed'
+         SET payload = 'changed'
          WHERE id = 'record-255'",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE e2ee_replica_payload_hashes
+         SET payload_hash = 'changed-hash'
+         WHERE record_id = 'record-255'",
     )
     .execute(db.pool())
     .await

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -363,6 +363,18 @@ pub const APP_MIGRATION_STEPS: &[anlg_db_migrate::MigrationStep] = &[
         scope: anlg_db_migrate::MigrationScope::Plain,
         sql: include_str!("../migrations/20260815100400_e2ee_ciphertext_ownership.sql"),
     },
+    anlg_db_migrate::MigrationStep {
+        id: "20260816100000_e2ee_replica_payload_hashes",
+        scope: anlg_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260816100000_e2ee_replica_payload_hashes.sql"),
+    },
+    anlg_db_migrate::MigrationStep {
+        id: "20260816100100_e2ee_payload_hash_local_state",
+        scope: anlg_db_migrate::MigrationScope::CloudsyncAlter {
+            table_name: "e2ee_records",
+        },
+        sql: include_str!("../migrations/20260816100100_e2ee_payload_hash_local_state.sql"),
+    },
 ];
 
 pub fn schema() -> anlg_db_migrate::DbSchema {

--- a/crates/db-app/src/schema_tests/encrypted_replica.rs
+++ b/crates/db-app/src/schema_tests/encrypted_replica.rs
@@ -57,6 +57,21 @@ fn ciphertext_ownership_migrations_use_the_required_scopes() {
         .find(|step| step.id == "20260815100400_e2ee_ciphertext_ownership")
         .unwrap();
     assert_eq!(ownership.scope, anlg_db_migrate::MigrationScope::Plain);
+    let local_hashes = APP_MIGRATION_STEPS
+        .iter()
+        .find(|step| step.id == "20260816100000_e2ee_replica_payload_hashes")
+        .unwrap();
+    assert_eq!(local_hashes.scope, anlg_db_migrate::MigrationScope::Plain);
+    let localization = APP_MIGRATION_STEPS
+        .iter()
+        .find(|step| step.id == "20260816100100_e2ee_payload_hash_local_state")
+        .unwrap();
+    assert_eq!(
+        localization.scope,
+        anlg_db_migrate::MigrationScope::CloudsyncAlter {
+            table_name: "e2ee_records"
+        }
+    );
 }
 
 #[tokio::test]
@@ -112,12 +127,27 @@ async fn ciphertext_ownership_migration_preserves_legacy_versions_and_is_resumab
     anlg_db_migrate::migrate(&db, schema()).await.unwrap();
     anlg_db_migrate::migrate(&db, schema()).await.unwrap();
 
-    let current: (String, String) =
-        sqlx::query_as("SELECT payload_hash, payload FROM e2ee_records WHERE id = 'record-1'")
-            .fetch_one(db.pool())
+    let current: (String, String) = sqlx::query_as(
+        "SELECT replica_hash.payload_hash, replica.payload
+         FROM e2ee_records AS replica
+         JOIN e2ee_replica_payload_hashes AS replica_hash
+           ON replica_hash.record_id = replica.id
+          AND replica_hash.workspace_id = replica.workspace_id
+         WHERE replica.id = 'record-1'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(current, (current_hash, current_payload.to_string()));
+    let replica_columns: Vec<String> =
+        sqlx::query_scalar("SELECT name FROM pragma_table_info('e2ee_records') ORDER BY cid")
+            .fetch_all(db.pool())
             .await
             .unwrap();
-    assert_eq!(current, (current_hash, current_payload.to_string()));
+    assert_eq!(
+        replica_columns,
+        ["id", "workspace_id", "payload", "created_at", "updated_at"]
+    );
     let base_payloads: (String, String) = sqlx::query_as(
         "SELECT local.payload, witness.payload
          FROM e2ee_local_state AS local
@@ -164,10 +194,17 @@ async fn current_ciphertext_is_shared_by_local_and_witness_metadata() {
     let current_payload = "current-ciphertext";
     let current_hash = anlg_e2ee::payload_hash(current_payload);
     sqlx::query(
-        "INSERT INTO e2ee_records (id, workspace_id, payload, payload_hash)
-         VALUES ('record-1', 'workspace-a', ?, ?)",
+        "INSERT INTO e2ee_records (id, workspace_id, payload)
+         VALUES ('record-1', 'workspace-a', ?)",
     )
     .bind(current_payload)
+    .execute(db.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE e2ee_replica_payload_hashes
+         SET payload_hash = ? WHERE record_id = 'record-1'",
+    )
     .bind(&current_hash)
     .execute(db.pool())
     .await
@@ -216,10 +253,8 @@ async fn current_ciphertext_is_shared_by_local_and_witness_metadata() {
     assert_eq!(archive_count, 0);
 
     let rollback_payload = "replayed-ciphertext";
-    let rollback_hash = anlg_e2ee::payload_hash(rollback_payload);
-    sqlx::query("UPDATE e2ee_records SET payload = ?, payload_hash = ? WHERE id = 'record-1'")
+    sqlx::query("UPDATE e2ee_records SET payload = ? WHERE id = 'record-1'")
         .bind(rollback_payload)
-        .bind(rollback_hash)
         .execute(db.pool())
         .await
         .unwrap();
@@ -259,12 +294,20 @@ async fn representative_ciphertext_corpus_uses_one_steady_state_copy() {
         let record_id = format!("record-{index}");
         expected_payload_bytes += i64::try_from(payload.len()).unwrap();
         sqlx::query(
-            "INSERT INTO e2ee_records (id, workspace_id, payload, payload_hash)
-             VALUES (?, 'workspace-a', ?, ?)",
+            "INSERT INTO e2ee_records (id, workspace_id, payload)
+             VALUES (?, 'workspace-a', ?)",
         )
         .bind(&record_id)
         .bind(&payload)
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "UPDATE e2ee_replica_payload_hashes
+             SET payload_hash = ? WHERE record_id = ?",
+        )
         .bind(&payload_hash)
+        .bind(&record_id)
         .execute(db.pool())
         .await
         .unwrap();

--- a/crates/db-app/src/schema_tests/migrations.rs
+++ b/crates/db-app/src/schema_tests/migrations.rs
@@ -51,6 +51,7 @@ async fn migrations_apply_cleanly() {
             "e2ee_local_device",
             "e2ee_local_state",
             "e2ee_records",
+            "e2ee_replica_payload_hashes",
             "e2ee_replica_pending",
             "e2ee_witness_pending",
             "e2ee_witness_records",

--- a/plugins/db/src/runtime/tests/sync_hook.rs
+++ b/plugins/db/src/runtime/tests/sync_hook.rs
@@ -426,10 +426,13 @@ async fn idle_sync_skips_replica_reconciliation_until_new_work_arrives() {
     let (record_id, original_payload): (String, String) = sqlx::query_as(
         "SELECT replica.id, replica.payload
              FROM e2ee_records AS replica
+             INNER JOIN e2ee_replica_payload_hashes AS replica_hash
+              ON replica_hash.record_id = replica.id
+             AND replica_hash.workspace_id = replica.workspace_id
              INNER JOIN e2ee_witness_records AS witness
               ON witness.workspace_id = replica.workspace_id
              AND witness.record_id = replica.id
-              AND witness.payload_hash = replica.payload_hash
+              AND witness.payload_hash = replica_hash.payload_hash
              WHERE replica.workspace_id = 'workspace-1'
              ORDER BY replica.id
              LIMIT 1",


### PR DESCRIPTION
Move replica payload hashes into local derived state and restore the production five-column e2ee_records contract.

Validation:
- cargo test --locked -p db-app --lib
- cargo test --locked -p tauri-plugin-db
- cargo clippy --locked -p db-app --all-targets --no-deps -- -D warnings
- cargo check
- API CI commands and verifier unit tests
- live production CloudSync E2EE sync, isolation, and cleanup verifier

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches E2EE replica schema, migrations, and sync/witness/apply logic; incorrect hash handling could break CloudSync compatibility or ciphertext resolution.
> 
> **Overview**
> Restores the **production CloudSync contract** for `e2ee_records` to five columns (`id`, `workspace_id`, `payload`, `created_at`, `updated_at`) by **dropping `payload_hash`** from the synced replica table. Hashes are now **client-only derived state** in a new `e2ee_replica_payload_hashes` table, backfilled from the old column before removal.
> 
> **Migrations** add the side table, migrate existing hashes, rebuild `e2ee_local_state_resolved` / `e2ee_witness_records_resolved` to join hashes from that table, and replace archive/normalize triggers so ciphertext ownership no longer depends on a hash column on `e2ee_records`.
> 
> **Rust E2EE paths** (`replica_apply`, `replica_encrypt`, `witness`, `re2ee_storage`) stop writing or reading `payload_hash` on `e2ee_records`; they join `e2ee_replica_payload_hashes`, compute hashes via `normalize_replica_payload_hashes` / `upsert_replica_payload_hash`, and treat empty replica payloads as placeholders until ciphertext arrives. **CI** (`verify_cloudsync_e2ee`) enforces the five-column schema and rejects an extra `payload_hash` on the cloud table.
> 
> Tests cover empty placeholders, hash normalization without bumping `updated_at`, and updated witness/repair fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc770f47ce983c3b6b2185872e219828222e468f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->