### PR TITLE
Finalize capture media before terminal state

### DIFF
--- a/enterprise/control-plane/tests/postgres.rs
+++ b/enterprise/control-plane/tests/postgres.rs
@@ -82,9 +82,9 @@ impl CaptureJobRuntime for CompletingRuntime {
         Ok(())
     }
 
-    async fn cleanup(&mut self) -> Result<(), Self::Error> {
+    async fn cleanup(&mut self) -> Result<Vec<CaptureEventPayload>, Self::Error> {
         self.cleaned.store(true, Ordering::SeqCst);
-        Ok(())
+        Ok(Vec::new())
     }
 }
 

--- a/enterprise/google-meet-worker/src/audio_sink.rs
+++ b/enterprise/google-meet-worker/src/audio_sink.rs
@@ -2,13 +2,35 @@ use std::error::Error;
 
 use async_trait::async_trait;
 
+use anlg_meeting_capture::{CaptureEventPayload, RecordingChunk, Speaker, TranscriptSegment};
+
 use crate::AudioFrame;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AudioFrameSinkOutput {
+    Transcript(TranscriptSegment),
+    SpeakerUpserted(Speaker),
+    RecordingChunkReady(RecordingChunk),
+}
+
+impl From<AudioFrameSinkOutput> for CaptureEventPayload {
+    fn from(output: AudioFrameSinkOutput) -> Self {
+        match output {
+            AudioFrameSinkOutput::Transcript(segment) => Self::Transcript(segment),
+            AudioFrameSinkOutput::SpeakerUpserted(speaker) => Self::SpeakerUpserted(speaker),
+            AudioFrameSinkOutput::RecordingChunkReady(chunk) => Self::RecordingChunkReady(chunk),
+        }
+    }
+}
 
 #[async_trait]
 pub trait AudioFrameSink: Send {
     type Error: Error + Send + Sync + 'static;
 
-    async fn write_frame(&mut self, frame: AudioFrame) -> Result<(), Self::Error>;
+    async fn write_frame(
+        &mut self,
+        frame: AudioFrame,
+    ) -> Result<Vec<AudioFrameSinkOutput>, Self::Error>;
 
-    async fn finish(&mut self) -> Result<(), Self::Error>;
+    async fn finish(&mut self) -> Result<Vec<AudioFrameSinkOutput>, Self::Error>;
 }

--- a/enterprise/google-meet-worker/src/google_meet_runtime.rs
+++ b/enterprise/google-meet-worker/src/google_meet_runtime.rs
@@ -1,16 +1,16 @@
 use std::{error::Error, time::Duration};
 
-use anlg_meeting_capture::{CaptureEvent, TransitionError};
+use anlg_meeting_capture::{CaptureEvent, CaptureEventPayload, TransitionError};
 use async_trait::async_trait;
 use chrono::Utc;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc;
 
 use crate::{
     AdmissionMonitor, AdmissionMonitorConfig, AdmissionMonitorError, AudioFrameSink,
-    BrowserCapture, BrowserCaptureError, CaptureJobRuntime, ChromiumLaunchConfig, LobbyController,
-    LobbyError, MeetingSession, MeetingSessionLaunchError, MeetingSessionShutdownError,
-    RuntimeMonitor, RuntimeMonitorError, WorkerCheckpoint, WorkerLifecycle, X11Input,
-    X11InputConfig, X11InputError,
+    AudioFrameSinkOutput, BrowserCapture, BrowserCaptureError, CaptureJobRuntime,
+    ChromiumLaunchConfig, LobbyController, LobbyError, MeetingSession, MeetingSessionLaunchError,
+    MeetingSessionShutdownError, RuntimeMonitor, RuntimeMonitorError, WorkerCheckpoint,
+    WorkerLifecycle, X11Input, X11InputConfig, X11InputError,
 };
 
 #[derive(Debug, Clone)]
