### PR TITLE
ANLG-70: stamp mobile sessions with account ownership

### DIFF
--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { useAuth } from "@/auth/context";
 import { ProfileSheet } from "@/components/profile-sheet";
 import { SessionCard } from "@/components/session-card";
 import { Button } from "@/components/ui/button";
@@ -45,6 +46,7 @@ function SearchAnalytics({ resultCount }: { resultCount: number }) {
 
 export default function HomeScreen() {
   const router = useRouter();
+  const auth = useAuth();
   const { items, isLoading } = useTimelineSessions();
   const [profileOpen, setProfileOpen] = useState(false);
   const [importing, setImporting] = useState(false);
@@ -112,6 +114,7 @@ export default function HomeScreen() {
     try {
       const sessionId = await createSession({
         entryPoint: query.includes("listen=1") ? "start_listening" : "new_note",
+        ownerUserId: auth.session?.user.id,
       });
       router.push(`/note/${sessionId}${query}`);
     } catch (error) {
@@ -133,7 +136,7 @@ export default function HomeScreen() {
     busyRef.current = true;
     setImporting(true);
     try {
-      const sessionIds = await importVoiceMemos();
+      const sessionIds = await importVoiceMemos(auth.session?.user.id);
       if (sessionIds.length === 1) {
         router.push(`/note/${sessionIds[0]}`);
       }

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -139,7 +139,9 @@ async function importAsset(
   return sessionId;
 }
 
-export async function importVoiceMemos(): Promise<string[]> {
+export async function importVoiceMemos(
+  ownerUserId?: string,
+): Promise<string[]> {
   const result = await getDocumentAsync({
     type: ["audio/*"],
     multiple: true,
@@ -150,7 +152,9 @@ export async function importVoiceMemos(): Promise<string[]> {
   const created: string[] = [];
   for (const asset of result.assets) {
     try {
-      created.push(await importAsset(asset, "voice_memo_import"));
+      created.push(
+        await importAsset(asset, "voice_memo_import", { ownerUserId }),
+      );
     } catch (error) {
       captureOperationalError(error, {
         operation: "voice_memo_import",


### PR DESCRIPTION
## Summary

- Stamp newly created notes and live-recording sessions with the authenticated mobile user ID.
- Carry the same owner into sessions created by the voice-memo importer.
- Preserve the existing legacy-local owner behavior when auth is bypassed in development.

This keeps pre-sync mobile writes attributable before workspace binding, matching the ownership path already used for Watch imports.

## Validation

- `pnpm exec dprint fmt`
- `pnpm fmt:check`
- `pnpm -F @anlg/mobile typecheck`
- `pnpm -F @anlg/mobile test` (49/49)
- `pnpm exec oxlint --quiet --format=github apps/mobile/src/`

## QA

Simulator and device QA deferred for this non-release slice per the mobile workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session ownership at creation time, which affects sync and multi-account boundaries, but changes are narrow and reuse existing `ownerUserId` plumbing.
> 
> **Overview**
> Mobile home now reads the auth session and passes the signed-in user id when **creating meetings** and **importing voice memos**, so new local sessions get `owner_user_id` from the account instead of only the default/fallback in `createSession`.
> 
> `importVoiceMemos` takes an optional `ownerUserId` and forwards it into the existing import path (`importAsset` → `createSession`). When the user is not signed in, `auth.session?.user.id` is undefined and behavior matches the prior optional-owner fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f67b54d5be4a937b7a9af4416337c181583dabc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->