### PR TITLE
ANLG-70: add mobile live transcription fallback

### DIFF
--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -400,6 +400,8 @@ export default function NoteScreen() {
           failure={recorder.failure}
           amplitude={recorder.amplitude}
           durationMs={recorder.durationMs}
+          liveStatus={recorder.liveStatus}
+          liveTranscript={recorder.liveTranscript}
           onStop={() => void handleStop()}
           onRetry={() => void handleRetryRecording()}
           onOpenSettings={() => void handleOpenSettings()}

--- a/apps/mobile/src/audio/pcm-wav.test.mjs
+++ b/apps/mobile/src/audio/pcm-wav.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { pcmAmplitude, wavHeader } from "./pcm-wav.ts";
+
+test("writes a little-endian PCM WAV header", () => {
+  const header = wavHeader(32_000, 16_000, 1);
+  const view = new DataView(header.buffer);
+
+  assert.equal(new TextDecoder().decode(header.slice(0, 4)), "RIFF");
+  assert.equal(view.getUint32(4, true), 32_036);
+  assert.equal(new TextDecoder().decode(header.slice(8, 12)), "WAVE");
+  assert.equal(view.getUint16(20, true), 1);
+  assert.equal(view.getUint16(22, true), 1);
+  assert.equal(view.getUint32(24, true), 16_000);
+  assert.equal(view.getUint32(28, true), 32_000);
+  assert.equal(view.getUint16(34, true), 16);
+  assert.equal(view.getUint32(40, true), 32_000);
+});
+
+test("normalizes int16 PCM amplitude", () => {
+  const samples = new Int16Array([0, 0, 0, 0, 16_384, 0, 0, 0]);
+  assert.equal(pcmAmplitude(samples.buffer), 0.5);
+  assert.equal(pcmAmplitude(new Int16Array([-32_768]).buffer), 1);
+});

--- a/apps/mobile/src/audio/pcm-wav.ts
+++ b/apps/mobile/src/audio/pcm-wav.ts
@@ -1,0 +1,40 @@
+const WAV_HEADER_BYTES = 44;
+
+function writeAscii(view: DataView, offset: number, value: string) {
+  for (let index = 0; index < value.length; index += 1) {
+    view.setUint8(offset + index, value.charCodeAt(index));
+  }
+}
+
+export function wavHeader(
+  dataBytes: number,
+  sampleRate: number,
+  channels: number,
+): Uint8Array {
+  const buffer = new ArrayBuffer(WAV_HEADER_BYTES);
+  const view = new DataView(buffer);
+  const bytesPerSample = 2;
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataBytes, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * channels * bytesPerSample, true);
+  view.setUint16(32, channels * bytesPerSample, true);
+  view.setUint16(34, bytesPerSample * 8, true);
+  writeAscii(view, 36, "data");
+  view.setUint32(40, dataBytes, true);
+  return new Uint8Array(buffer);
+}
+
+export function pcmAmplitude(buffer: ArrayBuffer): number {
+  const samples = new Int16Array(buffer);
+  let peak = 0;
+  for (let index = 0; index < samples.length; index += 4) {
+    peak = Math.max(peak, Math.abs(samples[index] ?? 0));
+  }
+  return Math.min(1, peak / 32_768);
+}

--- a/apps/mobile/src/audio/session-wav-writer.ts
+++ b/apps/mobile/src/audio/session-wav-writer.ts
@@ -1,0 +1,80 @@
+import {
+  Directory,
+  File,
+  FileMode,
+  Paths,
+  type FileHandle,
+} from "expo-file-system";
+
+import { wavHeader } from "@/audio/pcm-wav";
+
+export class SessionWavWriter {
+  readonly file: File;
+
+  private handle: FileHandle | null;
+  private dataBytes = 0;
+  private sampleRate = 16_000;
+  private channels = 1;
+  private initialized = false;
+  private finalized = false;
+  private checkpointDataBytes = 0;
+
+  constructor(sessionId: string) {
+    const directory = new Directory(Paths.document, "sessions", sessionId);
+    directory.create({ intermediates: true, idempotent: true });
+    this.file = new File(directory, "audio.wav");
+    this.file.create({ overwrite: true });
+    this.handle = this.file.open(FileMode.ReadWrite);
+  }
+
+  append(buffer: ArrayBuffer, sampleRate: number, channels: number) {
+    if (!this.handle || this.finalized) {
+      throw new Error("Recording file is closed");
+    }
+    if (!this.initialized) {
+      this.sampleRate = sampleRate;
+      this.channels = channels;
+      this.handle.writeBytes(wavHeader(0, sampleRate, channels));
+      this.initialized = true;
+    }
+    if (sampleRate !== this.sampleRate || channels !== this.channels) {
+      throw new Error("Audio stream format changed during recording");
+    }
+    const bytes = new Uint8Array(buffer);
+    this.handle.writeBytes(bytes);
+    this.dataBytes += bytes.byteLength;
+    const checkpointIntervalBytes = this.sampleRate * this.channels * 2 * 5;
+    if (this.dataBytes - this.checkpointDataBytes >= checkpointIntervalBytes) {
+      this.writeHeader();
+      this.checkpointDataBytes = this.dataBytes;
+    }
+  }
+
+  finalize(): File {
+    if (this.finalized) return this.file;
+    if (!this.handle) throw new Error("Recording file is unavailable");
+    if (!this.initialized) {
+      this.handle.writeBytes(wavHeader(0, this.sampleRate, this.channels));
+      this.initialized = true;
+    }
+    this.writeHeader();
+    this.handle.close();
+    this.handle = null;
+    this.finalized = true;
+    return this.file;
+  }
+
+  close() {
+    if (this.handle && this.initialized) this.writeHeader();
+    this.handle?.close();
+    this.handle = null;
+  }
+
+  private writeHeader() {
+    if (!this.handle) throw new Error("Recording file is unavailable");
+    const header = wavHeader(this.dataBytes, this.sampleRate, this.channels);
+    this.handle.offset = 0;
+    this.handle.writeBytes(header);
+    this.handle.offset = header.byteLength + this.dataBytes;
+  }
+}

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -1,38 +1,29 @@
 import {
   getRecordingPermissionsAsync,
-  RecordingPresets,
-  type RecordingStatus,
   requestRecordingPermissionsAsync,
   setAudioModeAsync,
-  useAudioRecorder,
-  useAudioRecorderState,
+  useAudioStream,
+  type AudioStreamBuffer,
 } from "expo-audio";
