### PR TITLE
ANLG-229: persist and project capture events

### DIFF
--- a/crates/meeting-capture/src/model.rs
+++ b/crates/meeting-capture/src/model.rs
@@ -92,6 +92,8 @@ pub struct RecordingChunk {
     pub duration_ms: u64,
     pub content_type: String,
     pub uri: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
 }

--- a/enterprise/Cargo.lock
+++ b/enterprise/Cargo.lock
@@ -24,7 +24,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "chrono",
  "http",
+ "meeting-capture",
  "reqwest",
  "serde",
  "serde_json",
@@ -260,7 +262,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1133,6 +1138,17 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "meeting-capture"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "futures-core",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/enterprise/Cargo.toml
+++ b/enterprise/Cargo.toml
@@ -8,11 +8,13 @@ edition = "2024"
 license-file = "LICENSE"
 
 [workspace.dependencies]
+anlg-meeting-capture = { path = "../crates/meeting-capture", package = "meeting-capture" }
 anlg-session-ingest = { path = "../crates/session-ingest", package = "session-ingest", default-features = false }
 
 anyhow = "1"
 async-trait = "0.1"
 axum = "0.8"
+chrono = "0.4"
 http = "1"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 serde = "1"

--- a/enterprise/control-plane/Cargo.toml
+++ b/enterprise/control-plane/Cargo.toml
@@ -5,11 +5,13 @@ edition.workspace = true
 license-file.workspace = true
 
 [dependencies]
+anlg-meeting-capture.workspace = true
 anlg-session-ingest.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true
 axum = { workspace = true, features = ["json", "query", "tokio"] }
+chrono = { workspace = true, features = ["serde"] }
 http.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/enterprise/control-plane/Dockerfile.dockerignore
+++ b/enterprise/control-plane/Dockerfile.dockerignore
@@ -17,6 +17,8 @@ crates/**
 !crates/*/
 crates/*/**
 !crates/*/Cargo.toml
