### PR TITLE
Add trusted Google Meet lobby input

### DIFF
--- a/enterprise/google-meet-worker/THIRD_PARTY_NOTICES.md
+++ b/enterprise/google-meet-worker/THIRD_PARTY_NOTICES.md
@@ -9,6 +9,9 @@ Reference modules:
 - `core/meetings/modules/remote-browser/src/args.ts`
 - `core/meetings/modules/join/src/browser-args.ts`
 - `core/meetings/modules/join/src/googlemeet/admission.ts`
+- `core/meetings/modules/join/src/googlemeet/humanized/humanizedInteraction.ts`
+- `core/meetings/modules/join/src/googlemeet/humanized/x11Input.ts`
+- `core/meetings/modules/join/src/googlemeet/join.ts`
 - `core/meetings/modules/join/src/googlemeet/selectors.ts`
 
 The Anarlog implementation was rewritten in Rust, reorganized around Anarlog's provider-neutral capture contract, and modified for direct Chromium DevTools ownership. Files carrying an adaptation notice have been changed by Fastrepl, Inc.

--- a/enterprise/google-meet-worker/src/cdp.rs
+++ b/enterprise/google-meet-worker/src/cdp.rs
@@ -125,6 +125,17 @@ impl CdpPage {
             .await
             .map_err(CdpError::WebSocket)
     }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_websocket(
+        websocket: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    ) -> Self {
+        Self {
+            websocket,
+            next_command_id: 1,
+            command_timeout: Duration::from_secs(1),
+        }
+    }
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/enterprise/google-meet-worker/src/lib.rs
+++ b/enterprise/google-meet-worker/src/lib.rs
@@ -2,8 +2,12 @@ mod admission;
 mod browser;
 mod cdp;
 mod lifecycle;
+mod lobby;
+mod x11;
 
 pub use admission::*;
 pub use browser::*;
 pub use cdp::*;
 pub use lifecycle::*;
+pub use lobby::*;
+pub use x11::*;