-import { Directory, File, Paths } from "expo-file-system";
 import { useCallback, useRef, useState } from "react";
 import { AppState } from "react-native";
 
-import {
-  recoverableRecordingUri,
-  recorderRecoveryAction,
-  recorderStatusFailure,
-  shouldHandleRecorderFailure,
-  type RecorderPhase,
-} from "@/audio/recorder-status";
+import { pcmAmplitude } from "@/audio/pcm-wav";
+import { type RecorderPhase } from "@/audio/recorder-status";
+import { SessionWavWriter } from "@/audio/session-wav-writer";
 import { catalogSessionAudio } from "@/data/audio-catalog";
+import {
+  HostedLiveTranscription,
+  markSessionAudioTranscribed,
+  type LiveTranscriptionStatus,
+} from "@/data/live-transcription";
 import { transcribeSession } from "@/data/transcribe";
 import { captureAnalytics } from "@/lib/analytics";
 import { captureOperationalError } from "@/lib/error-reporting";
 import { useMountEffect } from "@/lib/use-mount-effect";
 
-const METERING_FLOOR_DB = -50;
-
-const CONTENT_TYPES: Record<string, string> = {
-  m4a: "audio/mp4",
-  mp3: "audio/mpeg",
-  wav: "audio/wav",
-  ogg: "audio/ogg",
-  caf: "audio/x-caf",
-};
+const STREAM_SAMPLE_RATE = 16_000;
+const STREAM_CHANNELS = 1;
 
 export type { RecorderPhase } from "@/audio/recorder-status";
 
