### PR TITLE
ANLG-230: harden live Google Meet startup

### DIFF
--- a/enterprise/google-meet-worker/src/admission.rs
+++ b/enterprise/google-meet-worker/src/admission.rs
@@ -157,6 +157,31 @@ mod tests {
     }
 
     #[test]
+    fn terminal_video_call_denial_wins_over_captcha_and_stale_waiting_copy() {
+        let mut classifier = AdmissionClassifier::default();
+        let outcome = classifier.classify(
+            &AdmissionSnapshot {
+                waiting_room_visible: true,
+                explicit_denial_indicator: Some("can't join this video call".into()),
+                ambiguous_error_indicator: Some("Try again".into()),
+                visible_recaptcha_challenge: true,
+                ..Default::default()
+            },
+            Instant::now(),
+        );
+
+        assert_eq!(
+            outcome,
+            AdmissionOutcome::Rejected(AdmissionRejection {
+                reason: AdmissionRejectionReason::HostDenied,
+                indicator: "can't join this video call".into(),
+            })
+        );
+        assert!(ADMISSION_PROBE_EXPRESSION.contains("can't join this video call"));
+        assert!(ADMISSION_PROBE_EXPRESSION.contains("h1,h2,h3"));
+    }
+
+    #[test]
     fn captcha_suppression_expires_instead_of_polling_forever() {
         let grace = Duration::from_secs(120);
         let mut classifier = AdmissionClassifier::new(grace);

--- a/enterprise/google-meet-worker/src/admission_probe.js
+++ b/enterprise/google-meet-worker/src/admission_probe.js
@@ -14,7 +14,10 @@
   };
   const normalizedText = (element) =>
     (element.textContent || "").replace(/\s+/g, " ").trim().toLowerCase();
-  const visibleText = (copies, selectors = "button,div,p,span") => {
+  const visibleText = (
+    copies,
+    selectors = 'button,div,p,span,h1,h2,h3,[role="heading"]',
+  ) => {
     const lowered = copies.map((copy) => copy.toLowerCase());
     for (const element of document.querySelectorAll(selectors)) {
       if (!visible(element)) continue;
@@ -49,6 +52,9 @@
     "not allowed to join",
     "not admitted",
     "ask to join again",
+    "can't join this video call",
+    "can’t join this video call",
+    "cannot join this video call",
   ]);
   const ambiguousError = visibleText([
     "meeting not found",
@@ -71,7 +77,6 @@
       "please wait until a meeting host brings you into the call",
       "waiting for the host to let you in",
       "you're in the waiting room",
-      "return to home screen",
     ]) ||
     visibleSelectorCount([
       '[aria-label*="waiting room" i]',

--- a/enterprise/google-meet-worker/src/lobby.rs
+++ b/enterprise/google-meet-worker/src/lobby.rs
@@ -18,6 +18,8 @@ const INSTALL_MOUSE_PROBE: &str = r#"(() => {
 })()"#;
 const LAST_MOUSE_POSITION: &str = "window.__anlgLastMouse || null";
 const TARGET_VERIFY_ATTEMPTS: usize = 3;
+const LOBBY_READY_TIMEOUT: Duration = Duration::from_secs(30);
+const LOBBY_READY_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const POINTER_SETTLE: Duration = Duration::from_millis(120);
 const CLICK_HOLD: Duration = Duration::from_millis(70);
 const NAME_TYPING_DELAY: Duration = Duration::from_millis(75);
@@ -47,6 +49,8 @@ pub struct LobbySnapshot {
     pub microphone_on: Option<LobbyTarget>,
     pub camera_on: Option<LobbyTarget>,
     #[serde(default)]
+    pub device_error_dismissal: Option<LobbyTarget>,
+    #[serde(default)]
     pub cta_candidates: Vec<String>,
 }
 
@@ -63,6 +67,7 @@ enum LobbyTargetKind {
     JoinCta,
     MicrophoneOn,
     CameraOn,
+    DeviceErrorDismissal,
 }
 
 impl LobbyTargetKind {
@@ -72,6 +77,7 @@ impl LobbyTargetKind {
             Self::JoinCta => "join_cta",
             Self::MicrophoneOn => "microphone_on",
             Self::CameraOn => "camera_on",
+            Self::DeviceErrorDismissal => "device_error_dismissal",
         }
     }
 
@@ -81,6 +87,7 @@ impl LobbyTargetKind {
             Self::JoinCta => snapshot.join_cta,
             Self::MicrophoneOn => snapshot.microphone_on,
             Self::CameraOn => snapshot.camera_on,
+            Self::DeviceErrorDismissal => snapshot.device_error_dismissal,
         }
     }
 }