--- a/enterprise/google-meet-worker/src/lobby.rs
+++ b/enterprise/google-meet-worker/src/lobby.rs
@@ -1,0 +1,408 @@
+// Adapted for Anarlog from Vexa v0.12.18. See ../THIRD_PARTY_NOTICES.md.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::{CdpError, CdpPage, X11Input, X11InputError};
+
+const LOBBY_PROBE_EXPRESSION: &str = include_str!("lobby_probe.js");
+const INSTALL_MOUSE_PROBE: &str = r#"(() => {
+  if (window.__anlgMouseProbeInstalled) return true;
+  window.__anlgMouseProbeInstalled = true;
+  window.__anlgLastMouse = null;
+  window.addEventListener("mousemove", (event) => {
+    window.__anlgLastMouse = { x: event.clientX, y: event.clientY };
+  }, { capture: true });
+  return true;
+})()"#;
+const LAST_MOUSE_POSITION: &str = "window.__anlgLastMouse || null";
+const TARGET_VERIFY_ATTEMPTS: usize = 3;
+const POINTER_SETTLE: Duration = Duration::from_millis(120);
+const CLICK_HOLD: Duration = Duration::from_millis(70);
+const NAME_TYPING_DELAY: Duration = Duration::from_millis(75);
+
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+pub struct PagePoint {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+pub struct LobbyTarget {
+    pub center_x: f64,
+    pub center_y: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct LobbySnapshot {
+    pub screen_x: f64,
+    pub screen_y: f64,
+    pub inner_width: f64,
+    pub inner_height: f64,
+    pub device_pixel_ratio: f64,
+    pub signed_out_lobby: bool,
+    pub name_input: Option<LobbyTarget>,
+    pub join_cta: Option<LobbyTarget>,
+    pub microphone_on: Option<LobbyTarget>,
+    pub camera_on: Option<LobbyTarget>,
+    #[serde(default)]
+    pub cta_candidates: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PointerCalibration {
+    offset_x: f64,
+    offset_y: f64,
+    device_pixel_ratio: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum LobbyTargetKind {
+    NameInput,
+    JoinCta,
+    MicrophoneOn,
+    CameraOn,
+}
+
+impl LobbyTargetKind {
+    fn marker(self) -> &'static str {
+        match self {
+            Self::NameInput => "name_input",
+            Self::JoinCta => "join_cta",
+            Self::MicrophoneOn => "microphone_on",
+            Self::CameraOn => "camera_on",
+        }
+    }
+
+    fn target_in(self, snapshot: &LobbySnapshot) -> Option<LobbyTarget> {
+        match self {
+            Self::NameInput => snapshot.name_input,
+            Self::JoinCta => snapshot.join_cta,
+            Self::MicrophoneOn => snapshot.microphone_on,
+            Self::CameraOn => snapshot.camera_on,
+        }
+    }
+}
+
+pub struct LobbyController<'a> {
+    page: &'a mut CdpPage,
+    input: &'a X11Input,
+    calibration: Option<PointerCalibration>,
+}
+
+impl<'a> LobbyController<'a> {
+    pub fn new(page: &'a mut CdpPage, input: &'a X11Input) -> Self {
+        Self {
+            page,
+            input,
+            calibration: None,
+        }
+    }
+
+    pub async fn join(&mut self, bot_name: &str, authenticated: bool) -> Result<(), LobbyError> {
+        self.input.verify_available().await?;
+        let initial = self.probe().await?;
+        if authenticated && initial.signed_out_lobby {
+            return Err(LobbyError::AuthenticatedProfileSignedOut);
+        }
+        if !authenticated {
+            X11Input::validate_text(bot_name, NAME_TYPING_DELAY)?;
+            self.trusted_click(LobbyTargetKind::NameInput).await?;
+            self.input.type_text(bot_name, NAME_TYPING_DELAY).await?;
+        }
+        self.click_if_present(LobbyTargetKind::MicrophoneOn).await?;
+        self.click_if_present(LobbyTargetKind::CameraOn).await?;
+        self.trusted_click(LobbyTargetKind::JoinCta).await
+    }
+
+    pub async fn probe(&mut self) -> Result<LobbySnapshot, LobbyError> {
+        let snapshot: LobbySnapshot = self.page.evaluate(LOBBY_PROBE_EXPRESSION).await?;
+        validate_geometry(&snapshot)?;
+        Ok(snapshot)
+    }
+
+    async fn click_if_present(&mut self, kind: LobbyTargetKind) -> Result<(), LobbyError> {
+        if kind.target_in(&self.probe().await?).is_some() {
+            self.trusted_click(kind).await?;
+        }
+        Ok(())
+    }
+
+    async fn trusted_click(&mut self, kind: LobbyTargetKind) -> Result<(), LobbyError> {
+        for _ in 0..TARGET_VERIFY_ATTEMPTS {
+            if self.calibration.is_none() {
+                self.calibration = Some(self.calibrate().await?);
+            }
+            let calibration = self.calibration.expect("calibration was initialized");
+            let snapshot = self.probe().await?;
+            let target = kind
+                .target_in(&snapshot)
+                .ok_or(LobbyError::TargetMissing(kind.marker()))?;
+            let target_x = to_x11_coordinate(
+                calibration.offset_x + target.center_x * calibration.device_pixel_ratio,
+            )?;
+            let target_y = to_x11_coordinate(
+                calibration.offset_y + target.center_y * calibration.device_pixel_ratio,
+            )?;
+            self.input.move_absolute(target_x, target_y).await?;
+            tokio::time::sleep(POINTER_SETTLE).await;
+
+            let pointer = self.input.pointer_location().await?;
+            let page_x =
+                (f64::from(pointer.x) - calibration.offset_x) / calibration.device_pixel_ratio;
+            let page_y =
+                (f64::from(pointer.y) - calibration.offset_y) / calibration.device_pixel_ratio;
+            if self.verify_target(kind, page_x, page_y).await? {
+                self.input.button_down().await?;
+                tokio::time::sleep(CLICK_HOLD).await;
+                self.input.button_up().await?;
+                return Ok(());
+            }
+            self.calibration = None;
+        }
+        Err(LobbyError::TargetVerificationFailed(kind.marker()))
+    }
+
+    async fn calibrate(&mut self) -> Result<PointerCalibration, LobbyError> {
+        let _: bool = self.page.evaluate(INSTALL_MOUSE_PROBE).await?;
+        let geometry = self.probe().await?;
+        let probes = [(0.35, 0.4), (0.6, 0.6)];
+        for (x_ratio, y_ratio) in probes {
+            let screen_x = to_x11_coordinate(
+                (geometry.screen_x + geometry.inner_width * x_ratio) * geometry.device_pixel_ratio,
+            )?;
+            let screen_y = to_x11_coordinate(
+                (geometry.screen_y + geometry.inner_height * y_ratio) * geometry.device_pixel_ratio,
+            )?;
+            self.input.move_absolute(screen_x, screen_y).await?;
+            tokio::time::sleep(POINTER_SETTLE).await;
+            let observed: Option<PagePoint> = self.page.evaluate(LAST_MOUSE_POSITION).await?;
+            if let Some(observed) = observed {
+                return Ok(PointerCalibration {
+                    offset_x: f64::from(screen_x) - observed.x * geometry.device_pixel_ratio,
+                    offset_y: f64::from(screen_y) - observed.y * geometry.device_pixel_ratio,
+                    device_pixel_ratio: geometry.device_pixel_ratio,
+                });
+            }
+        }
+        Err(LobbyError::PointerCalibrationUnavailable)
+    }
+
+    async fn verify_target(
+        &mut self,
+        kind: LobbyTargetKind,
+        page_x: f64,
+        page_y: f64,
+    ) -> Result<bool, LobbyError> {
+        let expression = target_verification_expression(kind, page_x, page_y);
+        self.page.evaluate(&expression).await.map_err(Into::into)
+    }
+}
+
+fn target_verification_expression(kind: LobbyTargetKind, page_x: f64, page_y: f64) -> String {
+    let marker = serde_json::to_string(kind.marker()).expect("static marker is serializable");
+    format!(
+        r#"(() => {{
+  const marker = {marker};
+  const target = document.querySelector(`[data-anlg-worker-target="${{marker}}"]`);
+  const hit = document.elementFromPoint({page_x}, {page_y});
+  return Boolean(target && hit && (target === hit || target.contains(hit) || hit.contains(target)));
+}})()"#
+    )
+}
+
+fn validate_geometry(snapshot: &LobbySnapshot) -> Result<(), LobbyError> {
+    let values = [
+        snapshot.screen_x,
+        snapshot.screen_y,
+        snapshot.inner_width,
+        snapshot.inner_height,
+        snapshot.device_pixel_ratio,
+    ];
+    if values.iter().any(|value| !value.is_finite())
+        || snapshot.inner_width <= 0.0
+        || snapshot.inner_height <= 0.0
+        || snapshot.device_pixel_ratio <= 0.0
+    {
+        return Err(LobbyError::InvalidBrowserGeometry);
+    }
+    Ok(())
+}
+
+fn to_x11_coordinate(value: f64) -> Result<i32, LobbyError> {
+    if !value.is_finite() || value < f64::from(i32::MIN) || value > f64::from(i32::MAX) {
+        return Err(LobbyError::InvalidBrowserGeometry);
+    }
+    Ok(value.round() as i32)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LobbyError {
+    #[error(transparent)]
+    Cdp(#[from] CdpError),
+    #[error(transparent)]
+    X11(#[from] X11InputError),
+    #[error("authenticated Chromium profile is signed out")]
+    AuthenticatedProfileSignedOut,
+    #[error("Google Meet lobby target is not available: {0}")]
+    TargetMissing(&'static str),
+    #[error("browser window geometry is invalid")]
+    InvalidBrowserGeometry,
+    #[error("real X11 pointer movement did not reach the browser page")]
+    PointerCalibrationUnavailable,
+    #[error("real X11 pointer could not be verified over lobby target: {0}")]
+    TargetVerificationFailed(&'static str),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use futures_util::{SinkExt, StreamExt};
+    use serde_json::{Value, json};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::{accept_async, connect_async, tungstenite::Message};
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn snapshot() -> LobbySnapshot {
+        LobbySnapshot {
+            screen_x: 0.0,
+            screen_y: 0.0,
+            inner_width: 1280.0,
+            inner_height: 720.0,
+            device_pixel_ratio: 2.0,
+            signed_out_lobby: true,
+            name_input: Some(LobbyTarget {
+                center_x: 640.0,
+                center_y: 300.0,
+            }),
+            join_cta: None,
+            microphone_on: None,
+            camera_on: None,
+            cta_candidates: vec![],
+        }
+    }
+
+    #[test]
+    fn rejects_non_finite_or_zero_browser_geometry() {
+        for invalid in [f64::NAN, f64::INFINITY, 0.0, -1.0] {
+            let mut value = snapshot();
+            value.device_pixel_ratio = invalid;
+            assert!(matches!(
+                validate_geometry(&value),
+                Err(LobbyError::InvalidBrowserGeometry)
+            ));
+        }
+    }
+
+    #[test]
+    fn converts_page_targets_to_checked_x11_coordinates() {
+        assert_eq!(to_x11_coordinate(123.6).unwrap(), 124);
+        assert!(to_x11_coordinate(f64::NAN).is_err());
+        assert!(to_x11_coordinate(f64::from(i32::MAX) + 1.0).is_err());
+    }
+
+    #[test]
+    fn target_verification_uses_the_tagged_element_and_real_pointer_position() {
+        let expression = target_verification_expression(LobbyTargetKind::JoinCta, 123.5, 456.25);
+
+        assert!(expression.contains("const marker = \"join_cta\""));
+        assert!(expression.contains("document.elementFromPoint(123.5, 456.25)"));
+        assert!(expression.contains("data-anlg-worker-target"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn guest_join_uses_verified_xtest_input_for_name_and_cta() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+            while let Some(Ok(Message::Text(command))) = websocket.next().await {
+                let command: Value = serde_json::from_str(command.as_ref()).unwrap();
+                let expression = command["params"]["expression"].as_str().unwrap();
+                let value = if expression.contains("cta_candidates") {
+                    json!({
+                        "screen_x": 0.0,
+                        "screen_y": 0.0,
+                        "inner_width": 1000.0,
+                        "inner_height": 720.0,
+                        "device_pixel_ratio": 1.0,
+                        "signed_out_lobby": true,
+                        "name_input": {"center_x": 100.0, "center_y": 120.0},
+                        "join_cta": {"center_x": 800.0, "center_y": 600.0},
+                        "microphone_on": null,
+                        "camera_on": null,
+                        "cta_candidates": ["Ask to join"]
+                    })
+                } else if expression == LAST_MOUSE_POSITION {
+                    json!({"x": 350.0, "y": 288.0})
+                } else {
+                    json!(true)
+                };
+                websocket
+                    .send(Message::Text(
+                        json!({
+                            "id": command["id"],
+                            "result": {"result": {"type": "object", "value": value}}
+                        })
+                        .to_string()
+                        .into(),
+                    ))
+                    .await
+                    .unwrap();
+            }
+        });
+        let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let mut page = CdpPage::from_test_websocket(websocket);
+
+        let directory = tempfile::tempdir().unwrap();
+        let executable = directory.path().join("xdotool");
+        let pointer = directory.path().join("pointer");
+        let calls = directory.path().join("calls");
+        std::fs::write(&pointer, "0 0\n").unwrap();
+        std::fs::write(
+            &executable,
+            format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> "{}"
+if [ "$1" = "mousemove" ]; then
+  printf '%s %s\n' "$3" "$4" > "{}"
+elif [ "$1" = "getmouselocation" ]; then
+  read x y < "{}"
+  printf 'X=%s\nY=%s\nSCREEN=0\nWINDOW=1\n' "$x" "$y"
+fi
+"#,
+                calls.display(),
+                pointer.display(),
+                pointer.display()
+            ),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions).unwrap();
+        let input = X11Input::new(crate::X11InputConfig {
+            binary: executable,
+            display: ":99".into(),
+            command_timeout: Duration::from_secs(1),
+        })
+        .unwrap();
+
+        LobbyController::new(&mut page, &input)
+            .join("Anarlog Notes", false)
+            .await
+            .unwrap();
+        page.close().await.unwrap();
+        server.await.unwrap();
+
+        let calls = std::fs::read_to_string(calls).unwrap();
+        assert!(calls.contains("type --clearmodifiers --delay 75 -- Anarlog Notes"));
+        assert_eq!(calls.matches("mousedown 1").count(), 2);
+        assert_eq!(calls.matches("mouseup 1").count(), 2);
+    }
+}

--- a/enterprise/google-meet-worker/src/lobby_probe.js
+++ b/enterprise/google-meet-worker/src/lobby_probe.js
@@ -1,0 +1,94 @@
+// Adapted for Anarlog from Vexa v0.12.18. See ../THIRD_PARTY_NOTICES.md.
+(() => {
+  const marker = "data-anlg-worker-target";
+  const visible = (element) => {
+    if (!(element instanceof HTMLElement)) return false;
+    const style = window.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return (
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      Number(style.opacity) !== 0 &&
+      rect.width > 0 &&
+      rect.height > 0
+    );
+  };
+  const firstVisible = (selectors) => {
+    for (const selector of selectors) {
+      for (const element of document.querySelectorAll(selector)) {
+        if (visible(element)) return element;
+      }
+    }
+    return null;
+  };
+  const buttonText = (button) =>
+    (button.textContent || "").replace(/\s+/g, " ").trim();
+  const buttons = Array.from(document.querySelectorAll("button")).filter(
+    (button) =>
+      visible(button) &&
+      !button.disabled &&
+      button.getAttribute("aria-disabled") !== "true",
+  );
+  const exactCtaLabels = ["Ask to join", "Join now", "Switch here", "Join"];
+  let joinCta = buttons.find((button) =>
+    exactCtaLabels.includes(buttonText(button)),
+  );
+  if (!joinCta) {
+    const iconSelector =
+      'i,svg,img,[class*="material-icons"],[class*="material-symbols"],[data-icon-name]';
+    const structural = buttons.filter((button) => {
+      if (
+        button.hasAttribute("aria-label") ||
+        button.querySelector(iconSelector)
+      ) {
+        return false;
+      }
+      const text = buttonText(button);
+      return (
+        text.length > 0 &&
+        text.length <= 48 &&
+        !text.includes("_") &&
+        /\p{L}/u.test(text)
+      );
+    });
+    if (structural.length === 1) joinCta = structural[0];
+  }
+
+  const nameInput = firstVisible([
+    'input[jsname][type="text"]',
+    'div[jscontroller] input[type="text"]',
+    'input[type="text"][aria-label="Your name"]',
+    'input[type="text"]:not([aria-hidden="true"])',
+  ]);
+  const microphone = firstVisible([
+    'button[aria-label*="Turn off microphone" i]',
+  ]);
+  const camera = firstVisible(['button[aria-label*="Turn off camera" i]']);
+
+  for (const element of document.querySelectorAll(`[${marker}]`)) {
+    element.removeAttribute(marker);
+  }
+  const target = (element, kind) => {
+    if (!element) return null;
+    element.setAttribute(marker, kind);
+    const rect = element.getBoundingClientRect();
+    return {
+      center_x: rect.left + rect.width / 2,
+      center_y: rect.top + rect.height / 2,
+    };
+  };
+
+  return {
+    screen_x: window.screenX,
+    screen_y: window.screenY,
+    inner_width: window.innerWidth,
+    inner_height: window.innerHeight,
+    device_pixel_ratio: window.devicePixelRatio || 1,
+    signed_out_lobby: Boolean(nameInput),
+    name_input: target(nameInput, "name_input"),
+    join_cta: target(joinCta, "join_cta"),
+    microphone_on: target(microphone, "microphone_on"),
+    camera_on: target(camera, "camera_on"),
+    cta_candidates: buttons.map(buttonText).filter(Boolean),
+  };
+})();

--- a/enterprise/google-meet-worker/src/x11.rs
+++ b/enterprise/google-meet-worker/src/x11.rs
@@ -1,0 +1,205 @@
+// Adapted for Anarlog from Vexa v0.12.18. See ../THIRD_PARTY_NOTICES.md.
+
+use std::{path::PathBuf, process::Stdio, time::Duration};
+
+#[derive(Debug, Clone)]
+pub struct X11InputConfig {
+    pub binary: PathBuf,
+    pub display: String,
+    pub command_timeout: Duration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PointerLocation {
+    pub x: i32,
+    pub y: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct X11Input {
+    config: X11InputConfig,
+}
+
+impl X11Input {
+    pub fn new(config: X11InputConfig) -> Result<Self, X11InputError> {
+        if config.display.is_empty() || config.display.contains('\0') {
+            return Err(X11InputError::InvalidDisplay);
+        }
+        if config.command_timeout.is_zero() {
+            return Err(X11InputError::InvalidTimeout);
+        }
+        Ok(Self { config })
+    }
+
+    pub async fn verify_available(&self) -> Result<(), X11InputError> {
+        self.run(["getdisplaygeometry"]).await.map(|_| ())
+    }
+
+    pub async fn pointer_location(&self) -> Result<PointerLocation, X11InputError> {
+        let output = self.run(["getmouselocation", "--shell"]).await?;
+        let x = parse_shell_coordinate(&output, "X=")?;
+        let y = parse_shell_coordinate(&output, "Y=")?;
+        Ok(PointerLocation { x, y })
+    }
+
+    pub async fn move_absolute(&self, x: i32, y: i32) -> Result<(), X11InputError> {
+        self.run([
+            "mousemove".to_owned(),
+            "--sync".to_owned(),
+            x.to_string(),
+            y.to_string(),
+        ])
+        .await
+        .map(|_| ())
+    }
+
+    pub async fn button_down(&self) -> Result<(), X11InputError> {
+        self.run(["mousedown", "1"]).await.map(|_| ())
+    }
+
+    pub async fn button_up(&self) -> Result<(), X11InputError> {
+        self.run(["mouseup", "1"]).await.map(|_| ())
+    }
+
+    pub async fn type_text(&self, text: &str, delay: Duration) -> Result<(), X11InputError> {
+        Self::validate_text(text, delay)?;
+        let delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX);
+        self.run([
+            "type".to_owned(),
+            "--clearmodifiers".to_owned(),
+            "--delay".to_owned(),
+            delay_ms.to_string(),
+            "--".to_owned(),
+            text.to_owned(),
+        ])
+        .await
+        .map(|_| ())
+    }
+
+    pub fn validate_text(text: &str, delay: Duration) -> Result<(), X11InputError> {
+        if text.is_empty() || text.chars().count() > 80 || text.chars().any(char::is_control) {
+            return Err(X11InputError::InvalidText);
+        }
+        let delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX);
+        if !(1..=1_000).contains(&delay_ms) {
+            return Err(X11InputError::InvalidTypingDelay(delay));
+        }
+        Ok(())
+    }
+
+    async fn run<I, S>(&self, args: I) -> Result<String, X11InputError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        let mut command = tokio::process::Command::new(&self.config.binary);
+        command
+            .args(args)
+            .env("DISPLAY", &self.config.display)
+            .stdin(Stdio::null())
+            .kill_on_drop(true);
+        let output = tokio::time::timeout(self.config.command_timeout, command.output())
+            .await
+            .map_err(|_| X11InputError::Timeout(self.config.command_timeout))?
+            .map_err(X11InputError::Spawn)?;
+        if !output.status.success() {
+            return Err(X11InputError::CommandFailed {
+                code: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+            });
+        }
+        String::from_utf8(output.stdout).map_err(X11InputError::OutputEncoding)
+    }
+}
+
+fn parse_shell_coordinate(output: &str, prefix: &'static str) -> Result<i32, X11InputError> {
+    output
+        .lines()
+        .find_map(|line| line.strip_prefix(prefix))
+        .and_then(|value| value.parse().ok())
+        .ok_or_else(|| X11InputError::PointerOutput(output.into()))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum X11InputError {
+    #[error("X11 display must be a non-empty string without NUL bytes")]
+    InvalidDisplay,
+    #[error("X11 command timeout must be greater than zero")]
+    InvalidTimeout,
+    #[error("bot display name must contain 1-80 non-control characters")]
+    InvalidText,
+    #[error("X11 typing delay must be between 1ms and 1s, got {0:?}")]
+    InvalidTypingDelay(Duration),
+    #[error("failed to execute xdotool")]
+    Spawn(#[source] std::io::Error),
+    #[error("xdotool timed out after {0:?}")]
+    Timeout(Duration),
+    #[error("xdotool failed with exit code {code:?}: {stderr}")]
+    CommandFailed { code: Option<i32>, stderr: String },
+    #[error("xdotool returned non-UTF-8 output")]
+    OutputEncoding(#[source] std::string::FromUtf8Error),
+    #[error("invalid xdotool pointer output: {0:?}")]
+    PointerOutput(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn validates_names_before_passing_them_to_xdotool() {
+        assert!(matches!(
+            X11Input::validate_text("bad\nname", Duration::from_millis(60)),
+            Err(X11InputError::InvalidText)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uses_argument_safe_xtest_commands_and_parses_the_pointer() {
+        let directory = tempfile::tempdir().unwrap();
+        let executable = directory.path().join("xdotool");
+        let log = directory.path().join("calls");
+        std::fs::write(
+            &executable,
+            format!(
+                r#"#!/bin/sh
+printf '%s|%s\n' "$DISPLAY" "$*" >> "{}"
+if [ "$1" = "getmouselocation" ]; then
+  printf 'X=321\nY=654\nSCREEN=0\nWINDOW=1\n'
+fi
+"#,
+                log.display()
+            ),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions).unwrap();
+
+        let input = X11Input::new(X11InputConfig {
+            binary: executable,
+            display: ":77".into(),
+            command_timeout: Duration::from_secs(1),
+        })
+        .unwrap();
+        input.verify_available().await.unwrap();
+        input.move_absolute(100, 200).await.unwrap();
+        input
+            .type_text("A; $(safe)", Duration::from_millis(60))
+            .await
+            .unwrap();
+        assert_eq!(
+            input.pointer_location().await.unwrap(),
+            PointerLocation { x: 321, y: 654 }
+        );
+
+        let calls = std::fs::read_to_string(log).unwrap();
+        assert!(calls.contains(":77|mousemove --sync 100 200"));
+        assert!(calls.contains(":77|type --clearmodifiers --delay 60 -- A; $(safe)"));
+        assert!(calls.contains(":77|getmouselocation --shell"));
+    }
+}


### PR DESCRIPTION
## Summary
- drive lobby input through X11/XTEST so Chromium receives trusted pointer and keyboard events
- calibrate browser page coordinates against the real X11 pointer
- verify the pointer is over the latest tagged DOM target before clicking
- fail closed for ambiguous CTAs and signed-out authenticated profiles
- type guest names without a shell and enforce bounded input
- extend Apache-2.0 Vexa provenance for the source-informed behavior

## Validation
- pnpm fmt:check
- cargo test --manifest-path enterprise/Cargo.toml --workspace --locked
- cargo check --manifest-path enterprise/Cargo.toml --workspace --locked
- cargo clippy --manifest-path enterprise/Cargo.toml --workspace --all-targets --locked -- -D warnings
- node --check enterprise/google-meet-worker/src/lobby_probe.js
- jsdom exact and ambiguous CTA fixtures
- python3 .github/scripts/test_check_license_boundary.py
- python3 .github/scripts/check_license_boundary.py

Linear: ANLG-228

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New meeting-join automation depends on X11/xdotool and fragile Meet DOM heuristics; mis-clicks or selector drift could block joins, but scope is isolated to the worker crate with validation and fail-closed paths.
> 
> **Overview**
> Adds **trusted Google Meet lobby automation** so the worker can join using real X11 pointer/keyboard events (via `xdotool`) instead of synthetic CDP-only input.
> 
> **`LobbyController`** probes the lobby through CDP (`lobby_probe.js`), tags targets with `data-anlg-worker-target`, calibrates page vs screen coordinates using a mouse-move probe, and only clicks after `elementFromPoint` confirms the pointer is over the tagged control. Guest flow types a bounded display name; authenticated profiles **fail closed** if the signed-out name lobby appears. Optional mic/camera “on” controls are clicked when present.
> 
> New **`X11Input`** wraps xdotool with timeouts, display validation, and argument-safe typing (no shell). **`CdpPage::from_test_websocket`** supports integration tests with a mock CDP server and fake xdotool.
> 
> Vexa Apache-2.0 provenance in `THIRD_PARTY_NOTICES.md` is extended for the adapted humanized join/x11 modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 096bdbbe7928f31beb92c4de0a0234f0ca8f8014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->