### PR TITLE
Add workspace Team checkout plumbing

### DIFF
--- a/apps/stripe/src/billing-bridge.test.ts
+++ b/apps/stripe/src/billing-bridge.test.ts
@@ -27,7 +27,6 @@ const dependencies = (
     throw new Error("should not delete a workspace customer");
   },
   syncWorkspaceCustomer: async () => "cus_team123",
-  teamPriceIds: new Set(["price_team"]),
   ...overrides,
 });
 
@@ -37,7 +36,7 @@ describe("syncBillingBridge", () => {
     const subscription = {
       customer: "cus_team123",
       items: {
-        data: [{ price: { id: "price_team" }, quantity: 4 }],
+        data: [{ price: { id: "price_pro" }, quantity: 4 }],
       },
     } as Stripe.Subscription;
 
@@ -65,7 +64,7 @@ describe("syncBillingBridge", () => {
     const subscription = {
       customer: "cus_team123",
       items: {
-        data: [{ price: { id: "price_team" }, quantity: 4 }],
+        data: [{ price: { id: "price_pro" }, quantity: 4 }],
       },
     } as Stripe.Subscription;
 
@@ -83,7 +82,7 @@ describe("syncBillingBridge", () => {
     const subscription = {
       customer: "cus_team123",
       items: {
-        data: [{ price: { id: "price_team" }, quantity: 4 }],
+        data: [{ price: { id: "price_pro" }, quantity: 4 }],
       },
     } as Stripe.Subscription;
 

--- a/apps/stripe/src/billing-bridge.ts
+++ b/apps/stripe/src/billing-bridge.ts
@@ -32,7 +32,6 @@ type BillingBridgeDependencies = {
     seatLimit: number | null;
     updateSeatLimit: boolean;
   }) => Promise<string | null | undefined>;
-  teamPriceIds: ReadonlySet<string>;
 };
 
 export async function syncBillingBridge(
@@ -64,10 +63,7 @@ export async function syncBillingBridge(
   }
 
   if (owner.kind === "workspace") {
-    const update = getWorkspaceBillingUpdate(
-      event,
-      activeDependencies.teamPriceIds,
-    );
+    const update = getWorkspaceBillingUpdate(event);
     const assignedCustomerId = await activeDependencies.syncWorkspaceCustomer({
       workspaceId: owner.id,
       customerId,
@@ -151,8 +147,7 @@ export const getUserIdFromCustomer = (
 };
 
 async function createDefaultDependencies(): Promise<BillingBridgeDependencies> {
-  const [{ env }, { stripe }, { supabaseAdmin }] = await Promise.all([
-    import("./env"),
+  const [{ stripe }, { supabaseAdmin }] = await Promise.all([
     import("./integration/stripe"),
     import("./integration/supabase"),
   ]);
@@ -218,11 +213,5 @@ async function createDefaultDependencies(): Promise<BillingBridgeDependencies> {
       }
       return data?.[0]?.assigned_customer_id as string | null | undefined;
     },
-    teamPriceIds: new Set(
-      [
-        env.STRIPE_TEAM_MONTHLY_PRICE_ID,
-        env.STRIPE_TEAM_YEARLY_PRICE_ID,
-      ].filter((priceId): priceId is string => Boolean(priceId)),
-    ),
   };
 }

--- a/apps/stripe/src/env.ts
+++ b/apps/stripe/src/env.ts
@@ -15,8 +15,6 @@ export const env = createEnv({
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
     STRIPE_SECRET_KEY: z.string().min(1),
     STRIPE_WEBHOOK_SECRET: z.string().min(1),
-    STRIPE_TEAM_MONTHLY_PRICE_ID: z.string().min(1).optional(),
-    STRIPE_TEAM_YEARLY_PRICE_ID: z.string().min(1).optional(),
     POSTHOG_API_KEY: z.string().min(1).optional(),
     LOOPS_API_KEY: requiredInProduction(z.string().min(1)),
   },

--- a/apps/stripe/src/workspace-billing.test.ts
+++ b/apps/stripe/src/workspace-billing.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 
 import {
-  getTeamSubscriptionSeatLimit,
   getWorkspaceBillingUpdate,
+  getWorkspaceSubscriptionSeatLimit,
 } from "./workspace-billing";
 
 const subscriptionWithItems = (
@@ -10,46 +10,37 @@ const subscriptionWithItems = (
 ) =>
   ({
     items: { data: items },
-  }) as Parameters<typeof getTeamSubscriptionSeatLimit>[0];
+  }) as Parameters<typeof getWorkspaceSubscriptionSeatLimit>[0];
 
-test("reads the configured Team subscription quantity", () => {
+test("reads the shared Pro subscription quantity as workspace seats", () => {
   expect(
-    getTeamSubscriptionSeatLimit(
-      subscriptionWithItems([
-        { price: { id: "price_team" }, quantity: 7 },
-        { price: { id: "price_addon" }, quantity: 1 },
-      ]),
-      new Set(["price_team"]),
+    getWorkspaceSubscriptionSeatLimit(
+      subscriptionWithItems([{ price: { id: "price_pro" }, quantity: 7 }]),
     ),
   ).toBe(7);
 });
 
-test("uses Stripe's default quantity for a Team subscription item", () => {
+test("uses Stripe's default quantity for a workspace subscription item", () => {
   expect(
-    getTeamSubscriptionSeatLimit(
-      subscriptionWithItems([{ price: { id: "price_team" }, quantity: null }]),
-      new Set(["price_team"]),
+    getWorkspaceSubscriptionSeatLimit(
+      subscriptionWithItems([{ price: { id: "price_pro" }, quantity: null }]),
     ),
   ).toBe(1);
 });
 
-test("ignores subscriptions without a configured Team price", () => {
+test("rejects workspace subscriptions without a price item", () => {
   expect(
-    getTeamSubscriptionSeatLimit(
-      subscriptionWithItems([{ price: { id: "price_personal" }, quantity: 1 }]),
-      new Set(["price_team"]),
-    ),
+    getWorkspaceSubscriptionSeatLimit(subscriptionWithItems([])),
   ).toBeNull();
 });
 
-test("rejects ambiguous Team subscription items", () => {
+test("rejects ambiguous workspace subscription items", () => {
   expect(
-    getTeamSubscriptionSeatLimit(
+    getWorkspaceSubscriptionSeatLimit(
       subscriptionWithItems([
-        { price: { id: "price_team_monthly" }, quantity: 3 },
-        { price: { id: "price_team_yearly" }, quantity: 3 },
+        { price: { id: "price_pro" }, quantity: 3 },
+        { price: { id: "price_addon" }, quantity: 1 },
       ]),
-      new Set(["price_team_monthly", "price_team_yearly"]),
     ),
   ).toBeNull();
 });
@@ -59,12 +50,12 @@ test("reconciles quantities from subscription lifecycle events", () => {
     type: "customer.subscription.updated",
     data: {
       object: subscriptionWithItems([
-        { price: { id: "price_team" }, quantity: 4 },
+        { price: { id: "price_pro" }, quantity: 4 },
       ]),
     },
   } as Parameters<typeof getWorkspaceBillingUpdate>[0];
 
-  expect(getWorkspaceBillingUpdate(event, new Set(["price_team"]))).toEqual({
+  expect(getWorkspaceBillingUpdate(event)).toEqual({
     seatLimit: 4,
     updateSeatLimit: true,
   });
@@ -75,12 +66,12 @@ test("clears the seat limit when a Team subscription is deleted", () => {
     type: "customer.subscription.deleted",
     data: {
       object: subscriptionWithItems([
-        { price: { id: "price_team" }, quantity: 4 },
+        { price: { id: "price_pro" }, quantity: 4 },
       ]),
     },
   } as Parameters<typeof getWorkspaceBillingUpdate>[0];
 
-  expect(getWorkspaceBillingUpdate(event, new Set(["price_team"]))).toEqual({
+  expect(getWorkspaceBillingUpdate(event)).toEqual({
     seatLimit: null,
     updateSeatLimit: true,
   });
@@ -92,7 +83,7 @@ test("binds customer events without changing the seat limit", () => {
     data: { object: {} },
   } as Parameters<typeof getWorkspaceBillingUpdate>[0];
 
-  expect(getWorkspaceBillingUpdate(event, new Set(["price_team"]))).toEqual({
+  expect(getWorkspaceBillingUpdate(event)).toEqual({
     seatLimit: null,
     updateSeatLimit: false,
   });

--- a/apps/stripe/src/workspace-billing.ts
+++ b/apps/stripe/src/workspace-billing.ts
@@ -6,17 +6,13 @@ const WORKSPACE_SUBSCRIPTION_EVENTS: Stripe.Event.Type[] = [
   "customer.subscription.deleted",
 ];
 
-export function getWorkspaceBillingUpdate(
-  event: Stripe.Event,
-  teamPriceIds: ReadonlySet<string>,
-) {
+export function getWorkspaceBillingUpdate(event: Stripe.Event) {
   if (!WORKSPACE_SUBSCRIPTION_EVENTS.includes(event.type)) {
     return { seatLimit: null, updateSeatLimit: false };
   }
 
-  const seatLimit = getTeamSubscriptionSeatLimit(
+  const seatLimit = getWorkspaceSubscriptionSeatLimit(
     event.data.object as Stripe.Subscription,
-    teamPriceIds,
   );
 
   if (event.type === "customer.subscription.deleted") {
@@ -32,18 +28,13 @@ export function getWorkspaceBillingUpdate(
   };
 }
 
-export function getTeamSubscriptionSeatLimit(
+export function getWorkspaceSubscriptionSeatLimit(
   subscription: Pick<Stripe.Subscription, "items">,
-  teamPriceIds: ReadonlySet<string>,
 ) {
-  const teamItems = subscription.items.data.filter((item) =>
-    teamPriceIds.has(item.price.id),
-  );
-
-  if (teamItems.length !== 1) {
+  if (subscription.items.data.length !== 1) {
     return null;
   }
 
-  const quantity = teamItems[0]?.quantity ?? 1;
+  const quantity = subscription.items.data[0]?.quantity ?? 1;
   return Number.isSafeInteger(quantity) && quantity > 0 ? quantity : null;
 }

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -25,6 +25,8 @@ export const env = createEnv({
     STRIPE_SECRET_KEY: requiredInProd(z.string().min(1)),
     STRIPE_MONTHLY_PRICE_ID: requiredInProd(z.string().min(1)),
     STRIPE_YEARLY_PRICE_ID: requiredInProd(z.string().min(1)),
+    STRIPE_TEAM_MONTHLY_PRICE_ID: z.string().min(1).optional(),
+    STRIPE_TEAM_YEARLY_PRICE_ID: z.string().min(1).optional(),
 
     LOOPS_KEY: requiredInProd(z.string().min(1)),
 

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -25,8 +25,6 @@ export const env = createEnv({
     STRIPE_SECRET_KEY: requiredInProd(z.string().min(1)),
     STRIPE_MONTHLY_PRICE_ID: requiredInProd(z.string().min(1)),
     STRIPE_YEARLY_PRICE_ID: requiredInProd(z.string().min(1)),
-    STRIPE_TEAM_MONTHLY_PRICE_ID: z.string().min(1).optional(),
-    STRIPE_TEAM_YEARLY_PRICE_ID: z.string().min(1).optional(),
 
     LOOPS_KEY: requiredInProd(z.string().min(1)),
 

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -36,6 +36,10 @@ import {
   getStripeCustomerOwnership,
 } from "@/lib/stripe-customer";
 import { WEB_TRIAL_CHECKOUT_FIELDS } from "@/lib/trial-policy";
+import {
+  startWorkspaceCheckout,
+  type WorkspaceCheckoutContext,
+} from "@/lib/workspace-checkout";
 
 type SupabaseClient = ReturnType<typeof getSupabaseServerClient>;
 
@@ -152,6 +156,20 @@ const getProPriceId = (period: "monthly" | "yearly") => {
   }
 
   return requireEnv(env.STRIPE_MONTHLY_PRICE_ID, "STRIPE_MONTHLY_PRICE_ID");
+};
+
+const getTeamPriceId = (period: "monthly" | "yearly") => {
+  if (period === "yearly") {
+    return requireEnv(
+      env.STRIPE_TEAM_YEARLY_PRICE_ID,
+      "STRIPE_TEAM_YEARLY_PRICE_ID",
+    );
+  }
+
+  return requireEnv(
+    env.STRIPE_TEAM_MONTHLY_PRICE_ID,
+    "STRIPE_TEAM_MONTHLY_PRICE_ID",
+  );
 };
 
 async function getCurrentSubscription(
@@ -488,6 +506,158 @@ export const createCheckoutSession = createServerFn({ method: "POST" })
       }
       throw error;
     }
+  });
+
+const createTeamCheckoutSessionInput = z.object({
+  workspaceId: z.string().uuid(),
+  period: z.enum(["monthly", "yearly"]),
+  quantity: z.number().int().positive().max(999_999),
+  scheme: desktopSchemeSchema.optional(),
+  returnTo: z.string().optional(),
+});
+
+export const createTeamCheckoutSession = createServerFn({ method: "POST" })
+  .inputValidator(createTeamCheckoutSessionInput)
+  .handler(async ({ data }) => {
+    const supabase = getSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user?.id || user.is_anonymous) {
+      throw new Error("Unauthorized");
+    }
+
+    const stripe = getStripeClient();
+    const admin = getSupabaseAdminClient();
+    const customerProvisioningAttemptId = crypto.randomUUID();
+    const returnTo = sanitizeInternalReturnPath(data.returnTo);
+    const appOrigin = getRequestAppOrigin();
+    const successReturnPath = addInternalReturnPathSearch(returnTo, {
+      success: "true",
+      checkout: "paid",
+    });
+    const cancelReturnPath = addInternalReturnPathSearch(returnTo, {
+      checkout: "canceled",
+      checkout_type: "paid",
+    });
+    const returnUrl = data.scheme
+      ? getBillingReturnUrl(data.scheme)
+      : toAbsoluteInternalReturnUrl(appOrigin, returnTo);
+    const successUrl = data.scheme
+      ? `${getBillingReturnUrl(data.scheme)}&checkout=paid`
+      : toAbsoluteInternalReturnUrl(appOrigin, successReturnPath);
+    const cancelUrl = data.scheme
+      ? `${getBillingReturnUrl(data.scheme)}&checkout=canceled&checkout_type=paid`
+      : toAbsoluteInternalReturnUrl(appOrigin, cancelReturnPath);
+
+    return startWorkspaceCheckout(
+      {
+        workspaceId: data.workspaceId,
+        period: data.period,
+        quantity: data.quantity,
+        successUrl,
+        cancelUrl,
+        returnUrl,
+      },
+      {
+        async getContext(workspaceId) {
+          const { data: rows, error } = await supabase.rpc(
+            "get_workspace_billing_checkout_context",
+            { p_workspace_id: workspaceId },
+          );
+          const row = Array.isArray(rows) ? rows[0] : undefined;
+          if (error || !row) {
+            throw error ?? new Error("Workspace billing is unavailable");
+          }
+          return {
+            workspaceName: row.workspace_name,
+            stripeCustomerId: row.stripe_customer_id,
+            usedSeats: row.used_seats,
+          } as WorkspaceCheckoutContext;
+        },
+        getPriceId: getTeamPriceId,
+        async createCustomer({ workspaceId, workspaceName }) {
+          return stripe.customers.create(
+            {
+              name: workspaceName,
+              metadata: { workspaceId },
+            },
+            {
+              idempotencyKey: `create-workspace-customer-${workspaceId}-${customerProvisioningAttemptId}`,
+            },
+          );
+        },
+        async bindCustomer(workspaceId, customerId) {
+          const { data: rows, error } = await admin.rpc(
+            "sync_workspace_stripe_billing",
+            {
+              p_workspace_id: workspaceId,
+              p_stripe_customer_id: customerId,
+              p_seat_limit: null,
+              p_update_seat_limit: false,
+            },
+          );
+          if (error) throw error;
+          return rows?.[0]?.assigned_customer_id as string | null | undefined;
+        },
+        async deleteCustomer(customerId) {
+          await stripe.customers.del(customerId);
+        },
+        async retrieveCustomer(customerId) {
+          const customer = await stripe.customers.retrieve(customerId);
+          return {
+            id: customer.id,
+            deleted: "deleted" in customer && customer.deleted === true,
+            metadata: "metadata" in customer ? customer.metadata : null,
+          };
+        },
+        async listSubscriptions(customerId) {
+          const subscriptions = await stripe.subscriptions.list({
+            customer: customerId,
+            status: "all",
+            limit: 10,
+          });
+          return subscriptions.data;
+        },
+        async createCheckoutSession(input) {
+          return stripe.checkout.sessions.create({
+            customer: input.customerId,
+            success_url: input.successUrl,
+            cancel_url: input.cancelUrl,
+            client_reference_id: input.workspaceId,
+            line_items: [
+              {
+                price: input.priceId,
+                quantity: input.quantity,
+                adjustable_quantity: {
+                  enabled: true,
+                  minimum: input.minimumQuantity,
+                  maximum: 999_999,
+                },
+              },
+            ],
+            mode: "subscription",
+            metadata: {
+              checkout_type: "team",
+              workspace_id: input.workspaceId,
+            },
+            subscription_data: {
+              metadata: {
+                checkout_type: "team",
+                workspace_id: input.workspaceId,
+              },
+            },
+          });
+        },
+        async createPortalSession({ customerId, returnUrl }) {
+          return stripe.billingPortal.sessions.create({
+            customer: customerId,
+            return_url: returnUrl,
+          });
+        },
+      },
+    );
   });
 
 const releaseTrialReservation = async (

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -158,20 +158,6 @@ const getProPriceId = (period: "monthly" | "yearly") => {
   return requireEnv(env.STRIPE_MONTHLY_PRICE_ID, "STRIPE_MONTHLY_PRICE_ID");
 };
 
-const getTeamPriceId = (period: "monthly" | "yearly") => {
-  if (period === "yearly") {
-    return requireEnv(
-      env.STRIPE_TEAM_YEARLY_PRICE_ID,
-      "STRIPE_TEAM_YEARLY_PRICE_ID",
-    );
-  }
-
-  return requireEnv(
-    env.STRIPE_TEAM_MONTHLY_PRICE_ID,
-    "STRIPE_TEAM_MONTHLY_PRICE_ID",
-  );
-};
-
 async function getCurrentSubscription(
   stripe: Stripe,
   stripeCustomerId: string,
@@ -576,7 +562,7 @@ export const createTeamCheckoutSession = createServerFn({ method: "POST" })
             usedSeats: row.used_seats,
           } as WorkspaceCheckoutContext;
         },
-        getPriceId: getTeamPriceId,
+        getPriceId: getProPriceId,
         async createCustomer({ workspaceId, workspaceName }) {
           return stripe.customers.create(
             {

--- a/apps/web/src/lib/workspace-checkout.test.ts
+++ b/apps/web/src/lib/workspace-checkout.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getWorkspaceCustomerOwnership,
+  startWorkspaceCheckout,
+  type WorkspaceCheckoutContext,
+} from "./workspace-checkout.ts";
+
+const workspaceId = "0d69f853-2010-45e7-83ab-a7f14375f506";
+
+function dependencies(
+  context: WorkspaceCheckoutContext = {
+    workspaceName: "Checkout HQ",
+    stripeCustomerId: "cus_team123",
+    usedSeats: 2,
+  },
+) {
+  const checkoutInputs: unknown[] = [];
+  const portalInputs: unknown[] = [];
+  const deletedCustomers: string[] = [];
+  return {
+    checkoutInputs,
+    portalInputs,
+    deletedCustomers,
+    value: {
+      getContext: async () => context,
+      getPriceId: (period: "monthly" | "yearly") => `price_team_${period}`,
+      createCustomer: async () => ({ id: "cus_created123" }),
+      bindCustomer: async (_workspaceId: string, customerId: string) =>
+        customerId,
+      deleteCustomer: async (customerId: string) => {
+        deletedCustomers.push(customerId);
+      },
+      retrieveCustomer: async (customerId: string) => ({
+        id: customerId,
+        metadata: { workspaceId },
+      }),
+      listSubscriptions: async (): Promise<{ status: string }[]> => [],
+      createCheckoutSession: async (input: unknown) => {
+        checkoutInputs.push(input);
+        return { url: "https://checkout.stripe.test/team" };
+      },
+      createPortalSession: async (input: unknown) => {
+        portalInputs.push(input);
+        return { url: "https://billing.stripe.test/team" };
+      },
+    },
+  };
+}
+
+const input = {
+  workspaceId,
+  period: "monthly" as const,
+  quantity: 3,
+  successUrl: "https://anarlog.test/success",
+  cancelUrl: "https://anarlog.test/cancel",
+  returnUrl: "https://anarlog.test/team",
+};
+
+test("provisions a workspace customer and starts per-seat checkout", async () => {
+  const deps = dependencies({
+    workspaceName: "Checkout HQ",
+    stripeCustomerId: null,
+    usedSeats: 2,
+  });
+
+  const result = await startWorkspaceCheckout(input, deps.value);
+
+  assert.deepEqual(result, {
+    url: "https://checkout.stripe.test/team",
+    stripeCustomerId: "cus_created123",
+  });
+  assert.deepEqual(deps.checkoutInputs, [
+    {
+      customerId: "cus_created123",
+      priceId: "price_team_monthly",
+      quantity: 3,
+      minimumQuantity: 2,
+      workspaceId,
+      successUrl: input.successUrl,
+      cancelUrl: input.cancelUrl,
+    },
+  ]);
+});
+
+test("rejects checkout that would underfill occupied seats", async () => {
+  const deps = dependencies();
+
+  await assert.rejects(
+    startWorkspaceCheckout({ ...input, quantity: 1 }, deps.value),
+    /cover every occupied seat/,
+  );
+  assert.deepEqual(deps.checkoutInputs, []);
+});
+
+test("a concurrent customer assignment wins without leaking the loser", async () => {
+  const deps = dependencies({
+    workspaceName: "Checkout HQ",
+    stripeCustomerId: null,
+    usedSeats: 2,
+  });
+  deps.value.bindCustomer = async () => "cus_existing123";
+
+  const result = await startWorkspaceCheckout(input, deps.value);
+
+  assert.equal(result.stripeCustomerId, "cus_existing123");
+  assert.deepEqual(deps.deletedCustomers, ["cus_created123"]);
+});
+
+test("missing Team pricing fails before provisioning a customer", async () => {
+  const deps = dependencies({
+    workspaceName: "Checkout HQ",
+    stripeCustomerId: null,
+    usedSeats: 2,
+  });
+  let created = false;
+  deps.value.getPriceId = () => {
+    throw new Error("Missing Team price");
+  };
+  deps.value.createCustomer = async () => {
+    created = true;
+    return { id: "cus_created123" };
+  };
+
+  await assert.rejects(
+    startWorkspaceCheckout(input, deps.value),
+    /Missing Team price/,
+  );
+  assert.equal(created, false);
+});
+
+for (const status of ["active", "trialing", "past_due", "unpaid"]) {
+  test(`${status} subscriptions reopen the portal instead of duplicating`, async () => {
+    const deps = dependencies();
+    deps.value.listSubscriptions = async () => [{ status }];
+
+    const result = await startWorkspaceCheckout(input, deps.value);
+
+    assert.equal(result.url, "https://billing.stripe.test/team");
+    assert.deepEqual(deps.checkoutInputs, []);
+    assert.deepEqual(deps.portalInputs, [
+      {
+        customerId: "cus_team123",
+        returnUrl: input.returnUrl,
+      },
+    ]);
+  });
+}
+
+test("an existing subscription can reach the portal without Team price config", async () => {
+  const deps = dependencies();
+  deps.value.getPriceId = () => {
+    throw new Error("Missing Team price");
+  };
+  deps.value.listSubscriptions = async () => [{ status: "active" }];
+
+  const result = await startWorkspaceCheckout(input, deps.value);
+
+  assert.equal(result.url, "https://billing.stripe.test/team");
+});
+
+test("workspace metadata cannot also claim a personal owner", () => {
+  assert.equal(
+    getWorkspaceCustomerOwnership({ workspace_id: workspaceId }, workspaceId),
+    "owned",
+  );
+  assert.equal(
+    getWorkspaceCustomerOwnership(
+      { workspaceId, userId: "other-user" },
+      workspaceId,
+    ),
+    "unowned",
+  );
+  assert.equal(
+    getWorkspaceCustomerOwnership(
+      { workspaceId: "other-workspace" },
+      workspaceId,
+    ),
+    "unowned",
+  );
+});

--- a/apps/web/src/lib/workspace-checkout.test.ts
+++ b/apps/web/src/lib/workspace-checkout.test.ts
@@ -25,7 +25,7 @@ function dependencies(
     deletedCustomers,
     value: {
       getContext: async () => context,
-      getPriceId: (period: "monthly" | "yearly") => `price_team_${period}`,
+      getPriceId: (period: "monthly" | "yearly") => `price_pro_${period}`,
       createCustomer: async () => ({ id: "cus_created123" }),
       bindCustomer: async (_workspaceId: string, customerId: string) =>
         customerId,
@@ -74,7 +74,7 @@ test("provisions a workspace customer and starts per-seat checkout", async () =>
   assert.deepEqual(deps.checkoutInputs, [
     {
       customerId: "cus_created123",
-      priceId: "price_team_monthly",
+      priceId: "price_pro_monthly",
       quantity: 3,
       minimumQuantity: 2,
       workspaceId,
@@ -108,7 +108,7 @@ test("a concurrent customer assignment wins without leaking the loser", async ()
   assert.deepEqual(deps.deletedCustomers, ["cus_created123"]);
 });
 
-test("missing Team pricing fails before provisioning a customer", async () => {
+test("missing Pro pricing fails before provisioning a customer", async () => {
   const deps = dependencies({
     workspaceName: "Checkout HQ",
     stripeCustomerId: null,
@@ -116,7 +116,7 @@ test("missing Team pricing fails before provisioning a customer", async () => {
   });
   let created = false;
   deps.value.getPriceId = () => {
-    throw new Error("Missing Team price");
+    throw new Error("Missing Pro price");
   };
   deps.value.createCustomer = async () => {
     created = true;
@@ -125,7 +125,7 @@ test("missing Team pricing fails before provisioning a customer", async () => {
 
   await assert.rejects(
     startWorkspaceCheckout(input, deps.value),
-    /Missing Team price/,
+    /Missing Pro price/,
   );
   assert.equal(created, false);
 });
@@ -148,10 +148,10 @@ for (const status of ["active", "trialing", "past_due", "unpaid"]) {
   });
 }
 
-test("an existing subscription can reach the portal without Team price config", async () => {
+test("an existing subscription can reach the portal without Pro price config", async () => {
   const deps = dependencies();
   deps.value.getPriceId = () => {
-    throw new Error("Missing Team price");
+    throw new Error("Missing Pro price");
   };
   deps.value.listSubscriptions = async () => [{ status: "active" }];
 

--- a/apps/web/src/lib/workspace-checkout.ts
+++ b/apps/web/src/lib/workspace-checkout.ts
@@ -1,0 +1,164 @@
+export type WorkspaceCheckoutContext = {
+  workspaceName: string;
+  stripeCustomerId: string | null;
+  usedSeats: number;
+};
+
+type WorkspaceCustomer = {
+  id: string;
+  deleted?: boolean;
+  metadata?: Record<string, string> | null;
+};
+
+type WorkspaceSubscription = {
+  status: string;
+};
+
+type WorkspaceCheckoutDependencies = {
+  getContext: (workspaceId: string) => Promise<WorkspaceCheckoutContext>;
+  getPriceId: (period: "monthly" | "yearly") => string;
+  createCustomer: (input: {
+    workspaceId: string;
+    workspaceName: string;
+  }) => Promise<{ id: string }>;
+  bindCustomer: (
+    workspaceId: string,
+    customerId: string,
+  ) => Promise<string | null | undefined>;
+  deleteCustomer: (customerId: string) => Promise<void>;
+  retrieveCustomer: (customerId: string) => Promise<WorkspaceCustomer>;
+  listSubscriptions: (customerId: string) => Promise<WorkspaceSubscription[]>;
+  createCheckoutSession: (input: {
+    customerId: string;
+    priceId: string;
+    quantity: number;
+    minimumQuantity: number;
+    workspaceId: string;
+    successUrl: string;
+    cancelUrl: string;
+  }) => Promise<{ url: string | null }>;
+  createPortalSession: (input: {
+    customerId: string;
+    returnUrl: string;
+  }) => Promise<{ url: string }>;
+};
+
+const MANAGEABLE_SUBSCRIPTION_STATUSES = new Set([
+  "active",
+  "trialing",
+  "past_due",
+  "unpaid",
+  "incomplete",
+  "paused",
+]);
+
+export async function startWorkspaceCheckout(
+  input: {
+    workspaceId: string;
+    period: "monthly" | "yearly";
+    quantity: number;
+    successUrl: string;
+    cancelUrl: string;
+    returnUrl: string;
+  },
+  dependencies: WorkspaceCheckoutDependencies,
+) {
+  const context = await dependencies.getContext(input.workspaceId);
+
+  if (context.usedSeats < 1 || input.quantity < context.usedSeats) {
+    throw new Error("Team checkout must cover every occupied seat");
+  }
+
+  let priceId: string | undefined;
+  let customerId = context.stripeCustomerId;
+
+  if (!customerId) {
+    priceId = dependencies.getPriceId(input.period);
+    const createdCustomer = await dependencies.createCustomer({
+      workspaceId: input.workspaceId,
+      workspaceName: context.workspaceName,
+    });
+
+    let assignedCustomerId: string | null | undefined;
+    try {
+      assignedCustomerId = await dependencies.bindCustomer(
+        input.workspaceId,
+        createdCustomer.id,
+      );
+    } catch (error) {
+      await dependencies
+        .deleteCustomer(createdCustomer.id)
+        .catch(() => undefined);
+      throw error;
+    }
+
+    if (!assignedCustomerId) {
+      await dependencies
+        .deleteCustomer(createdCustomer.id)
+        .catch(() => undefined);
+      throw new Error("Workspace billing is unavailable");
+    }
+
+    if (assignedCustomerId !== createdCustomer.id) {
+      await dependencies
+        .deleteCustomer(createdCustomer.id)
+        .catch(() => undefined);
+    }
+    customerId = assignedCustomerId;
+  }
+
+  const customer = await dependencies.retrieveCustomer(customerId);
+  if (
+    customer.deleted ||
+    getWorkspaceCustomerOwnership(customer.metadata, input.workspaceId) !==
+      "owned"
+  ) {
+    throw new Error("Stripe customer does not belong to this workspace");
+  }
+
+  const subscriptions = await dependencies.listSubscriptions(customerId);
+  if (
+    subscriptions.some((subscription) =>
+      MANAGEABLE_SUBSCRIPTION_STATUSES.has(subscription.status),
+    )
+  ) {
+    const portal = await dependencies.createPortalSession({
+      customerId,
+      returnUrl: input.returnUrl,
+    });
+    return { url: portal.url, stripeCustomerId: customerId };
+  }
+
+  priceId ??= dependencies.getPriceId(input.period);
+  const checkout = await dependencies.createCheckoutSession({
+    customerId,
+    priceId,
+    quantity: input.quantity,
+    minimumQuantity: context.usedSeats,
+    workspaceId: input.workspaceId,
+    successUrl: input.successUrl,
+    cancelUrl: input.cancelUrl,
+  });
+  return { url: checkout.url, stripeCustomerId: customerId };
+}
+
+export function getWorkspaceCustomerOwnership(
+  metadata: Record<string, string> | null | undefined,
+  workspaceId: string,
+) {
+  const workspaceIds = [
+    metadata?.["workspaceId"],
+    metadata?.["workspace_id"],
+  ].filter((value): value is string => Boolean(value));
+  const userIds = [
+    metadata?.["userId"],
+    metadata?.["user_id"],
+    metadata?.["userID"],
+  ].filter((value): value is string => Boolean(value));
+
+  return userIds.length === 0 &&
+    workspaceIds.length > 0 &&
+    workspaceIds.every((value) => value === workspaceId)
+    ? "owned"
+    : "unowned";
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -46,6 +46,7 @@ import { Route as ViewCallbackSignoutRouteImport } from './routes/_view/callback
 import { Route as ViewCallbackIntegrationRouteImport } from './routes/_view/callback/integration'
 import { Route as ViewCallbackBillingRouteImport } from './routes/_view/callback/billing'
 import { Route as ViewCallbackAuthRouteImport } from './routes/_view/callback/auth'
+import { Route as ViewAppTeamCheckoutRouteImport } from './routes/_view/app/team-checkout'
 import { Route as ViewAppSwitchPlanRouteImport } from './routes/_view/app/switch-plan'
 import { Route as ViewAppPortalRouteImport } from './routes/_view/app/portal'
 import { Route as ViewAppIntegrationRouteImport } from './routes/_view/app/integration'
@@ -267,6 +268,11 @@ const ViewCallbackAuthRoute = ViewCallbackAuthRouteImport.update({
   path: '/callback/auth',
   getParentRoute: () => ViewRouteRoute,
 } as any)
+const ViewAppTeamCheckoutRoute = ViewAppTeamCheckoutRouteImport.update({
+  id: '/team-checkout',
+  path: '/team-checkout',
+  getParentRoute: () => ViewAppRouteRoute,
+} as any)
 const ViewAppSwitchPlanRoute = ViewAppSwitchPlanRouteImport.update({
   id: '/switch-plan',
   path: '/switch-plan',
@@ -472,6 +478,7 @@ export interface FileRoutesByFullPath {
   '/app/integration': typeof ViewAppIntegrationRoute
   '/app/portal': typeof ViewAppPortalRoute
   '/app/switch-plan': typeof ViewAppSwitchPlanRoute
+  '/app/team-checkout': typeof ViewAppTeamCheckoutRoute
   '/callback/auth': typeof ViewCallbackAuthRoute
   '/callback/billing': typeof ViewCallbackBillingRoute
   '/callback/integration': typeof ViewCallbackIntegrationRoute
@@ -543,6 +550,7 @@ export interface FileRoutesByTo {
   '/app/integration': typeof ViewAppIntegrationRoute
   '/app/portal': typeof ViewAppPortalRoute
   '/app/switch-plan': typeof ViewAppSwitchPlanRoute
+  '/app/team-checkout': typeof ViewAppTeamCheckoutRoute
   '/callback/auth': typeof ViewCallbackAuthRoute
   '/callback/billing': typeof ViewCallbackBillingRoute
   '/callback/integration': typeof ViewCallbackIntegrationRoute
@@ -617,6 +625,7 @@ export interface FileRoutesById {
   '/_view/app/integration': typeof ViewAppIntegrationRoute
   '/_view/app/portal': typeof ViewAppPortalRoute
   '/_view/app/switch-plan': typeof ViewAppSwitchPlanRoute
+  '/_view/app/team-checkout': typeof ViewAppTeamCheckoutRoute
   '/_view/callback/auth': typeof ViewCallbackAuthRoute
   '/_view/callback/billing': typeof ViewCallbackBillingRoute
   '/_view/callback/integration': typeof ViewCallbackIntegrationRoute
@@ -691,6 +700,7 @@ export interface FileRouteTypes {
     | '/app/integration'
     | '/app/portal'
     | '/app/switch-plan'
+    | '/app/team-checkout'
     | '/callback/auth'
     | '/callback/billing'
     | '/callback/integration'
@@ -762,6 +772,7 @@ export interface FileRouteTypes {
     | '/app/integration'
     | '/app/portal'
     | '/app/switch-plan'
+    | '/app/team-checkout'
     | '/callback/auth'
     | '/callback/billing'
     | '/callback/integration'
@@ -835,6 +846,7 @@ export interface FileRouteTypes {
     | '/_view/app/integration'
     | '/_view/app/portal'
     | '/_view/app/switch-plan'
+    | '/_view/app/team-checkout'
     | '/_view/callback/auth'
     | '/_view/callback/billing'
     | '/_view/callback/integration'
@@ -1201,6 +1213,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ViewCallbackAuthRouteImport
       parentRoute: typeof ViewRouteRoute
     }
+    '/_view/app/team-checkout': {
+      id: '/_view/app/team-checkout'
+      path: '/team-checkout'
+      fullPath: '/app/team-checkout'
+      preLoaderRoute: typeof ViewAppTeamCheckoutRouteImport
+      parentRoute: typeof ViewAppRouteRoute
+    }
     '/_view/app/switch-plan': {
       id: '/_view/app/switch-plan'
       path: '/switch-plan'
@@ -1448,6 +1467,7 @@ interface ViewAppRouteRouteChildren {
   ViewAppIntegrationRoute: typeof ViewAppIntegrationRoute
   ViewAppPortalRoute: typeof ViewAppPortalRoute
   ViewAppSwitchPlanRoute: typeof ViewAppSwitchPlanRoute
+  ViewAppTeamCheckoutRoute: typeof ViewAppTeamCheckoutRoute
   ViewAppIndexRoute: typeof ViewAppIndexRoute
 }
 
@@ -1457,6 +1477,7 @@ const ViewAppRouteRouteChildren: ViewAppRouteRouteChildren = {
   ViewAppIntegrationRoute: ViewAppIntegrationRoute,
   ViewAppPortalRoute: ViewAppPortalRoute,
   ViewAppSwitchPlanRoute: ViewAppSwitchPlanRoute,
+  ViewAppTeamCheckoutRoute: ViewAppTeamCheckoutRoute,
   ViewAppIndexRoute: ViewAppIndexRoute,
 }
 

--- a/apps/web/src/routes/_view/app/team-checkout.tsx
+++ b/apps/web/src/routes/_view/app/team-checkout.tsx
@@ -1,0 +1,62 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { createTeamCheckoutSession } from "@/functions/billing";
+import { desktopSchemeSchema } from "@/functions/desktop-flow";
+import {
+  addInternalReturnPathSearch,
+  sanitizeInternalReturnPath,
+} from "@/lib/auth-redirect";
+import { captureOperationalError } from "@/lib/error-reporting";
+
+const validateSearch = z.object({
+  workspace_id: z.string().uuid(),
+  period: z.enum(["monthly", "yearly"]).catch("monthly"),
+  quantity: z.coerce.number().int().positive().max(999_999),
+  scheme: desktopSchemeSchema.optional(),
+  return_to: z.string().optional(),
+});
+
+export const Route = createFileRoute("/_view/app/team-checkout")({
+  validateSearch,
+  beforeLoad: async ({ search }) => {
+    const returnTo = sanitizeInternalReturnPath(search.return_to);
+    let url: string | null | undefined;
+    try {
+      ({ url } = await createTeamCheckoutSession({
+        data: {
+          workspaceId: search.workspace_id,
+          period: search.period,
+          quantity: search.quantity,
+          scheme: search.scheme,
+          returnTo,
+        },
+      }));
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "team_checkout_session_create",
+        context: {
+          workspace_id: search.workspace_id,
+          period: search.period,
+        },
+      });
+    }
+
+    if (url) {
+      throw redirect({ href: url } as any);
+    }
+
+    if (search.scheme) {
+      throw redirect({
+        href: `/callback/billing?scheme=${search.scheme}&checkout=failed&checkout_type=paid`,
+      } as any);
+    }
+
+    throw redirect({
+      href: addInternalReturnPathSearch(returnTo, {
+        checkout: "failed",
+        checkout_type: "paid",
+      }),
+    } as any);
+  },
+});

--- a/supabase/migrations/20260816135127_authorize_workspace_billing_checkout.sql
+++ b/supabase/migrations/20260816135127_authorize_workspace_billing_checkout.sql
@@ -1,0 +1,71 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION private.get_workspace_billing_checkout_context(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  workspace_name text,
+  stripe_customer_id text,
+  used_seats integer
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    workspace.name,
+    workspace.stripe_customer_id,
+    usage.used_seats
+  FROM public.workspaces AS workspace
+  JOIN public.workspace_memberships AS membership
+    ON membership.workspace_id = workspace.id
+  JOIN auth.users AS actor
+    ON actor.id = membership.user_id
+  CROSS JOIN LATERAL private.workspace_seat_usage(workspace.id) AS usage
+  WHERE workspace.id = p_workspace_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+    AND membership.user_id = auth.uid()
+    AND membership.role IN ('owner', 'admin')
+    AND membership.deleted_at IS NULL
+    AND actor.email_confirmed_at IS NOT NULL
+    AND COALESCE(actor.is_anonymous, false) = false;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'workspace billing operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.get_workspace_billing_checkout_context(uuid)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION private.get_workspace_billing_checkout_context(uuid)
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_workspace_billing_checkout_context(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  workspace_name text,
+  stripe_customer_id text,
+  used_seats integer
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.get_workspace_billing_checkout_context(p_workspace_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.get_workspace_billing_checkout_context(uuid)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_workspace_billing_checkout_context(uuid)
+  TO authenticated;
+
+COMMIT;

--- a/supabase/tests/039-authorize-workspace-billing-checkout.sql
+++ b/supabase/tests/039-authorize-workspace-billing-checkout.sql
@@ -1,0 +1,178 @@
+begin;
+select plan(8);
+
+select tests.create_supabase_user('checkout_owner', 'checkout-owner@example.com');
+select tests.create_supabase_user('checkout_admin', 'checkout-admin@example.com');
+select tests.create_supabase_user('checkout_member', 'checkout-member@example.com');
+select tests.create_supabase_user('checkout_outsider', 'checkout-outsider@example.com');
+
+create temporary table workspace_checkout_test_state (
+  workspace_id uuid primary key
+);
+
+grant all on workspace_checkout_test_state to authenticated;
+
+reset role;
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('checkout_owner'),
+  tests.get_supabase_uid('checkout_admin'),
+  tests.get_supabase_uid('checkout_member'),
+  tests.get_supabase_uid('checkout_outsider')
+);
+
+select ok(
+  has_function_privilege(
+    'authenticated',
+    'public.get_workspace_billing_checkout_context(uuid)',
+    'EXECUTE'
+  )
+    and not has_function_privilege(
+      'anon',
+      'public.get_workspace_billing_checkout_context(uuid)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'service_role',
+      'public.get_workspace_billing_checkout_context(uuid)',
+      'EXECUTE'
+    ),
+  'Only authenticated users can request a workspace checkout context'
+);
+
+select tests.authenticate_as_hyprnote_pro('checkout_owner');
+
+insert into workspace_checkout_test_state (workspace_id)
+select workspace_id from public.create_workspace('Checkout HQ');
+
+select tests.clear_authentication();
+reset role;
+
+insert into public.workspace_memberships (workspace_id, user_id, role)
+values
+  (
+    (select workspace_id from workspace_checkout_test_state),
+    tests.get_supabase_uid('checkout_admin'),
+    'admin'
+  ),
+  (
+    (select workspace_id from workspace_checkout_test_state),
+    tests.get_supabase_uid('checkout_member'),
+    'member'
+  );
+
+update public.workspaces
+set stripe_customer_id = 'cus_checkout123'
+where id = (select workspace_id from workspace_checkout_test_state);
+
+select tests.authenticate_as_hyprnote_pro('checkout_owner');
+
+select results_eq(
+  $$
+    select workspace_name, stripe_customer_id, used_seats
+    from public.get_workspace_billing_checkout_context(
+      (select workspace_id from workspace_checkout_test_state)
+    )
+  $$,
+  $$values ('Checkout HQ'::text, 'cus_checkout123'::text, 3)$$,
+  'The owner receives the workspace billing identity and live seat floor'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_hyprnote_pro('checkout_admin');
+
+select results_eq(
+  $$
+    select workspace_name, stripe_customer_id, used_seats
+    from public.get_workspace_billing_checkout_context(
+      (select workspace_id from workspace_checkout_test_state)
+    )
+  $$,
+  $$values ('Checkout HQ'::text, 'cus_checkout123'::text, 3)$$,
+  'An active workspace admin can start billing checkout'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_hyprnote_pro('checkout_member');
+
+select throws_ok(
+  $$
+    select * from public.get_workspace_billing_checkout_context(
+      (select workspace_id from workspace_checkout_test_state)
+    )
+  $$,
+  '42501',
+  'workspace billing operation not permitted',
+  'A regular member cannot start workspace billing checkout'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_hyprnote_pro('checkout_outsider');
+
+select throws_ok(
+  $$
+    select * from public.get_workspace_billing_checkout_context(
+      (select workspace_id from workspace_checkout_test_state)
+    )
+  $$,
+  '42501',
+  'workspace billing operation not permitted',
+  'A non-member cannot read workspace billing context'
+);
+
+select throws_ok(
+  $$
+    select * from public.get_workspace_billing_checkout_context(
+      tests.get_supabase_uid('checkout_outsider')
+    )
+  $$,
+  '42501',
+  'workspace billing operation not permitted',
+  'A personal workspace cannot be used for Team checkout'
+);
+
+select tests.clear_authentication();
+reset role;
+
+update public.workspace_memberships
+set deleted_at = now()
+where workspace_id = (select workspace_id from workspace_checkout_test_state)
+  and user_id = tests.get_supabase_uid('checkout_admin');
+
+select tests.authenticate_as_hyprnote_pro('checkout_admin');
+
+select throws_ok(
+  $$
+    select * from public.get_workspace_billing_checkout_context(
+      (select workspace_id from workspace_checkout_test_state)
+    )
+  $$,
+  '42501',
+  'workspace billing operation not permitted',
+  'A removed admin immediately loses checkout authority'
+);
+
+select tests.clear_authentication();
+reset role;
+
+update public.workspaces
+set deleted_at = now()
+where id = (select workspace_id from workspace_checkout_test_state);
+
+select tests.authenticate_as_hyprnote_pro('checkout_owner');
+
+select throws_ok(
+  $$
+    select * from public.get_workspace_billing_checkout_context(
+      (select workspace_id from workspace_checkout_test_state)
+    )
+  $$,
+  '42501',
+  'workspace billing operation not permitted',
+  'A deleted workspace cannot start checkout'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- authorize Team checkout context for active workspace owners and admins
- provision and bind workspace Stripe customers safely under concurrent requests
- create per-seat Checkout sessions with live usage as the minimum quantity
- route existing subscriptions to the billing portal without requiring Team price config
- keep Team monthly/yearly price IDs optional and leave the Team tier/price decision untouched

## Validation
- OrbStack clean Supabase reset
- Supabase pgTAP: 40 files, 1090 tests
- web tests: 233 passed
- @anlg/supabase: 15 tests passed
- web typecheck and production Vite build
- dprint format/check
- media figure check (existing missing-upload warnings only)

Depends on #6808.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches payment flows, Stripe customer binding, seat-limit reconciliation, and new SECURITY DEFINER checkout authorization—errors could block billing or mis-sync seats.
> 
> **Overview**
> Adds **end-to-end Team (workspace) checkout**: a `/app/team-checkout` route and `createTeamCheckoutSession` call into new `startWorkspaceCheckout`, which loads authorized context from `get_workspace_billing_checkout_context`, provisions/binds workspace Stripe customers (with cleanup on concurrent assignment), starts **per-seat Pro** Checkout with adjustable quantity floored at live `used_seats`, or sends workspaces with an existing manageable subscription to the **billing portal** without needing price IDs for that path.
> 
> The **Stripe billing bridge** no longer uses Team-specific price env vars or `teamPriceIds`; workspace **seat limits** from webhooks come from subscriptions with **exactly one** line item (`getWorkspaceSubscriptionSeatLimit`), treating that quantity as seats instead of matching dedicated Team prices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ccea9c7d9606c4b3d6f0b9b09a47e8451d50ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->