### PR TITLE
Preserve desktop identity for integration connects

### DIFF
--- a/apps/desktop/src/calendar/components/oauth/provider-content.tsx
+++ b/apps/desktop/src/calendar/components/oauth/provider-content.tsx
@@ -18,10 +18,7 @@ import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
 import { useConnections } from "~/auth/useConnections";
 import type { CalendarProvider } from "~/calendar/components/shared";
-import {
-  openIntegrationUrl,
-  useOpenIntegrationUrl,
-} from "~/shared/integration";
+import { useOpenIntegrationUrl } from "~/shared/integration";
 
 export function OAuthProviderContent({
   config,
@@ -216,6 +213,7 @@ function ConnectedContent({
   connections: ConnectionItem[];
   returnTo: string;
 }) {
+  const { openIntegration } = useOpenIntegrationUrl();
   const {
     groups,
     connectionSourceMap,
@@ -242,23 +240,23 @@ function ConnectedContent({
               id: `reconnect-${connection.connection_id}`,
               text: "Reconnect",
               action: () =>
-                void openIntegrationUrl(
-                  config.nangoIntegrationId,
-                  connection.connection_id,
-                  "reconnect",
+                void openIntegration({
+                  nangoIntegrationId: config.nangoIntegrationId,
+                  connectionId: connection.connection_id,
+                  action: "reconnect",
                   returnTo,
-                ),
+                }),
             },
             {
               id: `disconnect-${connection.connection_id}`,
               text: "Disconnect",
               action: () =>
-                void openIntegrationUrl(
-                  config.nangoIntegrationId,
-                  connection.connection_id,
-                  "disconnect",
+                void openIntegration({
+                  nangoIntegrationId: config.nangoIntegrationId,
+                  connectionId: connection.connection_id,
+                  action: "disconnect",
                   returnTo,
-                ),
+                }),
             },
           ],
         };
@@ -268,6 +266,7 @@ function ConnectedContent({
       connectionSourceMap,
       connections,
       groups,
+      openIntegration,
       returnTo,
     ],
   );

--- a/apps/desktop/src/calendar/components/sidebar.tsx
+++ b/apps/desktop/src/calendar/components/sidebar.tsx
@@ -26,10 +26,7 @@ import { useBillingAccess } from "~/auth/billing-context";
 import { useConnections } from "~/auth/useConnections";
 import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
 import { usePermission } from "~/shared/hooks/usePermissions";
-import {
-  openIntegrationUrl,
-  useOpenIntegrationUrl,
-} from "~/shared/integration";
+import { useOpenIntegrationUrl } from "~/shared/integration";
 
 function getProviderBadgeClassName(badge: string) {
   if (badge === "Beta") {
@@ -254,12 +251,11 @@ function ProviderAccordionItem({
               id: `add-${provider.id}-account`,
               text: t`Add ${provider.displayName} account`,
               action: () =>
-                void openIntegrationUrl(
-                  provider.nangoIntegrationId,
-                  undefined,
-                  "connect",
+                void openIntegration({
+                  nangoIntegrationId: provider.nangoIntegrationId,
+                  action: "connect",
                   returnTo,
-                ),
+                }),
             },
           ]
         : [],
@@ -268,6 +264,7 @@ function ProviderAccordionItem({
       provider.displayName,
       provider.id,
       provider.nangoIntegrationId,
+      openIntegration,
       returnTo,
       t,
     ],

--- a/apps/desktop/src/onboarding/calendar.tsx
+++ b/apps/desktop/src/onboarding/calendar.tsx
@@ -5,7 +5,6 @@ import { motion } from "motion/react";
 import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 
 import type { ConnectionItem } from "@anlg/api-client";
-import { commands as openerCommands } from "@anlg/plugin-opener2";
 
 import { OnboardingButton } from "./shared";
 
@@ -25,7 +24,7 @@ import { PROVIDERS } from "~/calendar/components/shared";
 import { useEnabledCalendars } from "~/calendar/hooks";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { usePermission } from "~/shared/hooks/usePermissions";
-import { buildWebAppUrl } from "~/shared/utils";
+import { openIntegrationUrl } from "~/shared/integration";
 
 const GOOGLE_PROVIDER = PROVIDERS.find((provider) => provider.id === "google");
 const OUTLOOK_PROVIDER = PROVIDERS.find(
@@ -36,20 +35,16 @@ async function openOnboardingIntegrationUrl(
   nangoIntegrationId: string | undefined,
   connectionId: string | undefined,
   action: "connect" | "reconnect" | "disconnect",
+  headers: Record<string, string> | null,
 ) {
-  if (!nangoIntegrationId) return;
-
-  const params: Record<string, string> = {
+  await openIntegrationUrl(
+    nangoIntegrationId,
+    connectionId,
     action,
-    integration_id: nangoIntegrationId,
-  };
-
-  if (connectionId) {
-    params.connection_id = connectionId;
-  }
-
-  const url = await buildWebAppUrl("/app/integration", params);
-  await openerCommands.openUrl(url, null);
+    undefined,
+    headers,
+    false,
+  );
 }
 
 function getCalendarSelectionKey(groups: CalendarGroup[]) {
@@ -135,6 +130,7 @@ function GoogleCalendarConnectedContent({
 }: {
   providerConnections: ConnectionItem[];
 }) {
+  const auth = useAuth();
   const { scheduleSync } = useSync();
   const {
     groups,
@@ -157,8 +153,9 @@ function GoogleCalendarConnectedContent({
         connections: providerConnections,
         connectionSourceMap,
         provider: GOOGLE_PROVIDER!,
+        getHeaders: auth.getHeaders,
       }),
-    [connectionSourceMap, groups, providerConnections],
+    [auth.getHeaders, connectionSourceMap, groups, providerConnections],
   );
 
   useMountEffect(() => {
@@ -197,11 +194,13 @@ function addIntegrationMenus({
   connections,
   connectionSourceMap,
   provider,
+  getHeaders,
 }: {
   groups: CalendarGroup[];
   connections: ConnectionItem[];
   connectionSourceMap: Map<string, string>;
   provider: (typeof PROVIDERS)[number];
+  getHeaders: () => Record<string, string> | null;
 }) {
   return groups.map((group) => {
     const connection = connections.find(
@@ -223,6 +222,7 @@ function addIntegrationMenus({
               provider.nangoIntegrationId,
               connection.connection_id,
               "reconnect",
+              getHeaders(),
             ),
         },
         {
@@ -233,6 +233,7 @@ function addIntegrationMenus({
               provider.nangoIntegrationId,
               connection.connection_id,
               "disconnect",
+              getHeaders(),
             ),
         },
       ],
@@ -245,6 +246,7 @@ function OutlookCalendarConnectedContent({
 }: {
   providerConnections: ConnectionItem[];
 }) {
+  const auth = useAuth();
   const { scheduleSync } = useSync();
   const {
     groups,
@@ -267,8 +269,9 @@ function OutlookCalendarConnectedContent({
         connections: providerConnections,
         connectionSourceMap,
         provider: OUTLOOK_PROVIDER!,
+        getHeaders: auth.getHeaders,
       }),
-    [connectionSourceMap, groups, providerConnections],
+    [auth.getHeaders, connectionSourceMap, groups, providerConnections],
   );
 
   useMountEffect(() => {
@@ -421,11 +424,12 @@ function OutlookCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
       OUTLOOK_PROVIDER?.nangoIntegrationId,
       undefined,
       "connect",
+      auth.getHeaders(),
     ).finally(() => {
       openInFlightRef.current = false;
       setIsOpening(false);
     });
-  }, [auth.session, isPro, onSignIn, upgradeToPro]);
+  }, [auth.getHeaders, auth.session, isPro, onSignIn, upgradeToPro]);
 
   if (!OUTLOOK_PROVIDER) {
     return null;
@@ -506,11 +510,12 @@ function GoogleCalendarProvider({ onSignIn }: { onSignIn: () => void }) {
       GOOGLE_PROVIDER?.nangoIntegrationId,
       undefined,
       "connect",
+      auth.getHeaders(),
     ).finally(() => {
       openInFlightRef.current = false;
       setIsOpening(false);
     });
-  }, [auth.session, isPro, onSignIn, upgradeToPro]);
+  }, [auth.getHeaders, auth.session, isPro, onSignIn, upgradeToPro]);
 
   if (!GOOGLE_PROVIDER) {
     return null;

--- a/apps/desktop/src/shared/integration-handoff.test.ts
+++ b/apps/desktop/src/shared/integration-handoff.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { addNangoSessionHandoff } from "./integration-handoff";
+
+describe("addNangoSessionHandoff", () => {
+  it("keeps the desktop flow parameters and puts the scoped token in the fragment", () => {
+    const result = new URL(
+      addNangoSessionHandoff(
+        "https://anarlog.so/app/integration?flow=desktop&action=connect&integration_id=google-calendar",
+        "nango.token+value",
+      ),
+    );
+
+    expect(result.searchParams.get("flow")).toBe("desktop");
+    expect(result.searchParams.get("action")).toBe("connect");
+    expect(result.searchParams.get("handoff")).toBe("nango");
+    expect(result.searchParams.has("session_token")).toBe(false);
+    expect(new URLSearchParams(result.hash.slice(1)).get("session_token")).toBe(
+      "nango.token+value",
+    );
+  });
+});

--- a/apps/desktop/src/shared/integration-handoff.ts
+++ b/apps/desktop/src/shared/integration-handoff.ts
@@ -1,0 +1,10 @@
+export function addNangoSessionHandoff(url: string, sessionToken: string) {
+  const handoffUrl = new URL(url);
+  handoffUrl.searchParams.set("handoff", "nango");
+  // The fragment stays out of HTTP requests and referrers; the web app removes
+  // it from browser history as soon as it captures the scoped credential.
+  handoffUrl.hash = new URLSearchParams({
+    session_token: sessionToken,
+  }).toString();
+  return handoffUrl.toString();
+}

--- a/apps/desktop/src/shared/integration.ts
+++ b/apps/desktop/src/shared/integration.ts
@@ -1,9 +1,16 @@
 import { useMutation } from "@tanstack/react-query";
 import { useCallback, useRef } from "react";
 
+import { createSession } from "@anlg/api-client";
+import { createClient } from "@anlg/api-client/client";
 import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { openUrlWithInstruction } from "@anlg/plugin-windows";
+import { sonnerToast } from "@anlg/ui/components/ui/toast";
 
+import { useAuth } from "~/auth";
+import { env } from "~/env";
+import { captureOperationalError } from "~/error-reporting";
+import { addNangoSessionHandoff } from "~/shared/integration-handoff";
 import { buildWebAppUrl } from "~/shared/utils";
 
 export async function openIntegrationUrl(
@@ -11,28 +18,75 @@ export async function openIntegrationUrl(
   connectionId: string | undefined,
   action: "connect" | "reconnect" | "disconnect",
   returnTo?: string,
+  headers?: Record<string, string> | null,
+  showInstruction = true,
 ) {
   if (!nangoIntegrationId) return;
-  const params: Record<string, string> = {
-    action,
-    integration_id: nangoIntegrationId,
-  };
-  if (returnTo) {
-    params.return_to = returnTo;
+
+  try {
+    const params: Record<string, string> = {
+      action,
+      integration_id: nangoIntegrationId,
+    };
+    if (returnTo) {
+      params.return_to = returnTo;
+    }
+    if (connectionId) {
+      params.connection_id = connectionId;
+    }
+
+    let url = await buildWebAppUrl("/app/integration", params);
+
+    if (action !== "disconnect") {
+      if (!headers) {
+        throw new Error("No authentication session is available");
+      }
+
+      const client = createClient({ baseUrl: env.VITE_API_URL, headers });
+      const { data, error } = await createSession({
+        client,
+        body: {
+          integration_id: nangoIntegrationId,
+          mode: action,
+          connection_id: connectionId,
+        },
+      });
+
+      if (error) {
+        throw error;
+      }
+      if (!data) {
+        throw new Error("Integration session was not created");
+      }
+
+      url = addNangoSessionHandoff(url, data.token);
+    }
+
+    if (!showInstruction) {
+      await openerCommands.openUrl(url, null);
+      return;
+    }
+
+    await openUrlWithInstruction(
+      url,
+      "integration",
+      (u) => openerCommands.openUrl(u, null),
+      { integrationId: nangoIntegrationId },
+    );
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "integration_open",
+      tags: {
+        integration: nangoIntegrationId,
+        mode: action,
+      },
+    });
+    sonnerToast.error("Could not start the integration setup. Try again.");
   }
-  if (connectionId) {
-    params.connection_id = connectionId;
-  }
-  const url = await buildWebAppUrl("/app/integration", params);
-  await openUrlWithInstruction(
-    url,
-    "integration",
-    (u) => openerCommands.openUrl(u, null),
-    { integrationId: nangoIntegrationId },
-  );
 }
 
 export function useOpenIntegrationUrl() {
+  const auth = useAuth();
   // React state cannot gate re-entry: a second click can land before the
   // pending state commits, opening a duplicate integration flow.
   const inFlightRef = useRef(false);
@@ -48,6 +102,7 @@ export function useOpenIntegrationUrl() {
         input.connectionId,
         input.action,
         input.returnTo,
+        auth.getHeaders(),
       ),
   });
 

--- a/apps/web/src/lib/integration-handoff.test.ts
+++ b/apps/web/src/lib/integration-handoff.test.ts
@@ -1,10 +1,24 @@
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import test from "node:test";
+import { StrictMode, act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 
 import {
   getNangoSessionToken,
   isDesktopIntegrationHandoff,
+  useNangoSessionHandoffToken,
 } from "./integration-handoff.ts";
+
+const require = createRequire(import.meta.url);
+const { JSDOM } = require("jsdom") as {
+  JSDOM: new (
+    html?: string,
+    options?: { url?: string },
+  ) => {
+    window: Window & typeof globalThis & { close: () => void };
+  };
+};
 
 test("recognizes a desktop Nango integration handoff", () => {
   assert.equal(
@@ -50,3 +64,78 @@ test("reads the scoped Nango token from the URL fragment", () => {
   assert.equal(getNangoSessionToken("session_token=token"), null);
   assert.equal(getNangoSessionToken(""), null);
 });
+
+test("preserves the handoff token across StrictMode effect replay", async () => {
+  const dom = new JSDOM('<div id="root"></div>', {
+    url: "https://anarlog.so/app/integration?flow=desktop#session_token=nango.token",
+  });
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousNavigator = globalThis.navigator;
+  const previousActEnvironment = Reflect.get(
+    globalThis,
+    "IS_REACT_ACT_ENVIRONMENT",
+  );
+  const renderedTokens: Array<string | null | undefined> = [];
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: dom.window,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: dom.window.document,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+    configurable: true,
+    value: true,
+  });
+
+  function HandoffProbe() {
+    renderedTokens.push(useNangoSessionHandoffToken());
+    return null;
+  }
+
+  const rootElement = document.getElementById("root");
+  assert.ok(rootElement);
+  const root = createRoot(rootElement);
+
+  try {
+    await act(async () => {
+      root.render(createElement(StrictMode, null, createElement(HandoffProbe)));
+    });
+
+    assert.equal(renderedTokens.at(-1), "nango.token");
+    assert.equal(renderedTokens.includes(null), false);
+    assert.equal(dom.window.location.hash, "");
+    assert.equal(
+      dom.window.location.href,
+      "https://anarlog.so/app/integration?flow=desktop",
+    );
+  } finally {
+    await act(async () => {
+      root.unmount();
+    });
+    dom.window.close();
+    restoreGlobal("window", previousWindow);
+    restoreGlobal("document", previousDocument);
+    restoreGlobal("navigator", previousNavigator);
+    restoreGlobal("IS_REACT_ACT_ENVIRONMENT", previousActEnvironment);
+  }
+});
+
+function restoreGlobal(key: string, value: unknown) {
+  if (value === undefined) {
+    Reflect.deleteProperty(globalThis, key);
+    return;
+  }
+
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value,
+  });
+}

--- a/apps/web/src/lib/integration-handoff.test.ts
+++ b/apps/web/src/lib/integration-handoff.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getNangoSessionToken,
+  isDesktopIntegrationHandoff,
+} from "./integration-handoff.ts";
+
+test("recognizes a desktop Nango integration handoff", () => {
+  assert.equal(
+    isDesktopIntegrationHandoff({
+      pathname: "/app/integration/",
+      search: {
+        flow: "desktop",
+        action: "connect",
+        handoff: "nango",
+      },
+    }),
+    true,
+  );
+});
+
+test("does not bypass app authentication for web or disconnect flows", () => {
+  for (const search of [
+    { flow: "web", action: "connect", handoff: "nango" },
+    { flow: "desktop", action: "disconnect", handoff: "nango" },
+    { flow: "desktop", action: "unknown", handoff: "nango" },
+    { flow: "desktop", action: "connect" },
+  ]) {
+    assert.equal(
+      isDesktopIntegrationHandoff({
+        pathname: "/app/integration/",
+        search,
+      }),
+      false,
+    );
+  }
+});
+
+test("reads the scoped Nango token from the URL fragment", () => {
+  assert.equal(
+    getNangoSessionToken("#session_token=nango%2Etoken%2Bvalue"),
+    "nango.token+value",
+  );
+  assert.equal(getNangoSessionToken("#session_token="), null);
+  assert.equal(
+    getNangoSessionToken("#session_token=first&session_token=second"),
+    null,
+  );
+  assert.equal(getNangoSessionToken("session_token=token"), null);
+  assert.equal(getNangoSessionToken(""), null);
+});

--- a/apps/web/src/lib/integration-handoff.ts
+++ b/apps/web/src/lib/integration-handoff.ts
@@ -1,3 +1,7 @@
+import { useRef, useState } from "react";
+
+import { useMountEffect } from "../hooks/useMountEffect.ts";
+
 export function isDesktopIntegrationHandoff({
   pathname,
   search,
@@ -25,4 +29,28 @@ export function getNangoSessionToken(hash: string) {
 
   const token = entries[0][1].trim();
   return token || null;
+}
+
+export function useNangoSessionHandoffToken() {
+  const capturedRef = useRef(false);
+  const [sessionToken, setSessionToken] = useState<string | null | undefined>(
+    undefined,
+  );
+
+  useMountEffect(() => {
+    if (capturedRef.current) {
+      return;
+    }
+    capturedRef.current = true;
+
+    const token = getNangoSessionToken(window.location.hash);
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${window.location.search}`,
+    );
+    setSessionToken(token);
+  });
+
+  return sessionToken;
 }

--- a/apps/web/src/lib/integration-handoff.ts
+++ b/apps/web/src/lib/integration-handoff.ts
@@ -1,0 +1,28 @@
+export function isDesktopIntegrationHandoff({
+  pathname,
+  search,
+}: {
+  pathname: string;
+  search: Record<string, unknown>;
+}) {
+  return (
+    pathname.replace(/\/+$/, "") === "/app/integration" &&
+    search.flow === "desktop" &&
+    search.handoff === "nango" &&
+    (search.action === "connect" || search.action === "reconnect")
+  );
+}
+
+export function getNangoSessionToken(hash: string) {
+  if (!hash.startsWith("#")) {
+    return null;
+  }
+
+  const entries = [...new URLSearchParams(hash.slice(1)).entries()];
+  if (entries.length !== 1 || entries[0]?.[0] !== "session_token") {
+    return null;
+  }
+
+  const token = entries[0][1].trim();
+  return token || null;
+}

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -30,7 +30,7 @@ function getConnectionErrorMessage(
   return `${providerName} rejected the connection. Please try again or contact support if it keeps happening.`;
 }
 
-export function ConnectFlow() {
+export function ConnectFlow({ sessionToken }: { sessionToken?: string } = {}) {
   const search = Route.useSearch();
   const navigate = useNavigate();
   const { track } = useAnalytics();
@@ -69,34 +69,54 @@ export function ConnectFlow() {
       flow: search.flow,
     });
 
-    let sessionToken: string;
+    let connectSessionToken = sessionToken;
 
-    try {
-      const token = await getAccessToken();
-      const apiClient = createClient({
-        baseUrl: env.VITE_API_URL,
-        headers: { Authorization: `Bearer ${token}` },
-      });
+    if (!connectSessionToken) {
+      try {
+        const token = await getAccessToken();
+        const apiClient = createClient({
+          baseUrl: env.VITE_API_URL,
+          headers: { Authorization: `Bearer ${token}` },
+        });
 
-      const { data, error } = await createSession({
-        client: apiClient,
-        body: {
-          integration_id: search.integration_id,
-          mode: search.action as "connect" | "reconnect",
-          connection_id: search.connection_id,
-        },
-      });
-      if (error || !data) {
-        captureOperationalError(
-          error ?? new Error("Integration session was not created"),
-          {
-            operation: "integration_connection_session",
-            tags: {
-              integration: search.integration_id,
-              mode: search.action,
-            },
+        const { data, error } = await createSession({
+          client: apiClient,
+          body: {
+            integration_id: search.integration_id,
+            mode: search.action as "connect" | "reconnect",
+            connection_id: search.connection_id,
           },
-        );
+        });
+        if (error || !data) {
+          captureOperationalError(
+            error ?? new Error("Integration session was not created"),
+            {
+              operation: "integration_connection_session",
+              tags: {
+                integration: search.integration_id,
+                mode: search.action,
+              },
+            },
+          );
+          inFlightRef.current = false;
+          updateStatus("error");
+          track("integration_connection_failed", {
+            integration: search.integration_id,
+            mode: search.action,
+            flow: search.flow,
+            failure_stage: "session",
+          });
+          return;
+        }
+        connectSessionToken = data.token;
+      } catch (error) {
+        captureOperationalError(error, {
+          operation: "integration_connection_session",
+          tags: {
+            integration: search.integration_id,
+            mode: search.action,
+          },
+        });
         inFlightRef.current = false;
         updateStatus("error");
         track("integration_connection_failed", {
@@ -107,24 +127,6 @@ export function ConnectFlow() {
         });
         return;
       }
-      sessionToken = data.token;
-    } catch (error) {
-      captureOperationalError(error, {
-        operation: "integration_connection_session",
-        tags: {
-          integration: search.integration_id,
-          mode: search.action,
-        },
-      });
-      inFlightRef.current = false;
-      updateStatus("error");
-      track("integration_connection_failed", {
-        integration: search.integration_id,
-        mode: search.action,
-        flow: search.flow,
-        failure_stage: "session",
-      });
-      return;
     }
 
     if (disposedRef.current) return;
@@ -206,7 +208,7 @@ export function ConnectFlow() {
     });
 
     connectUIRef.current = connect;
-    connect.setSessionToken(sessionToken);
+    connect.setSessionToken(connectSessionToken);
   };
 
   // Nango's Connect UI repeats the connect prompt, so only calendars (which

--- a/apps/web/src/routes/_view/app/integration.tsx
+++ b/apps/web/src/routes/_view/app/integration.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
 import { z } from "zod";
 
 import {
@@ -7,7 +8,9 @@ import {
   flowSearchSchema,
 } from "@/functions/desktop-flow";
 import { useBilling } from "@/hooks/use-billing";
+import { useMountEffect } from "@/hooks/useMountEffect";
 import { getIntegrationBillingGate } from "@/lib/integration-billing-gate";
+import { getNangoSessionToken } from "@/lib/integration-handoff";
 
 import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
 import { ConnectFlow } from "./-integrations-connect-flow";
@@ -19,6 +22,7 @@ const commonSearch = {
   connection_id: z.string().optional(),
   action: z.enum(["connect", "reconnect", "disconnect"]).default("connect"),
   return_to: z.string().optional(),
+  handoff: z.literal("nango").optional(),
 };
 
 const validateSearch = flowSearchSchema(commonSearch);
@@ -82,6 +86,60 @@ export const Route = createFileRoute("/_view/app/integration")({
 
 function Component() {
   const search = Route.useSearch();
+  const isDesktopHandoff =
+    search.flow === "desktop" &&
+    search.handoff === "nango" &&
+    (search.action === "connect" || search.action === "reconnect");
+
+  if (isDesktopHandoff) {
+    return <DesktopHandoffConnect />;
+  }
+
+  return <BrowserAuthorizedIntegration />;
+}
+
+function DesktopHandoffConnect() {
+  const [desktopSessionToken, setDesktopSessionToken] = useState<
+    string | null | undefined
+  >(undefined);
+
+  useMountEffect(() => {
+    const sessionToken = getNangoSessionToken(window.location.hash);
+    // Do not leave the scoped credential in history while the provider flow is open.
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${window.location.search}`,
+    );
+    setDesktopSessionToken(sessionToken);
+  });
+
+  if (desktopSessionToken === undefined) {
+    return (
+      <IntegrationPageLayout>
+        <p className="text-neutral-500">Loading...</p>
+      </IntegrationPageLayout>
+    );
+  }
+
+  if (!desktopSessionToken) {
+    return (
+      <IntegrationPageLayout>
+        <div className="flex flex-col gap-4">
+          <p className="text-neutral-600">
+            This connection link is invalid or expired. Return to Anarlog and
+            try again.
+          </p>
+        </div>
+      </IntegrationPageLayout>
+    );
+  }
+
+  return <ConnectFlow sessionToken={desktopSessionToken} />;
+}
+
+function BrowserAuthorizedIntegration() {
+  const search = Route.useSearch();
   const billing = useBilling();
   const billingVerification = useQuery({
     queryKey: [
@@ -98,6 +156,7 @@ function Component() {
     staleTime: Infinity,
     retry: 1,
   });
+
   const gate = getIntegrationBillingGate({
     action: search.action,
     isBillingReady: billing.isReady,

--- a/apps/web/src/routes/_view/app/integration.tsx
+++ b/apps/web/src/routes/_view/app/integration.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
 import { z } from "zod";
 
 import {
@@ -8,9 +7,8 @@ import {
   flowSearchSchema,
 } from "@/functions/desktop-flow";
 import { useBilling } from "@/hooks/use-billing";
-import { useMountEffect } from "@/hooks/useMountEffect";
 import { getIntegrationBillingGate } from "@/lib/integration-billing-gate";
-import { getNangoSessionToken } from "@/lib/integration-handoff";
+import { useNangoSessionHandoffToken } from "@/lib/integration-handoff";
 
 import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
 import { ConnectFlow } from "./-integrations-connect-flow";
@@ -99,20 +97,7 @@ function Component() {
 }
 
 function DesktopHandoffConnect() {
-  const [desktopSessionToken, setDesktopSessionToken] = useState<
-    string | null | undefined
-  >(undefined);
-
-  useMountEffect(() => {
-    const sessionToken = getNangoSessionToken(window.location.hash);
-    // Do not leave the scoped credential in history while the provider flow is open.
-    window.history.replaceState(
-      window.history.state,
-      "",
-      `${window.location.pathname}${window.location.search}`,
-    );
-    setDesktopSessionToken(sessionToken);
-  });
+  const desktopSessionToken = useNangoSessionHandoffToken();
 
   if (desktopSessionToken === undefined) {
     return (

--- a/apps/web/src/routes/_view/app/route.tsx
+++ b/apps/web/src/routes/_view/app/route.tsx
@@ -3,12 +3,22 @@ import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { fetchUser } from "@/functions/auth";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import { setErrorReportingUser } from "@/lib/error-reporting";
+import { isDesktopIntegrationHandoff } from "@/lib/integration-handoff";
 
 export const Route = createFileRoute("/_view/app")({
   head: () => ({
     meta: [{ name: "robots", content: "noindex, nofollow" }],
   }),
   beforeLoad: async ({ location }) => {
+    if (
+      isDesktopIntegrationHandoff({
+        pathname: location.pathname,
+        search: location.search as Record<string, unknown>,
+      })
+    ) {
+      return { user: null };
+    }
+
     const user = await fetchUser();
     if (!user) {
       const searchStr =
@@ -30,6 +40,10 @@ export const Route = createFileRoute("/_view/app")({
 
 function AppRoute() {
   const { user } = Route.useRouteContext();
+
+  if (!user) {
+    return <Outlet />;
+  }
 
   return (
     <ErrorReportingIdentity key={user.id} userId={user.id}>


### PR DESCRIPTION
Authorize scoped Nango sessions with the signed-in desktop account so browser account state cannot trigger a false paywall.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth bypass for a narrow desktop handoff path and integration session creation; mitigated by strict handoff detection, fragment-only tokens, and tests, but errors in those guards would affect connect/reconnect security and billing gates.
> 
> **Overview**
> **Desktop calendar connects/reconnects** now create a scoped Nango session with the **signed-in desktop account** before opening the browser, then pass the token via a URL fragment (`handoff=nango`) so the web flow does not rely on whatever user is logged into the browser (avoiding false billing/paywall mismatches).
> 
> On the **web app**, desktop handoff URLs skip the normal `/app` auth gate, read the token from the hash once (and strip it from history), and **`ConnectFlow`** can start Nango with that pre-issued token instead of calling `createSession` with browser credentials. **Disconnect** still opens the integration URL without a handoff token.
> 
> Desktop call sites consolidate on **`useOpenIntegrationUrl`** / shared **`openIntegrationUrl`** with auth headers; onboarding uses the same path with instructions suppressed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de5d7471e23380ec7f31bcdf6e2469026eac19a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->