### PR TITLE
Establish mixed-license enterprise boundary

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+/enterprise/ @ComputelessComputer
+/LICENSE.enterprise @ComputelessComputer
+/LICENSING.md @ComputelessComputer
+/.github/CODEOWNERS @ComputelessComputer
+/.github/scripts/check_license_boundary.py @ComputelessComputer
+/.github/scripts/test_check_license_boundary.py @ComputelessComputer
+/.github/workflows/ci.yaml @ComputelessComputer

--- a/.github/scripts/check_license_boundary.py
+++ b/.github/scripts/check_license_boundary.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+
+REQUIRED_NOTICE = "are not licensed under the MIT License"
+DEPENDENCY_SECTIONS = (
+    "dependencies",
+    "dev-dependencies",
+    "build-dependencies",
+)
+NODE_DEPENDENCY_SECTIONS = (
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+)
+IGNORED_DIRECTORIES = {".git", "node_modules", "target"}
+
+
+def is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def manifests(root: Path, filename: str) -> list[Path]:
+    paths = []
+    for current, directories, filenames in os.walk(root):
+        directories[:] = [
+            directory
+            for directory in directories
+            if directory not in IGNORED_DIRECTORIES
+        ]
+        if filename in filenames:
+            paths.append(Path(current) / filename)
+    return sorted(paths)
+
+
+def rust_dependency_tables(manifest: dict[str, object]) -> list[dict[str, object]]:
+    tables = [
+        table
+        for section in DEPENDENCY_SECTIONS
+        if isinstance((table := manifest.get(section)), dict)
+    ]
+    targets = manifest.get("target")
+    if isinstance(targets, dict):
+        for target in targets.values():
+            if not isinstance(target, dict):
+                continue
+            tables.extend(
+                table
+                for section in DEPENDENCY_SECTIONS
+                if isinstance((table := target.get(section)), dict)
+            )
+    workspace = manifest.get("workspace")
+    if isinstance(workspace, dict) and isinstance(
+        (dependencies := workspace.get("dependencies")), dict
+    ):
+        tables.append(dependencies)
+    return tables
+
+
+def enterprise_rust_packages(enterprise: Path) -> set[str]:
+    packages = set()
+    for path in manifests(enterprise, "Cargo.toml"):
+        package = tomllib.loads(path.read_text()).get("package")
+        if isinstance(package, dict) and isinstance(package.get("name"), str):
+            packages.add(package["name"])
+    return packages
+
+
+def enterprise_node_packages(enterprise: Path) -> set[str]:
+    packages = set()
+    for path in manifests(enterprise, "package.json"):
+        package = json.loads(path.read_text())
+        if isinstance(package.get("name"), str):
+            packages.add(package["name"])
+    return packages
+
+
+def check_boundary(root: Path) -> list[str]:
+    root = root.resolve()
+    enterprise = root / "enterprise"
+    errors = []
+
+    root_notice = root / "LICENSE.enterprise"
+    directory_notice = enterprise / "LICENSE"
+    for notice in (root_notice, directory_notice):
+        if not notice.is_file():
+            errors.append(
+                f"missing commercial license notice: {notice.relative_to(root)}"
+            )
+        elif REQUIRED_NOTICE not in notice.read_text():
+            errors.append(
+                f"invalid commercial license notice: {notice.relative_to(root)}"
+            )
+    if root_notice.is_file() and directory_notice.is_file():
+        if root_notice.read_bytes() != directory_notice.read_bytes():
+            errors.append("LICENSE.enterprise and enterprise/LICENSE must be identical")
+
+    enterprise_rust = enterprise_rust_packages(enterprise)
+    for path in manifests(root, "Cargo.toml"):
+        if is_within(path, enterprise):
+            continue
+        manifest = tomllib.loads(path.read_text())
+        for table in rust_dependency_tables(manifest):
+            for dependency_name, specification in table.items():
+                package_name = dependency_name
+                if isinstance(specification, dict):
+                    if isinstance(specification.get("package"), str):
+                        package_name = specification["package"]
+                    dependency_path = specification.get("path")
+                    if isinstance(dependency_path, str) and is_within(
+                        path.parent / dependency_path, enterprise
+                    ):
+                        errors.append(
+                            f"MIT Rust manifest {path.relative_to(root)} depends on enterprise path {dependency_path}"
+                        )
+                if package_name in enterprise_rust:
+                    errors.append(
+                        f"MIT Rust manifest {path.relative_to(root)} depends on enterprise package {package_name}"
+                    )
+
+    enterprise_node = enterprise_node_packages(enterprise)
+    for path in manifests(root, "package.json"):
+        if is_within(path, enterprise):
+            continue
+        package = json.loads(path.read_text())
+        for section in NODE_DEPENDENCY_SECTIONS:
+            dependencies = package.get(section)
+            if not isinstance(dependencies, dict):
+                continue
+            for dependency_name, specification in dependencies.items():
+                if dependency_name in enterprise_node:
+                    errors.append(
+                        f"MIT JavaScript package {path.relative_to(root)} depends on enterprise package {dependency_name}"
+                    )
+                if not isinstance(specification, str):
+                    continue
+                if any(
+                    specification == f"npm:{package_name}"
+                    or specification.startswith(f"npm:{package_name}@")
+                    for package_name in enterprise_node
+                ):
+                    errors.append(
+                        f"MIT JavaScript package {path.relative_to(root)} aliases an enterprise package"
+                    )
+                protocol, separator, dependency_path = specification.partition(":")
+                if not separator:
+                    dependency_path = specification
+                is_local_reference = not separator or protocol in {
+                    "file",
+                    "link",
+                    "portal",
+                    "workspace",
+                }
+                if is_local_reference and is_within(
+                    path.parent / dependency_path, enterprise
+                ):
+                    errors.append(
+                        f"MIT JavaScript package {path.relative_to(root)} depends on enterprise path {dependency_path}"
+                    )
+
+    return errors
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[2]
+    errors = check_boundary(root)
+    if errors:
+        print("License boundary check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        raise SystemExit(1)
+    print("License boundary check passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_check_license_boundary.py
+++ b/.github/scripts/test_check_license_boundary.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_license_boundary import REQUIRED_NOTICE, check_boundary
+
+
+NOTICE = f"Enterprise files {REQUIRED_NOTICE}.\n"
+
+
+class LicenseBoundaryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        (self.root / "enterprise" / "crates" / "server").mkdir(parents=True)
+        (self.root / "crates" / "client").mkdir(parents=True)
+        (self.root / "enterprise" / "packages" / "admin").mkdir(parents=True)
+        (self.root / "packages" / "app").mkdir(parents=True)
+        (self.root / "LICENSE.enterprise").write_text(NOTICE)
+        (self.root / "enterprise" / "LICENSE").write_text(NOTICE)
+        (self.root / "enterprise" / "crates" / "server" / "Cargo.toml").write_text(
+            '[package]\nname = "enterprise-server"\nversion = "0.1.0"\n'
+        )
+        (self.root / "crates" / "client" / "Cargo.toml").write_text(
+            '[package]\nname = "community-client"\nversion = "0.1.0"\n'
+        )
+        (self.root / "enterprise" / "packages" / "admin" / "package.json").write_text(
+            '{"name":"@anlg/enterprise-admin"}\n'
+        )
+        (self.root / "packages" / "app" / "package.json").write_text(
+            '{"name":"@anlg/app"}\n'
+        )
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def test_accepts_one_way_enterprise_boundary(self) -> None:
+        self.assertEqual(check_boundary(self.root), [])
+
+    def test_rejects_rust_path_from_community_to_enterprise(self) -> None:
+        (self.root / "crates" / "client" / "Cargo.toml").write_text(
+            '[package]\nname = "community-client"\nversion = "0.1.0"\n'
+            '[dependencies]\nenterprise-server = { path = "../../enterprise/crates/server" }\n'
+        )
+
+        errors = check_boundary(self.root)
+
+        self.assertTrue(any("depends on enterprise path" in error for error in errors))
+
+    def test_rejects_workspace_rust_dependency_by_enterprise_package_name(self) -> None:
+        (self.root / "crates" / "client" / "Cargo.toml").write_text(
+            '[package]\nname = "community-client"\nversion = "0.1.0"\n'
+            "[dependencies]\nenterprise-server = { workspace = true }\n"
+        )
+
+        errors = check_boundary(self.root)
+
+        self.assertTrue(
+            any("enterprise package enterprise-server" in error for error in errors)
+        )
+
+    def test_rejects_virtual_workspace_rust_dependency_on_enterprise_path(self) -> None:
+        (self.root / "Cargo.toml").write_text(
+            '[workspace]\nmembers = ["crates/client"]\n'
+            '[workspace.dependencies]\nserver = { path = "enterprise/crates/server", package = "enterprise-server" }\n'
+        )
+
+        errors = check_boundary(self.root)
+
+        self.assertTrue(any("depends on enterprise path" in error for error in errors))
+
+    def test_rejects_javascript_dependency_on_enterprise_package(self) -> None:
+        (self.root / "packages" / "app" / "package.json").write_text(
+            '{"name":"@anlg/app","dependencies":{"@anlg/enterprise-admin":"workspace:*"}}\n'
+        )
+
+        errors = check_boundary(self.root)
+
+        self.assertTrue(
+            any(
+                "enterprise package @anlg/enterprise-admin" in error for error in errors
+            )
+        )
+
+    def test_rejects_javascript_alias_for_enterprise_package(self) -> None:
+        for specification in (
+            "npm:@anlg/enterprise-admin",
+            "npm:@anlg/enterprise-admin@1.0.0",
+        ):
+            with self.subTest(specification=specification):
+                (self.root / "packages" / "app" / "package.json").write_text(
+                    '{"name":"@anlg/app","dependencies":{"admin":"'
+                    + specification
+                    + '"}}\n'
+                )
+
+                errors = check_boundary(self.root)
+
+                self.assertTrue(
+                    any("aliases an enterprise package" in error for error in errors)
+                )
+
+    def test_rejects_javascript_workspace_path_into_enterprise(self) -> None:
+        (self.root / "packages" / "app" / "package.json").write_text(
+            '{"name":"@anlg/app","dependencies":{"admin":"workspace:../../enterprise/packages/admin"}}\n'
+        )
+
+        errors = check_boundary(self.root)
+
+        self.assertTrue(any("depends on enterprise path" in error for error in errors))
+
+    def test_rejects_javascript_root_paths_without_dot_prefix(self) -> None:
+        for specification in (
+            "file:enterprise/packages/admin",
+            "enterprise/packages/admin",
+        ):
+            with self.subTest(specification=specification):
+                (self.root / "package.json").write_text(
+                    '{"name":"root","dependencies":{"admin":"' + specification + '"}}\n'
+                )
+
+                errors = check_boundary(self.root)
+
+                self.assertTrue(
+                    any("depends on enterprise path" in error for error in errors)
+                )
+
+    def test_rejects_mismatched_commercial_notices(self) -> None:
+        (self.root / "enterprise" / "LICENSE").write_text(NOTICE + "changed\n")
+
+        errors = check_boundary(self.root)
+
+        self.assertIn(
+            "LICENSE.enterprise and enterprise/LICENSE must be identical", errors
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: |
+          python3 .github/scripts/test_check_license_boundary.py
+          python3 .github/scripts/check_license_boundary.py
       - run: >-
           node --test
           scripts/desktop-release-provenance.test.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 Development documentation is available at [docs.anarlog.so](https://docs.anarlog.so).
 
-By submitting a contribution to this repository, you agree that it may be distributed under the repository's [MIT License](LICENSE). Only submit material you have the right to license this way.
+By submitting a contribution outside `enterprise/`, you agree that it may be distributed under the repository's [MIT License](LICENSE). Only submit material you have the right to license this way.
 
-Do not include Fastrepl enterprise source, customer configuration, credentials, or untracked third-party code. Record the immutable upstream revision and license before reusing third-party material. See [Licensing and product boundary](LICENSING.md) for the component-placement and provenance rules.
+Do not submit changes under `enterprise/` unless Fastrepl has confirmed the applicable contribution terms in writing. Never include customer configuration, credentials, confidential material, or untracked third-party code. Record the immutable upstream revision and license before reusing third-party material. See [Licensing and product boundary](LICENSING.md) for the component-placement and provenance rules.

--- a/LICENSE.enterprise
+++ b/LICENSE.enterprise
@@ -1,0 +1,18 @@
+Anarlog Enterprise Commercial License Notice
+
+Copyright (c) 2026-present Fastrepl, Inc. All rights reserved.
+
+The source code and associated documentation under the `enterprise/` directory
+(the "Enterprise Software") are not licensed under the MIT License that applies
+to Anarlog's community software.
+
+Any limited rights required by the terms of the service hosting this repository
+remain unaffected. Those platform rights do not grant a commercial software
+license. No other rights to use, copy, modify, distribute, sublicense, sell, or
+operate the Enterprise Software in production are granted except under a written
+commercial agreement signed by Fastrepl, Inc. or as required by applicable law.
+
+Third-party components incorporated into the Enterprise Software remain subject
+to their original licenses and notices.
+
+For commercial licensing, contact founders@anarlog.so.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,55 +1,54 @@
 # Licensing and product boundary
 
-Anarlog uses a repository boundary, not a source-available license, to separate the open-source application from Fastrepl's commercial enterprise software.
+Anarlog is developed in a mixed-license monorepo. The community application and shared contracts remain open source under MIT, while source-visible enterprise components are commercially licensed.
 
-## Open-source repository
+This is path-based mixed licensing, not a choice between two licenses for the same file.
 
-Everything in this repository is licensed under the [MIT License](LICENSE) unless a file or bundled third-party component says otherwise. This includes:
+## License scope
 
-- the desktop, web, mobile, and command-line applications;
+| Path | License |
+| --- | --- |
+| `enterprise/**` | [Anarlog Enterprise Commercial License Notice](enterprise/LICENSE) and the applicable written agreement with Fastrepl, Inc. |
+| Everything else | [MIT License](LICENSE), unless a nearer license or third-party notice says otherwise |
+
+The nearest license file controls. Moving code across the `enterprise/` boundary requires an explicit licensing review; a file does not keep its previous license merely because it was moved.
+
+Public availability of enterprise source does not place it under MIT or make it open source. Access, evaluation, production use, modification, redistribution, support, warranty, and termination rights come only from a written agreement with Fastrepl, Inc. The commercial notice is a boundary marker, not a substitute for customer terms reviewed by counsel.
+
+## MIT community layer
+
+The MIT layer includes:
+
+- the desktop, web, mobile, command-line, and community server applications;
 - local meeting capture, transcription, storage, export, and sync clients;
-- provider-neutral meeting-capture contracts, normalized events, and behavior fixtures; and
-- public APIs and SDKs required for an MIT client to communicate with a separately deployed service.
+- provider-neutral contracts, normalized events, behavior fixtures, and ingestion interfaces; and
+- public APIs and SDKs required for independently developed clients and integrations.
 
-Contributions accepted into this repository must be distributable under MIT. A contribution must not contain Fastrepl enterprise source code, credentials, customer configuration, or third-party code whose terms are incompatible with MIT distribution.
+The MIT layer must build and test without `enterprise/`. It must never import, depend on, generate from, or require a commercially licensed package. Shared contracts needed on both sides of the boundary belong in the MIT layer.
 
-## Commercial enterprise software
+## Commercial enterprise layer
 
-Fastrepl enterprise software is developed and distributed from a separate private repository under a commercial agreement. It includes:
+Commercial components live only in `enterprise/`. They may depend on MIT packages from this repository and may provide customer-hosted orchestration, meeting-capture services, administration, deployment, policy, or license enforcement.
 
-- customer-hosted meeting-bot workers and their browser automation;
-- scheduling, orchestration, capacity management, and job persistence;
-- enterprise administration, SSO enforcement, audit export, policy, and license enforcement; and
-- Docker, Kubernetes, air-gapped, and regulated-environment deployment packages.
+Keeping both layers in one monorepo permits atomic contract changes and end-to-end tests. It does not change the dependency direction: enterprise may depend on MIT; MIT may not depend on enterprise. CI enforces that rule for Rust and JavaScript package manifests.
 
-Enterprise software may depend on versioned MIT packages from this repository. Code in this repository must never depend on, import, generate from, or require the enterprise repository.
+## Contributions
 
-Enterprise source delivery, binary delivery, evaluation rights, redistribution, support, warranty, and termination terms must come from a counsel-approved Fastrepl Enterprise Software License and the applicable customer agreement. Those terms are intentionally not defined in this MIT repository.
+Contributions outside `enterprise/` must be distributable under MIT. Do not submit changes under `enterprise/` unless Fastrepl has confirmed the applicable contribution terms in writing. Public pull requests do not, by themselves, grant Fastrepl the additional rights needed to distribute a contribution commercially.
+
+Never submit credentials, customer configuration, confidential material, or third-party code without compatible rights and complete provenance.
 
 ## Self-hosted licensing
 
-Customer-hosted enterprise deployments must support a signed, time-bounded or perpetual license file that can be validated offline. The deployment must not require an outbound licensing request after installation unless the customer explicitly enables one. Activation, enforcement, and signing-key material belong only in the enterprise repository.
+Customer-hosted enterprise deployments should support signed, time-bounded or perpetual licenses that can be validated offline. They must not require an outbound licensing request after installation unless the customer explicitly enables one. Activation, enforcement, and signing-key material belong in `enterprise/`; public verification contracts may remain in the MIT layer when independently useful.
 
 ## Third-party provenance
 
-Before third-party code or assets are incorporated into either product:
+Before third-party code or assets are incorporated into either layer:
 
 1. Record the upstream repository, immutable revision, file paths, copyright holder, license, and whether the material was copied, modified, or used only as behavioral reference.
 2. Preserve all required license, copyright, patent, trademark, modification, and NOTICE material in the delivered source or binary distribution.
 3. Keep provenance records beside the consuming code and generate the distribution's third-party notices from those records.
 4. Do not incorporate AGPL, GPL, SSPL, source-available, or unknown-license material without written legal approval.
 
-Apache-2.0 material can be used in commercial software when its conditions are satisfied. That does not make untracked copying acceptable: directly reused files must retain the required notices and modifications must be identified.
-
-Behavioral observation is preferred when replacing a third-party implementation. Tests and fixtures should record public API behavior without copying implementation source, confidential data, or trademarks into product identity.
-
-## Component placement test
-
-A component belongs in this MIT repository only when all of the following are true:
-
-- an independent MIT client needs the component;
-- the component is useful without Fastrepl's enterprise control plane;
-- publishing it does not expose enterprise enforcement, orchestration, or deployment logic; and
-- every dependency and incorporated asset is compatible with MIT distribution.
-
-If any condition is false, build it in the enterprise repository or request a licensing review before implementation.
+Third-party components remain under their original licenses regardless of which Anarlog layer consumes them.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Note:** The team is now building **[char](https://char.com)**. **anarlog** remains open-source, MIT-licensed, and maintained as the local-first meeting notetaker in this repo.
+> **Note:** The team is now building **[char](https://char.com)**. The **anarlog** community application remains open-source, MIT-licensed, and maintained as the local-first meeting notetaker in this repo. Source-visible enterprise components are commercially licensed.
 
 ![anarlog](https://repository-images.githubusercontent.com/900550981/a4267a9f-414b-4c36-965c-419313ce2417)
 
@@ -25,7 +25,7 @@ To self-host, clone the repo, build it, and run it.
 - **Your data, your device.** Sessions, notes, and transcripts are stored locally in SQLite. Attachments and recordings remain local files, and you can export Markdown when you need it.
 - **Local transcription.** Transcription runs on-device, so audio never leaves your machine.
 - **Bring your own AI.** Use any LLM provider, including OpenAI-compatible services and local models.
-- **Open source, MIT.** Fork it, sell it, or self-host it.
+- **Open-source community layer, MIT.** Fork it, sell it, or self-host it.
 - **Optional cloud features.** You can use local or bring-your-own-key workflows, or opt into hosted AI, encrypted CloudSync, and sharing when those fit your workflow.
 
 ## Name history
@@ -34,7 +34,7 @@ To self-host, clone the repo, build it, and run it.
 
 We later split the work into two projects. **[char](https://char.com)** is the team's current productivity app. **anarlog** is this open-source, local-first meeting notetaker.
 
-This repository is not the current char codebase, and anarlog is not being retired. It keeps the open-source path: MIT-licensed, forkable, self-hostable, and built for local notes you control.
+This repository is not the current char codebase, and anarlog is not being retired. Its community application stays MIT-licensed, forkable, self-hostable, and built for local notes you control.
 
 If you came here from Granola, welcome. If you came here from Hyprnote, welcome back.
 
@@ -42,4 +42,4 @@ Either way, it's yours.
 
 ---
 
-**License:** [MIT](LICENSE) · [Product boundary](LICENSING.md) · **Maintainers:** [fastrepl](https://github.com/fastrepl)
+**License:** Community [MIT](LICENSE) · Enterprise [commercial](LICENSE.enterprise) · [Full boundary](LICENSING.md) · **Maintainers:** [fastrepl](https://github.com/fastrepl)

--- a/apps/web/content/legal/terms.mdx
+++ b/apps/web/content/legal/terms.mdx
@@ -4,7 +4,7 @@ title: "Terms of Service"
 summary: "The agreement between you and us when you use Anarlog."
 ---
 
-> **The short version:** Anarlog is free and open source. Pro is a subscription you can cancel anytime, with a trial that never charges you automatically. Your content is yours. You're responsible for recording meetings lawfully. If you connect your own paid AI provider, its usage charges are your responsibility. Encrypted sync means we can't recover your notes if you lose your recovery key. The full terms below are the ones that govern.
+> **The short version:** The Anarlog community application is free and open source. Pro is a subscription you can cancel anytime, with a trial that never charges you automatically. Your content is yours. You're responsible for recording meetings lawfully. If you connect your own paid AI provider, its usage charges are your responsibility. Encrypted sync means we can't recover your notes if you lose your recovery key. The full terms below are the ones that govern.
 
 ## 1. Agreement to terms
 
@@ -12,7 +12,7 @@ By using Anarlog ("the Service"), you agree to these Terms of Service. If you do
 
 ## 2. What Anarlog is
 
-Anarlog is an open-source note-taking and meeting transcription application. It helps you capture, organize, and manage your notes and meeting context.
+The Anarlog community application is an open-source note-taking and meeting transcription application. It helps you capture, organize, and manage your notes and meeting context.
 
 ### 2.1 Local-first architecture
 
@@ -38,7 +38,7 @@ Delete your account anytime from the Account page in the web app (`anarlog.so/ap
 
 ## 4. Subscriptions, trials, and payment
 
-Anarlog is free and open source. Cloud features require a paid subscription — Anarlog Pro.
+The Anarlog community application is free and open source. Cloud features require a paid subscription — Anarlog Pro.
 
 - **Billing and renewal.** Subscriptions are billed in advance, monthly or yearly, and renew automatically until you cancel. You authorize our payment processor to charge your payment method each renewal.
 - **Cancellation.** Cancel anytime from the billing portal in the app's account settings. You keep paid features until the end of the current billing period.
@@ -63,7 +63,7 @@ Anarlog can record meeting audio, which may include other people's voices. Recor
 
 ## 7. Intellectual property
 
-The Anarlog source code is open source under the MIT License. Anarlog also includes and works with third-party components under their own licenses. The Anarlog name, logo, and trademarks belong to Fastrepl, Inc. The Anarlog cloud service and any proprietary components are protected by copyright, trademark, patent, trade secret, and other intellectual property laws.
+The Anarlog community application and shared public contracts are open source under the MIT License. Source-visible enterprise components are commercially licensed as identified in the repository, and third-party components remain under their own licenses. The Anarlog name, logo, and trademarks belong to Fastrepl, Inc. The Anarlog cloud service and proprietary components are protected by copyright, trademark, patent, trade secret, and other intellectual property laws.
 
 ## 8. Your content
 

--- a/enterprise/AGENTS.md
+++ b/enterprise/AGENTS.md
@@ -1,0 +1,8 @@
+# Enterprise directory
+
+- Everything under this directory is commercially licensed under `enterprise/LICENSE` unless a nearer third-party license says otherwise.
+- Enterprise packages may depend on MIT packages outside this directory. Packages outside this directory must never depend on enterprise packages.
+- Put shared protocols, normalized contracts, and independently useful client interfaces in the MIT community layer.
+- Never commit customer configuration, credentials, signing keys, confidential material, or untracked third-party source.
+- Keep third-party provenance and required notices beside the consuming enterprise component.
+- Do not implement or change commercial license terms without an explicit decision and legal review.

--- a/enterprise/LICENSE
+++ b/enterprise/LICENSE
@@ -1,0 +1,18 @@
+Anarlog Enterprise Commercial License Notice
+
+Copyright (c) 2026-present Fastrepl, Inc. All rights reserved.
+
+The source code and associated documentation under the `enterprise/` directory
+(the "Enterprise Software") are not licensed under the MIT License that applies
+to Anarlog's community software.
+
+Any limited rights required by the terms of the service hosting this repository
+remain unaffected. Those platform rights do not grant a commercial software
+license. No other rights to use, copy, modify, distribute, sublicense, sell, or
+operate the Enterprise Software in production are granted except under a written
+commercial agreement signed by Fastrepl, Inc. or as required by applicable law.
+
+Third-party components incorporated into the Enterprise Software remain subject
+to their original licenses and notices.
+
+For commercial licensing, contact founders@anarlog.so.

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -1,0 +1,7 @@
+# Anarlog Enterprise
+
+This directory contains source-visible, commercially licensed Anarlog Enterprise components. It is part of the Anarlog monorepo but is not licensed under the repository's MIT License. See [LICENSE](LICENSE) and the repository's [licensing boundary](../LICENSING.md).
+
+Enterprise packages may depend on the MIT community layer. Community packages must never depend on this directory. Shared contracts and provider-neutral interfaces needed by independent clients belong in the community layer.
+
+Customer configuration, credentials, license-signing keys, and confidential deployment material must never be committed. Third-party material requires complete provenance and must retain its original notices.


### PR DESCRIPTION
## Summary
- keep the community application and shared contracts under MIT
- reserve `enterprise/**` for source-visible commercially licensed components
- enforce the one-way dependency rule for Rust and JavaScript manifests in CI
- align repository, contribution, and public legal copy with the path-based boundary

## Validation
- `pnpm exec dprint fmt`
- `pnpm fmt:check`
- `python3 .github/scripts/test_check_license_boundary.py`
- `python3 .github/scripts/check_license_boundary.py`
- root CI Node test suite (39 tests)
- full web CI job, including typechecks and 252 tests across web and Supabase

Tracks ANLG-225. The commercial notice marks the repository boundary; counsel-approved customer terms remain a separate written agreement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes licensing posture and contribution terms across the repo; CI enforcement is new but limited to manifest scanning with no runtime behavior changes.
> 
> **Overview**
> Introduces a **path-based mixed-license monorepo**: MIT for the community layer outside `enterprise/`, and a commercial notice for source-visible code under `enterprise/`. Adds matching `LICENSE.enterprise` and `enterprise/LICENSE`, plus lightweight `enterprise/` docs (`README`, `AGENTS.md`).
> 
> **CI enforcement** adds `check_license_boundary.py` (with unit tests) on pull requests. It verifies the commercial notices exist and match, and blocks MIT-side Rust `Cargo.toml` and JavaScript `package.json` manifests from depending on enterprise packages, path deps, workspace aliases, or `npm:` aliases into `enterprise/`.
> 
> **Contributor and public copy** updates `LICENSING.md`, `CONTRIBUTING.md`, `README.md`, and web terms to describe the community vs enterprise split and contribution rules. `CODEOWNERS` routes review for enterprise and licensing-related paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25fd7010f871f38ef4ad9638fd5a43b19bf50196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->