### PR TITLE
ANLG-70: align mobile timeline and meeting detail

### DIFF
--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import {
   Pressable,
   ScrollView,
@@ -30,6 +30,18 @@ import { useTimelineSessions, type TimelineSession } from "@/data/timeline";
 import { captureAnalytics } from "@/lib/analytics";
 import { confirmDestructive } from "@/lib/confirm";
 import { captureOperationalError } from "@/lib/error-reporting";
+import { useMountEffect } from "@/lib/use-mount-effect";
+
+function SearchAnalytics({ resultCount }: { resultCount: number }) {
+  useMountEffect(() => {
+    captureAnalytics("search_performed", {
+      entry_point: "mobile_home",
+      result_count: resultCount,
+      entity_types: ["note"],
+    });
+  });
+  return null;
+}
 
 export default function HomeScreen() {
   const router = useRouter();
@@ -37,22 +49,46 @@ export default function HomeScreen() {
   const [profileOpen, setProfileOpen] = useState(false);
   const [importing, setImporting] = useState(false);
   const [query, setQuery] = useState<string | null>(null);
+  const [settledSearchQuery, setSettledSearchQuery] = useState("");
   const searching = query !== null;
   const search = useSessionSearch(query ?? "");
   // Ref, not state: two taps in the same frame both pass a state check.
   const busyRef = useRef(false);
+  const searchAnalyticsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
-  useEffect(() => {
-    if (!searching || !query?.trim() || search.isLoading) return;
-    const timeout = setTimeout(() => {
-      captureAnalytics("search_performed", {
-        entry_point: "mobile_home",
-        result_count: search.results.length,
-        entity_types: ["note"],
-      });
+  useMountEffect(() => () => {
+    if (searchAnalyticsTimerRef.current) {
+      clearTimeout(searchAnalyticsTimerRef.current);
+    }
+  });
+
+  const handleSearchChange = (value: string) => {
+    setQuery(value);
+    if (searchAnalyticsTimerRef.current) {
+      clearTimeout(searchAnalyticsTimerRef.current);
+      searchAnalyticsTimerRef.current = null;
+    }
+    const term = value.trim();
+    if (term === "") {
+      setSettledSearchQuery("");
+      return;
+    }
+    searchAnalyticsTimerRef.current = setTimeout(() => {
+      searchAnalyticsTimerRef.current = null;
+      setSettledSearchQuery(term);
     }, 300);
-    return () => clearTimeout(timeout);
-  }, [query, search.isLoading, search.results.length, searching]);
+  };
+
+  const closeSearch = () => {
+    if (searchAnalyticsTimerRef.current) {
+      clearTimeout(searchAnalyticsTimerRef.current);
+      searchAnalyticsTimerRef.current = null;
+    }
+    setSettledSearchQuery("");
+    setQuery(null);
+  };
 
   const handleDelete = async (session: TimelineSession) => {
     const confirmed = await confirmDestructive(
@@ -120,14 +156,14 @@ export default function HomeScreen() {
               style={styles.searchInput}
               autoFocus
               value={query ?? ""}
-              onChangeText={setQuery}
-              placeholder="Search notes"
+              onChangeText={handleSearchChange}
+              placeholder="Search meetings"
               placeholderTextColor={Colors.muted}
             />
             <IconButton
               accessibilityLabel="Close search"
               icon="close"
-              onPress={() => setQuery(null)}
+              onPress={closeSearch}
             />
           </>
         ) : (
@@ -139,7 +175,7 @@ export default function HomeScreen() {
               variant="surface"
             />
             <IconButton
-              accessibilityLabel="Search notes"
+              accessibilityLabel="Search meetings"
               icon="search"
               onPress={() => setQuery("")}
             />
@@ -154,6 +190,14 @@ export default function HomeScreen() {
       >
         {searching ? (
           <>
+            {settledSearchQuery !== "" &&
+              settledSearchQuery === query.trim() &&
+              !search.isLoading && (
+                <SearchAnalytics
+                  key={settledSearchQuery}
+                  resultCount={search.results.length}
+                />
+              )}
             {query.trim() !== "" &&
               !search.isLoading &&
               search.results.length === 0 && (
@@ -180,26 +224,25 @@ export default function HomeScreen() {
           <>
             {!isLoading && items.length === 0 && (
               <View style={styles.empty}>
-                <Text style={styles.emptyTitle}>No notes yet</Text>
+                <Text style={styles.emptyTitle}>No meetings yet</Text>
                 <Text style={styles.emptyBody}>
-                  Start listening, write a note, or import a voice memo.
+                  Start listening, create a meeting, or import a recording.
                 </Text>
               </View>
             )}
             {items.map((item) => {
+              if (item.type === "group") {
+                return (
+                  <Text key={item.key} style={styles.groupLabel}>
+                    {item.label}
+                  </Text>
+                );
+              }
               if (item.type === "header") {
                 return (
                   <Text key={item.key} style={styles.sectionLabel}>
                     {item.label}
                   </Text>
-                );
-              }
-              if (item.type === "now") {
-                return (
-                  <View key={item.key} style={styles.nowDivider}>
-                    <View style={styles.nowDot} />
-                    <View style={styles.nowLine} />
-                  </View>
                 );
               }
               return (
@@ -217,7 +260,7 @@ export default function HomeScreen() {
 
       <View style={styles.actions}>
         <Button
-          label="New note"
+          label="New meeting"
           onPress={() => void createAndOpen()}
           leading={
             <Ionicons name="create-outline" size={17} color={Colors.ink} />
@@ -226,7 +269,7 @@ export default function HomeScreen() {
           variant="outline"
         />
         <Button
-          label={importing ? "Importing…" : "Import memo"}
+          label={importing ? "Importing…" : "Import recording"}
           onPress={handleImport}
           disabled={importing}
           leading={
@@ -302,28 +345,16 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   sectionLabel: {
-    ...Typography.section,
-    color: Colors.ink,
-    marginTop: Spacing.md,
+    ...Typography.captionStrong,
+    color: Colors.muted,
+    marginTop: Spacing.xs,
     marginBottom: Spacing.sm,
   },
-  nowDivider: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: Spacing.md,
-    marginLeft: -Spacing.lg,
-  },
-  nowDot: {
-    width: 12,
-    height: 12,
-    borderRadius: 6,
-    borderCurve: CornerCurve.squircle,
-    backgroundColor: Colors.accent,
-  },
-  nowLine: {
-    flex: 1,
-    height: 2,
-    backgroundColor: Colors.accent,
+  groupLabel: {
+    ...Typography.title,
+    color: Colors.ink,
+    marginTop: Spacing.lg,
+    marginBottom: Spacing.sm,
   },
   actions: {
     flexDirection: "row",

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -309,6 +309,19 @@ export default function NoteScreen() {
             placeholderTextColor={Colors.muted}
             onChangeText={(title) => onEdit({ title })}
           />
+          {data.summary && (
+            <Card style={styles.summary} tone="muted">
+              <Text style={styles.summaryLabel}>Summary</Text>
+              {data.summary.title !== "Summary" && (
+                <Text style={styles.summaryTitle}>{data.summary.title}</Text>
+              )}
+              {data.summary.text !== "" && (
+                <ScrollView style={styles.summaryScroll} nestedScrollEnabled>
+                  <Text style={styles.summaryText}>{data.summary.text}</Text>
+                </ScrollView>
+              )}
+            </Card>
+          )}
           {audio.data && (
             <View key={`${audio.data.filename}:${audio.data.createdAt}`}>
               <AudioChip
@@ -358,6 +371,7 @@ export default function NoteScreen() {
               </ScrollView>
             </Card>
           )}
+          <Text style={styles.noteLabel}>Notes</Text>
           {!data.plainEditable && (
             <View style={styles.readOnlyChip}>
               <Ionicons
@@ -415,6 +429,28 @@ const styles = StyleSheet.create({
     ...Typography.title,
     color: Colors.ink,
   },
+  summary: {
+    marginHorizontal: Spacing.lg,
+    marginTop: Spacing.md,
+    padding: Spacing.md,
+  },
+  summaryLabel: {
+    ...Typography.captionStrong,
+    color: Colors.muted,
+  },
+  summaryTitle: {
+    marginTop: Spacing.xs,
+    ...Typography.section,
+    color: Colors.ink,
+  },
+  summaryScroll: {
+    maxHeight: 220,
+    marginTop: Spacing.sm,
+  },
+  summaryText: {
+    ...Typography.body,
+    color: Colors.ink,
+  },
   transcribeStatus: {
     marginHorizontal: Spacing.lg,
     marginTop: Spacing.xs,
@@ -449,6 +485,12 @@ const styles = StyleSheet.create({
     ...Typography.body,
     color: Colors.ink,
     marginBottom: Spacing.sm,
+  },
+  noteLabel: {
+    marginHorizontal: Spacing.lg,
+    marginTop: Spacing.md,
+    ...Typography.captionStrong,
+    color: Colors.muted,
   },
   readOnlyChip: {
     flexDirection: "row",

--- a/apps/mobile/src/components/listening-sheet.tsx
+++ b/apps/mobile/src/components/listening-sheet.tsx
@@ -116,8 +116,8 @@ export function ListeningSheet({
           </Text>
         </View>
         <Text style={styles.detailHint}>
-          Leave your phone on the table and talk. Audio saves locally first;
-          transcription starts after you stop.
+          Leave your phone on the table and talk. Audio stays locally durable
+          while Anarlog listens.
         </Text>
       </Animated.View>
 

--- a/apps/mobile/src/data/session-detail.test.mjs
+++ b/apps/mobile/src/data/session-detail.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mapSessionDetailRows } from "./session-detail.ts";
+
+const baseRow = {
+  id: "session-1",
+  title: "Weekly planning",
+  created_at: "2026-08-17T00:00:00.000Z",
+  raw_body: JSON.stringify({
+    type: "doc",
+    content: [
+      {
+        type: "heading",
+        attrs: { level: 1 },
+        content: [{ type: "text", text: "Weekly planning" }],
+      },
+      { type: "paragraph", content: [{ type: "text", text: "My note" }] },
+    ],
+  }),
+  raw_body_format: "prosemirror_json",
+  summary_id: "summary-1",
+  summary_title: "Key decisions",
+  summary_body: "# Generated summary\n\nShip the mobile timeline.",
+  summary_body_format: "markdown",
+};
+
+test("maps a canonical summary alongside the editable note", () => {
+  assert.deepEqual(mapSessionDetailRows([baseRow]), {
+    id: "session-1",
+    title: "Weekly planning",
+    createdAt: "2026-08-17T00:00:00.000Z",
+    noteText: "My note",
+    bodyFormat: "prosemirror_json",
+    plainEditable: true,
+    summary: {
+      title: "Key decisions",
+      text: "Ship the mobile timeline.",
+    },
+  });
+});
+
+test("keeps a meeting without a generated summary as an empty note surface", () => {
+  assert.deepEqual(
+    mapSessionDetailRows([
+      {
+        ...baseRow,
+        raw_body: "",
+        summary_id: "",
+        summary_title: "",
+        summary_body: "",
+        summary_body_format: "prosemirror_json",
+      },
+    ]),
+    {
+      id: "session-1",
+      title: "Weekly planning",
+      createdAt: "2026-08-17T00:00:00.000Z",
+      noteText: "",
+      bodyFormat: "prosemirror_json",
+      plainEditable: true,
+      summary: null,
+    },
+  );
+});
+
+test("does not render an empty synced summary document", () => {
+  const detail = mapSessionDetailRows([
+    {
+      ...baseRow,
+      summary_title: "",
+      summary_body: "",
+      summary_body_format: "prosemirror_json",
+    },
+  ]);
+
+  assert.equal(detail?.summary, null);
+});
+
+test("uses the body heading when a synced summary has no stored title", () => {
+  const detail = mapSessionDetailRows([
+    {
+      ...baseRow,
+      summary_title: "",
+      summary_body: "# Decisions\n\nUse hosted live transcription.",
+    },
+  ]);
+
+  assert.deepEqual(detail?.summary, {
+    title: "Decisions",
+    text: "Use hosted live transcription.",
+  });
+});

--- a/apps/mobile/src/data/session-detail.ts
+++ b/apps/mobile/src/data/session-detail.ts
@@ -1,0 +1,76 @@
+import {
+  docToPlainText,
+  isPlainTextDoc,
+  stripMarkdownTitle,
+} from "./note-doc.ts";
+
+export type SessionDetail = {
+  id: string;
+  title: string;
+  createdAt: string;
+  noteText: string;
+  bodyFormat: "prosemirror_json" | "markdown";
+  plainEditable: boolean;
+  summary: { title: string; text: string } | null;
+};
+
+export type SessionDetailRow = {
+  id: string;
+  title: string;
+  created_at: string;
+  raw_body: string;
+  raw_body_format: string;
+  summary_id: string;
+  summary_title: string;
+  summary_body: string;
+  summary_body_format: string;
+};
+
+function documentText(
+  body: string,
+  bodyFormat: string,
+): {
+  title: string;
+  text: string;
+} {
+  return bodyFormat === "markdown"
+    ? stripMarkdownTitle(body)
+    : docToPlainText(body);
+}
+
+export function mapSessionDetailRows(
+  rows: SessionDetailRow[],
+): SessionDetail | null {
+  const row = rows[0];
+  if (!row) return null;
+  const isMarkdown = row.raw_body_format === "markdown";
+  const note = documentText(row.raw_body, row.raw_body_format);
+  const summaryDocument = documentText(
+    row.summary_body,
+    row.summary_body_format,
+  );
+  const summaryTitle =
+    row.summary_title.trim() || summaryDocument.title.trim() || "Summary";
+  const summaryText =
+    summaryDocument.text.trim() ||
+    (summaryDocument.title.trim() !== summaryTitle
+      ? summaryDocument.title.trim()
+      : "");
+  const hasSummaryContent = summaryTitle !== "Summary" || summaryText !== "";
+
+  return {
+    id: row.id,
+    title: row.title,
+    createdAt: row.created_at,
+    noteText: note.text,
+    bodyFormat: isMarkdown ? "markdown" : "prosemirror_json",
+    plainEditable: isMarkdown || isPlainTextDoc(row.raw_body),
+    summary:
+      row.summary_id === "" || !hasSummaryContent
+        ? null
+        : {
+            title: summaryTitle,
+            text: summaryText,
+          },
+  };
+}

--- a/apps/mobile/src/data/session.ts
+++ b/apps/mobile/src/data/session.ts
@@ -1,11 +1,13 @@
 import {
-  docToPlainText,
-  isPlainTextDoc,
   markdownWithTitle,
   plainTextToDoc,
   retitleBody,
-  stripMarkdownTitle,
 } from "@/data/note-doc";
+import {
+  mapSessionDetailRows,
+  type SessionDetail,
+  type SessionDetailRow,
+} from "@/data/session-detail";
 import { execute, executeTransaction, useLiveQuery } from "@/db";
 import { captureAnalytics } from "@/lib/analytics";
 import { DEFAULT_USER_ID, id, nowIso } from "@/lib/ids";
@@ -138,14 +140,7 @@ export async function createSession(options?: {
   return sessionId;
 }
 
-export type SessionDetail = {
-  id: string;
-  title: string;
-  createdAt: string;
-  noteText: string;
-  bodyFormat: "prosemirror_json" | "markdown";
-  plainEditable: boolean;
-};
+export type { SessionDetail } from "@/data/session-detail";
 
 const SESSION_DETAIL_SQL = `
 SELECT
@@ -153,37 +148,49 @@ SELECT
   sessions.title,
   sessions.created_at,
   COALESCE(note.body, '') AS raw_body,
-  COALESCE(note.body_format, 'prosemirror_json') AS raw_body_format
+  COALESCE(note.body_format, 'prosemirror_json') AS raw_body_format,
+  COALESCE(summary.id, '') AS summary_id,
+  COALESCE(summary.title, '') AS summary_title,
+  COALESCE(summary.body, '') AS summary_body,
+  COALESCE(summary.body_format, 'prosemirror_json') AS summary_body_format
 FROM sessions
 LEFT JOIN session_documents AS note
-  ON note.id = sessions.id AND note.kind = 'note' AND note.deleted_at IS NULL
+  ON note.id = COALESCE(
+    (
+      SELECT canonical.id
+      FROM session_documents AS canonical
+      WHERE canonical.id = sessions.id
+        AND canonical.session_id = sessions.id
+        AND canonical.kind = 'note'
+        AND canonical.deleted_at IS NULL
+      LIMIT 1
+    ),
+    (
+      SELECT fallback.id
+      FROM session_documents AS fallback
+      WHERE fallback.session_id = sessions.id
+        AND fallback.kind = 'note'
+        AND fallback.deleted_at IS NULL
+      ORDER BY fallback.created_at, fallback.id
+      LIMIT 1
+    )
+  )
+LEFT JOIN session_documents AS summary
+  ON summary.id = (
+    SELECT candidate.id
+    FROM session_documents AS candidate
+    WHERE candidate.session_id = sessions.id
+      AND candidate.kind IN ('summary', 'template_output')
+      AND candidate.deleted_at IS NULL
+    ORDER BY
+      CASE candidate.kind WHEN 'summary' THEN 0 ELSE 1 END,
+      candidate.sort_order,
+      candidate.created_at,
+      candidate.id
+    LIMIT 1
+  )
 WHERE sessions.id = ? AND sessions.deleted_at IS NULL
 `;
-
-type SessionDetailRow = {
-  id: string;
-  title: string;
-  created_at: string;
-  raw_body: string;
-  raw_body_format: string;
-};
-
-function mapSessionDetailRows(rows: SessionDetailRow[]): SessionDetail | null {
-  const row = rows[0];
-  if (!row) return null;
-  const isMarkdown = row.raw_body_format === "markdown";
-  const noteText = isMarkdown
-    ? stripMarkdownTitle(row.raw_body).text
-    : docToPlainText(row.raw_body).text;
-  return {
-    id: row.id,
-    title: row.title,
-    createdAt: row.created_at,
-    noteText,
-    bodyFormat: isMarkdown ? "markdown" : "prosemirror_json",
-    plainEditable: isMarkdown || isPlainTextDoc(row.raw_body),
-  };
-}
 
 export function useSessionDetail(sessionId: string): {
   data: SessionDetail | null;

--- a/apps/mobile/src/data/timeline-model.test.mjs
+++ b/apps/mobile/src/data/timeline-model.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildSessionList,
+  mapTimelineRows,
+  nextTimelineRefreshAt,
+} from "./timeline-model.ts";
+
+test("groups upcoming meetings nearest-first and past meetings newest-first", () => {
+  const now = new Date(2026, 7, 17, 12).getTime();
+  const iso = (offsetHours) =>
+    new Date(now + offsetHours * 60 * 60 * 1000).toISOString();
+  const items = buildSessionList(
+    [
+      { id: "past-old", title: "Past old", startedAt: iso(-24) },
+      { id: "upcoming-far", title: "Upcoming far", startedAt: iso(24) },
+      { id: "past-recent", title: "Past recent", startedAt: iso(-1) },
+      { id: "upcoming-near", title: "Upcoming near", startedAt: iso(1) },
+    ],
+    now,
+  );
+
+  assert.deepEqual(
+    items.filter((item) => item.type === "group").map((item) => item.label),
+    ["Upcoming", "Past"],
+  );
+  assert.deepEqual(
+    items
+      .filter((item) => item.type === "session")
+      .map((item) => item.session.id),
+    ["upcoming-near", "upcoming-far", "past-recent", "past-old"],
+  );
+});
+
+test("omits empty timeline groups", () => {
+  const now = new Date(2026, 7, 17, 12).getTime();
+  const items = buildSessionList(
+    [
+      {
+        id: "past",
+        title: "Past",
+        startedAt: new Date(now - 1_000).toISOString(),
+      },
+    ],
+    now,
+  );
+
+  assert.deepEqual(
+    items.filter((item) => item.type === "group").map((item) => item.label),
+    ["Past"],
+  );
+});
+
+test("prefers canonical event start time and falls back to creation time", () => {
+  assert.deepEqual(
+    mapTimelineRows([
+      {
+        id: "scheduled",
+        title: "Scheduled",
+        created_at: "2026-08-17T00:00:00.000Z",
+        event_json: JSON.stringify({ started_at: "2026-08-18T01:00:00.000Z" }),
+      },
+      {
+        id: "local",
+        title: "Local",
+        created_at: "2026-08-17T02:00:00.000Z",
+        event_json: "not-json",
+      },
+      {
+        id: "malformed-event",
+        title: "Malformed event",
+        created_at: "2026-08-17T03:00:00.000Z",
+        event_json: JSON.stringify({ started_at: "not-a-date" }),
+      },
+    ]),
+    [
+      {
+        id: "scheduled",
+        title: "Scheduled",
+        startedAt: "2026-08-18T01:00:00.000Z",
+      },
+      {
+        id: "local",
+        title: "Local",
+        startedAt: "2026-08-17T02:00:00.000Z",
+      },
+      {
+        id: "malformed-event",
+        title: "Malformed event",
+        startedAt: "2026-08-17T03:00:00.000Z",
+      },
+    ],
+  );
+});
+
+test("retains a session with an invalid date in the past group", () => {
+  const items = buildSessionList(
+    [{ id: "invalid", title: "Invalid", startedAt: "not-a-date" }],
+    Date.now(),
+  );
+
+  assert.deepEqual(
+    items.filter((item) => item.type === "group").map((item) => item.label),
+    ["Past"],
+  );
+  assert.equal(
+    items.find((item) => item.type === "header")?.label,
+    "Date unavailable",
+  );
+});
+
+test("refreshes at the next meeting boundary before the minute tick", () => {
+  const now = new Date("2026-08-17T12:00:30.000Z").getTime();
+  const meeting = new Date(now + 5_000).toISOString();
+
+  assert.equal(
+    nextTimelineRefreshAt(
+      [
+        { id: "past", title: "Past", startedAt: "2026-08-17T11:00:00.000Z" },
+        { id: "invalid", title: "Invalid", startedAt: "not-a-date" },
+        { id: "next", title: "Next", startedAt: meeting },
+      ],
+      now,
+    ),
+    new Date(meeting).getTime() + 1,
+  );
+});
+
+test("refreshes at the next minute when no meeting starts sooner", () => {
+  const now = new Date("2026-08-17T12:00:30.000Z").getTime();
+
+  assert.equal(
+    nextTimelineRefreshAt(
+      [
+        {
+          id: "later",
+          title: "Later",
+          startedAt: "2026-08-17T12:05:00.000Z",
+        },
+      ],
+      now,
+    ),
+    new Date("2026-08-17T12:01:00.001Z").getTime(),
+  );
+});

--- a/apps/mobile/src/data/timeline-model.ts
+++ b/apps/mobile/src/data/timeline-model.ts
@@ -1,0 +1,151 @@
+export type TimelineSession = {
+  id: string;
+  title: string;
+  startedAt: string;
+};
+
+export type SessionListItem =
+  | { type: "group"; key: string; label: "Upcoming" | "Past" }
+  | { type: "header"; key: string; label: string }
+  | { type: "session"; key: string; session: TimelineSession };
+
+export type TimelineRow = {
+  id: string;
+  title: string;
+  created_at: string;
+  event_json: string;
+};
+
+const DAY = 24 * 60 * 60 * 1000;
+const MINUTE = 60 * 1000;
+
+function startOfDay(timestamp: number): number {
+  const date = new Date(timestamp);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+export function dayLabel(iso: string, now = Date.now()): string {
+  const timestamp = new Date(iso).getTime();
+  if (!Number.isFinite(timestamp)) return "Date unavailable";
+  const today = startOfDay(now);
+  const day = startOfDay(timestamp);
+  if (day === today) return "Today";
+  if (day === today + DAY) return "Tomorrow";
+  if (day === today - DAY) return "Yesterday";
+  const date = new Date(day);
+  const sameYear = date.getFullYear() === new Date(today).getFullYear();
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
+}
+
+export function relativeLabel(iso: string): string {
+  const timestamp = new Date(iso).getTime();
+  if (!Number.isFinite(timestamp)) return "date unavailable";
+  const diff = timestamp - Date.now();
+  const minutes = Math.round(Math.abs(diff) / 60000);
+  if (minutes < 1) return "now";
+  const unit =
+    minutes < 60
+      ? `${minutes} min${minutes === 1 ? "" : "s"}`
+      : `${Math.round(minutes / 60)} hour${Math.round(minutes / 60) === 1 ? "" : "s"}`;
+  return diff > 0 ? `${unit} later` : `${unit} ago`;
+}
+
+export function buildSessionList(
+  sessions: TimelineSession[],
+  now = Date.now(),
+): SessionListItem[] {
+  const items: SessionListItem[] = [];
+  const appendGroup = (
+    label: "Upcoming" | "Past",
+    group: TimelineSession[],
+  ) => {
+    if (group.length === 0) return;
+    const groupKey = label.toLowerCase();
+    items.push({ type: "group", key: `group-${groupKey}`, label });
+    let currentLabel: string | null = null;
+    for (const session of group) {
+      const sessionDayLabel = dayLabel(session.startedAt, now);
+      if (sessionDayLabel !== currentLabel) {
+        items.push({
+          type: "header",
+          key: `header-${groupKey}-${sessionDayLabel}`,
+          label: sessionDayLabel,
+        });
+        currentLabel = sessionDayLabel;
+      }
+      items.push({ type: "session", key: session.id, session });
+    }
+  };
+
+  const withTimestamps = sessions.map((session) => {
+    const timestamp = new Date(session.startedAt).getTime();
+    return {
+      session,
+      timestamp: Number.isFinite(timestamp) ? timestamp : null,
+    };
+  });
+  const upcoming = withTimestamps
+    .filter(
+      (item): item is { session: TimelineSession; timestamp: number } =>
+        item.timestamp !== null && item.timestamp > now,
+    )
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .map((item) => item.session);
+  const past = withTimestamps
+    .filter((item) => item.timestamp === null || item.timestamp <= now)
+    .sort((a, b) => (b.timestamp ?? -Infinity) - (a.timestamp ?? -Infinity))
+    .map((item) => item.session);
+
+  appendGroup("Upcoming", upcoming);
+  appendGroup("Past", past);
+  return items;
+}
+
+export function nextTimelineRefreshAt(
+  sessions: TimelineSession[],
+  now = Date.now(),
+): number {
+  const nextMinute = now - (now % MINUTE) + MINUTE + 1;
+  const nextMeeting = sessions.reduce((earliest, session) => {
+    const timestamp = new Date(session.startedAt).getTime();
+    return Number.isFinite(timestamp) && timestamp > now
+      ? Math.min(earliest, timestamp + 1)
+      : earliest;
+  }, Number.POSITIVE_INFINITY);
+  return Math.min(nextMinute, nextMeeting);
+}
+
+function sessionStartedAt(row: TimelineRow): string {
+  if (row.event_json) {
+    try {
+      const event: unknown = JSON.parse(row.event_json);
+      if (
+        event &&
+        typeof event === "object" &&
+        typeof (event as { started_at?: unknown }).started_at === "string" &&
+        (event as { started_at: string }).started_at !== "" &&
+        Number.isFinite(
+          new Date((event as { started_at: string }).started_at).getTime(),
+        )
+      ) {
+        return (event as { started_at: string }).started_at;
+      }
+    } catch {
+      return row.created_at;
+    }
+  }
+  return row.created_at;
+}
+
+export function mapTimelineRows(rows: TimelineRow[]): TimelineSession[] {
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    startedAt: sessionStartedAt(row),
+  }));
+}

--- a/apps/mobile/src/data/timeline.ts
+++ b/apps/mobile/src/data/timeline.ts
@@ -1,81 +1,16 @@
-import { useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 
 import { useLiveQuery } from "@/db";
 
-export type TimelineSession = {
-  id: string;
-  title: string;
-  startedAt: string;
-};
+import {
+  buildSessionList,
+  mapTimelineRows,
+  nextTimelineRefreshAt,
+  type TimelineRow,
+  type TimelineSession,
+} from "./timeline-model";
 
-export type SessionListItem =
-  | { type: "header"; key: string; label: string }
-  | { type: "session"; key: string; session: TimelineSession }
-  | { type: "now"; key: string };
-
-const DAY = 24 * 60 * 60 * 1000;
-
-function startOfDay(timestamp: number): number {
-  const date = new Date(timestamp);
-  date.setHours(0, 0, 0, 0);
-  return date.getTime();
-}
-
-export function dayLabel(iso: string): string {
-  const today = startOfDay(Date.now());
-  const day = startOfDay(new Date(iso).getTime());
-  if (day === today) return "Today";
-  if (day === today + DAY) return "Tomorrow";
-  if (day === today - DAY) return "Yesterday";
-  const date = new Date(day);
-  // Section labels double as React keys, so an older year has to be spelled out
-  // or the same calendar day across years collides.
-  const sameYear = date.getFullYear() === new Date(today).getFullYear();
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    ...(sameYear ? {} : { year: "numeric" }),
-  });
-}
-
-export function relativeLabel(iso: string): string {
-  const diff = new Date(iso).getTime() - Date.now();
-  const minutes = Math.round(Math.abs(diff) / 60000);
-  if (minutes < 1) return "now";
-  const unit =
-    minutes < 60
-      ? `${minutes} min${minutes === 1 ? "" : "s"}`
-      : `${Math.round(minutes / 60)} hour${Math.round(minutes / 60) === 1 ? "" : "s"}`;
-  return diff > 0 ? `${unit} later` : `${unit} ago`;
-}
-
-export function buildSessionList(
-  sessions: TimelineSession[],
-): SessionListItem[] {
-  const sorted = [...sessions].sort(
-    (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
-  );
-
-  const items: SessionListItem[] = [];
-  const nowIso = new Date().toISOString();
-  let currentLabel: string | null = null;
-  let nowInserted = false;
-
-  for (const session of sorted) {
-    const label = dayLabel(session.startedAt);
-    if (label !== currentLabel) {
-      items.push({ type: "header", key: `header-${label}`, label });
-      currentLabel = label;
-    }
-    if (!nowInserted && session.startedAt <= nowIso && label === "Today") {
-      items.push({ type: "now", key: "now" });
-      nowInserted = true;
-    }
-    items.push({ type: "session", key: session.id, session });
-  }
-
-  return items;
-}
+export * from "./timeline-model";
 
 const TIMELINE_SQL = `
 SELECT id, title, created_at, event_json
@@ -84,38 +19,40 @@ WHERE deleted_at IS NULL
 ORDER BY created_at DESC
 `;
 
-export type TimelineRow = {
-  id: string;
-  title: string;
-  created_at: string;
-  event_json: string;
-};
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
-function sessionStartedAt(row: TimelineRow): string {
-  if (row.event_json) {
-    try {
-      const event: unknown = JSON.parse(row.event_json);
-      if (
-        event &&
-        typeof event === "object" &&
-        typeof (event as { started_at?: unknown }).started_at === "string" &&
-        (event as { started_at: string }).started_at !== ""
-      ) {
-        return (event as { started_at: string }).started_at;
-      }
-    } catch {
-      return row.created_at;
-    }
-  }
-  return row.created_at;
-}
+function createTimelineClock(sessions: TimelineSession[]) {
+  let snapshot = Date.now();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const listeners = new Set<() => void>();
 
-export function mapTimelineRows(rows: TimelineRow[]): TimelineSession[] {
-  return rows.map((row) => ({
-    id: row.id,
-    title: row.title,
-    startedAt: sessionStartedAt(row),
-  }));
+  const schedule = () => {
+    const current = Date.now();
+    const delay = Math.min(
+      Math.max(1, nextTimelineRefreshAt(sessions, current) - current),
+      MAX_TIMER_DELAY_MS,
+    );
+    timer = setTimeout(() => {
+      snapshot = Date.now();
+      for (const listener of listeners) listener();
+      if (listeners.size > 0) schedule();
+    }, delay);
+  };
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      if (listeners.size === 1) schedule();
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0 && timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+      };
+    },
+  };
 }
 
 export function useTimelineSessions(): {
@@ -126,6 +63,13 @@ export function useTimelineSessions(): {
     sql: TIMELINE_SQL,
     mapRows: mapTimelineRows,
   });
-  const items = useMemo(() => buildSessionList(data ?? []), [data]);
+  const sessions = useMemo(() => data ?? [], [data]);
+  const clock = useMemo(() => createTimelineClock(sessions), [sessions]);
+  const now = useSyncExternalStore(
+    clock.subscribe,
+    clock.getSnapshot,
+    clock.getSnapshot,
+  );
+  const items = useMemo(() => buildSessionList(sessions, now), [sessions, now]);
   return { items, isLoading };
 }


### PR DESCRIPTION
## Summary
- make Home explicitly group upcoming meetings nearest-first and past meetings newest-first
- rename meeting creation, import, search, and empty-state copy around the Pro meeting workflow
- read the canonical synced summary/template output and render it above the editable session note
- preserve debounced search analytics without direct useEffect
- keep recording guidance neutral so the UI can move from batch to live transcription

## Validation
- pnpm exec dprint fmt
- pnpm fmt:check
- pnpm -F @anlg/mobile typecheck
- pnpm -F @anlg/mobile test (37 passed)
- pnpm exec oxlint --quiet --format=github apps/mobile/src/ (0 warnings, 0 errors)

No simulator QA was run because this is not a release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Session detail SQL and document joins affect which note/summary users see; timeline grouping changes list order and labels across the app.
> 
> **Overview**
> **Home** now splits the list into **Upcoming** (soonest first) and **Past** (newest first), with day headers inside each section and a clock that re-sorts when a meeting crosses “now” or the calendar day changes. The old “now” divider is removed. Copy and actions are reframed around **meetings** (search, empty state, New meeting, Import recording).
> 
> **Meeting detail** loads the canonical synced **summary** or **template_output** document (with smarter note document resolution) and shows it in a read-only card above **Notes**. Session detail mapping moves into `session-detail` with tests.
> 
> **Search analytics** still debounce at 300ms but fire via a `SearchAnalytics` mount helper instead of `useEffect`. **Listening** hint copy no longer promises post-stop transcription only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad0321bb615b0f8fd3e06f2f80d3075d4e12d94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->