+!crates/meeting-capture/src/
+!crates/meeting-capture/src/**
 !crates/session-ingest/src/
 !crates/session-ingest/src/**
 

--- a/enterprise/control-plane/README.md
+++ b/enterprise/control-plane/README.md
@@ -1,6 +1,6 @@
 # Anarlog Enterprise control plane
 
-This commercially licensed service packages the workspace-scoped enterprise capture delivery API with automatic PostgreSQL migrations, fail-closed startup configuration, and graceful shutdown.
+This commercially licensed service packages the workspace-scoped enterprise capture API with automatic PostgreSQL migrations, fail-closed startup configuration, and graceful shutdown. It durably appends provider-neutral capture events, projects each revision into the shared session-ingest contract, and delivers those revisions to authorized clients.
 
 ## Evaluation deployment
 
@@ -62,7 +62,9 @@ See the official [`infisical run` documentation](https://infisical.com/docs/cli/
 | `ANARLOG_ENTERPRISE_DATABASE_MAX_CONNECTIONS` | No | PostgreSQL pool size from 1–100. Defaults to `10`. |
 | `RUST_LOG` | No | Standard tracing filter. Defaults to request and service information. No telemetry is exported. |
 
-`GET /health/live` is process-only liveness. `GET /health/ready` checks PostgreSQL. Delivery routes require `Authorization: Bearer <token>` and reject a token used against any workspace other than its configured workspace.
+`GET /health/live` is process-only liveness. `GET /health/ready` checks PostgreSQL. Capture and delivery routes require `Authorization: Bearer <token>` and reject a token used against any workspace other than its configured workspace.
+
+Capture workers create a durable job with `POST /v1/workspaces/{workspace_id}/capture-jobs/{job_id}` and append normalized events with `POST /v1/workspaces/{workspace_id}/capture-jobs/{job_id}/events`. Event IDs and zero-based sequences are idempotency keys. Each accepted event atomically advances the PostgreSQL checkpoint and publishes a delivery revision; retries return the existing byte-equivalent revision, while conflicting IDs, sequences, or lifecycle transitions fail closed.
 
 The static token map is intended for the evaluation bundle and sits behind the `WorkspaceAuthenticator` interface. Production OIDC, SCIM, offline license enforcement, object storage, and meeting browser workers are outside this service.
 

--- a/enterprise/control-plane/migrations/0002_capture_projection.sql
+++ b/enterprise/control-plane/migrations/0002_capture_projection.sql
@@ -1,0 +1,49 @@
+CREATE TABLE capture_jobs (
+    workspace_id TEXT NOT NULL CHECK (length(workspace_id) BETWEEN 1 AND 128),
+    job_id TEXT NOT NULL CHECK (length(job_id) BETWEEN 1 AND 128),
+    bot_id TEXT NOT NULL CHECK (length(bot_id) BETWEEN 1 AND 128),
+    owner_user_id TEXT NOT NULL CHECK (length(owner_user_id) BETWEEN 1 AND 128),
+    requesting_actor_id TEXT NOT NULL CHECK (length(requesting_actor_id) BETWEEN 1 AND 128),
+    session_id TEXT NOT NULL CHECK (length(session_id) BETWEEN 1 AND 128),
+    session_title TEXT NOT NULL CHECK (length(session_title) BETWEEN 1 AND 1024),
+    provider TEXT NOT NULL,
+    meeting JSONB NOT NULL,
+    state TEXT NOT NULL DEFAULT 'queued',
+    terminal_reason JSONB,
+    last_sequence BIGINT NOT NULL DEFAULT -1 CHECK (last_sequence >= -1),
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (workspace_id, job_id),
+    UNIQUE (workspace_id, bot_id)
+);
+
+CREATE TABLE capture_events (
+    workspace_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    sequence BIGINT NOT NULL CHECK (sequence >= 0),
+    event_id TEXT NOT NULL CHECK (length(event_id) BETWEEN 1 AND 128),
+    occurred_at TIMESTAMPTZ NOT NULL,
+    event JSONB NOT NULL,
+    persisted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (workspace_id, job_id, sequence),
+    UNIQUE (workspace_id, job_id, event_id),
+    FOREIGN KEY (workspace_id, job_id)
+        REFERENCES capture_jobs (workspace_id, job_id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE capture_projection_checkpoints (
+    workspace_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    last_sequence BIGINT NOT NULL CHECK (last_sequence >= 0),
+    revision BIGINT NOT NULL CHECK (revision > 0),
+    content_hash TEXT NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (workspace_id, job_id),
+    FOREIGN KEY (workspace_id, job_id)
+        REFERENCES capture_jobs (workspace_id, job_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY (workspace_id, job_id, revision)
+        REFERENCES session_envelopes (workspace_id, job_id, revision)
+        ON DELETE CASCADE
+);

--- a/enterprise/control-plane/src/api.rs
+++ b/enterprise/control-plane/src/api.rs
@@ -13,22 +13,26 @@ use tower_http::trace::TraceLayer;
 
 use crate::{
     auth::{AuthenticationError, WorkspaceAuthenticator},
-    store::{DeliveryStore, StoreError},
+    capture::{
+        AppendCaptureEventRequest, CaptureJob, CaptureJobStatus, CreateCaptureJobRequest,
+        ProjectionPublication,
+    },
+    store::{ControlPlaneStore, StoreError},
 };
 
-const MAX_REQUEST_BYTES: usize = 64 * 1024;
+const MAX_REQUEST_BYTES: usize = 256 * 1024;
 const DEFAULT_PAGE_LIMIT: u16 = 10;
 const MAX_PAGE_LIMIT: u16 = 100;
 
 #[derive(Clone)]
 pub struct AppState {
-    store: Arc<dyn DeliveryStore>,
+    store: Arc<dyn ControlPlaneStore>,
     authenticator: Arc<dyn WorkspaceAuthenticator>,
 }
 
 impl AppState {
     pub fn new(
-        store: Arc<dyn DeliveryStore>,
+        store: Arc<dyn ControlPlaneStore>,
         authenticator: Arc<dyn WorkspaceAuthenticator>,
     ) -> Self {
         Self {
@@ -42,6 +46,14 @@ pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/health/live", get(liveness))
         .route("/health/ready", get(readiness))
+        .route(
+            "/v1/workspaces/{workspace_id}/capture-jobs/{job_id}",
+            post(create_capture_job),
+        )
+        .route(
+            "/v1/workspaces/{workspace_id}/capture-jobs/{job_id}/events",
+            post(append_capture_event),
+        )
         .route(
             "/v1/workspaces/{workspace_id}/session-envelopes",
             get(list_deliveries),
@@ -57,6 +69,68 @@ pub fn router(state: AppState) -> Router {
         .layer(DefaultBodyLimit::max(MAX_REQUEST_BYTES))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
+}
+
+async fn create_capture_job(
+    State(state): State<AppState>,
+    Path((workspace_id, job_id)): Path<(String, String)>,
+    headers: HeaderMap,
+    Json(request): Json<CreateCaptureJobRequest>,
+) -> Result<(StatusCode, Json<CaptureJobStatus>), ApiError> {
+    authorize(&state, &headers, &workspace_id)?;
+    validate_identifier(&workspace_id, "workspace_id")?;
+    validate_identifier(&job_id, "job_id")?;
+    validate_identifier(&request.bot_id, "bot_id")?;
+    validate_identifier(&request.owner_user_id, "owner_user_id")?;
+    validate_identifier(&request.requesting_actor_id, "requesting_actor_id")?;
+    validate_identifier(&request.session_id, "session_id")?;
+    if request.session_title.trim().is_empty() || request.session_title.len() > 1024 {
+        return Err(ApiError::bad_request(
+            "invalid_session_title",
+            "sessionTitle must be between 1 and 1024 bytes",
+        ));
+    }
+    let status = state
+        .store
+        .create_capture_job(&CaptureJob {
+            workspace_id,
+            job_id,
+            bot_id: request.bot_id,
+            owner_user_id: request.owner_user_id,
+            requesting_actor_id: request.requesting_actor_id,
+            session_id: request.session_id,
+            session_title: request.session_title,
+            provider: request.provider,
+            meeting: request.meeting,
+            created_at: request.created_at,
+        })
+        .await
+        .map_err(ApiError::from_store)?;
+    let response_status = if status.created {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
+    Ok((response_status, Json(status)))
+}
+
+async fn append_capture_event(
+    State(state): State<AppState>,
+    Path((workspace_id, job_id)): Path<(String, String)>,
+    headers: HeaderMap,
+    Json(request): Json<AppendCaptureEventRequest>,
+) -> Result<Json<ProjectionPublication>, ApiError> {
+    authorize(&state, &headers, &workspace_id)?;
+    validate_identifier(&workspace_id, "workspace_id")?;
+    validate_identifier(&job_id, "job_id")?;
+    validate_identifier(&request.event.id, "event_id")?;
+    validate_identifier(&request.event.bot_id, "bot_id")?;
+    let publication = state
+        .store
+        .append_capture_event(&workspace_id, &job_id, &request.event)
+        .await
+        .map_err(ApiError::from_store)?;
+    Ok(Json(publication))
 }
 
 async fn liveness() -> Json<HealthResponse> {
@@ -272,6 +346,30 @@ impl ApiError {
                 status: StatusCode::CONFLICT,
                 code: "revision_conflict",
                 message: "revision or contentHash does not match the delivery",
+                authenticate: false,
+            },
+            StoreError::CaptureJobConflict => Self {
+                status: StatusCode::CONFLICT,
+                code: "capture_job_conflict",
+                message: "capture job already exists with different immutable fields",
+                authenticate: false,
+            },
+            StoreError::CaptureBotConflict => Self {
+                status: StatusCode::CONFLICT,
+                code: "capture_bot_conflict",
+                message: "capture bot is already assigned to a different job",
+                authenticate: false,
+            },
+            StoreError::CaptureEventConflict | StoreError::CaptureSequenceConflict { .. } => Self {
+                status: StatusCode::CONFLICT,
+                code: "capture_event_conflict",
+                message: "capture event id, sequence, or content conflicts with persisted data",
+                authenticate: false,
+            },
+            StoreError::InvalidCaptureEvent(_) => Self {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                code: "invalid_capture_event",
+                message: "capture event violates the normalized capture contract",
                 authenticate: false,
             },
             error => {

--- a/enterprise/control-plane/src/capture.rs
+++ b/enterprise/control-plane/src/capture.rs
@@ -1,0 +1,56 @@
+use anlg_meeting_capture::{BotState, CaptureEvent, CaptureProviderKind, MeetingReference};
+use anlg_session_ingest::SessionIngestEnvelope;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CaptureJob {
+    pub workspace_id: String,
+    pub job_id: String,
+    pub bot_id: String,
+    pub owner_user_id: String,
+    pub requesting_actor_id: String,
+    pub session_id: String,
+    pub session_title: String,
+    pub provider: CaptureProviderKind,
+    pub meeting: MeetingReference,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptureJobStatus {
+    pub job_id: String,
+    pub created: bool,
+    pub state: BotState,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectionPublication {
+    pub job_id: String,
+    pub revision: u64,
+    pub finalized: bool,
+    pub content_hash: String,
+    pub envelope: SessionIngestEnvelope,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CreateCaptureJobRequest {
+    pub bot_id: String,
+    pub owner_user_id: String,
+    pub requesting_actor_id: String,
+    pub session_id: String,
+    pub session_title: String,
+    pub provider: CaptureProviderKind,
+    pub meeting: MeetingReference,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AppendCaptureEventRequest {
+    pub event: CaptureEvent,
+}

--- a/enterprise/control-plane/src/lib.rs
+++ b/enterprise/control-plane/src/lib.rs
@@ -2,7 +2,9 @@
 
 pub mod api;
 pub mod auth;
+pub mod capture;
 pub mod config;
+pub mod projector;
 pub mod store;
 
 use std::{future::Future, sync::Arc};

--- a/enterprise/control-plane/src/projector.rs
+++ b/enterprise/control-plane/src/projector.rs
@@ -1,0 +1,584 @@
+use std::collections::BTreeMap;
+
+use anlg_meeting_capture::{
+    BotState, CaptureEvent, CaptureEventPayload, CaptureProviderKind, Participant, RecordingChunk,
+    Speaker,
+};
+use anlg_session_ingest::{
+    IngestAttachment, IngestParticipant, IngestSession, IngestSpeakerHint, IngestTranscript,
+    IngestWord, SESSION_INGEST_SCHEMA_VERSION, SessionIngestEnvelope,
+};
+use chrono::{DateTime, Utc};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::capture::CaptureJob;
+
+pub fn project(
+    job: &CaptureJob,
+    events: &[CaptureEvent],
+) -> Result<SessionIngestEnvelope, ProjectionError> {
+    if events.is_empty() {
+        return Err(ProjectionError::NoEvents);
+    }
+
+    let mut state = BotState::Queued;
+    let mut started_at = None;
+    let mut ended_at = None;
+    let mut speakers = BTreeMap::<String, Speaker>::new();
+    let mut participants = BTreeMap::<String, ProjectedParticipant>::new();
+    let mut segments = BTreeMap::new();
+    let mut chunks = BTreeMap::<String, RecordingChunk>::new();
+
+    for (expected_sequence, event) in events.iter().enumerate() {
+        let expected_sequence = expected_sequence as u64;
+        if event.sequence != expected_sequence {
+            return Err(ProjectionError::NonContiguousSequence {
+                expected: expected_sequence,
+                actual: event.sequence,
+            });
+        }
+        if event.bot_id != job.bot_id {
+            return Err(ProjectionError::WrongBot);
+        }
+        if state.is_terminal() {
+            return Err(ProjectionError::EventAfterTerminal);
+        }
+
+        match &event.payload {
+            CaptureEventPayload::Lifecycle(transition) => {
+                if transition.from != state {
+                    return Err(ProjectionError::StateMismatch);
+                }
+                let validated = state
+                    .transition_to(transition.to, transition.reason.clone())
+                    .map_err(ProjectionError::InvalidTransition)?;
+                if validated != *transition {
+                    return Err(ProjectionError::StateMismatch);
+                }
+                state = transition.to;
+                if started_at.is_none() && matches!(state, BotState::Joined | BotState::Capturing) {
+                    started_at = Some(event.occurred_at);
+                }
+                if state.is_terminal() {
+                    ended_at = Some(event.occurred_at);
+                }
+            }
+            CaptureEventPayload::Transcript(segment) => {
+                segments.insert(segment.id.clone(), segment.clone());
+            }
+            CaptureEventPayload::SpeakerUpserted(speaker) => {
+                speakers.insert(speaker.id.clone(), speaker.clone());
+            }
+            CaptureEventPayload::ParticipantUpserted(participant) => {
+                participants
+                    .entry(participant.id.clone())
+                    .and_modify(|projected| {
+                        projected.participant = participant.clone();
+                        projected.last_seen_at = event.occurred_at;
+                    })
+                    .or_insert_with(|| ProjectedParticipant {
+                        participant: participant.clone(),
+                        first_seen_at: event.occurred_at,
+                        last_seen_at: event.occurred_at,
+                        left_at: None,
+                    });
+            }
+            CaptureEventPayload::ParticipantLeft { participant_id } => {
+                let participant = participants
+                    .entry(participant_id.clone())
+                    .or_insert_with(|| ProjectedParticipant {
+                        participant: Participant {
+                            id: participant_id.clone(),
+                            display_name: None,
+                            email: None,
+                        },
+                        first_seen_at: event.occurred_at,
+                        last_seen_at: event.occurred_at,
+                        left_at: None,
+                    });
+                participant.last_seen_at = event.occurred_at;
+                participant.left_at = Some(event.occurred_at);
+            }
+            CaptureEventPayload::RecordingChunkReady(chunk) => {
+                chunks.insert(chunk.id.clone(), chunk.clone());
+            }
+        }
+    }
+
+    let updated_at = events.last().expect("events are not empty").occurred_at;
+    let finalized = state.is_terminal();
+    let attachments = project_attachments(&chunks, updated_at);
+    let transcripts =
+        project_transcript(&job.session_id, &segments, &speakers, &chunks, updated_at);
+
+    Ok(SessionIngestEnvelope {
+        schema_version: SESSION_INGEST_SCHEMA_VERSION,
+        source_id: job.job_id.clone(),
+        revision: events.len() as u64,
+        finalized,
+        attach_to_existing: false,
+        workspace_id: job.workspace_id.clone(),
+        owner_user_id: job.owner_user_id.clone(),
+        session: IngestSession {
+            id: job.session_id.clone(),
+            title: job.session_title.clone(),
+            status: session_status(state).into(),
+            created_at: timestamp(job.created_at),
+            updated_at: timestamp(updated_at),
+            started_at: started_at.map(timestamp).unwrap_or_default(),
+            ended_at: ended_at.map(timestamp).unwrap_or_default(),
+            timezone: String::new(),
+            language: String::new(),
+            event_id: job.meeting.calendar_event_id.clone().unwrap_or_default(),
+            external_event_id: job.meeting.external_id.clone().unwrap_or_default(),
+            external_provider: platform_name(job.meeting.platform).into(),
+            series_id: String::new(),
+            event: serde_json::to_value(&job.meeting).expect("meeting reference serializes"),
+            metadata: session_metadata(job, state, events),
+        },
+        documents: vec![],
+        transcripts,
+        participants: participants
+            .into_values()
+            .map(project_participant)
+            .collect(),
+        attachments,
+    })
+}
+
+pub fn content_hash(envelope: &SessionIngestEnvelope) -> Result<String, serde_json::Error> {
+    let serialized = serde_json::to_vec(envelope)?;
+    Ok(hex_digest(Sha256::digest(serialized)))
+}
+
+fn project_transcript(
+    session_id: &str,
+    segments: &BTreeMap<String, anlg_meeting_capture::TranscriptSegment>,
+    speakers: &BTreeMap<String, Speaker>,
+    chunks: &BTreeMap<String, RecordingChunk>,
+    updated_at: DateTime<Utc>,
+) -> Vec<IngestTranscript> {
+    if segments.is_empty() {
+        return vec![];
+    }
+
+    let mut ordered = segments.values().collect::<Vec<_>>();
+    ordered.sort_by_key(|segment| (segment.sequence, segment.id.as_str()));
+    let words = ordered
+        .iter()
+        .map(|segment| {
+            let speaker = segment.speaker.as_ref().map(|speaker| {
+                speakers
+                    .get(&speaker.id)
+                    .and_then(|known| known.display_name.clone())
+                    .or_else(|| speaker.display_name.clone())
+                    .unwrap_or_else(|| speaker.id.clone())
+            });
+            IngestWord {
+                id: stable_id("word", &segment.id),
+                text: segment.text.clone(),
+                start_ms: saturating_i64(segment.start_ms),
+                end_ms: saturating_i64(segment.end_ms.unwrap_or(segment.start_ms)),
+                channel: 0,
+                speaker,
+                metadata: map([
+                    ("captureSegmentId", json!(segment.id)),
+                    ("captureSequence", json!(segment.sequence)),
+                    ("final", json!(segment.is_final)),
+                ]),
+            }
+        })
+        .collect::<Vec<_>>();
+    let speaker_hints = ordered
+        .iter()
+        .filter_map(|segment| {
+            segment.speaker.as_ref().map(|speaker| IngestSpeakerHint {
+                id: stable_id("speaker-hint", &segment.id),
+                word_id: stable_id("word", &segment.id),
+                kind: "capture_speaker_id".into(),
+                value: speaker.id.clone(),
+            })
+        })
+        .collect();
+    let ended_at_ms = ordered
+        .iter()
+        .filter_map(|segment| segment.end_ms)
+        .max()
+        .map(saturating_i64);
+    let first_chunk = chunks.values().min_by_key(|chunk| chunk.sequence);
+
+    vec![IngestTranscript {
+        id: stable_id("transcript", session_id),
+        provider: "enterprise_capture".into(),
+        model: String::new(),
+        language: String::new(),
+        started_at_ms: ordered
+            .iter()
+            .map(|segment| segment.start_ms)
+            .min()
+            .map(saturating_i64)
+            .unwrap_or_default(),
+        ended_at_ms,
+        audio_attachment_id: first_chunk
+            .map(|chunk| stable_id("attachment", &chunk.id))
+            .unwrap_or_default(),
+        memo: String::new(),
+        words,
+        speaker_hints,
+        metadata: Map::new(),
+        created_at: timestamp(updated_at),
+        updated_at: timestamp(updated_at),
+    }]
+}
+
+fn project_attachments(
+    chunks: &BTreeMap<String, RecordingChunk>,
+    updated_at: DateTime<Utc>,
+) -> Vec<IngestAttachment> {
+    let mut ordered = chunks.values().collect::<Vec<_>>();
+    ordered.sort_by_key(|chunk| (chunk.sequence, chunk.id.as_str()));
+    ordered
+        .into_iter()
+        .map(|chunk| IngestAttachment {
+            id: stable_id("attachment", &chunk.id),
+            filename: format!("recording-{:06}.{}", chunk.sequence, extension(chunk)),
+            content_type: chunk.content_type.clone(),
+            size_bytes: chunk.size_bytes.unwrap_or_default(),
+            sha256: chunk.sha256.clone().unwrap_or_default(),
+            object_key: chunk.uri.clone(),
+            metadata: map([
+                ("captureChunkId", json!(chunk.id)),
+                ("captureSequence", json!(chunk.sequence)),
+                ("startMs", json!(chunk.start_ms)),
+                ("durationMs", json!(chunk.duration_ms)),
+            ]),
+            created_at: timestamp(updated_at),
+            updated_at: timestamp(updated_at),
+        })
+        .collect()
+}
+
+fn project_participant(participant: ProjectedParticipant) -> IngestParticipant {
+    let mut metadata = Map::new();
+    metadata.insert(
+        "captureParticipantId".into(),
+        json!(participant.participant.id),
+    );
+    if let Some(left_at) = participant.left_at {
+        metadata.insert("leftAt".into(), json!(timestamp(left_at)));
+    }
+    IngestParticipant {
+        id: stable_id("participant", &participant.participant.id),
+        human_id: String::new(),
+        display_name: participant.participant.display_name.unwrap_or_default(),
+        email: participant.participant.email.unwrap_or_default(),
+        role: String::new(),
+        metadata,
+        created_at: timestamp(participant.first_seen_at),
+        updated_at: timestamp(participant.last_seen_at),
+    }
+}
+
+fn session_metadata(
+    job: &CaptureJob,
+    state: BotState,
+    events: &[CaptureEvent],
+) -> Map<String, Value> {
+    map([
+        ("captureBotId", json!(job.bot_id)),
+        ("captureProvider", json!(provider_name(job.provider))),
+        ("captureState", json!(state_name(state))),
+        ("requestingActorId", json!(job.requesting_actor_id)),
+        (
+            "lastCaptureSequence",
+            json!(events.last().expect("events are not empty").sequence),
+        ),
+    ])
+}
+
+fn session_status(state: BotState) -> &'static str {
+    match state {
+        BotState::Completed => "completed",
+        BotState::Failed => "failed",
+        BotState::Canceled => "canceled",
+        BotState::Stopping => "stopping",
+        _ => "recording",
+    }
+}
+
+fn provider_name(provider: CaptureProviderKind) -> &'static str {
+    match provider {
+        CaptureProviderKind::Anarlog => "anarlog",
+        CaptureProviderKind::Recall => "recall",
+        CaptureProviderKind::ZoomRtms => "zoom_rtms",
+    }
+}
+
+fn platform_name(platform: anlg_meeting_capture::MeetingPlatform) -> &'static str {
+    use anlg_meeting_capture::MeetingPlatform;
+    match platform {
+        MeetingPlatform::GoogleMeet => "google_meet",
+        MeetingPlatform::Zoom => "zoom",
+        MeetingPlatform::MicrosoftTeams => "microsoft_teams",
+        MeetingPlatform::Webex => "webex",
+        MeetingPlatform::Jitsi => "jitsi",
+    }
+}
+
+fn state_name(state: BotState) -> &'static str {
+    match state {
+        BotState::Queued => "queued",
+        BotState::Launching => "launching",
+        BotState::WaitingForAdmission => "waiting_for_admission",
+        BotState::Joined => "joined",
+        BotState::Capturing => "capturing",
+        BotState::Stopping => "stopping",
+        BotState::Completed => "completed",
+        BotState::Failed => "failed",
+        BotState::Canceled => "canceled",
+    }
+}
+
+fn extension(chunk: &RecordingChunk) -> &'static str {
+    match chunk.content_type.as_str() {
+        "audio/mpeg" => "mp3",
+        "audio/ogg" => "ogg",
+        "audio/wav" | "audio/x-wav" => "wav",
+        "audio/webm" => "webm",
+        _ => "bin",
+    }
+}
+
+fn stable_id(prefix: &str, value: &str) -> String {
+    format!("{prefix}-{}", hex_digest(Sha256::digest(value.as_bytes())))
+}
+
+fn hex_digest(digest: impl AsRef<[u8]>) -> String {
+    use std::fmt::Write;
+
+    digest
+        .as_ref()
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            write!(output, "{byte:02x}").expect("writing to a string cannot fail");
+            output
+        })
+}
+
+fn timestamp(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+fn saturating_i64(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+fn map<const N: usize>(entries: [(&str, Value); N]) -> Map<String, Value> {
+    entries
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
+}
+
+struct ProjectedParticipant {
+    participant: Participant,
+    first_seen_at: DateTime<Utc>,
+    last_seen_at: DateTime<Utc>,
+    left_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProjectionError {
+    #[error("capture projection requires at least one event")]
+    NoEvents,
+    #[error("capture event sequence is not contiguous: expected {expected}, got {actual}")]
+    NonContiguousSequence { expected: u64, actual: u64 },
+    #[error("capture event belongs to a different bot")]
+    WrongBot,
+    #[error("capture event was emitted after a terminal lifecycle event")]
+    EventAfterTerminal,
+    #[error("capture lifecycle event does not match the projected state")]
+    StateMismatch,
+    #[error("capture lifecycle transition is invalid")]
+    InvalidTransition(#[source] anlg_meeting_capture::TransitionError),
+}
+
+#[cfg(test)]
+mod tests {
+    use anlg_meeting_capture::{
+        BotState, CaptureEvent, CaptureEventPayload, CaptureProviderKind, MeetingPlatform,
+        MeetingReference, Participant, RecordingChunk, Speaker, TerminalReason, TerminalReasonKind,
+        TranscriptSegment,
+    };
+    use chrono::{DateTime, TimeDelta, Utc};
+
+    use super::{ProjectionError, content_hash, project};
+    use crate::capture::CaptureJob;
+
+    #[test]
+    fn replay_is_deterministic_and_only_terminal_events_finalize() {
+        let job = job();
+        let events = events();
+        let in_progress = project(&job, &events[..events.len() - 1]).unwrap();
+        let first = project(&job, &events).unwrap();
+        let replayed = project(&job, &events).unwrap();
+
+        assert!(!in_progress.finalized);
+        assert!(first.finalized);
+        assert_eq!(first, replayed);
+        assert_eq!(
+            content_hash(&first).unwrap(),
+            content_hash(&replayed).unwrap()
+        );
+        assert_eq!(first.session.status, "completed");
+        assert_eq!(first.transcripts.len(), 1);
+        assert_eq!(first.transcripts[0].words.len(), 1);
+        assert_eq!(
+            first.transcripts[0].words[0].speaker.as_deref(),
+            Some("Ada")
+        );
+        assert_eq!(first.participants.len(), 1);
+        assert_eq!(first.attachments.len(), 1);
+        assert_eq!(first.attachments[0].object_key, "recordings/job-a/0.webm");
+        assert_eq!(first.attachments[0].size_bytes, 4_096);
+    }
+
+    #[test]
+    fn rejects_non_contiguous_sequences_and_events_after_terminal_state() {
+        let job = job();
+        let mut gap = events();
+        gap[1].sequence = 2;
+        assert!(matches!(
+            project(&job, &gap),
+            Err(ProjectionError::NonContiguousSequence { .. })
+        ));
+
+        let mut after_terminal = events();
+        after_terminal.push(event(
+            8,
+            CaptureEventPayload::ParticipantUpserted(Participant {
+                id: "participant-b".into(),
+                display_name: None,
+                email: None,
+            }),
+        ));
+        assert!(matches!(
+            project(&job, &after_terminal),
+            Err(ProjectionError::EventAfterTerminal)
+        ));
+    }
+
+    fn job() -> CaptureJob {
+        CaptureJob {
+            workspace_id: "workspace-a".into(),
+            job_id: "job-a".into(),
+            bot_id: "bot-a".into(),
+            owner_user_id: "owner-a".into(),
+            requesting_actor_id: "actor-a".into(),
+            session_id: "session-a".into(),
+            session_title: "Architecture review".into(),
+            provider: CaptureProviderKind::Anarlog,
+            meeting: MeetingReference {
+                platform: MeetingPlatform::GoogleMeet,
+                url: "https://meet.google.com/abc-defg-hij".into(),
+                external_id: Some("abc-defg-hij".into()),
+                calendar_event_id: Some("calendar-event-a".into()),
+            },
+            created_at: at(0),
+        }
+    }
+
+    fn events() -> Vec<CaptureEvent> {
+        vec![
+            lifecycle(0, BotState::Queued, BotState::Launching, None),
+            lifecycle(1, BotState::Launching, BotState::Joined, None),
+            lifecycle(2, BotState::Joined, BotState::Capturing, None),
+            event(
+                3,
+                CaptureEventPayload::ParticipantUpserted(Participant {
+                    id: "participant-a".into(),
+                    display_name: Some("Ada".into()),
+                    email: Some("ada@example.com".into()),
+                }),
+            ),
+            event(
+                4,
+                CaptureEventPayload::SpeakerUpserted(Speaker {
+                    id: "speaker-a".into(),
+                    display_name: Some("Ada".into()),
+                    participant_id: Some("participant-a".into()),
+                }),
+            ),
+            event(
+                5,
+                CaptureEventPayload::Transcript(TranscriptSegment {
+                    id: "segment-a".into(),
+                    sequence: 0,
+                    start_ms: 100,
+                    end_ms: Some(450),
+                    text: "Ship the deterministic projector.".into(),
+                    speaker: Some(Speaker {
+                        id: "speaker-a".into(),
+                        display_name: None,
+                        participant_id: Some("participant-a".into()),
+                    }),
+                    is_final: true,
+                }),
+            ),
+            event(
+                6,
+                CaptureEventPayload::RecordingChunkReady(RecordingChunk {
+                    id: "chunk-a".into(),
+                    sequence: 0,
+                    start_ms: 0,
+                    duration_ms: 1_000,
+                    content_type: "audio/webm".into(),
+                    uri: "recordings/job-a/0.webm".into(),
+                    size_bytes: Some(4_096),
+                    sha256: Some("a".repeat(64)),
+                }),
+            ),
+            lifecycle(
+                7,
+                BotState::Capturing,
+                BotState::Completed,
+                Some(TerminalReason {
+                    kind: TerminalReasonKind::MeetingEnded,
+                    message: None,
+                    retryable: false,
+                }),
+            ),
+        ]
+    }
+
+    fn lifecycle(
+        sequence: u64,
+        from: BotState,
+        to: BotState,
+        reason: Option<TerminalReason>,
+    ) -> CaptureEvent {
+        event(
+            sequence,
+            CaptureEventPayload::Lifecycle(from.transition_to(to, reason).unwrap()),
+        )
+    }
+
+    fn event(sequence: u64, payload: CaptureEventPayload) -> CaptureEvent {
+        CaptureEvent {
+            id: format!("event-{sequence}"),
+            bot_id: "bot-a".into(),
+            sequence,
+            occurred_at: at(sequence as i64),
+            payload,
+            metadata: Default::default(),
+        }
+    }
+
+    fn at(seconds: i64) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-08-17T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+            + TimeDelta::seconds(seconds)
+    }
+}

--- a/enterprise/control-plane/src/store.rs
+++ b/enterprise/control-plane/src/store.rs
@@ -1,16 +1,32 @@
 use std::{sync::Arc, time::Duration};
 
+use anlg_meeting_capture::{BotState, CaptureEvent, CaptureEventPayload};
 use anlg_session_ingest::{
     AcknowledgeRequest, DeliveryItem, DeliveryPage, SessionIngestEnvelope, SessionRead,
 };
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+
+use crate::{
+    capture::{CaptureJob, CaptureJobStatus, ProjectionPublication},
+    projector,
+};
 
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!();
 
 #[async_trait]
-pub trait DeliveryStore: Send + Sync {
+pub trait ControlPlaneStore: Send + Sync {
     async fn readiness(&self) -> Result<(), StoreError>;
+
+    async fn create_capture_job(&self, job: &CaptureJob) -> Result<CaptureJobStatus, StoreError>;
+
+    async fn append_capture_event(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+        event: &CaptureEvent,
+    ) -> Result<ProjectionPublication, StoreError>;
 
     async fn list_deliveries(
         &self,
@@ -58,16 +74,320 @@ impl PostgresStore {
         Ok(())
     }
 
-    pub fn into_shared(self) -> Arc<dyn DeliveryStore> {
+    pub fn into_shared(self) -> Arc<dyn ControlPlaneStore> {
         Arc::new(self)
     }
 }
 
 #[async_trait]
-impl DeliveryStore for PostgresStore {
+impl ControlPlaneStore for PostgresStore {
     async fn readiness(&self) -> Result<(), StoreError> {
         sqlx::query("SELECT 1").execute(&self.pool).await?;
         Ok(())
+    }
+
+    async fn create_capture_job(&self, job: &CaptureJob) -> Result<CaptureJobStatus, StoreError> {
+        let provider = enum_name(job.provider)?;
+        let meeting = serde_json::to_value(&job.meeting)?;
+        let result = sqlx::query(
+            r#"
+            INSERT INTO capture_jobs (
+                workspace_id,
+                job_id,
+                bot_id,
+                owner_user_id,
+                requesting_actor_id,
+                session_id,
+                session_title,
+                provider,
+                meeting,
+                created_at,
+                updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
+            ON CONFLICT DO NOTHING
+            "#,
+        )
+        .bind(&job.workspace_id)
+        .bind(&job.job_id)
+        .bind(&job.bot_id)
+        .bind(&job.owner_user_id)
+        .bind(&job.requesting_actor_id)
+        .bind(&job.session_id)
+        .bind(&job.session_title)
+        .bind(&provider)
+        .bind(&meeting)
+        .bind(job.created_at)
+        .execute(&self.pool)
+        .await?;
+        let created = result.rows_affected() == 1;
+
+        let stored = sqlx::query(
+            r#"
+            SELECT
+                bot_id,
+                owner_user_id,
+                requesting_actor_id,
+                session_id,
+                session_title,
+                provider,
+                meeting,
+                state,
+                created_at
+            FROM capture_jobs
+            WHERE workspace_id = $1 AND job_id = $2
+            "#,
+        )
+        .bind(&job.workspace_id)
+        .bind(&job.job_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        let Some(stored) = stored else {
+            let bot_owner = sqlx::query_scalar::<_, String>(
+                r#"
+                SELECT job_id
+                FROM capture_jobs
+                WHERE workspace_id = $1 AND bot_id = $2
+                "#,
+            )
+            .bind(&job.workspace_id)
+            .bind(&job.bot_id)
+            .fetch_optional(&self.pool)
+            .await?;
+            return Err(if bot_owner.is_some() {
+                StoreError::CaptureBotConflict
+            } else {
+                StoreError::CaptureJobConflict
+            });
+        };
+        let stored_created_at = stored.try_get::<DateTime<Utc>, _>("created_at")?;
+        if stored.try_get::<String, _>("bot_id")? != job.bot_id
+            || stored.try_get::<String, _>("owner_user_id")? != job.owner_user_id
+            || stored.try_get::<String, _>("requesting_actor_id")? != job.requesting_actor_id
+            || stored.try_get::<String, _>("session_id")? != job.session_id
+            || stored.try_get::<String, _>("session_title")? != job.session_title
+            || stored.try_get::<String, _>("provider")? != provider
+            || stored.try_get::<serde_json::Value, _>("meeting")? != meeting
+            || stored_created_at.timestamp_micros() != job.created_at.timestamp_micros()
+        {
+            return Err(StoreError::CaptureJobConflict);
+        }
+
+        Ok(CaptureJobStatus {
+            job_id: job.job_id.clone(),
+            created,
+            state: parse_enum(&stored.try_get::<String, _>("state")?)?,
+        })
+    }
+
+    async fn append_capture_event(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+        event: &CaptureEvent,
+    ) -> Result<ProjectionPublication, StoreError> {
+        let mut transaction = self.pool.begin().await?;
+        let job_row = sqlx::query(
+            r#"
+            SELECT
+                workspace_id,
+                job_id,
+                bot_id,
+                owner_user_id,
+                requesting_actor_id,
+                session_id,
+                session_title,
+                provider,
+                meeting,
+                created_at,
+                last_sequence
+            FROM capture_jobs
+            WHERE workspace_id = $1 AND job_id = $2
+            FOR UPDATE
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or(StoreError::NotFound)?;
+        let last_sequence = job_row.try_get::<i64, _>("last_sequence")?;
+        let job = capture_job(job_row)?;
+        if event.bot_id != job.bot_id {
+            return Err(StoreError::InvalidCaptureEvent(
+                "capture event belongs to a different bot".into(),
+            ));
+        }
+
+        let event_value = serde_json::to_value(event)?;
+        let sequence = to_i64(event.sequence, "capture event sequence")?;
+        let existing = sqlx::query(
+            r#"
+            SELECT sequence, event_id, event
+            FROM capture_events
+            WHERE workspace_id = $1
+              AND job_id = $2
+              AND (sequence = $3 OR event_id = $4)
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .bind(sequence)
+        .bind(&event.id)
+        .fetch_optional(&mut *transaction)
+        .await?;
+        if let Some(existing) = existing {
+            let identical = existing.try_get::<i64, _>("sequence")? == sequence
+                && existing.try_get::<String, _>("event_id")? == event.id
+                && existing.try_get::<serde_json::Value, _>("event")? == event_value;
+            if !identical {
+                return Err(StoreError::CaptureEventConflict);
+            }
+            let revision = event
+                .sequence
+                .checked_add(1)
+                .ok_or(StoreError::OutOfRange("revision"))?;
+            let publication =
+                read_publication(&mut transaction, workspace_id, job_id, revision).await?;
+            transaction.commit().await?;
+            return Ok(publication);
+        }
+
+        let expected = last_sequence
+            .checked_add(1)
+            .ok_or(StoreError::OutOfRange("capture event sequence"))?;
+        if sequence != expected {
+            return Err(StoreError::CaptureSequenceConflict {
+                expected: from_i64(expected, "capture event sequence")?,
+                actual: event.sequence,
+            });
+        }
+
+        let rows = sqlx::query(
+            r#"
+            SELECT event
+            FROM capture_events
+            WHERE workspace_id = $1 AND job_id = $2
+            ORDER BY sequence ASC
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .fetch_all(&mut *transaction)
+        .await?;
+        let mut events = rows
+            .into_iter()
+            .map(|row| -> Result<CaptureEvent, StoreError> {
+                let value = row.try_get("event")?;
+                Ok(serde_json::from_value(value)?)
+            })
+            .collect::<Result<Vec<CaptureEvent>, StoreError>>()?;
+        events.push(event.clone());
+        let envelope = projector::project(&job, &events)
+            .map_err(|error| StoreError::InvalidCaptureEvent(error.to_string()))?;
+        let content_hash = projector::content_hash(&envelope)?;
+        let revision = to_i64(envelope.revision, "revision")?;
+        let finalized = envelope.finalized;
+        let envelope_value = serde_json::to_value(&envelope)?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO capture_events (
+                workspace_id,
+                job_id,
+                sequence,
+                event_id,
+                occurred_at,
+                event
+            ) VALUES ($1, $2, $3, $4, $5, $6)
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .bind(sequence)
+        .bind(&event.id)
+        .bind(event.occurred_at)
+        .bind(&event_value)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            r#"
+            INSERT INTO session_envelopes (
+                workspace_id,
+                job_id,
+                revision,
+                finalized,
+                content_hash,
+                envelope
+            ) VALUES ($1, $2, $3, $4, $5, $6)
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .bind(revision)
+        .bind(finalized)
+        .bind(&content_hash)
+        .bind(&envelope_value)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            r#"
+            INSERT INTO capture_projection_checkpoints (
+                workspace_id,
+                job_id,
+                last_sequence,
+                revision,
+                content_hash
+            ) VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (workspace_id, job_id)
+            DO UPDATE SET
+                last_sequence = EXCLUDED.last_sequence,
+                revision = EXCLUDED.revision,
+                content_hash = EXCLUDED.content_hash,
+                updated_at = now()
+            WHERE capture_projection_checkpoints.last_sequence < EXCLUDED.last_sequence
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .bind(sequence)
+        .bind(revision)
+        .bind(&content_hash)
+        .execute(&mut *transaction)
+        .await?;
+        let (state, terminal_reason) = projected_lifecycle(&events);
+        sqlx::query(
+            r#"
+            UPDATE capture_jobs
+            SET
+                state = $3,
+                terminal_reason = $4,
+                last_sequence = $5,
+                updated_at = $6
+            WHERE workspace_id = $1 AND job_id = $2
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .bind(enum_name(state)?)
+        .bind(
+            terminal_reason
+                .as_ref()
+                .map(serde_json::to_value)
+                .transpose()?,
+        )
+        .bind(sequence)
+        .bind(event.occurred_at)
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+
+        Ok(ProjectionPublication {
+            job_id: job_id.to_string(),
+            revision: envelope.revision,
+            finalized,
+            content_hash,
+            envelope,
+        })
     }
 
     async fn list_deliveries(
@@ -259,6 +579,78 @@ fn parse_envelope(
     Ok(envelope)
 }
 
+fn capture_job(row: sqlx::postgres::PgRow) -> Result<CaptureJob, StoreError> {
+    Ok(CaptureJob {
+        workspace_id: row.try_get("workspace_id")?,
+        job_id: row.try_get("job_id")?,
+        bot_id: row.try_get("bot_id")?,
+        owner_user_id: row.try_get("owner_user_id")?,
+        requesting_actor_id: row.try_get("requesting_actor_id")?,
+        session_id: row.try_get("session_id")?,
+        session_title: row.try_get("session_title")?,
+        provider: parse_enum(&row.try_get::<String, _>("provider")?)?,
+        meeting: serde_json::from_value(row.try_get("meeting")?)?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+async fn read_publication(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workspace_id: &str,
+    job_id: &str,
+    revision: u64,
+) -> Result<ProjectionPublication, StoreError> {
+    let row = sqlx::query(
+        r#"
+        SELECT revision, finalized, content_hash, envelope
+        FROM session_envelopes
+        WHERE workspace_id = $1 AND job_id = $2 AND revision = $3
+        "#,
+    )
+    .bind(workspace_id)
+    .bind(job_id)
+    .bind(to_i64(revision, "revision")?)
+    .fetch_optional(&mut **transaction)
+    .await?
+    .ok_or(StoreError::CorruptEnvelope)?;
+    let finalized = row.try_get("finalized")?;
+    let envelope = parse_envelope(workspace_id, revision, finalized, row.try_get("envelope")?)?;
+    Ok(ProjectionPublication {
+        job_id: job_id.to_string(),
+        revision,
+        finalized,
+        content_hash: row.try_get("content_hash")?,
+        envelope,
+    })
+}
+
+fn projected_lifecycle(
+    events: &[CaptureEvent],
+) -> (BotState, Option<anlg_meeting_capture::TerminalReason>) {
+    events
+        .iter()
+        .fold((BotState::Queued, None), |current, event| {
+            if let CaptureEventPayload::Lifecycle(transition) = &event.payload {
+                (transition.to, transition.reason.clone())
+            } else {
+                current
+            }
+        })
+}
+
+fn enum_name<T: serde::Serialize>(value: T) -> Result<String, StoreError> {
+    serde_json::to_value(value)?
+        .as_str()
+        .map(str::to_owned)
+        .ok_or(StoreError::CorruptEnvelope)
+}
+
+fn parse_enum<T: serde::de::DeserializeOwned>(value: &str) -> Result<T, StoreError> {
+    Ok(serde_json::from_value(serde_json::Value::String(
+        value.to_string(),
+    ))?)
+}
+
 fn to_i64(value: u64, field: &'static str) -> Result<i64, StoreError> {
     i64::try_from(value).map_err(|_| StoreError::OutOfRange(field))
 }
@@ -279,6 +671,18 @@ pub enum StoreError {
     RevisionConflict,
     #[error("stored delivery envelope is invalid")]
     CorruptEnvelope,
+    #[error("capture job already exists with different immutable fields")]
+    CaptureJobConflict,
+    #[error("capture bot is already assigned to a different job")]
+    CaptureBotConflict,
+    #[error("capture event id or sequence already exists with different content")]
+    CaptureEventConflict,
+    #[error("capture event sequence conflict: expected {expected}, got {actual}")]
+    CaptureSequenceConflict { expected: u64, actual: u64 },
+    #[error("capture event is invalid: {0}")]
+    InvalidCaptureEvent(String),
+    #[error("stored capture JSON is invalid")]
+    Json(#[from] serde_json::Error),
     #[error("{0} is outside the supported range")]
     OutOfRange(&'static str),
 }

--- a/enterprise/control-plane/tests/api.rs
+++ b/enterprise/control-plane/tests/api.rs
@@ -3,14 +3,16 @@ use std::sync::Arc;
 use anarlog_enterprise_control_plane::{
     api::{AppState, router},
     auth::StaticTokenAuthenticator,
+    capture::{CaptureJob, CaptureJobStatus, ProjectionPublication},
     serve,
-    store::{DeliveryStore, StoreError},
+    store::{ControlPlaneStore, StoreError},
 };
+use anlg_meeting_capture::{BotState, CaptureEvent};
 use anlg_session_ingest::{AcknowledgeRequest, DeliveryPage, SessionRead};
 use async_trait::async_trait;
 use axum::{
     body::{Body, to_bytes},
-    http::{Request, StatusCode, header},
+    http::{Method, Request, StatusCode, header},
 };
 use serde_json::Value;
 use tokio::{net::TcpListener, sync::oneshot, time::Duration};
@@ -24,13 +26,30 @@ struct MemoryStore {
 }
 
 #[async_trait]
-impl DeliveryStore for MemoryStore {
+impl ControlPlaneStore for MemoryStore {
     async fn readiness(&self) -> Result<(), StoreError> {
         if self.ready {
             Ok(())
         } else {
             Err(StoreError::CorruptEnvelope)
         }
+    }
+
+    async fn create_capture_job(&self, job: &CaptureJob) -> Result<CaptureJobStatus, StoreError> {
+        Ok(CaptureJobStatus {
+            job_id: job.job_id.clone(),
+            created: true,
+            state: BotState::Queued,
+        })
+    }
+
+    async fn append_capture_event(
+        &self,
+        _workspace_id: &str,
+        _job_id: &str,
+        _event: &CaptureEvent,
+    ) -> Result<ProjectionPublication, StoreError> {
+        Err(StoreError::NotFound)
     }
 
     async fn list_deliveries(
@@ -127,6 +146,52 @@ async fn requires_workspace_scoped_credentials() {
 }
 
 #[tokio::test]
+async fn authenticates_capture_job_creation_before_writing() {
+    let app = router(state(true));
+    let path = "/v1/workspaces/workspace-a/capture-jobs/job-a";
+    let body = serde_json::json!({
+        "botId": "bot-a",
+        "ownerUserId": "owner-a",
+        "requestingActorId": "actor-a",
+        "sessionId": "session-a",
+        "sessionTitle": "Architecture review",
+        "provider": "anarlog",
+        "meeting": {
+            "platform": "google_meet",
+            "url": "https://meet.google.com/abc-defg-hij"
+        },
+        "createdAt": "2026-08-17T00:00:00Z"
+    });
+
+    let missing = app
+        .clone()
+        .oneshot(json_request(Method::POST, path, None, &body))
+        .await
+        .unwrap();
+    let wrong_workspace = app
+        .clone()
+        .oneshot(json_request(Method::POST, path, Some(TOKEN_B), &body))
+        .await
+        .unwrap();
+    let created = app
+        .oneshot(json_request(Method::POST, path, Some(TOKEN_A), &body))
+        .await
+        .unwrap();
+
+    assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(wrong_workspace.status(), StatusCode::FORBIDDEN);
+    assert_eq!(created.status(), StatusCode::CREATED);
+    assert_eq!(
+        response_json(created).await,
+        serde_json::json!({
+            "jobId": "job-a",
+            "created": true,
+            "state": "queued"
+        })
+    );
+}
+
+#[tokio::test]
 async fn boots_on_a_real_listener_and_shuts_down_gracefully() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
@@ -153,6 +218,17 @@ fn authorized_request(path: &str, token: &str) -> Request<Body> {
         .header(header::AUTHORIZATION, format!("Bearer {token}"))
         .body(Body::empty())
         .unwrap()
+}
+
+fn json_request(method: Method, path: &str, token: Option<&str>, body: &Value) -> Request<Body> {
+    let mut request = Request::builder()
+        .method(method)
+        .uri(path)
+        .header(header::CONTENT_TYPE, "application/json");
+    if let Some(token) = token {
+        request = request.header(header::AUTHORIZATION, format!("Bearer {token}"));
+    }
+    request.body(Body::from(body.to_string())).unwrap()
 }
 
 async fn response_json(response: axum::response::Response) -> Value {

--- a/enterprise/control-plane/tests/compose-smoke.sh
+++ b/enterprise/control-plane/tests/compose-smoke.sh
@@ -44,6 +44,32 @@ base_url="http://127.0.0.1:$port"
 
 curl --connect-timeout 3 --max-time 10 --fail --silent --show-error "$base_url/health/ready" >/dev/null
 
+create_status=$(curl \
+    --connect-timeout 3 \
+    --max-time 10 \
+    --silent \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    --request POST \
+    --header "Authorization: Bearer $token" \
+    --header 'Content-Type: application/json' \
+    --data '{"botId":"bot-a","ownerUserId":"owner-a","requestingActorId":"actor-a","sessionId":"session-a","sessionTitle":"Compose smoke","provider":"anarlog","meeting":{"platform":"google_meet","url":"https://meet.google.com/abc-defg-hij"},"createdAt":"2026-08-17T00:00:00Z"}' \
+    "$base_url/v1/workspaces/workspace-a/capture-jobs/job-a")
+test "$create_status" = 201
+
+append_status=$(curl \
+    --connect-timeout 3 \
+    --max-time 10 \
+    --silent \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    --request POST \
+    --header "Authorization: Bearer $token" \
+    --header 'Content-Type: application/json' \
+    --data '{"event":{"id":"event-0","bot_id":"bot-a","sequence":0,"occurred_at":"2026-08-17T00:00:01Z","payload":{"type":"lifecycle","data":{"from":"queued","to":"launching"}},"metadata":{}}}' \
+    "$base_url/v1/workspaces/workspace-a/capture-jobs/job-a/events")
+test "$append_status" = 200
+
 authorized_status=$(curl \
     --connect-timeout 3 \
     --max-time 10 \

--- a/enterprise/control-plane/tests/postgres.rs
+++ b/enterprise/control-plane/tests/postgres.rs
@@ -1,6 +1,10 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anarlog_enterprise_control_plane::{api::router, config::Config, configured_state};
+use anlg_meeting_capture::{
+    BotState, CaptureEvent, CaptureEventPayload, Participant, RecordingChunk, Speaker,
+    TerminalReason, TerminalReasonKind, TranscriptSegment,
+};
 use axum::{
     body::{Body, to_bytes},
     http::{Method, Request, StatusCode, header},
@@ -113,6 +117,180 @@ async fn migrates_postgres_and_enforces_workspace_delivery() {
     assert_eq!(wrong_workspace.status(), StatusCode::FORBIDDEN);
 }
 
+#[tokio::test]
+async fn persists_projects_and_replays_capture_events_idempotently() {
+    let Ok(database_url) = std::env::var(TEST_DATABASE_URL_ENV) else {
+        return;
+    };
+    let suffix = format!(
+        "{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let workspace_id = format!("workspace-projection-{suffix}");
+    let job_id = format!("job-projection-{suffix}");
+    let bot_id = format!("bot-projection-{suffix}");
+    let config = Config::from_values(
+        database_url.clone(),
+        Some("127.0.0.1:0".into()),
+        Some("2".into()),
+        format!(r#"{{"{workspace_id}":"{TOKEN}"}}"#),
+    )
+    .unwrap();
+    let app = router(configured_state(&config).await.unwrap());
+    let create_path = format!("/v1/workspaces/{workspace_id}/capture-jobs/{job_id}");
+    let created = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::POST,
+            &create_path,
+            Body::from(
+                serde_json::json!({
+                    "botId": bot_id,
+                    "ownerUserId": "owner-a",
+                    "requestingActorId": "actor-a",
+                    "sessionId": format!("session-{suffix}"),
+                    "sessionTitle": "Deterministic capture",
+                    "provider": "anarlog",
+                    "meeting": {
+                        "platform": "google_meet",
+                        "url": "https://meet.google.com/abc-defg-hij",
+                        "external_id": "abc-defg-hij",
+                        "calendar_event_id": "calendar-event-a"
+                    },
+                    "createdAt": "2026-08-17T00:00:00Z"
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+
+    let conflicting_job_path =
+        format!("/v1/workspaces/{workspace_id}/capture-jobs/other-job-{suffix}");
+    let bot_conflict = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::POST,
+            &conflicting_job_path,
+            Body::from(
+                serde_json::json!({
+                    "botId": bot_id,
+                    "ownerUserId": "owner-a",
+                    "requestingActorId": "actor-a",
+                    "sessionId": format!("other-session-{suffix}"),
+                    "sessionTitle": "Conflicting capture",
+                    "provider": "anarlog",
+                    "meeting": {
+                        "platform": "google_meet",
+                        "url": "https://meet.google.com/abc-defg-hij"
+                    },
+                    "createdAt": "2026-08-17T00:00:00Z"
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(bot_conflict.status(), StatusCode::CONFLICT);
+    assert_eq!(
+        response_json(bot_conflict).await["error"]["code"],
+        "capture_bot_conflict"
+    );
+
+    let events = capture_events(&bot_id);
+    let event_path = format!("{create_path}/events");
+    let mut final_publication = Value::Null;
+    for event in &events {
+        let response = app
+            .clone()
+            .oneshot(authorized_request(
+                Method::POST,
+                &event_path,
+                Body::from(serde_json::json!({ "event": event }).to_string()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        final_publication = response_json(response).await;
+    }
+    assert_eq!(final_publication["revision"], 8);
+    assert_eq!(final_publication["finalized"], true);
+    assert_eq!(
+        final_publication["envelope"]["transcripts"][0]["words"][0]["speaker"],
+        "Ada"
+    );
+    assert_eq!(
+        final_publication["envelope"]["attachments"][0]["object_key"],
+        "recordings/job-a/0.webm"
+    );
+
+    let retried = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::POST,
+            &event_path,
+            Body::from(serde_json::json!({ "event": events.last().unwrap() }).to_string()),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(retried.status(), StatusCode::OK);
+    assert_eq!(response_json(retried).await, final_publication);
+
+    let mut conflicting = events.last().unwrap().clone();
+    conflicting.id = "different-event-id".into();
+    let conflict = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::POST,
+            &event_path,
+            Body::from(serde_json::json!({ "event": conflicting }).to_string()),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(conflict.status(), StatusCode::CONFLICT);
+
+    let restarted = router(configured_state(&config).await.unwrap());
+    let session_path = format!("/v1/workspaces/{workspace_id}/sessions/{job_id}");
+    let session = restarted
+        .oneshot(authorized_request(
+            Method::GET,
+            &session_path,
+            Body::empty(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(session.status(), StatusCode::OK);
+    let session = response_json(session).await;
+    assert_eq!(session["revision"], final_publication["revision"]);
+    assert_eq!(session["contentHash"], final_publication["contentHash"]);
+    assert_eq!(session["envelope"], final_publication["envelope"]);
+
+    let pool = sqlx::PgPool::connect(&database_url).await.unwrap();
+    let event_count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM capture_events WHERE workspace_id = $1 AND job_id = $2",
+    )
+    .bind(&workspace_id)
+    .bind(&job_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let envelope_count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM session_envelopes WHERE workspace_id = $1 AND job_id = $2",
+    )
+    .bind(&workspace_id)
+    .bind(&job_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(event_count, 8);
+    assert_eq!(envelope_count, 8);
+}
+
 fn authorized_request(method: Method, path: &str, body: Body) -> Request<Body> {
     Request::builder()
         .method(method)
@@ -126,4 +304,100 @@ fn authorized_request(method: Method, path: &str, body: Body) -> Request<Body> {
 async fn response_json(response: axum::response::Response) -> Value {
     let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
     serde_json::from_slice(&body).unwrap()
+}
+
+fn capture_events(bot_id: &str) -> Vec<CaptureEvent> {
+    vec![
+        lifecycle(bot_id, 0, BotState::Queued, BotState::Launching, None),
+        lifecycle(bot_id, 1, BotState::Launching, BotState::Joined, None),
+        lifecycle(bot_id, 2, BotState::Joined, BotState::Capturing, None),
+        capture_event(
+            bot_id,
+            3,
+            CaptureEventPayload::ParticipantUpserted(Participant {
+                id: "participant-a".into(),
+                display_name: Some("Ada".into()),
+                email: Some("ada@example.com".into()),
+            }),
+        ),
+        capture_event(
+            bot_id,
+            4,
+            CaptureEventPayload::SpeakerUpserted(Speaker {
+                id: "speaker-a".into(),
+                display_name: Some("Ada".into()),
+                participant_id: Some("participant-a".into()),
+            }),
+        ),
+        capture_event(
+            bot_id,
+            5,
+            CaptureEventPayload::Transcript(TranscriptSegment {
+                id: "segment-a".into(),
+                sequence: 0,
+                start_ms: 100,
+                end_ms: Some(450),
+                text: "Ship the deterministic projector.".into(),
+                speaker: Some(Speaker {
+                    id: "speaker-a".into(),
+                    display_name: None,
+                    participant_id: Some("participant-a".into()),
+                }),
+                is_final: true,
+            }),
+        ),
+        capture_event(
+            bot_id,
+            6,
+            CaptureEventPayload::RecordingChunkReady(RecordingChunk {
+                id: "chunk-a".into(),
+                sequence: 0,
+                start_ms: 0,
+                duration_ms: 1_000,
+                content_type: "audio/webm".into(),
+                uri: "recordings/job-a/0.webm".into(),
+                size_bytes: Some(4_096),
+                sha256: Some("a".repeat(64)),
+            }),
+        ),
+        lifecycle(
+            bot_id,
+            7,
+            BotState::Capturing,
+            BotState::Completed,
+            Some(TerminalReason {
+                kind: TerminalReasonKind::MeetingEnded,
+                message: None,
+                retryable: false,
+            }),
+        ),
+    ]
+}
+
+fn lifecycle(
+    bot_id: &str,
+    sequence: u64,
+    from: BotState,
+    to: BotState,
+    reason: Option<TerminalReason>,
+) -> CaptureEvent {
+    capture_event(
+        bot_id,
+        sequence,
+        CaptureEventPayload::Lifecycle(from.transition_to(to, reason).unwrap()),
+    )
+}
+
+fn capture_event(bot_id: &str, sequence: u64, payload: CaptureEventPayload) -> CaptureEvent {
+    CaptureEvent {
+        id: format!("event-{sequence}"),
+        bot_id: bot_id.into(),
+        sequence,
+        occurred_at: chrono::DateTime::parse_from_rfc3339("2026-08-17T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+            + chrono::TimeDelta::seconds(sequence as i64),
+        payload,
+        metadata: Default::default(),
+    }
 }


### PR DESCRIPTION
## Summary
- add a durable provider-neutral capture job/event log and projection checkpoint in PostgreSQL
- project normalized lifecycle, transcript, speaker, participant, and recording events into stable session-ingest envelopes
- expose authenticated idempotent job creation and event append routes
- preserve recording object references and byte sizes without embedding media
- verify deterministic replay, restart recovery, conflicts, workspace isolation, and packaged OrbStack startup

## Validation
- pnpm exec dprint fmt
- pnpm fmt:check
- cargo test --locked for meeting-capture and enterprise control-plane
- cargo clippy --locked with warnings denied for both affected crates
- real PostgreSQL integration tests on OrbStack
- enterprise Compose smoke on OrbStack
- license boundary checker and 9 unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New transactional write path and projection logic affect core session delivery data; behavior is heavily tested but sequence/idempotency and lifecycle validation must stay correct under retries and conflicts.
> 
> **Overview**
> Adds **durable capture ingestion** to the enterprise control plane: workers register jobs and append normalized `meeting-capture` events, and each accepted event is projected into a versioned **session-ingest** envelope for existing delivery/read APIs.
> 
> New authenticated routes are `POST .../capture-jobs/{job_id}` (idempotent create with bot uniqueness) and `POST .../events` (strict sequence + event-id idempotency). PostgreSQL gains `capture_jobs`, `capture_events`, and projection checkpoints linked to `session_envelopes`; appends run in a transaction (lock job, validate, replay events through the projector, write envelope + checkpoint, update job state). Conflicts map to explicit API errors; identical retries return the prior publication.
> 
> `RecordingChunk` gains optional **`size_bytes`**, projected into ingest attachments (URI/sha only, no media). Store trait is renamed to `ControlPlaneStore`; request body limit raised to 256KiB. Docs, Docker build context, compose smoke, and Postgres integration tests cover projection, replay after restart, and bot/job conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69bc1c889c14528f0a2959ff27f3edb6a36d3ef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->