### PR TITLE
Add durable capture worker checkpoints

### DIFF
--- a/enterprise/Cargo.lock
+++ b/enterprise/Cargo.lock
@@ -54,6 +54,7 @@ name = "anarlog-enterprise-control-plane"
 version = "0.1.0"
 dependencies = [
  "agent-access",
+ "anarlog-enterprise-google-meet-worker",
  "anyhow",
  "async-trait",
  "axum",
@@ -2028,6 +2029,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2047,12 +2049,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -2921,6 +2925,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3272,6 +3289,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/enterprise/Cargo.toml
+++ b/enterprise/Cargo.toml
@@ -21,7 +21,7 @@ base64 = "0.22"
 chrono = "0.4"
 futures-util = "0.3"
 http = "1"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
 serde = "1"
 serde_json = "1"
 sha2 = "0.11"

--- a/enterprise/control-plane/Cargo.toml
+++ b/enterprise/control-plane/Cargo.toml
@@ -24,6 +24,7 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [dev-dependencies]
+anarlog-enterprise-google-meet-worker = { path = "../google-meet-worker" }
 anlg-agent-access.workspace = true
 anlg-db-app.workspace = true
 anlg-db-core.workspace = true

--- a/enterprise/control-plane/src/api.rs
+++ b/enterprise/control-plane/src/api.rs
@@ -14,8 +14,8 @@ use tower_http::trace::TraceLayer;
 use crate::{
     auth::{AuthenticationError, WorkspaceAuthenticator},
     capture::{
-        AppendCaptureEventRequest, CaptureJob, CaptureJobStatus, CreateCaptureJobRequest,
-        ProjectionPublication,
+        AppendCaptureEventRequest, CaptureJob, CaptureJobCheckpoint, CaptureJobStatus,
+        CreateCaptureJobRequest, ProjectionPublication,
     },
     store::{ControlPlaneStore, StoreError},
 };
@@ -48,7 +48,7 @@ pub fn router(state: AppState) -> Router {
         .route("/health/ready", get(readiness))
         .route(
             "/v1/workspaces/{workspace_id}/capture-jobs/{job_id}",
-            post(create_capture_job),
+            post(create_capture_job).get(read_capture_checkpoint),
         )
         .route(
             "/v1/workspaces/{workspace_id}/capture-jobs/{job_id}/events",
@@ -69,6 +69,22 @@ pub fn router(state: AppState) -> Router {
         .layer(DefaultBodyLimit::max(MAX_REQUEST_BYTES))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
+}
+
+async fn read_capture_checkpoint(
+    State(state): State<AppState>,
+    Path((workspace_id, job_id)): Path<(String, String)>,
+    headers: HeaderMap,
+) -> Result<Json<CaptureJobCheckpoint>, ApiError> {
+    authorize(&state, &headers, &workspace_id)?;
+    validate_identifier(&workspace_id, "workspace_id")?;
+    validate_identifier(&job_id, "job_id")?;
+    let checkpoint = state
+        .store
+        .read_capture_checkpoint(&workspace_id, &job_id)
+        .await
+        .map_err(ApiError::from_store)?;
+    Ok(Json(checkpoint))
 }
 
 async fn create_capture_job(

--- a/enterprise/control-plane/src/capture.rs
+++ b/enterprise/control-plane/src/capture.rs
@@ -28,6 +28,14 @@ pub struct CaptureJobStatus {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct CaptureJobCheckpoint {
+    pub job: CaptureJob,
+    pub state: BotState,
+    pub next_sequence: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProjectionPublication {
     pub job_id: String,
     pub revision: u64,

--- a/enterprise/control-plane/src/store.rs
+++ b/enterprise/control-plane/src/store.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 
 use crate::{
-    capture::{CaptureJob, CaptureJobStatus, ProjectionPublication},
+    capture::{CaptureJob, CaptureJobCheckpoint, CaptureJobStatus, ProjectionPublication},
     projector,
 };
 
@@ -20,6 +20,12 @@ pub trait ControlPlaneStore: Send + Sync {
     async fn readiness(&self) -> Result<(), StoreError>;
 
     async fn create_capture_job(&self, job: &CaptureJob) -> Result<CaptureJobStatus, StoreError>;
+
+    async fn read_capture_checkpoint(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+    ) -> Result<CaptureJobCheckpoint, StoreError>;
 
     async fn append_capture_event(
         &self,
@@ -176,6 +182,47 @@ impl ControlPlaneStore for PostgresStore {
             job_id: job.job_id.clone(),
             created,
             state: parse_enum(&stored.try_get::<String, _>("state")?)?,
+        })
+    }
+
+    async fn read_capture_checkpoint(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+    ) -> Result<CaptureJobCheckpoint, StoreError> {
+        let row = sqlx::query(
+            r#"
+            SELECT
+                workspace_id,
+                job_id,
+                bot_id,
+                owner_user_id,
+                requesting_actor_id,
+                session_id,
+                session_title,
+                provider,
+                meeting,
+                state,
+                last_sequence,
+                created_at
+            FROM capture_jobs
+            WHERE workspace_id = $1 AND job_id = $2
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(StoreError::NotFound)?;
+        let state = parse_enum(&row.try_get::<String, _>("state")?)?;
+        let next_sequence = row
+            .try_get::<i64, _>("last_sequence")?
+            .checked_add(1)
+            .ok_or(StoreError::OutOfRange("capture event sequence"))?;
+        Ok(CaptureJobCheckpoint {
+            job: capture_job(row)?,
+            state,
+            next_sequence: from_i64(next_sequence, "capture event sequence")?,
         })
     }
 

--- a/enterprise/control-plane/tests/api.rs
+++ b/enterprise/control-plane/tests/api.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 use anarlog_enterprise_control_plane::{
     api::{AppState, router},
     auth::StaticTokenAuthenticator,
-    capture::{CaptureJob, CaptureJobStatus, ProjectionPublication},
+    capture::{CaptureJob, CaptureJobCheckpoint, CaptureJobStatus, ProjectionPublication},
     serve,
     store::{ControlPlaneStore, StoreError},
 };
+use anarlog_enterprise_google_meet_worker::{ControlPlaneEventSink, ControlPlaneEventSinkConfig};
 use anlg_meeting_capture::{BotState, CaptureEvent};
 use anlg_session_ingest::{AcknowledgeRequest, DeliveryPage, SessionRead};
 use async_trait::async_trait;
@@ -40,6 +41,21 @@ impl ControlPlaneStore for MemoryStore {
             job_id: job.job_id.clone(),
             created: true,
             state: BotState::Queued,
+        })
+    }
+
+    async fn read_capture_checkpoint(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+    ) -> Result<CaptureJobCheckpoint, StoreError> {
+        if workspace_id != "workspace-a" || job_id != "job-a" {
+            return Err(StoreError::NotFound);
+        }
+        Ok(CaptureJobCheckpoint {
+            job: capture_job(),
+            state: BotState::Capturing,
+            next_sequence: 7,
         })
     }
 
@@ -192,6 +208,53 @@ async fn authenticates_capture_job_creation_before_writing() {
 }
 
 #[tokio::test]
+async fn reads_only_the_authorized_workspace_capture_checkpoint() {
+    let app = router(state(true));
+    let path = "/v1/workspaces/workspace-a/capture-jobs/job-a";
+
+    let missing = app
+        .clone()
+        .oneshot(Request::get(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let wrong_workspace = app
+        .clone()
+        .oneshot(authorized_request(path, TOKEN_B))
+        .await
+        .unwrap();
+    let checkpoint = app
+        .oneshot(authorized_request(path, TOKEN_A))
+        .await
+        .unwrap();
+
+    assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(wrong_workspace.status(), StatusCode::FORBIDDEN);
+    assert_eq!(checkpoint.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(checkpoint).await,
+        serde_json::json!({
+            "job": {
+                "workspaceId": "workspace-a",
+                "jobId": "job-a",
+                "botId": "bot-a",
+                "ownerUserId": "owner-a",
+                "requestingActorId": "actor-a",
+                "sessionId": "session-a",
+                "sessionTitle": "Architecture review",
+                "provider": "anarlog",
+                "meeting": {
+                    "platform": "google_meet",
+                    "url": "https://meet.google.com/abc-defg-hij"
+                },
+                "createdAt": "2026-08-17T00:00:00Z"
+            },
+            "state": "capturing",
+            "nextSequence": 7
+        })
+    );
+}
+
+#[tokio::test]
 async fn boots_on_a_real_listener_and_shuts_down_gracefully() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
@@ -205,6 +268,36 @@ async fn boots_on_a_real_listener_and_shuts_down_gracefully() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
+    shutdown_tx.send(()).unwrap();
+    tokio::time::timeout(Duration::from_secs(2), server)
+        .await
+        .expect("server did not stop")
+        .unwrap()
+        .unwrap();
+}
+
+#[tokio::test]
+async fn worker_reads_the_checkpoint_over_real_http() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let server = tokio::spawn(serve(listener, state(true), async move {
+        shutdown_rx.await.ok();
+    }));
+    let sink = ControlPlaneEventSink::new(ControlPlaneEventSinkConfig::new(
+        reqwest::Url::parse(&format!("http://{address}")).unwrap(),
+        "workspace-a",
+        "job-a",
+        TOKEN_A,
+    ))
+    .unwrap();
+
+    let checkpoint = sink.read_checkpoint().await.unwrap();
+
+    assert_eq!(checkpoint.job_id, "job-a");
+    assert_eq!(checkpoint.bot_id, "bot-a");
+    assert_eq!(checkpoint.state, BotState::Capturing);
+    assert_eq!(checkpoint.next_sequence, 7);
     shutdown_tx.send(()).unwrap();
     tokio::time::timeout(Duration::from_secs(2), server)
         .await
@@ -234,4 +327,26 @@ fn json_request(method: Method, path: &str, token: Option<&str>, body: &Value) -
 async fn response_json(response: axum::response::Response) -> Value {
     let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
     serde_json::from_slice(&body).unwrap()
+}
+
+fn capture_job() -> CaptureJob {
+    CaptureJob {
+        workspace_id: "workspace-a".into(),
+        job_id: "job-a".into(),
+        bot_id: "bot-a".into(),
+        owner_user_id: "owner-a".into(),
+        requesting_actor_id: "actor-a".into(),
+        session_id: "session-a".into(),
+        session_title: "Architecture review".into(),
+        provider: anlg_meeting_capture::CaptureProviderKind::Anarlog,
+        meeting: anlg_meeting_capture::MeetingReference {
+            platform: anlg_meeting_capture::MeetingPlatform::GoogleMeet,
+            url: "https://meet.google.com/abc-defg-hij".into(),
+            external_id: None,
+            calendar_event_id: None,
+        },
+        created_at: chrono::DateTime::parse_from_rfc3339("2026-08-17T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+    }
 }

--- a/enterprise/control-plane/tests/postgres.rs
+++ b/enterprise/control-plane/tests/postgres.rs
@@ -170,6 +170,16 @@ async fn persists_projects_and_replays_capture_events_idempotently() {
         .unwrap();
     assert_eq!(created.status(), StatusCode::CREATED);
 
+    let queued_checkpoint = app
+        .clone()
+        .oneshot(authorized_request(Method::GET, &create_path, Body::empty()))
+        .await
+        .unwrap();
+    assert_eq!(queued_checkpoint.status(), StatusCode::OK);
+    let queued_checkpoint = response_json(queued_checkpoint).await;
+    assert_eq!(queued_checkpoint["state"], "queued");
+    assert_eq!(queued_checkpoint["nextSequence"], 0);
+
     let conflicting_job_path =
         format!("/v1/workspaces/{workspace_id}/capture-jobs/other-job-{suffix}");
     let bot_conflict = app
@@ -255,6 +265,16 @@ async fn persists_projects_and_replays_capture_events_idempotently() {
     assert_eq!(conflict.status(), StatusCode::CONFLICT);
 
     let restarted = router(configured_state(&config).await.unwrap());
+    let resumed_checkpoint = restarted
+        .clone()
+        .oneshot(authorized_request(Method::GET, &create_path, Body::empty()))
+        .await
+        .unwrap();
+    assert_eq!(resumed_checkpoint.status(), StatusCode::OK);
+    let resumed_checkpoint = response_json(resumed_checkpoint).await;
+    assert_eq!(resumed_checkpoint["state"], "completed");
+    assert_eq!(resumed_checkpoint["nextSequence"], 8);
+
     let session_path = format!("/v1/workspaces/{workspace_id}/sessions/{job_id}");
     let session = restarted
         .oneshot(authorized_request(

--- a/enterprise/google-meet-worker/src/event_sink.rs
+++ b/enterprise/google-meet-worker/src/event_sink.rs
@@ -1,15 +1,17 @@
 use std::{collections::VecDeque, time::Duration};
 
-use anlg_meeting_capture::CaptureEvent;
+use anlg_meeting_capture::{BotState, CaptureEvent, CaptureProviderKind, MeetingPlatform};
 use async_trait::async_trait;
+use futures_util::StreamExt;
 use reqwest::StatusCode;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_MAX_ATTEMPTS: u8 = 4;
 const DEFAULT_INITIAL_RETRY_DELAY: Duration = Duration::from_millis(200);
 const DEFAULT_MAX_RETRY_DELAY: Duration = Duration::from_secs(2);
+const MAX_CHECKPOINT_RESPONSE_BYTES: usize = 64 * 1024;
 
 #[async_trait]
 pub trait CaptureEventSink: Send + Sync {
@@ -78,7 +80,10 @@ impl Default for CaptureEventRetryConfig {
 
 pub struct ControlPlaneEventSink {
     client: reqwest::Client,
-    endpoint: Url,
+    job_endpoint: Url,
+    event_endpoint: Url,
+    workspace_id: String,
+    job_id: String,
     bearer_token: String,
     retry: CaptureEventRetryConfig,
 }
@@ -95,17 +100,17 @@ impl ControlPlaneEventSink {
         }
         validate_retry(config.retry)?;
 
-        let mut endpoint = config.base_url;
-        if !matches!(endpoint.scheme(), "http" | "https")
-            || endpoint.host_str().is_none()
-            || !endpoint.username().is_empty()
-            || endpoint.password().is_some()
-            || endpoint.query().is_some()
-            || endpoint.fragment().is_some()
+        let mut job_endpoint = config.base_url;
+        if !matches!(job_endpoint.scheme(), "http" | "https")
+            || job_endpoint.host_str().is_none()
+            || !job_endpoint.username().is_empty()
+            || job_endpoint.password().is_some()
+            || job_endpoint.query().is_some()
+            || job_endpoint.fragment().is_some()
         {
             return Err(CaptureEventSinkConfigError::InvalidBaseUrl);
         }
-        endpoint
+        job_endpoint
             .path_segments_mut()
             .map_err(|_| CaptureEventSinkConfigError::InvalidBaseUrl)?
             .pop_if_empty()
@@ -115,8 +120,12 @@ impl ControlPlaneEventSink {
                 &config.workspace_id,
                 "capture-jobs",
                 &config.job_id,
-                "events",
             ]);
+        let mut event_endpoint = job_endpoint.clone();
+        event_endpoint
+            .path_segments_mut()
+            .map_err(|_| CaptureEventSinkConfigError::InvalidBaseUrl)?
+            .push("events");
         let client = reqwest::Client::builder()
             .timeout(config.request_timeout)
             .redirect(reqwest::redirect::Policy::none())
@@ -124,10 +133,44 @@ impl ControlPlaneEventSink {
             .map_err(CaptureEventSinkConfigError::Client)?;
         Ok(Self {
             client,
-            endpoint,
+            job_endpoint,
+            event_endpoint,
+            workspace_id: config.workspace_id,
+            job_id: config.job_id,
             bearer_token: config.bearer_token,
             retry: config.retry,
         })
+    }
+
+    pub async fn read_checkpoint(&self) -> Result<WorkerCheckpoint, CaptureEventSinkError> {
+        let mut retry_delay = self.retry.initial_delay;
+        for attempt in 1..=self.retry.max_attempts {
+            match self
+                .client
+                .get(self.job_endpoint.clone())
+                .bearer_auth(&self.bearer_token)
+                .send()
+                .await
+            {
+                Ok(response) if response.status().is_success() => {
+                    return decode_checkpoint(response, &self.workspace_id, &self.job_id).await;
+                }
+                Ok(response) => {
+                    let status = response.status();
+                    if attempt == self.retry.max_attempts || !retryable_status(status) {
+                        return Err(CaptureEventSinkError::ControlPlaneStatus(status));
+                    }
+                }
+                Err(error) => {
+                    if attempt == self.retry.max_attempts {
+                        return Err(CaptureEventSinkError::Request(error));
+                    }
+                }
+            }
+            tokio::time::sleep(retry_delay).await;
+            retry_delay = retry_delay.saturating_mul(2).min(self.retry.max_delay);
+        }
+        unreachable!("validated retry configuration always performs at least one attempt")
     }
 }
 
@@ -141,7 +184,7 @@ impl CaptureEventSink for ControlPlaneEventSink {
         for attempt in 1..=self.retry.max_attempts {
             match self
                 .client
-                .post(self.endpoint.clone())
+                .post(self.event_endpoint.clone())
                 .bearer_auth(&self.bearer_token)
                 .json(&request)
                 .send()
@@ -170,6 +213,91 @@ impl CaptureEventSink for ControlPlaneEventSink {
 #[derive(Serialize)]
 struct AppendCaptureEventRequest<'a> {
     event: &'a CaptureEvent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerCheckpoint {
+    pub job_id: String,
+    pub bot_id: String,
+    pub meeting_url: crate::GoogleMeetUrl,
+    pub state: BotState,
+    pub next_sequence: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct WireCaptureJobCheckpoint {
+    job: WireCaptureJob,
+    state: BotState,
+    next_sequence: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireCaptureJob {
+    workspace_id: String,
+    job_id: String,
+    bot_id: String,
+    provider: CaptureProviderKind,
+    meeting: WireMeetingReference,
+}
+
+#[derive(Deserialize)]
+struct WireMeetingReference {
+    platform: MeetingPlatform,
+    url: String,
+}
+
+async fn decode_checkpoint(
+    response: reqwest::Response,
+    expected_workspace_id: &str,
+    expected_job_id: &str,
+) -> Result<WorkerCheckpoint, CaptureEventSinkError> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_CHECKPOINT_RESPONSE_BYTES as u64)
+    {
+        return Err(CaptureEventSinkError::CheckpointResponseTooLarge);
+    }
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(CaptureEventSinkError::ResponseBody)?;
+        if body.len().saturating_add(chunk.len()) > MAX_CHECKPOINT_RESPONSE_BYTES {
+            return Err(CaptureEventSinkError::CheckpointResponseTooLarge);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    let checkpoint: WireCaptureJobCheckpoint =
+        serde_json::from_slice(&body).map_err(CaptureEventSinkError::InvalidCheckpointResponse)?;
+    if checkpoint.job.workspace_id != expected_workspace_id {
+        return Err(CaptureEventSinkError::InvalidCheckpoint("workspace ID"));
+    }
+    if checkpoint.job.job_id != expected_job_id {
+        return Err(CaptureEventSinkError::InvalidCheckpoint("job ID"));
+    }
+    validate_identifier(&checkpoint.job.bot_id, "checkpoint bot ID")
+        .map_err(|_| CaptureEventSinkError::InvalidCheckpoint("bot ID"))?;
+    if checkpoint.job.provider != CaptureProviderKind::Anarlog {
+        return Err(CaptureEventSinkError::InvalidCheckpoint("capture provider"));
+    }
+    if checkpoint.job.meeting.platform != MeetingPlatform::GoogleMeet {
+        return Err(CaptureEventSinkError::InvalidCheckpoint("meeting platform"));
+    }
+    if checkpoint.state == BotState::Queued && checkpoint.next_sequence != 0
+        || checkpoint.state != BotState::Queued && checkpoint.next_sequence == 0
+    {
+        return Err(CaptureEventSinkError::InvalidCheckpoint("next sequence"));
+    }
+    let meeting_url = crate::GoogleMeetUrl::parse(&checkpoint.job.meeting.url)
+        .map_err(|_| CaptureEventSinkError::InvalidCheckpoint("meeting URL"))?;
+    Ok(WorkerCheckpoint {
+        job_id: checkpoint.job.job_id,
+        bot_id: checkpoint.job.bot_id,
+        meeting_url,
+        state: checkpoint.state,
+        next_sequence: checkpoint.next_sequence,
+    })
 }
 
 pub struct CaptureEventPublisher<S> {
@@ -264,6 +392,14 @@ pub enum CaptureEventSinkError {
     Request(#[source] reqwest::Error),
     #[error("control plane rejected capture event with HTTP {0}")]
     ControlPlaneStatus(StatusCode),
+    #[error("failed to read control-plane checkpoint response")]
+    ResponseBody(#[source] reqwest::Error),
+    #[error("control-plane checkpoint response exceeded 64 KiB")]
+    CheckpointResponseTooLarge,
+    #[error("control-plane checkpoint response is invalid")]
+    InvalidCheckpointResponse(#[source] serde_json::Error),
+    #[error("control-plane checkpoint contains an invalid {0}")]
+    InvalidCheckpoint(&'static str),
 }
 
 #[cfg(test)]
@@ -340,6 +476,41 @@ mod tests {
         )
     }
 
+    async fn checkpoint_server(body: String) -> (Url, tokio::task::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut bytes = Vec::new();
+            loop {
+                let mut chunk = [0; 4096];
+                let count = stream.read(&mut chunk).await.unwrap();
+                if count == 0 {
+                    break;
+                }
+                bytes.extend_from_slice(&chunk[..count]);
+                if bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            String::from_utf8(bytes).unwrap()
+        });
+        (
+            Url::parse(&format!("http://{address}/root/")).unwrap(),
+            task,
+        )
+    }
+
     fn complete_request_length(bytes: &[u8]) -> Option<usize> {
         let headers_end = bytes.windows(4).position(|window| window == b"\r\n\r\n")? + 4;
         let headers = std::str::from_utf8(&bytes[..headers_end]).ok()?;
@@ -386,6 +557,66 @@ mod tests {
                 .contains("authorization: bearer super-secret-token")
         );
         assert!(requests[0].contains("\"event\":{\"id\":\"capture-event-1\""));
+    }
+
+    #[tokio::test]
+    async fn reads_and_validates_the_durable_worker_checkpoint() {
+        let body = serde_json::json!({
+            "job": {
+                "workspaceId": "workspace-a",
+                "jobId": "job-1",
+                "botId": "bot-1",
+                "ownerUserId": "owner-a",
+                "requestingActorId": "actor-a",
+                "sessionId": "session-a",
+                "sessionTitle": "Architecture review",
+                "provider": "anarlog",
+                "meeting": {
+                    "platform": "google_meet",
+                    "url": "https://meet.google.com/abc-defg-hij"
+                },
+                "createdAt": "2026-08-17T00:00:00Z"
+            },
+            "state": "capturing",
+            "nextSequence": 7
+        })
+        .to_string();
+        let (base_url, server) = checkpoint_server(body).await;
+        let sink = ControlPlaneEventSink::new(sink_config(base_url)).unwrap();
+
+        let checkpoint = sink.read_checkpoint().await.unwrap();
+
+        assert_eq!(checkpoint.job_id, "job-1");
+        assert_eq!(checkpoint.bot_id, "bot-1");
+        assert_eq!(
+            checkpoint.meeting_url.as_str(),
+            "https://meet.google.com/abc-defg-hij"
+        );
+        assert_eq!(checkpoint.state, BotState::Capturing);
+        assert_eq!(checkpoint.next_sequence, 7);
+        let request = server.await.unwrap();
+        assert!(
+            request.starts_with("GET /root/v1/workspaces/workspace-a/capture-jobs/job-1 HTTP/1.1")
+        );
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("authorization: bearer super-secret-token")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_an_oversized_checkpoint_before_deserializing_it() {
+        let (base_url, server) =
+            checkpoint_server("x".repeat(MAX_CHECKPOINT_RESPONSE_BYTES + 1)).await;
+        let sink = ControlPlaneEventSink::new(sink_config(base_url)).unwrap();
+
+        assert!(matches!(
+            sink.read_checkpoint().await,
+            Err(CaptureEventSinkError::CheckpointResponseTooLarge)
+        ));
+
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/enterprise/google-meet-worker/src/lifecycle.rs
+++ b/enterprise/google-meet-worker/src/lifecycle.rs
@@ -35,6 +35,26 @@ impl WorkerLifecycle {
         self.state
     }
 
+    pub fn resume(
+        bot_id: impl Into<String>,
+        state: BotState,
+        next_sequence: u64,
+    ) -> Result<Self, WorkerLifecycleResumeError> {
+        if (state == BotState::Queued) != (next_sequence == 0) {
+            return Err(WorkerLifecycleResumeError {
+                state,
+                next_sequence,
+            });
+        }
+        Ok(Self {
+            bot_id: bot_id.into(),
+            state,
+            next_sequence,
+            admission: AdmissionClassifier::default(),
+            runtime: RuntimeClassifier::default(),
+        })
+    }
+
     pub fn launch_started(
         &mut self,
         occurred_at: DateTime<Utc>,
@@ -111,6 +131,22 @@ impl WorkerLifecycle {
             Some(TerminalReason {
                 kind: TerminalReasonKind::AdmissionTimeout,
                 message: Some("Google Meet host did not admit the bot before the deadline".into()),
+                retryable: true,
+            }),
+            occurred_at,
+        )
+    }
+
+    pub fn worker_exited(
+        &mut self,
+        message: impl Into<String>,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<CaptureEvent, TransitionError> {
+        self.transition(
+            BotState::Failed,
+            Some(TerminalReason {
+                kind: TerminalReasonKind::WorkerExited,
+                message: Some(message.into()),
                 retryable: true,
             }),
             occurred_at,
@@ -226,6 +262,13 @@ impl WorkerLifecycle {
     }
 }
 
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error("capture checkpoint state {state:?} is inconsistent with next sequence {next_sequence}")]
+pub struct WorkerLifecycleResumeError {
+    pub state: BotState,
+    pub next_sequence: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -301,6 +344,31 @@ mod tests {
                     .bytes()
                     .all(|byte| byte.is_ascii_alphanumeric() || b"-_.".contains(&byte))
         );
+    }
+
+    #[test]
+    fn resumes_at_the_durable_sequence_and_can_terminalize_an_interrupted_worker() {
+        let mut lifecycle = WorkerLifecycle::resume("bot-1", BotState::Capturing, 7).unwrap();
+
+        let event = lifecycle.worker_exited("worker restarted", now()).unwrap();
+        let CaptureEventPayload::Lifecycle(transition) = event.payload else {
+            panic!("expected lifecycle event")
+        };
+
+        assert_eq!(event.sequence, 7);
+        assert_eq!(event.id, "capture-event-7");
+        assert_eq!(transition.from, BotState::Capturing);
+        assert_eq!(transition.to, BotState::Failed);
+        assert_eq!(
+            transition.reason.unwrap().kind,
+            TerminalReasonKind::WorkerExited
+        );
+    }
+
+    #[test]
+    fn rejects_inconsistent_durable_sequence_origins() {
+        assert!(WorkerLifecycle::resume("bot-1", BotState::Queued, 1).is_err());
+        assert!(WorkerLifecycle::resume("bot-1", BotState::Launching, 0).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- expose an authenticated capture-job checkpoint from the control plane
- restore worker lifecycle state and sequence from durable control-plane data
- validate the contract with in-process, real-HTTP, and OrbStack Postgres tests

## Validation
- pnpm exec dprint fmt
- pnpm fmt:check
- cargo check --manifest-path enterprise/Cargo.toml --workspace --all-targets
- cargo clippy --manifest-path enterprise/Cargo.toml --workspace --all-targets --locked -- -D warnings
- ANARLOG_ENTERPRISE_TEST_DATABASE_URL=postgresql://postgres:***@127.0.0.1:54322/postgres cargo test --manifest-path enterprise/Cargo.toml --workspace --all-targets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes capture event sequencing and a new authenticated read path; incorrect checkpoint or resume logic could cause sequence conflicts or duplicate lifecycle events.
> 
> **Overview**
> Adds **durable capture-job checkpoints** so Google Meet workers can resume after restarts without duplicating event sequences.
> 
> The control plane exposes an authenticated **GET** on the same capture-job path as job creation, returning job metadata, current **bot state**, and **nextSequence** (derived from persisted `last_sequence`). Postgres reads this from `capture_jobs`; the store trait and API handler mirror existing workspace auth and identifier validation.
> 
> The **google-meet-worker** `ControlPlaneEventSink` now targets separate job vs `/events` URLs, implements **`read_checkpoint`** with retries, a 64 KiB response cap, and strict wire validation (workspace/job IDs, Google Meet, Anarlog provider, queued/sequence consistency). **`WorkerLifecycle::resume`** restores state and sequence from the checkpoint; **`worker_exited`** emits a retryable failed terminal transition for interrupted workers.
> 
> Coverage extends to in-process API tests, a real-HTTP worker↔control-plane test, and Postgres integration asserting checkpoints at queue time and after a full event stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54a75d54792b4f6e5242615f20d3e08bbc84773a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->