### PR TITLE
Wire the Google Meet capture runtime

### DIFF
--- a/enterprise/control-plane/tests/postgres.rs
+++ b/enterprise/control-plane/tests/postgres.rs
@@ -10,7 +10,7 @@ use anarlog_enterprise_control_plane::{api::router, config::Config, configured_s
 use anarlog_enterprise_google_meet_worker::{
     CaptureJobRuntime, CaptureJobSupervisor, CaptureJobSupervisorConfig,
     CaptureJobSupervisorOutcome, ControlPlaneEventSink, ControlPlaneEventSinkConfig,
-    WorkerLifecycle,
+    WorkerCheckpoint, WorkerLifecycle,
 };
 use anlg_meeting_capture::{
     BotState, CaptureEvent, CaptureEventPayload, Participant, RecordingChunk, Speaker,
@@ -45,9 +45,11 @@ impl CaptureJobRuntime for CompletingRuntime {
 
     async fn run(
         &mut self,
+        checkpoint: &WorkerCheckpoint,
         lifecycle: &mut WorkerLifecycle,
         events: mpsc::Sender<CaptureEvent>,
     ) -> Result<(), Self::Error> {
+        assert!(checkpoint.job_id.starts_with("job-supervisor-"));
         events
             .send(lifecycle.launch_started(chrono::Utc::now()).unwrap())
             .await

--- a/enterprise/google-meet-worker/src/admission_monitor.rs
+++ b/enterprise/google-meet-worker/src/admission_monitor.rs
@@ -2,6 +2,7 @@ use std::{future::Future, time::Duration};
 
 use anlg_meeting_capture::{BotState, CaptureEvent, TransitionError};
 use chrono::Utc;
+use tokio::sync::mpsc;
 use tokio::time::Instant;
 
 use crate::{AdmissionSnapshot, CdpError, CdpPage, WorkerLifecycle};
@@ -59,6 +60,49 @@ impl AdmissionMonitor {
         self.wait_with_source(page, lifecycle).await
     }
 
+    pub async fn wait_streaming(
+        &self,
+        page: &mut CdpPage,
+        lifecycle: &mut WorkerLifecycle,
+        events: &mpsc::Sender<CaptureEvent>,
+    ) -> Result<(), AdmissionMonitorError> {
+        self.wait_streaming_with_source(page, lifecycle, events)
+            .await
+    }
+
+    async fn wait_streaming_with_source<S: AdmissionProbeSource>(
+        &self,
+        source: &mut S,
+        lifecycle: &mut WorkerLifecycle,
+        events: &mpsc::Sender<CaptureEvent>,
+    ) -> Result<(), AdmissionMonitorError> {
+        let started_at = Instant::now();
+        let deadline = started_at + self.config.timeout;
+        loop {
+            let snapshot = source.probe().await?;
+            let observed_at = Instant::now();
+            if let Some(event) =
+                lifecycle.observe_admission(&snapshot, observed_at.into_std(), Utc::now())?
+            {
+                events
+                    .send(event)
+                    .await
+                    .map_err(|_| AdmissionMonitorError::EventChannelClosed)?;
+            }
+            if matches!(lifecycle.state(), BotState::Joined | BotState::Failed) {
+                return Ok(());
+            }
+            if observed_at >= deadline {
+                events
+                    .send(lifecycle.admission_timed_out(Utc::now())?)
+                    .await
+                    .map_err(|_| AdmissionMonitorError::EventChannelClosed)?;
+                return Ok(());
+            }
+            tokio::time::sleep(self.config.poll_interval.min(deadline - observed_at)).await;
+        }
+    }
+
     async fn wait_with_source<S: AdmissionProbeSource>(
         &self,
         source: &mut S,
@@ -106,6 +150,8 @@ pub enum AdmissionMonitorError {
         timeout: Duration,
         poll_interval: Duration,
     },
+    #[error("capture supervisor stopped accepting admission events")]
+    EventChannelClosed,
     #[error(transparent)]
     Cdp(#[from] CdpError),
     #[error(transparent)]
@@ -156,6 +202,43 @@ mod tests {
 
         assert_eq!(events.len(), 2);
         assert_eq!(lifecycle.state(), BotState::Joined);
+    }
+
+    #[tokio::test]
+    async fn streams_waiting_before_admission_finishes() {
+        let mut source = Snapshots(VecDeque::from([
+            AdmissionSnapshot {
+                waiting_room_visible: true,
+                ..Default::default()
+            },
+            AdmissionSnapshot {
+                participant_tile_labels: vec!["Ada Lovelace".into()],
+                ..Default::default()
+            },
+        ]));
+        let mut lifecycle = WorkerLifecycle::new("bot-1");
+        lifecycle.launch_started(Utc::now()).unwrap();
+        let (events_tx, mut events_rx) = mpsc::channel(1);
+
+        let waiting = events_rx.recv();
+        let admission_monitor = monitor(Duration::from_secs(1), Duration::from_millis(1));
+        let monitoring =
+            admission_monitor.wait_streaming_with_source(&mut source, &mut lifecycle, &events_tx);
+        let (first, result) = tokio::join!(waiting, monitoring);
+
+        result.unwrap();
+        assert_eq!(
+            first.unwrap().payload,
+            anlg_meeting_capture::CaptureEventPayload::Lifecycle(
+                anlg_meeting_capture::LifecycleTransition {
+                    from: BotState::Launching,
+                    to: BotState::WaitingForAdmission,
+                    reason: None,
+                }
+            )
+        );
+        assert_eq!(lifecycle.state(), BotState::Joined);
+        assert!(events_rx.recv().await.is_some());
     }
 
     #[tokio::test]

--- a/enterprise/google-meet-worker/src/audio_sink.rs
+++ b/enterprise/google-meet-worker/src/audio_sink.rs
@@ -1,0 +1,14 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+
+use crate::AudioFrame;
+
+#[async_trait]
+pub trait AudioFrameSink: Send {
+    type Error: Error + Send + Sync + 'static;
+
+    async fn write_frame(&mut self, frame: AudioFrame) -> Result<(), Self::Error>;
+
+    async fn finish(&mut self) -> Result<(), Self::Error>;
+}

--- a/enterprise/google-meet-worker/src/capture.rs
+++ b/enterprise/google-meet-worker/src/capture.rs
@@ -34,22 +34,28 @@ impl BrowserCapture {
     pub async fn next_frame(&mut self) -> Result<AudioFrame, BrowserCaptureError> {
         loop {
             let payload = self.events.next_payload(CAPTURE_BINDING).await?;
-            if payload.len() <= 1024
-                && let Ok(signal) = serde_json::from_str::<CaptureSignal>(&payload)
-                && signal.version == 1
-            {
-                let scope = signal.scope.unwrap_or_else(|| "unknown".into());
-                let message = signal.message.unwrap_or_else(|| "unknown failure".into());
-                if signal.kind == "warning" {
-                    self.last_warning = Some(CaptureWarning { scope, message });
-                    continue;
-                }
-                if signal.kind == "error" {
-                    return Err(BrowserCaptureError::Script { scope, message });
-                }
+            if let Some(frame) = self.decode_payload(&payload)? {
+                return Ok(frame);
             }
-            return self.protocol.decode(&payload).map_err(Into::into);
         }
+    }
+
+    pub async fn stop_and_drain(
+        &mut self,
+        page: &mut CdpPage,
+    ) -> Result<Vec<AudioFrame>, BrowserCaptureError> {
+        let stopped = page.evaluate::<bool>(STOP_CAPTURE_EXPRESSION).await?;
+        if !stopped {
+            return Err(BrowserCaptureError::StopRejected);
+        }
+        let mut frames = Vec::new();
+        while let Some(payload) = self.events.try_next_payload(CAPTURE_BINDING)? {
+            if let Some(frame) = self.decode_payload(&payload)? {
+                frames.push(frame);
+            }
+        }
+        page.close_binding_events().await?;
+        Ok(frames)
     }
 
     pub async fn stop(page: &mut CdpPage) -> Result<(), BrowserCaptureError> {
@@ -64,6 +70,24 @@ impl BrowserCapture {
 
     pub fn take_last_warning(&mut self) -> Option<CaptureWarning> {
         self.last_warning.take()
+    }
+
+    fn decode_payload(&mut self, payload: &str) -> Result<Option<AudioFrame>, BrowserCaptureError> {
+        if payload.len() <= 1024
+            && let Ok(signal) = serde_json::from_str::<CaptureSignal>(payload)
+            && signal.version == 1
+        {
+            let scope = signal.scope.unwrap_or_else(|| "unknown".into());
+            let message = signal.message.unwrap_or_else(|| "unknown failure".into());
+            if signal.kind == "warning" {
+                self.last_warning = Some(CaptureWarning { scope, message });
+                return Ok(None);
+            }
+            if signal.kind == "error" {
+                return Err(BrowserCaptureError::Script { scope, message });
+            }
+        }
+        self.protocol.decode(payload).map(Some).map_err(Into::into)
     }
 }
 
@@ -322,6 +346,67 @@ mod tests {
                 CdpError::BindingEventsAlreadyTaken
             ))
         ));
+
+        page.close().await.unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn drains_the_final_audio_frame_before_closing_capture_events() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+
+            let binding = next_command(&mut websocket).await;
+            reply(&mut websocket, &binding, json!({})).await;
+            let install = next_command(&mut websocket).await;
+            reply(
+                &mut websocket,
+                &install,
+                json!({"result": {"value": {"streamCount": 1}}}),
+            )
+            .await;
+
+            let stop = next_command(&mut websocket).await;
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "method": "Runtime.bindingCalled",
+                        "params": {
+                            "name": CAPTURE_BINDING,
+                            "payload": json!({
+                                "v": 1,
+                                "kind": "audio",
+                                "sequence": 1,
+                                "track_index": 0,
+                                "sample_rate": 16000,
+                                "start_ms": 0,
+                                "pcm_s16le": "AQA="
+                            }).to_string()
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+            reply(&mut websocket, &stop, json!({"result": {"value": true}})).await;
+
+            assert!(matches!(
+                websocket.next().await,
+                Some(Ok(Message::Close(_)))
+            ));
+        });
+
+        let (websocket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let mut page = CdpPage::from_test_websocket(websocket);
+        let (mut capture, _) = BrowserCapture::install(&mut page).await.unwrap();
+
+        let frames = capture.stop_and_drain(&mut page).await.unwrap();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].samples, vec![1]);
 
         page.close().await.unwrap();
         server.await.unwrap();

--- a/enterprise/google-meet-worker/src/cdp.rs
+++ b/enterprise/google-meet-worker/src/cdp.rs
@@ -250,6 +250,30 @@ impl CdpBindingEventStream {
         }
         Err(CdpError::BindingEventStreamClosed)
     }
+
+    pub fn try_next_payload(&mut self, binding_name: &str) -> Result<Option<String>, CdpError> {
+        loop {
+            let event = match self.receiver.try_recv() {
+                Ok(event) => event,
+                Err(mpsc::error::TryRecvError::Empty) => return Ok(None),
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    return Err(CdpError::BindingEventStreamClosed);
+                }
+            };
+            let Some(params) = event.get("params") else {
+                continue;
+            };
+            if params.get("name").and_then(Value::as_str) != Some(binding_name) {
+                continue;
+            }
+            return params
+                .get("payload")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .map(Some)
+                .ok_or(CdpError::InvalidBindingEvent);
+        }
+    }
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/enterprise/google-meet-worker/src/google_meet_runtime.rs
+++ b/enterprise/google-meet-worker/src/google_meet_runtime.rs
@@ -1,0 +1,335 @@
+use std::{error::Error, time::Duration};
+
+use anlg_meeting_capture::{CaptureEvent, TransitionError};
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::sync::{mpsc, watch};
+
+use crate::{
+    AdmissionMonitor, AdmissionMonitorConfig, AdmissionMonitorError, AudioFrameSink,
+    BrowserCapture, BrowserCaptureError, CaptureJobRuntime, ChromiumLaunchConfig, LobbyController,
+    LobbyError, MeetingSession, MeetingSessionLaunchError, MeetingSessionShutdownError,
+    RuntimeMonitor, RuntimeMonitorError, WorkerCheckpoint, WorkerLifecycle, X11Input,
+    X11InputConfig, X11InputError,
+};
+
+#[derive(Debug, Clone)]
+pub struct GoogleMeetRuntimeConfig {
+    pub chromium: ChromiumLaunchConfig,
+    pub x11: X11InputConfig,
+    pub bot_name: String,
+    pub admission: AdmissionMonitorConfig,
+    pub runtime_poll_interval: Duration,
+}
+
+pub struct GoogleMeetRuntime<S> {
+    chromium: ChromiumLaunchConfig,
+    input: X11Input,
+    bot_name: String,
+    admission: AdmissionMonitor,
+    runtime_monitor: RuntimeMonitor,
+    audio_sink: S,
+    session: Option<MeetingSession>,
+    capture: Option<BrowserCapture>,
+    started: bool,
+    sink_started: bool,
+}
+
+impl<S> GoogleMeetRuntime<S> {
+    pub fn new(
+        config: GoogleMeetRuntimeConfig,
+        audio_sink: S,
+    ) -> Result<Self, GoogleMeetRuntimeConfigError> {
+        validate_bot_name(&config.bot_name)?;
+        let input = X11Input::new(config.x11)?;
+        let admission = AdmissionMonitor::new(config.admission)?;
+        let runtime_monitor = RuntimeMonitor::new(config.runtime_poll_interval)?;
+        Ok(Self {
+            chromium: config.chromium,
+            input,
+            bot_name: config.bot_name,
+            admission,
+            runtime_monitor,
+            audio_sink,
+            session: None,
+            capture: None,
+            started: false,
+            sink_started: false,
+        })
+    }
+}
+
+#[async_trait]
+impl<S> CaptureJobRuntime for GoogleMeetRuntime<S>
+where
+    S: AudioFrameSink,
+{
+    type Error = GoogleMeetRuntimeError<S::Error>;
+
+    async fn run(
+        &mut self,
+        checkpoint: &WorkerCheckpoint,
+        lifecycle: &mut WorkerLifecycle,
+        events: mpsc::Sender<CaptureEvent>,
+    ) -> Result<(), Self::Error> {
+        if self.started {
+            return Err(GoogleMeetRuntimeError::AlreadyStarted);
+        }
+        self.started = true;
+        send_event(&events, lifecycle.launch_started(Utc::now())?).await?;
+
+        let session =
+            MeetingSession::launch(self.chromium.clone(), &checkpoint.meeting_url).await?;
+        self.session = Some(session);
+
+        {
+            let page = self
+                .session
+                .as_mut()
+                .expect("launched runtime owns a session")
+                .page_mut();
+            LobbyController::new(page, &self.input)
+                .join(&self.bot_name, self.chromium.authenticated)
+                .await?;
+            self.admission
+                .wait_streaming(page, lifecycle, &events)
+                .await?;
+        }
+        if lifecycle.state().is_terminal() {
+            return Ok(());
+        }
+
+        let (capture, _) = BrowserCapture::install(
+            self.session
+                .as_mut()
+                .expect("launched runtime owns a session")
+                .page_mut(),
+        )
+        .await?;
+        self.capture = Some(capture);
+        self.sink_started = true;
+        send_event(&events, lifecycle.capture_started(Utc::now())?).await?;
+
+        let runtime_events = {
+            let page = self
+                .session
+                .as_mut()
+                .expect("launched runtime owns a session")
+                .page_mut();
+            let (_stop_tx, stop_rx) = watch::channel(false);
+            let monitor = self.runtime_monitor.run(page, lifecycle, stop_rx);
+            tokio::pin!(monitor);
+
+            loop {
+                tokio::select! {
+                    result = &mut monitor => break result?,
+                    frame = self.capture.as_mut().expect("capture was installed").next_frame() => {
+                        self.audio_sink
+                            .write_frame(frame?)
+                            .await
+                            .map_err(GoogleMeetRuntimeError::AudioSink)?;
+                    }
+                }
+            }
+        };
+
+        for frame in self.stop_capture().await? {
+            self.audio_sink
+                .write_frame(frame)
+                .await
+                .map_err(GoogleMeetRuntimeError::AudioSink)?;
+        }
+        for event in runtime_events {
+            send_event(&events, event).await?;
+        }
+        Ok(())
+    }
+
+    async fn cleanup(&mut self) -> Result<(), Self::Error> {
+        let (capture_error, trailing_frames) = match self.stop_capture().await {
+            Ok(frames) => (None, frames),
+            Err(error) => (Some(error), Vec::new()),
+        };
+        let mut sink_error = None;
+        for frame in trailing_frames {
+            if let Err(error) = self.audio_sink.write_frame(frame).await {
+                sink_error = Some(error);
+                break;
+            }
+        }
+        if self.sink_started {
+            self.sink_started = false;
+            if let Err(error) = self.audio_sink.finish().await
+                && sink_error.is_none()
+            {
+                sink_error = Some(error);
+            }
+        }
+        let session_error = match self.session.take() {
+            Some(session) => session.shutdown().await.err(),
+            None => None,
+        };
+
+        if capture_error.is_none() && sink_error.is_none() && session_error.is_none() {
+            Ok(())
+        } else {
+            Err(GoogleMeetRuntimeError::Cleanup {
+                capture_error,
+                sink_error,
+                session_error,
+            })
+        }
+    }
+}
+
+impl<S> GoogleMeetRuntime<S>
+where
+    S: AudioFrameSink,
+{
+    async fn stop_capture(&mut self) -> Result<Vec<crate::AudioFrame>, BrowserCaptureError> {
+        let Some(mut capture) = self.capture.take() else {
+            return Ok(Vec::new());
+        };
+        let Some(session) = self.session.as_mut() else {
+            return Ok(Vec::new());
+        };
+        capture.stop_and_drain(session.page_mut()).await
+    }
+}
+
+async fn send_event<E>(
+    events: &mpsc::Sender<CaptureEvent>,
+    event: CaptureEvent,
+) -> Result<(), GoogleMeetRuntimeError<E>>
+where
+    E: Error + Send + Sync + 'static,
+{
+    events
+        .send(event)
+        .await
+        .map_err(|_| GoogleMeetRuntimeError::EventChannelClosed)
+}
+
+fn validate_bot_name(value: &str) -> Result<(), GoogleMeetRuntimeConfigError> {
+    if value.is_empty() || value.chars().count() > 80 || value.chars().any(char::is_control) {
+        return Err(GoogleMeetRuntimeConfigError::InvalidBotName);
+    }
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GoogleMeetRuntimeConfigError {
+    #[error("bot display name must contain 1-80 non-control characters")]
+    InvalidBotName,
+    #[error(transparent)]
+    X11(#[from] X11InputError),
+    #[error(transparent)]
+    Admission(#[from] AdmissionMonitorError),
+    #[error(transparent)]
+    RuntimeMonitor(#[from] RuntimeMonitorError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GoogleMeetRuntimeError<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    #[error("Google Meet runtime can only be started once")]
+    AlreadyStarted,
+    #[error("capture supervisor stopped accepting runtime events")]
+    EventChannelClosed,
+    #[error(transparent)]
+    Transition(#[from] TransitionError),
+    #[error(transparent)]
+    Launch(#[from] MeetingSessionLaunchError),
+    #[error(transparent)]
+    Lobby(#[from] LobbyError),
+    #[error(transparent)]
+    Admission(#[from] AdmissionMonitorError),
+    #[error(transparent)]
+    Capture(#[from] BrowserCaptureError),
+    #[error(transparent)]
+    RuntimeMonitor(#[from] RuntimeMonitorError),
+    #[error("audio frame sink failed")]
+    AudioSink(#[source] E),
+    #[error("Google Meet runtime cleanup failed")]
+    Cleanup {
+        capture_error: Option<BrowserCaptureError>,
+        sink_error: Option<E>,
+        session_error: Option<MeetingSessionShutdownError>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    struct UnusedSink;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("unused sink failed")]
+    struct UnusedSinkError;
+
+    #[async_trait]
+    impl AudioFrameSink for UnusedSink {
+        type Error = UnusedSinkError;
+
+        async fn write_frame(&mut self, _frame: crate::AudioFrame) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn finish(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    fn config(bot_name: &str) -> GoogleMeetRuntimeConfig {
+        GoogleMeetRuntimeConfig {
+            chromium: ChromiumLaunchConfig {
+                binary: PathBuf::from("chromium"),
+                user_data_dir: PathBuf::from("profile"),
+                locale: "en-US".into(),
+                authenticated: false,
+                headless: false,
+                disable_sandbox: false,
+                startup_timeout: Duration::from_secs(10),
+            },
+            x11: X11InputConfig {
+                binary: PathBuf::from("xdotool"),
+                display: ":99".into(),
+                command_timeout: Duration::from_secs(5),
+            },
+            bot_name: bot_name.into(),
+            admission: AdmissionMonitorConfig::default(),
+            runtime_poll_interval: Duration::from_secs(1),
+        }
+    }
+
+    #[test]
+    fn validates_runtime_configuration_before_launching_processes() {
+        assert!(matches!(
+            GoogleMeetRuntime::new(config("bad\nname"), UnusedSink),
+            Err(GoogleMeetRuntimeConfigError::InvalidBotName)
+        ));
+
+        let mut invalid_x11 = config("Anarlog Notes");
+        invalid_x11.x11.display.clear();
+        assert!(matches!(
+            GoogleMeetRuntime::new(invalid_x11, UnusedSink),
+            Err(GoogleMeetRuntimeConfigError::X11(
+                X11InputError::InvalidDisplay
+            ))
+        ));
+
+        let mut invalid_monitor = config("Anarlog Notes");
+        invalid_monitor.runtime_poll_interval = Duration::ZERO;
+        assert!(matches!(
+            GoogleMeetRuntime::new(invalid_monitor, UnusedSink),
+            Err(GoogleMeetRuntimeConfigError::RuntimeMonitor(
+                RuntimeMonitorError::InvalidPollInterval
+            ))
+        ));
+    }
+}

--- a/enterprise/google-meet-worker/src/lib.rs
+++ b/enterprise/google-meet-worker/src/lib.rs
@@ -1,10 +1,12 @@
 mod admission;
 mod admission_monitor;
+mod audio_sink;
 mod browser;
 mod capture;
 mod capture_protocol;
 mod cdp;
 mod event_sink;
+mod google_meet_runtime;
 mod lifecycle;
 mod lobby;
 mod runtime;
@@ -15,11 +17,13 @@ mod x11;
 
 pub use admission::*;
 pub use admission_monitor::*;
+pub use audio_sink::*;
 pub use browser::*;
 pub use capture::*;
 pub use capture_protocol::*;
 pub use cdp::*;
 pub use event_sink::*;
+pub use google_meet_runtime::*;
 pub use lifecycle::*;
 pub use lobby::*;
 pub use runtime::*;

--- a/enterprise/google-meet-worker/src/supervisor.rs
+++ b/enterprise/google-meet-worker/src/supervisor.rs
@@ -51,6 +51,7 @@ pub trait CaptureJobRuntime: Send {
 
     async fn run(
         &mut self,
+        checkpoint: &WorkerCheckpoint,
         lifecycle: &mut WorkerLifecycle,
         events: mpsc::Sender<CaptureEvent>,
     ) -> Result<(), Self::Error>;
@@ -152,7 +153,7 @@ where
             ));
         }
         let mut lifecycle = WorkerLifecycle::resume(
-            checkpoint.bot_id,
+            checkpoint.bot_id.clone(),
             checkpoint.state,
             checkpoint.next_sequence,
         )?;
@@ -174,7 +175,7 @@ where
             tokio::time::Instant::now() + self.config.lease_renew_interval,
             self.config.lease_renew_interval,
         );
-        let mut runtime = Box::pin(self.runtime.run(&mut lifecycle, events_tx));
+        let mut runtime = Box::pin(self.runtime.run(&checkpoint, &mut lifecycle, events_tx));
         let mut events_closed = false;
         let mut deferred_terminal = None;
         let exit = loop {
@@ -415,9 +416,15 @@ mod tests {
 
         async fn run(
             &mut self,
+            checkpoint: &WorkerCheckpoint,
             lifecycle: &mut WorkerLifecycle,
             events: mpsc::Sender<CaptureEvent>,
         ) -> Result<(), Self::Error> {
+            assert_eq!(checkpoint.job_id, "job-a");
+            assert_eq!(
+                checkpoint.meeting_url.as_str(),
+                "https://meet.google.com/abc-defg-hij"
+            );
             events
                 .send(lifecycle.launch_started(now()).unwrap())
                 .await


### PR DESCRIPTION
Summary:
- launch the meeting URL from the claimed worker checkpoint
- join and stream admission lifecycle events without buffering
- send normalized PCM through a provider-neutral audio sink
- retain capture ownership through cleanup and drain final flushed audio

Validation:
- 95 enterprise tests with OrbStack Postgres
- cargo check for root and enterprise workspaces
- strict enterprise workspace Clippy
- pnpm dprint fmt and fmt:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live capture path (browser session, admission timing, audio drain/cleanup) and changes the runtime trait contract; failures or missed frames would affect recording quality and lifecycle events, but changes are localized to the worker with tests.
> 
> **Overview**
> Adds **`GoogleMeetRuntime`** as the real **`CaptureJobRuntime`**: it opens the claimed **`WorkerCheckpoint`** meeting URL, joins via lobby/X11, streams admission lifecycle events to the supervisor (no buffering), installs browser capture, multiplexes **`RuntimeMonitor`** with PCM frames into an injectable **`AudioFrameSink`**, and on shutdown/cleanup **stops capture, drains trailing frames**, then **`finish`**es the sink.
> 
> **`CaptureJobRuntime::run`** now receives **`&WorkerCheckpoint`** so runtimes use job id / meeting URL from the lease; supervisor and integration tests were updated accordingly.
> 
> **Admission** gains **`wait_streaming`** (channel-backed, **`EventChannelClosed`** on supervisor drop). **CDP/capture** add **`try_next_payload`** and **`BrowserCapture::stop_and_drain`** so the last binding audio frame is not lost when stopping capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc16855a461ec7e30a1f086fe4788ed38789400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->