### PR TITLE
Supervise leased capture job execution

### DIFF
--- a/enterprise/control-plane/tests/postgres.rs
+++ b/enterprise/control-plane/tests/postgres.rs
@@ -1,19 +1,90 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
-use anarlog_enterprise_control_plane::{api::router, config::Config, configured_state};
+use anarlog_enterprise_control_plane::{api::router, config::Config, configured_state, serve};
+use anarlog_enterprise_google_meet_worker::{
+    CaptureJobRuntime, CaptureJobSupervisor, CaptureJobSupervisorConfig,
+    CaptureJobSupervisorOutcome, ControlPlaneEventSink, ControlPlaneEventSinkConfig,
+    WorkerLifecycle,
+};
 use anlg_meeting_capture::{
     BotState, CaptureEvent, CaptureEventPayload, Participant, RecordingChunk, Speaker,
     TerminalReason, TerminalReasonKind, TranscriptSegment,
 };
+use async_trait::async_trait;
 use axum::{
     body::{Body, to_bytes},
     http::{Method, Request, StatusCode, header},
 };
 use serde_json::Value;
+use tokio::{
+    net::TcpListener,
+    sync::{mpsc, oneshot, watch},
+};
 use tower::ServiceExt;
 
 const TEST_DATABASE_URL_ENV: &str = "ANARLOG_ENTERPRISE_TEST_DATABASE_URL";
 const TOKEN: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+#[derive(Debug, thiserror::Error)]
