### PR TITLE
Build Rust Chromium admission foundation

### DIFF
--- a/enterprise/Cargo.lock
+++ b/enterprise/Cargo.lock
@@ -77,6 +77,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "anarlog-enterprise-google-meet-worker"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "meeting-capture",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "url",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +559,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "db-app"
@@ -1428,6 +1451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,8 +1861,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1858,12 +1897,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2043,6 +2101,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2712,6 +2783,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,6 +2904,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2938,6 +3034,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1",
+ "thiserror",
+]
 
 [[package]]
 name = "typenum"

--- a/enterprise/Cargo.toml
+++ b/enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["control-plane"]
+members = ["control-plane", "google-meet-worker"]
 
 [workspace.package]
 version = "0.1.0"
@@ -18,6 +18,7 @@ anyhow = "1"
 async-trait = "0.1"
 axum = "0.8"
 chrono = "0.4"
+futures-util = "0.3"
 http = "1"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 serde = "1"
@@ -26,7 +27,9 @@ sha2 = "0.11"
 sqlx = { version = "=0.9.0-alpha.1", default-features = false }
 thiserror = "2"
 tokio = "1"
+tokio-tungstenite = "0.29"
 tower = "0.5"
 tower-http = "0.6"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+url = "2"

--- a/enterprise/google-meet-worker/Cargo.toml
+++ b/enterprise/google-meet-worker/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "anarlog-enterprise-google-meet-worker"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+
+[dependencies]
+anlg-meeting-capture.workspace = true
+
+chrono = { workspace = true, features = ["serde"] }
+futures-util.workspace = true
+reqwest.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["fs", "macros", "net", "process", "rt", "time"] }
+tokio-tungstenite.workspace = true
+url.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/enterprise/google-meet-worker/THIRD_PARTY_NOTICES.md
+++ b/enterprise/google-meet-worker/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,16 @@
+# Third-party notices
+
+This component contains source-informed adaptations of Google Meet browser-launch and admission-classification behavior from Vexa `v0.12.18`, commit `1b62993e7e97c6ee04a5dcb116f7749ec74169df`.
+
+Upstream: https://github.com/Vexa-ai/vexa
+
+Reference modules:
+
+- `core/meetings/modules/remote-browser/src/args.ts`
+- `core/meetings/modules/join/src/browser-args.ts`
+- `core/meetings/modules/join/src/googlemeet/admission.ts`
+- `core/meetings/modules/join/src/googlemeet/selectors.ts`
+
+The Anarlog implementation was rewritten in Rust, reorganized around Anarlog's provider-neutral capture contract, and modified for direct Chromium DevTools ownership. Files carrying an adaptation notice have been changed by Fastrepl, Inc.
+
+Vexa is licensed under the Apache License, Version 2.0. A copy is provided in `third-party/VEXA-LICENSE`.