@@ -53,24 +44,28 @@ export function useSessionRecorder(
   failure: RecorderFailure | null;
   amplitude: number;
   durationMs: number;
+  liveStatus: LiveTranscriptionStatus;
+  liveTranscript: string;
   stop: () => Promise<StopResult>;
   retry: () => Promise<StopResult>;
 } {
   const [phase, setPhaseState] = useState<RecorderPhase>("idle");
   const [failure, setFailure] = useState<RecorderFailure | null>(null);
+  const [amplitude, setAmplitude] = useState(0);
+  const [durationMs, setDurationMs] = useState(0);
+  const [liveStatus, setLiveStatus] =
+    useState<LiveTranscriptionStatus>("connecting");
+  const [liveTranscript, setLiveTranscript] = useState("");
   const phaseRef = useRef<RecorderPhase>("idle");
   const activeRef = useRef(true);
-  const pendingUriRef = useRef<string | null>(null);
-  const pendingDurationRef = useRef(0);
-  const completionReasonRef = useRef<"user_stopped" | "interrupted">(
-    "user_stopped",
-  );
+  const writerRef = useRef<SessionWavWriter | null>(null);
+  const liveRef = useRef<HostedLiveTranscription | null>(null);
   const startGenerationRef = useRef(0);
   const startRef = useRef<Promise<void> | null>(null);
   const stopOperationRef = useRef<Promise<StopResult> | null>(null);
   const completionTrackedRef = useRef(false);
   const reportedFailureRef = useRef<string | null>(null);
-  const recorderRef = useRef<ReturnType<typeof useAudioRecorder> | null>(null);
+  const durationRef = useRef(0);
 
   const setPhase = useCallback((next: RecorderPhase) => {
     phaseRef.current = next;
@@ -81,9 +76,7 @@ export function useSessionRecorder(
     (reason: RecorderFailure, error: unknown, operation: string) => {
       if (reportedFailureRef.current !== reason) {
         reportedFailureRef.current = reason;
-        captureAnalytics("recording_failed", {
-          failure_stage: reason,
-        });
+        captureAnalytics("recording_failed", { failure_stage: reason });
       }
       if (reason !== "permission_denied") {
         captureOperationalError(error, {
@@ -96,95 +89,75 @@ export function useSessionRecorder(
     [],
   );
 
-  const handleRecorderStatus = useCallback(
-    (status: RecordingStatus) => {
-      const statusFailure = recorderStatusFailure(status);
-      if (!statusFailure || !shouldHandleRecorderFailure(phaseRef.current)) {
+  const handleBuffer = useCallback(
+    (buffer: AudioStreamBuffer) => {
+      if (phaseRef.current !== "starting" && phaseRef.current !== "recording") {
         return;
       }
-
-      const recoverableUri = recoverableRecordingUri(
-        status.url,
-        recorderRef.current?.uri,
-      );
-      if (recoverableUri) pendingUriRef.current = recoverableUri;
-      completionReasonRef.current = "interrupted";
-      reportFailure(
-        statusFailure.reason,
-        new Error(statusFailure.message),
-        statusFailure.reason === "media_services_reset"
-          ? "recording_media_services_reset"
-          : "recording_native_status",
-      );
-      setPhase(statusFailure.phase);
-    },
-    [reportFailure, setPhase],
-  );
-
-  const recorder = useAudioRecorder(
-    {
-      ...RecordingPresets.HIGH_QUALITY,
-      directory: "document",
-      isMeteringEnabled: true,
-    },
-    handleRecorderStatus,
-  );
-  recorderRef.current = recorder;
-  const recorderState = useAudioRecorderState(recorder, 50);
-
-  const persistRecording = useCallback(
-    async (sourceUri: string, durationMs: number): Promise<StopResult> => {
-      setPhase("saving");
       try {
-        const extension = sourceUri.split(".").pop()?.toLowerCase() ?? "m4a";
-        const directory = new Directory(Paths.document, "sessions", sessionId);
-        directory.create({ intermediates: true, idempotent: true });
-        const destination = new File(directory, `audio.${extension}`);
-        if (sourceUri !== destination.uri) {
-          if (destination.exists) destination.delete();
-          const source = new File(sourceUri);
-          await source.move(destination);
-          pendingUriRef.current = destination.uri;
-        }
-        await catalogSessionAudio(sessionId, {
-          filename: `audio.${extension}`,
-          contentType: CONTENT_TYPES[extension] ?? "application/octet-stream",
-          sizeBytes: destination.size ?? 0,
-        });
-        if (!completionTrackedRef.current) {
-          completionTrackedRef.current = true;
-          captureAnalytics("recording_completed", {
-            duration_seconds: Math.round(durationMs / 1_000),
-            completion_reason: completionReasonRef.current,
-            transcription_requested: true,
-          });
-          captureAnalytics("session_completed", {
-            duration_seconds: Math.round(durationMs / 1_000),
-            completion_reason: completionReasonRef.current,
-            transcription_requested: true,
-          });
-        }
-        pendingUriRef.current = null;
-        setFailure(null);
-        void transcribeSession(sessionId);
-        setPhase("saved");
-        return "saved";
+        writerRef.current?.append(
+          buffer.data,
+          buffer.sampleRate,
+          buffer.channels,
+        );
       } catch (error) {
-        reportFailure("save_failed", error, "recording_save");
+        reportFailure("save_failed", error, "recording_stream_write");
         setPhase("save_error");
-        return "failed";
+        try {
+          streamRef.current.stop();
+        } catch {}
+        return;
+      }
+      const generation = startGenerationRef.current;
+      liveRef.current ??= new HostedLiveTranscription(
+        sessionId,
+        buffer.sampleRate,
+        buffer.channels,
+        ({ status, text }) => {
+          if (!activeRef.current || generation !== startGenerationRef.current) {
+            return;
+          }
+          setLiveStatus(status);
+          if (text !== "") setLiveTranscript(text);
+        },
+      );
+      liveRef.current?.sendAudio(buffer.data);
+      const frameDuration =
+        buffer.data.byteLength /
+        2 /
+        Math.max(1, buffer.channels) /
+        Math.max(1, buffer.sampleRate);
+      durationRef.current = Math.max(
+        durationRef.current,
+        Math.round((buffer.timestamp + frameDuration) * 1_000),
+      );
+      if (activeRef.current) {
+        setAmplitude(pcmAmplitude(buffer.data));
+        setDurationMs(durationRef.current);
       }
     },
     [reportFailure, sessionId, setPhase],
   );
 
+  const { stream } = useAudioStream({
+    sampleRate: STREAM_SAMPLE_RATE,
+    channels: STREAM_CHANNELS,
+    encoding: "int16",
+    onBuffer: handleBuffer,
+  });
+  const streamRef = useRef(stream);
+  streamRef.current = stream;
+
   const start = useCallback(async () => {
     const generation = ++startGenerationRef.current;
     const isCurrent = () =>
       activeRef.current && generation === startGenerationRef.current;
-    pendingDurationRef.current = 0;
-    completionReasonRef.current = "user_stopped";
     completionTrackedRef.current = false;
+    durationRef.current = 0;
+    setDurationMs(0);
+    setAmplitude(0);
+    setLiveStatus("connecting");
+    setLiveTranscript("");
     setFailure(null);
     reportedFailureRef.current = null;
     setPhase("starting");
@@ -216,6 +189,7 @@ export function useSessionRecorder(
         setPhase("unavailable");
         return;
       }
+
       await setAudioModeAsync({
         allowsRecording: true,
         playsInSilentMode: true,
@@ -223,26 +197,42 @@ export function useSessionRecorder(
         interruptionMode: "doNotMix",
       });
       if (!isCurrent()) return;
-      await recorder.prepareToRecordAsync();
-      if (!isCurrent()) return;
-      recorder.record();
+      writerRef.current = new SessionWavWriter(sessionId);
+      await stream.start();
+      if (!isCurrent()) {
+        phaseRef.current = "recording";
+        return;
+      }
       captureAnalytics("recording_started", {
         entry_point: "mobile_recorder",
-        transcription_mode: "post_capture",
+        transcription_mode: "live_with_batch_fallback",
       });
       captureAnalytics("session_started", {
         entry_point: "mobile_recorder",
-        transcription_mode: "post_capture",
+        transcription_mode: "live_with_batch_fallback",
       });
       setPhase("recording");
     } catch (error) {
+      try {
+        stream.stop();
+      } catch {}
+      try {
+        writerRef.current?.close();
+      } catch (cleanupError) {
+        captureOperationalError(cleanupError, {
+          operation: "recording_start_cleanup",
+        });
+      }
+      writerRef.current = null;
+      void liveRef.current?.stop();
+      liveRef.current = null;
       reportFailure("start_failed", error, "recording_start");
       captureAnalytics("session_start_failed", {
         failure_stage: "capture_start",
       });
       setPhase("error");
     }
-  }, [recorder, reportFailure, setPhase]);
+  }, [reportFailure, sessionId, setPhase, stream]);
 
   useMountEffect(() => {
     activeRef.current = true;
@@ -258,71 +248,73 @@ export function useSessionRecorder(
         nextState === "active" &&
         phaseRef.current === "unavailable";
       previousState = nextState;
-      if (returnedFromSettings) {
-        startRef.current = start();
-      }
+      if (returnedFromSettings) startRef.current = start();
     });
     return () => subscription.remove();
   });
 
   const performStop = async (): Promise<StopResult> => {
-    let action = recorderRecoveryAction(
-      phaseRef.current,
-      pendingUriRef.current !== null,
-      "stop",
-    );
-    const pendingUri = pendingUriRef.current;
-    if (action === "persist" && pendingUri) {
-      return persistRecording(pendingUri, pendingDurationRef.current);
-    }
-    if (action !== "stop") return "noop";
-
     await startRef.current?.catch(() => {});
-    action = recorderRecoveryAction(
-      phaseRef.current,
-      pendingUriRef.current !== null,
-      "stop",
-    );
-    const startedPendingUri = pendingUriRef.current;
-    if (action === "persist" && startedPendingUri) {
-      return persistRecording(startedPendingUri, pendingDurationRef.current);
+    if (
+      !["recording", "save_error", "error", "interrupted"].includes(
+        phaseRef.current,
+      )
+    ) {
+      return "noop";
     }
-    if (phaseRef.current === "starting") return "noop";
-    if (action !== "stop") return "noop";
-
+    if (!writerRef.current) return "noop";
     setPhase("saving");
-    pendingDurationRef.current =
-      recorderState.durationMillis ?? pendingDurationRef.current;
     try {
-      await recorder.stop();
-    } catch (error) {
-      const uri = recorder.uri;
-      if (uri) {
-        pendingUriRef.current = uri;
-        return persistRecording(uri, pendingDurationRef.current);
+      streamRef.current.stop();
+      const writer = writerRef.current;
+      if (!writer) throw new Error("Recording file is unavailable");
+      const live = liveRef.current;
+      const file = writer.finalize();
+      await catalogSessionAudio(sessionId, {
+        filename: "audio.wav",
+        contentType: "audio/wav",
+        sizeBytes: file.size,
+      });
+      const liveComplete = await (live?.stop() ?? Promise.resolve(false));
+      let transcriptionMode = liveComplete ? "live" : "batch_fallback";
+      if (liveComplete) {
+        await markSessionAudioTranscribed(sessionId).catch((error) => {
+          transcriptionMode = "batch_fallback";
+          captureOperationalError(error, {
+            operation: "transcription_live_mark_complete",
+            tags: { mode: "live" },
+          });
+          void transcribeSession(sessionId);
+        });
+      } else {
+        void transcribeSession(sessionId);
       }
-      reportFailure("save_failed", error, "recording_stop");
+      if (!completionTrackedRef.current) {
+        completionTrackedRef.current = true;
+        const properties = {
+          duration_seconds: Math.round(durationRef.current / 1_000),
+          completion_reason: "user_stopped",
+          transcription_requested: true,
+          transcription_mode: transcriptionMode,
+        };
+        captureAnalytics("recording_completed", properties);
+        captureAnalytics("session_completed", properties);
+      }
+      writerRef.current = null;
+      liveRef.current = null;
+      setFailure(null);
+      setPhase("saved");
+      return "saved";
+    } catch (error) {
+      reportFailure("save_failed", error, "recording_save");
       setPhase("save_error");
       return "failed";
     }
-    const uri = recorder.uri;
-    if (!uri) {
-      reportFailure(
-        "save_failed",
-        new Error("recording produced no file"),
-        "recording_stop",
-      );
-      setPhase("save_error");
-      return "failed";
-    }
-    pendingUriRef.current = uri;
-    return persistRecording(uri, pendingDurationRef.current);
   };
 
   const stop = (): Promise<StopResult> => {
     const currentOperation = stopOperationRef.current;
     if (currentOperation) return currentOperation;
-
     const operation = performStop();
     stopOperationRef.current = operation;
     const clearOperation = () => {
@@ -335,15 +327,13 @@ export function useSessionRecorder(
   };
 
   const retry = async (): Promise<StopResult> => {
-    const action = recorderRecoveryAction(
-      phaseRef.current,
-      pendingUriRef.current !== null,
-      "retry",
-    );
-    if (action === "persist" || action === "stop") {
+    if (
+      writerRef.current &&
+      ["save_error", "interrupted", "error"].includes(phaseRef.current)
+    ) {
       return stop();
     }
-    if (action === "restart") {
+    if (["unavailable", "interrupted", "error"].includes(phaseRef.current)) {
       startRef.current = start();
       await startRef.current;
     }
@@ -358,25 +348,13 @@ export function useSessionRecorder(
     void stopRef.current();
   });
 
-  const metering = recorderState.metering;
-  if (
-    phase === "recording" &&
-    (recorderState.durationMillis ?? 0) > pendingDurationRef.current
-  ) {
-    pendingDurationRef.current = recorderState.durationMillis ?? 0;
-  }
-  const normalizedLevel =
-    typeof metering === "number" && phase === "recording"
-      ? Math.min(
-          1,
-          Math.max(0, (metering - METERING_FLOOR_DB) / -METERING_FLOOR_DB),
-        )
-      : null;
   return {
     phase,
     failure,
-    amplitude: normalizedLevel ?? 0,
-    durationMs: recorderState.durationMillis ?? pendingDurationRef.current,
+    amplitude,
+    durationMs,
+    liveStatus,
+    liveTranscript,
     stop,
     retry,
   };

--- a/apps/mobile/src/components/listening-sheet.tsx
+++ b/apps/mobile/src/components/listening-sheet.tsx
@@ -28,7 +28,7 @@ import {
   Typography,
 } from "@/constants/theme";
 
-const DETAIL_HEIGHT = 96;
+const DETAIL_HEIGHT = 124;
 
 function formatDuration(ms: number): string {
   const totalSeconds = Math.floor(ms / 1000);
@@ -58,11 +58,24 @@ function statusLabel(phase: RecorderPhase, durationMs: number): string {
   }
 }
 
+function transcriptionLabel(status: "connecting" | "live" | "fallback") {
+  switch (status) {
+    case "live":
+      return "Live transcription";
+    case "fallback":
+      return "Recording locally · transcript after stop";
+    default:
+      return "Connecting live transcript…";
+  }
+}
+
 export function ListeningSheet({
   phase,
   failure,
   amplitude,
   durationMs,
+  liveStatus,
+  liveTranscript,
   onStop,
   onRetry,
   onOpenSettings,
@@ -71,6 +84,8 @@ export function ListeningSheet({
   failure: RecorderFailure | null;
   amplitude: number;
   durationMs: number;
+  liveStatus: "connecting" | "live" | "fallback";
+  liveTranscript: string;
   onStop: () => void;
   onRetry: () => void;
   onOpenSettings: () => void;
@@ -115,9 +130,12 @@ export function ListeningSheet({
             {statusLabel(phase, durationMs)}
           </Text>
         </View>
-        <Text style={styles.detailHint}>
-          Leave your phone on the table and talk. Audio stays locally durable
-          while Anarlog listens.
+        <Text style={styles.transcriptionStatus}>
+          {transcriptionLabel(liveStatus)}
+        </Text>
+        <Text numberOfLines={2} style={styles.detailHint}>
+          {liveTranscript ||
+            "Leave your phone on the table and talk. Audio stays locally durable while Anarlog listens."}
         </Text>
       </Animated.View>
 
@@ -212,6 +230,12 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.sm,
     ...Typography.caption,
     color: Colors.muted,
+  },
+  transcriptionStatus: {
+    paddingHorizontal: Spacing.sm,
+    paddingTop: Spacing.xs,
+    ...Typography.captionStrong,
+    color: Colors.ink,
   },
   panel: {
     height: LISTENING_CONTROL_HEIGHT,

--- a/apps/mobile/src/data/live-transcription-model.test.mjs
+++ b/apps/mobile/src/data/live-transcription-model.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseHostedTranscriptionMessage } from "./live-transcription-model.ts";
+
+test("maps partial and finalized hosted transcript responses", () => {
+  assert.deepEqual(
+    parseHostedTranscriptionMessage(
+      JSON.stringify({
+        type: "Results",
+        is_final: false,
+        start: 0,
+        duration: 1,
+        channel_index: [0, 1],
+        channel: { alternatives: [{ transcript: "hello", words: [] }] },
+      }),
+      "transcript",
+    ),
+    [{ type: "partial", text: "hello" }],
+  );
+
+  const [event] = parseHostedTranscriptionMessage(
+    JSON.stringify({
+      type: "Results",
+      is_final: true,
+      start: 1,
+      duration: 1,
+      channel_index: [0, 1],
+      channel: {
+        alternatives: [
+          {
+            transcript: "Hello world.",
+            words: [
+              {
+                word: "hello",
+                punctuated_word: "Hello",
+                start: 1,
+                end: 1.4,
+                speaker: 2,
+              },
+              {
+                word: "world",
+                punctuated_word: "world.",
+                start: 1.4,
+                end: 2,
+              },
+            ],
+          },
+        ],
+      },
+    }),
+    "transcript",
+  );
+
+  assert.equal(event?.type, "final");
+  assert.deepEqual(event?.words, [
+    {
+      id: "transcript:0:1000:0",
+      text: "Hello",
+      start_ms: 1000,
+      end_ms: 1400,
+      channel: 0,
+      state: "final",
+      speaker_index: 2,
+    },
+    {
+      id: "transcript:0:1000:1",
+      text: "world.",
+      start_ms: 1400,
+      end_ms: 2000,
+      channel: 0,
+      state: "final",
+    },
+  ]);
+  assert.equal(event?.hints.length, 1);
+});
+
+test("synthesizes timings when a provider omits word details", () => {
+  const [event] = parseHostedTranscriptionMessage(
+    JSON.stringify({
+      type: "Results",
+      is_final: true,
+      start: 2,
+      duration: 0,
+      channel_index: [0, 1],
+      channel: {
+        alternatives: [{ transcript: "one two", words: [] }],
+      },
+    }),
+    "transcript",
+  );
+
+  assert.equal(event?.type, "final");
+  assert.deepEqual(
+    event?.words.map((word) => [word.text, word.start_ms, word.end_ms]),
+    [
+      ["one", 2000, 2400],
+      ["two", 2400, 2800],
+    ],
+  );
+});
+
+test("handles response batches, terminal messages, and provider errors", () => {
+  assert.deepEqual(
+    parseHostedTranscriptionMessage(
+      JSON.stringify([
+        { type: "SpeechStarted" },
+        { type: "Metadata" },
+        { type: "Error", error_message: "upstream unavailable" },
+      ]),
+      "transcript",
+    ),
+    [{ type: "terminal" }, { type: "error", message: "upstream unavailable" }],
+  );
+});
+
+test("rejects malformed and oversized responses without throwing", () => {
+  assert.deepEqual(parseHostedTranscriptionMessage("not-json", "transcript"), [
+    { type: "error", message: "Live transcription returned invalid data" },
+  ]);
+  assert.deepEqual(
+    parseHostedTranscriptionMessage("x".repeat(1_000_001), "transcript"),
+    [
+      {
+        type: "error",
+        message: "Live transcription response is too large",
+      },
+    ],
+  );
+});

--- a/apps/mobile/src/data/live-transcription-model.ts
+++ b/apps/mobile/src/data/live-transcription-model.ts
@@ -1,0 +1,221 @@
+import { assertBoundedTranscriptionResponse } from "./transcription-response.ts";
+
+const MAX_STREAM_MESSAGE_BYTES = 1_000_000;
+const MAX_WORDS_PER_MESSAGE = 5_000;
+const SYNTHETIC_WORD_MS = 400;
+
+type StreamWord = {
+  word?: unknown;
+  punctuated_word?: unknown;
+  start?: unknown;
+  end?: unknown;
+  speaker?: unknown;
+};
+
+export type LiveTranscriptWord = {
+  id: string;
+  text: string;
+  start_ms: number;
+  end_ms: number;
+  channel: number;
+  state: "final";
+  speaker_index?: number;
+};
+
+export type LiveSpeakerHint = {
+  id: string;
+  word_id: string;
+  type: "provider_speaker_index";
+  value: string;
+};
+
+export type HostedTranscriptEvent =
+  | { type: "partial"; text: string }
+  | {
+      type: "final";
+      segmentId: string;
+      text: string;
+      words: LiveTranscriptWord[];
+      hints: LiveSpeakerHint[];
+    }
+  | { type: "terminal" }
+  | { type: "error"; message: string };
+
+function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function normalizedChannel(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : 0;
+}
+
+function mapFinalWords({
+  transcriptId,
+  segmentId,
+  channel,
+  streamWords,
+  transcript,
+  start,
+  duration,
+}: {
+  transcriptId: string;
+  segmentId: string;
+  channel: number;
+  streamWords: StreamWord[];
+  transcript: string;
+  start: number;
+  duration: number;
+}): { words: LiveTranscriptWord[]; hints: LiveSpeakerHint[] } {
+  const sourceWords = streamWords.slice(0, MAX_WORDS_PER_MESSAGE);
+  const words: LiveTranscriptWord[] = [];
+  const hints: LiveSpeakerHint[] = [];
+
+  sourceWords.forEach((word, index) => {
+    const rawText =
+      typeof word.punctuated_word === "string" && word.punctuated_word !== ""
+        ? word.punctuated_word
+        : word.word;
+    if (typeof rawText !== "string" || rawText.trim() === "") return;
+    const startMs = Math.max(
+      0,
+      Math.round(finiteNumber(word.start, start) * 1_000),
+    );
+    const endMs = Math.max(
+      startMs,
+      Math.round(finiteNumber(word.end, start) * 1_000),
+    );
+    const wordId = `${transcriptId}:${segmentId}:${index}`;
+    const speaker =
+      typeof word.speaker === "number" && Number.isInteger(word.speaker)
+        ? word.speaker
+        : undefined;
+    words.push({
+      id: wordId,
+      text: rawText,
+      start_ms: startMs,
+      end_ms: endMs,
+      channel,
+      state: "final",
+      ...(speaker === undefined ? {} : { speaker_index: speaker }),
+    });
+    if (speaker !== undefined) {
+      hints.push({
+        id: `${wordId}:speaker`,
+        word_id: wordId,
+        type: "provider_speaker_index",
+        value: JSON.stringify({
+          provider: "anarlog",
+          channel,
+          speaker_index: speaker,
+        }),
+      });
+    }
+  });
+
+  if (words.length > 0 || transcript.trim() === "") return { words, hints };
+  const tokens = transcript.trim().split(/\s+/).slice(0, MAX_WORDS_PER_MESSAGE);
+  const durationMs = Math.max(
+    Math.round(Math.max(0, duration) * 1_000),
+    tokens.length * SYNTHETIC_WORD_MS,
+  );
+  const startMs = Math.max(0, Math.round(start * 1_000));
+  return {
+    words: tokens.map((text, index) => ({
+      id: `${transcriptId}:${segmentId}:${index}`,
+      text,
+      start_ms: startMs + Math.round((index / tokens.length) * durationMs),
+      end_ms: startMs + Math.round(((index + 1) / tokens.length) * durationMs),
+      channel,
+      state: "final",
+    })),
+    hints,
+  };
+}
+
+function parsePayload(
+  payload: unknown,
+  transcriptId: string,
+): HostedTranscriptEvent[] {
+  if (Array.isArray(payload)) {
+    return payload.flatMap((item) => parsePayload(item, transcriptId));
+  }
+  if (!payload || typeof payload !== "object") return [];
+  const response = payload as Record<string, unknown>;
+  if (response.type === "Metadata") return [{ type: "terminal" }];
+  if (response.type === "Error") {
+    return [
+      {
+        type: "error",
+        message:
+          typeof response.error_message === "string"
+            ? response.error_message
+            : "Live transcription failed",
+      },
+    ];
+  }
+  if (response.type !== "Results") return [];
+
+  const channelObject =
+    response.channel && typeof response.channel === "object"
+      ? (response.channel as { alternatives?: unknown })
+      : null;
+  const alternatives = Array.isArray(channelObject?.alternatives)
+    ? channelObject.alternatives
+    : [];
+  const alternative =
+    alternatives[0] && typeof alternatives[0] === "object"
+      ? (alternatives[0] as { transcript?: unknown; words?: unknown })
+      : null;
+  const transcript =
+    typeof alternative?.transcript === "string" ? alternative.transcript : "";
+  const streamWords = Array.isArray(alternative?.words)
+    ? (alternative.words as StreamWord[])
+    : [];
+  const channelIndex = Array.isArray(response.channel_index)
+    ? response.channel_index[0]
+    : 0;
+  const channel = normalizedChannel(channelIndex);
+  const start = Math.max(0, finiteNumber(response.start, 0));
+  const duration = Math.max(0, finiteNumber(response.duration, 0));
+  if (response.is_final !== true) {
+    return transcript.trim() === ""
+      ? []
+      : [{ type: "partial", text: transcript.trim() }];
+  }
+
+  const segmentId = `${channel}:${Math.round(start * 1_000)}`;
+  const { words, hints } = mapFinalWords({
+    transcriptId,
+    segmentId,
+    channel,
+    streamWords,
+    transcript,
+    start,
+    duration,
+  });
+  return words.length === 0
+    ? []
+    : [{ type: "final", segmentId, text: transcript.trim(), words, hints }];
+}
+
+export function parseHostedTranscriptionMessage(
+  message: string,
+  transcriptId: string,
+): HostedTranscriptEvent[] {
+  try {
+    assertBoundedTranscriptionResponse(message, null, MAX_STREAM_MESSAGE_BYTES);
+  } catch {
+    return [
+      { type: "error", message: "Live transcription response is too large" },
+    ];
+  }
+  try {
+    return parsePayload(JSON.parse(message), transcriptId);
+  } catch {
+    return [
+      { type: "error", message: "Live transcription returned invalid data" },
+    ];
+  }
+}

--- a/apps/mobile/src/data/live-transcription.ts
+++ b/apps/mobile/src/data/live-transcription.ts
@@ -1,0 +1,433 @@
+import { supabase } from "@/auth/client";
+import { execute, executeTransaction } from "@/db";
+import { captureAnalytics } from "@/lib/analytics";
+import { env } from "@/lib/env";
+import { captureOperationalError } from "@/lib/error-reporting";
+import { id, nowIso } from "@/lib/ids";
+
+import {
+  parseHostedTranscriptionMessage,
+  type LiveSpeakerHint,
+  type LiveTranscriptWord,
+} from "./live-transcription-model";
+
+export type LiveTranscriptionStatus = "connecting" | "live" | "fallback";
+
+const MAX_QUEUED_AUDIO_BYTES = 320_000;
+const MAX_SOCKET_BUFFERED_BYTES = 1_000_000;
+const FINALIZE_TIMEOUT_MS = 3_000;
+const KEEP_ALIVE_INTERVAL_MS = 5_000;
+
+const TRANSCRIPT_TOMBSTONE_SQL = `
+UPDATE transcripts
+SET deleted_at = ?, updated_at = ?
+WHERE session_id = ? AND deleted_at IS NULL
+`;
+
+const LIVE_TRANSCRIPT_INSERT_SQL = `
+INSERT INTO transcripts (
+  id, workspace_id, owner_user_id, session_id, source, provider,
+  model, language, started_at_ms, ended_at_ms, audio_attachment_id,
+  memo, words_json, speaker_hints_json, metadata_json, created_at,
+  updated_at, deleted_at
+)
+SELECT ?, session.workspace_id, session.owner_user_id, session.id,
+  'live_capture', 'anarlog', 'cloud', '', ?, NULL, ?,
+  COALESCE((
+    SELECT note.body FROM session_documents AS note
+    WHERE note.id = session.id AND note.kind = 'note' AND note.deleted_at IS NULL
+  ), ''),
+  ?, ?, '{}', ?, ?, NULL
+FROM sessions AS session
+WHERE session.id = ? AND session.deleted_at IS NULL
+`;
+
+const TRANSCRIPT_FINISH_SQL = `
+UPDATE transcripts
+SET words_json = ?, speaker_hints_json = ?, ended_at_ms = ?,
+  content_revision = content_revision + 1, updated_at = ?
+WHERE id = ? AND deleted_at IS NULL
+`;
+
+const LIVE_STATE_INSERT_SQL = `
+INSERT OR IGNORE INTO transcript_live_state (
+  transcript_id, next_sequence, updated_at
+)
+SELECT id, 0, ?
+FROM transcripts
+WHERE id = ? AND deleted_at IS NULL
+`;
+
+const LIVE_DELTA_INSERT_SQL = `
+INSERT INTO transcript_live_deltas (
+  id, transcript_id, sequence, delta_json, created_at
+)
+SELECT ?, transcript_id, next_sequence, ?, ?
+FROM transcript_live_state
+WHERE transcript_id = ?
+`;
+
+const LIVE_STATE_ADVANCE_SQL = `
+UPDATE transcript_live_state
+SET next_sequence = next_sequence + 1, updated_at = ?
+WHERE transcript_id = ?
+`;
+
+const LIVE_STATE_DELETE_SQL = `
+DELETE FROM transcript_live_state
+WHERE transcript_id = ?
+`;
+
+const MARK_AUDIO_COMPLETE_SQL = `
+UPDATE session_attachments
+SET metadata_json = json_set(
+  CASE WHEN json_valid(metadata_json) THEN metadata_json ELSE '{}' END,
+  '$.transcript_status', 'complete'
+), updated_at = ?
+WHERE id = ? AND session_id = ? AND source_type = 'session_audio'
+  AND source_id = 'primary' AND deleted_at IS NULL
+`;
+
+type NativeWebSocketConstructor = new (
+  url: string,
+  protocols?: string[] | null,
+  options?: { headers?: Record<string, string> },
+) => WebSocket;
+
+function liveUrl(sampleRate: number, channels: number): string {
+  const url = new URL(`${env.apiUrl}/stt/listen`);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.searchParams.set("provider", "anarlog");
+  url.searchParams.set("model", "cloud");
+  url.searchParams.set("encoding", "linear16");
+  url.searchParams.set("sample_rate", String(sampleRate));
+  url.searchParams.set("channels", String(channels));
+  return url.toString();
+}
+
+export class HostedLiveTranscription {
+  readonly transcriptId = id();
+
+  private socket: WebSocket | null = null;
+  private status: LiveTranscriptionStatus = "connecting";
+  private queuedAudio: ArrayBuffer[] = [];
+  private queuedAudioBytes = 0;
+  private wordsById = new Map<string, LiveTranscriptWord>();
+  private hintsById = new Map<string, LiveSpeakerHint>();
+  private segmentWordIds = new Map<string, string[]>();
+  private inserted = false;
+  private readonly startedAtMs = Date.now();
+  private writeChain = Promise.resolve();
+  private stopping = false;
+  private stopPromise: Promise<boolean> | null = null;
+  private connectPromise: Promise<void>;
+  private keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+  private terminalResolve: (() => void) | null = null;
+  private terminalPromise = new Promise<void>((resolve) => {
+    this.terminalResolve = resolve;
+  });
+
+  constructor(
+    private readonly sessionId: string,
+    sampleRate: number,
+    channels: number,
+    private readonly onUpdate: (update: {
+      status: LiveTranscriptionStatus;
+      text: string;
+    }) => void,
+  ) {
+    this.connectPromise = this.connect(sampleRate, channels);
+  }
+
+  private setStatus(status: LiveTranscriptionStatus, text = "") {
+    this.status = status;
+    this.onUpdate({ status, text });
+  }
+
+  private async connect(sampleRate: number, channels: number) {
+    try {
+      const auth = await supabase?.auth.getSession();
+      if (auth?.error) throw auth.error;
+      const token = auth?.data.session?.access_token;
+      if (!token)
+        throw new Error("Live transcription requires a signed-in session");
+      if (this.stopping || this.status === "fallback") return;
+
+      const Socket = WebSocket as unknown as NativeWebSocketConstructor;
+      const socket = new Socket(liveUrl(sampleRate, channels), null, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      socket.binaryType = "arraybuffer";
+      socket.onopen = () => {
+        if (this.stopping || this.status === "fallback") {
+          socket.close();
+          return;
+        }
+        this.setStatus("live");
+        for (const buffer of this.queuedAudio) socket.send(buffer);
+        this.queuedAudio = [];
+        this.queuedAudioBytes = 0;
+        this.keepAliveTimer = setInterval(() => {
+          if (socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({ type: "KeepAlive" }));
+          }
+        }, KEEP_ALIVE_INTERVAL_MS);
+      };
+      socket.onmessage = (event) => {
+        if (typeof event.data !== "string") return;
+        this.handleMessage(event.data);
+      };
+      socket.onerror = () => {
+        this.fail(new Error("Live transcription socket failed"), "socket");
+      };
+      socket.onclose = () => {
+        this.clearKeepAlive();
+        this.terminalResolve?.();
+        if (!this.stopping && this.status !== "fallback") {
+          this.fail(
+            new Error("Live transcription socket closed unexpectedly"),
+            "socket_closed",
+          );
+        }
+      };
+      this.socket = socket;
+    } catch (error) {
+      this.fail(error, "connect");
+    }
+  }
+
+  sendAudio(buffer: ArrayBuffer) {
+    if (this.status === "fallback" || this.stopping) return;
+    const socket = this.socket;
+    if (socket?.readyState === WebSocket.OPEN) {
+      if (socket.bufferedAmount > MAX_SOCKET_BUFFERED_BYTES) {
+        this.fail(
+          new Error("Live transcription upload fell behind"),
+          "backpressure",
+        );
+        return;
+      }
+      socket.send(buffer);
+      return;
+    }
+
+    if (this.queuedAudioBytes + buffer.byteLength > MAX_QUEUED_AUDIO_BYTES) {
+      this.fail(new Error("Live transcription connection timed out"), "queue");
+      return;
+    }
+    const copy = buffer.slice(0);
+    this.queuedAudio.push(copy);
+    this.queuedAudioBytes += copy.byteLength;
+  }
+
+  private handleMessage(message: string) {
+    for (const event of parseHostedTranscriptionMessage(
+      message,
+      this.transcriptId,
+    )) {
+      if (event.type === "error") {
+        this.fail(new Error(event.message), "response");
+        continue;
+      }
+      if (event.type === "terminal") {
+        this.terminalResolve?.();
+        continue;
+      }
+      if (event.type === "partial") {
+        this.onUpdate({ status: this.status, text: event.text });
+        continue;
+      }
+
+      const replacedIds = this.segmentWordIds.get(event.segmentId) ?? [];
+      for (const wordId of replacedIds) {
+        this.wordsById.delete(wordId);
+        this.hintsById.delete(`${wordId}:speaker`);
+      }
+      this.segmentWordIds.set(
+        event.segmentId,
+        event.words.map((word) => word.id),
+      );
+      for (const word of event.words) this.wordsById.set(word.id, word);
+      for (const hint of event.hints) this.hintsById.set(hint.id, hint);
+      this.onUpdate({ status: this.status, text: event.text });
+      this.persistDelta(event.words, replacedIds);
+    }
+  }
+
+  private persistDelta(
+    deltaWords: LiveTranscriptWord[],
+    replacedIds: string[],
+  ) {
+    const words = [...this.wordsById.values()].sort(
+      (a, b) => a.start_ms - b.start_ms || a.end_ms - b.end_ms,
+    );
+    const hints = [...this.hintsById.values()];
+    const deltaJson = JSON.stringify({
+      new_words: deltaWords,
+      replaced_ids: replacedIds,
+      partials: [],
+    });
+    this.writeChain = this.writeChain
+      .then(async () => {
+        const now = nowIso();
+        if (!this.inserted) {
+          const [, inserted = 0, stateInserted = 0] = await executeTransaction([
+            {
+              sql: TRANSCRIPT_TOMBSTONE_SQL,
+              params: [now, now, this.sessionId],
+            },
+            {
+              sql: LIVE_TRANSCRIPT_INSERT_SQL,
+              params: [
+                this.transcriptId,
+                this.startedAtMs,
+                `session-audio:${this.sessionId}`,
+                JSON.stringify(words),
+                JSON.stringify(hints),
+                now,
+                now,
+                this.sessionId,
+              ],
+            },
+            {
+              sql: LIVE_STATE_INSERT_SQL,
+              params: [now, this.transcriptId],
+            },
+          ]);
+          if (inserted !== 1 || stateInserted !== 1) {
+            throw new Error("Live transcript could not be initialized");
+          }
+          this.inserted = true;
+          return;
+        }
+        const [deltaInserted = 0, stateAdvanced = 0] = await executeTransaction(
+          [
+            {
+              sql: LIVE_DELTA_INSERT_SQL,
+              params: [id(), deltaJson, now, this.transcriptId],
+            },
+            {
+              sql: LIVE_STATE_ADVANCE_SQL,
+              params: [now, this.transcriptId],
+            },
+          ],
+        );
+        if (deltaInserted !== 1 || stateAdvanced !== 1) {
+          throw new Error("Live transcript delta could not be saved");
+        }
+      })
+      .then(() => {})
+      .catch((error) => this.fail(error, "persist"));
+  }
+
+  private fail(error: unknown, stage: string) {
+    if (this.status === "fallback") return;
+    this.setStatus("fallback");
+    this.clearKeepAlive();
+    this.queuedAudio = [];
+    this.queuedAudioBytes = 0;
+    this.socket?.close();
+    captureOperationalError(error, {
+      operation: "transcription_live",
+      tags: { mode: "live", stage },
+    });
+    captureAnalytics("transcription_failed", {
+      mode: "live",
+      entry_point: "mobile_audio",
+      failure_stage: stage,
+    });
+  }
+
+  stop(): Promise<boolean> {
+    if (this.stopPromise) return this.stopPromise;
+    this.stopPromise = this.performStop();
+    return this.stopPromise;
+  }
+
+  private async performStop(): Promise<boolean> {
+    this.stopping = true;
+    await this.connectPromise;
+    this.clearKeepAlive();
+    const socket = this.socket;
+    try {
+      if (socket?.readyState === WebSocket.OPEN && this.status === "live") {
+        socket.send(JSON.stringify({ type: "Finalize" }));
+        let timer: ReturnType<typeof setTimeout>;
+        await Promise.race([
+          this.terminalPromise,
+          new Promise<void>((resolve) => {
+            timer = setTimeout(resolve, FINALIZE_TIMEOUT_MS);
+          }),
+        ]);
+        clearTimeout(timer!);
+        if (socket.readyState === WebSocket.OPEN) {
+          socket.send(JSON.stringify({ type: "CloseStream" }));
+          socket.close();
+        }
+      } else {
+        socket?.close();
+      }
+    } catch (error) {
+      this.fail(error, "finalize");
+      try {
+        socket?.close();
+      } catch {}
+    }
+    await this.writeChain;
+    if (this.inserted) {
+      const words = [...this.wordsById.values()].sort(
+        (a, b) => a.start_ms - b.start_ms || a.end_ms - b.end_ms,
+      );
+      const hints = [...this.hintsById.values()];
+      const [finished = 0] = await executeTransaction([
+        {
+          sql: TRANSCRIPT_FINISH_SQL,
+          params: [
+            JSON.stringify(words),
+            JSON.stringify(hints),
+            Date.now(),
+            nowIso(),
+            this.transcriptId,
+          ],
+        },
+        {
+          sql: LIVE_STATE_DELETE_SQL,
+          params: [this.transcriptId],
+        },
+      ]).catch((error) => {
+        this.fail(error, "finish");
+        return [];
+      });
+      if (finished !== 1) {
+        this.fail(
+          new Error("Live transcript could not be finalized"),
+          "finish",
+        );
+      }
+    }
+    const complete =
+      this.status === "live" && this.inserted && this.wordsById.size > 0;
+    if (complete) {
+      captureAnalytics("transcription_completed", {
+        mode: "live",
+        entry_point: "mobile_audio",
+      });
+    }
+    return complete;
+  }
+
+  private clearKeepAlive() {
+    if (this.keepAliveTimer) clearInterval(this.keepAliveTimer);
+    this.keepAliveTimer = null;
+  }
+}
+
+export async function markSessionAudioTranscribed(
+  sessionId: string,
+): Promise<void> {
+  await execute(MARK_AUDIO_COMPLETE_SQL, [
+    nowIso(),
+    `session-audio:${sessionId}`,
+    sessionId,
+  ]);
+}


### PR DESCRIPTION
## Summary
- capture a single 16 kHz PCM microphone stream for both live STT and a checkpointed local WAV
- show hosted live transcript text while recording, with transparent batch fallback when the socket cannot complete
- journal finalized live deltas locally like desktop and materialize one canonical transcript snapshot on stop
- preserve existing transcripts until the first finalized live phrase and save/catalog local audio before waiting on network finalization

## Validation
- `pnpm exec dprint fmt`
- `pnpm fmt:check`
- `pnpm -F @anlg/mobile typecheck`
- `pnpm -F @anlg/mobile test` (47 passing)
- `pnpm exec oxlint --quiet --format=github apps/mobile/src/`

Simulator/device QA intentionally deferred because this is not a release, per product direction. Native iOS/Android release builds run in `mobile_ci`.

Linear: ANLG-70

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large change to the capture/stop pipeline and new network-backed transcription with local DB writes; mitigated by WAV-first persistence, explicit fallback, and parser bounds/tests.
> 
> **Overview**
> Mobile session recording now uses a **single 16 kHz int16 PCM stream** (`useAudioStream`) instead of the native file recorder. Each buffer is written to a **checkpointed local `audio.wav`** via `SessionWavWriter` and streamed to **hosted live STT** over an authenticated WebSocket (`HostedLiveTranscription`).
> 
> The listening UI shows **live connection status and partial/final transcript text**; on stop, audio is cataloged as WAV first, then live transcription is finalized when possible or **batch `transcribeSession`** runs as fallback. Live results are **parsed, bounded, and journaled** into local transcript tables (deltas + final snapshot), tombstoning prior session transcripts only when the first live phrase is persisted.
> 
> Analytics now report `transcription_mode: live_with_batch_fallback` / `live` vs `batch_fallback`. Unit tests cover WAV header/amplitude helpers and hosted message parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440e997a8a1f0c4093a5f768f01b056a17ad71a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->