### PR TITLE
ANLG-141: activate encrypted mobile sync

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -42,6 +42,7 @@
           "enableBackgroundRecording": true
         }
       ],
+      "expo-secure-store",
       "@sentry/react-native/expo"
     ],
     "experiments": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -39,6 +39,7 @@
     "expo-image": "~57.0.1",
     "expo-linking": "~57.0.4",
     "expo-router": "~57.0.8",
+    "expo-secure-store": "~57.0.1",
     "expo-sharing": "~57.0.12",
     "expo-splash-screen": "~57.0.5",
     "expo-status-bar": "~57.0.1",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -16,6 +16,7 @@ import {
   initializeErrorReporting,
 } from "@/lib/error-reporting";
 import { useMountEffect } from "@/lib/use-mount-effect";
+import { MobileSyncLifecycle } from "@/sync/mobile-sync-lifecycle";
 import { initializeWatchConnectivity } from "@/watch-connectivity";
 
 initializeErrorReporting();
@@ -119,7 +120,19 @@ function Gate() {
     );
   }
 
-  return <Screens accountUserId={auth.session?.user.id ?? null} />;
+  const session = auth.session;
+  if (!session) return null;
+
+  return (
+    <>
+      <MobileSyncLifecycle
+        key={`${session.user.id}:${session.access_token}`}
+        accessToken={session.access_token}
+        accountUserId={session.user.id}
+      />
+      <Screens accountUserId={session.user.id} />
+    </>
+  );
 }
 
 function RouteError({

--- a/apps/mobile/src/auth/context.tsx
+++ b/apps/mobile/src/auth/context.tsx
@@ -36,6 +36,7 @@ import {
   captureOperationalError,
   setErrorReportingUser,
 } from "@/lib/error-reporting";
+import { suspendMobileSync } from "@/sync/mobile-sync";
 import { updateWatchAccount } from "@/watch-connectivity";
 
 export type AuthState = {
@@ -407,6 +408,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    suspendMobileSync();
     captureAnalytics("user_signed_out");
     const { error } = await supabase.auth
       .signOut({ scope: "local" })

--- a/apps/mobile/src/components/profile-sheet.tsx
+++ b/apps/mobile/src/components/profile-sheet.tsx
@@ -23,7 +23,8 @@ import {
 } from "@/constants/theme";
 import type { MobileSyncPhase, MobileSyncSnapshot } from "@/sync/controller";
 import {
-  createMobileRecoveryKey,
+  confirmMobileRecoveryKey,
+  generateMobileRecoveryKey,
   getMobileSyncSnapshot,
   importMobileRecoveryKey,
   retryMobileSync,
@@ -143,7 +144,7 @@ export function ProfileSheet({
     setBusy(true);
     setActionError(null);
     try {
-      const key = await createMobileRecoveryKey();
+      const key = await generateMobileRecoveryKey();
       setGeneratedKey(key);
       setMode("generated");
     } catch (error) {
@@ -189,8 +190,25 @@ export function ProfileSheet({
     }
   };
 
-  const finishRecoveryKey = () => {
+  const finishRecoveryKey = async () => {
+    setBusy(true);
+    setActionError(null);
+    try {
+      await confirmMobileRecoveryKey(generatedKey);
+      setGeneratedKey("");
+      setMode("status");
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : "Could not protect the key.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const discardGeneratedKey = () => {
     setGeneratedKey("");
+    setActionError(null);
     setMode("status");
   };
 
@@ -381,7 +399,11 @@ export function ProfileSheet({
                     disabled={busy}
                     onPress={() => {
                       setActionError(null);
-                      setMode("choose");
+                      setMode(
+                        sync.phase === "identity_mismatch"
+                          ? "status"
+                          : "choose",
+                      );
                     }}
                     size="small"
                     variant="ghost"
@@ -406,7 +428,18 @@ export function ProfileSheet({
                     onPress={() => void shareRecoveryKey()}
                     variant="outline"
                   />
-                  <Button label="I saved it" onPress={finishRecoveryKey} />
+                  <Button
+                    label="I saved it"
+                    loading={busy}
+                    onPress={() => void finishRecoveryKey()}
+                  />
+                  <Button
+                    label="Cancel"
+                    disabled={busy}
+                    onPress={discardGeneratedKey}
+                    size="small"
+                    variant="ghost"
+                  />
                 </View>
               )}
 

--- a/apps/mobile/src/components/profile-sheet.tsx
+++ b/apps/mobile/src/components/profile-sheet.tsx
@@ -1,4 +1,16 @@
-import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import { useState, useSyncExternalStore } from "react";
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 
 import { useAuth } from "@/auth/context";
 import { Button } from "@/components/ui/button";
@@ -9,6 +21,86 @@ import {
   Spacing,
   Typography,
 } from "@/constants/theme";
+import type { MobileSyncPhase, MobileSyncSnapshot } from "@/sync/controller";
+import {
+  createMobileRecoveryKey,
+  getMobileSyncSnapshot,
+  importMobileRecoveryKey,
+  retryMobileSync,
+  subscribeMobileSync,
+  syncMobileNow,
+} from "@/sync/mobile-sync";
+
+type SheetMode = "status" | "choose" | "import" | "generated";
+
+const phaseCopy: Record<
+  MobileSyncPhase,
+  { title: string; description: string }
+> = {
+  inactive: {
+    title: "Cloud sync is off",
+    description: "Sign in with Anarlog Pro to sync this device.",
+  },
+  starting: {
+    title: "Connecting this device",
+    description: "Preparing your encrypted workspace…",
+  },
+  setup_required: {
+    title: "Protect cloud sync",
+    description:
+      "Create a recovery key, or use the one from another Anarlog device.",
+  },
+  ready: {
+    title: "Cloud sync is on",
+    description: "Your notes sync end-to-end encrypted across your devices.",
+  },
+  error: {
+    title: "Cloud sync needs attention",
+    description: "Your notes are safe on this device. Try connecting again.",
+  },
+  device_limit: {
+    title: "Device limit reached",
+    description: "Anarlog Pro supports cloud sync on up to five devices.",
+  },
+  identity_mismatch: {
+    title: "Use your existing recovery key",
+    description:
+      "This account already has encrypted notes. Use the same key as your other device.",
+  },
+  not_entitled: {
+    title: "Anarlog Pro required",
+    description: "Refresh your plan to continue syncing this device.",
+  },
+  reauth_required: {
+    title: "Sign in again",
+    description: "Your session expired before cloud sync could connect.",
+  },
+  account_mismatch: {
+    title: "This device belongs to another account",
+    description:
+      "Your local notes were created by a different account, so sync stays off to protect both workspaces.",
+  },
+};
+
+function relativeSyncTime(lastSyncAtMs: number | null): string | null {
+  if (!lastSyncAtMs) return null;
+  const elapsedMinutes = Math.max(
+    0,
+    Math.floor((Date.now() - lastSyncAtMs) / 60_000),
+  );
+  if (elapsedMinutes < 1) return "Synced just now";
+  if (elapsedMinutes < 60) return `Synced ${elapsedMinutes}m ago`;
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) return `Synced ${elapsedHours}h ago`;
+  return `Synced ${Math.floor(elapsedHours / 24)}d ago`;
+}
+
+function statusDetail(snapshot: MobileSyncSnapshot): string | null {
+  if (snapshot.phase !== "ready") return snapshot.errorMessage;
+  if (snapshot.syncingNow) return "Syncing now…";
+  if (snapshot.hasUnsentChanges) return "Changes waiting to sync";
+  return relativeSyncTime(snapshot.lastSyncAtMs);
+}
 
 export function ProfileSheet({
   visible,
@@ -18,6 +110,17 @@ export function ProfileSheet({
   onClose: () => void;
 }) {
   const auth = useAuth();
+  const sync = useSyncExternalStore(
+    subscribeMobileSync,
+    getMobileSyncSnapshot,
+    getMobileSyncSnapshot,
+  );
+  const [mode, setMode] = useState<SheetMode>("status");
+  const [recoveryKey, setRecoveryKey] = useState("");
+  const [generatedKey, setGeneratedKey] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
   const planLabel = auth.bypass
     ? "Local dev"
     : auth.billing.plan === "trial"
@@ -25,43 +128,310 @@ export function ProfileSheet({
       : auth.billing.plan === "pro"
         ? "Pro"
         : "Free";
+  const copy = phaseCopy[sync.phase];
+  const detail = statusDetail(sync);
+
+  const close = () => {
+    if (mode === "generated" || busy) return;
+    setMode("status");
+    setRecoveryKey("");
+    setActionError(null);
+    onClose();
+  };
+
+  const createRecoveryKey = async () => {
+    setBusy(true);
+    setActionError(null);
+    try {
+      const key = await createMobileRecoveryKey();
+      setGeneratedKey(key);
+      setMode("generated");
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : "Could not create the key.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const importRecoveryKey = async () => {
+    if (!recoveryKey.trim()) {
+      setActionError("Enter your recovery key.");
+      return;
+    }
+    setBusy(true);
+    setActionError(null);
+    try {
+      await importMobileRecoveryKey(recoveryKey);
+      setRecoveryKey("");
+      setMode("status");
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : "Could not use this key.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const shareRecoveryKey = async () => {
+    setActionError(null);
+    try {
+      await Share.share({
+        title: "Anarlog recovery key",
+        message: `Anarlog recovery key\n\n${generatedKey}`,
+      });
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : "Could not share the key.",
+      );
+    }
+  };
+
+  const finishRecoveryKey = () => {
+    setGeneratedKey("");
+    setMode("status");
+  };
+
+  const renderStatusActions = () => {
+    if (auth.bypass || sync.phase === "inactive") return null;
+    if (sync.phase === "identity_mismatch") {
+      return (
+        <View style={styles.actions}>
+          <Button
+            label="Use recovery key"
+            onPress={() => setMode("import")}
+            size="small"
+          />
+        </View>
+      );
+    }
+    if (sync.phase === "setup_required") {
+      return (
+        <View style={styles.actions}>
+          <Button
+            label="Set up sync"
+            onPress={() => setMode("choose")}
+            size="small"
+          />
+        </View>
+      );
+    }
+    if (sync.phase === "ready") {
+      return (
+        <View style={styles.actions}>
+          <Button
+            label="Sync now"
+            loading={sync.syncingNow}
+            onPress={() => void syncMobileNow()}
+            size="small"
+            variant="outline"
+          />
+        </View>
+      );
+    }
+    if (sync.phase === "not_entitled") {
+      return (
+        <View style={styles.actions}>
+          <Button
+            label="Refresh plan"
+            onPress={() => void auth.refreshBilling()}
+            size="small"
+            variant="outline"
+          />
+        </View>
+      );
+    }
+    if (sync.phase === "reauth_required") {
+      return (
+        <View style={styles.actions}>
+          <Button
+            label="Sign out"
+            onPress={() => {
+              close();
+              void auth.signOut();
+            }}
+            size="small"
+            variant="outline"
+          />
+        </View>
+      );
+    }
+    if (sync.phase === "error" || sync.phase === "device_limit") {
+      return (
+        <View style={styles.actions}>
+          <Button
+            label="Try again"
+            onPress={retryMobileSync}
+            size="small"
+            variant="outline"
+          />
+        </View>
+      );
+    }
+    return null;
+  };
 
   return (
     <Modal
       visible={visible}
       transparent
       animationType="slide"
-      onRequestClose={onClose}
+      onRequestClose={close}
     >
-      <Pressable style={styles.backdrop} onPress={onClose}>
-        <Pressable style={styles.sheet} onPress={(e) => e.stopPropagation()}>
-          <View style={styles.handle} />
-          <View style={styles.row}>
-            <Text style={styles.email} numberOfLines={1}>
-              {auth.bypass ? "Not signed in" : (auth.session?.user.email ?? "")}
-            </Text>
-            <View style={styles.planChip}>
-              <Text style={styles.planLabel}>{planLabel}</Text>
-            </View>
-          </View>
-          <Text style={styles.syncNote}>
-            Notes stay on this device for now. Cloud sync arrives with the
-            native sync bridge.
-          </Text>
-          {!auth.bypass && (
-            <Button
-              label="Sign out"
-              onPress={() => {
-                onClose();
-                void auth.signOut();
-              }}
-              size="small"
-              style={styles.signOut}
-              variant="ghost"
-            />
-          )}
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={styles.backdrop}
+      >
+        <Pressable style={styles.backdropPressable} onPress={close}>
+          <Pressable style={styles.sheet} onPress={(e) => e.stopPropagation()}>
+            <View style={styles.handle} />
+            <ScrollView
+              contentContainerStyle={styles.content}
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+            >
+              <View style={styles.row}>
+                <Text style={styles.email} numberOfLines={1}>
+                  {auth.bypass
+                    ? "Not signed in"
+                    : (auth.session?.user.email ?? "")}
+                </Text>
+                <View style={styles.planChip}>
+                  <Text style={styles.planLabel}>{planLabel}</Text>
+                </View>
+              </View>
+
+              {mode === "status" && (
+                <View style={styles.syncCard}>
+                  <View style={styles.statusHeading}>
+                    <View
+                      style={[
+                        styles.statusDot,
+                        sync.phase === "ready" && sync.running
+                          ? styles.statusDotReady
+                          : styles.statusDotQuiet,
+                      ]}
+                    />
+                    <Text style={styles.eyebrow}>Cloud sync</Text>
+                  </View>
+                  <Text style={styles.syncTitle}>{copy.title}</Text>
+                  <Text style={styles.syncDescription}>{copy.description}</Text>
+                  {detail && <Text style={styles.syncDetail}>{detail}</Text>}
+                  {renderStatusActions()}
+                </View>
+              )}
+
+              {mode === "choose" && (
+                <View style={styles.setup}>
+                  <Text style={styles.setupTitle}>Set up encrypted sync</Text>
+                  <Text style={styles.setupDescription}>
+                    Your recovery key protects every synced note. Anarlog cannot
+                    recover it for you.
+                  </Text>
+                  <Button
+                    label="Create a recovery key"
+                    loading={busy}
+                    onPress={() => void createRecoveryKey()}
+                  />
+                  <Button
+                    label="Use an existing key"
+                    disabled={busy}
+                    onPress={() => {
+                      setActionError(null);
+                      setMode("import");
+                    }}
+                    variant="outline"
+                  />
+                  <Button
+                    label="Back"
+                    disabled={busy}
+                    onPress={() => setMode("status")}
+                    size="small"
+                    variant="ghost"
+                  />
+                </View>
+              )}
+
+              {mode === "import" && (
+                <View style={styles.setup}>
+                  <Text style={styles.setupTitle}>Use a recovery key</Text>
+                  <Text style={styles.setupDescription}>
+                    Enter the key saved from Anarlog on another device.
+                  </Text>
+                  <TextInput
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    editable={!busy}
+                    multiline
+                    onChangeText={setRecoveryKey}
+                    placeholder="Paste recovery key"
+                    placeholderTextColor={Colors.muted}
+                    style={styles.keyInput}
+                    value={recoveryKey}
+                  />
+                  <Button
+                    label="Use this key"
+                    loading={busy}
+                    onPress={() => void importRecoveryKey()}
+                  />
+                  <Button
+                    label="Back"
+                    disabled={busy}
+                    onPress={() => {
+                      setActionError(null);
+                      setMode("choose");
+                    }}
+                    size="small"
+                    variant="ghost"
+                  />
+                </View>
+              )}
+
+              {mode === "generated" && (
+                <View style={styles.setup}>
+                  <Text style={styles.setupTitle}>Save your recovery key</Text>
+                  <Text style={styles.setupDescription}>
+                    Keep this in a password manager. You will need it to add
+                    another device or recover your synced notes.
+                  </Text>
+                  <View style={styles.generatedKeyBox}>
+                    <Text selectable style={styles.generatedKey}>
+                      {generatedKey}
+                    </Text>
+                  </View>
+                  <Button
+                    label="Save recovery key"
+                    onPress={() => void shareRecoveryKey()}
+                    variant="outline"
+                  />
+                  <Button label="I saved it" onPress={finishRecoveryKey} />
+                </View>
+              )}
+
+              {actionError && (
+                <Text accessibilityLiveRegion="polite" style={styles.error}>
+                  {actionError}
+                </Text>
+              )}
+
+              {!auth.bypass && mode === "status" && (
+                <Button
+                  label="Sign out"
+                  onPress={() => {
+                    close();
+                    void auth.signOut();
+                  }}
+                  size="small"
+                  style={styles.signOut}
+                  variant="ghost"
+                />
+              )}
+            </ScrollView>
+          </Pressable>
         </Pressable>
-      </Pressable>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }
@@ -69,16 +439,23 @@ export function ProfileSheet({
 const styles = StyleSheet.create({
   backdrop: {
     flex: 1,
+  },
+  backdropPressable: {
+    flex: 1,
     justifyContent: "flex-end",
     backgroundColor: Colors.scrim,
   },
   sheet: {
+    maxHeight: "88%",
     backgroundColor: Colors.surface,
     borderTopLeftRadius: Radius.sheet,
     borderTopRightRadius: Radius.sheet,
     paddingHorizontal: Spacing.lg,
     paddingBottom: Spacing.xl,
     paddingTop: Spacing.sm,
+  },
+  content: {
+    paddingBottom: Spacing.md,
   },
   handle: {
     alignSelf: "center",
@@ -113,10 +490,97 @@ const styles = StyleSheet.create({
     ...Typography.captionStrong,
     color: Colors.ink,
   },
-  syncNote: {
-    marginTop: Spacing.md,
+  syncCard: {
+    marginTop: Spacing.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: Colors.border,
+    borderRadius: Radius.card,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.background,
+    padding: Spacing.md,
+  },
+  statusHeading: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.sm,
+    marginBottom: Spacing.sm,
+  },
+  statusDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  statusDotReady: {
+    backgroundColor: Colors.primary,
+  },
+  statusDotQuiet: {
+    backgroundColor: Colors.border,
+  },
+  eyebrow: {
+    ...Typography.captionStrong,
+    color: Colors.muted,
+  },
+  syncTitle: {
+    ...Typography.section,
+    color: Colors.ink,
+  },
+  syncDescription: {
+    marginTop: Spacing.xs,
     ...Typography.body,
     color: Colors.muted,
+  },
+  syncDetail: {
+    marginTop: Spacing.sm,
+    ...Typography.caption,
+    color: Colors.muted,
+  },
+  actions: {
+    marginTop: Spacing.md,
+    flexDirection: "row",
+  },
+  setup: {
+    marginTop: Spacing.lg,
+    gap: Spacing.sm,
+  },
+  setupTitle: {
+    ...Typography.title,
+    color: Colors.ink,
+  },
+  setupDescription: {
+    marginBottom: Spacing.sm,
+    ...Typography.body,
+    color: Colors.muted,
+  },
+  keyInput: {
+    minHeight: 108,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: Colors.border,
+    borderRadius: Radius.control,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.background,
+    padding: Spacing.md,
+    ...Typography.body,
+    color: Colors.ink,
+    fontFamily: Platform.select({ ios: "Menlo", android: "monospace" }),
+    textAlignVertical: "top",
+  },
+  generatedKeyBox: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: Colors.border,
+    borderRadius: Radius.control,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.background,
+    padding: Spacing.md,
+  },
+  generatedKey: {
+    ...Typography.body,
+    color: Colors.ink,
+    fontFamily: Platform.select({ ios: "Menlo", android: "monospace" }),
+  },
+  error: {
+    marginTop: Spacing.sm,
+    ...Typography.caption,
+    color: Colors.destructive,
   },
   signOut: {
     marginTop: Spacing.lg,

--- a/apps/mobile/src/sync/controller.test.mjs
+++ b/apps/mobile/src/sync/controller.test.mjs
@@ -121,14 +121,18 @@ test("ignores a stale activation before booting the next account", async () => {
   assert.deepEqual(bootstrappedAccounts, ["user-456"]);
 });
 
-test("stores and returns a generated key before replica startup completes", async () => {
+test("does not store or claim a generated key until confirmation", async () => {
   let saved;
+  let claimCount = 0;
   let resolveBootstrap;
   const controller = new MobileSyncController(
     dependencies({
       readRecoveryKey: async () => saved ?? null,
       saveRecoveryKey: async (_accountUserId, recoveryKey) => {
         saved = recoveryKey;
+      },
+      claimIdentity: async () => {
+        claimCount += 1;
       },
       bootstrap: async () =>
         await new Promise((resolve) => {
@@ -141,9 +145,15 @@ test("stores and returns a generated key before replica startup completes", asyn
   controller.activate(session);
   await waitFor(() => controller.getSnapshot().phase === "setup_required");
 
-  const recoveryKey = await controller.createRecoveryKey();
+  const recoveryKey = await controller.generateRecoveryKey();
   assert.equal(recoveryKey, "generated-recovery-key");
+  assert.equal(saved, undefined);
+  assert.equal(claimCount, 0);
+  assert.equal(controller.getSnapshot().phase, "setup_required");
+
+  await controller.confirmRecoveryKey(recoveryKey);
   assert.equal(saved, recoveryKey);
+  assert.equal(claimCount, 1);
   await waitFor(() => resolveBootstrap !== undefined);
   resolveBootstrap("configured");
   await waitFor(() => controller.getSnapshot().phase === "ready");
@@ -172,13 +182,15 @@ test("rolls back secure storage when the server rejects a new identity", async (
   controller.activate(session);
   await waitFor(() => controller.getSnapshot().phase === "setup_required");
 
-  await assert.rejects(controller.createRecoveryKey(), /identity mismatch/);
+  await assert.rejects(
+    controller.confirmRecoveryKey("generated-recovery-key"),
+    /identity mismatch/,
+  );
   assert.equal(deleted, true);
   assert.equal(saved, null);
 });
 
 test("uses the refreshed session when setup finishes", async () => {
-  let resolveGeneratedKey;
   let saved = null;
   let claimedAccessToken;
   let bootstrappedAccessToken;
@@ -188,10 +200,6 @@ test("uses the refreshed session when setup finishes", async () => {
       saveRecoveryKey: async (_accountUserId, recoveryKey) => {
         saved = recoveryKey;
       },
-      generateRecoveryKey: async () =>
-        await new Promise((resolve) => {
-          resolveGeneratedKey = resolve;
-        }),
       claimIdentity: async (activeSession) => {
         claimedAccessToken = activeSession.accessToken;
       },
@@ -205,16 +213,68 @@ test("uses the refreshed session when setup finishes", async () => {
   );
   controller.activate(session);
   await waitFor(() => controller.getSnapshot().phase === "setup_required");
-  const setup = controller.createRecoveryKey();
-  await waitFor(() => resolveGeneratedKey !== undefined);
+  const recoveryKey = await controller.generateRecoveryKey();
 
   controller.activate({ ...session, accessToken: "refreshed-token" });
-  resolveGeneratedKey("generated-recovery-key");
-  await setup;
+  await waitFor(() => controller.getSnapshot().phase === "setup_required");
+  await controller.confirmRecoveryKey(recoveryKey);
   await waitFor(() => controller.getSnapshot().phase === "ready");
 
   assert.equal(claimedAccessToken, "refreshed-token");
   assert.equal(bootstrappedAccessToken, "refreshed-token");
+});
+
+test("does not leave a stale poll interval after re-activation", async () => {
+  let nextTimerId = 0;
+  const intervals = new Map();
+  const timeouts = new Map();
+  const timers = {
+    setInterval: (callback) => {
+      nextTimerId += 1;
+      intervals.set(nextTimerId, callback);
+      return nextTimerId;
+    },
+    clearInterval: (id) => {
+      intervals.delete(id);
+    },
+    setTimeout: (callback) => {
+      nextTimerId += 1;
+      timeouts.set(nextTimerId, callback);
+      return nextTimerId;
+    },
+    clearTimeout: (id) => {
+      timeouts.delete(id);
+    },
+  };
+  let statusCalls = 0;
+  let resolveFirstStatus;
+  const controller = new MobileSyncController(
+    dependencies({
+      getStatus: async () => {
+        statusCalls += 1;
+        if (statusCalls === 1) {
+          return await new Promise((resolve) => {
+            resolveFirstStatus = resolve;
+          });
+        }
+        return status;
+      },
+    }),
+    5_000,
+    0,
+    timers,
+  );
+  controller.activate(session);
+  await waitFor(() => resolveFirstStatus !== undefined);
+
+  controller.activate({ ...session, accessToken: "refreshed-token" });
+  resolveFirstStatus(status);
+  await waitFor(() => controller.getSnapshot().phase === "ready");
+  assert.equal(intervals.size, 1);
+
+  controller.suspend();
+  await waitFor(() => controller.getSnapshot().phase === "inactive");
+  assert.equal(intervals.size, 0);
 });
 
 test("stops native sync when the account lifecycle ends", async () => {

--- a/apps/mobile/src/sync/controller.test.mjs
+++ b/apps/mobile/src/sync/controller.test.mjs
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MobileSyncController } from "./controller.ts";
+
+const session = {
+  apiUrl: "https://api.anarlog.test",
+  accessToken: "access-token",
+  accountUserId: "user-123",
+};
+
+const status = {
+  configured: true,
+  running: true,
+  has_unsent_changes: false,
+  last_sync_at_ms: 1234,
+  last_error: null,
+  consecutive_failures: 0,
+};
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.fail("condition was not reached");
+}
+
+function dependencies(overrides = {}) {
+  return {
+    readRecoveryKey: async () => "recovery-key",
+    saveRecoveryKey: async () => {},
+    deleteRecoveryKey: async () => {},
+    generateRecoveryKey: async () => "generated-recovery-key",
+    inspectRecoveryKey: async () => ({
+      keyId: "ABCDEFGHIJKLMNOPQRSTUV",
+      memberPublicKey: "A".repeat(43),
+    }),
+    claimIdentity: async () => {},
+    getDevice: async () => ({ fingerprint: "device-1234" }),
+    bootstrap: async () => "configured",
+    stop: async () => {},
+    syncNow: async () => {},
+    getStatus: async () => status,
+    reportError: () => {},
+    ...overrides,
+  };
+}
+
+test("requires explicit recovery-key setup when this account has no key", async () => {
+  const controller = new MobileSyncController(
+    dependencies({ readRecoveryKey: async () => null }),
+    0,
+    0,
+  );
+  controller.activate(session);
+
+  await waitFor(() => controller.getSnapshot().phase === "setup_required");
+  assert.equal(controller.getSnapshot().running, false);
+});
+
+test("boots the native replica with the stored account key", async () => {
+  let bootstrapArguments;
+  const controller = new MobileSyncController(
+    dependencies({
+      bootstrap: async (...args) => {
+        bootstrapArguments = args;
+        return "configured";
+      },
+    }),
+    0,
+    0,
+  );
+  controller.activate(session);
+
+  await waitFor(() => controller.getSnapshot().phase === "ready");
+  assert.deepEqual(bootstrapArguments, [
+    session,
+    "recovery-key",
+    { fingerprint: "device-1234" },
+  ]);
+  assert.deepEqual(controller.getSnapshot(), {
+    phase: "ready",
+    running: true,
+    syncingNow: false,
+    hasUnsentChanges: false,
+    lastSyncAtMs: 1234,
+    errorMessage: null,
+    consecutiveFailures: 0,
+  });
+});
+
+test("ignores a stale activation before booting the next account", async () => {
+  let resolveFirstRead;
+  const readRecoveryKey = (accountUserId) => {
+    if (accountUserId === "user-123") {
+      return new Promise((resolve) => {
+        resolveFirstRead = resolve;
+      });
+    }
+    return Promise.resolve("second-key");
+  };
+  const bootstrappedAccounts = [];
+  const controller = new MobileSyncController(
+    dependencies({
+      readRecoveryKey,
+      bootstrap: async (activeSession) => {
+        bootstrappedAccounts.push(activeSession.accountUserId);
+        return "configured";
+      },
+    }),
+    0,
+    0,
+  );
+  controller.activate(session);
+  await waitFor(() => resolveFirstRead !== undefined);
+  controller.activate({ ...session, accountUserId: "user-456" });
+  resolveFirstRead("first-key");
+
+  await waitFor(() => controller.getSnapshot().phase === "ready");
+  assert.deepEqual(bootstrappedAccounts, ["user-456"]);
+});
+
+test("stores and returns a generated key before replica startup completes", async () => {
+  let saved;
+  let resolveBootstrap;
+  const controller = new MobileSyncController(
+    dependencies({
+      readRecoveryKey: async () => saved ?? null,
+      saveRecoveryKey: async (_accountUserId, recoveryKey) => {
+        saved = recoveryKey;
+      },
+      bootstrap: async () =>
+        await new Promise((resolve) => {
+          resolveBootstrap = resolve;
+        }),
+    }),
+    0,
+    0,
+  );
+  controller.activate(session);
+  await waitFor(() => controller.getSnapshot().phase === "setup_required");
+
+  const recoveryKey = await controller.createRecoveryKey();
+  assert.equal(recoveryKey, "generated-recovery-key");
+  assert.equal(saved, recoveryKey);
+  await waitFor(() => resolveBootstrap !== undefined);
+  resolveBootstrap("configured");
+  await waitFor(() => controller.getSnapshot().phase === "ready");
+});
+
+test("rolls back secure storage when the server rejects a new identity", async () => {
+  let saved = null;
+  let deleted = false;
+  const controller = new MobileSyncController(
+    dependencies({
+      readRecoveryKey: async () => saved,
+      saveRecoveryKey: async (_accountUserId, recoveryKey) => {
+        saved = recoveryKey;
+      },
+      deleteRecoveryKey: async () => {
+        deleted = true;
+        saved = null;
+      },
+      claimIdentity: async () => {
+        throw new Error("identity mismatch");
+      },
+    }),
+    0,
+    0,
+  );
+  controller.activate(session);
+  await waitFor(() => controller.getSnapshot().phase === "setup_required");
+
+  await assert.rejects(controller.createRecoveryKey(), /identity mismatch/);
+  assert.equal(deleted, true);
+  assert.equal(saved, null);
+});
+
+test("uses the refreshed session when setup finishes", async () => {
+  let resolveGeneratedKey;
+  let saved = null;
+  let claimedAccessToken;
+  let bootstrappedAccessToken;
+  const controller = new MobileSyncController(
+    dependencies({
+      readRecoveryKey: async () => saved,
+      saveRecoveryKey: async (_accountUserId, recoveryKey) => {
+        saved = recoveryKey;
+      },
+      generateRecoveryKey: async () =>
+        await new Promise((resolve) => {
+          resolveGeneratedKey = resolve;
+        }),
+      claimIdentity: async (activeSession) => {
+        claimedAccessToken = activeSession.accessToken;
+      },
+      bootstrap: async (activeSession) => {
+        bootstrappedAccessToken = activeSession.accessToken;
+        return "configured";
+      },
+    }),
+    0,
+    0,
+  );
+  controller.activate(session);
+  await waitFor(() => controller.getSnapshot().phase === "setup_required");
+  const setup = controller.createRecoveryKey();
+  await waitFor(() => resolveGeneratedKey !== undefined);
+
+  controller.activate({ ...session, accessToken: "refreshed-token" });
+  resolveGeneratedKey("generated-recovery-key");
+  await setup;
+  await waitFor(() => controller.getSnapshot().phase === "ready");
+
+  assert.equal(claimedAccessToken, "refreshed-token");
+  assert.equal(bootstrappedAccessToken, "refreshed-token");
+});
+
+test("stops native sync when the account lifecycle ends", async () => {
+  let stopCount = 0;
+  const controller = new MobileSyncController(
+    dependencies({
+      stop: async () => {
+        stopCount += 1;
+      },
+    }),
+    0,
+    0,
+  );
+  controller.activate(session);
+  await waitFor(() => controller.getSnapshot().phase === "ready");
+
+  controller.suspend();
+  await waitFor(() => stopCount === 2);
+  assert.equal(controller.getSnapshot().phase, "inactive");
+});

--- a/apps/mobile/src/sync/controller.ts
+++ b/apps/mobile/src/sync/controller.ts
@@ -62,6 +62,13 @@ type ControllerDependencies = {
   reportError: (error: unknown, operation: string) => void;
 };
 
+type ControllerTimers = {
+  setInterval: typeof setInterval;
+  clearInterval: typeof clearInterval;
+  setTimeout: typeof setTimeout;
+  clearTimeout: typeof clearTimeout;
+};
+
 const initialSnapshot: MobileSyncSnapshot = {
   phase: "inactive",
   running: false,
@@ -106,15 +113,23 @@ export class MobileSyncController {
   private readonly dependencies: ControllerDependencies;
   private readonly pollIntervalMs: number;
   private readonly retryDelayMs: number;
+  private readonly timers: ControllerTimers;
 
   constructor(
     dependencies: ControllerDependencies,
     pollIntervalMs = 5_000,
     retryDelayMs = 15_000,
+    timers: ControllerTimers = {
+      setInterval,
+      clearInterval,
+      setTimeout,
+      clearTimeout,
+    },
   ) {
     this.dependencies = dependencies;
     this.pollIntervalMs = pollIntervalMs;
     this.retryDelayMs = retryDelayMs;
+    this.timers = timers;
   }
 
   subscribe = (listener: () => void): (() => void) => {
@@ -154,13 +169,17 @@ export class MobileSyncController {
     }
   }
 
-  async createRecoveryKey(): Promise<string> {
-    const session = this.requireSession();
+  async generateRecoveryKey(): Promise<string> {
     const recoveryKey = await this.dependencies.generateRecoveryKey();
+    await this.dependencies.inspectRecoveryKey(recoveryKey);
+    return recoveryKey;
+  }
+
+  async confirmRecoveryKey(recoveryKey: string): Promise<void> {
+    const session = this.requireSession();
     const identity = await this.dependencies.inspectRecoveryKey(recoveryKey);
     await this.storeAndClaimIdentity(session, recoveryKey, identity.keyId);
     this.activateIfCurrentAccount(session.accountUserId);
-    return recoveryKey;
   }
 
   async importRecoveryKey(recoveryKey: string): Promise<void> {
@@ -231,6 +250,7 @@ export class MobileSyncController {
 
       this.update({ ...initialSnapshot, phase: "ready", running: true });
       await this.refreshStatus(generation);
+      if (generation !== this.generation) return;
       this.startPolling(generation);
     } catch (error) {
       if (generation !== this.generation) return;
@@ -267,14 +287,14 @@ export class MobileSyncController {
 
   private startPolling(generation: number): void {
     if (this.pollIntervalMs <= 0) return;
-    this.pollTimer = setInterval(() => {
+    this.pollTimer = this.timers.setInterval(() => {
       void this.refreshStatus(generation);
     }, this.pollIntervalMs);
   }
 
   private scheduleRetry(generation: number): void {
     if (this.retryDelayMs <= 0) return;
-    this.retryTimer = setTimeout(() => {
+    this.retryTimer = this.timers.setTimeout(() => {
       if (generation === this.generation && this.session) {
         this.activate(this.session);
       }
@@ -341,8 +361,8 @@ export class MobileSyncController {
   }
 
   private clearTimers(): void {
-    if (this.pollTimer) clearInterval(this.pollTimer);
-    if (this.retryTimer) clearTimeout(this.retryTimer);
+    if (this.pollTimer) this.timers.clearInterval(this.pollTimer);
+    if (this.retryTimer) this.timers.clearTimeout(this.retryTimer);
     this.pollTimer = null;
     this.retryTimer = null;
   }

--- a/apps/mobile/src/sync/controller.ts
+++ b/apps/mobile/src/sync/controller.ts
@@ -1,0 +1,354 @@
+export type MobileSyncPhase =
+  | "inactive"
+  | "starting"
+  | "setup_required"
+  | "ready"
+  | "error"
+  | "device_limit"
+  | "identity_mismatch"
+  | "not_entitled"
+  | "reauth_required"
+  | "account_mismatch";
+
+export type MobileSyncSnapshot = {
+  phase: MobileSyncPhase;
+  running: boolean;
+  syncingNow: boolean;
+  hasUnsentChanges: boolean | null;
+  lastSyncAtMs: number | null;
+  errorMessage: string | null;
+  consecutiveFailures: number;
+};
+
+export type MobileSyncSession = {
+  apiUrl: string;
+  accessToken: string;
+  accountUserId: string;
+};
+
+type NativeSyncStatus = {
+  configured: boolean;
+  running: boolean;
+  has_unsent_changes: boolean | null;
+  last_sync_at_ms: number | null;
+  last_error: string | null;
+  consecutive_failures: number;
+};
+
+type ControllerDependencies = {
+  readRecoveryKey: (accountUserId: string) => Promise<string | null>;
+  saveRecoveryKey: (
+    accountUserId: string,
+    recoveryKey: string,
+  ) => Promise<void>;
+  deleteRecoveryKey: (accountUserId: string) => Promise<void>;
+  generateRecoveryKey: () => Promise<string>;
+  inspectRecoveryKey: (
+    recoveryKey: string,
+  ) => Promise<{ keyId: string; memberPublicKey: string }>;
+  claimIdentity: (session: MobileSyncSession, keyId: string) => Promise<void>;
+  getDevice: () => Promise<{
+    fingerprint?: string | null;
+    name?: string | null;
+  }>;
+  bootstrap: (
+    session: MobileSyncSession,
+    recoveryKey: string,
+    device: { fingerprint?: string | null; name?: string | null },
+  ) => Promise<"configured" | "account_mismatch">;
+  stop: () => Promise<void>;
+  syncNow: () => Promise<void>;
+  getStatus: () => Promise<NativeSyncStatus>;
+  reportError: (error: unknown, operation: string) => void;
+};
+
+const initialSnapshot: MobileSyncSnapshot = {
+  phase: "inactive",
+  running: false,
+  syncingNow: false,
+  hasUnsentChanges: null,
+  lastSyncAtMs: null,
+  errorMessage: null,
+  consecutiveFailures: 0,
+};
+
+const errorPhases = new Set<MobileSyncPhase>([
+  "device_limit",
+  "identity_mismatch",
+  "not_entitled",
+  "reauth_required",
+]);
+
+function errorPhase(error: unknown): MobileSyncPhase {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return "error";
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" && errorPhases.has(code as MobileSyncPhase)
+    ? (code as MobileSyncPhase)
+    : "error";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Cloud sync is temporarily unavailable.";
+}
+
+export class MobileSyncController {
+  private snapshot = initialSnapshot;
+  private readonly listeners = new Set<() => void>();
+  private session: MobileSyncSession | null = null;
+  private generation = 0;
+  private operationQueue: Promise<void> = Promise.resolve();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly dependencies: ControllerDependencies;
+  private readonly pollIntervalMs: number;
+  private readonly retryDelayMs: number;
+
+  constructor(
+    dependencies: ControllerDependencies,
+    pollIntervalMs = 5_000,
+    retryDelayMs = 15_000,
+  ) {
+    this.dependencies = dependencies;
+    this.pollIntervalMs = pollIntervalMs;
+    this.retryDelayMs = retryDelayMs;
+  }
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  getSnapshot = (): MobileSyncSnapshot => this.snapshot;
+
+  activate(session: MobileSyncSession): () => void {
+    this.generation += 1;
+    const generation = this.generation;
+    this.session = session;
+    this.clearTimers();
+    this.update({ ...initialSnapshot, phase: "starting" });
+    this.enqueue(async () => this.start(generation, session));
+    return () => {
+      if (this.generation === generation) {
+        this.suspend();
+      }
+    };
+  }
+
+  suspend(): void {
+    this.generation += 1;
+    this.session = null;
+    this.clearTimers();
+    this.update(initialSnapshot);
+    this.enqueue(async () => {
+      await this.stopSafely();
+    });
+  }
+
+  retry(): void {
+    if (this.session) {
+      this.activate(this.session);
+    }
+  }
+
+  async createRecoveryKey(): Promise<string> {
+    const session = this.requireSession();
+    const recoveryKey = await this.dependencies.generateRecoveryKey();
+    const identity = await this.dependencies.inspectRecoveryKey(recoveryKey);
+    await this.storeAndClaimIdentity(session, recoveryKey, identity.keyId);
+    this.activateIfCurrentAccount(session.accountUserId);
+    return recoveryKey;
+  }
+
+  async importRecoveryKey(recoveryKey: string): Promise<void> {
+    const session = this.requireSession();
+    const normalized = recoveryKey.trim();
+    const identity = await this.dependencies.inspectRecoveryKey(normalized);
+    await this.storeAndClaimIdentity(session, normalized, identity.keyId);
+    this.activateIfCurrentAccount(session.accountUserId);
+  }
+
+  async syncNow(): Promise<void> {
+    if (this.snapshot.phase !== "ready" || this.snapshot.syncingNow) {
+      return;
+    }
+    const generation = this.generation;
+    this.update({ ...this.snapshot, syncingNow: true, errorMessage: null });
+    try {
+      await this.dependencies.syncNow();
+      await this.refreshStatus(generation);
+    } catch (error) {
+      this.dependencies.reportError(error, "mobile_sync_now");
+      if (generation === this.generation) {
+        this.update({
+          ...this.snapshot,
+          errorMessage: errorMessage(error),
+        });
+      }
+    } finally {
+      if (generation === this.generation) {
+        this.update({ ...this.snapshot, syncingNow: false });
+      }
+    }
+  }
+
+  private enqueue(operation: () => Promise<void>): void {
+    this.operationQueue = this.operationQueue.then(operation, operation);
+  }
+
+  private async start(
+    generation: number,
+    session: MobileSyncSession,
+  ): Promise<void> {
+    await this.stopSafely();
+    if (generation !== this.generation) return;
+
+    try {
+      const recoveryKey = await this.dependencies.readRecoveryKey(
+        session.accountUserId,
+      );
+      if (generation !== this.generation) return;
+      if (!recoveryKey) {
+        this.update({ ...initialSnapshot, phase: "setup_required" });
+        return;
+      }
+
+      const device = await this.dependencies.getDevice();
+      if (generation !== this.generation) return;
+      const result = await this.dependencies.bootstrap(
+        session,
+        recoveryKey,
+        device,
+      );
+      if (generation !== this.generation) return;
+      if (result === "account_mismatch") {
+        this.update({ ...initialSnapshot, phase: "account_mismatch" });
+        return;
+      }
+
+      this.update({ ...initialSnapshot, phase: "ready", running: true });
+      await this.refreshStatus(generation);
+      this.startPolling(generation);
+    } catch (error) {
+      if (generation !== this.generation) return;
+      const phase = errorPhase(error);
+      this.dependencies.reportError(error, "mobile_sync_start");
+      this.update({
+        ...initialSnapshot,
+        phase,
+        errorMessage: errorMessage(error),
+      });
+      if (phase === "error") {
+        this.scheduleRetry(generation);
+      }
+    }
+  }
+
+  private async refreshStatus(generation: number): Promise<void> {
+    try {
+      const status = await this.dependencies.getStatus();
+      if (generation !== this.generation) return;
+      this.update({
+        ...this.snapshot,
+        phase: "ready",
+        running: status.running,
+        hasUnsentChanges: status.has_unsent_changes,
+        lastSyncAtMs: status.last_sync_at_ms,
+        errorMessage: status.last_error,
+        consecutiveFailures: status.consecutive_failures,
+      });
+    } catch (error) {
+      this.dependencies.reportError(error, "mobile_sync_status");
+    }
+  }
+
+  private startPolling(generation: number): void {
+    if (this.pollIntervalMs <= 0) return;
+    this.pollTimer = setInterval(() => {
+      void this.refreshStatus(generation);
+    }, this.pollIntervalMs);
+  }
+
+  private scheduleRetry(generation: number): void {
+    if (this.retryDelayMs <= 0) return;
+    this.retryTimer = setTimeout(() => {
+      if (generation === this.generation && this.session) {
+        this.activate(this.session);
+      }
+    }, this.retryDelayMs);
+  }
+
+  private async stopSafely(): Promise<void> {
+    try {
+      await this.dependencies.stop();
+    } catch (error) {
+      this.dependencies.reportError(error, "mobile_sync_stop");
+    }
+  }
+
+  private requireSession(): MobileSyncSession {
+    if (!this.session) {
+      throw new Error("Sign in to configure cloud sync.");
+    }
+    return this.session;
+  }
+
+  private async storeAndClaimIdentity(
+    session: MobileSyncSession,
+    recoveryKey: string,
+    keyId: string,
+  ): Promise<void> {
+    const previousKey = await this.dependencies.readRecoveryKey(
+      session.accountUserId,
+    );
+    await this.dependencies.saveRecoveryKey(session.accountUserId, recoveryKey);
+    try {
+      const currentSession = this.session;
+      if (
+        !currentSession ||
+        currentSession.accountUserId !== session.accountUserId
+      ) {
+        throw new Error("The signed-in account changed during sync setup.");
+      }
+      await this.dependencies.claimIdentity(currentSession, keyId);
+    } catch (error) {
+      try {
+        if (previousKey) {
+          await this.dependencies.saveRecoveryKey(
+            session.accountUserId,
+            previousKey,
+          );
+        } else {
+          await this.dependencies.deleteRecoveryKey(session.accountUserId);
+        }
+      } catch (rollbackError) {
+        this.dependencies.reportError(
+          rollbackError,
+          "mobile_sync_identity_rollback",
+        );
+      }
+      throw error;
+    }
+  }
+
+  private activateIfCurrentAccount(accountUserId: string): void {
+    if (this.session?.accountUserId === accountUserId) {
+      this.activate(this.session);
+    }
+  }
+
+  private clearTimers(): void {
+    if (this.pollTimer) clearInterval(this.pollTimer);
+    if (this.retryTimer) clearTimeout(this.retryTimer);
+    this.pollTimer = null;
+    this.retryTimer = null;
+  }
+
+  private update(snapshot: MobileSyncSnapshot): void {
+    this.snapshot = snapshot;
+    for (const listener of this.listeners) listener();
+  }
+}

--- a/apps/mobile/src/sync/identity.test.mjs
+++ b/apps/mobile/src/sync/identity.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { claimReplicaIdentity } from "./identity.ts";
+import { ReplicaCredentialError } from "./replica-credentials.ts";
+
+const keyId = "ABCDEFGHIJKLMNOPQRSTUV";
+
+test("claims the account identity with the inspected key id", async () => {
+  let request;
+  await claimReplicaIdentity({
+    apiUrl: "https://api.anarlog.test/base",
+    accessToken: "access-token",
+    keyId,
+    fetcher: async (input, init) => {
+      request = { input, init };
+      return Response.json({ keyId });
+    },
+  });
+
+  assert.equal(
+    request.input.toString(),
+    "https://api.anarlog.test/sync/e2ee/identity",
+  );
+  assert.equal(request.init.method, "PUT");
+  assert.equal(
+    new Headers(request.init.headers).get("authorization"),
+    "Bearer access-token",
+  );
+  assert.deepEqual(JSON.parse(request.init.body), { keyId });
+});
+
+test("does not replace an existing account identity", async () => {
+  await assert.rejects(
+    claimReplicaIdentity({
+      apiUrl: "https://api.anarlog.test",
+      accessToken: "access-token",
+      keyId,
+      fetcher: async () => new Response(null, { status: 409 }),
+    }),
+    (error) =>
+      error instanceof ReplicaCredentialError &&
+      error.code === "identity_mismatch",
+  );
+});
+
+test("rejects a response for another identity", async () => {
+  await assert.rejects(
+    claimReplicaIdentity({
+      apiUrl: "https://api.anarlog.test",
+      accessToken: "access-token",
+      keyId,
+      fetcher: async () => Response.json({ keyId: "B".repeat(22) }),
+    }),
+    (error) =>
+      error instanceof ReplicaCredentialError &&
+      error.code === "invalid_response",
+  );
+});

--- a/apps/mobile/src/sync/identity.ts
+++ b/apps/mobile/src/sync/identity.ts
@@ -1,0 +1,67 @@
+import { ReplicaCredentialError } from "./replica-credentials.ts";
+
+const keyIdPattern = /^[A-Za-z0-9_-]{22}$/;
+
+export async function claimReplicaIdentity({
+  apiUrl,
+  accessToken,
+  keyId,
+  timeoutMs = 15_000,
+  fetcher = fetch,
+}: {
+  apiUrl: string;
+  accessToken: string;
+  keyId: string;
+  timeoutMs?: number;
+  fetcher?: typeof fetch;
+}): Promise<void> {
+  if (!keyIdPattern.test(keyId)) {
+    throw new ReplicaCredentialError("invalid_response");
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let response: Response;
+  try {
+    response = await fetcher(new URL("/sync/e2ee/identity", apiUrl), {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ keyId }),
+      signal: controller.signal,
+    });
+  } catch {
+    throw new ReplicaCredentialError("unavailable");
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (response.status === 401) {
+    throw new ReplicaCredentialError("reauth_required");
+  }
+  if (response.status === 403) {
+    throw new ReplicaCredentialError("not_entitled");
+  }
+  if (response.status === 409) {
+    throw new ReplicaCredentialError("identity_mismatch");
+  }
+  if (!response.ok) {
+    throw new ReplicaCredentialError("unavailable");
+  }
+
+  let value: unknown;
+  try {
+    value = await response.json();
+  } catch {
+    throw new ReplicaCredentialError("invalid_response");
+  }
+  if (
+    !value ||
+    typeof value !== "object" ||
+    (value as Record<string, unknown>).keyId !== keyId
+  ) {
+    throw new ReplicaCredentialError("invalid_response");
+  }
+}

--- a/apps/mobile/src/sync/mobile-sync-lifecycle.tsx
+++ b/apps/mobile/src/sync/mobile-sync-lifecycle.tsx
@@ -1,0 +1,13 @@
+import { useMountEffect } from "@/lib/use-mount-effect";
+import { activateMobileSync } from "@/sync/mobile-sync";
+
+export function MobileSyncLifecycle({
+  accessToken,
+  accountUserId,
+}: {
+  accessToken: string;
+  accountUserId: string;
+}) {
+  useMountEffect(() => activateMobileSync({ accessToken, accountUserId }));
+  return null;
+}

--- a/apps/mobile/src/sync/mobile-sync.ts
+++ b/apps/mobile/src/sync/mobile-sync.ts
@@ -121,8 +121,14 @@ export function retryMobileSync(): void {
   controller.retry();
 }
 
-export async function createMobileRecoveryKey(): Promise<string> {
-  return await controller.createRecoveryKey();
+export async function generateMobileRecoveryKey(): Promise<string> {
+  return await controller.generateRecoveryKey();
+}
+
+export async function confirmMobileRecoveryKey(
+  recoveryKey: string,
+): Promise<void> {
+  await controller.confirmRecoveryKey(recoveryKey);
 }
 
 export async function importMobileRecoveryKey(

--- a/apps/mobile/src/sync/mobile-sync.ts
+++ b/apps/mobile/src/sync/mobile-sync.ts
@@ -1,0 +1,136 @@
+import * as Crypto from "expo-crypto";
+import * as Device from "expo-device";
+import * as SecureStore from "expo-secure-store";
+
+import {
+  bootstrapE2eeReplica,
+  generateE2eeRecoveryKey,
+  getSyncStatus,
+  inspectE2eeRecoveryKey,
+  stopSync,
+  syncNow,
+} from "@/db/client";
+import { env } from "@/lib/env";
+import { captureOperationalError } from "@/lib/error-reporting";
+import { MobileSyncController } from "@/sync/controller";
+import { claimReplicaIdentity } from "@/sync/identity";
+
+const keychainOptions: SecureStore.SecureStoreOptions = {
+  keychainService: "so.anarlog.mobile.cloudsync",
+  keychainAccessible: SecureStore.WHEN_UNLOCKED,
+};
+const deviceFingerprintKey = "anarlog.sync.device-fingerprint";
+const accountIdPattern = /^[A-Za-z0-9_-]{1,128}$/;
+const fingerprintPattern = /^[A-Za-z0-9_-]{8,128}$/;
+
+function recoveryKeyStorageKey(accountUserId: string): string {
+  if (!accountIdPattern.test(accountUserId)) {
+    throw new Error("Unexpected account identity.");
+  }
+  return `anarlog.sync.recovery.${accountUserId}`;
+}
+
+async function getDeviceFingerprint(): Promise<string> {
+  const stored = await SecureStore.getItemAsync(
+    deviceFingerprintKey,
+    keychainOptions,
+  );
+  if (stored && fingerprintPattern.test(stored)) {
+    return stored;
+  }
+
+  const fingerprint = Crypto.randomUUID();
+  await SecureStore.setItemAsync(
+    deviceFingerprintKey,
+    fingerprint,
+    keychainOptions,
+  );
+  return fingerprint;
+}
+
+const controller = new MobileSyncController({
+  readRecoveryKey: async (accountUserId) =>
+    await SecureStore.getItemAsync(
+      recoveryKeyStorageKey(accountUserId),
+      keychainOptions,
+    ),
+  saveRecoveryKey: async (accountUserId, recoveryKey) => {
+    await SecureStore.setItemAsync(
+      recoveryKeyStorageKey(accountUserId),
+      recoveryKey,
+      keychainOptions,
+    );
+  },
+  deleteRecoveryKey: async (accountUserId) => {
+    await SecureStore.deleteItemAsync(
+      recoveryKeyStorageKey(accountUserId),
+      keychainOptions,
+    );
+  },
+  generateRecoveryKey: generateE2eeRecoveryKey,
+  inspectRecoveryKey: inspectE2eeRecoveryKey,
+  claimIdentity: async (session, keyId) => {
+    await claimReplicaIdentity({
+      apiUrl: session.apiUrl,
+      accessToken: session.accessToken,
+      keyId,
+    });
+  },
+  getDevice: async () => ({
+    fingerprint: await getDeviceFingerprint(),
+    name: Device.deviceName ?? Device.modelName,
+  }),
+  bootstrap: async (session, recoveryKeyCode, device) =>
+    await bootstrapE2eeReplica({
+      apiUrl: session.apiUrl,
+      accessToken: session.accessToken,
+      accountUserId: session.accountUserId,
+      recoveryKeyCode,
+      device,
+    }),
+  stop: stopSync,
+  syncNow,
+  getStatus: getSyncStatus,
+  reportError: (error, operation) => {
+    captureOperationalError(error, { operation, level: "warning" });
+  },
+});
+
+export const subscribeMobileSync = controller.subscribe;
+export const getMobileSyncSnapshot = controller.getSnapshot;
+
+export function activateMobileSync({
+  accessToken,
+  accountUserId,
+}: {
+  accessToken: string;
+  accountUserId: string;
+}): () => void {
+  return controller.activate({
+    apiUrl: env.apiUrl,
+    accessToken,
+    accountUserId,
+  });
+}
+
+export function suspendMobileSync(): void {
+  controller.suspend();
+}
+
+export function retryMobileSync(): void {
+  controller.retry();
+}
+
+export async function createMobileRecoveryKey(): Promise<string> {
+  return await controller.createRecoveryKey();
+}
+
+export async function importMobileRecoveryKey(
+  recoveryKey: string,
+): Promise<void> {
+  await controller.importRecoveryKey(recoveryKey);
+}
+
+export async function syncMobileNow(): Promise<void> {
+  await controller.syncNow();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,9 @@ importers:
       expo-router:
         specifier: ~57.0.8
         version: 57.0.8(0f0da6186d8383f761ba3e3050d20429)
+      expo-secure-store:
+        specifier: ~57.0.1
+        version: 57.0.1(expo@57.0.8)
       expo-sharing:
         specifier: ~57.0.12
         version: 57.0.12(expo@57.0.8)(react-native@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
@@ -11472,6 +11475,11 @@ packages:
         optional: true
       react-server-dom-webpack:
         optional: true
+
+  expo-secure-store@57.0.1:
+    resolution: {integrity: sha512-tLa1VmSadOq19mA/dwkl99RbHyjLE0T1qqBYMY3/OsguZTI+rlrDy/DDJjupqlVtmr95hD7o1pYqx5aL+B4YMA==}
+    peerDependencies:
+      expo: '*'
 
   expo-server@57.0.1:
     resolution: {integrity: sha512-sBfVDH6dmKVHZxqUxbfkzS00PZELMZt1IpnHKxcOTMZtR/t7CtRAFrbXcisG+EyzeqHSVDacZT+1tbYfZt5D8w==}
@@ -38382,6 +38390,10 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       pend: 1.2.0
+
+  expo-secure-store@57.0.1(expo@57.0.8):
+    dependencies:
+      expo: 57.0.8(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.7)(expo-router@57.0.8)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
 
   yesql@7.0.0: {}
 


### PR DESCRIPTION
## Summary
- store recovery keys per account with Expo SecureStore and claim the desktop-compatible E2EE identity
- start, poll, retry, refresh, and stop the native replica with stale-session protection
- add desktop-toned Profile setup, import, recovery-key save, status, and manual sync controls

## Validation
- pnpm -F @anlg/mobile typecheck
- pnpm -F @anlg/mobile test (59 tests)
- pnpm exec oxlint --quiet --format=github apps/mobile/src/
- pnpm fmt:check
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm -F @anlg/mobile exec expo config --type public

Simulator/device QA intentionally deferred per product direction; native iOS and Android CI cover this non-release change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches E2EE recovery keys, secure storage, server identity binding, and native replica bootstrap—mistakes could break multi-device encryption or leave keys in a bad state; mitigated by generation guards, rollback on failed claims, and tests.
> 
> **Overview**
> Turns on **end-to-end encrypted cloud sync** on mobile by wiring signed-in sessions to a new sync lifecycle, native replica bootstrap, and profile UI—replacing the previous “sync coming later” placeholder.
> 
> **Lifecycle & orchestration:** `MobileSyncLifecycle` starts sync when the user has a session (keyed on user id + access token) and `suspendMobileSync` runs on sign-out. A `MobileSyncController` drives phases (setup, ready, errors, device limit, identity/account mismatch, etc.), polls native status, retries failures, and ignores stale activations when accounts or tokens change. Recovery keys and a stable device fingerprint live in **Expo SecureStore**; claiming the desktop-compatible identity uses `PUT /sync/e2ee/identity`. Keys are only persisted and claimed after the user confirms a newly generated key, with rollback if the server rejects identity.
> 
> **Profile sheet:** The profile modal now shows live sync status, setup (create vs import recovery key), share/save flow for new keys, contextual actions (sync now, retry, refresh plan, sign out), and keyboard-friendly scrolling.
> 
> **Deps:** Adds `expo-secure-store` to app config and lockfile. Unit tests cover the controller and identity client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e397e642f5ee758cf5efb7747e62f34d5e3141b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->