--- a/enterprise/google-meet-worker/src/admission.rs
+++ b/enterprise/google-meet-worker/src/admission.rs
@@ -1,0 +1,223 @@
+// Adapted for Anarlog from Vexa v0.12.18. See ../THIRD_PARTY_NOTICES.md.
+
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_CAPTCHA_GRACE: Duration = Duration::from_secs(120);
+pub const ADMISSION_PROBE_EXPRESSION: &str = include_str!("admission_probe.js");
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdmissionSnapshot {
+    pub waiting_room_visible: bool,
+    pub consent_prompt_visible: bool,
+    pub explicit_denial_indicator: Option<String>,
+    pub ambiguous_error_indicator: Option<String>,
+    pub visible_recaptcha_challenge: bool,
+    #[serde(default)]
+    pub participant_tile_labels: Vec<String>,
+    pub self_name_nodes: usize,
+    pub visible_admission_controls: usize,
+}
+
+impl AdmissionSnapshot {
+    pub fn real_participant_tiles(&self) -> usize {
+        self.participant_tile_labels
+            .iter()
+            .filter(|label| {
+                let label = label.trim().to_lowercase();
+                !label.is_empty()
+                    && !label.contains("visual_effects")
+                    && !label.contains("backgrounds and effects")
+            })
+            .count()
+    }
+
+    fn has_admission_signal(&self) -> bool {
+        self.real_participant_tiles() > 0
+            || self.self_name_nodes > 0
+            || self.visible_admission_controls > 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdmissionOutcome {
+    WaitingForAdmission,
+    ConsentRequired,
+    CaptchaChallenge { remaining: Duration },
+    Admitted,
+    Rejected(AdmissionRejection),
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdmissionRejection {
+    pub reason: AdmissionRejectionReason,
+    pub indicator: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionRejectionReason {
+    HostDenied,
+    ErrorPage,
+    CaptchaUnsolved,
+}
+
+#[derive(Debug)]
+pub struct AdmissionClassifier {
+    captcha_grace: Duration,
+    captcha_suppressed_since: Option<Instant>,
+}
+
+impl Default for AdmissionClassifier {
+    fn default() -> Self {
+        Self::new(DEFAULT_CAPTCHA_GRACE)
+    }
+}
+
+impl AdmissionClassifier {
+    pub fn new(captcha_grace: Duration) -> Self {
+        Self {
+            captcha_grace,
+            captcha_suppressed_since: None,
+        }
+    }
+
+    pub fn classify(&mut self, snapshot: &AdmissionSnapshot, now: Instant) -> AdmissionOutcome {
+        if let Some(indicator) = snapshot.explicit_denial_indicator.as_ref() {
+            self.captcha_suppressed_since = None;
+            return AdmissionOutcome::Rejected(AdmissionRejection {
+                reason: AdmissionRejectionReason::HostDenied,
+                indicator: indicator.clone(),
+            });
+        }
+
+        if let Some(indicator) = snapshot.ambiguous_error_indicator.as_ref() {
+            if snapshot.visible_recaptcha_challenge {
+                let since = *self.captcha_suppressed_since.get_or_insert(now);
+                let elapsed = now.saturating_duration_since(since);
+                if elapsed < self.captcha_grace {
+                    return AdmissionOutcome::CaptchaChallenge {
+                        remaining: self.captcha_grace - elapsed,
+                    };
+                }
+                self.captcha_suppressed_since = None;
+                return AdmissionOutcome::Rejected(AdmissionRejection {
+                    reason: AdmissionRejectionReason::CaptchaUnsolved,
+                    indicator: indicator.clone(),
+                });
+            }
+
+            self.captcha_suppressed_since = None;
+            return AdmissionOutcome::Rejected(AdmissionRejection {
+                reason: AdmissionRejectionReason::ErrorPage,
+                indicator: indicator.clone(),
+            });
+        }
+
+        self.captcha_suppressed_since = None;
+        if snapshot.waiting_room_visible {
+            return AdmissionOutcome::WaitingForAdmission;
+        }
+        if snapshot.consent_prompt_visible {
+            return AdmissionOutcome::ConsentRequired;
+        }
+        if snapshot.has_admission_signal() {
+            return AdmissionOutcome::Admitted;
+        }
+        AdmissionOutcome::Unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_host_denial_wins_over_captcha_and_stale_waiting_copy() {
+        let mut classifier = AdmissionClassifier::default();
+        let outcome = classifier.classify(
+            &AdmissionSnapshot {
+                waiting_room_visible: true,
+                explicit_denial_indicator: Some("denied your request".into()),
+                ambiguous_error_indicator: Some("Try again".into()),
+                visible_recaptcha_challenge: true,
+                ..Default::default()
+            },
+            Instant::now(),
+        );
+
+        assert_eq!(
+            outcome,
+            AdmissionOutcome::Rejected(AdmissionRejection {
+                reason: AdmissionRejectionReason::HostDenied,
+                indicator: "denied your request".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn captcha_suppression_expires_instead_of_polling_forever() {
+        let grace = Duration::from_secs(120);
+        let mut classifier = AdmissionClassifier::new(grace);
+        let started = Instant::now();
+        let snapshot = AdmissionSnapshot {
+            ambiguous_error_indicator: Some("Try again".into()),
+            visible_recaptcha_challenge: true,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            classifier.classify(&snapshot, started),
+            AdmissionOutcome::CaptchaChallenge { remaining: grace }
+        );
+        assert_eq!(
+            classifier.classify(&snapshot, started + Duration::from_secs(119)),
+            AdmissionOutcome::CaptchaChallenge {
+                remaining: Duration::from_secs(1)
+            }
+        );
+        assert_eq!(
+            classifier.classify(&snapshot, started + grace),
+            AdmissionOutcome::Rejected(AdmissionRejection {
+                reason: AdmissionRejectionReason::CaptchaUnsolved,
+                indicator: "Try again".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn waiting_and_consent_guards_suppress_lobby_false_positives() {
+        for snapshot in [
+            AdmissionSnapshot {
+                waiting_room_visible: true,
+                visible_admission_controls: 3,
+                ..Default::default()
+            },
+            AdmissionSnapshot {
+                consent_prompt_visible: true,
+                participant_tile_labels: vec!["Ada".into()],
+                ..Default::default()
+            },
+        ] {
+            let mut classifier = AdmissionClassifier::default();
+            assert_ne!(
+                classifier.classify(&snapshot, Instant::now()),
+                AdmissionOutcome::Admitted
+            );
+        }
+    }
+
+    #[test]
+    fn effects_preview_is_not_a_real_participant() {
+        let snapshot = AdmissionSnapshot {
+            participant_tile_labels: vec![
+                "visual_effects Backgrounds and effects".into(),
+                "Grace Hopper".into(),
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(snapshot.real_participant_tiles(), 1);
+    }
+}

--- a/enterprise/google-meet-worker/src/admission_probe.js
+++ b/enterprise/google-meet-worker/src/admission_probe.js
@@ -1,0 +1,113 @@
+// Adapted for Anarlog from Vexa v0.12.18. See ../THIRD_PARTY_NOTICES.md.
+(() => {
+  const visible = (element) => {
+    if (!(element instanceof HTMLElement)) return false;
+    const style = window.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return (
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      Number(style.opacity) !== 0 &&
+      rect.width > 0 &&
+      rect.height > 0
+    );
+  };
+  const normalizedText = (element) =>
+    (element.textContent || "").replace(/\s+/g, " ").trim().toLowerCase();
+  const visibleText = (copies, selectors = "button,div,p,span") => {
+    const lowered = copies.map((copy) => copy.toLowerCase());
+    for (const element of document.querySelectorAll(selectors)) {
+      if (!visible(element)) continue;
+      const text = normalizedText(element);
+      const match = lowered.find((copy) => text.includes(copy));
+      if (match) return match;
+    }
+    return null;
+  };
+  const visibleSelectorCount = (selectors) =>
+    selectors.reduce((count, selector) => {
+      try {
+        return (
+          count +
+          Array.from(document.querySelectorAll(selector)).filter(visible).length
+        );
+      } catch {
+        return count;
+      }
+    }, 0);
+
+  const explicitDenial = visibleText([
+    "denied your request",
+    "request to join was denied",
+    "you were denied",
+    "weren't allowed to join",
+    "weren’t allowed to join",
+    "not allowed to join",
+    "not admitted",
+    "ask to join again",
+  ]);
+  const ambiguousError = visibleText([
+    "meeting not found",
+    "can't join the meeting",
+    "unable to join",
+    "access denied",
+    "meeting has ended",
+    "this meeting has ended",
+    "invalid meeting",
+    "meeting link expired",
+    "try again",
+    "retry",
+    "go back",
+  ]);
+  const waitingRoom = Boolean(
+    visibleText([
+      "asking to be let in",
+      "you'll join the call when someone lets you in",
+      "you’ll join the call when someone lets you in",
+      "please wait until a meeting host brings you into the call",
+      "waiting for the host to let you in",
+      "you're in the waiting room",
+      "return to home screen",
+    ]) ||
+    visibleSelectorCount([
+      '[aria-label*="waiting room" i]',
+      '[aria-label*="asking to be let in" i]',
+      '[aria-label*="waiting for admission" i]',
+    ]) > 0,
+  );
+  const consentPrompt = Boolean(
+    visibleText(
+      ["take notes for me", "taking notes"],
+      '[role="dialog"],[role="alertdialog"]',
+    ),
+  );
+  const recaptchaChallenge = Array.from(
+    document.querySelectorAll('iframe[src*="recaptcha"]'),
+  ).some((element) => {
+    if (!visible(element)) return false;
+    const rect = element.getBoundingClientRect();
+    return rect.width >= 120 && rect.height >= 40;
+  });
+  const participantTileLabels = Array.from(
+    document.querySelectorAll("[data-participant-id]"),
+  ).map(
+    (element) =>
+      element.getAttribute("aria-label") || (element.textContent || "").trim(),
+  );
+
+  return {
+    waiting_room_visible: waitingRoom,
+    consent_prompt_visible: consentPrompt,
+    explicit_denial_indicator: explicitDenial,
+    ambiguous_error_indicator: ambiguousError,
+    visible_recaptcha_challenge: recaptchaChallenge,
+    participant_tile_labels: participantTileLabels,
+    self_name_nodes: document.querySelectorAll("[data-self-name]").length,
+    visible_admission_controls: visibleSelectorCount([
+      'button[aria-label*="share screen" i]',
+      'button[aria-label*="present now" i]',
+      'button[aria-label*="leave call" i]',
+      'button[aria-label*="leave meeting" i]',
+    ]),
+  };
+})();

--- a/enterprise/google-meet-worker/src/browser.rs
+++ b/enterprise/google-meet-worker/src/browser.rs
@@ -1,0 +1,298 @@
+// Adapted for Anarlog from Vexa v0.12.18. See ../THIRD_PARTY_NOTICES.md.
+
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
+
+use tokio::{process::Child, time::Instant};
+
+const DEVTOOLS_ACTIVE_PORT: &str = "DevToolsActivePort";
+
+#[derive(Debug, Clone)]
+pub struct ChromiumLaunchConfig {
+    pub binary: PathBuf,
+    pub user_data_dir: PathBuf,
+    pub locale: String,
+    pub authenticated: bool,
+    pub headless: bool,
+    pub disable_sandbox: bool,
+    pub startup_timeout: Duration,
+}
+
+impl ChromiumLaunchConfig {
+    pub fn launch_args(&self) -> Result<Vec<OsString>, ChromiumLaunchError> {
+        validate_locale(&self.locale)?;
+        let primary_language = self.locale.split('-').next().unwrap_or(&self.locale);
+        let accept_language = if primary_language == self.locale {
+            self.locale.clone()
+        } else {
+            format!("{},{}", self.locale, primary_language)
+        };
+
+        let mut args = vec![
+            "--disable-blink-features=AutomationControlled".into(),
+            "--disable-infobars".into(),
+            "--disable-gpu".into(),
+            "--in-process-gpu".into(),
+            "--use-fake-ui-for-media-stream".into(),
+            "--use-file-for-fake-video-capture=/dev/null".into(),
+            "--autoplay-policy=no-user-gesture-required".into(),
+            "--password-store=basic".into(),
+            "--remote-debugging-port=0".into(),
+            "--remote-debugging-address=127.0.0.1".into(),
+            format!("--user-data-dir={}", self.user_data_dir.display()).into(),
+            format!("--lang={}", self.locale).into(),
+            format!("--accept-lang={accept_language}").into(),
+        ];
+        if self.disable_sandbox {
+            args.push("--no-sandbox".into());
+            args.push("--disable-setuid-sandbox".into());
+        }
+        if !self.authenticated {
+            args.push("--incognito".into());
+        }
+        if self.headless {
+            args.push("--headless=new".into());
+        }
+        args.push("about:blank".into());
+        Ok(args)
+    }
+}
+
+#[derive(Debug)]
+pub struct ChromiumProcess {
+    child: Child,
+    pub devtools_websocket_url: String,
+}
+
+impl ChromiumProcess {
+    pub async fn launch(config: ChromiumLaunchConfig) -> Result<Self, ChromiumLaunchError> {
+        tokio::fs::create_dir_all(&config.user_data_dir)
+            .await
+            .map_err(ChromiumLaunchError::ProfileDirectory)?;
+        let args = config.launch_args()?;
+        let mut command = tokio::process::Command::new(&config.binary);
+        command
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true);
+        let child = command.spawn().map_err(ChromiumLaunchError::Spawn)?;
+        let active_port = config.user_data_dir.join(DEVTOOLS_ACTIVE_PORT);
+        let mut process = Self {
+            child,
+            devtools_websocket_url: String::new(),
+        };
+        process.devtools_websocket_url = process
+            .wait_for_devtools(&active_port, config.startup_timeout)
+            .await?;
+        Ok(process)
+    }
+
+    pub fn id(&self) -> Option<u32> {
+        self.child.id()
+    }
+
+    pub async fn shutdown(mut self) -> Result<(), std::io::Error> {
+        if self.child.try_wait()?.is_none() {
+            self.child.kill().await?;
+        }
+        let _ = self.child.wait().await?;
+        Ok(())
+    }
+
+    async fn wait_for_devtools(
+        &mut self,
+        path: &Path,
+        timeout: Duration,
+    ) -> Result<String, ChromiumLaunchError> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = self
+                .child
+                .try_wait()
+                .map_err(ChromiumLaunchError::ProcessStatus)?
+            {
+                return Err(ChromiumLaunchError::ExitedBeforeReady(status.code()));
+            }
+            if let Ok(contents) = tokio::fs::read_to_string(path).await {
+                return parse_devtools_active_port(&contents);
+            }
+            if Instant::now() >= deadline {
+                return Err(ChromiumLaunchError::StartupTimeout(timeout));
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+}
+
+impl Drop for ChromiumProcess {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+fn validate_locale(locale: &str) -> Result<(), ChromiumLaunchError> {
+    if locale.is_empty()
+        || !locale
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return Err(ChromiumLaunchError::InvalidLocale(locale.into()));
+    }
+    Ok(())
+}
+
+fn parse_devtools_active_port(contents: &str) -> Result<String, ChromiumLaunchError> {
+    let mut lines = contents.lines();
+    let port = lines
+        .next()
+        .and_then(|port| port.parse::<u16>().ok())
+        .filter(|port| *port > 0)
+        .ok_or_else(|| ChromiumLaunchError::InvalidDevToolsFile(contents.into()))?;
+    let path = lines
+        .next()
+        .filter(|path| path.starts_with("/devtools/browser/"))
+        .ok_or_else(|| ChromiumLaunchError::InvalidDevToolsFile(contents.into()))?;
+    Ok(format!("ws://127.0.0.1:{port}{path}"))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChromiumLaunchError {
+    #[error("Chromium locale must be a non-empty language tag: {0}")]
+    InvalidLocale(String),
+    #[error("failed to prepare the Chromium profile directory")]
+    ProfileDirectory(#[source] std::io::Error),
+    #[error("failed to launch Chromium")]
+    Spawn(#[source] std::io::Error),
+    #[error("failed to read Chromium process status")]
+    ProcessStatus(#[source] std::io::Error),
+    #[error("Chromium exited before DevTools was ready (exit code {0:?})")]
+    ExitedBeforeReady(Option<i32>),
+    #[error("Chromium did not expose DevTools within {0:?}")]
+    StartupTimeout(Duration),
+    #[error("invalid Chromium DevToolsActivePort contents: {0:?}")]
+    InvalidDevToolsFile(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn config(authenticated: bool) -> ChromiumLaunchConfig {
+        ChromiumLaunchConfig {
+            binary: "/usr/bin/chromium".into(),
+            user_data_dir: "/tmp/anarlog-meet".into(),
+            locale: "en-US".into(),
+            authenticated,
+            headless: false,
+            disable_sandbox: false,
+            startup_timeout: Duration::from_secs(10),
+        }
+    }
+
+    #[test]
+    fn guest_launch_is_isolated_and_locale_pinned() {
+        let args = config(false).launch_args().unwrap();
+
+        assert!(args.contains(&OsString::from("--incognito")));
+        assert!(args.contains(&OsString::from("--lang=en-US")));
+        assert!(args.contains(&OsString::from("--accept-lang=en-US,en")));
+        assert!(args.contains(&OsString::from("--remote-debugging-port=0")));
+        assert!(!args.contains(&OsString::from("--no-sandbox")));
+        assert!(!args.iter().any(|arg| arg == "--disable-web-security"));
+        assert!(!args.iter().any(|arg| arg == "--ignore-certificate-errors"));
+    }
+
+    #[test]
+    fn sandbox_can_be_disabled_explicitly_for_containerized_chromium() {
+        let args = ChromiumLaunchConfig {
+            disable_sandbox: true,
+            ..config(false)
+        }
+        .launch_args()
+        .unwrap();
+
+        assert!(args.contains(&OsString::from("--no-sandbox")));
+        assert!(args.contains(&OsString::from("--disable-setuid-sandbox")));
+    }
+
+    #[test]
+    fn authenticated_launch_preserves_the_profile() {
+        let args = config(true).launch_args().unwrap();
+
+        assert!(!args.contains(&OsString::from("--incognito")));
+        assert!(args.contains(&OsString::from("--user-data-dir=/tmp/anarlog-meet")));
+    }
+
+    #[test]
+    fn parses_chromium_devtools_endpoint() {
+        assert_eq!(
+            parse_devtools_active_port("49231\n/devtools/browser/test-id\n").unwrap(),
+            "ws://127.0.0.1:49231/devtools/browser/test-id"
+        );
+    }
+
+    #[test]
+    fn rejects_shell_like_locale_values() {
+        assert!(matches!(
+            ChromiumLaunchConfig {
+                locale: "en-US;touch-pwned".into(),
+                ..config(false)
+            }
+            .launch_args(),
+            Err(ChromiumLaunchError::InvalidLocale(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn supervises_and_stops_the_browser_process() {
+        let directory = tempfile::tempdir().unwrap();
+        let executable = directory.path().join("fake-chromium");
+        std::fs::write(
+            &executable,
+            r#"#!/bin/sh
+profile=""
+for arg in "$@"; do
+  case "$arg" in
+    --user-data-dir=*) profile="${arg#--user-data-dir=}" ;;
+  esac
+done
+printf '49231\n/devtools/browser/test-id\n' > "$profile/DevToolsActivePort"
+trap 'exit 0' TERM INT
+while true; do sleep 1; done
+"#,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions).unwrap();
+
+        let process = ChromiumProcess::launch(ChromiumLaunchConfig {
+            binary: executable,
+            user_data_dir: directory.path().join("profile"),
+            locale: "en-US".into(),
+            authenticated: false,
+            headless: true,
+            disable_sandbox: false,
+            startup_timeout: Duration::from_secs(2),
+        })
+        .await
+        .unwrap();
+
+        assert!(process.id().is_some());
+        assert_eq!(
+            process.devtools_websocket_url,
+            "ws://127.0.0.1:49231/devtools/browser/test-id"
+        );
+        process.shutdown().await.unwrap();
+    }
+}

--- a/enterprise/google-meet-worker/src/cdp.rs
+++ b/enterprise/google-meet-worker/src/cdp.rs
@@ -1,0 +1,406 @@
+use std::{net::IpAddr, time::Duration};
+
+use futures_util::{SinkExt, StreamExt};
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream, connect_async,
+    tungstenite::{Error as WebSocketError, Message},
+};
+use url::Url;
+
+use crate::{ADMISSION_PROBE_EXPRESSION, AdmissionSnapshot};
+
+const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GoogleMeetUrl(Url);
+
+impl GoogleMeetUrl {
+    pub fn parse(value: &str) -> Result<Self, CdpError> {
+        let url = Url::parse(value).map_err(CdpError::InvalidMeetingUrl)?;
+        let valid_origin = url.scheme() == "https"
+            && url.host_str() == Some("meet.google.com")
+            && url.username().is_empty()
+            && url.password().is_none()
+            && url.port().is_none();
+        let valid_code = url
+            .path_segments()
+            .and_then(|mut segments| {
+                let code = segments.next()?;
+                (segments.next().is_none()).then_some(code)
+            })
+            .is_some_and(is_google_meet_code);
+
+        if !valid_origin || !valid_code || url.fragment().is_some() {
+            return Err(CdpError::UnsupportedMeetingUrl(value.into()));
+        }
+        Ok(Self(url))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+pub struct CdpPage {
+    websocket: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    next_command_id: u64,
+    command_timeout: Duration,
+}
+
+impl CdpPage {
+    pub async fn open(
+        browser_websocket_url: &str,
+        meeting_url: &GoogleMeetUrl,
+    ) -> Result<Self, CdpError> {
+        let browser_url = validate_loopback_websocket_url(browser_websocket_url)?;
+        let browser_port = browser_url
+            .port()
+            .ok_or_else(|| CdpError::UnsafeDevToolsEndpoint(browser_websocket_url.into()))?;
+        let discovery_url = discovery_url(browser_websocket_url, meeting_url)?;
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .map_err(CdpError::DiscoveryClient)?;
+        let response = client
+            .put(discovery_url)
+            .send()
+            .await
+            .map_err(CdpError::DiscoveryRequest)?;
+        if !response.status().is_success() {
+            return Err(CdpError::DiscoveryStatus(response.status().as_u16()));
+        }
+        let target: CdpTarget = response.json().await.map_err(CdpError::DiscoveryResponse)?;
+        let page_url =
+            validate_target_websocket_url(&target.web_socket_debugger_url, browser_port)?;
+        let (websocket, _) = connect_async(page_url.as_str())
+            .await
+            .map_err(CdpError::WebSocket)?;
+        Ok(Self {
+            websocket,
+            next_command_id: 1,
+            command_timeout: DEFAULT_COMMAND_TIMEOUT,
+        })
+    }
+
+    pub async fn probe_admission(&mut self) -> Result<AdmissionSnapshot, CdpError> {
+        self.evaluate(ADMISSION_PROBE_EXPRESSION).await
+    }
+
+    pub async fn evaluate<T: DeserializeOwned>(&mut self, expression: &str) -> Result<T, CdpError> {
+        let command_id = self.next_command_id;
+        self.next_command_id = self.next_command_id.saturating_add(1);
+        let command = json!({
+            "id": command_id,
+            "method": "Runtime.evaluate",
+            "params": {
+                "expression": expression,
+                "returnByValue": true,
+                "awaitPromise": true
+            }
+        });
+        self.websocket
+            .send(Message::Text(command.to_string().into()))
+            .await
+            .map_err(CdpError::WebSocket)?;
+
+        let result = tokio::time::timeout(
+            self.command_timeout,
+            receive_command_result(&mut self.websocket, command_id),
+        )
+        .await
+        .map_err(|_| CdpError::CommandTimeout(self.command_timeout))??;
+        let value = result
+            .pointer("/result/value")
+            .cloned()
+            .ok_or(CdpError::MissingEvaluationValue)?;
+        serde_json::from_value(value).map_err(CdpError::EvaluationValue)
+    }
+
+    pub async fn close(mut self) -> Result<(), CdpError> {
+        self.websocket
+            .close(None)
+            .await
+            .map_err(CdpError::WebSocket)
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CdpTarget {
+    #[serde(rename = "webSocketDebuggerUrl")]
+    web_socket_debugger_url: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CdpEnvelope {
+    id: Option<u64>,
+    result: Option<Value>,
+    error: Option<CdpProtocolError>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CdpProtocolError {
+    code: i64,
+    message: String,
+}
+
+async fn receive_command_result(
+    websocket: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+    command_id: u64,
+) -> Result<Value, CdpError> {
+    while let Some(message) = websocket.next().await {
+        let message = message.map_err(CdpError::WebSocket)?;
+        let Message::Text(message) = message else {
+            if matches!(message, Message::Close(_)) {
+                return Err(CdpError::ConnectionClosed);
+            }
+            continue;
+        };
+        let envelope: CdpEnvelope =
+            serde_json::from_str(message.as_ref()).map_err(CdpError::ProtocolMessage)?;
+        if envelope.id != Some(command_id) {
+            continue;
+        }
+        if let Some(error) = envelope.error {
+            return Err(CdpError::Protocol {
+                code: error.code,
+                message: error.message,
+            });
+        }
+        let result = envelope.result.ok_or(CdpError::MissingCommandResult)?;
+        if result.get("exceptionDetails").is_some() {
+            return Err(CdpError::EvaluationException(result));
+        }
+        return Ok(result);
+    }
+    Err(CdpError::ConnectionClosed)
+}
+
+fn discovery_url(
+    browser_websocket_url: &str,
+    meeting_url: &GoogleMeetUrl,
+) -> Result<Url, CdpError> {
+    let browser_url = validate_loopback_websocket_url(browser_websocket_url)?;
+    let port = browser_url
+        .port()
+        .ok_or_else(|| CdpError::UnsafeDevToolsEndpoint(browser_websocket_url.into()))?;
+    let encoded_meeting_url: String =
+        url::form_urlencoded::byte_serialize(meeting_url.as_str().as_bytes()).collect();
+    Url::parse(&format!(
+        "http://127.0.0.1:{port}/json/new?{encoded_meeting_url}"
+    ))
+    .map_err(CdpError::InvalidDiscoveryUrl)
+}
+
+fn validate_loopback_websocket_url(value: &str) -> Result<Url, CdpError> {
+    let url = Url::parse(value).map_err(CdpError::InvalidDevToolsUrl)?;
+    let is_loopback = url
+        .host()
+        .and_then(|host| match host {
+            url::Host::Ipv4(address) => Some(IpAddr::V4(address).is_loopback()),
+            url::Host::Ipv6(address) => Some(IpAddr::V6(address).is_loopback()),
+            url::Host::Domain(_) => None,
+        })
+        .unwrap_or(false);
+    if url.scheme() != "ws"
+        || !is_loopback
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port().is_none()
+    {
+        return Err(CdpError::UnsafeDevToolsEndpoint(value.into()));
+    }
+    Ok(url)
+}
+
+fn validate_target_websocket_url(value: &str, browser_port: u16) -> Result<Url, CdpError> {
+    let url = validate_loopback_websocket_url(value)?;
+    if url.port() != Some(browser_port) {
+        return Err(CdpError::UnexpectedTargetPort {
+            expected: browser_port,
+            actual: url.port(),
+        });
+    }
+    Ok(url)
+}
+
+fn is_google_meet_code(code: &str) -> bool {
+    let mut groups = code.split('-');
+    let valid = [3, 4, 3].into_iter().all(|expected_length| {
+        groups.next().is_some_and(|group| {
+            group.len() == expected_length && group.bytes().all(|byte| byte.is_ascii_lowercase())
+        })
+    });
+    valid && groups.next().is_none()
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CdpError {
+    #[error("invalid Google Meet URL")]
+    InvalidMeetingUrl(#[source] url::ParseError),
+    #[error("only canonical https://meet.google.com/xxx-xxxx-xxx URLs are supported: {0}")]
+    UnsupportedMeetingUrl(String),
+    #[error("invalid Chromium DevTools URL")]
+    InvalidDevToolsUrl(#[source] url::ParseError),
+    #[error("Chromium DevTools must use an explicit loopback WebSocket endpoint: {0}")]
+    UnsafeDevToolsEndpoint(String),
+    #[error("failed to construct Chromium target discovery URL")]
+    InvalidDiscoveryUrl(#[source] url::ParseError),
+    #[error("failed to ask Chromium to open the meeting")]
+    DiscoveryRequest(#[source] reqwest::Error),
+    #[error("failed to create the Chromium discovery client")]
+    DiscoveryClient(#[source] reqwest::Error),
+    #[error("Chromium target discovery returned HTTP {0}")]
+    DiscoveryStatus(u16),
+    #[error("invalid Chromium target discovery response")]
+    DiscoveryResponse(#[source] reqwest::Error),
+    #[error("Chromium target WebSocket used port {actual:?}, expected {expected}")]
+    UnexpectedTargetPort { expected: u16, actual: Option<u16> },
+    #[error("Chromium DevTools WebSocket failed")]
+    WebSocket(#[source] WebSocketError),
+    #[error("invalid Chromium DevTools protocol message")]
+    ProtocolMessage(#[source] serde_json::Error),
+    #[error("Chromium DevTools protocol error {code}: {message}")]
+    Protocol { code: i64, message: String },
+    #[error("Chromium DevTools connection closed")]
+    ConnectionClosed,
+    #[error("Chromium DevTools command timed out after {0:?}")]
+    CommandTimeout(Duration),
+    #[error("Chromium DevTools response did not include a result")]
+    MissingCommandResult,
+    #[error("Chromium JavaScript evaluation failed: {0}")]
+    EvaluationException(Value),
+    #[error("Chromium JavaScript evaluation returned no value")]
+    MissingEvaluationValue,
+    #[error("Chromium JavaScript evaluation returned an unexpected value")]
+    EvaluationValue(#[source] serde_json::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    #[test]
+    fn accepts_only_canonical_google_meet_urls() {
+        assert!(GoogleMeetUrl::parse("https://meet.google.com/abc-defg-hij").is_ok());
+        assert!(GoogleMeetUrl::parse("https://meet.google.com/abc-defg-hij?authuser=1").is_ok());
+
+        for value in [
+            "http://meet.google.com/abc-defg-hij",
+            "https://example.com/abc-defg-hij",
+            "https://meet.google.com/not-a-code",
+            "https://meet.google.com/abc-defg-hij/extra",
+            "https://meet.google.com/abc-defg-hij#fragment",
+        ] {
+            assert!(GoogleMeetUrl::parse(value).is_err(), "accepted {value}");
+        }
+    }
+
+    #[test]
+    fn target_discovery_is_pinned_to_the_loopback_browser_port() {
+        let meeting = GoogleMeetUrl::parse("https://meet.google.com/abc-defg-hij").unwrap();
+        let url = discovery_url("ws://127.0.0.1:49231/devtools/browser/test-id", &meeting).unwrap();
+
+        assert_eq!(url.host_str(), Some("127.0.0.1"));
+        assert_eq!(url.port(), Some(49231));
+        assert_eq!(
+            url.as_str(),
+            "http://127.0.0.1:49231/json/new?https%3A%2F%2Fmeet.google.com%2Fabc-defg-hij"
+        );
+    }
+
+    #[test]
+    fn rejects_non_loopback_devtools_endpoints() {
+        let meeting = GoogleMeetUrl::parse("https://meet.google.com/abc-defg-hij").unwrap();
+
+        for value in [
+            "ws://example.com:9222/devtools/browser/id",
+            "wss://127.0.0.1:9222/devtools/browser/id",
+            "ws://localhost:9222/devtools/browser/id",
+            "ws://127.0.0.1/devtools/browser/id",
+        ] {
+            assert!(discovery_url(value, &meeting).is_err(), "accepted {value}");
+        }
+    }
+
+    #[test]
+    fn target_websocket_cannot_pivot_to_another_loopback_port() {
+        assert!(matches!(
+            validate_target_websocket_url("ws://127.0.0.1:49232/devtools/page/id", 49231),
+            Err(CdpError::UnexpectedTargetPort {
+                expected: 49231,
+                actual: Some(49232)
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn evaluates_the_probe_and_ignores_unrelated_devtools_events() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+            let Message::Text(command) = websocket.next().await.unwrap().unwrap() else {
+                panic!("expected text command")
+            };
+            let command: Value = serde_json::from_str(command.as_ref()).unwrap();
+            assert_eq!(command["method"], "Runtime.evaluate");
+            assert!(
+                command["params"]["expression"]
+                    .as_str()
+                    .unwrap()
+                    .contains("waiting_room_visible")
+            );
+
+            websocket
+                .send(Message::Text(
+                    json!({"method": "Runtime.consoleAPICalled", "params": {}})
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "id": command["id"],
+                        "result": {
+                            "result": {
+                                "type": "object",
+                                "value": {
+                                    "waiting_room_visible": true,
+                                    "consent_prompt_visible": false,
+                                    "explicit_denial_indicator": null,
+                                    "ambiguous_error_indicator": null,
+                                    "visible_recaptcha_challenge": false,
+                                    "participant_tile_labels": [],
+                                    "self_name_nodes": 0,
+                                    "visible_admission_controls": 0
+                                }
+                            }
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        });
+
+        let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let mut page = CdpPage {
+            websocket,
+            next_command_id: 1,
+            command_timeout: Duration::from_secs(1),
+        };
+
+        assert!(page.probe_admission().await.unwrap().waiting_room_visible);
+        server.await.unwrap();
+    }
+}

--- a/enterprise/google-meet-worker/src/lib.rs
+++ b/enterprise/google-meet-worker/src/lib.rs
@@ -1,0 +1,9 @@
+mod admission;
+mod browser;
+mod cdp;
+mod lifecycle;
+
+pub use admission::*;
+pub use browser::*;
+pub use cdp::*;
+pub use lifecycle::*;

--- a/enterprise/google-meet-worker/src/lifecycle.rs
+++ b/enterprise/google-meet-worker/src/lifecycle.rs
@@ -1,0 +1,216 @@
+use std::time::Instant;
+
+use anlg_meeting_capture::{
+    BotState, CaptureEvent, CaptureEventPayload, LifecycleTransition, ProviderMetadata,
+    TerminalReason, TerminalReasonKind, TransitionError,
+};
+use chrono::{DateTime, Utc};
+
+use crate::{AdmissionClassifier, AdmissionOutcome, AdmissionRejectionReason, AdmissionSnapshot};
+
+#[derive(Debug)]
+pub struct WorkerLifecycle {
+    bot_id: String,
+    state: BotState,
+    next_sequence: u64,
+    admission: AdmissionClassifier,
+}
+
+impl WorkerLifecycle {
+    pub fn new(bot_id: impl Into<String>) -> Self {
+        Self {
+            bot_id: bot_id.into(),
+            state: BotState::Queued,
+            next_sequence: 1,
+            admission: AdmissionClassifier::default(),
+        }
+    }
+
+    pub fn state(&self) -> BotState {
+        self.state
+    }
+
+    pub fn launch_started(
+        &mut self,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<CaptureEvent, TransitionError> {
+        self.transition(BotState::Launching, None, occurred_at)
+    }
+
+    pub fn observe_admission(
+        &mut self,
+        snapshot: &AdmissionSnapshot,
+        observed_at: Instant,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<Option<CaptureEvent>, TransitionError> {
+        let outcome = self.admission.classify(snapshot, observed_at);
+        match outcome {
+            AdmissionOutcome::WaitingForAdmission
+            | AdmissionOutcome::ConsentRequired
+            | AdmissionOutcome::CaptchaChallenge { .. }
+                if self.state == BotState::Launching =>
+            {
+                self.transition(BotState::WaitingForAdmission, None, occurred_at)
+                    .map(Some)
+            }
+            AdmissionOutcome::Admitted
+                if matches!(
+                    self.state,
+                    BotState::Launching | BotState::WaitingForAdmission
+                ) =>
+            {
+                self.transition(BotState::Joined, None, occurred_at)
+                    .map(Some)
+            }
+            AdmissionOutcome::Rejected(rejection)
+                if matches!(
+                    self.state,
+                    BotState::Launching | BotState::WaitingForAdmission
+                ) =>
+            {
+                let kind = match rejection.reason {
+                    AdmissionRejectionReason::HostDenied => TerminalReasonKind::AdmissionDenied,
+                    AdmissionRejectionReason::CaptchaUnsolved => {
+                        TerminalReasonKind::AuthenticationFailed
+                    }
+                    AdmissionRejectionReason::ErrorPage => TerminalReasonKind::ProviderError,
+                };
+                self.transition(
+                    BotState::Failed,
+                    Some(TerminalReason {
+                        kind,
+                        message: Some(rejection.indicator),
+                        retryable: false,
+                    }),
+                    occurred_at,
+                )
+                .map(Some)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    pub fn capture_started(
+        &mut self,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<CaptureEvent, TransitionError> {
+        self.transition(BotState::Capturing, None, occurred_at)
+    }
+
+    pub fn transition(
+        &mut self,
+        next: BotState,
+        reason: Option<TerminalReason>,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<CaptureEvent, TransitionError> {
+        let transition: LifecycleTransition = self.state.transition_to(next, reason)?;
+        let sequence = self.next_sequence;
+        self.next_sequence += 1;
+        self.state = next;
+        Ok(CaptureEvent {
+            id: format!("{}:lifecycle:{sequence}", self.bot_id),
+            bot_id: self.bot_id.clone(),
+            sequence,
+            occurred_at,
+            payload: CaptureEventPayload::Lifecycle(transition),
+            metadata: ProviderMetadata::default(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-08-17T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn emits_the_normalized_join_and_capture_path() {
+        let mut lifecycle = WorkerLifecycle::new("bot-1");
+
+        let launching = lifecycle.launch_started(now()).unwrap();
+        let waiting = lifecycle
+            .observe_admission(
+                &AdmissionSnapshot {
+                    waiting_room_visible: true,
+                    ..Default::default()
+                },
+                Instant::now(),
+                now(),
+            )
+            .unwrap()
+            .unwrap();
+        let joined = lifecycle
+            .observe_admission(
+                &AdmissionSnapshot {
+                    participant_tile_labels: vec!["Ada Lovelace".into()],
+                    ..Default::default()
+                },
+                Instant::now(),
+                now(),
+            )
+            .unwrap()
+            .unwrap();
+        let capturing = lifecycle.capture_started(now()).unwrap();
+
+        assert_eq!(launching.sequence, 1);
+        assert_eq!(waiting.sequence, 2);
+        assert_eq!(joined.sequence, 3);
+        assert_eq!(capturing.sequence, 4);
+        assert_eq!(lifecycle.state(), BotState::Capturing);
+    }
+
+    #[test]
+    fn host_denial_is_terminal_and_non_retryable() {
+        let mut lifecycle = WorkerLifecycle::new("bot-1");
+        lifecycle.launch_started(now()).unwrap();
+
+        let event = lifecycle
+            .observe_admission(
+                &AdmissionSnapshot {
+                    explicit_denial_indicator: Some("denied your request".into()),
+                    ..Default::default()
+                },
+                Instant::now(),
+                now(),
+            )
+            .unwrap()
+            .unwrap();
+
+        let CaptureEventPayload::Lifecycle(transition) = event.payload else {
+            panic!("expected lifecycle event")
+        };
+        assert_eq!(transition.to, BotState::Failed);
+        assert_eq!(
+            transition.reason.unwrap().kind,
+            TerminalReasonKind::AdmissionDenied
+        );
+    }
+
+    #[test]
+    fn repeated_waiting_observations_do_not_duplicate_transitions() {
+        let mut lifecycle = WorkerLifecycle::new("bot-1");
+        lifecycle.launch_started(now()).unwrap();
+        let snapshot = AdmissionSnapshot {
+            waiting_room_visible: true,
+            ..Default::default()
+        };
+
+        assert!(
+            lifecycle
+                .observe_admission(&snapshot, Instant::now(), now())
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            lifecycle
+                .observe_admission(&snapshot, Instant::now(), now())
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/enterprise/google-meet-worker/third-party/VEXA-LICENSE
+++ b/enterprise/google-meet-worker/third-party/VEXA-LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## Summary
- add the commercial Rust Google Meet worker crate
- launch and supervise Chromium with explicit sandbox policy and loopback DevTools
- probe and classify lobby admission, denial, captcha, and consent states
- emit normalized provider-neutral lifecycle events
- preserve Vexa Apache-2.0 provenance without a runtime dependency

## Validation
- pnpm fmt:check
- cargo test --manifest-path enterprise/Cargo.toml --workspace --locked
- cargo check --manifest-path enterprise/Cargo.toml --workspace --locked
- cargo clippy --manifest-path enterprise/Cargo.toml --workspace --all-targets --locked -- -D warnings
- node --check enterprise/google-meet-worker/src/admission_probe.js
- python3 .github/scripts/test_check_license_boundary.py
- python3 .github/scripts/check_license_boundary.py

Linear: ANLG-228

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New subprocess and CDP automation around Chromium and Meet join flows is inherently fragile and security-sensitive (loopback DevTools, optional `--no-sandbox`), though mitigations and tests are included; no control-plane wiring yet limits blast radius.
> 
> **Overview**
> Adds a new **`google-meet-worker`** crate to the enterprise workspace as the commercial Google Meet capture foundation (library modules only; no binary entrypoint in this diff).
> 
> **Chromium ownership:** launches and supervises Chromium with explicit sandbox policy, guest incognito vs authenticated profile, locale validation, and loopback-only DevTools (`DevToolsActivePort` → WebSocket URL).
> 
> **CDP layer:** validates canonical Meet URLs, opens a page via `/json/new`, runs `Runtime.evaluate` (including the embedded **`admission_probe.js`**), and pins discovery/target WebSockets to `127.0.0.1` with port matching to limit pivot risk.
> 
> **Admission:** Rust **`AdmissionClassifier`** turns probe snapshots into waiting room, consent, captcha (with grace timeout), admitted, or terminal rejection outcomes; **`WorkerLifecycle`** maps those into **`anlg-meeting-capture`** `CaptureEvent` lifecycle transitions (launch → wait → join → capture / failed with terminal reasons).
> 
> **Provenance:** Vexa-informed browser/admission behavior is documented in **`THIRD_PARTY_NOTICES.md`** with Apache 2.0 license text; workspace lockfile picks up `tokio-tungstenite`, `futures-util`, and `url`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d6879cfc307525dac21876b62b39dcd52c1325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->