### PR TITLE
Fence capture workers with durable leases

### DIFF
--- a/enterprise/control-plane/README.md
+++ b/enterprise/control-plane/README.md
@@ -64,7 +64,7 @@ See the official [`infisical run` documentation](https://infisical.com/docs/cli/
 
 `GET /health/live` is process-only liveness. `GET /health/ready` checks PostgreSQL. Capture and delivery routes require `Authorization: Bearer <token>` and reject a token used against any workspace other than its configured workspace.
 
-Capture workers create a durable job with `POST /v1/workspaces/{workspace_id}/capture-jobs/{job_id}` and append normalized events with `POST /v1/workspaces/{workspace_id}/capture-jobs/{job_id}/events`. Event IDs and zero-based sequences are idempotency keys. Each accepted event atomically advances the PostgreSQL checkpoint and publishes a delivery revision; retries return the existing byte-equivalent revision, while conflicting IDs, sequences, or lifecycle transitions fail closed.
+Capture workers create a durable job with `POST /v1/workspaces/{workspace_id}/capture-jobs/{job_id}`, claim it through `/claim`, and renew the returned 60-second fencing lease through `/lease`. Every new event appended to `/events` must carry that lease identity. An expired lease can be reclaimed with a higher epoch, which prevents the prior worker from advancing the job; an identical already-persisted event remains safe to replay. Event IDs and zero-based sequences are idempotency keys. Each accepted event atomically advances the PostgreSQL checkpoint and publishes a delivery revision, while conflicting IDs, sequences, lifecycle transitions, or stale leases fail closed.
 
 The static token map is intended for the evaluation bundle and sits behind the `WorkspaceAuthenticator` interface. Production OIDC, SCIM, offline license enforcement, object storage, and meeting browser workers are outside this service.
 

--- a/enterprise/control-plane/migrations/0003_capture_job_leases.sql
+++ b/enterprise/control-plane/migrations/0003_capture_job_leases.sql
@@ -1,0 +1,25 @@
+ALTER TABLE capture_jobs
+    ADD COLUMN lease_owner TEXT,
+    ADD COLUMN lease_id TEXT,
+    ADD COLUMN lease_epoch BIGINT NOT NULL DEFAULT 0 CHECK (lease_epoch >= 0),
+    ADD COLUMN lease_expires_at TIMESTAMPTZ,
+    ADD CONSTRAINT capture_jobs_lease_shape CHECK (
+        (
+            lease_owner IS NULL
+            AND lease_id IS NULL
+            AND lease_expires_at IS NULL
+            AND lease_epoch = 0
+        )
+        OR (
+            lease_owner IS NOT NULL
+            AND lease_id IS NOT NULL
+            AND lease_expires_at IS NOT NULL
+            AND length(lease_owner) BETWEEN 1 AND 128
+            AND length(lease_id) BETWEEN 1 AND 128
+            AND lease_epoch > 0
+        )
+    );
+
+CREATE INDEX capture_jobs_claimable
+    ON capture_jobs (state, lease_expires_at, created_at)
+    WHERE state NOT IN ('completed', 'failed', 'canceled');

--- a/enterprise/control-plane/src/api.rs
+++ b/enterprise/control-plane/src/api.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use anlg_session_ingest::{AcknowledgeRequest, AcknowledgeResponse, DeliveryPage, SessionRead};
 use axum::{
@@ -14,8 +14,9 @@ use tower_http::trace::TraceLayer;
 use crate::{
     auth::{AuthenticationError, WorkspaceAuthenticator},
     capture::{
-        AppendCaptureEventRequest, CaptureJob, CaptureJobCheckpoint, CaptureJobStatus,
-        CreateCaptureJobRequest, ProjectionPublication,
+        AppendCaptureEventRequest, CaptureJob, CaptureJobCheckpoint, CaptureJobLease,
+        CaptureJobStatus, ClaimCaptureJobRequest, CreateCaptureJobRequest, ProjectionPublication,
+        RenewCaptureJobLeaseRequest,
     },
     store::{ControlPlaneStore, StoreError},
 };
@@ -23,6 +24,7 @@ use crate::{
 const MAX_REQUEST_BYTES: usize = 256 * 1024;
 const DEFAULT_PAGE_LIMIT: u16 = 10;
 const MAX_PAGE_LIMIT: u16 = 100;
+const CAPTURE_LEASE_DURATION: Duration = Duration::from_secs(60);
 
 #[derive(Clone)]
 pub struct AppState {
@@ -53,6 +55,14 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/v1/workspaces/{workspace_id}/capture-jobs/{job_id}/events",
             post(append_capture_event),
+        )
+        .route(
+            "/v1/workspaces/{workspace_id}/capture-jobs/{job_id}/claim",
+            post(claim_capture_job),
+        )
+        .route(
+            "/v1/workspaces/{workspace_id}/capture-jobs/{job_id}/lease",
+            post(renew_capture_job_lease),
         )
         .route(
             "/v1/workspaces/{workspace_id}/session-envelopes",
@@ -130,6 +140,61 @@ async fn create_capture_job(
     Ok((response_status, Json(status)))
 }
 
+async fn claim_capture_job(
+    State(state): State<AppState>,
+    Path((workspace_id, job_id)): Path<(String, String)>,
+    headers: HeaderMap,
+    Json(request): Json<ClaimCaptureJobRequest>,
+) -> Result<Json<CaptureJobLease>, ApiError> {
+    authorize(&state, &headers, &workspace_id)?;
+    validate_identifier(&workspace_id, "workspace_id")?;
+    validate_identifier(&job_id, "job_id")?;
+    validate_identifier(&request.worker_id, "worker_id")?;
+    validate_identifier(&request.lease_id, "lease_id")?;
+    let lease = state
+        .store
+        .claim_capture_job(
+            &workspace_id,
+            &job_id,
+            &request.worker_id,
+            &request.lease_id,
+            CAPTURE_LEASE_DURATION,
+        )
+        .await
+        .map_err(ApiError::from_store)?;
+    Ok(Json(lease))
+}
+
+async fn renew_capture_job_lease(
+    State(state): State<AppState>,
+    Path((workspace_id, job_id)): Path<(String, String)>,
+    headers: HeaderMap,
+    Json(request): Json<RenewCaptureJobLeaseRequest>,
+) -> Result<Json<CaptureJobLease>, ApiError> {
+    authorize(&state, &headers, &workspace_id)?;
+    validate_identifier(&workspace_id, "workspace_id")?;
+    validate_identifier(&job_id, "job_id")?;
+    validate_identifier(&request.lease.worker_id, "worker_id")?;
+    validate_identifier(&request.lease.lease_id, "lease_id")?;
+    if request.lease.epoch == 0 {
+        return Err(ApiError::bad_request(
+            "invalid_lease_epoch",
+            "lease epoch must be greater than zero",
+        ));
+    }
+    let lease = state
+        .store
+        .renew_capture_job_lease(
+            &workspace_id,
+            &job_id,
+            &request.lease,
+            CAPTURE_LEASE_DURATION,
+        )
+        .await
+        .map_err(ApiError::from_store)?;
+    Ok(Json(lease))
+}
+
 async fn append_capture_event(
     State(state): State<AppState>,
     Path((workspace_id, job_id)): Path<(String, String)>,
@@ -139,11 +204,19 @@ async fn append_capture_event(
     authorize(&state, &headers, &workspace_id)?;
     validate_identifier(&workspace_id, "workspace_id")?;
     validate_identifier(&job_id, "job_id")?;
+    validate_identifier(&request.lease.worker_id, "worker_id")?;
+    validate_identifier(&request.lease.lease_id, "lease_id")?;
+    if request.lease.epoch == 0 {
+        return Err(ApiError::bad_request(
+            "invalid_lease_epoch",
+            "lease epoch must be greater than zero",
+        ));
+    }
     validate_identifier(&request.event.id, "event_id")?;
     validate_identifier(&request.event.bot_id, "bot_id")?;
     let publication = state
         .store
-        .append_capture_event(&workspace_id, &job_id, &request.event)
+        .append_capture_event(&workspace_id, &job_id, &request.lease, &request.event)
         .await
         .map_err(ApiError::from_store)?;
     Ok(Json(publication))
@@ -286,6 +359,8 @@ fn validate_identifier(value: &str, field: &'static str) -> Result<(), ApiError>
             match field {
                 "consumerId" => "consumerId contains unsupported characters",
                 "job_id" => "job_id contains unsupported characters",
+                "worker_id" => "workerId contains unsupported characters",
+                "lease_id" => "leaseId contains unsupported characters",
                 _ => "workspace_id contains unsupported characters",
             },
         ));
@@ -386,6 +461,24 @@ impl ApiError {
                 status: StatusCode::UNPROCESSABLE_ENTITY,
                 code: "invalid_capture_event",
                 message: "capture event violates the normalized capture contract",
+                authenticate: false,
+            },
+            StoreError::CaptureJobTerminal => Self {
+                status: StatusCode::CONFLICT,
+                code: "capture_job_terminal",
+                message: "capture job is already terminal",
+                authenticate: false,
+            },
+            StoreError::CaptureLeaseUnavailable => Self {
+                status: StatusCode::CONFLICT,
+                code: "capture_lease_unavailable",
+                message: "capture job already has an active worker lease",
+                authenticate: false,
+            },
+            StoreError::CaptureLeaseLost => Self {
+                status: StatusCode::CONFLICT,
+                code: "capture_lease_lost",
+                message: "capture worker lease is expired or no longer current",
                 authenticate: false,
             },
             error => {

--- a/enterprise/control-plane/src/capture.rs
+++ b/enterprise/control-plane/src/capture.rs
@@ -34,6 +34,23 @@ pub struct CaptureJobCheckpoint {
     pub next_sequence: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptureJobLease {
+    pub worker_id: String,
+    pub lease_id: String,
+    pub epoch: u64,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CaptureJobLeaseIdentity {
+    pub worker_id: String,
+    pub lease_id: String,
+    pub epoch: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectionPublication {
@@ -59,6 +76,20 @@ pub struct CreateCaptureJobRequest {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClaimCaptureJobRequest {
+    pub worker_id: String,
+    pub lease_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RenewCaptureJobLeaseRequest {
+    pub lease: CaptureJobLeaseIdentity,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AppendCaptureEventRequest {
+    pub lease: CaptureJobLeaseIdentity,
     pub event: CaptureEvent,
 }

--- a/enterprise/control-plane/src/store.rs
+++ b/enterprise/control-plane/src/store.rs
@@ -9,7 +9,10 @@ use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 
 use crate::{
-    capture::{CaptureJob, CaptureJobCheckpoint, CaptureJobStatus, ProjectionPublication},
+    capture::{
+        CaptureJob, CaptureJobCheckpoint, CaptureJobLease, CaptureJobLeaseIdentity,
+        CaptureJobStatus, ProjectionPublication,
+    },
     projector,
 };
 
@@ -27,10 +30,28 @@ pub trait ControlPlaneStore: Send + Sync {
         job_id: &str,
     ) -> Result<CaptureJobCheckpoint, StoreError>;
 
+    async fn claim_capture_job(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+        worker_id: &str,
+        lease_id: &str,
+        lease_duration: Duration,
+    ) -> Result<CaptureJobLease, StoreError>;
+
+    async fn renew_capture_job_lease(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+        lease: &CaptureJobLeaseIdentity,
+        lease_duration: Duration,
+    ) -> Result<CaptureJobLease, StoreError>;
+
     async fn append_capture_event(
         &self,
         workspace_id: &str,
         job_id: &str,
+        lease: &CaptureJobLeaseIdentity,
         event: &CaptureEvent,
     ) -> Result<ProjectionPublication, StoreError>;
 
@@ -226,10 +247,131 @@ impl ControlPlaneStore for PostgresStore {
         })
     }
 
+    async fn claim_capture_job(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+        worker_id: &str,
+        lease_id: &str,
+        lease_duration: Duration,
+    ) -> Result<CaptureJobLease, StoreError> {
+        let lease_seconds = lease_seconds(lease_duration)?;
+        let mut transaction = self.pool.begin().await?;
+        let row = sqlx::query(
+            r#"
+            SELECT state, lease_owner, lease_id, lease_epoch, lease_expires_at
+            FROM capture_jobs
+            WHERE workspace_id = $1 AND job_id = $2
+            FOR UPDATE
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or(StoreError::NotFound)?;
+        let state: BotState = parse_enum(&row.try_get::<String, _>("state")?)?;
+        if state.is_terminal() {
+            return Err(StoreError::CaptureJobTerminal);
+        }
+
+        let current_owner = row.try_get::<Option<String>, _>("lease_owner")?;
+        let current_lease_id = row.try_get::<Option<String>, _>("lease_id")?;
+        let current_epoch = row.try_get::<i64, _>("lease_epoch")?;
+        let current_expires_at = row.try_get::<Option<DateTime<Utc>>, _>("lease_expires_at")?;
+        let now = sqlx::query_scalar::<_, DateTime<Utc>>("SELECT clock_timestamp()")
+            .fetch_one(&mut *transaction)
+            .await?;
+        let current_is_active = current_expires_at.is_some_and(|expires_at| expires_at > now);
+        if current_is_active
+            && (current_owner.as_deref() != Some(worker_id)
+                || current_lease_id.as_deref() != Some(lease_id))
+        {
+            return Err(StoreError::CaptureLeaseUnavailable);
+        }
+
+        let epoch = if current_is_active {
+            current_epoch
+        } else {
+            current_epoch
+                .checked_add(1)
+                .ok_or(StoreError::OutOfRange("capture lease epoch"))?
+        };
+        let row = sqlx::query(
+            r#"
+            UPDATE capture_jobs
+            SET
+                lease_owner = $3,
+                lease_id = $4,
+                lease_epoch = $5,
+                lease_expires_at = clock_timestamp() + $6 * INTERVAL '1 second'
+            WHERE workspace_id = $1 AND job_id = $2
+            RETURNING lease_expires_at
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .bind(worker_id)
+        .bind(lease_id)
+        .bind(epoch)
+        .bind(lease_seconds)
+        .fetch_one(&mut *transaction)
+        .await?;
+        let lease = CaptureJobLease {
+            worker_id: worker_id.to_string(),
+            lease_id: lease_id.to_string(),
+            epoch: from_i64(epoch, "capture lease epoch")?,
+            expires_at: row.try_get("lease_expires_at")?,
+        };
+        transaction.commit().await?;
+        Ok(lease)
+    }
+
+    async fn renew_capture_job_lease(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+        lease: &CaptureJobLeaseIdentity,
+        lease_duration: Duration,
+    ) -> Result<CaptureJobLease, StoreError> {
+        let lease_seconds = lease_seconds(lease_duration)?;
+        let epoch = to_i64(lease.epoch, "capture lease epoch")?;
+        let row = sqlx::query(
+            r#"
+            UPDATE capture_jobs
+            SET lease_expires_at = clock_timestamp() + $6 * INTERVAL '1 second'
+            WHERE workspace_id = $1
+              AND job_id = $2
+              AND lease_owner = $3
+              AND lease_id = $4
+              AND lease_epoch = $5
+              AND lease_expires_at > clock_timestamp()
+              AND state NOT IN ('completed', 'failed', 'canceled')
+            RETURNING lease_expires_at
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .bind(&lease.worker_id)
+        .bind(&lease.lease_id)
+        .bind(epoch)
+        .bind(lease_seconds)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(StoreError::CaptureLeaseLost)?;
+        Ok(CaptureJobLease {
+            worker_id: lease.worker_id.clone(),
+            lease_id: lease.lease_id.clone(),
+            epoch: lease.epoch,
+            expires_at: row.try_get("lease_expires_at")?,
+        })
+    }
+
     async fn append_capture_event(
         &self,
         workspace_id: &str,
         job_id: &str,
+        lease: &CaptureJobLeaseIdentity,
         event: &CaptureEvent,
     ) -> Result<ProjectionPublication, StoreError> {
         let mut transaction = self.pool.begin().await?;
@@ -246,7 +388,11 @@ impl ControlPlaneStore for PostgresStore {
                 provider,
                 meeting,
                 created_at,
-                last_sequence
+                last_sequence,
+                lease_owner,
+                lease_id,
+                lease_epoch,
+                lease_expires_at > clock_timestamp() AS lease_active
             FROM capture_jobs
             WHERE workspace_id = $1 AND job_id = $2
             FOR UPDATE
@@ -258,6 +404,10 @@ impl ControlPlaneStore for PostgresStore {
         .await?
         .ok_or(StoreError::NotFound)?;
         let last_sequence = job_row.try_get::<i64, _>("last_sequence")?;
+        let lease_owner = job_row.try_get::<Option<String>, _>("lease_owner")?;
+        let lease_id = job_row.try_get::<Option<String>, _>("lease_id")?;
+        let lease_epoch = job_row.try_get::<i64, _>("lease_epoch")?;
+        let lease_active = job_row.try_get::<Option<bool>, _>("lease_active")? == Some(true);
         let job = capture_job(job_row)?;
         if event.bot_id != job.bot_id {
             return Err(StoreError::InvalidCaptureEvent(
@@ -297,6 +447,14 @@ impl ControlPlaneStore for PostgresStore {
                 read_publication(&mut transaction, workspace_id, job_id, revision).await?;
             transaction.commit().await?;
             return Ok(publication);
+        }
+
+        let active_lease = lease_owner.as_deref() == Some(lease.worker_id.as_str())
+            && lease_id.as_deref() == Some(lease.lease_id.as_str())
+            && lease_epoch == to_i64(lease.epoch, "capture lease epoch")?
+            && lease_active;
+        if !active_lease {
+            return Err(StoreError::CaptureLeaseLost);
         }
 
         let expected = last_sequence
@@ -706,6 +864,13 @@ fn from_i64(value: i64, field: &'static str) -> Result<u64, StoreError> {
     u64::try_from(value).map_err(|_| StoreError::OutOfRange(field))
 }
 
+fn lease_seconds(duration: Duration) -> Result<i64, StoreError> {
+    i64::try_from(duration.as_secs())
+        .ok()
+        .filter(|seconds| *seconds > 0)
+        .ok_or(StoreError::OutOfRange("capture lease duration"))
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {
     #[error("database operation failed")]
@@ -726,6 +891,12 @@ pub enum StoreError {
     CaptureEventConflict,
     #[error("capture event sequence conflict: expected {expected}, got {actual}")]
     CaptureSequenceConflict { expected: u64, actual: u64 },
+    #[error("capture job is already terminal")]
+    CaptureJobTerminal,
+    #[error("capture job already has an active lease")]
+    CaptureLeaseUnavailable,
+    #[error("capture job lease is no longer active")]
+    CaptureLeaseLost,
     #[error("capture event is invalid: {0}")]
     InvalidCaptureEvent(String),
     #[error("stored capture JSON is invalid")]

--- a/enterprise/control-plane/tests/api.rs
+++ b/enterprise/control-plane/tests/api.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use anarlog_enterprise_control_plane::{
     api::{AppState, router},
     auth::StaticTokenAuthenticator,
-    capture::{CaptureJob, CaptureJobCheckpoint, CaptureJobStatus, ProjectionPublication},
+    capture::{
+        CaptureJob, CaptureJobCheckpoint, CaptureJobLease, CaptureJobLeaseIdentity,
+        CaptureJobStatus, ProjectionPublication,
+    },
     serve,
     store::{ControlPlaneStore, StoreError},
 };
@@ -59,10 +62,42 @@ impl ControlPlaneStore for MemoryStore {
         })
     }
 
+    async fn claim_capture_job(
+        &self,
+        _workspace_id: &str,
+        _job_id: &str,
+        worker_id: &str,
+        lease_id: &str,
+        lease_duration: std::time::Duration,
+    ) -> Result<CaptureJobLease, StoreError> {
+        Ok(CaptureJobLease {
+            worker_id: worker_id.into(),
+            lease_id: lease_id.into(),
+            epoch: 1,
+            expires_at: chrono::Utc::now() + chrono::Duration::from_std(lease_duration).unwrap(),
+        })
+    }
+
+    async fn renew_capture_job_lease(
+        &self,
+        _workspace_id: &str,
+        _job_id: &str,
+        lease: &CaptureJobLeaseIdentity,
+        lease_duration: std::time::Duration,
+    ) -> Result<CaptureJobLease, StoreError> {
+        Ok(CaptureJobLease {
+            worker_id: lease.worker_id.clone(),
+            lease_id: lease.lease_id.clone(),
+            epoch: lease.epoch,
+            expires_at: chrono::Utc::now() + chrono::Duration::from_std(lease_duration).unwrap(),
+        })
+    }
+
     async fn append_capture_event(
         &self,
         _workspace_id: &str,
         _job_id: &str,
+        _lease: &CaptureJobLeaseIdentity,
         _event: &CaptureEvent,
     ) -> Result<ProjectionPublication, StoreError> {
         Err(StoreError::NotFound)
@@ -255,6 +290,63 @@ async fn reads_only_the_authorized_workspace_capture_checkpoint() {
 }
 
 #[tokio::test]
+async fn claims_and_renews_only_an_authorized_worker_lease() {
+    let app = router(state(true));
+    let claim_path = "/v1/workspaces/workspace-a/capture-jobs/job-a/claim";
+    let claim_body = serde_json::json!({
+        "workerId": "worker-a",
+        "leaseId": "lease-a"
+    });
+
+    let wrong_workspace = app
+        .clone()
+        .oneshot(json_request(
+            Method::POST,
+            claim_path,
+            Some(TOKEN_B),
+            &claim_body,
+        ))
+        .await
+        .unwrap();
+    let claimed = app
+        .clone()
+        .oneshot(json_request(
+            Method::POST,
+            claim_path,
+            Some(TOKEN_A),
+            &claim_body,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(wrong_workspace.status(), StatusCode::FORBIDDEN);
+    assert_eq!(claimed.status(), StatusCode::OK);
+    let claimed = response_json(claimed).await;
+    assert_eq!(claimed["workerId"], "worker-a");
+    assert_eq!(claimed["leaseId"], "lease-a");
+    assert_eq!(claimed["epoch"], 1);
+    assert!(claimed["expiresAt"].is_string());
+
+    let renewed = app
+        .oneshot(json_request(
+            Method::POST,
+            "/v1/workspaces/workspace-a/capture-jobs/job-a/lease",
+            Some(TOKEN_A),
+            &serde_json::json!({
+                "lease": {
+                    "workerId": "worker-a",
+                    "leaseId": "lease-a",
+                    "epoch": 1
+                }
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(renewed.status(), StatusCode::OK);
+    assert_eq!(response_json(renewed).await["epoch"], 1);
+}
+
+#[tokio::test]
 async fn boots_on_a_real_listener_and_shuts_down_gracefully() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
@@ -277,7 +369,7 @@ async fn boots_on_a_real_listener_and_shuts_down_gracefully() {
 }
 
 #[tokio::test]
-async fn worker_reads_the_checkpoint_over_real_http() {
+async fn worker_reads_the_checkpoint_and_manages_its_lease_over_real_http() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -293,11 +385,17 @@ async fn worker_reads_the_checkpoint_over_real_http() {
     .unwrap();
 
     let checkpoint = sink.read_checkpoint().await.unwrap();
+    let lease = sink.claim("worker-a", "lease-a").await.unwrap();
+    let renewed = sink.renew_lease().await.unwrap();
 
     assert_eq!(checkpoint.job_id, "job-a");
     assert_eq!(checkpoint.bot_id, "bot-a");
     assert_eq!(checkpoint.state, BotState::Capturing);
     assert_eq!(checkpoint.next_sequence, 7);
+    assert_eq!(lease.worker_id, "worker-a");
+    assert_eq!(lease.lease_id, "lease-a");
+    assert_eq!(lease.epoch, 1);
+    assert_eq!(renewed.epoch, lease.epoch);
     shutdown_tx.send(()).unwrap();
     tokio::time::timeout(Duration::from_secs(2), server)
         .await

--- a/enterprise/control-plane/tests/postgres.rs
+++ b/enterprise/control-plane/tests/postgres.rs
@@ -118,6 +118,93 @@ async fn migrates_postgres_and_enforces_workspace_delivery() {
 }
 
 #[tokio::test]
+async fn concurrent_capture_claims_have_one_fenced_winner() {
+    let Ok(database_url) = std::env::var(TEST_DATABASE_URL_ENV) else {
+        return;
+    };
+    let suffix = format!(
+        "{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let workspace_id = format!("workspace-claim-{suffix}");
+    let job_id = format!("job-claim-{suffix}");
+    let config = Config::from_values(
+        database_url,
+        Some("127.0.0.1:0".into()),
+        Some("2".into()),
+        format!(r#"{{"{workspace_id}":"{TOKEN}"}}"#),
+    )
+    .unwrap();
+    let app = router(configured_state(&config).await.unwrap());
+    let create_path = format!("/v1/workspaces/{workspace_id}/capture-jobs/{job_id}");
+    let created = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::POST,
+            &create_path,
+            Body::from(
+                serde_json::json!({
+                    "botId": format!("bot-claim-{suffix}"),
+                    "ownerUserId": "owner-a",
+                    "requestingActorId": "actor-a",
+                    "sessionId": format!("session-claim-{suffix}"),
+                    "sessionTitle": "Concurrent claim",
+                    "provider": "anarlog",
+                    "meeting": {
+                        "platform": "google_meet",
+                        "url": "https://meet.google.com/abc-defg-hij"
+                    },
+                    "createdAt": "2026-08-17T00:00:00Z"
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+
+    let claim_path = format!("{create_path}/claim");
+    let first = app.clone().oneshot(authorized_request(
+        Method::POST,
+        &claim_path,
+        Body::from(r#"{"workerId":"worker-a","leaseId":"lease-a"}"#),
+    ));
+    let second = app.oneshot(authorized_request(
+        Method::POST,
+        &claim_path,
+        Body::from(r#"{"workerId":"worker-b","leaseId":"lease-b"}"#),
+    ));
+    let (first, second) = tokio::join!(first, second);
+    let first = first.unwrap();
+    let second = second.unwrap();
+
+    assert_eq!(
+        [first.status(), second.status()]
+            .into_iter()
+            .filter(|status| *status == StatusCode::OK)
+            .count(),
+        1
+    );
+    assert_eq!(
+        [first.status(), second.status()]
+            .into_iter()
+            .filter(|status| *status == StatusCode::CONFLICT)
+            .count(),
+        1
+    );
+    let winner = if first.status() == StatusCode::OK {
+        response_json(first).await
+    } else {
+        response_json(second).await
+    };
+    assert_eq!(winner["epoch"], 1);
+}
+
+#[tokio::test]
 async fn persists_projects_and_replays_capture_events_idempotently() {
     let Ok(database_url) = std::env::var(TEST_DATABASE_URL_ENV) else {
         return;
@@ -180,6 +267,103 @@ async fn persists_projects_and_replays_capture_events_idempotently() {
     assert_eq!(queued_checkpoint["state"], "queued");
     assert_eq!(queued_checkpoint["nextSequence"], 0);
 
+    let claim_path = format!("{create_path}/claim");
+    let first_lease = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::POST,
+            &claim_path,
+            Body::from(
+                serde_json::json!({
+                    "workerId": "worker-a",
+                    "leaseId": "lease-a"
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(first_lease.status(), StatusCode::OK);
+    let first_lease = response_json(first_lease).await;
+    assert_eq!(first_lease["epoch"], 1);
+
+    let replayed_claim = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::POST,
+            &claim_path,
+            Body::from(
+                serde_json::json!({
+                    "workerId": "worker-a",
+                    "leaseId": "lease-a"
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(replayed_claim.status(), StatusCode::OK);
+    assert_eq!(response_json(replayed_claim).await["epoch"], 1);
+
+    let competing_claim = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::POST,
+            &claim_path,
+            Body::from(
+                serde_json::json!({
+                    "workerId": "worker-b",
+                    "leaseId": "lease-b"
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(competing_claim.status(), StatusCode::CONFLICT);
+    assert_eq!(
+        response_json(competing_claim).await["error"]["code"],
+        "capture_lease_unavailable"
+    );
+
+    let pool = sqlx::PgPool::connect(&database_url).await.unwrap();
+    sqlx::query(
+        "UPDATE capture_jobs SET lease_expires_at = now() - INTERVAL '1 second' WHERE workspace_id = $1 AND job_id = $2",
+    )
+    .bind(&workspace_id)
+    .bind(&job_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let second_lease = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::POST,
+            &claim_path,
+            Body::from(
+                serde_json::json!({
+                    "workerId": "worker-b",
+                    "leaseId": "lease-b"
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(second_lease.status(), StatusCode::OK);
+    let second_lease = response_json(second_lease).await;
+    assert_eq!(second_lease["epoch"], 2);
+    let first_lease_identity = serde_json::json!({
+        "workerId": first_lease["workerId"],
+        "leaseId": first_lease["leaseId"],
+        "epoch": first_lease["epoch"]
+    });
+    let second_lease_identity = serde_json::json!({
+        "workerId": second_lease["workerId"],
+        "leaseId": second_lease["leaseId"],
+        "epoch": second_lease["epoch"]
+    });
+
     let conflicting_job_path =
         format!("/v1/workspaces/{workspace_id}/capture-jobs/other-job-{suffix}");
     let bot_conflict = app
@@ -214,6 +398,26 @@ async fn persists_projects_and_replays_capture_events_idempotently() {
 
     let events = capture_events(&bot_id);
     let event_path = format!("{create_path}/events");
+    let fenced = app
+        .clone()
+        .oneshot(authorized_request(
+            Method::POST,
+            &event_path,
+            Body::from(
+                serde_json::json!({
+                    "lease": first_lease_identity,
+                    "event": &events[0]
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(fenced.status(), StatusCode::CONFLICT);
+    assert_eq!(
+        response_json(fenced).await["error"]["code"],
+        "capture_lease_lost"
+    );
     let mut final_publication = Value::Null;
     for event in &events {
         let response = app
@@ -221,7 +425,13 @@ async fn persists_projects_and_replays_capture_events_idempotently() {
             .oneshot(authorized_request(
                 Method::POST,
                 &event_path,
-                Body::from(serde_json::json!({ "event": event }).to_string()),
+                Body::from(
+                    serde_json::json!({
+                        "lease": second_lease_identity,
+                        "event": event
+                    })
+                    .to_string(),
+                ),
             ))
             .await
             .unwrap();
@@ -244,7 +454,13 @@ async fn persists_projects_and_replays_capture_events_idempotently() {
         .oneshot(authorized_request(
             Method::POST,
             &event_path,
-            Body::from(serde_json::json!({ "event": events.last().unwrap() }).to_string()),
+            Body::from(
+                serde_json::json!({
+                    "lease": first_lease_identity,
+                    "event": events.last().unwrap()
+                })
+                .to_string(),
+            ),
         ))
         .await
         .unwrap();
@@ -258,7 +474,13 @@ async fn persists_projects_and_replays_capture_events_idempotently() {
         .oneshot(authorized_request(
             Method::POST,
             &event_path,
-            Body::from(serde_json::json!({ "event": conflicting }).to_string()),
+            Body::from(
+                serde_json::json!({
+                    "lease": second_lease_identity,
+                    "event": conflicting
+                })
+                .to_string(),
+            ),
         ))
         .await
         .unwrap();
@@ -290,7 +512,6 @@ async fn persists_projects_and_replays_capture_events_idempotently() {
     assert_eq!(session["contentHash"], final_publication["contentHash"]);
     assert_eq!(session["envelope"], final_publication["envelope"]);
 
-    let pool = sqlx::PgPool::connect(&database_url).await.unwrap();
     let event_count: i64 = sqlx::query_scalar(
         "SELECT count(*) FROM capture_events WHERE workspace_id = $1 AND job_id = $2",
     )

--- a/enterprise/google-meet-worker/src/event_sink.rs
+++ b/enterprise/google-meet-worker/src/event_sink.rs
@@ -11,7 +11,7 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_MAX_ATTEMPTS: u8 = 4;
 const DEFAULT_INITIAL_RETRY_DELAY: Duration = Duration::from_millis(200);
 const DEFAULT_MAX_RETRY_DELAY: Duration = Duration::from_secs(2);
-const MAX_CHECKPOINT_RESPONSE_BYTES: usize = 64 * 1024;
+const MAX_CONTROL_PLANE_RESPONSE_BYTES: usize = 64 * 1024;
 
 #[async_trait]
 pub trait CaptureEventSink: Send + Sync {
@@ -82,10 +82,13 @@ pub struct ControlPlaneEventSink {
     client: reqwest::Client,
     job_endpoint: Url,
     event_endpoint: Url,
+    claim_endpoint: Url,
+    lease_endpoint: Url,
     workspace_id: String,
     job_id: String,
     bearer_token: String,
     retry: CaptureEventRetryConfig,
+    lease: tokio::sync::RwLock<Option<WorkerLease>>,
 }
 
 impl ControlPlaneEventSink {
@@ -126,6 +129,16 @@ impl ControlPlaneEventSink {
             .path_segments_mut()
             .map_err(|_| CaptureEventSinkConfigError::InvalidBaseUrl)?
             .push("events");
+        let mut claim_endpoint = job_endpoint.clone();
+        claim_endpoint
+            .path_segments_mut()
+            .map_err(|_| CaptureEventSinkConfigError::InvalidBaseUrl)?
+            .push("claim");
+        let mut lease_endpoint = job_endpoint.clone();
+        lease_endpoint
+            .path_segments_mut()
+            .map_err(|_| CaptureEventSinkConfigError::InvalidBaseUrl)?
+            .push("lease");
         let client = reqwest::Client::builder()
             .timeout(config.request_timeout)
             .redirect(reqwest::redirect::Policy::none())
@@ -135,10 +148,13 @@ impl ControlPlaneEventSink {
             client,
             job_endpoint,
             event_endpoint,
+            claim_endpoint,
+            lease_endpoint,
             workspace_id: config.workspace_id,
             job_id: config.job_id,
             bearer_token: config.bearer_token,
             retry: config.retry,
+            lease: tokio::sync::RwLock::new(None),
         })
     }
 
@@ -172,6 +188,97 @@ impl ControlPlaneEventSink {
         }
         unreachable!("validated retry configuration always performs at least one attempt")
     }
+
+    pub async fn claim(
+        &self,
+        worker_id: impl Into<String>,
+        lease_id: impl Into<String>,
+    ) -> Result<WorkerLease, CaptureEventSinkError> {
+        let worker_id = worker_id.into();
+        let lease_id = lease_id.into();
+        validate_identifier(&worker_id, "worker ID")
+            .map_err(|_| CaptureEventSinkError::InvalidLeaseIdentity("worker ID"))?;
+        validate_identifier(&lease_id, "lease ID")
+            .map_err(|_| CaptureEventSinkError::InvalidLeaseIdentity("lease ID"))?;
+        let request = ClaimCaptureJobRequest {
+            worker_id: &worker_id,
+            lease_id: &lease_id,
+        };
+        let lease = self
+            .send_lease_request(self.claim_endpoint.clone(), &request)
+            .await?;
+        validate_lease(&lease, &worker_id, &lease_id, None)?;
+        *self.lease.write().await = Some(lease.clone());
+        Ok(lease)
+    }
+
+    pub async fn renew_lease(&self) -> Result<WorkerLease, CaptureEventSinkError> {
+        let current = self
+            .lease
+            .read()
+            .await
+            .clone()
+            .ok_or(CaptureEventSinkError::LeaseRequired)?;
+        let identity = WorkerLeaseIdentity::from(&current);
+        let request = RenewCaptureJobLeaseRequest { lease: &identity };
+        let renewed = match self
+            .send_lease_request(self.lease_endpoint.clone(), &request)
+            .await
+        {
+            Ok(renewed) => renewed,
+            Err(error) => {
+                *self.lease.write().await = None;
+                return Err(error);
+            }
+        };
+        if let Err(error) = validate_lease(
+            &renewed,
+            &current.worker_id,
+            &current.lease_id,
+            Some(current.epoch),
+        ) {
+            *self.lease.write().await = None;
+            return Err(error);
+        }
+        *self.lease.write().await = Some(renewed.clone());
+        Ok(renewed)
+    }
+
+    async fn send_lease_request<T: Serialize + Sync>(
+        &self,
+        endpoint: Url,
+        request: &T,
+    ) -> Result<WorkerLease, CaptureEventSinkError> {
+        let mut retry_delay = self.retry.initial_delay;
+        for attempt in 1..=self.retry.max_attempts {
+            match self
+                .client
+                .post(endpoint.clone())
+                .bearer_auth(&self.bearer_token)
+                .json(request)
+                .send()
+                .await
+            {
+                Ok(response) if response.status().is_success() => {
+                    return decode_bounded_json(response).await;
+                }
+                Ok(response) => {
+                    let status = response.status();
+                    if attempt == self.retry.max_attempts || !retryable_status(status) {
+                        return Err(CaptureEventSinkError::ControlPlaneStatus(status));
+                    }
+                }
+                Err(error) => {
+                    if attempt == self.retry.max_attempts {
+                        return Err(CaptureEventSinkError::Request(error));
+                    }
+                }
+            }
+            tokio::time::sleep(retry_delay).await;
+            retry_delay = retry_delay.saturating_mul(2).min(self.retry.max_delay);
+        }
+        unreachable!("validated retry configuration always performs at least one attempt")
+    }
 }
 
 #[async_trait]
@@ -179,7 +286,17 @@ impl CaptureEventSink for ControlPlaneEventSink {
     type Error = CaptureEventSinkError;
 
     async fn append(&self, event: &CaptureEvent) -> Result<(), CaptureEventSinkError> {
-        let request = AppendCaptureEventRequest { event };
+        let lease = self
+            .lease
+            .read()
+            .await
+            .clone()
+            .ok_or(CaptureEventSinkError::LeaseRequired)?;
+        let identity = WorkerLeaseIdentity::from(&lease);
+        let request = AppendCaptureEventRequest {
+            lease: &identity,
+            event,
+        };
         let mut retry_delay = self.retry.initial_delay;
         for attempt in 1..=self.retry.max_attempts {
             match self
@@ -211,8 +328,49 @@ impl CaptureEventSink for ControlPlaneEventSink {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct AppendCaptureEventRequest<'a> {
+    lease: &'a WorkerLeaseIdentity,
     event: &'a CaptureEvent,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ClaimCaptureJobRequest<'a> {
+    worker_id: &'a str,
+    lease_id: &'a str,
+}
+
+#[derive(Serialize)]
+struct RenewCaptureJobLeaseRequest<'a> {
+    lease: &'a WorkerLeaseIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WorkerLease {
+    pub worker_id: String,
+    pub lease_id: String,
+    pub epoch: u64,
+    pub expires_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkerLeaseIdentity {
+    worker_id: String,
+    lease_id: String,
+    epoch: u64,
+}
+
+impl From<&WorkerLease> for WorkerLeaseIdentity {
+    fn from(lease: &WorkerLease) -> Self {
+        Self {
+            worker_id: lease.worker_id.clone(),
+            lease_id: lease.lease_id.clone(),
+            epoch: lease.epoch,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -253,23 +411,7 @@ async fn decode_checkpoint(
     expected_workspace_id: &str,
     expected_job_id: &str,
 ) -> Result<WorkerCheckpoint, CaptureEventSinkError> {
-    if response
-        .content_length()
-        .is_some_and(|length| length > MAX_CHECKPOINT_RESPONSE_BYTES as u64)
-    {
-        return Err(CaptureEventSinkError::CheckpointResponseTooLarge);
-    }
-    let mut body = Vec::new();
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(CaptureEventSinkError::ResponseBody)?;
-        if body.len().saturating_add(chunk.len()) > MAX_CHECKPOINT_RESPONSE_BYTES {
-            return Err(CaptureEventSinkError::CheckpointResponseTooLarge);
-        }
-        body.extend_from_slice(&chunk);
-    }
-    let checkpoint: WireCaptureJobCheckpoint =
-        serde_json::from_slice(&body).map_err(CaptureEventSinkError::InvalidCheckpointResponse)?;
+    let checkpoint: WireCaptureJobCheckpoint = decode_bounded_json(response).await?;
     if checkpoint.job.workspace_id != expected_workspace_id {
         return Err(CaptureEventSinkError::InvalidCheckpoint("workspace ID"));
     }
@@ -298,6 +440,45 @@ async fn decode_checkpoint(
         state: checkpoint.state,
         next_sequence: checkpoint.next_sequence,
     })
+}
+
+async fn decode_bounded_json<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T, CaptureEventSinkError> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_CONTROL_PLANE_RESPONSE_BYTES as u64)
+    {
+        return Err(CaptureEventSinkError::ControlPlaneResponseTooLarge);
+    }
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(CaptureEventSinkError::ResponseBody)?;
+        if body.len().saturating_add(chunk.len()) > MAX_CONTROL_PLANE_RESPONSE_BYTES {
+            return Err(CaptureEventSinkError::ControlPlaneResponseTooLarge);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    serde_json::from_slice(&body).map_err(CaptureEventSinkError::InvalidControlPlaneResponse)
+}
+
+fn validate_lease(
+    lease: &WorkerLease,
+    expected_worker_id: &str,
+    expected_lease_id: &str,
+    expected_epoch: Option<u64>,
+) -> Result<(), CaptureEventSinkError> {
+    if lease.worker_id != expected_worker_id {
+        return Err(CaptureEventSinkError::InvalidLease("worker ID"));
+    }
+    if lease.lease_id != expected_lease_id {
+        return Err(CaptureEventSinkError::InvalidLease("lease ID"));
+    }
+    if lease.epoch == 0 || expected_epoch.is_some_and(|epoch| epoch != lease.epoch) {
+        return Err(CaptureEventSinkError::InvalidLease("epoch"));
+    }
+    Ok(())
 }
 
 pub struct CaptureEventPublisher<S> {
@@ -388,18 +569,24 @@ pub enum CaptureEventSinkConfigError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum CaptureEventSinkError {
-    #[error("capture event request failed")]
+    #[error("control-plane request failed")]
     Request(#[source] reqwest::Error),
-    #[error("control plane rejected capture event with HTTP {0}")]
+    #[error("control plane rejected the request with HTTP {0}")]
     ControlPlaneStatus(StatusCode),
-    #[error("failed to read control-plane checkpoint response")]
+    #[error("failed to read control-plane response")]
     ResponseBody(#[source] reqwest::Error),
-    #[error("control-plane checkpoint response exceeded 64 KiB")]
-    CheckpointResponseTooLarge,
-    #[error("control-plane checkpoint response is invalid")]
-    InvalidCheckpointResponse(#[source] serde_json::Error),
+    #[error("control-plane response exceeded 64 KiB")]
+    ControlPlaneResponseTooLarge,
+    #[error("control-plane response is invalid")]
+    InvalidControlPlaneResponse(#[source] serde_json::Error),
     #[error("control-plane checkpoint contains an invalid {0}")]
     InvalidCheckpoint(&'static str),
+    #[error("capture worker must hold a lease before publishing events")]
+    LeaseRequired,
+    #[error("capture lease contains an invalid {0}")]
+    InvalidLease(&'static str),
+    #[error("capture lease request contains an invalid {0}")]
+    InvalidLeaseIdentity(&'static str),
 }
 
 #[cfg(test)]
@@ -511,6 +698,45 @@ mod tests {
         )
     }
 
+    async fn json_server(bodies: Vec<String>) -> (Url, tokio::task::JoinHandle<Vec<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for body in bodies {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut bytes = Vec::new();
+                loop {
+                    let mut chunk = [0; 4096];
+                    let count = stream.read(&mut chunk).await.unwrap();
+                    if count == 0 {
+                        break;
+                    }
+                    bytes.extend_from_slice(&chunk[..count]);
+                    if complete_request_length(&bytes).is_some_and(|length| bytes.len() >= length) {
+                        break;
+                    }
+                }
+                requests.push(String::from_utf8(bytes).unwrap());
+                stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+            }
+            requests
+        });
+        (
+            Url::parse(&format!("http://{address}/root/")).unwrap(),
+            task,
+        )
+    }
+
     fn complete_request_length(bytes: &[u8]) -> Option<usize> {
         let headers_end = bytes.windows(4).position(|window| window == b"\r\n\r\n")? + 4;
         let headers = std::str::from_utf8(&bytes[..headers_end]).ok()?;
@@ -539,10 +765,20 @@ mod tests {
         config
     }
 
+    async fn install_test_lease(sink: &ControlPlaneEventSink) {
+        *sink.lease.write().await = Some(WorkerLease {
+            worker_id: "worker-a".into(),
+            lease_id: "lease-a".into(),
+            epoch: 3,
+            expires_at: Utc::now() + chrono::Duration::minutes(1),
+        });
+    }
+
     #[tokio::test]
     async fn posts_the_normalized_event_with_workspace_credentials() {
         let (base_url, server) = server(vec![StatusCode::OK]).await;
         let sink = ControlPlaneEventSink::new(sink_config(base_url)).unwrap();
+        install_test_lease(&sink).await;
 
         sink.append(&event(1)).await.unwrap();
 
@@ -556,7 +792,87 @@ mod tests {
                 .to_ascii_lowercase()
                 .contains("authorization: bearer super-secret-token")
         );
+        assert!(
+            requests[0].contains(
+                "\"lease\":{\"workerId\":\"worker-a\",\"leaseId\":\"lease-a\",\"epoch\":3}"
+            )
+        );
         assert!(requests[0].contains("\"event\":{\"id\":\"capture-event-1\""));
+    }
+
+    #[tokio::test]
+    async fn requires_a_worker_lease_before_event_delivery() {
+        let sink = ControlPlaneEventSink::new(sink_config(
+            Url::parse("http://127.0.0.1:1/root/").unwrap(),
+        ))
+        .unwrap();
+
+        assert!(matches!(
+            sink.append(&event(1)).await,
+            Err(CaptureEventSinkError::LeaseRequired)
+        ));
+    }
+
+    #[tokio::test]
+    async fn claims_and_renews_the_fenced_worker_lease() {
+        let lease = serde_json::json!({
+            "workerId": "worker-a",
+            "leaseId": "lease-a",
+            "epoch": 3,
+            "expiresAt": "2026-08-17T00:01:00Z"
+        })
+        .to_string();
+        let renewed = serde_json::json!({
+            "workerId": "worker-a",
+            "leaseId": "lease-a",
+            "epoch": 3,
+            "expiresAt": "2026-08-17T00:02:00Z"
+        })
+        .to_string();
+        let (base_url, server) = json_server(vec![lease, renewed]).await;
+        let sink = ControlPlaneEventSink::new(sink_config(base_url)).unwrap();
+
+        let claimed = sink.claim("worker-a", "lease-a").await.unwrap();
+        let renewed = sink.renew_lease().await.unwrap();
+
+        assert_eq!(claimed.epoch, 3);
+        assert!(renewed.expires_at > claimed.expires_at);
+        let requests = server.await.unwrap();
+        assert!(
+            requests[0].starts_with(
+                "POST /root/v1/workspaces/workspace-a/capture-jobs/job-1/claim HTTP/1.1"
+            )
+        );
+        assert!(requests[0].contains("\"workerId\":\"worker-a\",\"leaseId\":\"lease-a\""));
+        assert!(
+            requests[1].starts_with(
+                "POST /root/v1/workspaces/workspace-a/capture-jobs/job-1/lease HTTP/1.1"
+            )
+        );
+        assert!(
+            requests[1].contains(
+                "\"lease\":{\"workerId\":\"worker-a\",\"leaseId\":\"lease-a\",\"epoch\":3}"
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn stops_event_delivery_after_lease_renewal_is_rejected() {
+        let (base_url, server) = server(vec![StatusCode::CONFLICT]).await;
+        let sink = ControlPlaneEventSink::new(sink_config(base_url)).unwrap();
+        install_test_lease(&sink).await;
+
+        assert!(matches!(
+            sink.renew_lease().await,
+            Err(CaptureEventSinkError::ControlPlaneStatus(
+                StatusCode::CONFLICT
+            ))
+        ));
+        assert!(matches!(
+            sink.append(&event(1)).await,
+            Err(CaptureEventSinkError::LeaseRequired)
+        ));
+        assert_eq!(server.await.unwrap().len(), 1);
     }
 
     #[tokio::test]
@@ -608,12 +924,12 @@ mod tests {
     #[tokio::test]
     async fn rejects_an_oversized_checkpoint_before_deserializing_it() {
         let (base_url, server) =
-            checkpoint_server("x".repeat(MAX_CHECKPOINT_RESPONSE_BYTES + 1)).await;
+            checkpoint_server("x".repeat(MAX_CONTROL_PLANE_RESPONSE_BYTES + 1)).await;
         let sink = ControlPlaneEventSink::new(sink_config(base_url)).unwrap();
 
         assert!(matches!(
             sink.read_checkpoint().await,
-            Err(CaptureEventSinkError::CheckpointResponseTooLarge)
+            Err(CaptureEventSinkError::ControlPlaneResponseTooLarge)
         ));
 
         server.await.unwrap();
@@ -624,6 +940,7 @@ mod tests {
         let (base_url, server) =
             server(vec![StatusCode::SERVICE_UNAVAILABLE, StatusCode::OK]).await;
         let sink = ControlPlaneEventSink::new(sink_config(base_url)).unwrap();
+        install_test_lease(&sink).await;
 
         sink.append(&event(1)).await.unwrap();
 
@@ -639,6 +956,7 @@ mod tests {
     async fn does_not_retry_a_sequence_conflict() {
         let (base_url, server) = server(vec![StatusCode::CONFLICT]).await;
         let sink = ControlPlaneEventSink::new(sink_config(base_url)).unwrap();
+        install_test_lease(&sink).await;
 
         assert!(matches!(
             sink.append(&event(1)).await,


### PR DESCRIPTION
## Summary
- add atomic Postgres-backed capture job claims and 60-second renewals
- fence event appends with monotonic lease epochs while preserving identical replay
- make the Rust worker claim, renew, and fail closed after lease loss
- cover simultaneous claims, expiry takeover, API restart migration, and stale-worker rejection

## Validation
- pnpm exec dprint fmt
- pnpm fmt:check
- cargo check --manifest-path enterprise/Cargo.toml --workspace --all-targets
- cargo clippy --manifest-path enterprise/Cargo.toml --workspace --all-targets --locked -- -D warnings
- ANARLOG_ENTERPRISE_TEST_DATABASE_URL=postgresql://postgres:***@127.0.0.1:54322/postgres cargo test --manifest-path enterprise/Cargo.toml --workspace --all-targets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the capture event ingestion contract and core job-progression logic; risk is mitigated by transactional fencing, idempotent replay behavior, and broad integration tests.
> 
> **Overview**
> Introduces **Postgres-backed worker leases** so only one capture worker can advance a job at a time. Workers must **`POST …/claim`** to take a job, **`POST …/lease`** to extend a **60-second** lease, and include **`workerId` / `leaseId` / `epoch`** on every **`POST …/events`** body—a **breaking change** for event appends.
> 
> Claims are atomic under row lock: a second worker gets **409** while the lease is active; after expiry, reclaim **bumps the epoch** so the previous holder cannot append new events (**`capture_lease_lost`**). Identical event replays still succeed without re-checking the lease. The Google Meet **`ControlPlaneEventSink`** now claims, renews, attaches the lease to appends, and clears local state when renewal fails.
> 
> Adds migration **`0003_capture_job_leases`**, new API error codes, README flow updates, and Postgres/API/worker tests for concurrent claims, takeover, and fenced rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b428cf0744fe8f5b2cf117b4ce4fa529cea7fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->