### PR TITLE
ANLG-144: Guard remote mobile audio actions

### DIFF
--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -21,6 +21,7 @@ import { AudioChip } from "@/components/audio-chip";
 import { EditorAccessory } from "@/components/editor-accessory";
 import { HandoffCard } from "@/components/handoff-card";
 import { ListeningSheet } from "@/components/listening-sheet";
+import { RemoteAudioCard } from "@/components/remote-audio-card";
 import { Card } from "@/components/ui/card";
 import { IconButton } from "@/components/ui/icon-button";
 import { Colors, Spacing, Typography } from "@/constants/theme";
@@ -163,6 +164,11 @@ export default function NoteScreen() {
   const transcription = useTranscriptionState(id);
   const [listening, setListening] = useState(listen === "1");
   const recorder = useSessionRecorder(id, listening);
+  const localAudioFile = audio.data?.localRelativePath
+    ? new File(Paths.document, "sessions", id, audio.data.localRelativePath)
+    : null;
+  const localAudioAvailable =
+    audio.data?.availableLocally === true && localAudioFile?.exists === true;
 
   const dataRef = useRef(data);
   dataRef.current = data;
@@ -322,26 +328,22 @@ export default function NoteScreen() {
               )}
             </Card>
           )}
-          {audio.data && (
+          {audio.data && localAudioAvailable && localAudioFile && (
             <View key={`${audio.data.filename}:${audio.data.createdAt}`}>
               <AudioChip
-                uri={
-                  new File(Paths.document, "sessions", id, audio.data.filename)
-                    .uri
-                }
+                uri={localAudioFile.uri}
                 filename={audio.data.filename}
                 sizeBytes={audio.data.sizeBytes}
               />
               <HandoffCard
-                uri={
-                  new File(Paths.document, "sessions", id, audio.data.filename)
-                    .uri
-                }
+                uri={localAudioFile.uri}
                 filename={audio.data.filename}
               />
             </View>
           )}
+          {audio.data && !localAudioAvailable && <RemoteAudioCard />}
           {audio.data &&
+            localAudioAvailable &&
             audio.data.transcriptStatus !== "complete" &&
             transcripts.length === 0 &&
             (transcription === "running" ? (

--- a/apps/mobile/src/components/remote-audio-card.tsx
+++ b/apps/mobile/src/components/remote-audio-card.tsx
@@ -1,0 +1,43 @@
+import { Ionicons } from "@expo/vector-icons";
+import { StyleSheet, Text, View } from "react-native";
+
+import { Card } from "@/components/ui/card";
+import { Colors, Spacing, Typography } from "@/constants/theme";
+
+export function RemoteAudioCard() {
+  return (
+    <Card style={styles.card} tone="muted">
+      <Ionicons name="cloud-offline-outline" size={17} color={Colors.muted} />
+      <View style={styles.copy}>
+        <Text style={styles.title}>Recording not on this phone</Text>
+        <Text style={styles.description}>
+          Anarlog has the meeting details, but this phone does not have the
+          audio file.
+        </Text>
+      </View>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: Spacing.sm,
+    marginHorizontal: Spacing.lg,
+    marginTop: Spacing.sm,
+    padding: Spacing.md,
+  },
+  copy: {
+    flex: 1,
+  },
+  title: {
+    ...Typography.captionStrong,
+    color: Colors.ink,
+  },
+  description: {
+    marginTop: Spacing.xs,
+    ...Typography.caption,
+    color: Colors.muted,
+  },
+});

--- a/apps/mobile/src/data/audio-catalog-model.ts
+++ b/apps/mobile/src/data/audio-catalog-model.ts
@@ -1,0 +1,34 @@
+export type SessionAudioRow = {
+  filename: string;
+  size_bytes: number;
+  transcript_status: string;
+  created_at: string;
+  available_locally: number;
+  local_relative_path: string;
+};
+
+export type SessionAudio = {
+  filename: string;
+  sizeBytes: number;
+  transcriptStatus: string;
+  createdAt: string;
+  availableLocally: boolean;
+  localRelativePath: string | null;
+};
+
+export function mapSessionAudioRows(
+  rows: SessionAudioRow[],
+): SessionAudio | null {
+  const row = rows[0];
+  if (!row) return null;
+  const availableLocally =
+    row.available_locally === 1 && row.local_relative_path !== "";
+  return {
+    filename: row.filename,
+    sizeBytes: row.size_bytes,
+    transcriptStatus: row.transcript_status,
+    createdAt: row.created_at,
+    availableLocally,
+    localRelativePath: availableLocally ? row.local_relative_path : null,
+  };
+}

--- a/apps/mobile/src/data/audio-catalog.test.mjs
+++ b/apps/mobile/src/data/audio-catalog.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mapSessionAudioRows } from "./audio-catalog-model.ts";
+
+const row = {
+  filename: "audio.wav",
+  size_bytes: 42,
+  transcript_status: "complete",
+  created_at: "2026-08-17T00:00:00.000Z",
+  available_locally: 1,
+  local_relative_path: "audio.wav",
+};
+
+test("maps a device-local audio attachment to a playable file", () => {
+  assert.deepEqual(mapSessionAudioRows([row]), {
+    filename: "audio.wav",
+    sizeBytes: 42,
+    transcriptStatus: "complete",
+    createdAt: "2026-08-17T00:00:00.000Z",
+    availableLocally: true,
+    localRelativePath: "audio.wav",
+  });
+});
+
+test("does not treat synced metadata as a local audio file", () => {
+  assert.deepEqual(
+    mapSessionAudioRows([
+      { ...row, available_locally: 0, local_relative_path: "" },
+    ]),
+    {
+      filename: "audio.wav",
+      sizeBytes: 42,
+      transcriptStatus: "complete",
+      createdAt: "2026-08-17T00:00:00.000Z",
+      availableLocally: false,
+      localRelativePath: null,
+    },
+  );
+});
+
+test("requires a local relative path before exposing playback", () => {
+  const audio = mapSessionAudioRows([
+    { ...row, available_locally: 1, local_relative_path: "" },
+  ]);
+
+  assert.equal(audio?.availableLocally, false);
+  assert.equal(audio?.localRelativePath, null);
+});

--- a/apps/mobile/src/data/audio-catalog.ts
+++ b/apps/mobile/src/data/audio-catalog.ts
@@ -1,6 +1,14 @@
 import { executeTransaction, useLiveQuery } from "@/db";
 import { nowIso } from "@/lib/ids";
 
+import {
+  mapSessionAudioRows,
+  type SessionAudio,
+  type SessionAudioRow,
+} from "./audio-catalog-model";
+
+export type { SessionAudio } from "./audio-catalog-model";
+
 const ATTACHMENT_UPSERT_SQL = `
 INSERT INTO session_attachments (
   id, workspace_id, session_id, filename, relative_path, content_type,
@@ -77,39 +85,20 @@ export async function catalogSessionAudio(
 
 const SESSION_AUDIO_SQL = `
 SELECT
-  filename,
-  size_bytes,
-  COALESCE(json_extract(metadata_json, '$.transcript_status'), '') AS transcript_status,
-  created_at
-FROM session_attachments
-WHERE session_id = ? AND source_type = 'session_audio' AND deleted_at IS NULL
+  attachment.filename,
+  attachment.size_bytes,
+  COALESCE(json_extract(attachment.metadata_json, '$.transcript_status'), '') AS transcript_status,
+  attachment.created_at,
+  CASE WHEN local_state.availability = 'present' THEN 1 ELSE 0 END AS available_locally,
+  COALESCE(local_state.relative_path, '') AS local_relative_path
+FROM session_attachments AS attachment
+LEFT JOIN attachment_local_state AS local_state
+  ON local_state.attachment_id = attachment.id
+WHERE attachment.session_id = ?
+  AND attachment.source_type = 'session_audio'
+  AND attachment.deleted_at IS NULL
 LIMIT 1
 `;
-
-type SessionAudioRow = {
-  filename: string;
-  size_bytes: number;
-  transcript_status: string;
-  created_at: string;
-};
-
-export type SessionAudio = {
-  filename: string;
-  sizeBytes: number;
-  transcriptStatus: string;
-  createdAt: string;
-};
-
-function mapSessionAudioRows(rows: SessionAudioRow[]): SessionAudio | null {
-  const row = rows[0];
-  if (!row) return null;
-  return {
-    filename: row.filename,
-    sizeBytes: row.size_bytes,
-    transcriptStatus: row.transcript_status,
-    createdAt: row.created_at,
-  };
-}
 
 export function useSessionAudio(sessionId: string): {
   data: SessionAudio | null;


### PR DESCRIPTION
## What changed

- join canonical session-audio metadata with device-local attachment availability
- require both a local attachment state row and an existing file before exposing playback
- hide share handoff and retranscription when the audio bytes are absent
- show a shared-design-system placeholder explaining that the meeting is available but its recording is not on this phone
- add pure mapping tests for local, remote-only, and incomplete local attachment state

## Why

CloudSync carries `session_attachments` metadata but intentionally excludes `attachment_local_state` and local file bytes. A meeting synced from another device could therefore render play, share, and transcribe actions against a path that did not exist on the phone.

## User impact

Synced meetings remain readable and editable without broken audio controls. Playback, handoff, and retranscription are shown only for a file the phone can actually access.

## Validation

- `pnpm exec dprint fmt 'apps/mobile/src/**/*.{ts,tsx,mjs}'`
- `pnpm fmt:check`
- `pnpm -F @anlg/mobile typecheck`
- `pnpm -F @anlg/mobile test` — 71 passed
- `pnpm exec oxlint --quiet --format=github apps/mobile/src/`
- `git diff --check`

Simulator/device QA was intentionally skipped because this is not a release, per the current mobile QA policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mobile UI and query changes with tests; no auth or sync protocol changes.
> 
> **Overview**
> Synced meetings can include **session audio metadata** without the actual file on the phone. This change stops the note screen from offering **playback, share handoff, and re-transcribe** against missing paths.
> 
> **Data layer:** `useSessionAudio` now joins `attachment_local_state` and maps `availableLocally` / `localRelativePath` via a new `audio-catalog-model` module (with unit tests).
> 
> **Note screen:** Playback and handoff render only when catalog says the file is local **and** the file exists on disk; otherwise **`RemoteAudioCard`** explains the recording isn’t on this device. Transcribe UI is gated the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f9c73d7b8139fcd96ef632becd4ce7e0e02171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->