### PR TITLE
Bound Google Meet lifecycle and cleanup

### DIFF
--- a/enterprise/google-meet-worker/Cargo.toml
+++ b/enterprise/google-meet-worker/Cargo.toml
@@ -13,7 +13,7 @@ reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["fs", "macros", "net", "process", "rt", "time"] }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt", "sync", "time"] }
 tokio-tungstenite.workspace = true
 url.workspace = true
 

--- a/enterprise/google-meet-worker/THIRD_PARTY_NOTICES.md
+++ b/enterprise/google-meet-worker/THIRD_PARTY_NOTICES.md
@@ -13,6 +13,7 @@ Reference modules:
 - `core/meetings/modules/join/src/googlemeet/humanized/x11Input.ts`
 - `core/meetings/modules/join/src/googlemeet/join.ts`
 - `core/meetings/modules/join/src/googlemeet/selectors.ts`
+- `core/meetings/modules/join/src/googlemeet/removal.ts`
 
 The Anarlog implementation was rewritten in Rust, reorganized around Anarlog's provider-neutral capture contract, and modified for direct Chromium DevTools ownership. Files carrying an adaptation notice have been changed by Fastrepl, Inc.
 

--- a/enterprise/google-meet-worker/src/admission_monitor.rs
+++ b/enterprise/google-meet-worker/src/admission_monitor.rs
@@ -1,0 +1,194 @@
+use std::{future::Future, time::Duration};
+
+use anlg_meeting_capture::{BotState, CaptureEvent, TransitionError};
+use chrono::Utc;
+use tokio::time::Instant;
+
+use crate::{AdmissionSnapshot, CdpError, CdpPage, WorkerLifecycle};
+
+pub const DEFAULT_ADMISSION_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+pub const DEFAULT_ADMISSION_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdmissionMonitorConfig {
+    pub timeout: Duration,
+    pub poll_interval: Duration,
+}
+
+impl Default for AdmissionMonitorConfig {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_ADMISSION_TIMEOUT,
+            poll_interval: DEFAULT_ADMISSION_POLL_INTERVAL,
+        }
+    }
+}
+
+impl AdmissionMonitorConfig {
+    pub fn validate(self) -> Result<Self, AdmissionMonitorError> {
+        if self.timeout.is_zero()
+            || self.poll_interval.is_zero()
+            || self.poll_interval > self.timeout
+        {
+            return Err(AdmissionMonitorError::InvalidConfig {
+                timeout: self.timeout,
+                poll_interval: self.poll_interval,
+            });
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AdmissionMonitor {
+    config: AdmissionMonitorConfig,
+}
+
+impl AdmissionMonitor {
+    pub fn new(config: AdmissionMonitorConfig) -> Result<Self, AdmissionMonitorError> {
+        Ok(Self {
+            config: config.validate()?,
+        })
+    }
+
+    pub async fn wait(
+        &self,
+        page: &mut CdpPage,
+        lifecycle: &mut WorkerLifecycle,
+    ) -> Result<Vec<CaptureEvent>, AdmissionMonitorError> {
+        self.wait_with_source(page, lifecycle).await
+    }
+
+    async fn wait_with_source<S: AdmissionProbeSource>(
+        &self,
+        source: &mut S,
+        lifecycle: &mut WorkerLifecycle,
+    ) -> Result<Vec<CaptureEvent>, AdmissionMonitorError> {
+        let started_at = Instant::now();
+        let deadline = started_at + self.config.timeout;
+        let mut events = Vec::new();
+        loop {
+            let snapshot = source.probe().await?;
+            let observed_at = Instant::now();
+            if let Some(event) =
+                lifecycle.observe_admission(&snapshot, observed_at.into_std(), Utc::now())?
+            {
+                events.push(event);
+            }
+            if matches!(lifecycle.state(), BotState::Joined | BotState::Failed) {
+                return Ok(events);
+            }
+            if observed_at >= deadline {
+                events.push(lifecycle.admission_timed_out(Utc::now())?);
+                return Ok(events);
+            }
+            tokio::time::sleep(self.config.poll_interval.min(deadline - observed_at)).await;
+        }
+    }
+}
+
+trait AdmissionProbeSource {
+    fn probe(&mut self) -> impl Future<Output = Result<AdmissionSnapshot, CdpError>> + Send;
+}
+
+impl AdmissionProbeSource for CdpPage {
+    async fn probe(&mut self) -> Result<AdmissionSnapshot, CdpError> {
+        self.probe_admission().await
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AdmissionMonitorError {
+    #[error(
+        "admission timeout and poll interval must be non-zero, and interval cannot exceed timeout (timeout {timeout:?}, interval {poll_interval:?})"
+    )]
+    InvalidConfig {
+        timeout: Duration,
+        poll_interval: Duration,
+    },
+    #[error(transparent)]
+    Cdp(#[from] CdpError),
+    #[error(transparent)]
+    Transition(#[from] TransitionError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::VecDeque;
+
+    struct Snapshots(VecDeque<AdmissionSnapshot>);
+
+    impl AdmissionProbeSource for Snapshots {
+        async fn probe(&mut self) -> Result<AdmissionSnapshot, CdpError> {
+            Ok(self.0.pop_front().unwrap_or_default())
+        }
+    }
+
+    fn monitor(timeout: Duration, poll_interval: Duration) -> AdmissionMonitor {
+        AdmissionMonitor::new(AdmissionMonitorConfig {
+            timeout,
+            poll_interval,
+        })
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn emits_waiting_then_joined_without_resetting_the_deadline() {
+        let mut source = Snapshots(VecDeque::from([
+            AdmissionSnapshot {
+                waiting_room_visible: true,
+                ..Default::default()
+            },
+            AdmissionSnapshot {
+                participant_tile_labels: vec!["Ada Lovelace".into()],
+                ..Default::default()
+            },
+        ]));
+        let mut lifecycle = WorkerLifecycle::new("bot-1");
+        lifecycle.launch_started(Utc::now()).unwrap();
+
+        let events = monitor(Duration::from_secs(1), Duration::from_millis(1))
+            .wait_with_source(&mut source, &mut lifecycle)
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(lifecycle.state(), BotState::Joined);
+    }
+
+    #[tokio::test]
+    async fn performs_a_final_probe_then_emits_retryable_timeout() {
+        let mut source = Snapshots(VecDeque::new());
+        let mut lifecycle = WorkerLifecycle::new("bot-1");
+        lifecycle.launch_started(Utc::now()).unwrap();
+
+        let events = monitor(Duration::from_millis(2), Duration::from_millis(1))
+            .wait_with_source(&mut source, &mut lifecycle)
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(lifecycle.state(), BotState::Failed);
+    }
+
+    #[test]
+    fn rejects_invalid_deadline_configuration() {
+        for config in [
+            AdmissionMonitorConfig {
+                timeout: Duration::ZERO,
+                poll_interval: Duration::from_secs(1),
+            },
+            AdmissionMonitorConfig {
+                timeout: Duration::from_secs(1),
+                poll_interval: Duration::from_secs(2),
+            },
+        ] {
+            assert!(matches!(
+                AdmissionMonitor::new(config),
+                Err(AdmissionMonitorError::InvalidConfig { .. })
+            ));
+        }
+    }
+}

--- a/enterprise/google-meet-worker/src/lib.rs
+++ b/enterprise/google-meet-worker/src/lib.rs
@@ -1,13 +1,21 @@
 mod admission;
+mod admission_monitor;
 mod browser;
 mod cdp;
 mod lifecycle;
 mod lobby;
+mod runtime;
+mod runtime_monitor;
+mod session;
 mod x11;
 
 pub use admission::*;
+pub use admission_monitor::*;
 pub use browser::*;
 pub use cdp::*;
 pub use lifecycle::*;
 pub use lobby::*;
+pub use runtime::*;
+pub use runtime_monitor::*;
+pub use session::*;
 pub use x11::*;

--- a/enterprise/google-meet-worker/src/lifecycle.rs
+++ b/enterprise/google-meet-worker/src/lifecycle.rs
@@ -6,7 +6,10 @@ use anlg_meeting_capture::{
 };
 use chrono::{DateTime, Utc};
 
-use crate::{AdmissionClassifier, AdmissionOutcome, AdmissionRejectionReason, AdmissionSnapshot};
+use crate::{
+    AdmissionClassifier, AdmissionOutcome, AdmissionRejectionReason, AdmissionSnapshot,
+    RuntimeClassifier, RuntimeOutcome, RuntimeSnapshot,
+};
 
 #[derive(Debug)]
 pub struct WorkerLifecycle {
@@ -14,6 +17,7 @@ pub struct WorkerLifecycle {
     state: BotState,
     next_sequence: u64,
     admission: AdmissionClassifier,
+    runtime: RuntimeClassifier,
 }
 
 impl WorkerLifecycle {
@@ -23,6 +27,7 @@ impl WorkerLifecycle {
             state: BotState::Queued,
             next_sequence: 1,
             admission: AdmissionClassifier::default(),
+            runtime: RuntimeClassifier::default(),
         }
     }
 
@@ -95,6 +100,101 @@ impl WorkerLifecycle {
         occurred_at: DateTime<Utc>,
     ) -> Result<CaptureEvent, TransitionError> {
         self.transition(BotState::Capturing, None, occurred_at)
+    }
+
+    pub fn admission_timed_out(
+        &mut self,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<CaptureEvent, TransitionError> {
+        self.transition(
+            BotState::Failed,
+            Some(TerminalReason {
+                kind: TerminalReasonKind::AdmissionTimeout,
+                message: Some("Google Meet host did not admit the bot before the deadline".into()),
+                retryable: true,
+            }),
+            occurred_at,
+        )
+    }
+
+    pub fn observe_runtime(
+        &mut self,
+        snapshot: &RuntimeSnapshot,
+        observed_at: Instant,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<Option<CaptureEvent>, TransitionError> {
+        if !matches!(self.state, BotState::Joined | BotState::Capturing) {
+            return Ok(None);
+        }
+        match self.runtime.classify(snapshot, observed_at) {
+            RuntimeOutcome::Removed(indicator) => self
+                .transition(
+                    BotState::Failed,
+                    Some(TerminalReason {
+                        kind: TerminalReasonKind::RemovedFromMeeting,
+                        message: Some(indicator),
+                        retryable: false,
+                    }),
+                    occurred_at,
+                )
+                .map(Some),
+            RuntimeOutcome::MeetingEnded(indicator) => self
+                .transition(
+                    BotState::Completed,
+                    Some(TerminalReason {
+                        kind: TerminalReasonKind::MeetingEnded,
+                        message: Some(indicator),
+                        retryable: false,
+                    }),
+                    occurred_at,
+                )
+                .map(Some),
+            RuntimeOutcome::NetworkLost(indicator) => self
+                .transition(
+                    BotState::Failed,
+                    Some(TerminalReason {
+                        kind: TerminalReasonKind::NetworkLost,
+                        message: Some(indicator),
+                        retryable: true,
+                    }),
+                    occurred_at,
+                )
+                .map(Some),
+            RuntimeOutcome::StateLost => self
+                .transition(
+                    BotState::Failed,
+                    Some(TerminalReason {
+                        kind: TerminalReasonKind::ProviderError,
+                        message: Some(
+                            "Google Meet runtime indicators disappeared beyond the grace period"
+                                .into(),
+                        ),
+                        retryable: true,
+                    }),
+                    occurred_at,
+                )
+                .map(Some),
+            RuntimeOutcome::Active
+            | RuntimeOutcome::ConnectionInterrupted { .. }
+            | RuntimeOutcome::Unknown { .. } => Ok(None),
+        }
+    }
+
+    pub fn stopped_by_request(
+        &mut self,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<Vec<CaptureEvent>, TransitionError> {
+        let stopping = self.transition(BotState::Stopping, None, occurred_at)?;
+        let completed = self.transition(
+            BotState::Completed,
+            Some(TerminalReason {
+                kind: TerminalReasonKind::StoppedByRequest,
+                message: None,
+                retryable: false,
+            }),
+            occurred_at,
+        )?;
+        Ok(vec![stopping, completed])
     }
 
     pub fn transition(
@@ -212,5 +312,86 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn admission_timeout_is_terminal_and_retry_honest() {
+        let mut lifecycle = WorkerLifecycle::new("bot-1");
+        lifecycle.launch_started(now()).unwrap();
+
+        let event = lifecycle.admission_timed_out(now()).unwrap();
+        let CaptureEventPayload::Lifecycle(transition) = event.payload else {
+            panic!("expected lifecycle event")
+        };
+        let reason = transition.reason.unwrap();
+        assert_eq!(reason.kind, TerminalReasonKind::AdmissionTimeout);
+        assert!(reason.retryable);
+    }
+
+    #[test]
+    fn removal_and_meeting_end_map_to_distinct_terminal_reasons() {
+        for (snapshot, expected_state, expected_reason) in [
+            (
+                RuntimeSnapshot {
+                    removal_indicator: Some("you were removed".into()),
+                    ..Default::default()
+                },
+                BotState::Failed,
+                TerminalReasonKind::RemovedFromMeeting,
+            ),
+            (
+                RuntimeSnapshot {
+                    meeting_ended_indicator: Some("meeting ended".into()),
+                    ..Default::default()
+                },
+                BotState::Completed,
+                TerminalReasonKind::MeetingEnded,
+            ),
+        ] {
+            let mut lifecycle = WorkerLifecycle::new("bot-1");
+            lifecycle.launch_started(now()).unwrap();
+            lifecycle
+                .observe_admission(
+                    &AdmissionSnapshot {
+                        self_name_nodes: 1,
+                        ..Default::default()
+                    },
+                    Instant::now(),
+                    now(),
+                )
+                .unwrap();
+            lifecycle.capture_started(now()).unwrap();
+
+            let event = lifecycle
+                .observe_runtime(&snapshot, Instant::now(), now())
+                .unwrap()
+                .unwrap();
+            let CaptureEventPayload::Lifecycle(transition) = event.payload else {
+                panic!("expected lifecycle event")
+            };
+            assert_eq!(transition.to, expected_state);
+            assert_eq!(transition.reason.unwrap().kind, expected_reason);
+        }
+    }
+
+    #[test]
+    fn requested_stop_emits_stopping_before_completed() {
+        let mut lifecycle = WorkerLifecycle::new("bot-1");
+        lifecycle.launch_started(now()).unwrap();
+        lifecycle
+            .observe_admission(
+                &AdmissionSnapshot {
+                    self_name_nodes: 1,
+                    ..Default::default()
+                },
+                Instant::now(),
+                now(),
+            )
+            .unwrap();
+        lifecycle.capture_started(now()).unwrap();
+
+        let events = lifecycle.stopped_by_request(now()).unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(lifecycle.state(), BotState::Completed);
     }
 }

--- a/enterprise/google-meet-worker/src/lobby.rs
+++ b/enterprise/google-meet-worker/src/lobby.rs
@@ -389,7 +389,7 @@ fi
         let input = X11Input::new(crate::X11InputConfig {
             binary: executable,
             display: ":99".into(),
-            command_timeout: Duration::from_secs(1),
+            command_timeout: Duration::from_secs(5),
         })
         .unwrap();
 

--- a/enterprise/google-meet-worker/src/runtime.rs
+++ b/enterprise/google-meet-worker/src/runtime.rs
@@ -1,0 +1,200 @@
+// Adapted for Anarlog from Vexa v0.12.18. See ../THIRD_PARTY_NOTICES.md.
+
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{CdpError, CdpPage};
+
+pub const DEFAULT_CONNECTION_GRACE: Duration = Duration::from_secs(30);
+pub const DEFAULT_RUNTIME_UNKNOWN_GRACE: Duration = Duration::from_secs(30);
+pub const RUNTIME_PROBE_EXPRESSION: &str = include_str!("runtime_probe.js");
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeSnapshot {
+    pub removal_indicator: Option<String>,
+    pub meeting_ended_indicator: Option<String>,
+    pub connection_problem_indicator: Option<String>,
+    #[serde(default)]
+    pub participant_tile_labels: Vec<String>,
+    pub self_name_nodes: usize,
+    pub visible_meeting_controls: usize,
+}
+
+impl RuntimeSnapshot {
+    fn has_active_signal(&self) -> bool {
+        self.self_name_nodes > 0
+            || self.visible_meeting_controls > 0
+            || self.participant_tile_labels.iter().any(|label| {
+                let label = label.trim().to_lowercase();
+                !label.is_empty()
+                    && !label.contains("visual_effects")
+                    && !label.contains("backgrounds and effects")
+            })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeOutcome {
+    Active,
+    ConnectionInterrupted { remaining: Duration },
+    Removed(String),
+    MeetingEnded(String),
+    NetworkLost(String),
+    Unknown { remaining: Duration },
+    StateLost,
+}
+
+#[derive(Debug)]
+pub struct RuntimeClassifier {
+    connection_grace: Duration,
+    connection_problem_since: Option<Instant>,
+    unknown_grace: Duration,
+    unknown_since: Option<Instant>,
+}
+
+impl Default for RuntimeClassifier {
+    fn default() -> Self {
+        Self::with_grace(DEFAULT_CONNECTION_GRACE, DEFAULT_RUNTIME_UNKNOWN_GRACE)
+    }
+}
+
+impl RuntimeClassifier {
+    pub fn new(connection_grace: Duration) -> Self {
+        Self::with_grace(connection_grace, DEFAULT_RUNTIME_UNKNOWN_GRACE)
+    }
+
+    pub fn with_grace(connection_grace: Duration, unknown_grace: Duration) -> Self {
+        Self {
+            connection_grace,
+            connection_problem_since: None,
+            unknown_grace,
+            unknown_since: None,
+        }
+    }
+
+    pub fn classify(&mut self, snapshot: &RuntimeSnapshot, now: Instant) -> RuntimeOutcome {
+        if let Some(indicator) = snapshot.removal_indicator.as_ref() {
+            self.connection_problem_since = None;
+            self.unknown_since = None;
+            return RuntimeOutcome::Removed(indicator.clone());
+        }
+        if let Some(indicator) = snapshot.meeting_ended_indicator.as_ref() {
+            self.connection_problem_since = None;
+            self.unknown_since = None;
+            return RuntimeOutcome::MeetingEnded(indicator.clone());
+        }
+        if let Some(indicator) = snapshot.connection_problem_indicator.as_ref() {
+            self.unknown_since = None;
+            let since = *self.connection_problem_since.get_or_insert(now);
+            let elapsed = now.saturating_duration_since(since);
+            if elapsed < self.connection_grace {
+                return RuntimeOutcome::ConnectionInterrupted {
+                    remaining: self.connection_grace - elapsed,
+                };
+            }
+            self.connection_problem_since = None;
+            return RuntimeOutcome::NetworkLost(indicator.clone());
+        }
+        self.connection_problem_since = None;
+        if snapshot.has_active_signal() {
+            self.unknown_since = None;
+            RuntimeOutcome::Active
+        } else {
+            let since = *self.unknown_since.get_or_insert(now);
+            let elapsed = now.saturating_duration_since(since);
+            if elapsed < self.unknown_grace {
+                RuntimeOutcome::Unknown {
+                    remaining: self.unknown_grace - elapsed,
+                }
+            } else {
+                self.unknown_since = None;
+                RuntimeOutcome::StateLost
+            }
+        }
+    }
+}
+
+impl CdpPage {
+    pub async fn probe_runtime(&mut self) -> Result<RuntimeSnapshot, CdpError> {
+        self.evaluate(RUNTIME_PROBE_EXPRESSION).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_removal_wins_over_ended_and_connection_copy() {
+        let mut classifier = RuntimeClassifier::default();
+        assert_eq!(
+            classifier.classify(
+                &RuntimeSnapshot {
+                    removal_indicator: Some("you were removed".into()),
+                    meeting_ended_indicator: Some("meeting ended".into()),
+                    connection_problem_indicator: Some("connection lost".into()),
+                    ..Default::default()
+                },
+                Instant::now()
+            ),
+            RuntimeOutcome::Removed("you were removed".into())
+        );
+    }
+
+    #[test]
+    fn transient_reconnection_has_a_bounded_grace_period() {
+        let grace = Duration::from_secs(30);
+        let started = Instant::now();
+        let snapshot = RuntimeSnapshot {
+            connection_problem_indicator: Some("reconnecting".into()),
+            ..Default::default()
+        };
+        let mut classifier = RuntimeClassifier::new(grace);
+
+        assert_eq!(
+            classifier.classify(&snapshot, started),
+            RuntimeOutcome::ConnectionInterrupted { remaining: grace }
+        );
+        assert_eq!(
+            classifier.classify(&snapshot, started + grace),
+            RuntimeOutcome::NetworkLost("reconnecting".into())
+        );
+    }
+
+    #[test]
+    fn effects_preview_is_not_an_active_meeting_signal() {
+        let mut classifier = RuntimeClassifier::default();
+        let outcome = classifier.classify(
+            &RuntimeSnapshot {
+                participant_tile_labels: vec!["visual_effects Backgrounds and effects".into()],
+                ..Default::default()
+            },
+            Instant::now(),
+        );
+
+        assert_eq!(
+            outcome,
+            RuntimeOutcome::Unknown {
+                remaining: DEFAULT_RUNTIME_UNKNOWN_GRACE
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_runtime_state_cannot_poll_forever() {
+        let grace = Duration::from_secs(30);
+        let started = Instant::now();
+        let mut classifier = RuntimeClassifier::with_grace(grace, grace);
+        let snapshot = RuntimeSnapshot::default();
+
+        assert!(matches!(
+            classifier.classify(&snapshot, started),
+            RuntimeOutcome::Unknown { remaining } if remaining == grace
+        ));
+        assert_eq!(
+            classifier.classify(&snapshot, started + grace),
+            RuntimeOutcome::StateLost
+        );
+    }
+}

--- a/enterprise/google-meet-worker/src/runtime_monitor.rs
+++ b/enterprise/google-meet-worker/src/runtime_monitor.rs
@@ -1,0 +1,171 @@
+use std::{future::Future, time::Duration};
+
+use anlg_meeting_capture::{CaptureEvent, TransitionError};
+use chrono::Utc;
+use tokio::sync::watch;
+
+use crate::{CdpError, CdpPage, RuntimeSnapshot, WorkerLifecycle};
+
+pub const DEFAULT_RUNTIME_POLL_INTERVAL: Duration = Duration::from_millis(1500);
+
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeMonitor {
+    poll_interval: Duration,
+}
+
+impl RuntimeMonitor {
+    pub fn new(poll_interval: Duration) -> Result<Self, RuntimeMonitorError> {
+        if poll_interval.is_zero() {
+            return Err(RuntimeMonitorError::InvalidPollInterval);
+        }
+        Ok(Self { poll_interval })
+    }
+
+    pub async fn run(
+        &self,
+        page: &mut CdpPage,
+        lifecycle: &mut WorkerLifecycle,
+        stop: watch::Receiver<bool>,
+    ) -> Result<Vec<CaptureEvent>, RuntimeMonitorError> {
+        self.run_with_source(page, lifecycle, stop).await
+    }
+
+    async fn run_with_source<S: RuntimeProbeSource>(
+        &self,
+        source: &mut S,
+        lifecycle: &mut WorkerLifecycle,
+        mut stop: watch::Receiver<bool>,
+    ) -> Result<Vec<CaptureEvent>, RuntimeMonitorError> {
+        let mut events = Vec::new();
+        loop {
+            if *stop.borrow() {
+                events.extend(lifecycle.stopped_by_request(Utc::now())?);
+                return Ok(events);
+            }
+            let snapshot = source.probe().await?;
+            if let Some(event) =
+                lifecycle.observe_runtime(&snapshot, std::time::Instant::now(), Utc::now())?
+            {
+                events.push(event);
+            }
+            if lifecycle.state().is_terminal() {
+                return Ok(events);
+            }
+
+            tokio::select! {
+                _ = tokio::time::sleep(self.poll_interval) => {}
+                result = stop.changed() => {
+                    if result.is_err() || *stop.borrow() {
+                        events.extend(lifecycle.stopped_by_request(Utc::now())?);
+                        return Ok(events);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Default for RuntimeMonitor {
+    fn default() -> Self {
+        Self {
+            poll_interval: DEFAULT_RUNTIME_POLL_INTERVAL,
+        }
+    }
+}
+
+trait RuntimeProbeSource {
+    fn probe(&mut self) -> impl Future<Output = Result<RuntimeSnapshot, CdpError>> + Send;
+}
+
+impl RuntimeProbeSource for CdpPage {
+    async fn probe(&mut self) -> Result<RuntimeSnapshot, CdpError> {
+        self.probe_runtime().await
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeMonitorError {
+    #[error("runtime poll interval must be greater than zero")]
+    InvalidPollInterval,
+    #[error(transparent)]
+    Cdp(#[from] CdpError),
+    #[error(transparent)]
+    Transition(#[from] TransitionError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::VecDeque;
+
+    use anlg_meeting_capture::BotState;
+
+    use crate::AdmissionSnapshot;
+
+    struct Snapshots(VecDeque<RuntimeSnapshot>);
+
+    impl RuntimeProbeSource for Snapshots {
+        async fn probe(&mut self) -> Result<RuntimeSnapshot, CdpError> {
+            Ok(self.0.pop_front().unwrap_or_default())
+        }
+    }
+
+    fn capturing_lifecycle() -> WorkerLifecycle {
+        let mut lifecycle = WorkerLifecycle::new("bot-1");
+        lifecycle.launch_started(Utc::now()).unwrap();
+        lifecycle
+            .observe_admission(
+                &AdmissionSnapshot {
+                    self_name_nodes: 1,
+                    ..Default::default()
+                },
+                std::time::Instant::now(),
+                Utc::now(),
+            )
+            .unwrap();
+        lifecycle.capture_started(Utc::now()).unwrap();
+        lifecycle
+    }
+
+    #[tokio::test]
+    async fn meeting_end_finishes_the_monitor() {
+        let mut source = Snapshots(VecDeque::from([RuntimeSnapshot {
+            meeting_ended_indicator: Some("meeting ended".into()),
+            ..Default::default()
+        }]));
+        let mut lifecycle = capturing_lifecycle();
+        let (_stop_tx, stop_rx) = watch::channel(false);
+
+        let events = RuntimeMonitor::default()
+            .run_with_source(&mut source, &mut lifecycle, stop_rx)
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(lifecycle.state(), BotState::Completed);
+    }
+
+    #[tokio::test]
+    async fn explicit_stop_completes_without_an_extra_probe() {
+        let mut source = Snapshots(VecDeque::new());
+        let mut lifecycle = capturing_lifecycle();
+        let (_stop_tx, stop_rx) = watch::channel(true);
+
+        let events = RuntimeMonitor::default()
+            .run_with_source(&mut source, &mut lifecycle, stop_rx)
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(lifecycle.state(), BotState::Completed);
+    }
+
+    #[test]
+    fn rejects_zero_poll_interval() {
+        assert!(matches!(
+            RuntimeMonitor::new(Duration::ZERO),
+            Err(RuntimeMonitorError::InvalidPollInterval)
+        ));
+    }
+}

--- a/enterprise/google-meet-worker/src/runtime_probe.js
+++ b/enterprise/google-meet-worker/src/runtime_probe.js
@@ -1,0 +1,65 @@
+// Adapted for Anarlog from Vexa v0.12.18. See ../THIRD_PARTY_NOTICES.md.
+(() => {
+  const visible = (element) => {
+    if (!(element instanceof HTMLElement)) return false;
+    const style = window.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return (
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      Number(style.opacity) !== 0 &&
+      rect.width > 0 &&
+      rect.height > 0
+    );
+  };
+  const visibleText = (copies) => {
+    const lowered = copies.map((copy) => copy.toLowerCase());
+    for (const element of document.querySelectorAll(
+      'button,div,p,span,[role="dialog"],[role="alertdialog"]',
+    )) {
+      if (!visible(element)) continue;
+      const text = (element.textContent || "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .toLowerCase();
+      const match = lowered.find((copy) => text.includes(copy));
+      if (match) return match;
+    }
+    return null;
+  };
+  const visibleCount = (selector) =>
+    Array.from(document.querySelectorAll(selector)).filter(visible).length;
+
+  return {
+    removal_indicator: visibleText([
+      "you've been removed from this meeting",
+      "you have been removed from this meeting",
+      "you were removed from the meeting",
+      "removed you from the meeting",
+    ]),
+    meeting_ended_indicator: visibleText([
+      "meeting ended",
+      "this meeting has ended",
+      "call ended",
+      "you left the meeting",
+    ]),
+    connection_problem_indicator: visibleText([
+      "connection lost",
+      "unable to connect",
+      "reconnecting",
+    ]),
+    participant_tile_labels: Array.from(
+      document.querySelectorAll("[data-participant-id]"),
+    ).map(
+      (element) =>
+        element.getAttribute("aria-label") ||
+        (element.textContent || "").trim(),
+    ),
+    self_name_nodes: document.querySelectorAll("[data-self-name]").length,
+    visible_meeting_controls:
+      visibleCount('button[aria-label*="leave call" i]') +
+      visibleCount('button[aria-label*="leave meeting" i]') +
+      visibleCount('button[aria-label*="people" i]') +
+      visibleCount('button[aria-label*="chat" i]'),
+  };
+})();

--- a/enterprise/google-meet-worker/src/session.rs
+++ b/enterprise/google-meet-worker/src/session.rs
@@ -1,0 +1,184 @@
+use crate::{
+    CdpError, CdpPage, ChromiumLaunchConfig, ChromiumLaunchError, ChromiumProcess, GoogleMeetUrl,
+};
+
+pub struct MeetingSession {
+    browser: Option<ChromiumProcess>,
+    page: Option<CdpPage>,
+}
+
+impl MeetingSession {
+    pub async fn launch(
+        config: ChromiumLaunchConfig,
+        meeting_url: &GoogleMeetUrl,
+    ) -> Result<Self, MeetingSessionLaunchError> {
+        let browser = ChromiumProcess::launch(config).await?;
+        match CdpPage::open(&browser.devtools_websocket_url, meeting_url).await {
+            Ok(page) => Ok(Self {
+                browser: Some(browser),
+                page: Some(page),
+            }),
+            Err(source) => {
+                let cleanup_error = browser.shutdown().await.err();
+                Err(MeetingSessionLaunchError::OpenPage {
+                    source,
+                    cleanup_error,
+                })
+            }
+        }
+    }
+
+    pub fn page_mut(&mut self) -> &mut CdpPage {
+        self.page.as_mut().expect("active session owns a page")
+    }
+
+    pub fn browser_id(&self) -> Option<u32> {
+        self.browser.as_ref().and_then(ChromiumProcess::id)
+    }
+
+    pub async fn shutdown(mut self) -> Result<(), MeetingSessionShutdownError> {
+        let page_error = match self.page.take() {
+            Some(page) => page.close().await.err(),
+            None => None,
+        };
+        let browser_error = match self.browser.take() {
+            Some(browser) => browser.shutdown().await.err(),
+            None => None,
+        };
+        if page_error.is_none() && browser_error.is_none() {
+            Ok(())
+        } else {
+            Err(MeetingSessionShutdownError {
+                page_error,
+                browser_error,
+            })
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MeetingSessionLaunchError {
+    #[error(transparent)]
+    Chromium(#[from] ChromiumLaunchError),
+    #[error("failed to open the Google Meet page (Chromium cleanup error: {cleanup_error:?})")]
+    OpenPage {
+        #[source]
+        source: CdpError,
+        cleanup_error: Option<std::io::Error>,
+    },
+}
+
+#[derive(Debug)]
+pub struct MeetingSessionShutdownError {
+    pub page_error: Option<CdpError>,
+    pub browser_error: Option<std::io::Error>,
+}
+
+impl std::fmt::Display for MeetingSessionShutdownError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "meeting session cleanup failed (page: {:?}, Chromium: {:?})",
+            self.page_error, self.browser_error
+        )
+    }
+}
+
+impl std::error::Error for MeetingSessionShutdownError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::{path::Path, time::Duration};
+
+    use futures_util::StreamExt;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+    use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    #[cfg(unix)]
+    fn write_fake_chromium(path: &Path, port: u16) {
+        std::fs::write(
+            path,
+            format!(
+                r#"#!/bin/sh
+profile=""
+for arg in "$@"; do
+  case "$arg" in
+    --user-data-dir=*) profile="${{arg#--user-data-dir=}}" ;;
+  esac
+done
+printf '{port}\n/devtools/browser/test-id\n' > "$profile/DevToolsActivePort"
+while true; do sleep 1; done
+"#
+            ),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn owns_the_page_and_browser_cleanup_as_one_session() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut discovery, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = discovery.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("PUT /json/new?https%3A%2F%2Fmeet.google.com"));
+            let body =
+                format!(r#"{{"webSocketDebuggerUrl":"ws://{address}/devtools/page/test-id"}}"#);
+            discovery
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            discovery.shutdown().await.unwrap();
+
+            let (page, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(page).await.unwrap();
+            assert!(matches!(
+                websocket.next().await,
+                Some(Ok(Message::Close(_)))
+            ));
+        });
+
+        let directory = tempfile::tempdir().unwrap();
+        let executable = directory.path().join("chromium");
+        write_fake_chromium(&executable, address.port());
+        let meeting = GoogleMeetUrl::parse("https://meet.google.com/abc-defg-hij").unwrap();
+        let session = MeetingSession::launch(
+            ChromiumLaunchConfig {
+                binary: executable,
+                user_data_dir: directory.path().join("profile"),
+                locale: "en-US".into(),
+                authenticated: false,
+                headless: true,
+                disable_sandbox: false,
+                startup_timeout: Duration::from_secs(2),
+            },
+            &meeting,
+        )
+        .await
+        .unwrap();
+
+        assert!(session.browser_id().is_some());
+        session.shutdown().await.unwrap();
+        server.await.unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- enforce one absolute admission deadline with a final classification probe
- emit retryable admission-timeout lifecycle events
- distinguish removal, meeting end, network loss, and prolonged unknown runtime state
- bound reconnecting and missing-runtime-signal grace periods
- support explicit stop through stopping and completed transitions
- own CDP page and Chromium cleanup as one session
- add deterministic monitor, classifier, lifecycle, and session tests

## Validation
- changed-file dprint check (repository-wide check is currently blocked by four unrelated mobile formatting diffs)
- cargo test --manifest-path enterprise/Cargo.toml --workspace --locked
- cargo check --manifest-path enterprise/Cargo.toml --workspace --locked
- cargo clippy --manifest-path enterprise/Cargo.toml --workspace --all-targets --locked -- -D warnings
- node --check enterprise/google-meet-worker/src/runtime_probe.js
- jsdom runtime probe fixture
- python3 .github/scripts/test_check_license_boundary.py
- python3 .github/scripts/check_license_boundary.py

Linear: ANLG-228

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core bot lifecycle and terminal-reason semantics for Google Meet capture; mistakes could mis-classify meetings or leak Chromium, but behavior is heavily unit-tested and bounded by timeouts/grace periods.
> 
> **Overview**
> Adds **bounded Google Meet worker lifecycle** from lobby through capture teardown: admission polling with a fixed deadline, in-meeting runtime monitoring, and unified Chromium/CDP session cleanup.
> 
> **Admission** — New `AdmissionMonitor` polls CDP admission probes on a configurable interval until join, failure, or a **single absolute timeout** (default 10m). On expiry it emits a **retryable** `AdmissionTimeout` lifecycle event after a final probe.
> 
> **In-meeting runtime** — New `RuntimeClassifier` and `runtime_probe.js` (Vexa-adapted) classify removal, meeting end, connection problems, and missing UI signals with **30s grace** for reconnecting and unknown state. `RuntimeMonitor` loops until terminal state or an explicit stop via `watch` channel, mapping outcomes to distinct terminal reasons (e.g. `RemovedFromMeeting` vs `MeetingEnded` vs `NetworkLost`).
> 
> **Lifecycle** — `WorkerLifecycle` gains `admission_timed_out`, `observe_runtime`, and `stopped_by_request` (Stopping → Completed with `StoppedByRequest`).
> 
> **Session** — `MeetingSession` launches Chromium + CDP page together and shuts down page then browser, including cleanup on failed page open.
> 
> Minor: tokio gains `io-util`/`sync`; lobby X11 command timeout 1s → 5s; third-party notice cites Vexa `removal.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf955ad3634864c83b123f74f85ca3c6ff830c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->