@@ -102,18 +109,70 @@ impl<'a> LobbyController<'a> {
 
     pub async fn join(&mut self, bot_name: &str, authenticated: bool) -> Result<(), LobbyError> {
         self.input.verify_available().await?;
-        let initial = self.probe().await?;
-        if authenticated && initial.signed_out_lobby {
-            return Err(LobbyError::AuthenticatedProfileSignedOut);
-        }
+        self.wait_until_ready(authenticated).await?;
         if !authenticated {
             X11Input::validate_text(bot_name, NAME_TYPING_DELAY)?;
             self.trusted_click(LobbyTargetKind::NameInput).await?;
             self.input.type_text(bot_name, NAME_TYPING_DELAY).await?;
         }
+        self.wait_until_joinable().await?;
         self.click_if_present(LobbyTargetKind::MicrophoneOn).await?;
         self.click_if_present(LobbyTargetKind::CameraOn).await?;
         self.trusted_click(LobbyTargetKind::JoinCta).await
+    }
+
+    async fn wait_until_ready(&mut self, authenticated: bool) -> Result<(), LobbyError> {
+        let deadline = tokio::time::Instant::now() + LOBBY_READY_TIMEOUT;
+        loop {
+            let snapshot = self.probe().await?;
+            if snapshot.device_error_dismissal.is_some() {
+                self.click_if_present(LobbyTargetKind::DeviceErrorDismissal)
+                    .await?;
+                continue;
+            }
+            if authenticated && snapshot.signed_out_lobby && snapshot.name_input.is_some() {
+                return Err(LobbyError::AuthenticatedProfileSignedOut);
+            }
+            let lobby_ready = if authenticated {
+                snapshot.join_cta.is_some()
+            } else {
+                snapshot.name_input.is_some()
+            };
+            if lobby_ready {
+                return Ok(());
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return Err(LobbyError::LobbyNotReady {
+                    timeout: LOBBY_READY_TIMEOUT,
+                    cta_candidates: snapshot.cta_candidates,
+                });
+            }
+            tokio::time::sleep(LOBBY_READY_POLL_INTERVAL.min(deadline - now)).await;
+        }
+    }
+
+    async fn wait_until_joinable(&mut self) -> Result<(), LobbyError> {
+        let deadline = tokio::time::Instant::now() + LOBBY_READY_TIMEOUT;
+        loop {
+            let snapshot = self.probe().await?;
+            if snapshot.device_error_dismissal.is_some() {
+                self.click_if_present(LobbyTargetKind::DeviceErrorDismissal)
+                    .await?;
+                continue;
+            }
+            if snapshot.join_cta.is_some() {
+                return Ok(());
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return Err(LobbyError::LobbyNotReady {
+                    timeout: LOBBY_READY_TIMEOUT,
+                    cta_candidates: snapshot.cta_candidates,
+                });
+            }
+            tokio::time::sleep(LOBBY_READY_POLL_INTERVAL.min(deadline - now)).await;
+        }
     }
 
     pub async fn probe(&mut self) -> Result<LobbySnapshot, LobbyError> {
@@ -124,7 +183,10 @@ impl<'a> LobbyController<'a> {
 
     async fn click_if_present(&mut self, kind: LobbyTargetKind) -> Result<(), LobbyError> {
         if kind.target_in(&self.probe().await?).is_some() {
-            self.trusted_click(kind).await?;
+            match self.trusted_click(kind).await {
+                Err(LobbyError::TargetMissing(marker)) if marker == kind.marker() => {}
+                result => result?,
+            }
         }
         Ok(())
     }
@@ -245,6 +307,13 @@ pub enum LobbyError {
     X11(#[from] X11InputError),
     #[error("authenticated Chromium profile is signed out")]
     AuthenticatedProfileSignedOut,
+    #[error(
+        "Google Meet lobby did not become ready within {timeout:?} (CTA candidates: {cta_candidates:?})"
+    )]
+    LobbyNotReady {
+        timeout: Duration,
+        cta_candidates: Vec<String>,
+    },
     #[error("Google Meet lobby target is not available: {0}")]
     TargetMissing(&'static str),
     #[error("browser window geometry is invalid")]
@@ -282,6 +351,7 @@ mod tests {
             join_cta: None,
             microphone_on: None,
             camera_on: None,
+            device_error_dismissal: None,
             cta_candidates: vec![],
         }
     }
@@ -322,23 +392,73 @@ mod tests {
         let server = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
             let mut websocket = accept_async(stream).await.unwrap();
+            let mut lobby_probes = 0;
             while let Some(Ok(Message::Text(command))) = websocket.next().await {
                 let command: Value = serde_json::from_str(command.as_ref()).unwrap();
                 let expression = command["params"]["expression"].as_str().unwrap();
                 let value = if expression.contains("cta_candidates") {
-                    json!({
-                        "screen_x": 0.0,
-                        "screen_y": 0.0,
-                        "inner_width": 1000.0,
-                        "inner_height": 720.0,
-                        "device_pixel_ratio": 1.0,
-                        "signed_out_lobby": true,
-                        "name_input": {"center_x": 100.0, "center_y": 120.0},
-                        "join_cta": {"center_x": 800.0, "center_y": 600.0},
-                        "microphone_on": null,
-                        "camera_on": null,
-                        "cta_candidates": ["Ask to join"]
-                    })
+                    lobby_probes += 1;
+                    if lobby_probes == 1 {
+                        json!({
+                            "screen_x": 0.0,
+                            "screen_y": 0.0,
+                            "inner_width": 1000.0,
+                            "inner_height": 720.0,
+                            "device_pixel_ratio": 1.0,
+                            "signed_out_lobby": false,
+                            "name_input": null,
+                            "join_cta": null,
+                            "microphone_on": null,
+                            "camera_on": null,
+                            "cta_candidates": []
+                        })
+                    } else if lobby_probes <= 5 {
+                        json!({
+                            "screen_x": 0.0,
+                            "screen_y": 0.0,
+                            "inner_width": 1000.0,
+                            "inner_height": 720.0,
+                            "device_pixel_ratio": 1.0,
+                            "signed_out_lobby": false,
+                            "name_input": null,
+                            "join_cta": null,
+                            "microphone_on": null,
+                            "camera_on": null,
+                            "device_error_dismissal": {
+                                "center_x": 500.0,
+                                "center_y": 400.0
+                            },
+                            "cta_candidates": ["Close"]
+                        })
+                    } else if lobby_probes <= 7 {
+                        json!({
+                            "screen_x": 0.0,
+                            "screen_y": 0.0,
+                            "inner_width": 1000.0,
+                            "inner_height": 720.0,
+                            "device_pixel_ratio": 1.0,
+                            "signed_out_lobby": true,
+                            "name_input": {"center_x": 100.0, "center_y": 120.0},
+                            "join_cta": null,
+                            "microphone_on": null,
+                            "camera_on": null,
+                            "cta_candidates": []
+                        })
+                    } else {
+                        json!({
+                            "screen_x": 0.0,
+                            "screen_y": 0.0,
+                            "inner_width": 1000.0,
+                            "inner_height": 720.0,
+                            "device_pixel_ratio": 1.0,
+                            "signed_out_lobby": true,
+                            "name_input": {"center_x": 100.0, "center_y": 120.0},
+                            "join_cta": {"center_x": 800.0, "center_y": 600.0},
+                            "microphone_on": null,
+                            "camera_on": null,
+                            "cta_candidates": ["Ask to join"]
+                        })
+                    }
                 } else if expression == LAST_MOUSE_POSITION {
                     json!({"x": 350.0, "y": 288.0})
                 } else {
@@ -371,7 +491,7 @@ mod tests {
                 r#"#!/bin/sh
 printf '%s\n' "$*" >> "{}"
 if [ "$1" = "mousemove" ]; then
-  printf '%s %s\n' "$3" "$4" > "{}"
+  printf '%s %s\n' "$2" "$3" > "{}"
 elif [ "$1" = "getmouselocation" ]; then
   read x y < "{}"
   printf 'X=%s\nY=%s\nSCREEN=0\nWINDOW=1\n' "$x" "$y"
@@ -402,7 +522,7 @@ fi
 
         let calls = std::fs::read_to_string(calls).unwrap();
         assert!(calls.contains("type --clearmodifiers --delay 75 -- Anarlog Notes"));
-        assert_eq!(calls.matches("mousedown 1").count(), 2);
-        assert_eq!(calls.matches("mouseup 1").count(), 2);
+        assert_eq!(calls.matches("mousedown 1").count(), 3);
+        assert_eq!(calls.matches("mouseup 1").count(), 3);
     }
 }

--- a/enterprise/google-meet-worker/src/lobby_probe.js
+++ b/enterprise/google-meet-worker/src/lobby_probe.js
@@ -64,6 +64,25 @@
     'button[aria-label*="Turn off microphone" i]',
   ]);
   const camera = firstVisible(['button[aria-label*="Turn off camera" i]']);
+  const deviceErrorCopies = [
+    "mic not found",
+    "speaker not found",
+    "camera not found",
+  ];
+  const deviceErrorDismissal = buttons.find((button) => {
+    if (
+      !["close", "dismiss", "got it"].includes(buttonText(button).toLowerCase())
+    ) {
+      return false;
+    }
+    let ancestor = button.parentElement;
+    for (let depth = 0; ancestor && depth < 8; depth += 1) {
+      const text = buttonText(ancestor).toLowerCase();
+      if (deviceErrorCopies.some((copy) => text.includes(copy))) return true;
+      ancestor = ancestor.parentElement;
+    }
+    return false;
+  });
 
   for (const element of document.querySelectorAll(`[${marker}]`)) {
     element.removeAttribute(marker);
@@ -89,6 +108,10 @@
     join_cta: target(joinCta, "join_cta"),
     microphone_on: target(microphone, "microphone_on"),
     camera_on: target(camera, "camera_on"),
+    device_error_dismissal: target(
+      deviceErrorDismissal,
+      "device_error_dismissal",
+    ),
     cta_candidates: buttons
       .slice(0, 64)
       .map((button) => buttonText(button).slice(0, 64))

--- a/enterprise/google-meet-worker/src/x11.rs
+++ b/enterprise/google-meet-worker/src/x11.rs
@@ -43,14 +43,9 @@ impl X11Input {
     }
 
     pub async fn move_absolute(&self, x: i32, y: i32) -> Result<(), X11InputError> {
-        self.run([
-            "mousemove".to_owned(),
-            "--sync".to_owned(),
-            x.to_string(),
-            y.to_string(),
-        ])
-        .await
-        .map(|_| ())
+        self.run(["mousemove".to_owned(), x.to_string(), y.to_string()])
+            .await
+            .map(|_| ())
     }
 
     pub async fn button_down(&self) -> Result<(), X11InputError> {
@@ -198,7 +193,7 @@ fi
         );
 
         let calls = std::fs::read_to_string(log).unwrap();
-        assert!(calls.contains(":77|mousemove --sync 100 200"));
+        assert!(calls.contains(":77|mousemove 100 200"));
         assert!(calls.contains(":77|type --clearmodifiers --delay 60 -- A; $(safe)"));
         assert!(calls.contains(":77|getmouselocation --shell"));
     }

--- a/enterprise/google-meet-worker/tests/live_google_meet.rs
+++ b/enterprise/google-meet-worker/tests/live_google_meet.rs
@@ -1,0 +1,119 @@
+use std::{env, path::PathBuf, time::Duration};
+
+use anarlog_enterprise_google_meet_worker::{
+    AdmissionMonitorConfig, CaptureJobRuntime, ChromiumLaunchConfig, ChunkedRecordingConfig,
+    ChunkedRecordingSink, FilesystemRecordingStore, GoogleMeetRuntime, GoogleMeetRuntimeConfig,
+    GoogleMeetUrl, WorkerCheckpoint, WorkerLifecycle, X11InputConfig,
+};
+use anlg_meeting_capture::{BotState, CaptureEventPayload};
+use tokio::sync::mpsc;
+
+#[tokio::test]
+#[ignore = "requires a disposable live Google Meet and a Linux desktop runtime"]
+async fn captures_a_live_google_meet_and_cleans_up() -> Result<(), Box<dyn std::error::Error>> {
+    let meeting_url = GoogleMeetUrl::parse(&env::var("ANLG_LIVE_GOOGLE_MEET_URL")?)?;
+    let run_timeout = Duration::from_secs(env_u64("ANLG_LIVE_RUN_SECONDS", 300)?);
+    let directory = tempfile::tempdir()?;
+    let recording_root = env::var_os("ANLG_LIVE_RECORDING_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| directory.path().join("recordings"));
+    let store = FilesystemRecordingStore::new(&recording_root).await?;
+    let sink = ChunkedRecordingSink::new(
+        ChunkedRecordingConfig {
+            object_prefix: "live-google-meet".into(),
+            chunk_duration: Duration::from_secs(10),
+            max_lateness: Duration::from_secs(2),
+        },
+        store,
+    )?;
+    let mut runtime = GoogleMeetRuntime::new(
+        GoogleMeetRuntimeConfig {
+            chromium: ChromiumLaunchConfig {
+                binary: env_path("ANLG_LIVE_CHROMIUM_BINARY", "/usr/bin/chromium"),
+                user_data_dir: directory.path().join("chromium-profile"),
+                locale: "en-US".into(),
+                authenticated: false,
+                headless: false,
+                disable_sandbox: true,
+                startup_timeout: Duration::from_secs(30),
+            },
+            x11: X11InputConfig {
+                binary: env_path("ANLG_LIVE_XDOTOOL_BINARY", "/usr/bin/xdotool"),
+                display: env::var("DISPLAY").unwrap_or_else(|_| ":99".into()),
+                command_timeout: Duration::from_secs(5),
+            },
+            bot_name: "Anarlog Reliability Bot".into(),
+            admission: AdmissionMonitorConfig {
+                timeout: Duration::from_secs(120),
+                poll_interval: Duration::from_millis(500),
+            },
+            runtime_poll_interval: Duration::from_secs(1),
+        },
+        sink,
+    )?;
+    let checkpoint = WorkerCheckpoint {
+        job_id: "live-google-meet-job".into(),
+        bot_id: "live-google-meet-bot".into(),
+        meeting_url,
+        state: BotState::Queued,
+        next_sequence: 0,
+    };
+    let mut lifecycle = WorkerLifecycle::new(checkpoint.bot_id.clone());
+    let (events_tx, mut events_rx) = mpsc::channel(32);
+    let event_collector = tokio::spawn(async move {
+        let mut events = Vec::new();
+        while let Some(event) = events_rx.recv().await {
+            println!("ANLG_LIVE_EVENT {event:?}");
+            events.push(event);
+        }
+        events
+    });
+
+    let run_result = tokio::time::timeout(
+        run_timeout,
+        runtime.run(&checkpoint, &mut lifecycle, events_tx.clone()),
+    )
+    .await;
+    let cleanup_outputs = runtime.cleanup().await?;
+    for payload in cleanup_outputs {
+        println!("ANLG_LIVE_CLEANUP_OUTPUT {payload:?}");
+    }
+    drop(events_tx);
+    let events = event_collector.await?;
+
+    run_result??;
+    assert!(lifecycle.state().is_terminal());
+    assert!(events.iter().any(|event| {
+        matches!(
+            &event.payload,
+            CaptureEventPayload::Lifecycle(transition) if transition.to == BotState::Joined
+        )
+    }));
+    assert!(events.iter().any(|event| {
+        matches!(
+            &event.payload,
+            CaptureEventPayload::Lifecycle(transition) if transition.to == BotState::Capturing
+        )
+    }));
+    assert!(
+        events
+            .iter()
+            .any(|event| { matches!(event.payload, CaptureEventPayload::RecordingChunkReady(_)) })
+    );
+    assert!(recording_root.join("live-google-meet").is_dir());
+    Ok(())
+}
+
+fn env_u64(name: &str, default: u64) -> Result<u64, Box<dyn std::error::Error>> {
+    Ok(match env::var(name) {
+        Ok(value) => value.parse()?,
+        Err(env::VarError::NotPresent) => default,
+        Err(error) => return Err(error.into()),
+    })
+}
+
+fn env_path(name: &str, default: &str) -> PathBuf {
+    env::var_os(name)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| default.into())
+}


### PR DESCRIPTION
Wait for Google Meet lobby readiness, dismiss device-error overlays, avoid xdotool pointer deadlocks, classify terminal Meet denial pages, and add an ignored OrbStack-ready live harness.

Validated with the full enterprise workspace tests, root and enterprise checks, strict clippy, formatting, and a live denial fixture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Meet join/admission automation and X11 input behavior; misclassification or timing could cause false denials or failed joins, but scope is isolated to the google-meet-worker and includes tests.
> 
> **Overview**
> Improves **Google Meet bot startup** so lobby join and admission classification behave reliably on real Meet UI variants.
> 
> **Lobby join** now **polls until the pre-join screen is ready** (guest name field or authenticated join CTA), **dismisses device-error overlays** (mic/speaker/camera not found via Close/Dismiss/Got it), then **waits again for the join CTA** before clicking mic/camera and Ask to join. Failures surface as **`LobbyNotReady`** with a timeout and visible CTA candidates; optional clicks tolerate a missing target between probes.
> 
> **Admission probing** treats **“can’t join this video call”** heading copy as **explicit host denial** (ahead of captcha and stale waiting-room text), scans **headings** for denial/error strings, and stops treating **“return to home screen”** as waiting-room signal.
> 
> **X11 pointer moves** drop **`xdotool mousemove --sync`** to reduce pointer deadlocks during lobby automation.
> 
> Adds an **`#[ignore]` live integration test** that runs the full runtime against a disposable Meet URL when env vars and a Linux desktop are available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c549b90a496ac23129b580536ad0b65cf016818f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->