+#[error("test capture runtime failed")]
+struct TestRuntimeError;
+
+struct CompletingRuntime {
+    cleaned: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl CaptureJobRuntime for CompletingRuntime {
+    type Error = TestRuntimeError;
+
+    async fn run(
+        &mut self,
+        lifecycle: &mut WorkerLifecycle,
+        events: mpsc::Sender<CaptureEvent>,
+    ) -> Result<(), Self::Error> {
+        events
+            .send(lifecycle.launch_started(chrono::Utc::now()).unwrap())
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        events
+            .send(
+                lifecycle
+                    .transition(BotState::Joined, None, chrono::Utc::now())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        events
+            .send(
+                lifecycle
+                    .transition(
+                        BotState::Completed,
+                        Some(TerminalReason {
+                            kind: TerminalReasonKind::MeetingEnded,
+                            message: None,
+                            retryable: false,
+                        }),
+                        chrono::Utc::now(),
+                    )
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        Ok(())
+    }
+
+    async fn cleanup(&mut self) -> Result<(), Self::Error> {
+        self.cleaned.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+}
 
 #[tokio::test]
 async fn migrates_postgres_and_enforces_workspace_delivery() {
@@ -202,6 +273,106 @@ async fn concurrent_capture_claims_have_one_fenced_winner() {
         response_json(second).await
     };
     assert_eq!(winner["epoch"], 1);
+}
+
+#[tokio::test]
+async fn supervises_a_capture_job_over_real_http_and_postgres() {
+    let Ok(database_url) = std::env::var(TEST_DATABASE_URL_ENV) else {
+        return;
+    };
+    let suffix = format!(
+        "{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let workspace_id = format!("workspace-supervisor-{suffix}");
+    let job_id = format!("job-supervisor-{suffix}");
+    let config = Config::from_values(
+        database_url,
+        Some("127.0.0.1:0".into()),
+        Some("2".into()),
+        format!(r#"{{"{workspace_id}":"{TOKEN}"}}"#),
+    )
+    .unwrap();
+    let state = configured_state(&config).await.unwrap();
+    let create_path = format!("/v1/workspaces/{workspace_id}/capture-jobs/{job_id}");
+    let created = router(state.clone())
+        .oneshot(authorized_request(
+            Method::POST,
+            &create_path,
+            Body::from(
+                serde_json::json!({
+                    "botId": format!("bot-supervisor-{suffix}"),
+                    "ownerUserId": "owner-a",
+                    "requestingActorId": "actor-a",
+                    "sessionId": format!("session-supervisor-{suffix}"),
+                    "sessionTitle": "Supervisor contract",
+                    "provider": "anarlog",
+                    "meeting": {
+                        "platform": "google_meet",
+                        "url": "https://meet.google.com/abc-defg-hij"
+                    },
+                    "createdAt": "2026-08-17T00:00:00Z"
+                })
+                .to_string(),
+            ),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let (server_shutdown_tx, server_shutdown_rx) = oneshot::channel();
+    let server = tokio::spawn(serve(listener, state, async move {
+        server_shutdown_rx.await.ok();
+    }));
+    let sink_config = || {
+        ControlPlaneEventSinkConfig::new(
+            reqwest::Url::parse(&format!("http://{address}")).unwrap(),
+            &workspace_id,
+            &job_id,
+            TOKEN,
+        )
+    };
+    let cleaned = Arc::new(AtomicBool::new(false));
+    let supervisor = CaptureJobSupervisor::new(
+        ControlPlaneEventSink::new(sink_config()).unwrap(),
+        CompletingRuntime {
+            cleaned: cleaned.clone(),
+        },
+        "worker-supervisor-a",
+        "lease-supervisor-a",
+        CaptureJobSupervisorConfig {
+            lease_renew_interval: Duration::from_millis(1),
+        },
+    )
+    .unwrap();
+    let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let outcome = supervisor.run(shutdown_rx).await.unwrap();
+
+    assert_eq!(
+        outcome,
+        CaptureJobSupervisorOutcome::Terminal(BotState::Completed)
+    );
+    assert!(cleaned.load(Ordering::SeqCst));
+    let checkpoint = ControlPlaneEventSink::new(sink_config())
+        .unwrap()
+        .read_checkpoint()
+        .await
+        .unwrap();
+    assert_eq!(checkpoint.state, BotState::Completed);
+    assert_eq!(checkpoint.next_sequence, 3);
+    server_shutdown_tx.send(()).unwrap();
+    tokio::time::timeout(Duration::from_secs(2), server)
+        .await
+        .expect("server did not stop")
+        .unwrap()
+        .unwrap();
 }
 
 #[tokio::test]

--- a/enterprise/google-meet-worker/src/lib.rs
+++ b/enterprise/google-meet-worker/src/lib.rs
@@ -10,6 +10,7 @@ mod lobby;
 mod runtime;
 mod runtime_monitor;
 mod session;
+mod supervisor;
 mod x11;
 
 pub use admission::*;
@@ -24,4 +25,5 @@ pub use lobby::*;
 pub use runtime::*;
 pub use runtime_monitor::*;
 pub use session::*;
+pub use supervisor::*;
 pub use x11::*;

--- a/enterprise/google-meet-worker/src/lifecycle.rs
+++ b/enterprise/google-meet-worker/src/lifecycle.rs
@@ -220,17 +220,29 @@ impl WorkerLifecycle {
         &mut self,
         occurred_at: DateTime<Utc>,
     ) -> Result<Vec<CaptureEvent>, TransitionError> {
-        let stopping = self.transition(BotState::Stopping, None, occurred_at)?;
-        let completed = self.transition(
-            BotState::Completed,
-            Some(TerminalReason {
-                kind: TerminalReasonKind::StoppedByRequest,
-                message: None,
-                retryable: false,
-            }),
-            occurred_at,
-        )?;
-        Ok(vec![stopping, completed])
+        let reason = || TerminalReason {
+            kind: TerminalReasonKind::StoppedByRequest,
+            message: None,
+            retryable: false,
+        };
+        match self.state {
+            BotState::Queued => self
+                .transition(BotState::Canceled, Some(reason()), occurred_at)
+                .map(|event| vec![event]),
+            BotState::Launching
+            | BotState::WaitingForAdmission
+            | BotState::Joined
+            | BotState::Capturing => {
+                let stopping = self.transition(BotState::Stopping, None, occurred_at)?;
+                let completed =
+                    self.transition(BotState::Completed, Some(reason()), occurred_at)?;
+                Ok(vec![stopping, completed])
+            }
+            BotState::Stopping => self
+                .transition(BotState::Completed, Some(reason()), occurred_at)
+                .map(|event| vec![event]),
+            BotState::Completed | BotState::Failed | BotState::Canceled => Ok(Vec::new()),
+        }
     }
 
     pub fn transition(
@@ -369,6 +381,19 @@ mod tests {
     fn rejects_inconsistent_durable_sequence_origins() {
         assert!(WorkerLifecycle::resume("bot-1", BotState::Queued, 1).is_err());
         assert!(WorkerLifecycle::resume("bot-1", BotState::Launching, 0).is_err());
+    }
+
+    #[test]
+    fn stop_is_phase_aware_before_launch_and_during_cleanup() {
+        let mut queued = WorkerLifecycle::new("bot-queued");
+        let canceled = queued.stopped_by_request(now()).unwrap();
+        assert_eq!(canceled.len(), 1);
+        assert_eq!(queued.state(), BotState::Canceled);
+
+        let mut stopping = WorkerLifecycle::resume("bot-stopping", BotState::Stopping, 4).unwrap();
+        let completed = stopping.stopped_by_request(now()).unwrap();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(stopping.state(), BotState::Completed);
     }
 
     #[test]

--- a/enterprise/google-meet-worker/src/supervisor.rs
+++ b/enterprise/google-meet-worker/src/supervisor.rs
@@ -1,0 +1,716 @@
+use std::{error::Error, time::Duration};
+
+use anlg_meeting_capture::{BotState, CaptureEvent, CaptureEventPayload, TransitionError};
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::sync::{mpsc, watch};
+
+use crate::{
+    CaptureEventSink, CaptureEventSinkError, ControlPlaneEventSink, WorkerCheckpoint, WorkerLease,
+    WorkerLifecycle, WorkerLifecycleResumeError,
+};
+
+pub const DEFAULT_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(20);
+pub const MAX_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30);
+const EVENT_CHANNEL_CAPACITY: usize = 32;
+
+#[async_trait]
+pub trait CaptureJobControlPlane: Send + Sync {
+    type Error: Error + Send + Sync + 'static;
+
+    async fn read_checkpoint(&self) -> Result<WorkerCheckpoint, Self::Error>;
+    async fn claim(&self, worker_id: &str, lease_id: &str) -> Result<WorkerLease, Self::Error>;
+    async fn renew_lease(&self) -> Result<WorkerLease, Self::Error>;
+    async fn append(&self, event: &CaptureEvent) -> Result<(), Self::Error>;
+}
+
+#[async_trait]
+impl CaptureJobControlPlane for ControlPlaneEventSink {
+    type Error = CaptureEventSinkError;
+
+    async fn read_checkpoint(&self) -> Result<WorkerCheckpoint, Self::Error> {
+        self.read_checkpoint().await
+    }
+
+    async fn claim(&self, worker_id: &str, lease_id: &str) -> Result<WorkerLease, Self::Error> {
+        self.claim(worker_id, lease_id).await
+    }
+
+    async fn renew_lease(&self) -> Result<WorkerLease, Self::Error> {
+        self.renew_lease().await
+    }
+
+    async fn append(&self, event: &CaptureEvent) -> Result<(), Self::Error> {
+        CaptureEventSink::append(self, event).await
+    }
+}
+
+#[async_trait]
+pub trait CaptureJobRuntime: Send {
+    type Error: Error + Send + Sync + 'static;
+
+    async fn run(
+        &mut self,
+        lifecycle: &mut WorkerLifecycle,
+        events: mpsc::Sender<CaptureEvent>,
+    ) -> Result<(), Self::Error>;
+
+    async fn cleanup(&mut self) -> Result<(), Self::Error>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CaptureJobSupervisorConfig {
+    pub lease_renew_interval: Duration,
+}
+
+impl Default for CaptureJobSupervisorConfig {
+    fn default() -> Self {
+        Self {
+            lease_renew_interval: DEFAULT_LEASE_RENEW_INTERVAL,
+        }
+    }
+}
+
+impl CaptureJobSupervisorConfig {
+    pub fn validate(self) -> Result<Self, CaptureJobSupervisorConfigError> {
+        if self.lease_renew_interval.is_zero()
+            || self.lease_renew_interval > MAX_LEASE_RENEW_INTERVAL
+        {
+            return Err(CaptureJobSupervisorConfigError::InvalidLeaseRenewInterval);
+        }
+        Ok(self)
+    }
+}
+
+pub struct CaptureJobSupervisor<C, R> {
+    control_plane: C,
+    runtime: R,
+    worker_id: String,
+    lease_id: String,
+    config: CaptureJobSupervisorConfig,
+}
+
+impl<C, R> CaptureJobSupervisor<C, R>
+where
+    C: CaptureJobControlPlane,
+    R: CaptureJobRuntime,
+{
+    pub fn new(
+        control_plane: C,
+        runtime: R,
+        worker_id: impl Into<String>,
+        lease_id: impl Into<String>,
+        config: CaptureJobSupervisorConfig,
+    ) -> Result<Self, CaptureJobSupervisorConfigError> {
+        let worker_id = worker_id.into();
+        let lease_id = lease_id.into();
+        if worker_id.is_empty() || lease_id.is_empty() {
+            return Err(CaptureJobSupervisorConfigError::MissingLeaseIdentity);
+        }
+        if !valid_identifier(&worker_id) || !valid_identifier(&lease_id) {
+            return Err(CaptureJobSupervisorConfigError::InvalidLeaseIdentity);
+        }
+        Ok(Self {
+            control_plane,
+            runtime,
+            worker_id,
+            lease_id,
+            config: config.validate()?,
+        })
+    }
+
+    pub async fn run(
+        mut self,
+        mut shutdown: watch::Receiver<bool>,
+    ) -> Result<CaptureJobSupervisorOutcome, CaptureJobSupervisorError<C::Error, R::Error>> {
+        let checkpoint = self
+            .control_plane
+            .read_checkpoint()
+            .await
+            .map_err(CaptureJobSupervisorError::ControlPlane)?;
+        if checkpoint.state.is_terminal() {
+            return Ok(CaptureJobSupervisorOutcome::AlreadyTerminal(
+                checkpoint.state,
+            ));
+        }
+        if *shutdown.borrow() {
+            return Ok(CaptureJobSupervisorOutcome::ShutdownBeforeClaim);
+        }
+
+        self.control_plane
+            .claim(&self.worker_id, &self.lease_id)
+            .await
+            .map_err(CaptureJobSupervisorError::ControlPlane)?;
+        let checkpoint = self
+            .control_plane
+            .read_checkpoint()
+            .await
+            .map_err(CaptureJobSupervisorError::ControlPlane)?;
+        if checkpoint.state.is_terminal() {
+            return Ok(CaptureJobSupervisorOutcome::AlreadyTerminal(
+                checkpoint.state,
+            ));
+        }
+        let mut lifecycle = WorkerLifecycle::resume(
+            checkpoint.bot_id,
+            checkpoint.state,
+            checkpoint.next_sequence,
+        )?;
+
+        if lifecycle.state() != BotState::Queued {
+            let event = lifecycle.worker_exited(
+                "capture worker restarted after losing browser ownership",
+                Utc::now(),
+            )?;
+            self.control_plane
+                .append(&event)
+                .await
+                .map_err(CaptureJobSupervisorError::ControlPlane)?;
+            return Ok(CaptureJobSupervisorOutcome::Terminal(lifecycle.state()));
+        }
+
+        let (events_tx, mut events_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
+        let mut renewals = tokio::time::interval_at(
+            tokio::time::Instant::now() + self.config.lease_renew_interval,
+            self.config.lease_renew_interval,
+        );
+        let mut runtime = Box::pin(self.runtime.run(&mut lifecycle, events_tx));
+        let mut events_closed = false;
+        let mut deferred_terminal = None;
+        let exit = loop {
+            tokio::select! {
+                event = events_rx.recv(), if !events_closed => {
+                    match event {
+                        Some(event) if is_terminal_event(&event) => deferred_terminal = Some(event),
+                        Some(event) => {
+                            if let Err(error) = self.control_plane.append(&event).await {
+                                break RuntimeExit::ControlPlane(error);
+                            }
+                        }
+                        None => events_closed = true,
+                    }
+                }
+                result = &mut runtime => break RuntimeExit::Runtime(result),
+                _ = renewals.tick() => {
+                    if let Err(error) = self.control_plane.renew_lease().await {
+                        break RuntimeExit::LeaseLost(error);
+                    }
+                }
+                changed = shutdown.changed() => {
+                    if changed.is_err() || *shutdown.borrow() {
+                        break RuntimeExit::Shutdown;
+                    }
+                }
+            }
+        };
+        drop(runtime);
+
+        if matches!(exit, RuntimeExit::Runtime(_) | RuntimeExit::Shutdown) {
+            while let Ok(event) = events_rx.try_recv() {
+                if is_terminal_event(&event) {
+                    deferred_terminal = Some(event);
+                } else if let Err(error) = self.control_plane.append(&event).await {
+                    self.runtime
+                        .cleanup()
+                        .await
+                        .map_err(CaptureJobSupervisorError::Cleanup)?;
+                    return Err(CaptureJobSupervisorError::ControlPlane(error));
+                }
+            }
+        }
+        self.runtime
+            .cleanup()
+            .await
+            .map_err(CaptureJobSupervisorError::Cleanup)?;
+
+        if matches!(exit, RuntimeExit::Runtime(_) | RuntimeExit::Shutdown)
+            && let Some(event) = deferred_terminal
+        {
+            self.control_plane
+                .append(&event)
+                .await
+                .map_err(CaptureJobSupervisorError::ControlPlane)?;
+        }
+
+        match exit {
+            RuntimeExit::ControlPlane(error) | RuntimeExit::LeaseLost(error) => {
+                Err(CaptureJobSupervisorError::ControlPlane(error))
+            }
+            RuntimeExit::Shutdown => {
+                for event in lifecycle.stopped_by_request(Utc::now())? {
+                    self.control_plane
+                        .append(&event)
+                        .await
+                        .map_err(CaptureJobSupervisorError::ControlPlane)?;
+                }
+                Ok(CaptureJobSupervisorOutcome::Terminal(lifecycle.state()))
+            }
+            RuntimeExit::Runtime(result) => {
+                if lifecycle.state().is_terminal() {
+                    return Ok(CaptureJobSupervisorOutcome::Terminal(lifecycle.state()));
+                }
+                if let Err(error) = result {
+                    let event = lifecycle
+                        .worker_exited(format!("capture runtime exited: {error}"), Utc::now())?;
+                    self.control_plane
+                        .append(&event)
+                        .await
+                        .map_err(CaptureJobSupervisorError::ControlPlane)?;
+                } else if !lifecycle.state().is_terminal() {
+                    let event = lifecycle.worker_exited(
+                        "capture runtime exited without a terminal state",
+                        Utc::now(),
+                    )?;
+                    self.control_plane
+                        .append(&event)
+                        .await
+                        .map_err(CaptureJobSupervisorError::ControlPlane)?;
+                }
+                Ok(CaptureJobSupervisorOutcome::Terminal(lifecycle.state()))
+            }
+        }
+    }
+}
+
+enum RuntimeExit<C, R> {
+    ControlPlane(C),
+    LeaseLost(C),
+    Runtime(Result<(), R>),
+    Shutdown,
+}
+
+fn is_terminal_event(event: &CaptureEvent) -> bool {
+    matches!(
+        &event.payload,
+        CaptureEventPayload::Lifecycle(transition) if transition.to.is_terminal()
+    )
+}
+
+fn valid_identifier(value: &str) -> bool {
+    value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"-_.".contains(&byte))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureJobSupervisorOutcome {
+    AlreadyTerminal(BotState),
+    ShutdownBeforeClaim,
+    Terminal(BotState),
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CaptureJobSupervisorConfigError {
+    #[error("capture worker and lease IDs must be non-empty")]
+    MissingLeaseIdentity,
+    #[error("capture worker and lease IDs contain unsupported characters")]
+    InvalidLeaseIdentity,
+    #[error("capture lease renewal interval must be between one nanosecond and 30 seconds")]
+    InvalidLeaseRenewInterval,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CaptureJobSupervisorError<C, R>
+where
+    C: Error + 'static,
+    R: Error + 'static,
+{
+    #[error("capture control-plane operation failed")]
+    ControlPlane(#[source] C),
+    #[error("capture runtime cleanup failed")]
+    Cleanup(#[source] R),
+    #[error(transparent)]
+    Resume(#[from] WorkerLifecycleResumeError),
+    #[error(transparent)]
+    Transition(#[from] TransitionError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use anlg_meeting_capture::{CaptureEventPayload, TerminalReason, TerminalReasonKind};
+    use chrono::{DateTime, Utc};
+
+    use super::*;
+
+    #[derive(Debug, Clone, thiserror::Error)]
+    #[error("{0}")]
+    struct TestError(&'static str);
+
+    #[derive(Clone)]
+    struct TestControlPlane {
+        checkpoint: WorkerCheckpoint,
+        events: Arc<Mutex<Vec<CaptureEvent>>>,
+        renewals: Arc<Mutex<usize>>,
+        cleaned: Arc<Mutex<bool>>,
+        append_cleanup_states: Arc<Mutex<Vec<bool>>>,
+        reject_renewal: bool,
+    }
+
+    #[async_trait]
+    impl CaptureJobControlPlane for TestControlPlane {
+        type Error = TestError;
+
+        async fn read_checkpoint(&self) -> Result<WorkerCheckpoint, Self::Error> {
+            Ok(self.checkpoint.clone())
+        }
+
+        async fn claim(&self, worker_id: &str, lease_id: &str) -> Result<WorkerLease, Self::Error> {
+            Ok(WorkerLease {
+                worker_id: worker_id.into(),
+                lease_id: lease_id.into(),
+                epoch: 1,
+                expires_at: now() + chrono::Duration::minutes(1),
+            })
+        }
+
+        async fn renew_lease(&self) -> Result<WorkerLease, Self::Error> {
+            *self.renewals.lock().unwrap() += 1;
+            if self.reject_renewal {
+                return Err(TestError("lease lost"));
+            }
+            Ok(WorkerLease {
+                worker_id: "worker-a".into(),
+                lease_id: "lease-a".into(),
+                epoch: 1,
+                expires_at: now() + chrono::Duration::minutes(1),
+            })
+        }
+
+        async fn append(&self, event: &CaptureEvent) -> Result<(), Self::Error> {
+            self.events.lock().unwrap().push(event.clone());
+            self.append_cleanup_states
+                .lock()
+                .unwrap()
+                .push(*self.cleaned.lock().unwrap());
+            Ok(())
+        }
+    }
+
+    struct TestRuntime {
+        mode: RuntimeMode,
+        cleaned: Arc<Mutex<bool>>,
+    }
+
+    enum RuntimeMode {
+        Complete,
+        Fail,
+        TerminalThenWait,
+        Wait,
+    }
+
+    struct TestHarness {
+        supervisor: CaptureJobSupervisor<TestControlPlane, TestRuntime>,
+        events: Arc<Mutex<Vec<CaptureEvent>>>,
+        renewals: Arc<Mutex<usize>>,
+        cleaned: Arc<Mutex<bool>>,
+        append_cleanup_states: Arc<Mutex<Vec<bool>>>,
+    }
+
+    #[async_trait]
+    impl CaptureJobRuntime for TestRuntime {
+        type Error = TestError;
+
+        async fn run(
+            &mut self,
+            lifecycle: &mut WorkerLifecycle,
+            events: mpsc::Sender<CaptureEvent>,
+        ) -> Result<(), Self::Error> {
+            events
+                .send(lifecycle.launch_started(now()).unwrap())
+                .await
+                .unwrap();
+            match self.mode {
+                RuntimeMode::Complete => {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    let joined = lifecycle.transition(BotState::Joined, None, now()).unwrap();
+                    events.send(joined).await.unwrap();
+                    let completed = lifecycle
+                        .transition(
+                            BotState::Completed,
+                            Some(TerminalReason {
+                                kind: TerminalReasonKind::MeetingEnded,
+                                message: None,
+                                retryable: false,
+                            }),
+                            now(),
+                        )
+                        .unwrap();
+                    events.send(completed).await.unwrap();
+                    Ok(())
+                }
+                RuntimeMode::Fail => Err(TestError("browser exited")),
+                RuntimeMode::TerminalThenWait => {
+                    let joined = lifecycle.transition(BotState::Joined, None, now()).unwrap();
+                    events.send(joined).await.unwrap();
+                    let completed = lifecycle
+                        .transition(
+                            BotState::Completed,
+                            Some(TerminalReason {
+                                kind: TerminalReasonKind::MeetingEnded,
+                                message: None,
+                                retryable: false,
+                            }),
+                            now(),
+                        )
+                        .unwrap();
+                    events.send(completed).await.unwrap();
+                    std::future::pending().await
+                }
+                RuntimeMode::Wait => std::future::pending().await,
+            }
+        }
+
+        async fn cleanup(&mut self) -> Result<(), Self::Error> {
+            *self.cleaned.lock().unwrap() = true;
+            Ok(())
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-08-17T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn checkpoint(state: BotState, next_sequence: u64) -> WorkerCheckpoint {
+        WorkerCheckpoint {
+            job_id: "job-a".into(),
+            bot_id: "bot-a".into(),
+            meeting_url: crate::GoogleMeetUrl::parse("https://meet.google.com/abc-defg-hij")
+                .unwrap(),
+            state,
+            next_sequence,
+        }
+    }
+
+    fn harness(
+        state: BotState,
+        next_sequence: u64,
+        mode: RuntimeMode,
+        reject_renewal: bool,
+    ) -> TestHarness {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let renewals = Arc::new(Mutex::new(0));
+        let cleaned = Arc::new(Mutex::new(false));
+        let append_cleanup_states = Arc::new(Mutex::new(Vec::new()));
+        let supervisor = CaptureJobSupervisor::new(
+            TestControlPlane {
+                checkpoint: checkpoint(state, next_sequence),
+                events: events.clone(),
+                renewals: renewals.clone(),
+                cleaned: cleaned.clone(),
+                append_cleanup_states: append_cleanup_states.clone(),
+                reject_renewal,
+            },
+            TestRuntime {
+                mode,
+                cleaned: cleaned.clone(),
+            },
+            "worker-a",
+            "lease-a",
+            CaptureJobSupervisorConfig {
+                lease_renew_interval: Duration::from_millis(1),
+            },
+        )
+        .unwrap();
+        TestHarness {
+            supervisor,
+            events,
+            renewals,
+            cleaned,
+            append_cleanup_states,
+        }
+    }
+
+    #[tokio::test]
+    async fn renews_while_running_and_cleans_up_before_terminal_success() {
+        let harness = harness(BotState::Queued, 0, RuntimeMode::Complete, false);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let outcome = harness.supervisor.run(shutdown_rx).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            CaptureJobSupervisorOutcome::Terminal(BotState::Completed)
+        );
+        assert!(*harness.renewals.lock().unwrap() > 0);
+        assert!(*harness.cleaned.lock().unwrap());
+        assert_eq!(
+            harness
+                .events
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        assert_eq!(
+            *harness.append_cleanup_states.lock().unwrap(),
+            vec![false, false, true]
+        );
+    }
+
+    #[tokio::test]
+    async fn terminalizes_an_interrupted_nonqueued_checkpoint_without_relaunching() {
+        let harness = harness(BotState::Capturing, 7, RuntimeMode::Wait, false);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let outcome = harness.supervisor.run(shutdown_rx).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            CaptureJobSupervisorOutcome::Terminal(BotState::Failed)
+        );
+        assert!(!*harness.cleaned.lock().unwrap());
+        let events = harness.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].sequence, 7);
+        let CaptureEventPayload::Lifecycle(transition) = &events[0].payload else {
+            panic!("expected lifecycle event")
+        };
+        assert_eq!(
+            transition.reason.as_ref().unwrap().kind,
+            TerminalReasonKind::WorkerExited
+        );
+    }
+
+    #[tokio::test]
+    async fn lease_loss_cancels_and_cleans_up_without_emitting_a_stale_terminal_event() {
+        let harness = harness(BotState::Queued, 0, RuntimeMode::Wait, true);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        assert!(matches!(
+            harness.supervisor.run(shutdown_rx).await,
+            Err(CaptureJobSupervisorError::ControlPlane(TestError(
+                "lease lost"
+            )))
+        ));
+        assert_eq!(*harness.renewals.lock().unwrap(), 1);
+        assert!(*harness.cleaned.lock().unwrap());
+        assert!(harness.events.lock().unwrap().iter().all(|event| {
+            !matches!(
+                &event.payload,
+                CaptureEventPayload::Lifecycle(transition) if transition.to.is_terminal()
+            )
+        }));
+    }
+
+    #[tokio::test]
+    async fn lease_loss_discards_a_terminal_event_that_was_not_yet_committed() {
+        let mut harness = harness(BotState::Queued, 0, RuntimeMode::TerminalThenWait, true);
+        harness.supervisor.config.lease_renew_interval = Duration::from_millis(10);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        assert!(matches!(
+            harness.supervisor.run(shutdown_rx).await,
+            Err(CaptureJobSupervisorError::ControlPlane(TestError(
+                "lease lost"
+            )))
+        ));
+        assert!(*harness.cleaned.lock().unwrap());
+        assert_eq!(
+            harness
+                .events
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_failure_cleans_up_then_emits_an_actionable_terminal_event() {
+        let harness = harness(BotState::Queued, 0, RuntimeMode::Fail, false);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let outcome = harness.supervisor.run(shutdown_rx).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            CaptureJobSupervisorOutcome::Terminal(BotState::Failed)
+        );
+        assert!(*harness.cleaned.lock().unwrap());
+        let events = harness.events.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].sequence, 0);
+        assert_eq!(events[1].sequence, 1);
+        let CaptureEventPayload::Lifecycle(transition) = &events[1].payload else {
+            panic!("expected lifecycle event")
+        };
+        assert_eq!(
+            transition.reason.as_ref().unwrap().kind,
+            TerminalReasonKind::WorkerExited
+        );
+        assert_eq!(
+            transition.reason.as_ref().unwrap().message.as_deref(),
+            Some("capture runtime exited: browser exited")
+        );
+        assert_eq!(
+            *harness.append_cleanup_states.lock().unwrap(),
+            vec![false, true]
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_cleans_up_and_publishes_phase_aware_terminal_events() {
+        let harness = harness(BotState::Queued, 0, RuntimeMode::Wait, false);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let run = tokio::spawn(harness.supervisor.run(shutdown_rx));
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while harness.events.lock().unwrap().is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        shutdown_tx.send(true).unwrap();
+
+        let outcome = run.await.unwrap().unwrap();
+
+        assert_eq!(
+            outcome,
+            CaptureJobSupervisorOutcome::Terminal(BotState::Completed)
+        );
+        assert!(*harness.cleaned.lock().unwrap());
+        let events = harness.events.lock().unwrap();
+        assert_eq!(events.last().unwrap().sequence, 2);
+        assert!(matches!(
+            &events.last().unwrap().payload,
+            CaptureEventPayload::Lifecycle(transition)
+                if transition.to == BotState::Completed
+        ));
+    }
+
+    #[test]
+    fn rejects_an_unsafe_renewal_configuration() {
+        assert!(valid_identifier("worker-a.1"));
+        assert!(!valid_identifier("../worker"));
+        assert_eq!(
+            CaptureJobSupervisorConfig::default()
+                .validate()
+                .unwrap()
+                .lease_renew_interval,
+            DEFAULT_LEASE_RENEW_INTERVAL
+        );
+        assert_eq!(
+            CaptureJobSupervisorConfig {
+                lease_renew_interval: Duration::ZERO,
+            }
+            .validate(),
+            Err(CaptureJobSupervisorConfigError::InvalidLeaseRenewInterval)
+        );
+        assert_eq!(
+            CaptureJobSupervisorConfig {
+                lease_renew_interval: MAX_LEASE_RENEW_INTERVAL + Duration::from_nanos(1),
+            }
+            .validate(),
+            Err(CaptureJobSupervisorConfigError::InvalidLeaseRenewInterval)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a runtime-agnostic capture job supervisor around the fenced control-plane client
- renew leases fairly while serializing runtime events and honoring shutdown
- clean runtime resources before committing terminal success
- recover interrupted checkpoints as actionable worker-exited failures
- prove the supervisor over real HTTP and OrbStack Postgres

## Validation
- pnpm exec dprint fmt
- pnpm fmt:check
- cargo check --manifest-path enterprise/Cargo.toml --workspace --all-targets
- cargo clippy --manifest-path enterprise/Cargo.toml --workspace --all-targets --locked -- -D warnings
- ANARLOG_ENTERPRISE_TEST_DATABASE_URL=postgresql://postgres:***@127.0.0.1:54322/postgres cargo test --manifest-path enterprise/Cargo.toml --workspace --all-targets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes capture job lifecycle ordering and terminalization semantics (lease, cleanup, shutdown), which affect durable state and retries; mitigated by broad unit tests and a real HTTP/Postgres integration test.
> 
> **Overview**
> Introduces **`CaptureJobSupervisor`**, which claims a capture job lease, resumes from the control-plane checkpoint, runs a pluggable **`CaptureJobRuntime`**, renews the lease while work is in flight, and appends non-terminal events over the fenced control-plane client. **Terminal lifecycle events are held until runtime `cleanup` finishes**, so success is not committed before resources are torn down; lease loss aborts without publishing an uncommitted terminal event.
> 
> On resume, a **non-`Queued` checkpoint** is terminalized with a **`WorkerExited`** failure instead of relaunching the browser. Shutdown and stop paths use an updated **`stopped_by_request`**: queued jobs go to **`Canceled`**, in-flight jobs emit **Stopping → Completed**, and **`Stopping`** only completes.
> 
> Exports the supervisor from the google-meet-worker crate and adds a **Postgres integration test** that runs the supervisor against a live control-plane server with a stub completing runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458bad047cb65eaf419583c8168d04a3e1e00b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->