### PR TITLE
Build owned Google Meet audio transport

### DIFF
--- a/enterprise/Cargo.lock
+++ b/enterprise/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
 name = "anarlog-enterprise-google-meet-worker"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "chrono",
  "futures-util",
  "meeting-capture",

--- a/enterprise/Cargo.toml
+++ b/enterprise/Cargo.toml
@@ -17,6 +17,7 @@ anlg-session-ingest = { path = "../crates/session-ingest", package = "session-in
 anyhow = "1"
 async-trait = "0.1"
 axum = "0.8"
+base64 = "0.22"
 chrono = "0.4"
 futures-util = "0.3"
 http = "1"

--- a/enterprise/google-meet-worker/Cargo.toml
+++ b/enterprise/google-meet-worker/Cargo.toml
@@ -7,6 +7,7 @@ license-file.workspace = true
 [dependencies]
 anlg-meeting-capture.workspace = true
 
+base64.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 futures-util.workspace = true
 reqwest.workspace = true

--- a/enterprise/google-meet-worker/THIRD_PARTY_NOTICES.md
+++ b/enterprise/google-meet-worker/THIRD_PARTY_NOTICES.md
@@ -14,6 +14,10 @@ Reference modules:
 - `core/meetings/modules/join/src/googlemeet/join.ts`
 - `core/meetings/modules/join/src/googlemeet/selectors.ts`
 - `core/meetings/modules/join/src/googlemeet/removal.ts`
+- `core/meetings/modules/gmeet-capture/src/gmeet-capture.ts`
+- `core/meetings/modules/gmeet-capture/src/gmeet-capture-v1.ts`
+- `core/meetings/modules/gmeet-capture/src/gmeet-speakers.ts`
+- `core/meetings/modules/gmeet-capture/src/pcm-capture.ts`
 
 The Anarlog implementation was rewritten in Rust, reorganized around Anarlog's provider-neutral capture contract, and modified for direct Chromium DevTools ownership. Files carrying an adaptation notice have been changed by Fastrepl, Inc.
 

--- a/enterprise/google-meet-worker/src/admission_probe.js
+++ b/enterprise/google-meet-worker/src/admission_probe.js
@@ -35,6 +35,10 @@
         return count;
       }
     }, 0);
