### PR TITLE
ANLG-144: Restore verified mobile audio

### DIFF
--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -26,6 +26,7 @@ import { Card } from "@/components/ui/card";
 import { IconButton } from "@/components/ui/icon-button";
 import { Colors, Spacing, Typography } from "@/constants/theme";
 import { useSessionAudio } from "@/data/audio-catalog";
+import { restoreSessionAudioFromPicker } from "@/data/restore-session-audio";
 import {
   deleteSession,
   saveSessionNote,
@@ -164,6 +165,11 @@ export default function NoteScreen() {
   const transcription = useTranscriptionState(id);
   const [listening, setListening] = useState(listen === "1");
   const recorder = useSessionRecorder(id, listening);
+  const [audioRestoreError, setAudioRestoreError] = useState<string | null>(
+    null,
+  );
+  const [restoringAudio, setRestoringAudio] = useState(false);
+  const audioRestoreBusyRef = useRef(false);
   const localAudioFile = audio.data?.localRelativePath
     ? new File(Paths.document, "sessions", id, audio.data.localRelativePath)
     : null;
@@ -269,6 +275,36 @@ export default function NoteScreen() {
     }
   };
 
+  const handleChooseRecording = async () => {
+    if (audioRestoreBusyRef.current || !audio.data) return;
+    audioRestoreBusyRef.current = true;
+    setRestoringAudio(true);
+    setAudioRestoreError(null);
+    try {
+      const result = await restoreSessionAudioFromPicker(id, audio.data);
+      if (result === "restored") {
+        captureAnalytics("file_uploaded", {
+          entry_point: "mobile_audio_restore",
+          file_type: "audio",
+          content_type: audio.data.contentType,
+          size_bytes: audio.data.sizeBytes,
+        });
+      }
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "session_audio_restore",
+      });
+      setAudioRestoreError(
+        error instanceof Error
+          ? error.message
+          : "The recording could not be added to this phone.",
+      );
+    } finally {
+      audioRestoreBusyRef.current = false;
+      setRestoringAudio(false);
+    }
+  };
+
   const handleDelete = async () => {
     const confirmed = await confirmDestructive(
       `Delete "${data?.title || "Untitled"}"?`,
@@ -341,7 +377,13 @@ export default function NoteScreen() {
               />
             </View>
           )}
-          {audio.data && !localAudioAvailable && <RemoteAudioCard />}
+          {audio.data && !localAudioAvailable && (
+            <RemoteAudioCard
+              errorMessage={audioRestoreError}
+              loading={restoringAudio}
+              onChooseRecording={() => void handleChooseRecording()}
+            />
+          )}
           {audio.data &&
             localAudioAvailable &&
             audio.data.transcriptStatus !== "complete" &&

--- a/apps/mobile/src/components/remote-audio-card.tsx
+++ b/apps/mobile/src/components/remote-audio-card.tsx
@@ -1,10 +1,19 @@
 import { Ionicons } from "@expo/vector-icons";
 import { StyleSheet, Text, View } from "react-native";
 
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Colors, Spacing, Typography } from "@/constants/theme";
 
-export function RemoteAudioCard() {
+export function RemoteAudioCard({
+  errorMessage,
+  loading,
+  onChooseRecording,
+}: {
+  errorMessage: string | null;
+  loading: boolean;
+  onChooseRecording: () => void;
+}) {
   return (
     <Card style={styles.card} tone="muted">
       <Ionicons name="cloud-offline-outline" size={17} color={Colors.muted} />
@@ -14,6 +23,15 @@ export function RemoteAudioCard() {
           Anarlog has the meeting details, but this phone does not have the
           audio file.
         </Text>
+        {errorMessage && <Text style={styles.error}>{errorMessage}</Text>}
+        <Button
+          label="Choose recording"
+          loading={loading}
+          onPress={onChooseRecording}
+          size="small"
+          style={styles.action}
+          variant="outline"
+        />
       </View>
     </Card>
   );
@@ -39,5 +57,14 @@ const styles = StyleSheet.create({
     marginTop: Spacing.xs,
     ...Typography.caption,
     color: Colors.muted,
+  },
+  error: {
+    marginTop: Spacing.sm,
+    ...Typography.caption,
+    color: Colors.destructive,
+  },
+  action: {
+    alignSelf: "flex-start",
+    marginTop: Spacing.md,
   },
 });

--- a/apps/mobile/src/data/audio-catalog-model.ts
+++ b/apps/mobile/src/data/audio-catalog-model.ts
@@ -1,6 +1,9 @@
 export type SessionAudioRow = {
+  id: string;
   filename: string;
+  content_type: string;
   size_bytes: number;
+  sha256: string;
   transcript_status: string;
   created_at: string;
   available_locally: number;
@@ -8,8 +11,11 @@ export type SessionAudioRow = {
 };
 
 export type SessionAudio = {
+  attachmentId: string;
   filename: string;
+  contentType: string;
   sizeBytes: number;
+  sha256: string;
   transcriptStatus: string;
   createdAt: string;
   availableLocally: boolean;
@@ -24,8 +30,11 @@ export function mapSessionAudioRows(
   const availableLocally =
     row.available_locally === 1 && row.local_relative_path !== "";
   return {
+    attachmentId: row.id,
     filename: row.filename,
+    contentType: row.content_type,
     sizeBytes: row.size_bytes,
+    sha256: row.sha256,
     transcriptStatus: row.transcript_status,
     createdAt: row.created_at,
     availableLocally,

--- a/apps/mobile/src/data/audio-catalog.test.mjs
+++ b/apps/mobile/src/data/audio-catalog.test.mjs
@@ -4,8 +4,11 @@ import test from "node:test";
 import { mapSessionAudioRows } from "./audio-catalog-model.ts";
 
 const row = {
+  id: "session-audio:session-1",
   filename: "audio.wav",
+  content_type: "audio/wav",
   size_bytes: 42,
+  sha256: "a".repeat(64),
   transcript_status: "complete",
   created_at: "2026-08-17T00:00:00.000Z",
   available_locally: 1,
@@ -14,8 +17,11 @@ const row = {
 
 test("maps a device-local audio attachment to a playable file", () => {
   assert.deepEqual(mapSessionAudioRows([row]), {
+    attachmentId: "session-audio:session-1",
     filename: "audio.wav",
+    contentType: "audio/wav",
     sizeBytes: 42,
+    sha256: "a".repeat(64),
     transcriptStatus: "complete",
     createdAt: "2026-08-17T00:00:00.000Z",
     availableLocally: true,
@@ -29,8 +35,11 @@ test("does not treat synced metadata as a local audio file", () => {
       { ...row, available_locally: 0, local_relative_path: "" },
     ]),
     {
+      attachmentId: "session-audio:session-1",
       filename: "audio.wav",
+      contentType: "audio/wav",
       sizeBytes: 42,
+      sha256: "a".repeat(64),
       transcriptStatus: "complete",
       createdAt: "2026-08-17T00:00:00.000Z",
       availableLocally: false,

--- a/apps/mobile/src/data/audio-catalog.ts
+++ b/apps/mobile/src/data/audio-catalog.ts
@@ -99,8 +99,11 @@ export async function catalogSessionAudio(
 
 const SESSION_AUDIO_SQL = `
 SELECT
+  attachment.id,
   attachment.filename,
+  attachment.content_type,
   attachment.size_bytes,
+  attachment.sha256,
   COALESCE(json_extract(attachment.metadata_json, '$.transcript_status'), '') AS transcript_status,
   attachment.created_at,
   CASE WHEN local_state.availability = 'present' THEN 1 ELSE 0 END AS available_locally,

--- a/apps/mobile/src/data/audio-restore-model.test.mjs
+++ b/apps/mobile/src/data/audio-restore-model.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertRestorableAudioMetadata,
+  assertRestoredAudioMatches,
+  restoredAudioRelativePath,
+} from "./audio-restore-model.ts";
+
+const sha256 = "a".repeat(64);
+
+test("accepts an exact recording match", () => {
+  assert.doesNotThrow(() =>
+    assertRestoredAudioMatches(
+      { sha256, sizeBytes: 42 },
+      { sha256, sizeBytes: 42 },
+    ),
+  );
+});
+
+test("rejects unverified legacy metadata", () => {
+  assert.throws(
+    () =>
+      assertRestoredAudioMatches(
+        { sha256: "", sizeBytes: 42 },
+        { sha256, sizeBytes: 42 },
+      ),
+    /older recording cannot be verified/,
+  );
+});
+
+test("rejects invalid synced audio sizes", () => {
+  assert.throws(
+    () => assertRestorableAudioMetadata({ sha256, sizeBytes: 0 }),
+    /invalid synced file metadata/,
+  );
+});
+
+test("rejects the wrong bytes or size", () => {
+  assert.throws(
+    () =>
+      assertRestoredAudioMatches(
+        { sha256, sizeBytes: 42 },
+        { sha256: "b".repeat(64), sizeBytes: 42 },
+      ),
+    /does not match/,
+  );
+  assert.throws(
+    () =>
+      assertRestoredAudioMatches(
+        { sha256, sizeBytes: 42 },
+        { sha256, sizeBytes: 41 },
+      ),
+    /does not match/,
+  );
+});
+
+test("derives only safe device-local audio filenames", () => {
+  assert.equal(restoredAudioRelativePath("Meeting.M4A"), "restored-audio.m4a");
+  assert.equal(
+    restoredAudioRelativePath("../../another-session/audio.wav"),
+    "restored-audio.wav",
+  );
+  assert.equal(
+    restoredAudioRelativePath("recording.command"),
+    "restored-audio.bin",
+  );
+});

--- a/apps/mobile/src/data/audio-restore-model.ts
+++ b/apps/mobile/src/data/audio-restore-model.ts
@@ -1,0 +1,45 @@
+const AUDIO_EXTENSIONS = new Set([
+  "aac",
+  "caf",
+  "flac",
+  "m4a",
+  "mp3",
+  "mp4",
+  "ogg",
+  "wav",
+  "webm",
+]);
+
+export function restoredAudioRelativePath(filename: string): string {
+  const extension = filename.split(".").at(-1)?.toLowerCase() ?? "";
+  return AUDIO_EXTENSIONS.has(extension)
+    ? `restored-audio.${extension}`
+    : "restored-audio.bin";
+}
+
+export function assertRestoredAudioMatches(
+  expected: { sha256: string; sizeBytes: number },
+  actual: { sha256: string; sizeBytes: number },
+): void {
+  assertRestorableAudioMetadata(expected);
+  if (
+    actual.sizeBytes !== expected.sizeBytes ||
+    actual.sha256 !== expected.sha256
+  ) {
+    throw new Error("That file does not match this meeting recording.");
+  }
+}
+
+export function assertRestorableAudioMetadata(expected: {
+  sha256: string;
+  sizeBytes: number;
+}): void {
+  if (!/^[0-9a-f]{64}$/.test(expected.sha256)) {
+    throw new Error(
+      "This older recording cannot be verified on mobile. Open it on the device that recorded it.",
+    );
+  }
+  if (!Number.isSafeInteger(expected.sizeBytes) || expected.sizeBytes <= 0) {
+    throw new Error("This recording has invalid synced file metadata.");
+  }
+}

--- a/apps/mobile/src/data/restore-session-audio.ts
+++ b/apps/mobile/src/data/restore-session-audio.ts
@@ -1,0 +1,81 @@
+import { getDocumentAsync } from "expo-document-picker";
+import { Directory, File, FileMode, Paths } from "expo-file-system";
+
+import type { SessionAudio } from "@/data/audio-catalog";
+import {
+  assertRestorableAudioMetadata,
+  assertRestoredAudioMatches,
+  restoredAudioRelativePath,
+} from "@/data/audio-restore-model";
+import { hashFileSha256 } from "@/data/file-sha256";
+import { executeTransaction } from "@/db";
+import { nowIso } from "@/lib/ids";
+
+export async function restoreSessionAudioFromPicker(
+  sessionId: string,
+  audio: SessionAudio,
+): Promise<"cancelled" | "restored"> {
+  assertRestorableAudioMetadata(audio);
+  const result = await getDocumentAsync({
+    type: ["audio/*"],
+    multiple: false,
+    copyToCacheDirectory: true,
+  });
+  if (result.canceled) return "cancelled";
+
+  const directory = new Directory(Paths.document, "sessions", sessionId);
+  directory.create({ intermediates: true, idempotent: true });
+  const relativePath = restoredAudioRelativePath(audio.filename);
+  const destination = new File(directory, relativePath);
+
+  try {
+    await new File(result.assets[0].uri).copy(destination, { overwrite: true });
+    const verified = await hashFileSha256({
+      open: () => destination.open(FileMode.ReadOnly),
+    });
+    assertRestoredAudioMatches(audio, verified);
+
+    const [rowsAffected = 0] = await executeTransaction([
+      {
+        sql: `
+          INSERT INTO attachment_local_state (
+            attachment_id, session_id, relative_path, availability, updated_at
+          )
+          SELECT id, session_id, ?, 'present', ?
+          FROM session_attachments
+          WHERE id = ?
+            AND session_id = ?
+            AND sha256 = ?
+            AND size_bytes = ?
+            AND deleted_at IS NULL
+          ON CONFLICT(attachment_id) DO UPDATE SET
+            session_id = excluded.session_id,
+            relative_path = excluded.relative_path,
+            availability = excluded.availability,
+            updated_at = excluded.updated_at
+        `,
+        params: [
+          relativePath,
+          nowIso(),
+          audio.attachmentId,
+          sessionId,
+          audio.sha256,
+          audio.sizeBytes,
+        ],
+      },
+    ]);
+    if (rowsAffected !== 1) {
+      throw new Error(
+        "The meeting recording changed while it was being restored. Try again.",
+      );
+    }
+    return "restored";
+  } catch (error) {
+    try {
+      if (destination.exists) destination.delete();
+    } catch {
+      // The unreferenced copy is harmless and can be replaced on retry.
+    }
+    throw error;
+  }
+}

--- a/apps/mobile/src/data/transcribe.ts
+++ b/apps/mobile/src/data/transcribe.ts
@@ -71,10 +71,18 @@ export function useTranscriptionState(sessionId: string): TranscriptionState {
 }
 
 const PENDING_AUDIO_SQL = `
-SELECT filename, content_type, size_bytes
-FROM session_attachments
-WHERE session_id = ? AND source_type = 'session_audio' AND deleted_at IS NULL
-  AND COALESCE(json_extract(metadata_json, '$.transcript_status'), '') <> 'complete'
+SELECT
+  attachment.content_type,
+  attachment.size_bytes,
+  local_state.relative_path AS local_relative_path
+FROM session_attachments AS attachment
+JOIN attachment_local_state AS local_state
+  ON local_state.attachment_id = attachment.id
+ AND local_state.availability = 'present'
+WHERE attachment.session_id = ?
+  AND attachment.source_type = 'session_audio'
+  AND attachment.deleted_at IS NULL
+  AND COALESCE(json_extract(attachment.metadata_json, '$.transcript_status'), '') <> 'complete'
 LIMIT 1
 `;
 
@@ -348,14 +356,19 @@ async function requestTranscription(
 
 async function runTranscription(sessionId: string): Promise<void> {
   const rows = await execute<{
-    filename: string;
     content_type: string;
     size_bytes: number;
+    local_relative_path: string;
   }>(PENDING_AUDIO_SQL, [sessionId]);
   const audio = rows[0];
   if (!audio) return;
 
-  const file = new File(Paths.document, "sessions", sessionId, audio.filename);
+  const file = new File(
+    Paths.document,
+    "sessions",
+    sessionId,
+    audio.local_relative_path,
+  );
   if (!file.exists) {
     throw transcriptionFailure("Audio file missing", "load_audio", {
       code: "audio_missing",


### PR DESCRIPTION
## Summary
- add a `Choose recording` recovery action when synced audio metadata has no local file
- copy and hash the selected recording, accepting only an exact synced SHA-256 and size match
- update only device-local attachment availability, fenced against concurrent canonical changes
- make playback, sharing, and batch transcription all consume the verified device-local path
- reject unsafe local filenames and clean mismatched/unreferenced copies

## Validation
- `pnpm exec dprint fmt apps/mobile/src/data/transcribe.ts`
- `pnpm fmt:check`
- `pnpm -F @anlg/mobile typecheck`
- `pnpm -F @anlg/mobile test` (80 passed)
- `pnpm exec oxlint --quiet --format=github apps/mobile/src/`
- `git diff --check`

No simulator/device QA was run because this is not a release, per the current mobile QA policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local file I/O, cryptographic verification, and SQLite local-state updates for session audio; mistakes could block playback/transcription or accept wrong files, but strict hash/size checks and fenced updates limit exposure.
> 
> **Overview**
> Adds a **Choose recording** path on the note screen when synced session audio exists but the file is not on the device. `RemoteAudioCard` now drives loading, errors, and the picker callback; the note screen wires `restoreSessionAudioFromPicker` with analytics and operational error reporting.
> 
> Restore copies a user-selected audio file into the session documents folder under a **sanitized** `restored-audio.*` name, hashes it, and accepts only an **exact SHA-256 and size match** to synced attachment metadata. Legacy rows without a valid hash are rejected. On success, only `attachment_local_state` is updated, with SQL guards on attachment id, session, hash, and size so concurrent canonical changes fail safely; mismatched copies are deleted on failure.
> 
> `SessionAudio` / catalog queries now expose `attachmentId`, `contentType`, and `sha256` for verification. **Transcription** loads audio via `attachment_local_state` and `local_relative_path` instead of assuming the attachment filename is always present locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a345458f1a46c0934f1a49a877ea90ad273af6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->