### PR TITLE
ANLG-141: add mobile replica credential bootstrap

### DIFF
--- a/apps/mobile/src/db/client.ts
+++ b/apps/mobile/src/db/client.ts
@@ -14,6 +14,12 @@ import {
 } from "@anlg/mobile-bridge";
 
 import { captureOperationalError } from "@/lib/error-reporting";
+import {
+  requestReplicaCredentials,
+  type E2eeRecoveryKeyIdentity,
+} from "@/sync/replica-credentials";
+
+export type { E2eeRecoveryKeyIdentity } from "@/sync/replica-credentials";
 
 let bridge: MobileDbBridgeLike | null = null;
 
@@ -124,6 +130,48 @@ export type MobileSyncStatus = {
   consecutive_failures: number;
 };
 
+export async function generateE2eeRecoveryKey(): Promise<string> {
+  try {
+    return getBridge().generateE2eeRecoveryKey();
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "database_recovery_key_generate",
+    });
+    throw error;
+  }
+}
+
+export async function inspectE2eeRecoveryKey(
+  recoveryKeyCode: string,
+): Promise<E2eeRecoveryKeyIdentity> {
+  try {
+    const value: unknown = JSON.parse(
+      getBridge().inspectE2eeRecoveryKey(recoveryKeyCode),
+    );
+    if (!value || typeof value !== "object") {
+      throw new Error("Unexpected recovery key identity");
+    }
+    const candidate = value as Record<string, unknown>;
+    if (
+      typeof candidate.keyId !== "string" ||
+      !/^[A-Za-z0-9_-]{22}$/.test(candidate.keyId) ||
+      typeof candidate.memberPublicKey !== "string" ||
+      !/^[A-Za-z0-9_-]{43}$/.test(candidate.memberPublicKey)
+    ) {
+      throw new Error("Unexpected recovery key identity");
+    }
+    return {
+      keyId: candidate.keyId,
+      memberPublicKey: candidate.memberPublicKey,
+    };
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "database_recovery_key_inspect",
+    });
+    throw error;
+  }
+}
+
 export async function configureE2eeReplica({
   workspaceId,
   witnessEndpoint,
@@ -149,6 +197,49 @@ export async function configureE2eeReplica({
   } catch (error) {
     captureOperationalError(error, {
       operation: "database_replica_configure",
+    });
+    throw error;
+  }
+}
+
+export async function bootstrapE2eeReplica({
+  apiUrl,
+  accessToken,
+  accountUserId,
+  recoveryKeyCode,
+  device,
+}: {
+  apiUrl: string;
+  accessToken: string;
+  accountUserId: string;
+  recoveryKeyCode: string;
+  device?: { fingerprint?: string | null; name?: string | null };
+}): Promise<"configured" | "account_mismatch"> {
+  try {
+    const identity = await inspectE2eeRecoveryKey(recoveryKeyCode);
+    const credentials = await requestReplicaCredentials({
+      apiUrl,
+      accessToken,
+      accountUserId,
+      identity,
+      device,
+    });
+    const result = await configureE2eeReplica({
+      workspaceId: credentials.workspaceId,
+      witnessEndpoint: new URL(
+        `/sync/e2ee/witness/${encodeURIComponent(credentials.workspaceId)}`,
+        apiUrl,
+      ).toString(),
+      witnessAccessToken: accessToken,
+      recoveryKeyCode,
+    });
+    if (result === "configured") {
+      await startSync();
+    }
+    return result;
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "database_replica_bootstrap",
     });
     throw error;
   }

--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -3,11 +3,15 @@ import { createUseLiveQuery } from "@anlg/db-react";
 import { mobileLiveQueryClient, mobileTransactionClient } from "@/db/client";
 
 export {
+  bootstrapE2eeReplica,
   configureE2eeReplica,
+  generateE2eeRecoveryKey,
   getSyncStatus,
+  inspectE2eeRecoveryKey,
   startSync,
   stopSync,
   syncNow,
+  type E2eeRecoveryKeyIdentity,
   type MobileSyncStatus,
 } from "@/db/client";
 

--- a/apps/mobile/src/sync/replica-credentials.test.mjs
+++ b/apps/mobile/src/sync/replica-credentials.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ReplicaCredentialError,
+  requestReplicaCredentials,
+} from "./replica-credentials.ts";
+
+const identity = {
+  keyId: "ABCDEFGHIJKLMNOPQRSTUV",
+  memberPublicKey: "A".repeat(43),
+};
+
+const credentials = {
+  transport: "replica",
+  encryptionVersion: 2,
+  encryptionKeyId: identity.keyId,
+  expiresAt: "2026-08-18T00:00:00Z",
+  workspaceId: "user-123",
+  accountUserId: "user-123",
+};
+
+test("requests validated replica credentials with the E2EE identity", async () => {
+  let request;
+  const result = await requestReplicaCredentials({
+    apiUrl: "https://api.anarlog.test/base",
+    accessToken: "access-token",
+    accountUserId: "user-123",
+    identity,
+    device: { fingerprint: "device-1234", name: "John's iPhone" },
+    fetcher: async (input, init) => {
+      request = { input, init };
+      return new Response(JSON.stringify(credentials), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  });
+
+  assert.deepEqual(result, credentials);
+  assert.equal(
+    request.input.toString(),
+    "https://api.anarlog.test/sync/replica/credentials",
+  );
+  assert.equal(request.init.method, "POST");
+  const headers = new Headers(request.init.headers);
+  assert.equal(headers.get("authorization"), "Bearer access-token");
+  assert.equal(headers.get("x-anarlog-e2ee-key-id"), identity.keyId);
+  assert.equal(
+    headers.get("x-anarlog-e2ee-member-public-key"),
+    identity.memberPublicKey,
+  );
+  assert.equal(headers.get("x-device-fingerprint"), "device-1234");
+  assert.equal(headers.get("x-anarlog-device-name"), "John's iPhone");
+});
+
+test("rejects credentials that do not match the signed-in identity", async () => {
+  await assert.rejects(
+    requestReplicaCredentials({
+      apiUrl: "https://api.anarlog.test",
+      accessToken: "access-token",
+      accountUserId: "user-123",
+      identity,
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({ ...credentials, accountUserId: "user-456" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    }),
+    (error) =>
+      error instanceof ReplicaCredentialError &&
+      error.code === "invalid_response",
+  );
+});
+
+test("surfaces the sync device limit distinctly", async () => {
+  await assert.rejects(
+    requestReplicaCredentials({
+      apiUrl: "https://api.anarlog.test",
+      accessToken: "access-token",
+      accountUserId: "user-123",
+      identity,
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({
+            error: { code: "sync_device_limit_reached" },
+          }),
+          { status: 403, headers: { "Content-Type": "application/json" } },
+        ),
+    }),
+    (error) =>
+      error instanceof ReplicaCredentialError && error.code === "device_limit",
+  );
+});
+
+test("rejects a malformed local identity before making a request", async () => {
+  let requested = false;
+  await assert.rejects(
+    requestReplicaCredentials({
+      apiUrl: "https://api.anarlog.test",
+      accessToken: "access-token",
+      accountUserId: "user-123",
+      identity: { keyId: "invalid", memberPublicKey: "invalid" },
+      fetcher: async () => {
+        requested = true;
+        return new Response();
+      },
+    }),
+    (error) =>
+      error instanceof ReplicaCredentialError &&
+      error.code === "invalid_response",
+  );
+  assert.equal(requested, false);
+});
+
+test("bounds an unavailable credential request", async () => {
+  await assert.rejects(
+    requestReplicaCredentials({
+      apiUrl: "https://api.anarlog.test",
+      accessToken: "access-token",
+      accountUserId: "user-123",
+      identity,
+      timeoutMs: 0,
+      fetcher: async (_input, init) =>
+        await new Promise((_resolve, reject) => {
+          init.signal.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        }),
+    }),
+    (error) =>
+      error instanceof ReplicaCredentialError && error.code === "unavailable",
+  );
+});

--- a/apps/mobile/src/sync/replica-credentials.ts
+++ b/apps/mobile/src/sync/replica-credentials.ts
@@ -1,0 +1,156 @@
+export type E2eeRecoveryKeyIdentity = {
+  keyId: string;
+  memberPublicKey: string;
+};
+
+export type ReplicaCredentials = {
+  transport: "replica";
+  encryptionVersion: 2;
+  encryptionKeyId: string;
+  expiresAt: string;
+  workspaceId: string;
+  accountUserId: string;
+};
+
+export type ReplicaCredentialErrorCode =
+  | "device_limit"
+  | "identity_mismatch"
+  | "invalid_response"
+  | "not_entitled"
+  | "reauth_required"
+  | "unavailable";
+
+export class ReplicaCredentialError extends Error {
+  readonly code: ReplicaCredentialErrorCode;
+
+  constructor(code: ReplicaCredentialErrorCode) {
+    super(
+      {
+        device_limit: "Cloud sync is limited to five devices.",
+        identity_mismatch: "This account uses a different recovery key.",
+        invalid_response: "The sync service returned an invalid response.",
+        not_entitled: "Anarlog Pro is required for cloud sync.",
+        reauth_required: "Sign in again to continue syncing.",
+        unavailable: "Cloud sync is temporarily unavailable.",
+      }[code],
+    );
+    this.name = "ReplicaCredentialError";
+    this.code = code;
+  }
+}
+
+const keyIdPattern = /^[A-Za-z0-9_-]{22}$/;
+const memberPublicKeyPattern = /^[A-Za-z0-9_-]{43}$/;
+
+function isReplicaCredentials(
+  value: unknown,
+  accountUserId: string,
+  keyId: string,
+): value is ReplicaCredentials {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.transport === "replica" &&
+    candidate.encryptionVersion === 2 &&
+    candidate.encryptionKeyId === keyId &&
+    typeof candidate.encryptionKeyId === "string" &&
+    keyIdPattern.test(candidate.encryptionKeyId) &&
+    typeof candidate.expiresAt === "string" &&
+    Number.isFinite(Date.parse(candidate.expiresAt)) &&
+    candidate.workspaceId === accountUserId &&
+    candidate.accountUserId === accountUserId
+  );
+}
+
+async function errorCode(response: Response): Promise<string | null> {
+  try {
+    const body: unknown = await response.json();
+    if (!body || typeof body !== "object") return null;
+    const error = (body as Record<string, unknown>).error;
+    if (!error || typeof error !== "object") return null;
+    const code = (error as Record<string, unknown>).code;
+    return typeof code === "string" ? code : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function requestReplicaCredentials({
+  apiUrl,
+  accessToken,
+  accountUserId,
+  identity,
+  device,
+  timeoutMs = 15_000,
+  fetcher = fetch,
+}: {
+  apiUrl: string;
+  accessToken: string;
+  accountUserId: string;
+  identity: E2eeRecoveryKeyIdentity;
+  device?: { fingerprint?: string | null; name?: string | null };
+  timeoutMs?: number;
+  fetcher?: typeof fetch;
+}): Promise<ReplicaCredentials> {
+  if (
+    !keyIdPattern.test(identity.keyId) ||
+    !memberPublicKeyPattern.test(identity.memberPublicKey)
+  ) {
+    throw new ReplicaCredentialError("invalid_response");
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${accessToken}`,
+    "X-Anarlog-E2EE-Key-Id": identity.keyId,
+    "X-Anarlog-E2EE-Member-Public-Key": identity.memberPublicKey,
+  };
+  if (device?.fingerprint) {
+    headers["X-Device-Fingerprint"] = device.fingerprint;
+  }
+  if (device?.name) {
+    headers["X-Anarlog-Device-Name"] = device.name;
+  }
+
+  let response: Response;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    response = await fetcher(new URL("/sync/replica/credentials", apiUrl), {
+      method: "POST",
+      headers,
+      signal: controller.signal,
+    });
+  } catch {
+    throw new ReplicaCredentialError("unavailable");
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new ReplicaCredentialError("reauth_required");
+    }
+    if (response.status === 403) {
+      throw new ReplicaCredentialError(
+        (await errorCode(response)) === "sync_device_limit_reached"
+          ? "device_limit"
+          : "not_entitled",
+      );
+    }
+    if (response.status === 409) {
+      throw new ReplicaCredentialError("identity_mismatch");
+    }
+    throw new ReplicaCredentialError("unavailable");
+  }
+
+  let credentials: unknown;
+  try {
+    credentials = await response.json();
+  } catch {
+    throw new ReplicaCredentialError("invalid_response");
+  }
+  if (!isReplicaCredentials(credentials, accountUserId, identity.keyId)) {
+    throw new ReplicaCredentialError("invalid_response");
+  }
+  return credentials;
+}

--- a/crates/mobile-bridge/src/lib.rs
+++ b/crates/mobile-bridge/src/lib.rs
@@ -301,6 +301,30 @@ impl MobileDbBridge {
         .map_err(cloudsync_runtime_error)
     }
 
+    pub fn generate_e2ee_recovery_key(&self) -> Result<String, BridgeError> {
+        self.with_state(|_| Ok(()))?;
+        let recovery_key = anlg_e2ee::RecoveryKey::generate().map_err(cloudsync_error)?;
+        Ok(recovery_key.expose_code().to_string())
+    }
+
+    pub fn inspect_e2ee_recovery_key(
+        &self,
+        recovery_key_code: String,
+    ) -> Result<String, BridgeError> {
+        self.with_state(|_| Ok(()))?;
+        let recovery_key =
+            anlg_e2ee::RecoveryKey::parse(&recovery_key_code).map_err(cloudsync_error)?;
+        let member_public_key = recovery_key
+            .member_identity_key()
+            .map_err(cloudsync_error)?
+            .public_key();
+        serde_json::to_string(&serde_json::json!({
+            "keyId": recovery_key.key_id(),
+            "memberPublicKey": member_public_key,
+        }))
+        .map_err(serialization_error)
+    }
+
     pub fn configure_e2ee_replica(
         &self,
         workspace_id: String,
@@ -870,6 +894,37 @@ mod tests {
 
         assert_eq!(bridge.cloudsync_sync_now().unwrap(), "{}");
         bridge.stop_cloudsync().unwrap();
+    }
+
+    #[test]
+    fn recovery_key_identity_roundtrips() {
+        let (_dir, bridge) = new_bridge(None);
+
+        let recovery_key = bridge.generate_e2ee_recovery_key().unwrap();
+        let identity: serde_json::Value = serde_json::from_str(
+            &bridge
+                .inspect_e2ee_recovery_key(recovery_key.clone())
+                .unwrap(),
+        )
+        .unwrap();
+        let parsed = anlg_e2ee::RecoveryKey::parse(&recovery_key).unwrap();
+
+        assert_eq!(identity["keyId"], parsed.key_id());
+        assert_eq!(
+            identity["memberPublicKey"],
+            parsed.member_identity_key().unwrap().public_key()
+        );
+    }
+
+    #[test]
+    fn inspect_e2ee_recovery_key_rejects_invalid_input() {
+        let (_dir, bridge) = new_bridge(None);
+
+        let error = bridge
+            .inspect_e2ee_recovery_key("invalid-recovery-key".to_string())
+            .unwrap_err();
+
+        assert!(matches!(error, BridgeError::CloudsyncFailed { .. }));
     }
 
     #[test]

--- a/packages/mobile-bridge-rn/cpp/generated/mobile_bridge.cpp
+++ b/packages/mobile-bridge-rn/cpp/generated/mobile_bridge.cpp
@@ -234,6 +234,15 @@ extern "C" {
         RustBuffer statements_json, 
         RustCallStatus *uniffi_out_err
     );
+    RustBuffer uniffi_mobile_bridge_fn_method_mobiledbbridge_generate_e2ee_recovery_key(
+        /*handle*/ uint64_t ptr, 
+        RustCallStatus *uniffi_out_err
+    );
+    RustBuffer uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key(
+        /*handle*/ uint64_t ptr, 
+        RustBuffer recovery_key_code, 
+        RustCallStatus *uniffi_out_err
+    );
     void uniffi_mobile_bridge_fn_method_mobiledbbridge_start_cloudsync(
         /*handle*/ uint64_t ptr, 
         RustCallStatus *uniffi_out_err
@@ -499,6 +508,10 @@ extern "C" {
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_proxy(
     );
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_transaction(
+    );
+    uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key(
+    );
+    uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(
     );
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_start_cloudsync(
     );
@@ -2652,6 +2665,22 @@ NativeMobileBridge::NativeMobileBridge(
             return this->cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute_transaction(rt, thisVal, args, count);
         }
     );
+    props["ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_generate_e2ee_recovery_key"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_generate_e2ee_recovery_key"),
+        1,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_generate_e2ee_recovery_key(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key"),
+        2,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key(rt, thisVal, args, count);
+        }
+    );
     props["ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_start_cloudsync"] = jsi::Function::createFromHostFunction(
         rt,
         jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_start_cloudsync"),
@@ -2834,6 +2863,22 @@ NativeMobileBridge::NativeMobileBridge(
         0,
         [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
             return this->cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_transaction(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key"),
+        0,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key"),
+        0,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(rt, thisVal, args, count);
         }
     );
     props["ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_start_cloudsync"] = jsi::Function::createFromHostFunction(
@@ -3247,6 +3292,26 @@ jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge
         
         return uniffi::mobile_bridge::Bridging<RustBuffer>::toJs(rt, callInvoker, value);
 }
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_generate_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        RustCallStatus status = uniffi::mobile_bridge::Bridging<RustCallStatus>::rustSuccess(rt);
+        auto value = uniffi_mobile_bridge_fn_method_mobiledbbridge_generate_e2ee_recovery_key(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), 
+            &status
+        );
+        uniffi::mobile_bridge::Bridging<RustCallStatus>::copyIntoJs(rt, callInvoker, status, args[count - 1]);
+
+        
+        return uniffi::mobile_bridge::Bridging<RustBuffer>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        RustCallStatus status = uniffi::mobile_bridge::Bridging<RustCallStatus>::rustSuccess(rt);
+        auto value = uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1]), 
+            &status
+        );
+        uniffi::mobile_bridge::Bridging<RustCallStatus>::copyIntoJs(rt, callInvoker, status, args[count - 1]);
+
+        
+        return uniffi::mobile_bridge::Bridging<RustBuffer>::toJs(rt, callInvoker, value);
+}
 jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_start_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         RustCallStatus status = uniffi::mobile_bridge::Bridging<RustCallStatus>::rustSuccess(rt);
         uniffi_mobile_bridge_fn_method_mobiledbbridge_start_cloudsync(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), 
@@ -3437,6 +3502,20 @@ jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledb
 }
 jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_transaction(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         auto value = uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_transaction(
+        );
+
+        
+        return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key(
+        );
+
+        
+        return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(
         );
 
         

--- a/packages/mobile-bridge-rn/cpp/generated/mobile_bridge.hpp
+++ b/packages/mobile-bridge-rn/cpp/generated/mobile_bridge.hpp
@@ -39,6 +39,8 @@ class NativeMobileBridge : public jsi::HostObject {
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute_proxy(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute_transaction(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_generate_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_start_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_stop_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_subscribe(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
@@ -62,6 +64,8 @@ class NativeMobileBridge : public jsi::HostObject {
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_proxy(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_transaction(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_start_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_stop_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_subscribe(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);

--- a/packages/mobile-bridge-rn/src/generated/mobile_bridge-ffi.ts
+++ b/packages/mobile-bridge-rn/src/generated/mobile_bridge-ffi.ts
@@ -263,6 +263,15 @@ interface NativeModuleInterface {
     statementsJson: Uint8Array,
     uniffi_out_err: UniffiRustCallStatus,
   ): Uint8Array;
+  ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_generate_e2ee_recovery_key(
+    uniffiSelf: bigint,
+    uniffi_out_err: UniffiRustCallStatus,
+  ): Uint8Array;
+  ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key(
+    uniffiSelf: bigint,
+    recoveryKeyCode: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus,
+  ): Uint8Array;
   ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_start_cloudsync(
     uniffiSelf: bigint,
     uniffi_out_err: UniffiRustCallStatus,
@@ -309,6 +318,8 @@ interface NativeModuleInterface {
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_proxy(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_transaction(): number;
+  ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key(): number;
+  ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_start_cloudsync(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_stop_cloudsync(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_subscribe(): number;

--- a/packages/mobile-bridge-rn/src/generated/mobile_bridge.ts
+++ b/packages/mobile-bridge-rn/src/generated/mobile_bridge.ts
@@ -843,6 +843,8 @@ export interface MobileDbBridgeLike {
     method: string,
   ) /*throws*/ : string;
   executeTransaction(statementsJson: string) /*throws*/ : string;
+  generateE2eeRecoveryKey() /*throws*/ : string;
+  inspectE2eeRecoveryKey(recoveryKeyCode: string) /*throws*/ : string;
   startCloudsync() /*throws*/ : void;
   stopCloudsync() /*throws*/ : void;
   subscribe(
@@ -1241,6 +1243,56 @@ export class MobileDbBridge
     );
   }
 
+  generateE2eeRecoveryKey(): string /*throws*/ {
+    return ((__rb: Uint8Array) => {
+      try {
+        return FfiConverterString.lift(__rb);
+      } finally {
+        nativeModule().rustbuffer_free(__rb);
+      }
+    })(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeBridgeError.lift.bind(
+          FfiConverterTypeBridgeError,
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_generate_e2ee_recovery_key(
+            uniffiTypeMobileDbBridgeObjectFactory.clonePointer(this),
+            callStatus,
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+      ),
+    );
+  }
+
+  inspectE2eeRecoveryKey(recoveryKeyCode: string): string /*throws*/ {
+    return ((__rb: Uint8Array) => {
+      try {
+        return FfiConverterString.lift(__rb);
+      } finally {
+        nativeModule().rustbuffer_free(__rb);
+      }
+    })(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeBridgeError.lift.bind(
+          FfiConverterTypeBridgeError,
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key(
+            uniffiTypeMobileDbBridgeObjectFactory.clonePointer(this),
+            FfiConverterString.lower(
+              recoveryKeyCode,
+              nativeModule().rustbuffer_alloc,
+            ),
+            callStatus,
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+      ),
+    );
+  }
+
   startCloudsync(): void /*throws*/ {
     uniffiCaller.rustCallWithError(
       /*liftError:*/ FfiConverterTypeBridgeError.lift.bind(
@@ -1555,6 +1607,22 @@ function uniffiEnsureInitialized() {
   ) {
     throw new UniffiInternalError.ApiChecksumMismatch(
       "uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_transaction",
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key() !==
+    32900
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      "uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key",
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key() !==
+    2453
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      "uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key",
     );
   }
   if (


### PR DESCRIPTION
## Summary
- expose recovery-key generation and identity inspection through the native mobile bridge and regenerated JSI bindings
- add a bounded, validated replica credential exchange that enforces the signed-in account and local E2EE identity
- add a mobile bootstrap helper that configures the witness-backed replica runtime and starts sync only after successful credential validation
- preserve recovery keys in caller-owned memory only; secure persistence and setup UI remain a separate slice

## Validation
- cargo test -p mobile-bridge (16 passed)
- cargo check -p mobile-bridge
- cargo clippy -p mobile-bridge --no-deps -- -D warnings
- pnpm -F @anlg/mobile typecheck
- pnpm -F @anlg/mobile-bridge typecheck
- pnpm -F @anlg/mobile test (31 passed)
- pnpm fmt:check
- cargo xtask mobile-bridge ios (device plus arm64 and x86_64 simulators)

Local Android native compilation is unavailable because this Mac has no Android SDK or NDK; Android Release CI is required before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches E2EE identity, replica credential exchange, and sync startup; mistakes could mis-bind workspaces or start sync with invalid credentials, though validation and typed errors reduce exposure.
> 
> **Overview**
> Adds an end-to-end mobile path to turn a recovery key plus signed-in session into a running E2EE cloud replica sync.
> 
> The **native bridge** gains `generateE2eeRecoveryKey` and `inspectE2eeRecoveryKey` (UniFFI/JSI regenerated), so JS can create keys and read `keyId` / `memberPublicKey` without persisting them in the bridge.
> 
> A new **`requestReplicaCredentials`** client POSTs to `/sync/replica/credentials` with bearer auth, E2EE identity headers, optional device fingerprint/name, a 15s timeout, and strict response validation. Failures map to typed `ReplicaCredentialError` codes (reauth, entitlement, device limit, identity mismatch, etc.).
> 
> **`bootstrapE2eeReplica`** wires inspect → credential exchange → `configureE2eeReplica` (witness URL derived from `apiUrl`) and calls **`startSync`** only when configuration succeeds. Recovery keys stay in caller-owned memory; secure storage and setup UI are out of scope for this slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9ea1b6065c05bfba75234073b3b8b219f03fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->