+  const participantTileLabel = (element) =>
+    (
+      element.getAttribute("aria-label") || (element.textContent || "").trim()
+    ).slice(0, 128);
 
   const explicitDenial = visibleText([
     "denied your request",
@@ -90,10 +94,9 @@
   });
   const participantTileLabels = Array.from(
     document.querySelectorAll("[data-participant-id]"),
-  ).map(
-    (element) =>
-      element.getAttribute("aria-label") || (element.textContent || "").trim(),
-  );
+  )
+    .slice(0, 128)
+    .map(participantTileLabel);
 
   return {
     waiting_room_visible: waitingRoom,

--- a/enterprise/google-meet-worker/src/capture.rs
+++ b/enterprise/google-meet-worker/src/capture.rs
@@ -1,0 +1,353 @@
+use serde::Deserialize;
+
+use crate::{
+    AudioFrame, CaptureProtocol, CaptureProtocolError, CdpBindingEventStream, CdpError, CdpPage,
+};
+
+const CAPTURE_BINDING: &str = "anlgCapture";
+const CAPTURE_AUDIO_EXPRESSION: &str = include_str!("capture_audio.js");
+const STOP_CAPTURE_EXPRESSION: &str =
+    "globalThis.__anlgCapture ? globalThis.__anlgCapture.stop().then(() => true) : true";
+
+pub struct BrowserCapture {
+    events: CdpBindingEventStream,
+    protocol: CaptureProtocol,
+    last_warning: Option<CaptureWarning>,
+}
+
+impl BrowserCapture {
+    pub async fn install(page: &mut CdpPage) -> Result<(Self, usize), BrowserCaptureError> {
+        page.ensure_binding_events_available()?;
+        page.add_binding(CAPTURE_BINDING).await?;
+        let installed: CaptureInstallation = page.evaluate(CAPTURE_AUDIO_EXPRESSION).await?;
+        let events = page.take_binding_events()?;
+        Ok((
+            Self {
+                events,
+                protocol: CaptureProtocol::default(),
+                last_warning: None,
+            },
+            installed.stream_count,
+        ))
+    }
+
+    pub async fn next_frame(&mut self) -> Result<AudioFrame, BrowserCaptureError> {
+        loop {
+            let payload = self.events.next_payload(CAPTURE_BINDING).await?;
+            if payload.len() <= 1024
+                && let Ok(signal) = serde_json::from_str::<CaptureSignal>(&payload)
+                && signal.version == 1
+            {
+                let scope = signal.scope.unwrap_or_else(|| "unknown".into());
+                let message = signal.message.unwrap_or_else(|| "unknown failure".into());
+                if signal.kind == "warning" {
+                    self.last_warning = Some(CaptureWarning { scope, message });
+                    continue;
+                }
+                if signal.kind == "error" {
+                    return Err(BrowserCaptureError::Script { scope, message });
+                }
+            }
+            return self.protocol.decode(&payload).map_err(Into::into);
+        }
+    }
+
+    pub async fn stop(page: &mut CdpPage) -> Result<(), BrowserCaptureError> {
+        let stop_result = page.evaluate::<bool>(STOP_CAPTURE_EXPRESSION).await;
+        page.close_binding_events().await?;
+        let stopped = stop_result?;
+        if !stopped {
+            return Err(BrowserCaptureError::StopRejected);
+        }
+        Ok(())
+    }
+
+    pub fn take_last_warning(&mut self) -> Option<CaptureWarning> {
+        self.last_warning.take()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureWarning {
+    pub scope: String,
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CaptureInstallation {
+    stream_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct CaptureSignal {
+    #[serde(rename = "v")]
+    version: u8,
+    kind: String,
+    scope: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BrowserCaptureError {
+    #[error(transparent)]
+    Cdp(#[from] CdpError),
+    #[error(transparent)]
+    Protocol(#[from] CaptureProtocolError),
+    #[error("Google Meet capture script failed in {scope}: {message}")]
+    Script { scope: String, message: String },
+    #[error("Google Meet capture script rejected stop")]
+    StopRejected,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures_util::{SinkExt, StreamExt};
+    use serde_json::{Value, json};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::{accept_async, connect_async, tungstenite::Message};
+
+    use super::*;
+
+    #[test]
+    fn shares_one_audio_context_across_participant_streams() {
+        assert_eq!(
+            CAPTURE_AUDIO_EXPRESSION.matches("new AudioContext").count(),
+            1
+        );
+        assert_eq!(
+            CAPTURE_AUDIO_EXPRESSION
+                .matches("audioWorklet.addModule")
+                .count(),
+            1
+        );
+        assert!(CAPTURE_AUDIO_EXPRESSION.contains("postMessage(\"flush\")"));
+        assert!(CAPTURE_AUDIO_EXPRESSION.contains("kind: \"flushed\""));
+    }
+
+    #[tokio::test]
+    async fn installs_capture_and_decodes_a_binding_frame() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+
+            let binding = next_command(&mut websocket).await;
+            assert_eq!(binding["method"], "Runtime.addBinding");
+            reply(&mut websocket, &binding, json!({})).await;
+
+            let evaluate = next_command(&mut websocket).await;
+            assert_eq!(evaluate["method"], "Runtime.evaluate");
+            assert!(
+                evaluate["params"]["expression"]
+                    .as_str()
+                    .unwrap()
+                    .contains("AudioWorkletNode")
+            );
+            reply(
+                &mut websocket,
+                &evaluate,
+                json!({"result": {"value": {"streamCount": 2}}}),
+            )
+            .await;
+
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "method": "Runtime.bindingCalled",
+                        "params": {
+                            "name": CAPTURE_BINDING,
+                            "payload": json!({
+                                "v": 1,
+                                "kind": "warning",
+                                "scope": "connect_stream",
+                                "message": "track disappeared"
+                            }).to_string()
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "method": "Runtime.bindingCalled",
+                        "params": {
+                            "name": CAPTURE_BINDING,
+                            "payload": json!({
+                                "v": 1,
+                                "kind": "audio",
+                                "sequence": 1,
+                                "track_index": 2,
+                                "sample_rate": 16000,
+                                "start_ms": 256,
+                                "pcm_s16le": "AQD//w=="
+                            }).to_string()
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+
+            assert!(matches!(
+                websocket.next().await,
+                Some(Ok(Message::Close(_)))
+            ));
+        });
+
+        let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let mut page = CdpPage::from_test_websocket(websocket);
+        let (mut capture, initial_streams) = BrowserCapture::install(&mut page).await.unwrap();
+
+        assert_eq!(initial_streams, 2);
+        assert_eq!(capture.next_frame().await.unwrap().samples, vec![1, -1]);
+        assert_eq!(
+            capture.take_last_warning(),
+            Some(CaptureWarning {
+                scope: "connect_stream".into(),
+                message: "track disappeared".into(),
+            })
+        );
+        page.close().await.unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn retries_install_after_evaluation_failure_without_losing_events() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+
+            let binding = next_command(&mut websocket).await;
+            assert_eq!(binding["method"], "Runtime.addBinding");
+            reply(&mut websocket, &binding, json!({})).await;
+
+            let failed_evaluation = next_command(&mut websocket).await;
+            reply(
+                &mut websocket,
+                &failed_evaluation,
+                json!({"exceptionDetails": {"text": "capture failed"}}),
+            )
+            .await;
+
+            let retried_evaluation = next_command(&mut websocket).await;
+            assert_eq!(retried_evaluation["method"], "Runtime.evaluate");
+            reply(
+                &mut websocket,
+                &retried_evaluation,
+                json!({"result": {"value": {"streamCount": 0}}}),
+            )
+            .await;
+
+            assert!(matches!(
+                websocket.next().await,
+                Some(Ok(Message::Close(_)))
+            ));
+        });
+
+        let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let mut page = CdpPage::from_test_websocket(websocket);
+
+        assert!(matches!(
+            BrowserCapture::install(&mut page).await,
+            Err(BrowserCaptureError::Cdp(CdpError::EvaluationException(_)))
+        ));
+        let (_, initial_streams) = BrowserCapture::install(&mut page).await.unwrap();
+        assert_eq!(initial_streams, 0);
+
+        page.close().await.unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stop_unblocks_a_waiting_frame_consumer() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+
+            let binding = next_command(&mut websocket).await;
+            reply(&mut websocket, &binding, json!({})).await;
+            let install = next_command(&mut websocket).await;
+            reply(
+                &mut websocket,
+                &install,
+                json!({"result": {"value": {"streamCount": 0}}}),
+            )
+            .await;
+
+            let stop = next_command(&mut websocket).await;
+            assert_eq!(stop["method"], "Runtime.evaluate");
+            assert!(
+                stop["params"]["expression"]
+                    .as_str()
+                    .unwrap()
+                    .contains("__anlgCapture.stop")
+            );
+            reply(&mut websocket, &stop, json!({"result": {"value": true}})).await;
+
+            assert!(matches!(
+                websocket.next().await,
+                Some(Ok(Message::Close(_)))
+            ));
+        });
+
+        let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let mut page = CdpPage::from_test_websocket(websocket);
+        let (mut capture, _) = BrowserCapture::install(&mut page).await.unwrap();
+
+        let (frame_result, stop_result) = tokio::time::timeout(Duration::from_secs(1), async {
+            tokio::join!(capture.next_frame(), BrowserCapture::stop(&mut page))
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            frame_result,
+            Err(BrowserCaptureError::Cdp(CdpError::BindingEventStreamClosed))
+        ));
+        stop_result.unwrap();
+        assert!(matches!(
+            BrowserCapture::install(&mut page).await,
+            Err(BrowserCaptureError::Cdp(
+                CdpError::BindingEventsAlreadyTaken
+            ))
+        ));
+
+        page.close().await.unwrap();
+        server.await.unwrap();
+    }
+
+    async fn next_command(
+        websocket: &mut tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
+    ) -> Value {
+        let Message::Text(command) = websocket.next().await.unwrap().unwrap() else {
+            panic!("expected text command")
+        };
+        serde_json::from_str(command.as_ref()).unwrap()
+    }
+
+    async fn reply(
+        websocket: &mut tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
+        command: &Value,
+        result: Value,
+    ) {
+        websocket
+            .send(Message::Text(
+                json!({"id": command["id"], "result": result})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+    }
+}

--- a/enterprise/google-meet-worker/src/capture_audio.js
+++ b/enterprise/google-meet-worker/src/capture_audio.js
@@ -1,0 +1,378 @@
+// Source-informed adaptation of Vexa v0.12.18 gmeet-capture.ts and pcm-capture.ts.
+// Licensed under Apache-2.0; see ../THIRD_PARTY_NOTICES.md and ../third-party/VEXA-LICENSE.
+(async () => {
+  const existing = globalThis.__anlgCapture;
+  if (existing) {
+    await existing.ready;
+    return { streamCount: existing.streamCount() };
+  }
+
+  const SAMPLE_RATE = 16000;
+  const BLOCK_SIZE = 4096;
+  const SILENCE_THRESHOLD = 0.005;
+  const RESCAN_MS = 15000;
+  const SPEAKER_SCAN_MS = 250;
+  const PROCESSOR_NAME = "anlg-pcm-capture";
+  const BINDING_NAME = "anlgCapture";
+  const SPEAKING_CLASSES = [
+    "Oaajhc",
+    "HX2H7",
+    "wEsLMd",
+    "OgVli",
+    "speaking",
+    "active-speaker",
+    "speaker-active",
+    "speaking-indicator",
+  ];
+  const streamIndexes = new Map();
+  const connections = new Map();
+  const connectingStreamIds = new Set();
+  let nextIndex = 0;
+  let nextSequence = 1;
+  let running = true;
+  let activeSpeakers = [];
+  const captureStartedAt = performance.now();
+  const trackEndsMs = new Map();
+
+  const workletSource = `
+class AnlgPcmCapture extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.buffer = new Float32Array(${BLOCK_SIZE});
+    this.length = 0;
+    this.port.onmessage = ({ data }) => {
+      if (data !== "flush") return;
+      if (this.length > 0) {
+        const trailing = this.buffer.slice(0, this.length);
+        this.port.postMessage(trailing, [trailing.buffer]);
+        this.buffer = new Float32Array(${BLOCK_SIZE});
+        this.length = 0;
+      }
+      this.port.postMessage({ kind: "flushed" });
+    };
+  }
+
+  process(inputs) {
+    const channel = inputs[0] && inputs[0][0];
+    if (!channel) return true;
+    for (let index = 0; index < channel.length; index += 1) {
+      this.buffer[this.length] = channel[index];
+      this.length += 1;
+      if (this.length === ${BLOCK_SIZE}) {
+        this.port.postMessage(this.buffer, [this.buffer.buffer]);
+        this.buffer = new Float32Array(${BLOCK_SIZE});
+        this.length = 0;
+      }
+    }
+    return true;
+  }
+}
+registerProcessor("${PROCESSOR_NAME}", AnlgPcmCapture);
+`;
+
+  const context = new AudioContext({ sampleRate: SAMPLE_RATE });
+  const sink = context.createGain();
+  sink.gain.value = 0;
+  const contextReady = (async () => {
+    if (context.sampleRate !== SAMPLE_RATE) {
+      throw new Error(
+        `expected ${SAMPLE_RATE} Hz, got ${context.sampleRate} Hz`,
+      );
+    }
+    const moduleUrl = URL.createObjectURL(
+      new Blob([workletSource], { type: "application/javascript" }),
+    );
+    try {
+      await context.audioWorklet.addModule(moduleUrl);
+    } finally {
+      URL.revokeObjectURL(moduleUrl);
+    }
+    await context.resume();
+    if (context.state !== "running") {
+      throw new Error(`audio context is ${context.state}`);
+    }
+    sink.connect(context.destination);
+  })();
+
+  const toBase64Pcm = (samples) => {
+    const bytes = new Uint8Array(samples.length * 2);
+    const view = new DataView(bytes.buffer);
+    for (let index = 0; index < samples.length; index += 1) {
+      const sample = Math.max(-1, Math.min(1, samples[index]));
+      const quantized = sample < 0 ? sample * 32768 : sample * 32767;
+      view.setInt16(index * 2, Math.round(quantized), true);
+    }
+    let binary = "";
+    for (let index = 0; index < bytes.length; index += 1) {
+      binary += String.fromCharCode(bytes[index]);
+    }
+    return btoa(binary);
+  };
+
+  const reportWarning = (scope, error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    globalThis[BINDING_NAME](
+      JSON.stringify({
+        v: 1,
+        kind: "warning",
+        scope,
+        message: message.slice(0, 512),
+      }),
+    );
+  };
+
+  const tileName = (tile) => {
+    const translated = tile
+      .querySelector("span.notranslate")
+      ?.textContent?.trim();
+    const selfName = tile
+      .querySelector("[data-self-name]")
+      ?.getAttribute("data-self-name")
+      ?.trim();
+    const name = translated || selfName;
+    if (!name || name.length > 100 || /[\u0000-\u001f\u007f]/u.test(name))
+      return undefined;
+    return name;
+  };
+
+  const isSelfTile = (tile) =>
+    tile.hasAttribute("data-self-name") ||
+    tile.querySelector("[data-self-name]") !== null;
+
+  const isSpeakingTile = (tile) =>
+    SPEAKING_CLASSES.some(
+      (className) =>
+        tile.classList.contains(className) ||
+        tile.querySelector(`.${className}`) !== null,
+    );
+
+  const hintForTile = (tile) => {
+    if (!tile || isSelfTile(tile)) return {};
+    const speakerName = tileName(tile);
+    const rawParticipantId = tile.getAttribute("data-participant-id")?.trim();
+    const participantId =
+      rawParticipantId &&
+      rawParticipantId.length <= 256 &&
+      !/[\u0000-\u001f\u007f]/u.test(rawParticipantId)
+        ? rawParticipantId
+        : undefined;
+    return {
+      ...(speakerName ? { speaker_name: speakerName } : {}),
+      ...(participantId ? { participant_id: participantId } : {}),
+    };
+  };
+
+  const scanSpeakers = () => {
+    const speakers = [];
+    const seen = new Set();
+    for (const tile of document.querySelectorAll("[data-participant-id]")) {
+      const participantId = tile.getAttribute("data-participant-id");
+      if (
+        !participantId ||
+        seen.has(participantId) ||
+        isSelfTile(tile) ||
+        !isSpeakingTile(tile)
+      ) {
+        continue;
+      }
+      seen.add(participantId);
+      const hint = hintForTile(tile);
+      if (hint.speaker_name || hint.participant_id) speakers.push(hint);
+    }
+    activeSpeakers = speakers;
+  };
+
+  const speakerHint = (element) => {
+    const tile = element.closest("[data-participant-id]");
+    const direct = hintForTile(tile);
+    if (direct.speaker_name || direct.participant_id) return direct;
+    return activeSpeakers.length === 1 ? activeSpeakers[0] : {};
+  };
+
+  const disconnect = async (streamId) => {
+    const connection = connections.get(streamId);
+    if (!connection) return;
+    connections.delete(streamId);
+    await connection.flush();
+    try {
+      connection.source.disconnect();
+      connection.worklet.disconnect();
+    } catch {}
+  };
+
+  const connect = async (element) => {
+    const stream = element.srcObject;
+    if (
+      !(stream instanceof MediaStream) ||
+      stream.getAudioTracks().length === 0
+    )
+      return;
+    const participantTile = element.closest("[data-participant-id]");
+    if (participantTile && isSelfTile(participantTile)) return;
+    if (connections.has(stream.id) || connectingStreamIds.has(stream.id))
+      return;
+    const track = stream.getAudioTracks()[0];
+    let trackEnded = track.readyState === "ended";
+    const onTrackEnded = () => {
+      trackEnded = true;
+      void disconnect(stream.id);
+    };
+    track.addEventListener("ended", onTrackEnded, { once: true });
+    connectingStreamIds.add(stream.id);
+    let connected = false;
+
+    try {
+      let trackIndex = streamIndexes.get(stream.id);
+      if (trackIndex === undefined) {
+        trackIndex = nextIndex;
+        nextIndex += 1;
+        streamIndexes.set(stream.id, trackIndex);
+      }
+
+      const connectionStartedAt = Math.floor(
+        performance.now() - captureStartedAt,
+      );
+      let source;
+      let worklet;
+      try {
+        if (!running || trackEnded || track.readyState === "ended") {
+          return;
+        }
+
+        source = context.createMediaStreamSource(stream);
+        worklet = new AudioWorkletNode(context, PROCESSOR_NAME, {
+          numberOfInputs: 1,
+          numberOfOutputs: 1,
+          outputChannelCount: [1],
+          channelCount: 1,
+          channelCountMode: "explicit",
+          channelInterpretation: "speakers",
+        });
+        source.connect(worklet);
+        worklet.connect(sink);
+
+        let samplesSeen = 0;
+        let finishFlush;
+        worklet.port.onmessage = ({ data }) => {
+          if (data?.kind === "flushed") {
+            finishFlush?.();
+            return;
+          }
+          if (!(data instanceof Float32Array) || (!running && !finishFlush))
+            return;
+          const sampledStartMs =
+            connectionStartedAt +
+            Math.floor((samplesSeen * 1000) / SAMPLE_RATE);
+          const startMs = Math.max(
+            sampledStartMs,
+            trackEndsMs.get(trackIndex) ?? 0,
+          );
+          samplesSeen += data.length;
+          let peak = 0;
+          for (let index = 0; index < data.length; index += 1) {
+            peak = Math.max(peak, Math.abs(data[index]));
+          }
+          if (peak <= SILENCE_THRESHOLD) return;
+          const durationMs = Math.ceil((data.length * 1000) / SAMPLE_RATE);
+          const speaker = speakerHint(element);
+          globalThis[BINDING_NAME](
+            JSON.stringify({
+              v: 1,
+              kind: "audio",
+              sequence: nextSequence,
+              track_index: trackIndex,
+              sample_rate: SAMPLE_RATE,
+              start_ms: startMs,
+              pcm_s16le: toBase64Pcm(data),
+              ...speaker,
+            }),
+          );
+          trackEndsMs.set(trackIndex, startMs + durationMs);
+          nextSequence += 1;
+        };
+
+        const flush = () =>
+          new Promise((resolve) => {
+            let timeout;
+            const finish = () => {
+              clearTimeout(timeout);
+              finishFlush = undefined;
+              resolve();
+            };
+            finishFlush = finish;
+            timeout = setTimeout(finish, 500);
+            try {
+              worklet.port.postMessage("flush");
+            } catch {
+              finish();
+            }
+          });
+        connections.set(stream.id, { source, worklet, flush });
+        connected = true;
+      } catch (error) {
+        try {
+          source?.disconnect();
+          worklet?.disconnect();
+        } catch {}
+        throw error;
+      }
+    } finally {
+      if (!connected) track.removeEventListener("ended", onTrackEnded);
+      connectingStreamIds.delete(stream.id);
+    }
+  };
+
+  const scan = async () => {
+    if (!running) return;
+    const pending = [];
+    for (const element of document.querySelectorAll("audio, video")) {
+      pending.push(
+        connect(element).catch((error) => {
+          if (running) reportWarning("connect_stream", error);
+        }),
+      );
+    }
+    await Promise.all(pending);
+  };
+
+  let timer;
+  let speakerTimer;
+  const ready = (async () => {
+    await contextReady;
+    if (!running) return;
+    scanSpeakers();
+    await scan();
+    if (running) {
+      timer = setInterval(() => void scan(), RESCAN_MS);
+      speakerTimer = setInterval(scanSpeakers, SPEAKER_SCAN_MS);
+    }
+  })();
+  globalThis.__anlgCapture = {
+    ready,
+    streamCount: () => connections.size,
+    stop: async () => {
+      if (!running) return;
+      running = false;
+      if (timer !== undefined) clearInterval(timer);
+      if (speakerTimer !== undefined) clearInterval(speakerTimer);
+      await Promise.all([...connections.keys()].map(disconnect));
+      connectingStreamIds.clear();
+      try {
+        sink.disconnect();
+      } catch {}
+      await context.close().catch(() => {});
+      delete globalThis.__anlgCapture;
+    },
+  };
+  try {
+    await ready;
+    return { streamCount: connections.size };
+  } catch (error) {
+    delete globalThis.__anlgCapture;
+    try {
+      sink.disconnect();
+    } catch {}
+    await context.close().catch(() => {});
+    throw error;
+  }
+})();

--- a/enterprise/google-meet-worker/src/capture_protocol.rs
+++ b/enterprise/google-meet-worker/src/capture_protocol.rs
@@ -1,0 +1,359 @@
+// Source-informed adaptation of Vexa v0.12.18 gmeet-capture.ts and pcm-capture.ts.
+// Licensed under Apache-2.0; see ../THIRD_PARTY_NOTICES.md and ../third-party/VEXA-LICENSE.
+
+use std::collections::HashMap;
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+use serde::Deserialize;
+
+const PROTOCOL_VERSION: u8 = 1;
+const SAMPLE_RATE: u32 = 16_000;
+const MAX_PAYLOAD_BYTES: usize = 16 * 1024;
+const MAX_SAMPLES_PER_FRAME: usize = 4096;
+const MAX_TRACK_INDEX: u32 = 4095;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AudioFrame {
+    pub sequence: u64,
+    pub track_index: u32,
+    pub sample_rate: u32,
+    pub start_ms: u64,
+    pub samples: Vec<i16>,
+    pub speaker: Option<SpeakerHint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpeakerHint {
+    pub display_name: Option<String>,
+    pub participant_id: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct CaptureProtocol {
+    last_sequence: Option<u64>,
+    track_ends_ms: HashMap<u32, u64>,
+}
+
+impl CaptureProtocol {
+    pub fn decode(&mut self, payload: &str) -> Result<AudioFrame, CaptureProtocolError> {
+        if payload.len() > MAX_PAYLOAD_BYTES {
+            return Err(CaptureProtocolError::PayloadTooLarge(payload.len()));
+        }
+        let wire: WireAudioFrame = serde_json::from_str(payload)?;
+        if wire.version != PROTOCOL_VERSION {
+            return Err(CaptureProtocolError::UnsupportedVersion(wire.version));
+        }
+        if wire.kind != "audio" {
+            return Err(CaptureProtocolError::UnsupportedKind(wire.kind));
+        }
+        if wire.sample_rate != SAMPLE_RATE {
+            return Err(CaptureProtocolError::UnsupportedSampleRate(
+                wire.sample_rate,
+            ));
+        }
+        if wire.track_index > MAX_TRACK_INDEX {
+            return Err(CaptureProtocolError::TrackIndexOutOfRange(wire.track_index));
+        }
+        let expected_sequence = match self.last_sequence {
+            Some(sequence) => sequence
+                .checked_add(1)
+                .ok_or(CaptureProtocolError::SequenceExhausted)?,
+            None => 1,
+        };
+        if wire.sequence != expected_sequence {
+            return Err(CaptureProtocolError::UnexpectedSequence {
+                expected: expected_sequence,
+                actual: wire.sequence,
+            });
+        }
+
+        let bytes = STANDARD
+            .decode(wire.pcm_s16le)
+            .map_err(CaptureProtocolError::InvalidPcmEncoding)?;
+        if bytes.is_empty() || bytes.len() % 2 != 0 {
+            return Err(CaptureProtocolError::InvalidPcmLength(bytes.len()));
+        }
+        let sample_count = bytes.len() / 2;
+        if sample_count > MAX_SAMPLES_PER_FRAME {
+            return Err(CaptureProtocolError::TooManySamples(sample_count));
+        }
+        let duration_ms = (sample_count as u64 * 1000).div_ceil(SAMPLE_RATE as u64);
+        if let Some(previous_end_ms) = self.track_ends_ms.get(&wire.track_index)
+            && wire.start_ms < *previous_end_ms
+        {
+            return Err(CaptureProtocolError::OverlappingTrackFrame {
+                track_index: wire.track_index,
+                previous_end_ms: *previous_end_ms,
+                start_ms: wire.start_ms,
+            });
+        }
+
+        let samples = bytes
+            .chunks_exact(2)
+            .map(|sample| i16::from_le_bytes([sample[0], sample[1]]))
+            .collect();
+        let speaker = SpeakerHint::from_wire(wire.speaker_name, wire.participant_id);
+        let end_ms = wire
+            .start_ms
+            .checked_add(duration_ms)
+            .ok_or(CaptureProtocolError::TimestampOverflow)?;
+        self.last_sequence = Some(wire.sequence);
+        self.track_ends_ms.insert(wire.track_index, end_ms);
+        Ok(AudioFrame {
+            sequence: wire.sequence,
+            track_index: wire.track_index,
+            sample_rate: wire.sample_rate,
+            start_ms: wire.start_ms,
+            samples,
+            speaker,
+        })
+    }
+}
+
+impl SpeakerHint {
+    fn from_wire(display_name: Option<String>, participant_id: Option<String>) -> Option<Self> {
+        let display_name = display_name.and_then(|value| sanitize_hint(value, 100));
+        let participant_id = participant_id.and_then(|value| sanitize_hint(value, 256));
+        if display_name.is_none() && participant_id.is_none() {
+            None
+        } else {
+            Some(Self {
+                display_name,
+                participant_id,
+            })
+        }
+    }
+}
+
+fn sanitize_hint(value: String, max_length: usize) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.chars().count() > max_length
+        || trimmed.chars().any(char::is_control)
+    {
+        return None;
+    }
+    Some(trimmed.to_owned())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireAudioFrame {
+    #[serde(rename = "v")]
+    version: u8,
+    kind: String,
+    sequence: u64,
+    track_index: u32,
+    sample_rate: u32,
+    start_ms: u64,
+    pcm_s16le: String,
+    #[serde(default)]
+    speaker_name: Option<String>,
+    #[serde(default)]
+    participant_id: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CaptureProtocolError {
+    #[error("capture payload is too large: {0} bytes")]
+    PayloadTooLarge(usize),
+    #[error("invalid capture payload")]
+    Json(#[from] serde_json::Error),
+    #[error("unsupported capture protocol version: {0}")]
+    UnsupportedVersion(u8),
+    #[error("unsupported capture payload kind: {0}")]
+    UnsupportedKind(String),
+    #[error("unsupported capture sample rate: {0}")]
+    UnsupportedSampleRate(u32),
+    #[error("capture track index is out of range: {0}")]
+    TrackIndexOutOfRange(u32),
+    #[error("unexpected capture sequence: expected {expected}, got {actual}")]
+    UnexpectedSequence { expected: u64, actual: u64 },
+    #[error("capture sequence is exhausted")]
+    SequenceExhausted,
+    #[error("capture PCM is not valid base64")]
+    InvalidPcmEncoding(#[source] base64::DecodeError),
+    #[error("capture PCM has invalid byte length: {0}")]
+    InvalidPcmLength(usize),
+    #[error("capture PCM contains too many samples: {0}")]
+    TooManySamples(usize),
+    #[error("capture timestamp overflowed")]
+    TimestampOverflow,
+    #[error(
+        "capture frame overlaps track {track_index}: previous end {previous_end_ms}ms, start {start_ms}ms"
+    )]
+    OverlappingTrackFrame {
+        track_index: u32,
+        previous_end_ms: u64,
+        start_ms: u64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn payload(sequence: u64, track_index: u32, start_ms: u64, samples: &[i16]) -> String {
+        let bytes: Vec<_> = samples
+            .iter()
+            .flat_map(|sample| sample.to_le_bytes())
+            .collect();
+        json!({
+            "v": 1,
+            "kind": "audio",
+            "sequence": sequence,
+            "track_index": track_index,
+            "sample_rate": 16000,
+            "start_ms": start_ms,
+            "pcm_s16le": STANDARD.encode(bytes),
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn decodes_little_endian_pcm_and_tracks_sequence() {
+        let mut protocol = CaptureProtocol::default();
+
+        let frame = protocol
+            .decode(&payload(1, 3, 0, &[-32768, 0, 32767]))
+            .unwrap();
+
+        assert_eq!(frame.sequence, 1);
+        assert_eq!(frame.track_index, 3);
+        assert_eq!(frame.samples, vec![-32768, 0, 32767]);
+    }
+
+    #[test]
+    fn rejects_sequence_gaps_without_advancing_state() {
+        let mut protocol = CaptureProtocol::default();
+
+        assert!(matches!(
+            protocol.decode(&payload(2, 0, 0, &[1])),
+            Err(CaptureProtocolError::UnexpectedSequence {
+                expected: 1,
+                actual: 2
+            })
+        ));
+        assert!(protocol.decode(&payload(1, 0, 0, &[1])).is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_and_odd_length_pcm() {
+        let mut protocol = CaptureProtocol::default();
+        let invalid = json!({
+            "v": 1,
+            "kind": "audio",
+            "sequence": 1,
+            "track_index": 0,
+            "sample_rate": 16000,
+            "start_ms": 0,
+            "pcm_s16le": "not base64",
+        })
+        .to_string();
+        let odd = json!({
+            "v": 1,
+            "kind": "audio",
+            "sequence": 1,
+            "track_index": 0,
+            "sample_rate": 16000,
+            "start_ms": 0,
+            "pcm_s16le": STANDARD.encode([1]),
+        })
+        .to_string();
+
+        assert!(matches!(
+            protocol.decode(&invalid),
+            Err(CaptureProtocolError::InvalidPcmEncoding(_))
+        ));
+        assert!(matches!(
+            protocol.decode(&odd),
+            Err(CaptureProtocolError::InvalidPcmLength(1))
+        ));
+    }
+
+    #[test]
+    fn rejects_overlapping_frames_per_track() {
+        let mut protocol = CaptureProtocol::default();
+        protocol.decode(&payload(1, 4, 100, &[1; 160])).unwrap();
+
+        assert!(matches!(
+            protocol.decode(&payload(2, 4, 109, &[2])),
+            Err(CaptureProtocolError::OverlappingTrackFrame {
+                track_index: 4,
+                previous_end_ms: 110,
+                start_ms: 109
+            })
+        ));
+    }
+
+    #[test]
+    fn carries_bounded_speaker_attribution() {
+        let mut protocol = CaptureProtocol::default();
+        let bytes: Vec<_> = [1_i16]
+            .iter()
+            .flat_map(|sample| sample.to_le_bytes())
+            .collect();
+        let attributed = json!({
+            "v": 1,
+            "kind": "audio",
+            "sequence": 1,
+            "track_index": 0,
+            "sample_rate": 16000,
+            "start_ms": 0,
+            "pcm_s16le": STANDARD.encode(bytes),
+            "speaker_name": "  Ada Lovelace  ",
+            "participant_id": "spaces/abc/devices/123",
+        })
+        .to_string();
+
+        assert_eq!(
+            protocol.decode(&attributed).unwrap().speaker,
+            Some(SpeakerHint {
+                display_name: Some("Ada Lovelace".into()),
+                participant_id: Some("spaces/abc/devices/123".into()),
+            })
+        );
+    }
+
+    #[test]
+    fn drops_invalid_speaker_fields_without_desynchronizing_audio() {
+        let mut protocol = CaptureProtocol::default();
+        let bytes: Vec<_> = [1_i16]
+            .iter()
+            .flat_map(|sample| sample.to_le_bytes())
+            .collect();
+        let invalid = json!({
+            "v": 1,
+            "kind": "audio",
+            "sequence": 1,
+            "track_index": 0,
+            "sample_rate": 16000,
+            "start_ms": 0,
+            "pcm_s16le": STANDARD.encode(bytes),
+            "speaker_name": "Ada\nLovelace",
+            "participant_id": "spaces/abc/devices/123",
+        })
+        .to_string();
+
+        assert_eq!(
+            protocol.decode(&invalid).unwrap().speaker,
+            Some(SpeakerHint {
+                display_name: None,
+                participant_id: Some("spaces/abc/devices/123".into()),
+            })
+        );
+        assert!(protocol.decode(&payload(2, 1, 0, &[2])).is_ok());
+    }
+
+    #[test]
+    fn rejects_timestamp_overflow_without_advancing_sequence() {
+        let mut protocol = CaptureProtocol::default();
+
+        assert!(matches!(
+            protocol.decode(&payload(1, 0, u64::MAX, &[1])),
+            Err(CaptureProtocolError::TimestampOverflow)
+        ));
+        assert!(protocol.decode(&payload(1, 0, 0, &[1])).is_ok());
+    }
+}

--- a/enterprise/google-meet-worker/src/cdp.rs
+++ b/enterprise/google-meet-worker/src/cdp.rs
@@ -1,18 +1,33 @@
-use std::{net::IpAddr, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    net::IpAddr,
+    time::Duration,
+};
 
 use futures_util::{SinkExt, StreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
-use tokio::net::TcpStream;
+use tokio::{
+    net::TcpStream,
+    sync::{mpsc, mpsc::error::TrySendError, oneshot},
+    task::JoinHandle,
+};
 use tokio_tungstenite::{
-    MaybeTlsStream, WebSocketStream, connect_async,
-    tungstenite::{Error as WebSocketError, Message},
+    MaybeTlsStream, WebSocketStream, connect_async_with_config,
+    tungstenite::{Error as WebSocketError, Message, protocol::WebSocketConfig},
 };
 use url::Url;
+
+#[cfg(test)]
+use tokio_tungstenite::connect_async;
 
 use crate::{ADMISSION_PROBE_EXPRESSION, AdmissionSnapshot};
 
 const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+const CDP_EVENT_CAPACITY: usize = 2048;
+const CDP_MAX_MESSAGE_BYTES: usize = 256 * 1024;
+
+type PageWebSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GoogleMeetUrl(Url);
@@ -45,8 +60,10 @@ impl GoogleMeetUrl {
 }
 
 pub struct CdpPage {
-    websocket: WebSocketStream<MaybeTlsStream<TcpStream>>,
-    next_command_id: u64,
+    commands: mpsc::Sender<CdpRequest>,
+    binding_events: Option<mpsc::Receiver<Value>>,
+    bindings: HashSet<String>,
+    actor: JoinHandle<()>,
     command_timeout: Duration,
 }
 
@@ -75,14 +92,14 @@ impl CdpPage {
         let target: CdpTarget = response.json().await.map_err(CdpError::DiscoveryResponse)?;
         let page_url =
             validate_target_websocket_url(&target.web_socket_debugger_url, browser_port)?;
-        let (websocket, _) = connect_async(page_url.as_str())
-            .await
-            .map_err(CdpError::WebSocket)?;
-        Ok(Self {
-            websocket,
-            next_command_id: 1,
-            command_timeout: DEFAULT_COMMAND_TIMEOUT,
-        })
+        let websocket_config = WebSocketConfig::default()
+            .max_message_size(Some(CDP_MAX_MESSAGE_BYTES))
+            .max_frame_size(Some(CDP_MAX_MESSAGE_BYTES));
+        let (websocket, _) =
+            connect_async_with_config(page_url.as_str(), Some(websocket_config), false)
+                .await
+                .map_err(CdpError::WebSocket)?;
+        Ok(Self::from_websocket(websocket, DEFAULT_COMMAND_TIMEOUT))
     }
 
     pub async fn probe_admission(&mut self) -> Result<AdmissionSnapshot, CdpError> {
@@ -90,28 +107,19 @@ impl CdpPage {
     }
 
     pub async fn evaluate<T: DeserializeOwned>(&mut self, expression: &str) -> Result<T, CdpError> {
-        let command_id = self.next_command_id;
-        self.next_command_id = self.next_command_id.saturating_add(1);
-        let command = json!({
-            "id": command_id,
-            "method": "Runtime.evaluate",
-            "params": {
+        let result = self
+            .command(
+                "Runtime.evaluate",
+                json!({
                 "expression": expression,
                 "returnByValue": true,
                 "awaitPromise": true
-            }
-        });
-        self.websocket
-            .send(Message::Text(command.to_string().into()))
-            .await
-            .map_err(CdpError::WebSocket)?;
-
-        let result = tokio::time::timeout(
-            self.command_timeout,
-            receive_command_result(&mut self.websocket, command_id),
-        )
-        .await
-        .map_err(|_| CdpError::CommandTimeout(self.command_timeout))??;
+                }),
+            )
+            .await?;
+        if result.get("exceptionDetails").is_some() {
+            return Err(CdpError::EvaluationException(result));
+        }
         let value = result
             .pointer("/result/value")
             .cloned()
@@ -119,22 +127,128 @@ impl CdpPage {
         serde_json::from_value(value).map_err(CdpError::EvaluationValue)
     }
 
-    pub async fn close(mut self) -> Result<(), CdpError> {
-        self.websocket
-            .close(None)
+    pub async fn add_binding(&mut self, name: &str) -> Result<(), CdpError> {
+        if name.is_empty()
+            || !name
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        {
+            return Err(CdpError::InvalidBindingName(name.into()));
+        }
+        if self.bindings.contains(name) {
+            return Ok(());
+        }
+        self.command("Runtime.addBinding", json!({ "name": name }))
+            .await?;
+        self.bindings.insert(name.into());
+        Ok(())
+    }
+
+    pub fn take_binding_events(&mut self) -> Result<CdpBindingEventStream, CdpError> {
+        self.binding_events
+            .take()
+            .map(|receiver| CdpBindingEventStream { receiver })
+            .ok_or(CdpError::BindingEventsAlreadyTaken)
+    }
+
+    pub fn ensure_binding_events_available(&self) -> Result<(), CdpError> {
+        self.binding_events
+            .is_some()
+            .then_some(())
+            .ok_or(CdpError::BindingEventsAlreadyTaken)
+    }
+
+    pub async fn close_binding_events(&mut self) -> Result<(), CdpError> {
+        self.binding_events.take();
+        let (response, result) = oneshot::channel();
+        self.commands
+            .send(CdpRequest::CloseBindingEvents { response })
             .await
-            .map_err(CdpError::WebSocket)
+            .map_err(|_| CdpError::ActorUnavailable)?;
+        tokio::time::timeout(self.command_timeout, result)
+            .await
+            .map_err(|_| CdpError::CommandTimeout(self.command_timeout))?
+            .map_err(|_| CdpError::ActorUnavailable)
+    }
+
+    pub async fn close(self) -> Result<(), CdpError> {
+        let Self {
+            commands,
+            binding_events,
+            bindings: _,
+            actor,
+            command_timeout,
+        } = self;
+        drop(binding_events);
+        let (response, result) = oneshot::channel();
+        commands
+            .send(CdpRequest::Close { response })
+            .await
+            .map_err(|_| CdpError::ActorUnavailable)?;
+        tokio::time::timeout(command_timeout, result)
+            .await
+            .map_err(|_| CdpError::CommandTimeout(command_timeout))?
+            .map_err(|_| CdpError::ActorUnavailable)??;
+        actor.await.map_err(CdpError::ActorJoin)?;
+        Ok(())
+    }
+
+    async fn command(&mut self, method: &'static str, params: Value) -> Result<Value, CdpError> {
+        let (response, result) = oneshot::channel();
+        self.commands
+            .send(CdpRequest::Command {
+                method,
+                params,
+                response,
+            })
+            .await
+            .map_err(|_| CdpError::ActorUnavailable)?;
+        tokio::time::timeout(self.command_timeout, result)
+            .await
+            .map_err(|_| CdpError::CommandTimeout(self.command_timeout))?
+            .map_err(|_| CdpError::ActorUnavailable)?
+            .map_err(Into::into)
+    }
+
+    fn from_websocket(websocket: PageWebSocket, command_timeout: Duration) -> Self {
+        let (commands, command_receiver) = mpsc::channel(32);
+        let (event_sender, binding_events) = mpsc::channel(CDP_EVENT_CAPACITY);
+        let actor = tokio::spawn(run_cdp_actor(websocket, command_receiver, event_sender));
+        Self {
+            commands,
+            binding_events: Some(binding_events),
+            bindings: HashSet::new(),
+            actor,
+            command_timeout,
+        }
     }
 
     #[cfg(test)]
-    pub(crate) fn from_test_websocket(
-        websocket: WebSocketStream<MaybeTlsStream<TcpStream>>,
-    ) -> Self {
-        Self {
-            websocket,
-            next_command_id: 1,
-            command_timeout: Duration::from_secs(1),
+    pub(crate) fn from_test_websocket(websocket: PageWebSocket) -> Self {
+        Self::from_websocket(websocket, Duration::from_secs(1))
+    }
+}
+
+pub struct CdpBindingEventStream {
+    receiver: mpsc::Receiver<Value>,
+}
+
+impl CdpBindingEventStream {
+    pub async fn next_payload(&mut self, binding_name: &str) -> Result<String, CdpError> {
+        while let Some(event) = self.receiver.recv().await {
+            let Some(params) = event.get("params") else {
+                continue;
+            };
+            if params.get("name").and_then(Value::as_str) != Some(binding_name) {
+                continue;
+            }
+            return params
+                .get("payload")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .ok_or(CdpError::InvalidBindingEvent);
         }
+        Err(CdpError::BindingEventStreamClosed)
     }
 }
 
@@ -144,49 +258,143 @@ struct CdpTarget {
     web_socket_debugger_url: String,
 }
 
-#[derive(Debug, serde::Deserialize)]
-struct CdpEnvelope {
-    id: Option<u64>,
-    result: Option<Value>,
-    error: Option<CdpProtocolError>,
+enum CdpRequest {
+    Command {
+        method: &'static str,
+        params: Value,
+        response: oneshot::Sender<Result<Value, CdpActorError>>,
+    },
+    Close {
+        response: oneshot::Sender<Result<(), CdpActorError>>,
+    },
+    CloseBindingEvents {
+        response: oneshot::Sender<()>,
+    },
 }
 
-#[derive(Debug, serde::Deserialize)]
-struct CdpProtocolError {
-    code: i64,
-    message: String,
-}
-
-async fn receive_command_result(
-    websocket: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
-    command_id: u64,
-) -> Result<Value, CdpError> {
-    while let Some(message) = websocket.next().await {
-        let message = message.map_err(CdpError::WebSocket)?;
-        let Message::Text(message) = message else {
-            if matches!(message, Message::Close(_)) {
-                return Err(CdpError::ConnectionClosed);
+async fn run_cdp_actor(
+    mut websocket: PageWebSocket,
+    mut commands: mpsc::Receiver<CdpRequest>,
+    binding_events: mpsc::Sender<Value>,
+) {
+    let mut binding_events = Some(binding_events);
+    let mut next_command_id = 1_u64;
+    let mut pending = HashMap::<u64, oneshot::Sender<Result<Value, CdpActorError>>>::new();
+    loop {
+        tokio::select! {
+            request = commands.recv() => {
+                match request {
+                    Some(CdpRequest::Command { method, params, response }) => {
+                        let command_id = next_command_id;
+                        next_command_id = next_command_id.saturating_add(1);
+                        let command = json!({ "id": command_id, "method": method, "params": params });
+                        if let Err(error) = websocket.send(Message::Text(command.to_string().into())).await {
+                            let error = CdpActorError::WebSocket(error.to_string());
+                            let _ = response.send(Err(error.clone()));
+                            fail_pending(&mut pending, error);
+                            return;
+                        }
+                        pending.insert(command_id, response);
+                    }
+                    Some(CdpRequest::Close { response }) => {
+                        let result = websocket
+                            .close(None)
+                            .await
+                            .map_err(|error| CdpActorError::WebSocket(error.to_string()));
+                        let _ = response.send(result);
+                        fail_pending(&mut pending, CdpActorError::ConnectionClosed);
+                        return;
+                    }
+                    Some(CdpRequest::CloseBindingEvents { response }) => {
+                        binding_events.take();
+                        let _ = response.send(());
+                    }
+                    None => {
+                        let _ = websocket.close(None).await;
+                        fail_pending(&mut pending, CdpActorError::ConnectionClosed);
+                        return;
+                    }
+                }
             }
-            continue;
-        };
-        let envelope: CdpEnvelope =
-            serde_json::from_str(message.as_ref()).map_err(CdpError::ProtocolMessage)?;
-        if envelope.id != Some(command_id) {
-            continue;
+            message = websocket.next() => {
+                let value = match message {
+                    Some(Ok(Message::Text(message))) => match serde_json::from_str::<Value>(message.as_ref()) {
+                        Ok(value) => value,
+                        Err(error) => {
+                            fail_pending(&mut pending, CdpActorError::InvalidMessage(error.to_string()));
+                            return;
+                        }
+                    },
+                    Some(Ok(Message::Close(_))) | None => {
+                        fail_pending(&mut pending, CdpActorError::ConnectionClosed);
+                        return;
+                    }
+                    Some(Ok(_)) => continue,
+                    Some(Err(error)) => {
+                        fail_pending(&mut pending, CdpActorError::WebSocket(error.to_string()));
+                        return;
+                    }
+                };
+                if let Some(command_id) = value.get("id").and_then(Value::as_u64) {
+                    let Some(response) = pending.remove(&command_id) else {
+                        continue;
+                    };
+                    let result = if let Some(error) = value.get("error") {
+                        Err(CdpActorError::Protocol {
+                            code: error.get("code").and_then(Value::as_i64).unwrap_or_default(),
+                            message: error
+                                .get("message")
+                                .and_then(Value::as_str)
+                                .unwrap_or("unknown protocol error")
+                                .to_owned(),
+                        })
+                    } else {
+                        value
+                            .get("result")
+                            .cloned()
+                            .ok_or(CdpActorError::MissingCommandResult)
+                    };
+                    let _ = response.send(result);
+                } else if value.get("method").and_then(Value::as_str)
+                    == Some("Runtime.bindingCalled")
+                    && let Some(binding_events) = binding_events.as_ref()
+                {
+                    match binding_events.try_send(value) {
+                        Ok(()) | Err(TrySendError::Closed(_)) => {}
+                        Err(TrySendError::Full(_)) => {
+                            fail_pending(&mut pending, CdpActorError::BindingEventOverflow);
+                            return;
+                        }
+                    }
+                }
+            }
         }
-        if let Some(error) = envelope.error {
-            return Err(CdpError::Protocol {
-                code: error.code,
-                message: error.message,
-            });
-        }
-        let result = envelope.result.ok_or(CdpError::MissingCommandResult)?;
-        if result.get("exceptionDetails").is_some() {
-            return Err(CdpError::EvaluationException(result));
-        }
-        return Ok(result);
     }
-    Err(CdpError::ConnectionClosed)
+}
+
+fn fail_pending(
+    pending: &mut HashMap<u64, oneshot::Sender<Result<Value, CdpActorError>>>,
+    error: CdpActorError,
+) {
+    for (_, response) in pending.drain() {
+        let _ = response.send(Err(error.clone()));
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum CdpActorError {
+    #[error("Chromium DevTools WebSocket failed: {0}")]
+    WebSocket(String),
+    #[error("invalid Chromium DevTools protocol message: {0}")]
+    InvalidMessage(String),
+    #[error("Chromium DevTools protocol error {code}: {message}")]
+    Protocol { code: i64, message: String },
+    #[error("Chromium DevTools response did not include a result")]
+    MissingCommandResult,
+    #[error("Chromium DevTools connection closed")]
+    ConnectionClosed,
+    #[error("Chromium DevTools binding event buffer overflowed")]
+    BindingEventOverflow,
 }
 
 fn discovery_url(
@@ -271,22 +479,28 @@ pub enum CdpError {
     UnexpectedTargetPort { expected: u16, actual: Option<u16> },
     #[error("Chromium DevTools WebSocket failed")]
     WebSocket(#[source] WebSocketError),
-    #[error("invalid Chromium DevTools protocol message")]
-    ProtocolMessage(#[source] serde_json::Error),
-    #[error("Chromium DevTools protocol error {code}: {message}")]
-    Protocol { code: i64, message: String },
-    #[error("Chromium DevTools connection closed")]
-    ConnectionClosed,
+    #[error(transparent)]
+    Actor(#[from] CdpActorError),
+    #[error("Chromium DevTools actor is unavailable")]
+    ActorUnavailable,
+    #[error("Chromium DevTools actor task failed")]
+    ActorJoin(#[source] tokio::task::JoinError),
     #[error("Chromium DevTools command timed out after {0:?}")]
     CommandTimeout(Duration),
-    #[error("Chromium DevTools response did not include a result")]
-    MissingCommandResult,
     #[error("Chromium JavaScript evaluation failed: {0}")]
     EvaluationException(Value),
     #[error("Chromium JavaScript evaluation returned no value")]
     MissingEvaluationValue,
     #[error("Chromium JavaScript evaluation returned an unexpected value")]
     EvaluationValue(#[source] serde_json::Error),
+    #[error("Chromium binding name must contain only ASCII letters, numbers, and underscores: {0}")]
+    InvalidBindingName(String),
+    #[error("Chromium binding events were already taken")]
+    BindingEventsAlreadyTaken,
+    #[error("invalid Chromium binding event")]
+    InvalidBindingEvent,
+    #[error("Chromium binding event stream closed")]
+    BindingEventStreamClosed,
 }
 
 #[cfg(test)]
@@ -405,13 +619,155 @@ mod tests {
         });
 
         let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
-        let mut page = CdpPage {
-            websocket,
-            next_command_id: 1,
-            command_timeout: Duration::from_secs(1),
-        };
+        let mut page = CdpPage::from_test_websocket(websocket);
 
         assert!(page.probe_admission().await.unwrap().waiting_room_visible);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn routes_binding_events_without_blocking_commands() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+            let Message::Text(command) = websocket.next().await.unwrap().unwrap() else {
+                panic!("expected text command")
+            };
+            let command: Value = serde_json::from_str(command.as_ref()).unwrap();
+            assert_eq!(command["method"], "Runtime.addBinding");
+            websocket
+                .send(Message::Text(
+                    json!({"id": command["id"], "result": {}})
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "method": "Runtime.bindingCalled",
+                        "params": {"name": "anlgCapture", "payload": "frame-1"}
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+            assert!(matches!(
+                websocket.next().await,
+                Some(Ok(Message::Close(_)))
+            ));
+        });
+
+        let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let mut page = CdpPage::from_test_websocket(websocket);
+        page.add_binding("anlgCapture").await.unwrap();
+        page.add_binding("anlgCapture").await.unwrap();
+        let mut events = page.take_binding_events().unwrap();
+
+        assert_eq!(events.next_payload("anlgCapture").await.unwrap(), "frame-1");
+        page.close().await.unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_script_like_binding_names_before_devtools() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+            assert!(matches!(
+                websocket.next().await,
+                Some(Ok(Message::Close(_)))
+            ));
+        });
+        let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let mut page = CdpPage::from_test_websocket(websocket);
+
+        assert!(matches!(
+            page.add_binding("capture);alert(1)").await,
+            Err(CdpError::InvalidBindingName(_))
+        ));
+        page.close().await.unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dropping_the_binding_consumer_keeps_page_commands_available() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+
+            let Message::Text(binding) = websocket.next().await.unwrap().unwrap() else {
+                panic!("expected binding command")
+            };
+            let binding: Value = serde_json::from_str(binding.as_ref()).unwrap();
+            websocket
+                .send(Message::Text(
+                    json!({"id": binding["id"], "result": {}})
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "method": "Runtime.bindingCalled",
+                        "params": {"name": "anlgCapture", "payload": "ignored"}
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+
+            let Message::Text(evaluate) = websocket.next().await.unwrap().unwrap() else {
+                panic!("expected evaluate command")
+            };
+            let evaluate: Value = serde_json::from_str(evaluate.as_ref()).unwrap();
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "id": evaluate["id"],
+                        "result": {"result": {"value": {
+                            "waiting_room_visible": false,
+                            "consent_prompt_visible": false,
+                            "explicit_denial_indicator": null,
+                            "ambiguous_error_indicator": null,
+                            "visible_recaptcha_challenge": false,
+                            "participant_tile_labels": [],
+                            "self_name_nodes": 0,
+                            "visible_admission_controls": 0
+                        }}}
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+            assert!(matches!(
+                websocket.next().await,
+                Some(Ok(Message::Close(_)))
+            ));
+        });
+
+        let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let mut page = CdpPage::from_test_websocket(websocket);
+        page.add_binding("anlgCapture").await.unwrap();
+        drop(page.take_binding_events().unwrap());
+
+        assert_eq!(
+            page.probe_admission().await.unwrap(),
+            AdmissionSnapshot::default()
+        );
+        page.close().await.unwrap();
         server.await.unwrap();
     }
 }

--- a/enterprise/google-meet-worker/src/lib.rs
+++ b/enterprise/google-meet-worker/src/lib.rs
@@ -1,6 +1,8 @@
 mod admission;
 mod admission_monitor;
 mod browser;
+mod capture;
+mod capture_protocol;
 mod cdp;
 mod lifecycle;
 mod lobby;
@@ -12,6 +14,8 @@ mod x11;
 pub use admission::*;
 pub use admission_monitor::*;
 pub use browser::*;
+pub use capture::*;
+pub use capture_protocol::*;
 pub use cdp::*;
 pub use lifecycle::*;
 pub use lobby::*;

--- a/enterprise/google-meet-worker/src/lobby_probe.js
+++ b/enterprise/google-meet-worker/src/lobby_probe.js
@@ -89,6 +89,9 @@
     join_cta: target(joinCta, "join_cta"),
     microphone_on: target(microphone, "microphone_on"),
     camera_on: target(camera, "camera_on"),
-    cta_candidates: buttons.map(buttonText).filter(Boolean),
+    cta_candidates: buttons
+      .slice(0, 64)
+      .map((button) => buttonText(button).slice(0, 64))
+      .filter(Boolean),
   };
 })();

--- a/enterprise/google-meet-worker/src/runtime_probe.js
+++ b/enterprise/google-meet-worker/src/runtime_probe.js
@@ -29,6 +29,10 @@
   };
   const visibleCount = (selector) =>
     Array.from(document.querySelectorAll(selector)).filter(visible).length;
+  const participantTileLabel = (element) =>
+    (
+      element.getAttribute("aria-label") || (element.textContent || "").trim()
+    ).slice(0, 128);
 
   return {
     removal_indicator: visibleText([
@@ -50,11 +54,9 @@
     ]),
     participant_tile_labels: Array.from(
       document.querySelectorAll("[data-participant-id]"),
-    ).map(
-      (element) =>
-        element.getAttribute("aria-label") ||
-        (element.textContent || "").trim(),
-    ),
+    )
+      .slice(0, 128)
+      .map(participantTileLabel),
     self_name_nodes: document.querySelectorAll("[data-self-name]").length,
     visible_meeting_controls:
       visibleCount('button[aria-label*="leave call" i]') +

--- a/enterprise/google-meet-worker/src/x11.rs
+++ b/enterprise/google-meet-worker/src/x11.rs
@@ -183,7 +183,7 @@ fi
         let input = X11Input::new(X11InputConfig {
             binary: executable,
             display: ":77".into(),
-            command_timeout: Duration::from_secs(1),
+            command_timeout: Duration::from_secs(5),
         })
         .unwrap();
         input.verify_available().await.unwrap();


### PR DESCRIPTION
## Summary
- multiplex CDP commands and browser binding events without blocking
- capture bounded 16 kHz per-track PCM through an in-page AudioWorklet
- validate sequence, timing, encoding, and conservative speaker hints in Rust
- preserve Apache-2.0 Vexa provenance without any Vexa runtime dependency

## Validation
- pnpm fmt:check
- node --check enterprise/google-meet-worker/src/capture_audio.js
- cargo test --manifest-path enterprise/Cargo.toml --workspace --locked (62 passed)
- cargo clippy --manifest-path enterprise/Cargo.toml --workspace --all-targets --locked -- -D warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New real-time meeting audio path and a non-trivial CDP concurrency refactor; mitigated by strict wire validation, binding-name checks, and extensive unit tests, but still touches core browser automation reliability.
> 
> **Overview**
> Adds an **owned Google Meet audio transport**: in-page `capture_audio.js` taps participant `MediaStream`s via a shared 16 kHz `AudioWorklet`, emits bounded base64 PCM (and optional speaker hints) through the `anlgCapture` CDP binding, and Rust `BrowserCapture` / `CaptureProtocol` install, decode, and validate frames (sequence, timing, encoding, sanitized hints).
> 
> **Refactors `CdpPage`** from a single blocking WebSocket loop to a background actor that multiplexes DevTools commands with `Runtime.bindingCalled` events (buffered channel, binding name validation, larger message limits), so capture can stream without starving admission/runtime probes.
> 
> Probe scripts cap DOM-derived strings (participant tile labels, lobby CTA candidates). Vexa gmeet-capture provenance is documented; `base64` is added for PCM decoding. X11 integration test command timeout is relaxed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9762325eafe393a480f4dab72b38107e69247dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->