### PR TITLE
ANLG-144: Sync mobile on foreground resume

### DIFF
--- a/apps/mobile/src/auth/screens.tsx
+++ b/apps/mobile/src/auth/screens.tsx
@@ -140,8 +140,8 @@ export function PaywallScreen({
           <View style={styles.accentDot} />
         </View>
         <Text style={styles.copy}>
-          Record in-person meetings and voice notes from your phone. Notes stay
-          on this device while mobile sync is in development.
+          Record in-person meetings and voice notes from your phone, then keep
+          notes and transcripts in sync with Anarlog on your other devices.
         </Text>
         {accessPending && (
           <Text style={styles.pendingCopy}>

--- a/apps/mobile/src/components/profile-sheet.tsx
+++ b/apps/mobile/src/components/profile-sheet.tsx
@@ -21,7 +21,6 @@ import {
   Spacing,
   Typography,
 } from "@/constants/theme";
-import type { MobileSyncPhase, MobileSyncSnapshot } from "@/sync/controller";
 import {
   confirmMobileRecoveryKey,
   generateMobileRecoveryKey,
@@ -31,77 +30,9 @@ import {
   subscribeMobileSync,
   syncMobileNow,
 } from "@/sync/mobile-sync";
+import { syncStatusPresentation } from "@/sync/status-presentation";
 
 type SheetMode = "status" | "choose" | "import" | "generated";
-
-const phaseCopy: Record<
-  MobileSyncPhase,
-  { title: string; description: string }
-> = {
-  inactive: {
-    title: "Cloud sync is off",
-    description: "Sign in with Anarlog Pro to sync this device.",
-  },
-  starting: {
-    title: "Connecting this device",
-    description: "Preparing your encrypted workspace…",
-  },
-  setup_required: {
-    title: "Protect cloud sync",
-    description:
-      "Create a recovery key, or use the one from another Anarlog device.",
-  },
-  ready: {
-    title: "Cloud sync is on",
-    description: "Your notes sync end-to-end encrypted across your devices.",
-  },
-  error: {
-    title: "Cloud sync needs attention",
-    description: "Your notes are safe on this device. Try connecting again.",
-  },
-  device_limit: {
-    title: "Device limit reached",
-    description: "Anarlog Pro supports cloud sync on up to five devices.",
-  },
-  identity_mismatch: {
-    title: "Use your existing recovery key",
-    description:
-      "This account already has encrypted notes. Use the same key as your other device.",
-  },
-  not_entitled: {
-    title: "Anarlog Pro required",
-    description: "Refresh your plan to continue syncing this device.",
-  },
-  reauth_required: {
-    title: "Sign in again",
-    description: "Your session expired before cloud sync could connect.",
-  },
-  account_mismatch: {
-    title: "This device belongs to another account",
-    description:
-      "Your local notes were created by a different account, so sync stays off to protect both workspaces.",
-  },
-};
-
-function relativeSyncTime(lastSyncAtMs: number | null): string | null {
-  if (!lastSyncAtMs) return null;
-  const elapsedMinutes = Math.max(
-    0,
-    Math.floor((Date.now() - lastSyncAtMs) / 60_000),
-  );
-  if (elapsedMinutes < 1) return "Synced just now";
-  if (elapsedMinutes < 60) return `Synced ${elapsedMinutes}m ago`;
-  const elapsedHours = Math.floor(elapsedMinutes / 60);
-  if (elapsedHours < 24) return `Synced ${elapsedHours}h ago`;
-  return `Synced ${Math.floor(elapsedHours / 24)}d ago`;
-}
-
-function statusDetail(snapshot: MobileSyncSnapshot): string | null {
-  if (snapshot.phase !== "ready") return snapshot.errorMessage;
-  if (snapshot.syncingNow) return "Syncing now…";
-  if (snapshot.hasUnsentChanges) return "Changes waiting to sync";
-  return relativeSyncTime(snapshot.lastSyncAtMs);
-}
 
 export function ProfileSheet({
   visible,
@@ -129,8 +60,7 @@ export function ProfileSheet({
       : auth.billing.plan === "pro"
         ? "Pro"
         : "Free";
-  const copy = phaseCopy[sync.phase];
-  const detail = statusDetail(sync);
+  const presentation = syncStatusPresentation(sync);
 
   const close = () => {
     if (mode === "generated" || busy) return;
@@ -327,16 +257,22 @@ export function ProfileSheet({
                     <View
                       style={[
                         styles.statusDot,
-                        sync.phase === "ready" && sync.running
+                        presentation.healthy
                           ? styles.statusDotReady
-                          : styles.statusDotQuiet,
+                          : presentation.retrying || presentation.pending
+                            ? styles.statusDotRetrying
+                            : styles.statusDotQuiet,
                       ]}
                     />
                     <Text style={styles.eyebrow}>Cloud sync</Text>
                   </View>
-                  <Text style={styles.syncTitle}>{copy.title}</Text>
-                  <Text style={styles.syncDescription}>{copy.description}</Text>
-                  {detail && <Text style={styles.syncDetail}>{detail}</Text>}
+                  <Text style={styles.syncTitle}>{presentation.title}</Text>
+                  <Text style={styles.syncDescription}>
+                    {presentation.description}
+                  </Text>
+                  {presentation.detail && (
+                    <Text style={styles.syncDetail}>{presentation.detail}</Text>
+                  )}
                   {renderStatusActions()}
                 </View>
               )}
@@ -545,6 +481,9 @@ const styles = StyleSheet.create({
   },
   statusDotReady: {
     backgroundColor: Colors.primary,
+  },
+  statusDotRetrying: {
+    backgroundColor: Colors.alertForeground,
   },
   statusDotQuiet: {
     backgroundColor: Colors.border,

--- a/apps/mobile/src/sync/app-state.test.mjs
+++ b/apps/mobile/src/sync/app-state.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldSyncAfterAppStateChange } from "./app-state.ts";
+
+test("requests a sync when the app returns to the foreground", () => {
+  assert.equal(shouldSyncAfterAppStateChange("background", "active"), true);
+  assert.equal(shouldSyncAfterAppStateChange("inactive", "active"), true);
+});
+
+test("does not request duplicate or background sync rounds", () => {
+  assert.equal(shouldSyncAfterAppStateChange("active", "active"), false);
+  assert.equal(shouldSyncAfterAppStateChange("active", "background"), false);
+  assert.equal(shouldSyncAfterAppStateChange("inactive", "background"), false);
+});

--- a/apps/mobile/src/sync/app-state.ts
+++ b/apps/mobile/src/sync/app-state.ts
@@ -1,0 +1,6 @@
+export function shouldSyncAfterAppStateChange(
+  previousState: string,
+  nextState: string,
+): boolean {
+  return previousState !== "active" && nextState === "active";
+}

--- a/apps/mobile/src/sync/controller.test.mjs
+++ b/apps/mobile/src/sync/controller.test.mjs
@@ -295,3 +295,32 @@ test("stops native sync when the account lifecycle ends", async () => {
   await waitFor(() => stopCount === 2);
   assert.equal(controller.getSnapshot().phase, "inactive");
 });
+
+test("coalesces foreground and manual sync requests while one is active", async () => {
+  let syncCount = 0;
+  let finishSync;
+  const controller = new MobileSyncController(
+    dependencies({
+      syncNow: async () => {
+        syncCount += 1;
+        await new Promise((resolve) => {
+          finishSync = resolve;
+        });
+      },
+    }),
+    0,
+    0,
+  );
+  controller.activate(session);
+  await waitFor(() => controller.getSnapshot().phase === "ready");
+
+  const foregroundSync = controller.syncNow();
+  const manualSync = controller.syncNow();
+  await waitFor(() => finishSync !== undefined);
+  assert.equal(syncCount, 1);
+  assert.equal(controller.getSnapshot().syncingNow, true);
+
+  finishSync();
+  await Promise.all([foregroundSync, manualSync]);
+  assert.equal(controller.getSnapshot().syncingNow, false);
+});

--- a/apps/mobile/src/sync/mobile-sync-lifecycle.tsx
+++ b/apps/mobile/src/sync/mobile-sync-lifecycle.tsx
@@ -1,5 +1,8 @@
+import { AppState } from "react-native";
+
 import { useMountEffect } from "@/lib/use-mount-effect";
-import { activateMobileSync } from "@/sync/mobile-sync";
+import { shouldSyncAfterAppStateChange } from "@/sync/app-state";
+import { activateMobileSync, syncMobileNow } from "@/sync/mobile-sync";
 
 export function MobileSyncLifecycle({
   accessToken,
@@ -8,6 +11,20 @@ export function MobileSyncLifecycle({
   accessToken: string;
   accountUserId: string;
 }) {
-  useMountEffect(() => activateMobileSync({ accessToken, accountUserId }));
+  useMountEffect(() => {
+    const deactivate = activateMobileSync({ accessToken, accountUserId });
+    let previousState = AppState.currentState;
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      if (shouldSyncAfterAppStateChange(previousState, nextState)) {
+        void syncMobileNow();
+      }
+      previousState = nextState;
+    });
+
+    return () => {
+      subscription.remove();
+      deactivate();
+    };
+  });
   return null;
 }

--- a/apps/mobile/src/sync/status-presentation.test.mjs
+++ b/apps/mobile/src/sync/status-presentation.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { syncStatusPresentation } from "./status-presentation.ts";
+
+const ready = {
+  phase: "ready",
+  running: true,
+  syncingNow: false,
+  hasUnsentChanges: false,
+  lastSyncAtMs: 1_000_000,
+  errorMessage: null,
+  consecutiveFailures: 0,
+};
+
+test("shows a healthy synced state only after a successful round", () => {
+  assert.deepEqual(syncStatusPresentation(ready, 1_030_000), {
+    title: "Cloud sync is on",
+    description: "Your notes sync end-to-end encrypted across your devices.",
+    detail: "Synced just now",
+    healthy: true,
+    pending: false,
+    retrying: false,
+  });
+});
+
+test("does not label a failing runtime as healthy", () => {
+  const presentation = syncStatusPresentation({
+    ...ready,
+    errorMessage: "Network unavailable",
+    consecutiveFailures: 2,
+  });
+
+  assert.equal(presentation.title, "Cloud sync is retrying");
+  assert.equal(presentation.detail, "Network unavailable");
+  assert.equal(presentation.healthy, false);
+  assert.equal(presentation.pending, false);
+  assert.equal(presentation.retrying, true);
+});
+
+test("keeps local safety explicit when the native runtime is paused", () => {
+  const presentation = syncStatusPresentation({
+    ...ready,
+    running: false,
+    errorMessage: "Previous connection failed",
+    consecutiveFailures: 1,
+  });
+
+  assert.equal(presentation.title, "Cloud sync is paused");
+  assert.match(presentation.description, /safe on this device/);
+  assert.equal(presentation.detail, "Previous connection failed");
+  assert.equal(presentation.healthy, false);
+  assert.equal(presentation.pending, false);
+  assert.equal(presentation.retrying, false);
+});
+
+test("does not claim success before the first encrypted sync finishes", () => {
+  const presentation = syncStatusPresentation({
+    ...ready,
+    lastSyncAtMs: null,
+  });
+
+  assert.equal(presentation.title, "Finishing cloud sync");
+  assert.equal(presentation.detail, "Waiting for first sync");
+  assert.equal(presentation.healthy, false);
+  assert.equal(presentation.pending, true);
+});
+
+test("prioritizes active and pending sync detail", () => {
+  assert.equal(
+    syncStatusPresentation({ ...ready, syncingNow: true }).detail,
+    "Syncing now…",
+  );
+  assert.equal(
+    syncStatusPresentation({ ...ready, hasUnsentChanges: true }).detail,
+    "Changes waiting to sync",
+  );
+  assert.equal(
+    syncStatusPresentation({ ...ready, hasUnsentChanges: true }).pending,
+    true,
+  );
+});

--- a/apps/mobile/src/sync/status-presentation.ts
+++ b/apps/mobile/src/sync/status-presentation.ts
@@ -1,0 +1,143 @@
+import type { MobileSyncPhase, MobileSyncSnapshot } from "./controller";
+
+const phaseCopy: Record<
+  MobileSyncPhase,
+  { title: string; description: string }
+> = {
+  inactive: {
+    title: "Cloud sync is off",
+    description: "Sign in with Anarlog Pro to sync this device.",
+  },
+  starting: {
+    title: "Connecting this device",
+    description: "Preparing your encrypted workspace…",
+  },
+  setup_required: {
+    title: "Protect cloud sync",
+    description:
+      "Create a recovery key, or use the one from another Anarlog device.",
+  },
+  ready: {
+    title: "Cloud sync is on",
+    description: "Your notes sync end-to-end encrypted across your devices.",
+  },
+  error: {
+    title: "Cloud sync needs attention",
+    description: "Your notes are safe on this device. Try connecting again.",
+  },
+  device_limit: {
+    title: "Device limit reached",
+    description: "Anarlog Pro supports cloud sync on up to five devices.",
+  },
+  identity_mismatch: {
+    title: "Use your existing recovery key",
+    description:
+      "This account already has encrypted notes. Use the same key as your other device.",
+  },
+  not_entitled: {
+    title: "Anarlog Pro required",
+    description: "Refresh your plan to continue syncing this device.",
+  },
+  reauth_required: {
+    title: "Sign in again",
+    description: "Your session expired before cloud sync could connect.",
+  },
+  account_mismatch: {
+    title: "This device belongs to another account",
+    description:
+      "Your local notes were created by a different account, so sync stays off to protect both workspaces.",
+  },
+};
+
+function relativeSyncTime(
+  lastSyncAtMs: number | null,
+  nowMs: number,
+): string | null {
+  if (!lastSyncAtMs) return null;
+  const elapsedMinutes = Math.max(
+    0,
+    Math.floor((nowMs - lastSyncAtMs) / 60_000),
+  );
+  if (elapsedMinutes < 1) return "Synced just now";
+  if (elapsedMinutes < 60) return `Synced ${elapsedMinutes}m ago`;
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) return `Synced ${elapsedHours}h ago`;
+  return `Synced ${Math.floor(elapsedHours / 24)}d ago`;
+}
+
+export function syncStatusPresentation(
+  snapshot: MobileSyncSnapshot,
+  nowMs = Date.now(),
+): {
+  title: string;
+  description: string;
+  detail: string | null;
+  healthy: boolean;
+  pending: boolean;
+  retrying: boolean;
+} {
+  const retrying =
+    snapshot.phase === "ready" &&
+    snapshot.running &&
+    (snapshot.consecutiveFailures > 0 || snapshot.errorMessage !== null);
+  const paused = snapshot.phase === "ready" && !snapshot.running;
+  const awaitingFirstSync =
+    snapshot.phase === "ready" &&
+    snapshot.running &&
+    snapshot.lastSyncAtMs === null &&
+    !retrying;
+  const copy = retrying
+    ? {
+        title: "Cloud sync is retrying",
+        description:
+          "Your notes are safe on this device. Anarlog will keep trying in the background.",
+      }
+    : paused
+      ? {
+          title: "Cloud sync is paused",
+          description:
+            "Your notes are safe on this device. Sync this device again when you are online.",
+        }
+      : awaitingFirstSync
+        ? {
+            title: "Finishing cloud sync",
+            description:
+              "This device is connected. Waiting for its first encrypted sync to finish.",
+          }
+        : phaseCopy[snapshot.phase];
+
+  const detail =
+    snapshot.phase !== "ready"
+      ? snapshot.errorMessage
+      : snapshot.syncingNow
+        ? "Syncing now…"
+        : paused
+          ? (snapshot.errorMessage ?? "Sync is paused.")
+          : retrying
+            ? (snapshot.errorMessage ?? "Sync will retry automatically.")
+            : snapshot.hasUnsentChanges
+              ? "Changes waiting to sync"
+              : awaitingFirstSync
+                ? "Waiting for first sync"
+                : relativeSyncTime(snapshot.lastSyncAtMs, nowMs);
+
+  const pending =
+    snapshot.phase === "ready" &&
+    !retrying &&
+    (snapshot.syncingNow ||
+      snapshot.hasUnsentChanges === true ||
+      awaitingFirstSync);
+
+  return {
+    ...copy,
+    detail,
+    healthy:
+      snapshot.phase === "ready" &&
+      snapshot.running &&
+      snapshot.lastSyncAtMs !== null &&
+      !retrying &&
+      !pending,
+    pending,
+    retrying,
+  };
+}


### PR DESCRIPTION
## What changed

- request an encrypted replica sync round when Anarlog Mobile returns to the foreground
- coalesce a foreground request with an already-running manual sync
- distinguish first-sync, pending, retrying, paused, and healthy states in the profile sheet
- replace the stale Pro paywall claim that mobile sync is still in development

## Why

ANLG-144 requires immediate sync on resume and truthful delivery status. Mobile already ran the native encrypted replica in the background, but did not explicitly request a round after OS suspension. The profile sheet could also show a healthy green state before the first successful round or while the native runtime was retrying.

## User impact

Pro users see remote changes sooner after reopening the app, and the UI no longer claims a completed or healthy sync before native confirmation. Local notes remain readable and safe during retries or pauses.

## Validation

- `pnpm exec dprint fmt`
- `pnpm fmt:check`
- `pnpm -F @anlg/mobile typecheck`
- `pnpm -F @anlg/mobile test` — 68 passed
- `pnpm exec oxlint --quiet --format=github apps/mobile/src/`
- `git diff --check`

Simulator/device QA was intentionally skipped because this is not a release, per the current mobile QA policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches encrypted sync timing and user-facing sync truthfulness; behavior is well covered by unit tests but affects when data leaves the device after resume.
> 
> **Overview**
> **Mobile encrypted sync now runs when the app returns to the foreground**, via an `AppState` listener in `MobileSyncLifecycle` that calls `syncMobileNow()` when transitioning from background/inactive to active. Lifecycle cleanup also tears down the listener when sync deactivates.
> 
> **Cloud sync status in the profile sheet is centralized** in new `syncStatusPresentation`, which distinguishes healthy, pending, retrying, paused, and pre–first-sync states so the UI no longer shows a green “healthy” dot before a successful round or while the native runtime is failing/retrying. The Pro paywall copy no longer says mobile sync is still in development.
> 
> Tests cover foreground resume gating, presentation edge cases, and **coalescing overlapping `syncNow` requests** while a sync is already in flight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 011e7d0c85535b9a2ffdd5611f4754c8fb3f58ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->