### PR TITLE
ANLG-70: recover interrupted mobile recordings

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -4,6 +4,7 @@ import { StatusBar } from "expo-status-bar";
 import { useEffect, useRef, useState } from "react";
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 
+import { recoverInterruptedRecordings } from "@/audio/recover-recordings";
 import { AuthProvider, useAuth } from "@/auth/context";
 import { PaywallScreen, SignInScreen } from "@/auth/screens";
 import { Button } from "@/components/ui/button";
@@ -52,7 +53,17 @@ function AnalyticsLifecycle() {
   return null;
 }
 
-function Screens() {
+function Screens({ accountUserId }: { accountUserId: string | null }) {
+  useMountEffect(() => {
+    void recoverInterruptedRecordings(accountUserId).catch((error) => {
+      captureOperationalError(error, {
+        operation: "recording_recovery",
+        level: "warning",
+        tags: { stage: "candidate_query" },
+      });
+    });
+  });
+
   return (
     <Stack
       screenOptions={{
@@ -78,7 +89,7 @@ function Gate() {
     }
   };
 
-  if (auth.bypass) return <Screens />;
+  if (auth.bypass) return <Screens accountUserId={null} />;
 
   if (
     auth.status === "loading" ||
@@ -108,7 +119,7 @@ function Gate() {
     );
   }
 
-  return <Screens />;
+  return <Screens accountUserId={auth.session?.user.id ?? null} />;
 }
 
 function RouteError({

--- a/apps/mobile/src/audio/pcm-wav.test.mjs
+++ b/apps/mobile/src/audio/pcm-wav.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { pcmAmplitude, wavHeader } from "./pcm-wav.ts";
+import { pcmAmplitude, recoverableWav, wavHeader } from "./pcm-wav.ts";
 
 test("writes a little-endian PCM WAV header", () => {
   const header = wavHeader(32_000, 16_000, 1);
@@ -22,4 +22,30 @@ test("normalizes int16 PCM amplitude", () => {
   const samples = new Int16Array([0, 0, 0, 0, 16_384, 0, 0, 0]);
   assert.equal(pcmAmplitude(samples.buffer), 0.5);
   assert.equal(pcmAmplitude(new Int16Array([-32_768]).buffer), 1);
+});
+
+test("recovers PCM format and aligns bytes from an interrupted file", () => {
+  const header = wavHeader(0, 16_000, 1);
+
+  assert.deepEqual(recoverableWav(header, 44 + 32_001), {
+    channels: 1,
+    dataBytes: 32_000,
+    sampleRate: 16_000,
+  });
+});
+
+test("rejects empty, corrupt, and unsupported WAV files", () => {
+  assert.equal(recoverableWav(wavHeader(0, 16_000, 1), 44), null);
+  assert.equal(recoverableWav(wavHeader(0, 16_000, 1), Number.NaN), null);
+
+  const corrupt = wavHeader(32_000, 16_000, 1);
+  corrupt[0] = 0;
+  assert.equal(recoverableWav(corrupt, 44 + 32_000), null);
+
+  const inconsistent = wavHeader(32_000, 16_000, 1);
+  new DataView(inconsistent.buffer).setUint32(28, 0, true);
+  assert.equal(recoverableWav(inconsistent, 44 + 32_000), null);
+
+  const unsupported = wavHeader(32_000, 16_000, 3);
+  assert.equal(recoverableWav(unsupported, 44 + 32_000), null);
 });

--- a/apps/mobile/src/audio/pcm-wav.ts
+++ b/apps/mobile/src/audio/pcm-wav.ts
@@ -1,4 +1,10 @@
-const WAV_HEADER_BYTES = 44;
+export const WAV_HEADER_BYTES = 44;
+
+export type RecoverableWav = {
+  channels: number;
+  dataBytes: number;
+  sampleRate: number;
+};
 
 function writeAscii(view: DataView, offset: number, value: string) {
   for (let index = 0; index < value.length; index += 1) {
@@ -28,6 +34,62 @@ export function wavHeader(
   writeAscii(view, 36, "data");
   view.setUint32(40, dataBytes, true);
   return new Uint8Array(buffer);
+}
+
+function ascii(bytes: Uint8Array, offset: number, length: number): string {
+  let value = "";
+  for (let index = 0; index < length; index += 1) {
+    value += String.fromCharCode(bytes[offset + index] ?? 0);
+  }
+  return value;
+}
+
+export function recoverableWav(
+  header: Uint8Array,
+  fileSize: number,
+): RecoverableWav | null {
+  if (
+    header.byteLength < WAV_HEADER_BYTES ||
+    !Number.isSafeInteger(fileSize) ||
+    fileSize <= WAV_HEADER_BYTES
+  ) {
+    return null;
+  }
+  if (
+    ascii(header, 0, 4) !== "RIFF" ||
+    ascii(header, 8, 4) !== "WAVE" ||
+    ascii(header, 12, 4) !== "fmt " ||
+    ascii(header, 36, 4) !== "data"
+  ) {
+    return null;
+  }
+
+  const view = new DataView(
+    header.buffer,
+    header.byteOffset,
+    header.byteLength,
+  );
+  const channels = view.getUint16(22, true);
+  const sampleRate = view.getUint32(24, true);
+  const blockAlign = view.getUint16(32, true);
+  if (
+    view.getUint32(16, true) !== 16 ||
+    view.getUint16(20, true) !== 1 ||
+    view.getUint16(34, true) !== 16 ||
+    channels < 1 ||
+    channels > 2 ||
+    sampleRate < 8_000 ||
+    sampleRate > 192_000 ||
+    blockAlign !== channels * 2 ||
+    view.getUint32(28, true) !== sampleRate * blockAlign
+  ) {
+    return null;
+  }
+
+  const dataBytes =
+    Math.floor((fileSize - WAV_HEADER_BYTES) / blockAlign) * blockAlign;
+  if (dataBytes <= 0 || dataBytes > 0xffff_ffff - 36) return null;
+  return { channels, dataBytes, sampleRate };
 }
 
 export function pcmAmplitude(buffer: ArrayBuffer): number {

--- a/apps/mobile/src/audio/recover-recordings.ts
+++ b/apps/mobile/src/audio/recover-recordings.ts
@@ -14,6 +14,11 @@ WHERE session.deleted_at IS NULL
   AND (
     ? IS NULL
     OR session.owner_user_id = ?
+    OR session.owner_user_id = (
+      SELECT json_extract(value_json, '$.workspace_id')
+      FROM app_settings
+      WHERE id = 'cloudsync_workspace_binding'
+    )
     OR session.owner_user_id IS NULL
     OR session.owner_user_id = '00000000-0000-0000-0000-000000000000'
   )

--- a/apps/mobile/src/audio/recover-recordings.ts
+++ b/apps/mobile/src/audio/recover-recordings.ts
@@ -1,0 +1,90 @@
+import { File, FileMode, Paths } from "expo-file-system";
+
+import { recoverableWav, WAV_HEADER_BYTES, wavHeader } from "@/audio/pcm-wav";
+import { catalogSessionAudio } from "@/data/audio-catalog";
+import { transcribeSession } from "@/data/transcribe";
+import { execute } from "@/db";
+import { captureAnalytics } from "@/lib/analytics";
+import { captureOperationalError } from "@/lib/error-reporting";
+
+const RECOVERY_CANDIDATES_SQL = `
+SELECT session.id
+FROM sessions AS session
+WHERE session.deleted_at IS NULL
+  AND (
+    ? IS NULL
+    OR session.owner_user_id = ?
+    OR session.owner_user_id IS NULL
+    OR session.owner_user_id = '00000000-0000-0000-0000-000000000000'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM session_attachments AS attachment
+    WHERE attachment.session_id = session.id
+      AND attachment.source_type = 'session_audio'
+      AND attachment.source_id = 'primary'
+      AND attachment.deleted_at IS NULL
+  )
+`;
+
+function repairInterruptedWav(file: File): number | null {
+  if (!file.exists || file.size <= WAV_HEADER_BYTES) return null;
+
+  const handle = file.open(FileMode.ReadWrite);
+  try {
+    handle.offset = 0;
+    const format = recoverableWav(
+      handle.readBytes(WAV_HEADER_BYTES),
+      file.size,
+    );
+    if (!format) return null;
+
+    handle.offset = 0;
+    handle.writeBytes(
+      wavHeader(format.dataBytes, format.sampleRate, format.channels),
+    );
+    return file.size;
+  } finally {
+    handle.close();
+  }
+}
+
+export async function recoverInterruptedRecordings(
+  accountUserId: string | null,
+): Promise<number> {
+  const sessions = await execute<{ id: string }>(RECOVERY_CANDIDATES_SQL, [
+    accountUserId,
+    accountUserId,
+  ]);
+  const recoveredSessionIds: string[] = [];
+
+  for (const session of sessions) {
+    const file = new File(Paths.document, "sessions", session.id, "audio.wav");
+    try {
+      const sizeBytes = repairInterruptedWav(file);
+      if (sizeBytes === null) continue;
+      await catalogSessionAudio(session.id, {
+        filename: "audio.wav",
+        contentType: "audio/wav",
+        sizeBytes,
+      });
+      recoveredSessionIds.push(session.id);
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "recording_recovery",
+        level: "warning",
+        tags: { stage: "repair_or_catalog" },
+      });
+    }
+  }
+
+  if (recoveredSessionIds.length > 0) {
+    captureAnalytics("recording_recovered", {
+      recording_count: recoveredSessionIds.length,
+    });
+    for (const sessionId of recoveredSessionIds) {
+      void transcribeSession(sessionId);
+    }
+  }
+  return recoveredSessionIds.length;
+}


### PR DESCRIPTION
## Summary

- Repair checkpointed PCM WAV headers after app termination.
- Catalog recovered audio through the canonical session attachment transaction.
- Start best-effort batch transcription only after the local attachment is durable.
- Scope recovery to the signed-in account plus unclaimed legacy-local sessions.

## Validation

- `pnpm exec dprint check` on all changed files
- `pnpm -F @anlg/mobile typecheck`
- `pnpm -F @anlg/mobile test` (49/49)
- `pnpm exec oxlint --quiet --format=github apps/mobile/src/`

## QA

Simulator and device QA deferred for this non-release slice per the mobile workflow.

## Workspace note

The required workspace-wide `pnpm fmt:check` was also run. It is currently blocked by pre-existing unformatted changes in `enterprise/google-meet-worker/src/capture_audio.js` on the separate `chore/anlg-228-capture-transport` branch; those user-owned changes were left untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local SQLite session ownership, file I/O, and attachment cataloging on every authenticated launch; scoped to sessions without primary audio and wrapped in per-session error handling.
> 
> **Overview**
> Adds **startup recovery** for sessions that still have `audio.wav` on disk but no durable `session_audio` / primary attachment—typical when the app dies mid-recording before the normal save path runs.
> 
> **PCM/WAV:** New `recoverableWav` validates the 44-byte header against actual file size, aligns PCM data to block boundaries, and rejects corrupt or unsupported formats. `repairInterruptedWav` rewrites the header with corrected `data` length.
> 
> **Recovery flow:** `recoverInterruptedRecordings` queries eligible sessions (signed-in user, workspace binding, or legacy unclaimed owners), repairs each file, calls `catalogSessionAudio` (same path as a clean stop), emits `recording_recovered` analytics, and best-effort `transcribeSession` per recovered id. Failures are logged as operational warnings without blocking the UI.
> 
> **Wiring:** `Screens` runs recovery once on mount via `useMountEffect`, passing `accountUserId` from auth (or `null` in bypass mode).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c7a871de218a958c182b0545a04c6633f8ac99e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->