### PR TITLE
ANLG-144: Verify mobile audio metadata

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -46,6 +46,7 @@
     "expo-symbols": "~57.0.1",
     "expo-system-ui": "~57.0.1",
     "expo-web-browser": "~57.0.2",
+    "js-sha256": "0.10.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.0",

--- a/apps/mobile/src/audio/recover-recordings.ts
+++ b/apps/mobile/src/audio/recover-recordings.ts
@@ -71,7 +71,6 @@ export async function recoverInterruptedRecordings(
       await catalogSessionAudio(session.id, {
         filename: "audio.wav",
         contentType: "audio/wav",
-        sizeBytes,
       });
       recoveredSessionIds.push(session.id);
     } catch (error) {

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -269,11 +269,10 @@ export function useSessionRecorder(
       const writer = writerRef.current;
       if (!writer) throw new Error("Recording file is unavailable");
       const live = liveRef.current;
-      const file = writer.finalize();
+      writer.finalize();
       await catalogSessionAudio(sessionId, {
         filename: "audio.wav",
         contentType: "audio/wav",
-        sizeBytes: file.size,
       });
       const liveComplete = await (live?.stop() ?? Promise.resolve(false));
       let transcriptionMode = liveComplete ? "live" : "batch_fallback";

--- a/apps/mobile/src/data/audio-catalog.ts
+++ b/apps/mobile/src/data/audio-catalog.ts
@@ -1,3 +1,5 @@
+import { File, FileMode, Paths } from "expo-file-system";
+
 import { executeTransaction, useLiveQuery } from "@/db";
 import { nowIso } from "@/lib/ids";
 
@@ -6,6 +8,7 @@ import {
   type SessionAudio,
   type SessionAudioRow,
 } from "./audio-catalog-model";
+import { hashFileSha256 } from "./file-sha256";
 
 export type { SessionAudio } from "./audio-catalog-model";
 
@@ -54,12 +57,23 @@ export async function catalogSessionAudio(
   file: {
     filename: string;
     contentType: string;
-    sizeBytes: number;
-    sha256?: string;
+    signal?: AbortSignal;
   },
 ): Promise<void> {
   const attachmentId = `session-audio:${sessionId}`;
   const now = nowIso();
+  const localFile = new File(
+    Paths.document,
+    "sessions",
+    sessionId,
+    file.filename,
+  );
+  const verified = await hashFileSha256(
+    {
+      open: () => localFile.open(FileMode.ReadOnly),
+    },
+    file.signal,
+  );
 
   await executeTransaction([
     {
@@ -69,8 +83,8 @@ export async function catalogSessionAudio(
         file.filename,
         file.filename,
         file.contentType,
-        file.sizeBytes,
-        file.sha256 ?? "",
+        verified.sizeBytes,
+        verified.sha256,
         now,
         now,
         sessionId,

--- a/apps/mobile/src/data/file-sha256.test.mjs
+++ b/apps/mobile/src/data/file-sha256.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import { hashFileSha256 } from "./file-sha256.ts";
+
+function memoryFile(bytes, reportedSize = bytes.length) {
+  let closed = false;
+  let offset = 0;
+  return {
+    file: {
+      open: () => ({
+        close: () => {
+          closed = true;
+        },
+        get offset() {
+          return offset;
+        },
+        set offset(nextOffset) {
+          offset = nextOffset;
+        },
+        readBytes: (length) => {
+          const chunk = bytes.slice(offset, offset + length);
+          offset += chunk.length;
+          return chunk;
+        },
+        size: reportedSize,
+      }),
+    },
+    wasClosed: () => closed,
+  };
+}
+
+test("hashes a file incrementally and reports the observed size", async () => {
+  const bytes = Uint8Array.from({ length: 150_000 }, (_, index) => index % 251);
+  const source = memoryFile(bytes);
+
+  assert.deepEqual(await hashFileSha256(source.file), {
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    sizeBytes: bytes.length,
+  });
+  assert.equal(source.wasClosed(), true);
+});
+
+test("closes the handle when the file is shorter than its reported size", async () => {
+  const source = memoryFile(new Uint8Array([1, 2, 3]), 4);
+
+  await assert.rejects(
+    hashFileSha256(source.file),
+    /ended before its reported size/,
+  );
+  assert.equal(source.wasClosed(), true);
+});
+
+test("rejects empty files", async () => {
+  const source = memoryFile(new Uint8Array());
+
+  await assert.rejects(hashFileSha256(source.file), /empty or unavailable/);
+  assert.equal(source.wasClosed(), true);
+});
+
+test("does not open a file after verification is cancelled", async () => {
+  const controller = new AbortController();
+  controller.abort(new Error("cancelled"));
+  let opened = false;
+
+  await assert.rejects(
+    hashFileSha256(
+      {
+        open: () => {
+          opened = true;
+          throw new Error("unexpected open");
+        },
+      },
+      controller.signal,
+    ),
+    /cancelled/,
+  );
+  assert.equal(opened, false);
+});

--- a/apps/mobile/src/data/file-sha256.ts
+++ b/apps/mobile/src/data/file-sha256.ts
@@ -1,0 +1,65 @@
+import { sha256 } from "js-sha256";
+
+const CHUNK_BYTES = 64 * 1024;
+const YIELD_AFTER_BYTES = 4 * 1024 * 1024;
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new Error("Audio verification was cancelled");
+  }
+}
+
+export async function hashFileSha256(
+  file: {
+    open: () => {
+      close: () => void;
+      offset: number | null;
+      readBytes: (length: number) => Uint8Array;
+      size: number | null;
+    };
+  },
+  signal?: AbortSignal,
+): Promise<{ sha256: string; sizeBytes: number }> {
+  throwIfAborted(signal);
+  const handle = file.open();
+  try {
+    const expectedSize = handle.size;
+    if (expectedSize === null || expectedSize <= 0) {
+      throw new Error("Audio file is empty or unavailable");
+    }
+
+    handle.offset = 0;
+    const digest = sha256.create();
+    let sizeBytes = 0;
+    let bytesSinceYield = 0;
+
+    while (sizeBytes < expectedSize) {
+      throwIfAborted(signal);
+      const bytes = handle.readBytes(
+        Math.min(CHUNK_BYTES, expectedSize - sizeBytes),
+      );
+      if (bytes.length === 0) {
+        throw new Error("Audio file ended before its reported size");
+      }
+      digest.update(bytes);
+      sizeBytes += bytes.length;
+      bytesSinceYield += bytes.length;
+
+      if (bytesSinceYield >= YIELD_AFTER_BYTES) {
+        bytesSinceYield = 0;
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        throwIfAborted(signal);
+      }
+    }
+
+    if (sizeBytes !== expectedSize) {
+      throw new Error("Audio file changed while it was being verified");
+    }
+
+    return { sha256: digest.hex(), sizeBytes };
+  } finally {
+    handle.close();
+  }
+}

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -25,6 +25,7 @@ type AudioImportAsset = {
 };
 
 type AudioImportOptions = {
+  preserveSessionOnFailure?: boolean;
   sessionId?: string;
   ownerUserId?: string;
   signal?: AbortSignal;
@@ -84,12 +85,13 @@ async function importAsset(
   throwIfAborted(options?.signal);
 
   let cataloged = false;
+  let destination: File | null = null;
   try {
     const directory = new Directory(Paths.document, "sessions", sessionId);
     directory.create({ intermediates: true, idempotent: true });
 
     const filename = `audio.${extension}`;
-    const destination = new File(directory, filename);
+    destination = new File(directory, filename);
     if (options?.sessionId && destination.exists) {
       destination.delete();
     }
@@ -102,7 +104,7 @@ async function importAsset(
         asset.mimeType ??
         CONTENT_TYPES[extension] ??
         "application/octet-stream",
-      sizeBytes: asset.size ?? destination.size ?? 0,
+      signal: options?.signal,
     });
     cataloged = true;
     if (!options?.signal?.aborted) {
@@ -122,14 +124,25 @@ async function importAsset(
     }
   } catch (error) {
     if (!cataloged) {
-      // The session exists before the audio does, so a failed copy or catalog
-      // would otherwise strand an empty session on the timeline.
-      await deleteSession(sessionId).catch((cleanupError) => {
-        captureOperationalError(cleanupError, {
-          operation: "voice_memo_import_cleanup",
-          level: "warning",
+      if (options?.preserveSessionOnFailure) {
+        try {
+          if (destination?.exists) destination.delete();
+        } catch (cleanupError) {
+          captureOperationalError(cleanupError, {
+            operation: "voice_memo_import_cleanup",
+            level: "warning",
+          });
+        }
+      } else {
+        // The session exists before the audio does, so a failed copy or catalog
+        // would otherwise strand an empty session on the timeline.
+        await deleteSession(sessionId).catch((cleanupError) => {
+          captureOperationalError(cleanupError, {
+            operation: "voice_memo_import_cleanup",
+            level: "warning",
+          });
         });
-      });
+      }
     }
     throw error;
   }
@@ -228,6 +241,7 @@ export async function importWatchRecording(
     },
     "watch_recording",
     {
+      preserveSessionOnFailure: Boolean(existing),
       sessionId: recording.id,
       ownerUserId: recording.accountUserId,
       signal,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -517,6 +517,9 @@ importers:
       expo-web-browser:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.8)(react-native@0.86.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
+      js-sha256:
+        specifier: 0.10.1
+        version: 0.10.1
       react:
         specifier: 19.2.3
         version: 19.2.3


### PR DESCRIPTION
## Summary
- stream mobile recordings/imports through cancellable, chunked SHA-256 verification before cataloging them
- derive canonical byte size from the same verified read instead of caller-provided metadata
- preserve an existing synced session when a Watch audio copy fails verification

## Validation
- `pnpm exec dprint fmt 'apps/mobile/src/**/*.{ts,tsx,mjs}' apps/mobile/package.json pnpm-lock.yaml`
- `pnpm fmt:check`
- `pnpm -F @anlg/mobile typecheck`
- `pnpm -F @anlg/mobile test` (75 passed)
- `pnpm exec oxlint --quiet --format=github apps/mobile/src/`
- `pnpm install --lockfile-only --offline --frozen-lockfile`
- `git diff --check`

No simulator/device QA was run because this is not a release, per the current mobile QA policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared audio cataloging path and attachment metadata for all mobile recordings/imports; failures now surface during verification rather than trusting caller metadata, with unit tests covering the hasher.
> 
> **Overview**
> Session audio is now **verified on disk** before it is written to the catalog. `catalogSessionAudio` no longer accepts caller-supplied `sizeBytes` or optional `sha256`; it opens the session file under `Paths.document`, streams it through a new `hashFileSha256` helper (`js-sha256`, 64KB chunks, periodic yields, `AbortSignal` support), and persists the **observed** byte size and digest.
> 
> Recording stop, interrupted-recording recovery, and voice-memo/watch import paths were updated to call catalog with only filename/content-type (and import can pass `signal`). Watch re-imports for an **existing** session use `preserveSessionOnFailure` so a failed copy/verify removes the partial file but **does not** delete the synced session row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bbe28cee0030364fddf10a8d2ef7e9e8abfa466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->