### PR TITLE
Sync workspace Stripe seat billing

### DIFF
--- a/apps/stripe/src/billing-bridge.test.ts
+++ b/apps/stripe/src/billing-bridge.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+import type Stripe from "stripe";
+
+import { syncBillingBridge } from "./billing-bridge";
+
+const customer = (metadata: Record<string, string>) =>
+  ({ id: "cus_team123", metadata }) as Stripe.Customer;
+
+const event = (type: Stripe.Event.Type, object: Stripe.Event.Data.Object) =>
+  ({
+    id: "evt_team123",
+    type,
+    data: { object },
+  }) as Stripe.Event;
+
+const dependencies = (
+  overrides: Partial<NonNullable<Parameters<typeof syncBillingBridge>[1]>> = {},
+): NonNullable<Parameters<typeof syncBillingBridge>[1]> => ({
+  getCustomer: async () => customer({ workspaceId: "workspace-123" }),
+  updateCustomerMetadata: async () => {
+    throw new Error("should not update personal metadata");
+  },
+  assignProfileCustomer: async () => {
+    throw new Error("should not assign a personal customer");
+  },
+  deleteCustomer: async () => {
+    throw new Error("should not delete a workspace customer");
+  },
+  syncWorkspaceCustomer: async () => "cus_team123",
+  teamPriceIds: new Set(["price_team"]),
+  ...overrides,
+});
+
+describe("syncBillingBridge", () => {
+  it("routes Team subscription quantities to the workspace billing RPC", async () => {
+    const updates: Array<Record<string, unknown>> = [];
+    const subscription = {
+      customer: "cus_team123",
+      items: {
+        data: [{ price: { id: "price_team" }, quantity: 4 }],
+      },
+    } as Stripe.Subscription;
+
+    await syncBillingBridge(
+      event("customer.subscription.updated", subscription),
+      dependencies({
+        syncWorkspaceCustomer: async (update) => {
+          updates.push(update);
+          return update.customerId;
+        },
+      }),
+    );
+
+    expect(updates).toEqual([
+      {
+        workspaceId: "workspace-123",
+        customerId: "cus_team123",
+        seatLimit: 4,
+        updateSeatLimit: true,
+      },
+    ]);
+  });
+
+  it("fails closed when Stripe metadata conflicts with the bound customer", async () => {
+    const subscription = {
+      customer: "cus_team123",
+      items: {
+        data: [{ price: { id: "price_team" }, quantity: 4 }],
+      },
+    } as Stripe.Subscription;
+
+    await expect(
+      syncBillingBridge(
+        event("customer.subscription.updated", subscription),
+        dependencies({
+          syncWorkspaceCustomer: async () => "cus_another_workspace",
+        }),
+      ),
+    ).rejects.toThrow("Workspace Stripe customer assignment conflict");
+  });
+
+  it("ignores Stripe events for a workspace that no longer exists", async () => {
+    const subscription = {
+      customer: "cus_team123",
+      items: {
+        data: [{ price: { id: "price_team" }, quantity: 4 }],
+      },
+    } as Stripe.Subscription;
+
+    await expect(
+      syncBillingBridge(
+        event("customer.subscription.updated", subscription),
+        dependencies({
+          syncWorkspaceCustomer: async () => null,
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("preserves personal customer assignment and metadata repair", async () => {
+    const metadataUpdates: Array<Record<string, string>> = [];
+    const assignments: string[][] = [];
+
+    await syncBillingBridge(
+      event(
+        "customer.updated",
+        customer({ userId: "user-123" }) as Stripe.Event.Data.Object,
+      ),
+      dependencies({
+        getCustomer: async () => customer({ userId: "user-123" }),
+        updateCustomerMetadata: async (_customerId, metadata) => {
+          metadataUpdates.push(metadata);
+        },
+        assignProfileCustomer: async (userId, customerId) => {
+          assignments.push([userId, customerId]);
+          return customerId;
+        },
+        syncWorkspaceCustomer: async () => {
+          throw new Error("should not assign a workspace customer");
+        },
+      }),
+    );
+
+    expect(metadataUpdates).toEqual([
+      {
+        userId: "user-123",
+        posthog_person_distinct_id: "user-123",
+      },
+    ]);
+    expect(assignments).toEqual([["user-123", "cus_team123"]]);
+  });
+});

--- a/apps/stripe/src/billing-bridge.ts
+++ b/apps/stripe/src/billing-bridge.ts
@@ -1,11 +1,10 @@
-import Stripe from "stripe";
+import type Stripe from "stripe";
 
 import {
   getCustomerIdentityMetadata,
-  getCustomerUserId,
+  getCustomerOwner,
 } from "./customer-metadata";
-import { stripe } from "./integration/stripe";
-import { supabaseAdmin } from "./integration/supabase";
+import { getWorkspaceBillingUpdate } from "./workspace-billing";
 
 const CUSTOMER_EVENTS: Stripe.Event.Type[] = [
   "checkout.session.completed",
@@ -13,9 +12,33 @@ const CUSTOMER_EVENTS: Stripe.Event.Type[] = [
   "customer.updated",
   "customer.subscription.created",
   "customer.subscription.updated",
+  "customer.subscription.deleted",
 ];
 
-export async function syncBillingBridge(event: Stripe.Event) {
+type BillingBridgeDependencies = {
+  getCustomer: (customerId: string) => Promise<Stripe.Customer | null>;
+  updateCustomerMetadata: (
+    customerId: string,
+    metadata: Record<string, string>,
+  ) => Promise<void>;
+  assignProfileCustomer: (
+    userId: string,
+    customerId: string,
+  ) => Promise<string | null | undefined>;
+  deleteCustomer: (customerId: string) => Promise<void>;
+  syncWorkspaceCustomer: (update: {
+    workspaceId: string;
+    customerId: string;
+    seatLimit: number | null;
+    updateSeatLimit: boolean;
+  }) => Promise<string | null | undefined>;
+  teamPriceIds: ReadonlySet<string>;
+};
+
+export async function syncBillingBridge(
+  event: Stripe.Event,
+  dependencies?: BillingBridgeDependencies,
+) {
   if (!isCustomerEvent(event.type)) {
     return;
   }
@@ -26,64 +49,55 @@ export async function syncBillingBridge(event: Stripe.Event) {
     return;
   }
 
-  const customer = await getStripeCustomer(customerId);
+  const activeDependencies =
+    dependencies ?? (await createDefaultDependencies());
+  const customer = await activeDependencies.getCustomer(customerId);
 
   if (!customer) {
     return;
   }
 
-  const userId = getUserIdFromCustomer(customer);
+  const owner = getCustomerOwner(customer.metadata);
 
-  if (!userId) {
+  if (!owner) {
     return;
   }
+
+  if (owner.kind === "workspace") {
+    const update = getWorkspaceBillingUpdate(
+      event,
+      activeDependencies.teamPriceIds,
+    );
+    const assignedCustomerId = await activeDependencies.syncWorkspaceCustomer({
+      workspaceId: owner.id,
+      customerId,
+      ...update,
+    });
+    if (assignedCustomerId && assignedCustomerId !== customerId) {
+      throw new Error("Workspace Stripe customer assignment conflict");
+    }
+    return;
+  }
+
+  const userId = owner.id;
 
   const identityMetadata = getCustomerIdentityMetadata(
     customer.metadata,
     userId,
   );
   if (identityMetadata) {
-    await stripe.customers.update(customerId, {
-      metadata: identityMetadata,
-    });
+    await activeDependencies.updateCustomerMetadata(
+      customerId,
+      identityMetadata,
+    );
   }
 
-  const { data, error } = await supabaseAdmin.rpc(
-    "assign_profile_stripe_customer",
-    {
-      p_owner_user_id: userId,
-      p_stripe_customer_id: customerId,
-    },
+  const assignedCustomerId = await activeDependencies.assignProfileCustomer(
+    userId,
+    customerId,
   );
-
-  let assignedCustomerId = data?.[0]?.assigned_customer_id as
-    | string
-    | null
-    | undefined;
-  if (error) {
-    if (error.code !== "PGRST202") {
-      throw error;
-    }
-    const { error: updateError } = await supabaseAdmin
-      .from("profiles")
-      .update({ stripe_customer_id: customerId })
-      .eq("id", userId)
-      .is("stripe_customer_id", null);
-    if (updateError) {
-      throw updateError;
-    }
-    const { data: profile, error: profileError } = await supabaseAdmin
-      .from("profiles")
-      .select("stripe_customer_id")
-      .eq("id", userId)
-      .single();
-    if (profileError) {
-      throw profileError;
-    }
-    assignedCustomerId = profile.stripe_customer_id as string | null;
-  }
   if (assignedCustomerId !== customerId) {
-    await stripe.customers.del(customerId);
+    await activeDependencies.deleteCustomer(customerId);
   }
 }
 
@@ -114,6 +128,7 @@ export const getCustomerId = (
 };
 
 export const getStripeCustomer = async (customerId: string) => {
+  const { stripe } = await import("./integration/stripe");
   const customer = await stripe.customers.retrieve(customerId);
 
   if (isDeletedCustomer(customer)) {
@@ -130,4 +145,84 @@ const isDeletedCustomer = (
 
 export const getUserIdFromCustomer = (
   customer: Stripe.Customer,
-): string | null => getCustomerUserId(customer.metadata);
+): string | null => {
+  const owner = getCustomerOwner(customer.metadata);
+  return owner?.kind === "user" ? owner.id : null;
+};
+
+async function createDefaultDependencies(): Promise<BillingBridgeDependencies> {
+  const [{ env }, { stripe }, { supabaseAdmin }] = await Promise.all([
+    import("./env"),
+    import("./integration/stripe"),
+    import("./integration/supabase"),
+  ]);
+
+  return {
+    async getCustomer(customerId) {
+      const customer = await stripe.customers.retrieve(customerId);
+      return isDeletedCustomer(customer) ? null : customer;
+    },
+    async updateCustomerMetadata(customerId, metadata) {
+      await stripe.customers.update(customerId, { metadata });
+    },
+    async assignProfileCustomer(userId, customerId) {
+      const { data, error } = await supabaseAdmin.rpc(
+        "assign_profile_stripe_customer",
+        {
+          p_owner_user_id: userId,
+          p_stripe_customer_id: customerId,
+        },
+      );
+
+      if (!error) {
+        return data?.[0]?.assigned_customer_id as string | null | undefined;
+      }
+      if (error.code !== "PGRST202") {
+        throw error;
+      }
+
+      const { error: updateError } = await supabaseAdmin
+        .from("profiles")
+        .update({ stripe_customer_id: customerId })
+        .eq("id", userId)
+        .is("stripe_customer_id", null);
+      if (updateError) {
+        throw updateError;
+      }
+
+      const { data: profile, error: profileError } = await supabaseAdmin
+        .from("profiles")
+        .select("stripe_customer_id")
+        .eq("id", userId)
+        .single();
+      if (profileError) {
+        throw profileError;
+      }
+      return profile.stripe_customer_id as string | null;
+    },
+    async deleteCustomer(customerId) {
+      await stripe.customers.del(customerId);
+    },
+    async syncWorkspaceCustomer(update) {
+      const { data, error } = await supabaseAdmin.rpc(
+        "sync_workspace_stripe_billing",
+        {
+          p_workspace_id: update.workspaceId,
+          p_stripe_customer_id: update.customerId,
+          p_seat_limit: update.seatLimit,
+          p_update_seat_limit: update.updateSeatLimit,
+        },
+      );
+      if (error) {
+        throw error;
+      }
+      return data?.[0]?.assigned_customer_id as string | null | undefined;
+    },
+    teamPriceIds: new Set(
+      [
+        env.STRIPE_TEAM_MONTHLY_PRICE_ID,
+        env.STRIPE_TEAM_YEARLY_PRICE_ID,
+      ].filter((priceId): priceId is string => Boolean(priceId)),
+    ),
+  };
+}

--- a/apps/stripe/src/customer-metadata.test.ts
+++ b/apps/stripe/src/customer-metadata.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from "bun:test";
 
 import {
   getCustomerIdentityMetadata,
+  getCustomerOwner,
   getCustomerUserId,
+  getCustomerWorkspaceId,
 } from "./customer-metadata";
 
 test("requires every Stripe owner alias to agree", () => {
@@ -21,6 +23,40 @@ test("returns the shared Stripe owner", () => {
       user_id: "owner-user",
     }),
   ).toBe("owner-user");
+});
+
+test("requires every Stripe workspace alias to agree", () => {
+  expect(
+    getCustomerWorkspaceId({
+      workspaceId: "workspace-one",
+      workspace_id: "workspace-two",
+    }),
+  ).toBeNull();
+});
+
+test("returns the shared Stripe workspace", () => {
+  expect(
+    getCustomerWorkspaceId({
+      workspaceId: "workspace-one",
+      workspace_id: "workspace-one",
+    }),
+  ).toBe("workspace-one");
+});
+
+test("rejects ambiguous user and workspace ownership", () => {
+  expect(
+    getCustomerOwner({
+      userId: "owner-user",
+      workspaceId: "workspace-one",
+    }),
+  ).toBeNull();
+});
+
+test("returns an unambiguous workspace owner", () => {
+  expect(getCustomerOwner({ workspaceId: "workspace-one" })).toEqual({
+    kind: "workspace",
+    id: "workspace-one",
+  });
 });
 
 test("repairs incomplete PostHog identity metadata", () => {

--- a/apps/stripe/src/customer-metadata.ts
+++ b/apps/stripe/src/customer-metadata.ts
@@ -1,18 +1,55 @@
 const OWNER_METADATA_KEYS = ["userId", "user_id", "userID"] as const;
+const WORKSPACE_METADATA_KEYS = ["workspaceId", "workspace_id"] as const;
 
 export function getCustomerUserId(metadata: Record<string, string> | null) {
-  const ownerIds = OWNER_METADATA_KEYS.map((key) => metadata?.[key]).filter(
-    (ownerId): ownerId is string => Boolean(ownerId),
+  return getConsistentMetadataValue(metadata, OWNER_METADATA_KEYS);
+}
+
+export function getCustomerWorkspaceId(
+  metadata: Record<string, string> | null,
+) {
+  return getConsistentMetadataValue(metadata, WORKSPACE_METADATA_KEYS);
+}
+
+export function getCustomerOwner(metadata: Record<string, string> | null) {
+  const hasUserOwner = OWNER_METADATA_KEYS.some((key) =>
+    Boolean(metadata?.[key]),
+  );
+  const hasWorkspaceOwner = WORKSPACE_METADATA_KEYS.some((key) =>
+    Boolean(metadata?.[key]),
   );
 
-  if (
-    ownerIds.length === 0 ||
-    ownerIds.some((ownerId) => ownerId !== ownerIds[0])
-  ) {
+  if (hasUserOwner === hasWorkspaceOwner) {
     return null;
   }
 
-  return ownerIds[0];
+  const userId = getCustomerUserId(metadata);
+  const workspaceId = getCustomerWorkspaceId(metadata);
+
+  if (userId && !workspaceId) {
+    return { kind: "user" as const, id: userId };
+  }
+
+  if (workspaceId && !userId) {
+    return { kind: "workspace" as const, id: workspaceId };
+  }
+
+  return null;
+}
+
+function getConsistentMetadataValue(
+  metadata: Record<string, string> | null,
+  keys: readonly string[],
+) {
+  const values = keys
+    .map((key) => metadata?.[key])
+    .filter((value): value is string => Boolean(value));
+
+  if (values.length === 0 || values.some((value) => value !== values[0])) {
+    return null;
+  }
+
+  return values[0];
 }
 
 export function getCustomerIdentityMetadata(

--- a/apps/stripe/src/env.ts
+++ b/apps/stripe/src/env.ts
@@ -15,6 +15,8 @@ export const env = createEnv({
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
     STRIPE_SECRET_KEY: z.string().min(1),
     STRIPE_WEBHOOK_SECRET: z.string().min(1),
+    STRIPE_TEAM_MONTHLY_PRICE_ID: z.string().min(1).optional(),
+    STRIPE_TEAM_YEARLY_PRICE_ID: z.string().min(1).optional(),
     POSTHOG_API_KEY: z.string().min(1).optional(),
     LOOPS_API_KEY: requiredInProduction(z.string().min(1)),
   },

--- a/apps/stripe/src/workspace-billing.test.ts
+++ b/apps/stripe/src/workspace-billing.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test";
+
+import {
+  getTeamSubscriptionSeatLimit,
+  getWorkspaceBillingUpdate,
+} from "./workspace-billing";
+
+const subscriptionWithItems = (
+  items: Array<{ price: { id: string }; quantity: number | null }>,
+) =>
+  ({
+    items: { data: items },
+  }) as Parameters<typeof getTeamSubscriptionSeatLimit>[0];
+
+test("reads the configured Team subscription quantity", () => {
+  expect(
+    getTeamSubscriptionSeatLimit(
+      subscriptionWithItems([
+        { price: { id: "price_team" }, quantity: 7 },
+        { price: { id: "price_addon" }, quantity: 1 },
+      ]),
+      new Set(["price_team"]),
+    ),
+  ).toBe(7);
+});
+
+test("uses Stripe's default quantity for a Team subscription item", () => {
+  expect(
+    getTeamSubscriptionSeatLimit(
+      subscriptionWithItems([{ price: { id: "price_team" }, quantity: null }]),
+      new Set(["price_team"]),
+    ),
+  ).toBe(1);
+});
+
+test("ignores subscriptions without a configured Team price", () => {
+  expect(
+    getTeamSubscriptionSeatLimit(
+      subscriptionWithItems([{ price: { id: "price_personal" }, quantity: 1 }]),
+      new Set(["price_team"]),
+    ),
+  ).toBeNull();
+});
+
+test("rejects ambiguous Team subscription items", () => {
+  expect(
+    getTeamSubscriptionSeatLimit(
+      subscriptionWithItems([
+        { price: { id: "price_team_monthly" }, quantity: 3 },
+        { price: { id: "price_team_yearly" }, quantity: 3 },
+      ]),
+      new Set(["price_team_monthly", "price_team_yearly"]),
+    ),
+  ).toBeNull();
+});
+
+test("reconciles quantities from subscription lifecycle events", () => {
+  const event = {
+    type: "customer.subscription.updated",
+    data: {
+      object: subscriptionWithItems([
+        { price: { id: "price_team" }, quantity: 4 },
+      ]),
+    },
+  } as Parameters<typeof getWorkspaceBillingUpdate>[0];
+
+  expect(getWorkspaceBillingUpdate(event, new Set(["price_team"]))).toEqual({
+    seatLimit: 4,
+    updateSeatLimit: true,
+  });
+});
+
+test("clears the seat limit when a Team subscription is deleted", () => {
+  const event = {
+    type: "customer.subscription.deleted",
+    data: {
+      object: subscriptionWithItems([
+        { price: { id: "price_team" }, quantity: 4 },
+      ]),
+    },
+  } as Parameters<typeof getWorkspaceBillingUpdate>[0];
+
+  expect(getWorkspaceBillingUpdate(event, new Set(["price_team"]))).toEqual({
+    seatLimit: null,
+    updateSeatLimit: true,
+  });
+});
+
+test("binds customer events without changing the seat limit", () => {
+  const event = {
+    type: "customer.updated",
+    data: { object: {} },
+  } as Parameters<typeof getWorkspaceBillingUpdate>[0];
+
+  expect(getWorkspaceBillingUpdate(event, new Set(["price_team"]))).toEqual({
+    seatLimit: null,
+    updateSeatLimit: false,
+  });
+});

--- a/apps/stripe/src/workspace-billing.ts
+++ b/apps/stripe/src/workspace-billing.ts
@@ -1,0 +1,49 @@
+import type Stripe from "stripe";
+
+const WORKSPACE_SUBSCRIPTION_EVENTS: Stripe.Event.Type[] = [
+  "customer.subscription.created",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+];
+
+export function getWorkspaceBillingUpdate(
+  event: Stripe.Event,
+  teamPriceIds: ReadonlySet<string>,
+) {
+  if (!WORKSPACE_SUBSCRIPTION_EVENTS.includes(event.type)) {
+    return { seatLimit: null, updateSeatLimit: false };
+  }
+
+  const seatLimit = getTeamSubscriptionSeatLimit(
+    event.data.object as Stripe.Subscription,
+    teamPriceIds,
+  );
+
+  if (event.type === "customer.subscription.deleted") {
+    return {
+      seatLimit: null,
+      updateSeatLimit: seatLimit !== null,
+    };
+  }
+
+  return {
+    seatLimit,
+    updateSeatLimit: seatLimit !== null,
+  };
+}
+
+export function getTeamSubscriptionSeatLimit(
+  subscription: Pick<Stripe.Subscription, "items">,
+  teamPriceIds: ReadonlySet<string>,
+) {
+  const teamItems = subscription.items.data.filter((item) =>
+    teamPriceIds.has(item.price.id),
+  );
+
+  if (teamItems.length !== 1) {
+    return null;
+  }
+
+  const quantity = teamItems[0]?.quantity ?? 1;
+  return Number.isSafeInteger(quantity) && quantity > 0 ? quantity : null;
+}

--- a/supabase/migrations/20260816075300_sync_workspace_stripe_billing.sql
+++ b/supabase/migrations/20260816075300_sync_workspace_stripe_billing.sql
@@ -1,0 +1,139 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.sync_workspace_stripe_billing(
+  p_workspace_id uuid,
+  p_stripe_customer_id text,
+  p_seat_limit integer DEFAULT NULL,
+  p_update_seat_limit boolean DEFAULT false
+)
+RETURNS TABLE (
+  assigned_customer_id text,
+  seat_limit integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_workspace public.workspaces%ROWTYPE;
+BEGIN
+  IF p_workspace_id IS NULL
+    OR p_stripe_customer_id IS NULL
+    OR length(p_stripe_customer_id) > 255
+    OR p_stripe_customer_id !~ '^cus_[A-Za-z0-9]+$'
+    OR p_update_seat_limit IS NULL
+    OR (p_update_seat_limit AND p_seat_limit IS NOT NULL AND p_seat_limit <= 0)
+    OR (NOT p_update_seat_limit AND p_seat_limit IS NOT NULL)
+  THEN
+    RAISE EXCEPTION 'invalid workspace Stripe billing update'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(p_workspace_id::text, 75300)
+  );
+
+  SELECT workspace.*
+  INTO v_workspace
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = p_workspace_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    assigned_customer_id := NULL;
+    seat_limit := NULL;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  IF v_workspace.stripe_customer_id IS NULL
+    OR v_workspace.stripe_customer_id = p_stripe_customer_id
+  THEN
+    UPDATE public.workspaces AS workspace
+    SET
+      stripe_customer_id = p_stripe_customer_id,
+      seat_limit = CASE
+        WHEN p_update_seat_limit THEN p_seat_limit
+        ELSE workspace.seat_limit
+      END,
+      updated_at = clock_timestamp()
+    WHERE workspace.id = p_workspace_id
+    RETURNING workspace.stripe_customer_id, workspace.seat_limit
+    INTO assigned_customer_id, seat_limit;
+
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  assigned_customer_id := v_workspace.stripe_customer_id;
+  seat_limit := v_workspace.seat_limit;
+  RETURN NEXT;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.sync_workspace_stripe_billing(
+  uuid,
+  text,
+  integer,
+  boolean
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.sync_workspace_stripe_billing(
+  uuid,
+  text,
+  integer,
+  boolean
+) TO service_role;
+
+CREATE OR REPLACE FUNCTION private.get_workspace_seat_usage(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  seat_limit integer,
+  used_seats integer,
+  is_billed boolean
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.workspaces AS workspace
+    JOIN public.workspace_memberships AS membership
+      ON membership.workspace_id = workspace.id
+    WHERE workspace.id = p_workspace_id
+      AND workspace.deleted_at IS NULL
+      AND membership.user_id = auth.uid()
+      AND membership.role IN ('owner', 'admin')
+      AND membership.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'workspace billing operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    usage.seat_limit,
+    usage.used_seats,
+    EXISTS (
+      SELECT 1
+      FROM stripe.subscriptions AS subscription
+      WHERE subscription.customer = workspace.stripe_customer_id
+        AND subscription.status IN ('trialing', 'active')
+    )
+  FROM public.workspaces AS workspace
+  CROSS JOIN LATERAL private.workspace_seat_usage(workspace.id) AS usage
+  WHERE workspace.id = p_workspace_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.get_workspace_seat_usage(uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION private.get_workspace_seat_usage(uuid)
+  TO authenticated;
+
+COMMIT;

--- a/supabase/tests/038-sync-workspace-stripe-billing.sql
+++ b/supabase/tests/038-sync-workspace-stripe-billing.sql
@@ -1,0 +1,217 @@
+begin;
+select plan(12);
+
+select tests.create_supabase_user('billing_owner', 'billing-owner@example.com');
+
+create temporary table workspace_billing_sync_test_state (
+  name text primary key,
+  workspace_id uuid
+);
+
+grant all on workspace_billing_sync_test_state to authenticated, service_role;
+
+reset role;
+
+update auth.users
+set email_confirmed_at = now()
+where id = tests.get_supabase_uid('billing_owner');
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    'public.sync_workspace_stripe_billing(uuid,text,integer,boolean)',
+    'EXECUTE'
+  )
+    and not has_function_privilege(
+      'authenticated',
+      'public.sync_workspace_stripe_billing(uuid,text,integer,boolean)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'anon',
+      'public.sync_workspace_stripe_billing(uuid,text,integer,boolean)',
+      'EXECUTE'
+    ),
+  'Only the service role can synchronize workspace billing'
+);
+
+select tests.authenticate_as_hyprnote_pro('billing_owner');
+
+insert into workspace_billing_sync_test_state (name, workspace_id)
+select 'hq', workspace_id from public.create_workspace('Billing HQ');
+
+select throws_ok(
+  $$
+    select * from public.sync_workspace_stripe_billing(
+      (select workspace_id from workspace_billing_sync_test_state where name = 'hq'),
+      'cus_team123',
+      null,
+      false
+    )
+  $$,
+  '42501',
+  'permission denied for function sync_workspace_stripe_billing',
+  'Workspace managers cannot impersonate the billing service'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  $$
+    select assigned_customer_id, seat_limit
+    from public.sync_workspace_stripe_billing(
+      (select workspace_id from workspace_billing_sync_test_state where name = 'hq'),
+      'cus_team123',
+      null,
+      false
+    )
+  $$,
+  $$values ('cus_team123'::text, null::integer)$$,
+  'The service binds a Stripe customer without inventing a seat quantity'
+);
+
+select results_eq(
+  $$
+    select assigned_customer_id, seat_limit
+    from public.sync_workspace_stripe_billing(
+      (select workspace_id from workspace_billing_sync_test_state where name = 'hq'),
+      'cus_team123',
+      3,
+      true
+    )
+  $$,
+  $$values ('cus_team123'::text, 3)$$,
+  'A matching subscription reconciles its positive seat quantity'
+);
+
+select results_eq(
+  $$
+    select assigned_customer_id, seat_limit
+    from public.sync_workspace_stripe_billing(
+      (select workspace_id from workspace_billing_sync_test_state where name = 'hq'),
+      'cus_other456',
+      9,
+      true
+    )
+  $$,
+  $$values ('cus_team123'::text, 3)$$,
+  'A different Stripe customer cannot reassign or resize the workspace'
+);
+
+select throws_ok(
+  $$
+    select * from public.sync_workspace_stripe_billing(
+      (select workspace_id from workspace_billing_sync_test_state where name = 'hq'),
+      'cus_team123',
+      0,
+      true
+    )
+  $$,
+  '22023',
+  'invalid workspace Stripe billing update',
+  'Stripe cannot reduce the workspace to a non-positive seat quantity'
+);
+
+select results_eq(
+  $$
+    select assigned_customer_id, seat_limit
+    from public.sync_workspace_stripe_billing(
+      tests.get_supabase_uid('billing_owner'),
+      'cus_personal123',
+      2,
+      true
+    )
+  $$,
+  $$values (null::text, null::integer)$$,
+  'Personal workspaces cannot become Team billing owners'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_hyprnote_pro('billing_owner');
+
+select results_eq(
+  $$
+    select seat_limit, used_seats, is_billed
+    from public.get_workspace_seat_usage(
+      (select workspace_id from workspace_billing_sync_test_state where name = 'hq')
+    )
+  $$,
+  $$values (3, 1, false)$$,
+  'A customer binding alone does not report an active Team subscription'
+);
+
+select tests.clear_authentication();
+reset role;
+
+insert into stripe.customers (id)
+values ('cus_team123')
+on conflict (id) do nothing;
+
+insert into stripe.subscriptions (id, customer, status)
+values ('sub_team123', 'cus_team123', 'active'::stripe.subscription_status)
+on conflict (id) do nothing;
+
+select tests.authenticate_as_hyprnote_pro('billing_owner');
+
+select results_eq(
+  $$
+    select seat_limit, used_seats, is_billed
+    from public.get_workspace_seat_usage(
+      (select workspace_id from workspace_billing_sync_test_state where name = 'hq')
+    )
+  $$,
+  $$values (3, 1, true)$$,
+  'An active Team subscription reports the workspace as billed'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  $$
+    select assigned_customer_id, seat_limit
+    from public.sync_workspace_stripe_billing(
+      (select workspace_id from workspace_billing_sync_test_state where name = 'hq'),
+      'cus_team123',
+      null,
+      true
+    )
+  $$,
+  $$values ('cus_team123'::text, null::integer)$$,
+  'A canceled Team subscription clears the purchased seat limit'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_hyprnote_pro('billing_owner');
+
+select results_eq(
+  $$
+    select seat_limit, used_seats, is_billed
+    from public.get_workspace_seat_usage(
+      (select workspace_id from workspace_billing_sync_test_state where name = 'hq')
+    )
+  $$,
+  $$values (null::integer, 1, true)$$,
+  'Clearing the limit removes the cap without changing subscription truth'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  $$
+    select assigned_customer_id, seat_limit
+    from public.sync_workspace_stripe_billing(
+      '00000000-0000-4000-8000-000000000999'::uuid,
+      'cus_missing123',
+      null,
+      false
+    )
+  $$,
+  $$values (null::text, null::integer)$$,
+  'A missing workspace is not provisioned implicitly'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- recognize workspace-owned Stripe customers without changing personal billing behavior
- reconcile Team subscription quantities through a service-role-only workspace billing RPC
- keep Team price IDs optional until pricing and checkout are intentionally configured
- report workspaces as billed only for active or trialing subscriptions

## Validation
- `bunx tsc --noEmit` in `apps/stripe`
- `bun test --pass-with-no-tests` in `apps/stripe` (41 passed)
- `supabase db reset` on OrbStack
- `supabase test db` (39 files, 1080 tests)
- `pnpm exec dprint fmt`
- `pnpm fmt:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes payment reconciliation, workspace seat limits, and SECURITY DEFINER RPCs that can alter billing state; incorrect webhook handling could mis-cap seats or misreport billing.
> 
> **Overview**
> Extends the Stripe billing bridge so **workspace-owned** customers (via `workspaceId` metadata) reconcile Team plan **seat limits** from subscription webhooks, while **user-owned** customers keep the existing profile assignment and metadata repair path.
> 
> `syncBillingBridge` is refactored behind injectable dependencies and handles `customer.subscription.deleted`. Workspace events call a new `sync_workspace_stripe_billing` RPC (service role only) with seat updates derived from configured Team price IDs (`STRIPE_TEAM_*`, optional until checkout exists). The bridge **throws** on customer assignment conflicts and **no-ops** when the workspace row is missing.
> 
> Customer metadata parsing adds `getCustomerOwner` / workspace aliases with strict agreement rules (user vs workspace ambiguity returns null). **`is_billed`** for seat usage now requires an **active or trialing** Stripe subscription, not merely a bound customer ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cda0d6bfc85839f73241d037b68eaeb79d1d5fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->