@@ -110,72 +110,61 @@ where
         self.sink_started = true;
         send_event(&events, lifecycle.capture_started(Utc::now())?).await?;
 
-        let runtime_events = {
-            let page = self
-                .session
-                .as_mut()
-                .expect("launched runtime owns a session")
-                .page_mut();
-            let (_stop_tx, stop_rx) = watch::channel(false);
-            let monitor = self.runtime_monitor.run(page, lifecycle, stop_rx);
-            tokio::pin!(monitor);
-
-            loop {
-                tokio::select! {
-                    result = &mut monitor => break result?,
-                    frame = self.capture.as_mut().expect("capture was installed").next_frame() => {
-                        self.audio_sink
-                            .write_frame(frame?)
-                            .await
-                            .map_err(GoogleMeetRuntimeError::AudioSink)?;
+        let mut probes = tokio::time::interval(self.runtime_monitor.poll_interval());
+        probes.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let terminal_outcome = loop {
+            tokio::select! {
+                _ = probes.tick() => {
+                    let outcome = self.runtime_monitor
+                        .probe_outcome(
+                            self.session
+                                .as_mut()
+                                .expect("launched runtime owns a session")
+                                .page_mut(),
+                            lifecycle,
+                        )
+                        .await?;
+                    if let Some(outcome) = outcome {
+                        break outcome;
                     }
+                }
+                frame = self.capture.as_mut().expect("capture was installed").next_frame() => {
+                    let payloads = self.audio_sink
+                        .write_frame(frame?)
+                        .await
+                        .map_err(GoogleMeetRuntimeError::AudioSink)?;
+                    send_outputs(&events, lifecycle, payloads).await?;
                 }
             }
         };
 
-        for frame in self.stop_capture().await? {
-            self.audio_sink
-                .write_frame(frame)
-                .await
-                .map_err(GoogleMeetRuntimeError::AudioSink)?;
-        }
-        for event in runtime_events {
-            send_event(&events, event).await?;
-        }
+        let finalization = self.finalize_media().await;
+        let payloads = finalization.into_result()?;
+        send_outputs(&events, lifecycle, payloads).await?;
+        send_event(
+            &events,
+            lifecycle.apply_runtime_outcome(terminal_outcome, Utc::now())?,
+        )
+        .await?;
         Ok(())
     }
 
-    async fn cleanup(&mut self) -> Result<(), Self::Error> {
-        let (capture_error, trailing_frames) = match self.stop_capture().await {
-            Ok(frames) => (None, frames),
-            Err(error) => (Some(error), Vec::new()),
-        };
-        let mut sink_error = None;
-        for frame in trailing_frames {
-            if let Err(error) = self.audio_sink.write_frame(frame).await {
-                sink_error = Some(error);
-                break;
-            }
-        }
-        if self.sink_started {
-            self.sink_started = false;
-            if let Err(error) = self.audio_sink.finish().await
-                && sink_error.is_none()
-            {
-                sink_error = Some(error);
-            }
-        }
+    async fn cleanup(&mut self) -> Result<Vec<CaptureEventPayload>, Self::Error> {
+        let finalization = self.finalize_media().await;
         let session_error = match self.session.take() {
             Some(session) => session.shutdown().await.err(),
             None => None,
         };
 
-        if capture_error.is_none() && sink_error.is_none() && session_error.is_none() {
-            Ok(())
+        if finalization.capture_error.is_none()
+            && finalization.sink_error.is_none()
+            && session_error.is_none()
+        {
+            Ok(finalization.payloads.into_iter().map(Into::into).collect())
         } else {
             Err(GoogleMeetRuntimeError::Cleanup {
-                capture_error,
-                sink_error,
+                capture_error: finalization.capture_error,
+                sink_error: finalization.sink_error,
                 session_error,
             })
         }
@@ -195,6 +184,60 @@ where
         };
         capture.stop_and_drain(session.page_mut()).await
     }
+
+    async fn finalize_media(&mut self) -> MediaFinalization<S::Error> {
+        let (capture_error, trailing_frames) = match self.stop_capture().await {
+            Ok(frames) => (None, frames),
+            Err(error) => (Some(error), Vec::new()),
+        };
+        let mut payloads = Vec::new();
+        let mut sink_error = None;
+        for frame in trailing_frames {
+            match self.audio_sink.write_frame(frame).await {
+                Ok(output) => payloads.extend(output),
+                Err(error) => {
+                    sink_error = Some(error);
+                    break;
+                }
+            }
+        }
+        if self.sink_started {
+            match self.audio_sink.finish().await {
+                Ok(output) => {
+                    self.sink_started = false;
+                    payloads.extend(output);
+                }
+                Err(error) if sink_error.is_none() => sink_error = Some(error),
+                Err(_) => {}
+            }
+        }
+        MediaFinalization {
+            payloads,
+            capture_error,
+            sink_error,
+        }
+    }
+}
+
+struct MediaFinalization<E> {
+    payloads: Vec<AudioFrameSinkOutput>,
+    capture_error: Option<BrowserCaptureError>,
+    sink_error: Option<E>,
+}
+
+impl<E> MediaFinalization<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn into_result(self) -> Result<Vec<AudioFrameSinkOutput>, GoogleMeetRuntimeError<E>> {
+        if let Some(error) = self.capture_error {
+            return Err(GoogleMeetRuntimeError::Capture(error));
+        }
+        if let Some(error) = self.sink_error {
+            return Err(GoogleMeetRuntimeError::AudioSink(error));
+        }
+        Ok(self.payloads)
+    }
 }
 
 async fn send_event<E>(
@@ -208,6 +251,20 @@ where
         .send(event)
         .await
         .map_err(|_| GoogleMeetRuntimeError::EventChannelClosed)
+}
+
+async fn send_outputs<E>(
+    events: &mpsc::Sender<CaptureEvent>,
+    lifecycle: &mut WorkerLifecycle,
+    outputs: Vec<AudioFrameSinkOutput>,
+) -> Result<(), GoogleMeetRuntimeError<E>>
+where
+    E: Error + Send + Sync + 'static,
+{
+    for output in outputs {
+        send_event(events, lifecycle.emit_payload(output.into(), Utc::now())).await?;
+    }
+    Ok(())
 }
 
 fn validate_bot_name(value: &str) -> Result<(), GoogleMeetRuntimeConfigError> {
@@ -264,6 +321,8 @@ where
 mod tests {
     use std::path::PathBuf;
 
+    use anlg_meeting_capture::{BotState, TranscriptSegment};
+
     use super::*;
 
     struct UnusedSink;
@@ -272,17 +331,56 @@ mod tests {
     #[error("unused sink failed")]
     struct UnusedSinkError;
 
+    struct RetryingFinishSink {
+        attempts: usize,
+    }
+
     #[async_trait]
     impl AudioFrameSink for UnusedSink {
         type Error = UnusedSinkError;
 
-        async fn write_frame(&mut self, _frame: crate::AudioFrame) -> Result<(), Self::Error> {
-            Ok(())
+        async fn write_frame(
+            &mut self,
+            _frame: crate::AudioFrame,
+        ) -> Result<Vec<AudioFrameSinkOutput>, Self::Error> {
+            Ok(Vec::new())
         }
 
-        async fn finish(&mut self) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finish(&mut self) -> Result<Vec<AudioFrameSinkOutput>, Self::Error> {
+            Ok(Vec::new())
         }
+    }
+
+    #[async_trait]
+    impl AudioFrameSink for RetryingFinishSink {
+        type Error = UnusedSinkError;
+
+        async fn write_frame(
+            &mut self,
+            _frame: crate::AudioFrame,
+        ) -> Result<Vec<AudioFrameSinkOutput>, Self::Error> {
+            Ok(Vec::new())
+        }
+
+        async fn finish(&mut self) -> Result<Vec<AudioFrameSinkOutput>, Self::Error> {
+            self.attempts += 1;
+            if self.attempts == 1 {
+                return Err(UnusedSinkError);
+            }
+            Ok(vec![transcript_output()])
+        }
+    }
+
+    fn transcript_output() -> AudioFrameSinkOutput {
+        AudioFrameSinkOutput::Transcript(TranscriptSegment {
+            id: "segment-final".into(),
+            sequence: 0,
+            start_ms: 0,
+            end_ms: Some(500),
+            text: "final words".into(),
+            speaker: None,
+            is_final: true,
+        })
     }
 
     fn config(bot_name: &str) -> GoogleMeetRuntimeConfig {
@@ -331,5 +429,58 @@ mod tests {
                 RuntimeMonitorError::InvalidPollInterval
             ))
         ));
+    }
+
+    #[tokio::test]
+    async fn sequences_final_media_before_the_terminal_event() {
+        let mut lifecycle = WorkerLifecycle::new("bot-1");
+        lifecycle.launch_started(Utc::now()).unwrap();
+        lifecycle
+            .transition(BotState::Joined, None, Utc::now())
+            .unwrap();
+        lifecycle.capture_started(Utc::now()).unwrap();
+        let (events_tx, mut events_rx) = mpsc::channel(2);
+
+        send_outputs::<UnusedSinkError>(&events_tx, &mut lifecycle, vec![transcript_output()])
+            .await
+            .unwrap();
+        send_event::<UnusedSinkError>(
+            &events_tx,
+            lifecycle
+                .apply_runtime_outcome(
+                    crate::RuntimeOutcome::MeetingEnded("meeting ended".into()),
+                    Utc::now(),
+                )
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let media = events_rx.recv().await.unwrap();
+        let terminal = events_rx.recv().await.unwrap();
+        assert_eq!((media.sequence, terminal.sequence), (3, 4));
+        assert!(matches!(media.payload, CaptureEventPayload::Transcript(_)));
+        assert!(matches!(
+            terminal.payload,
+            CaptureEventPayload::Lifecycle(ref transition)
+                if transition.to == BotState::Completed
+        ));
+    }
+
+    #[tokio::test]
+    async fn retries_sink_finalization_during_cleanup_after_a_transient_failure() {
+        let mut runtime =
+            GoogleMeetRuntime::new(config("Anarlog Notes"), RetryingFinishSink { attempts: 0 })
+                .unwrap();
+        runtime.sink_started = true;
+
+        let first = runtime.finalize_media().await;
+        assert!(first.sink_error.is_some());
+        assert!(runtime.sink_started);
+
+        let second = runtime.finalize_media().await;
+        assert!(second.sink_error.is_none());
+        assert_eq!(second.payloads, vec![transcript_output()]);
+        assert!(!runtime.sink_started);
     }
 }

--- a/enterprise/google-meet-worker/src/lifecycle.rs
+++ b/enterprise/google-meet-worker/src/lifecycle.rs
@@ -159,60 +159,77 @@ impl WorkerLifecycle {
         observed_at: Instant,
         occurred_at: DateTime<Utc>,
     ) -> Result<Option<CaptureEvent>, TransitionError> {
-        if !matches!(self.state, BotState::Joined | BotState::Capturing) {
+        let Some(outcome) = self.classify_runtime(snapshot, observed_at) else {
             return Ok(None);
+        };
+        self.apply_runtime_outcome(outcome, occurred_at).map(Some)
+    }
+
+    pub(crate) fn classify_runtime(
+        &mut self,
+        snapshot: &RuntimeSnapshot,
+        observed_at: Instant,
+    ) -> Option<RuntimeOutcome> {
+        if !matches!(self.state, BotState::Joined | BotState::Capturing) {
+            return None;
         }
         match self.runtime.classify(snapshot, observed_at) {
-            RuntimeOutcome::Removed(indicator) => self
-                .transition(
-                    BotState::Failed,
-                    Some(TerminalReason {
-                        kind: TerminalReasonKind::RemovedFromMeeting,
-                        message: Some(indicator),
-                        retryable: false,
-                    }),
-                    occurred_at,
-                )
-                .map(Some),
-            RuntimeOutcome::MeetingEnded(indicator) => self
-                .transition(
-                    BotState::Completed,
-                    Some(TerminalReason {
-                        kind: TerminalReasonKind::MeetingEnded,
-                        message: Some(indicator),
-                        retryable: false,
-                    }),
-                    occurred_at,
-                )
-                .map(Some),
-            RuntimeOutcome::NetworkLost(indicator) => self
-                .transition(
-                    BotState::Failed,
-                    Some(TerminalReason {
-                        kind: TerminalReasonKind::NetworkLost,
-                        message: Some(indicator),
-                        retryable: true,
-                    }),
-                    occurred_at,
-                )
-                .map(Some),
-            RuntimeOutcome::StateLost => self
-                .transition(
-                    BotState::Failed,
-                    Some(TerminalReason {
-                        kind: TerminalReasonKind::ProviderError,
-                        message: Some(
-                            "Google Meet runtime indicators disappeared beyond the grace period"
-                                .into(),
-                        ),
-                        retryable: true,
-                    }),
-                    occurred_at,
-                )
-                .map(Some),
             RuntimeOutcome::Active
             | RuntimeOutcome::ConnectionInterrupted { .. }
-            | RuntimeOutcome::Unknown { .. } => Ok(None),
+            | RuntimeOutcome::Unknown { .. } => None,
+            outcome => Some(outcome),
+        }
+    }
+
+    pub(crate) fn apply_runtime_outcome(
+        &mut self,
+        outcome: RuntimeOutcome,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<CaptureEvent, TransitionError> {
+        match outcome {
+            RuntimeOutcome::Removed(indicator) => self.transition(
+                BotState::Failed,
+                Some(TerminalReason {
+                    kind: TerminalReasonKind::RemovedFromMeeting,
+                    message: Some(indicator),
+                    retryable: false,
+                }),
+                occurred_at,
+            ),
+            RuntimeOutcome::MeetingEnded(indicator) => self.transition(
+                BotState::Completed,
+                Some(TerminalReason {
+                    kind: TerminalReasonKind::MeetingEnded,
+                    message: Some(indicator),
+                    retryable: false,
+                }),
+                occurred_at,
+            ),
+            RuntimeOutcome::NetworkLost(indicator) => self.transition(
+                BotState::Failed,
+                Some(TerminalReason {
+                    kind: TerminalReasonKind::NetworkLost,
+                    message: Some(indicator),
+                    retryable: true,
+                }),
+                occurred_at,
+            ),
+            RuntimeOutcome::StateLost => self.transition(
+                BotState::Failed,
+                Some(TerminalReason {
+                    kind: TerminalReasonKind::ProviderError,
+                    message: Some(
+                        "Google Meet runtime indicators disappeared beyond the grace period".into(),
+                    ),
+                    retryable: true,
+                }),
+                occurred_at,
+            ),
+            RuntimeOutcome::Active
+            | RuntimeOutcome::ConnectionInterrupted { .. }
+            | RuntimeOutcome::Unknown { .. } => {
+                unreachable!("non-terminal runtime outcomes are not applied")
+            }
         }
     }
 

--- a/enterprise/google-meet-worker/src/runtime_monitor.rs
+++ b/enterprise/google-meet-worker/src/runtime_monitor.rs
@@ -4,7 +4,7 @@ use anlg_meeting_capture::{CaptureEvent, TransitionError};
 use chrono::Utc;
 use tokio::sync::watch;
 
-use crate::{CdpError, CdpPage, RuntimeSnapshot, WorkerLifecycle};
+use crate::{CdpError, CdpPage, RuntimeOutcome, RuntimeSnapshot, WorkerLifecycle};
 
 pub const DEFAULT_RUNTIME_POLL_INTERVAL: Duration = Duration::from_millis(1500);
 
@@ -28,6 +28,19 @@ impl RuntimeMonitor {
         stop: watch::Receiver<bool>,
     ) -> Result<Vec<CaptureEvent>, RuntimeMonitorError> {
         self.run_with_source(page, lifecycle, stop).await
+    }
+
+    pub(crate) fn poll_interval(&self) -> Duration {
+        self.poll_interval
+    }
+
+    pub(crate) async fn probe_outcome(
+        &self,
+        page: &mut CdpPage,
+        lifecycle: &mut WorkerLifecycle,
+    ) -> Result<Option<RuntimeOutcome>, RuntimeMonitorError> {
+        let snapshot = page.probe_runtime().await?;
+        Ok(lifecycle.classify_runtime(&snapshot, std::time::Instant::now()))
     }
 
     async fn run_with_source<S: RuntimeProbeSource>(

--- a/enterprise/google-meet-worker/src/supervisor.rs
+++ b/enterprise/google-meet-worker/src/supervisor.rs
@@ -56,7 +56,7 @@ pub trait CaptureJobRuntime: Send {
         events: mpsc::Sender<CaptureEvent>,
     ) -> Result<(), Self::Error>;
 
-    async fn cleanup(&mut self) -> Result<(), Self::Error>;
+    async fn cleanup(&mut self) -> Result<Vec<CaptureEventPayload>, Self::Error>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -219,10 +219,27 @@ where
                 }
             }
         }
-        self.runtime
+        let cleanup_payloads = self
+            .runtime
             .cleanup()
             .await
             .map_err(CaptureJobSupervisorError::Cleanup)?;
+
+        if matches!(exit, RuntimeExit::Runtime(_) | RuntimeExit::Shutdown) {
+            if lifecycle.state().is_terminal() && !cleanup_payloads.is_empty() {
+                return Err(CaptureJobSupervisorError::CleanupOutputAfterTerminal);
+            }
+            for payload in cleanup_payloads {
+                if matches!(payload, CaptureEventPayload::Lifecycle(_)) {
+                    return Err(CaptureJobSupervisorError::LifecycleOutputFromCleanup);
+                }
+                let event = lifecycle.emit_payload(payload, Utc::now());
+                self.control_plane
+                    .append(&event)
+                    .await
+                    .map_err(CaptureJobSupervisorError::ControlPlane)?;
+            }
+        }
 
         if matches!(exit, RuntimeExit::Runtime(_) | RuntimeExit::Shutdown)
             && let Some(event) = deferred_terminal
@@ -321,6 +338,10 @@ where
     ControlPlane(#[source] C),
     #[error("capture runtime cleanup failed")]
     Cleanup(#[source] R),
+    #[error("capture runtime produced cleanup output after entering a terminal state")]
+    CleanupOutputAfterTerminal,
+    #[error("capture runtime cleanup cannot produce lifecycle events")]
+    LifecycleOutputFromCleanup,
     #[error(transparent)]
     Resume(#[from] WorkerLifecycleResumeError),
     #[error(transparent)]
@@ -331,7 +352,9 @@ where
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use anlg_meeting_capture::{CaptureEventPayload, TerminalReason, TerminalReasonKind};
+    use anlg_meeting_capture::{
+        CaptureEventPayload, TerminalReason, TerminalReasonKind, TranscriptSegment,
+    };
     use chrono::{DateTime, Utc};
 
     use super::*;
@@ -398,6 +421,7 @@ mod tests {
     enum RuntimeMode {
         Complete,
         Fail,
+        FailWithCleanupOutput,
         TerminalThenWait,
         Wait,
     }
@@ -448,7 +472,9 @@ mod tests {
                     events.send(completed).await.unwrap();
                     Ok(())
                 }
-                RuntimeMode::Fail => Err(TestError("browser exited")),
+                RuntimeMode::Fail | RuntimeMode::FailWithCleanupOutput => {
+                    Err(TestError("browser exited"))
+                }
                 RuntimeMode::TerminalThenWait => {
                     let joined = lifecycle.transition(BotState::Joined, None, now()).unwrap();
                     events.send(joined).await.unwrap();
@@ -470,9 +496,21 @@ mod tests {
             }
         }
 
-        async fn cleanup(&mut self) -> Result<(), Self::Error> {
+        async fn cleanup(&mut self) -> Result<Vec<CaptureEventPayload>, Self::Error> {
             *self.cleaned.lock().unwrap() = true;
-            Ok(())
+            if matches!(self.mode, RuntimeMode::FailWithCleanupOutput) {
+                Ok(vec![CaptureEventPayload::Transcript(TranscriptSegment {
+                    id: "segment-cleanup".into(),
+                    sequence: 0,
+                    start_ms: 0,
+                    end_ms: Some(500),
+                    text: "final words".into(),
+                    speaker: None,
+                    is_final: true,
+                })])
+            } else {
+                Ok(Vec::new())
+            }
         }
     }
 
@@ -661,6 +699,46 @@ mod tests {
         assert_eq!(
             *harness.append_cleanup_states.lock().unwrap(),
             vec![false, true]
+        );
+    }
+
+    #[tokio::test]
+    async fn persists_final_media_output_before_runtime_failure_terminalizes() {
+        let harness = harness(
+            BotState::Queued,
+            0,
+            RuntimeMode::FailWithCleanupOutput,
+            false,
+        );
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let outcome = harness.supervisor.run(shutdown_rx).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            CaptureJobSupervisorOutcome::Terminal(BotState::Failed)
+        );
+        let events = harness.events.lock().unwrap();
+        assert_eq!(events.len(), 3);
+        assert!(matches!(
+            events[1].payload,
+            CaptureEventPayload::Transcript(_)
+        ));
+        assert!(matches!(
+            events[2].payload,
+            CaptureEventPayload::Lifecycle(ref transition)
+                if transition.to == BotState::Failed
+        ));
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        assert_eq!(
+            *harness.append_cleanup_states.lock().unwrap(),
+            vec![false, true, true]
         );
     }
 


### PR DESCRIPTION
Summary:
- let media sinks emit only normalized transcript, speaker, and recording output
- sequence final media output before terminal lifecycle events
- preserve cleanup output after runtime errors or requested shutdown
- retry transient media finalization during cleanup

Validation:
- 98 enterprise tests with OrbStack Postgres
- cargo check for root and enterprise workspaces
- strict enterprise workspace Clippy
- pnpm dprint fmt and fmt:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable event ordering and supervisor cleanup contracts for live capture jobs; mistakes could drop final media or publish events out of order.
> 
> **Overview**
> Ensures **final transcript, speaker, and recording payloads** are persisted before any terminal lifecycle transition, including on normal meeting end and on runtime failure/shutdown cleanup.
> 
> **`AudioFrameSink`** now returns normalized **`AudioFrameSinkOutput`** (mapped to `CaptureEventPayload`) from `write_frame` and `finish` instead of only signaling success. **`GoogleMeetRuntime`** interleaves frame processing with runtime probes via `probe_outcome`, runs shared **`finalize_media`** before emitting the terminal outcome on the happy path, and returns leftover payloads from **`cleanup`** when shutdown still has buffered media.
> 
> **`CaptureJobSupervisor`** appends cleanup payloads before deferred terminal events (e.g. failed run still gets a final transcript then `Failed`), and rejects cleanup that emits lifecycle events or media after the worker is already terminal. **`WorkerLifecycle`** splits runtime handling into **`classify_runtime`** / **`apply_runtime_outcome`** so the runtime can finalize sinks first; **`finalize_media`** leaves `sink_started` set on transient `finish` errors so cleanup can retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e43ddcc9699ce29cb82af5c4a695bf13060194d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->