### PR TITLE
Add native multi-platform capture adapters

### DIFF
--- a/crates/meeting-capture/src/adapter.rs
+++ b/crates/meeting-capture/src/adapter.rs
@@ -1,0 +1,478 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    BotState, CaptureEvent, CaptureEventPayload, CaptureProviderKind, CaptureWorkerCheckpoint,
+    CaptureWorkerCheckpointError, MeetingPlatform, Participant, ProviderMetadata, RecordingChunk,
+    Speaker, TerminalReason, TranscriptSegment, TransitionError,
+};
+
+pub const MEETING_SDK_BRIDGE_PROTOCOL_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+pub enum MeetingSdkBridgeCommand {
+    Start(MeetingSdkBridgeStart),
+    Stop { job_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MeetingSdkBridgeStart {
+    pub protocol_version: u16,
+    pub checkpoint: CaptureWorkerCheckpoint,
+    pub bot_name: String,
+}
+
+impl MeetingSdkBridgeStart {
+    pub fn new(
+        checkpoint: CaptureWorkerCheckpoint,
+        bot_name: impl Into<String>,
+    ) -> Result<Self, MeetingSdkBridgeError> {
+        let start = Self {
+            protocol_version: MEETING_SDK_BRIDGE_PROTOCOL_VERSION,
+            checkpoint,
+            bot_name: bot_name.into(),
+        };
+        start.validate()?;
+        Ok(start)
+    }
+
+    pub fn validate(&self) -> Result<(), MeetingSdkBridgeError> {
+        if self.protocol_version != MEETING_SDK_BRIDGE_PROTOCOL_VERSION {
+            return Err(MeetingSdkBridgeError::UnsupportedProtocolVersion(
+                self.protocol_version,
+            ));
+        }
+        self.checkpoint.validate()?;
+        validate_bridge_provider(self.checkpoint.provider, self.checkpoint.meeting.platform)?;
+        validate_bridge_meeting_url(
+            &self.checkpoint.meeting.url,
+            self.checkpoint.meeting.platform,
+        )?;
+        if self.bot_name.is_empty()
+            || self.bot_name.chars().count() > 80
+            || self.bot_name.chars().any(char::is_control)
+        {
+            return Err(MeetingSdkBridgeError::InvalidBotName);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MeetingSdkBridgeEvent {
+    pub protocol_version: u16,
+    pub sequence: u64,
+    pub platform: MeetingPlatform,
+    pub provider: CaptureProviderKind,
+    pub payload: MeetingSdkBridgeEventPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+pub enum MeetingSdkBridgeEventPayload {
+    Ready,
+    WaitingForAdmission,
+    Joined,
+    Capturing,
+    Transcript(MeetingSdkBridgeTranscript),
+    ParticipantUpserted(Participant),
+    ParticipantLeft { participant_id: String },
+    RecordingChunkReady(RecordingChunk),
+    Terminal(MeetingSdkBridgeTerminal),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MeetingSdkBridgeTranscript {
+    pub start_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_ms: Option<u64>,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speaker: Option<Speaker>,
+    pub is_final: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MeetingSdkBridgeTerminal {
+    pub state: BotState,
+    pub reason: TerminalReason,
+}
+
+pub struct MeetingSdkBridgeNormalizer {
+    bot_id: String,
+    platform: MeetingPlatform,
+    provider: CaptureProviderKind,
+    state: BotState,
+    next_event_sequence: u64,
+    next_bridge_sequence: u64,
+}
+
+impl MeetingSdkBridgeNormalizer {
+    pub fn new(checkpoint: &CaptureWorkerCheckpoint) -> Result<Self, MeetingSdkBridgeError> {
+        checkpoint.validate()?;
+        validate_bridge_provider(checkpoint.provider, checkpoint.meeting.platform)?;
+        validate_bridge_meeting_url(&checkpoint.meeting.url, checkpoint.meeting.platform)?;
+        Ok(Self {
+            bot_id: checkpoint.bot_id.clone(),
+            platform: checkpoint.meeting.platform,
+            provider: checkpoint.provider,
+            state: checkpoint.state,
+            next_event_sequence: checkpoint.next_sequence,
+            next_bridge_sequence: 0,
+        })
+    }
+
+    pub fn state(&self) -> BotState {
+        self.state
+    }
+
+    pub fn accept(
+        &mut self,
+        event: MeetingSdkBridgeEvent,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<CaptureEvent, MeetingSdkBridgeError> {
+        if event.protocol_version != MEETING_SDK_BRIDGE_PROTOCOL_VERSION {
+            return Err(MeetingSdkBridgeError::UnsupportedProtocolVersion(
+                event.protocol_version,
+            ));
+        }
+        if event.platform != self.platform || event.provider != self.provider {
+            return Err(MeetingSdkBridgeError::IdentityMismatch);
+        }
+        if event.sequence != self.next_bridge_sequence {
+            return Err(MeetingSdkBridgeError::SequenceMismatch {
+                expected: self.next_bridge_sequence,
+                actual: event.sequence,
+            });
+        }
+
+        let payload = match event.payload {
+            MeetingSdkBridgeEventPayload::Ready => self.transition(BotState::Launching, None)?,
+            MeetingSdkBridgeEventPayload::WaitingForAdmission => {
+                self.transition(BotState::WaitingForAdmission, None)?
+            }
+            MeetingSdkBridgeEventPayload::Joined => self.transition(BotState::Joined, None)?,
+            MeetingSdkBridgeEventPayload::Capturing => {
+                self.transition(BotState::Capturing, None)?
+            }
+            MeetingSdkBridgeEventPayload::Transcript(transcript) => {
+                if self.state != BotState::Capturing
+                    || transcript.text.trim().is_empty()
+                    || transcript.text.len() > 64 * 1024
+                    || transcript
+                        .end_ms
+                        .is_some_and(|end_ms| end_ms < transcript.start_ms)
+                {
+                    return Err(MeetingSdkBridgeError::InvalidTranscript);
+                }
+                CaptureEventPayload::Transcript(TranscriptSegment {
+                    id: format!("sdk-bridge-segment-{}", self.next_event_sequence),
+                    sequence: self.next_event_sequence,
+                    start_ms: transcript.start_ms,
+                    end_ms: transcript.end_ms,
+                    text: transcript.text,
+                    speaker: transcript.speaker,
+                    is_final: transcript.is_final,
+                })
+            }
+            MeetingSdkBridgeEventPayload::ParticipantUpserted(participant) => {
+                require_capturing(self.state)?;
+                CaptureEventPayload::ParticipantUpserted(participant)
+            }
+            MeetingSdkBridgeEventPayload::ParticipantLeft { participant_id } => {
+                require_capturing(self.state)?;
+                CaptureEventPayload::ParticipantLeft { participant_id }
+            }
+            MeetingSdkBridgeEventPayload::RecordingChunkReady(chunk) => {
+                require_capturing(self.state)?;
+                CaptureEventPayload::RecordingChunkReady(chunk)
+            }
+            MeetingSdkBridgeEventPayload::Terminal(terminal) => {
+                if !terminal.state.is_terminal() {
+                    return Err(MeetingSdkBridgeError::InvalidTerminalState(terminal.state));
+                }
+                self.transition(terminal.state, Some(terminal.reason))?
+            }
+        };
+
+        let sequence = self.next_event_sequence;
+        self.next_event_sequence = self
+            .next_event_sequence
+            .checked_add(1)
+            .ok_or(MeetingSdkBridgeError::SequenceExhausted)?;
+        self.next_bridge_sequence = self
+            .next_bridge_sequence
+            .checked_add(1)
+            .ok_or(MeetingSdkBridgeError::SequenceExhausted)?;
+        Ok(CaptureEvent {
+            id: format!("capture-event-{sequence}"),
+            bot_id: self.bot_id.clone(),
+            sequence,
+            occurred_at,
+            payload,
+            metadata: ProviderMetadata::default(),
+        })
+    }
+
+    fn transition(
+        &mut self,
+        next: BotState,
+        reason: Option<TerminalReason>,
+    ) -> Result<CaptureEventPayload, TransitionError> {
+        let transition = self.state.transition_to(next, reason)?;
+        self.state = next;
+        Ok(CaptureEventPayload::Lifecycle(transition))
+    }
+}
+
+fn validate_bridge_provider(
+    provider: CaptureProviderKind,
+    platform: MeetingPlatform,
+) -> Result<(), MeetingSdkBridgeError> {
+    if !matches!(
+        (provider, platform),
+        (
+            CaptureProviderKind::MicrosoftGraph,
+            MeetingPlatform::MicrosoftTeams
+        ) | (
+            CaptureProviderKind::WebexMeetingsSdk,
+            MeetingPlatform::Webex
+        )
+    ) {
+        return Err(MeetingSdkBridgeError::UnsupportedProvider { provider, platform });
+    }
+    Ok(())
+}
+
+fn validate_bridge_meeting_url(
+    value: &str,
+    platform: MeetingPlatform,
+) -> Result<(), MeetingSdkBridgeError> {
+    let Some(remainder) = value.strip_prefix("https://") else {
+        return Err(MeetingSdkBridgeError::InvalidMeetingUrl { platform });
+    };
+    let authority = remainder.split(['/', '?', '#']).next().unwrap_or_default();
+    if authority.is_empty()
+        || authority.contains(['@', ':', '%'])
+        || value.chars().any(char::is_whitespace)
+    {
+        return Err(MeetingSdkBridgeError::InvalidMeetingUrl { platform });
+    }
+    let host = authority.to_ascii_lowercase();
+    let matches_platform = match platform {
+        MeetingPlatform::MicrosoftTeams => {
+            matches!(host.as_str(), "teams.microsoft.com" | "teams.live.com")
+        }
+        MeetingPlatform::Webex => host == "webex.com" || host.ends_with(".webex.com"),
+        _ => false,
+    };
+    if !matches_platform {
+        return Err(MeetingSdkBridgeError::InvalidMeetingUrl { platform });
+    }
+    Ok(())
+}
+
+fn require_capturing(state: BotState) -> Result<(), MeetingSdkBridgeError> {
+    if state != BotState::Capturing {
+        return Err(MeetingSdkBridgeError::PayloadBeforeCapture(state));
+    }
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MeetingSdkBridgeError {
+    #[error(transparent)]
+    InvalidCheckpoint(#[from] CaptureWorkerCheckpointError),
+    #[error("meeting SDK bridge bot name must contain 1-80 non-control characters")]
+    InvalidBotName,
+    #[error("provider {provider:?} on {platform:?} does not use the meeting SDK bridge")]
+    UnsupportedProvider {
+        provider: CaptureProviderKind,
+        platform: MeetingPlatform,
+    },
+    #[error("meeting URL is not a canonical HTTPS URL for {platform:?}")]
+    InvalidMeetingUrl { platform: MeetingPlatform },
+    #[error("meeting SDK bridge protocol version {0} is unsupported")]
+    UnsupportedProtocolVersion(u16),
+    #[error("meeting SDK bridge platform or provider does not match the capture job")]
+    IdentityMismatch,
+    #[error("meeting SDK bridge sequence mismatch: expected {expected}, received {actual}")]
+    SequenceMismatch { expected: u64, actual: u64 },
+    #[error("meeting SDK bridge sequence was exhausted")]
+    SequenceExhausted,
+    #[error("meeting SDK bridge transcript is invalid for the current state")]
+    InvalidTranscript,
+    #[error("meeting SDK bridge emitted capture payload while state was {0:?}")]
+    PayloadBeforeCapture(BotState),
+    #[error("meeting SDK bridge terminal state {0:?} is not terminal")]
+    InvalidTerminalState(BotState),
+    #[error(transparent)]
+    Transition(#[from] TransitionError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{MeetingReference, TerminalReasonKind};
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-08-17T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn checkpoint(
+        provider: CaptureProviderKind,
+        platform: MeetingPlatform,
+    ) -> CaptureWorkerCheckpoint {
+        let url = match platform {
+            MeetingPlatform::MicrosoftTeams => "https://teams.microsoft.com/l/meetup-join/test",
+            MeetingPlatform::Webex => "https://anarlog.webex.com/meet/test",
+            _ => "https://example.com/meeting",
+        };
+        CaptureWorkerCheckpoint {
+            job_id: "job-1".into(),
+            bot_id: "bot-1".into(),
+            provider,
+            meeting: MeetingReference {
+                platform,
+                url: url.into(),
+                external_id: None,
+                calendar_event_id: None,
+            },
+            state: BotState::Queued,
+            next_sequence: 0,
+        }
+    }
+
+    fn event(
+        sequence: u64,
+        platform: MeetingPlatform,
+        provider: CaptureProviderKind,
+        payload: MeetingSdkBridgeEventPayload,
+    ) -> MeetingSdkBridgeEvent {
+        MeetingSdkBridgeEvent {
+            protocol_version: MEETING_SDK_BRIDGE_PROTOCOL_VERSION,
+            sequence,
+            platform,
+            provider,
+            payload,
+        }
+    }
+
+    #[test]
+    fn normalizes_teams_and_webex_sdk_lifecycles() {
+        for (provider, platform) in [
+            (
+                CaptureProviderKind::MicrosoftGraph,
+                MeetingPlatform::MicrosoftTeams,
+            ),
+            (
+                CaptureProviderKind::WebexMeetingsSdk,
+                MeetingPlatform::Webex,
+            ),
+        ] {
+            let checkpoint = checkpoint(provider, platform);
+            MeetingSdkBridgeStart::new(checkpoint.clone(), "Anarlog Notetaker").unwrap();
+            let mut normalizer = MeetingSdkBridgeNormalizer::new(&checkpoint).unwrap();
+            let payloads = [
+                MeetingSdkBridgeEventPayload::Ready,
+                MeetingSdkBridgeEventPayload::Joined,
+                MeetingSdkBridgeEventPayload::Capturing,
+                MeetingSdkBridgeEventPayload::Transcript(MeetingSdkBridgeTranscript {
+                    start_ms: 10,
+                    end_ms: Some(510),
+                    text: "Shared notes are ready".into(),
+                    speaker: None,
+                    is_final: true,
+                }),
+                MeetingSdkBridgeEventPayload::Terminal(MeetingSdkBridgeTerminal {
+                    state: BotState::Completed,
+                    reason: TerminalReason {
+                        kind: TerminalReasonKind::MeetingEnded,
+                        message: None,
+                        retryable: false,
+                    },
+                }),
+            ];
+
+            let events = payloads
+                .into_iter()
+                .enumerate()
+                .map(|(sequence, payload)| {
+                    normalizer
+                        .accept(event(sequence as u64, platform, provider, payload), now())
+                        .unwrap()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(normalizer.state(), BotState::Completed);
+            assert_eq!(
+                events
+                    .iter()
+                    .map(|event| event.sequence)
+                    .collect::<Vec<_>>(),
+                vec![0, 1, 2, 3, 4]
+            );
+            assert!(matches!(
+                events[3].payload,
+                CaptureEventPayload::Transcript(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn rejects_cross_platform_and_out_of_order_bridge_events() {
+        let checkpoint = checkpoint(
+            CaptureProviderKind::MicrosoftGraph,
+            MeetingPlatform::MicrosoftTeams,
+        );
+        let mut normalizer = MeetingSdkBridgeNormalizer::new(&checkpoint).unwrap();
+        assert!(matches!(
+            normalizer.accept(
+                event(
+                    0,
+                    MeetingPlatform::Webex,
+                    CaptureProviderKind::WebexMeetingsSdk,
+                    MeetingSdkBridgeEventPayload::Ready,
+                ),
+                now(),
+            ),
+            Err(MeetingSdkBridgeError::IdentityMismatch)
+        ));
+        assert!(matches!(
+            normalizer.accept(
+                event(
+                    1,
+                    MeetingPlatform::MicrosoftTeams,
+                    CaptureProviderKind::MicrosoftGraph,
+                    MeetingSdkBridgeEventPayload::Ready,
+                ),
+                now(),
+            ),
+            Err(MeetingSdkBridgeError::SequenceMismatch { .. })
+        ));
+
+        let unsafe_checkpoint = CaptureWorkerCheckpoint {
+            meeting: MeetingReference {
+                url: "https://teams.microsoft.com.evil.example/l/meetup-join/test".into(),
+                ..checkpoint.meeting.clone()
+            },
+            ..checkpoint.clone()
+        };
+        assert!(matches!(
+            MeetingSdkBridgeStart::new(unsafe_checkpoint, "Anarlog Notetaker"),
+            Err(MeetingSdkBridgeError::InvalidMeetingUrl { .. })
+        ));
+
+        let mut start = MeetingSdkBridgeStart::new(checkpoint, "Anarlog Notetaker").unwrap();
+        start.protocol_version += 1;
+        assert!(matches!(
+            start.validate(),
+            Err(MeetingSdkBridgeError::UnsupportedProtocolVersion(_))
+        ));
+    }
+}

--- a/crates/meeting-capture/src/lib.rs
+++ b/crates/meeting-capture/src/lib.rs
@@ -1,9 +1,13 @@
+mod adapter;
 mod lifecycle;
 mod metadata;
 mod model;
 mod provider;
+mod worker;
 
+pub use adapter::*;
 pub use lifecycle::*;
 pub use metadata::*;
 pub use model::*;
 pub use provider::*;
+pub use worker::*;

--- a/crates/meeting-capture/src/model.rs
+++ b/crates/meeting-capture/src/model.rs
@@ -19,6 +19,19 @@ pub enum CaptureProviderKind {
     Anarlog,
     Recall,
     ZoomRtms,
+    MicrosoftGraph,
+    WebexMeetingsSdk,
+}
+
+impl CaptureProviderKind {
+    pub fn native_platform(self) -> Option<MeetingPlatform> {
+        match self {
+            Self::ZoomRtms => Some(MeetingPlatform::Zoom),
+            Self::MicrosoftGraph => Some(MeetingPlatform::MicrosoftTeams),
+            Self::WebexMeetingsSdk => Some(MeetingPlatform::Webex),
+            Self::Anarlog | Self::Recall => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/meeting-capture/src/worker.rs
+++ b/crates/meeting-capture/src/worker.rs
@@ -1,0 +1,150 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{BotState, CaptureProviderKind, MeetingPlatform, MeetingReference};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CaptureWorkerCheckpoint {
+    pub job_id: String,
+    pub bot_id: String,
+    pub provider: CaptureProviderKind,
+    pub meeting: MeetingReference,
+    pub state: BotState,
+    pub next_sequence: u64,
+}
+
+impl CaptureWorkerCheckpoint {
+    pub fn validate(&self) -> Result<(), CaptureWorkerCheckpointError> {
+        validate_identifier(&self.job_id)
+            .map_err(|()| CaptureWorkerCheckpointError::InvalidJobId)?;
+        validate_identifier(&self.bot_id)
+            .map_err(|()| CaptureWorkerCheckpointError::InvalidBotId)?;
+        if self.meeting.url.is_empty()
+            || self.meeting.url.len() > 8192
+            || self.meeting.url.chars().any(char::is_control)
+        {
+            return Err(CaptureWorkerCheckpointError::InvalidMeetingUrl);
+        }
+        if self.state == BotState::Queued && self.next_sequence != 0
+            || self.state != BotState::Queued && self.next_sequence == 0
+        {
+            return Err(CaptureWorkerCheckpointError::InvalidSequence {
+                state: self.state,
+                next_sequence: self.next_sequence,
+            });
+        }
+        if let Some(expected) = self.provider.native_platform()
+            && self.meeting.platform != expected
+        {
+            return Err(CaptureWorkerCheckpointError::ProviderPlatformMismatch {
+                provider: self.provider,
+                expected,
+                actual: self.meeting.platform,
+            });
+        }
+        Ok(())
+    }
+}
+
+fn validate_identifier(value: &str) -> Result<(), ()> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"-_.".contains(&byte))
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CaptureWorkerCheckpointError {
+    #[error("capture job ID contains unsupported characters")]
+    InvalidJobId,
+    #[error("capture bot ID contains unsupported characters")]
+    InvalidBotId,
+    #[error("capture meeting URL must contain 1-8192 non-control characters")]
+    InvalidMeetingUrl,
+    #[error(
+        "capture checkpoint state {state:?} is inconsistent with next sequence {next_sequence}"
+    )]
+    InvalidSequence { state: BotState, next_sequence: u64 },
+    #[error("capture provider {provider:?} requires {expected:?}, but the job targets {actual:?}")]
+    ProviderPlatformMismatch {
+        provider: CaptureProviderKind,
+        expected: MeetingPlatform,
+        actual: MeetingPlatform,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn checkpoint(
+        provider: CaptureProviderKind,
+        platform: MeetingPlatform,
+    ) -> CaptureWorkerCheckpoint {
+        CaptureWorkerCheckpoint {
+            job_id: "job-1".into(),
+            bot_id: "bot-1".into(),
+            provider,
+            meeting: MeetingReference {
+                platform,
+                url: "https://example.com/meeting".into(),
+                external_id: None,
+                calendar_event_id: None,
+            },
+            state: BotState::Queued,
+            next_sequence: 0,
+        }
+    }
+
+    #[test]
+    fn pins_vendor_native_providers_to_their_platform() {
+        for (provider, platform) in [
+            (CaptureProviderKind::ZoomRtms, MeetingPlatform::Zoom),
+            (
+                CaptureProviderKind::MicrosoftGraph,
+                MeetingPlatform::MicrosoftTeams,
+            ),
+            (
+                CaptureProviderKind::WebexMeetingsSdk,
+                MeetingPlatform::Webex,
+            ),
+        ] {
+            checkpoint(provider, platform).validate().unwrap();
+        }
+
+        assert!(matches!(
+            checkpoint(CaptureProviderKind::ZoomRtms, MeetingPlatform::GoogleMeet).validate(),
+            Err(CaptureWorkerCheckpointError::ProviderPlatformMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn keeps_owned_and_external_aggregators_platform_neutral() {
+        for provider in [CaptureProviderKind::Anarlog, CaptureProviderKind::Recall] {
+            for platform in [
+                MeetingPlatform::GoogleMeet,
+                MeetingPlatform::Zoom,
+                MeetingPlatform::MicrosoftTeams,
+                MeetingPlatform::Webex,
+                MeetingPlatform::Jitsi,
+            ] {
+                checkpoint(provider, platform).validate().unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_inconsistent_resume_sequences() {
+        let mut checkpoint = checkpoint(CaptureProviderKind::ZoomRtms, MeetingPlatform::Zoom);
+        checkpoint.state = BotState::Capturing;
+        assert!(matches!(
+            checkpoint.validate(),
+            Err(CaptureWorkerCheckpointError::InvalidSequence { .. })
+        ));
+    }
+}

--- a/enterprise/Cargo.lock
+++ b/enterprise/Cargo.lock
@@ -98,6 +98,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "anarlog-enterprise-meeting-sdk-bridge-worker"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "meeting-capture",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "anarlog-enterprise-zoom-rtms-worker"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "hmac",
+ "meeting-capture",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "url",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,8 +2949,12 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3067,6 +3099,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
 ]
@@ -3330,6 +3364,24 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/enterprise/Cargo.toml
+++ b/enterprise/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 resolver = "2"
-members = ["control-plane", "google-meet-worker"]
+members = [
+  "control-plane",
+  "google-meet-worker",
+  "meeting-sdk-bridge-worker",
+  "zoom-rtms-worker",
+]
 
 [workspace.package]
 version = "0.1.0"
@@ -20,6 +25,7 @@ axum = "0.8"
 base64 = "0.22"
 chrono = "0.4"
 futures-util = "0.3"
+hmac = "0.12"
 http = "1"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
 serde = "1"

--- a/enterprise/control-plane/src/projector.rs
+++ b/enterprise/control-plane/src/projector.rs
@@ -312,6 +312,8 @@ fn provider_name(provider: CaptureProviderKind) -> &'static str {
         CaptureProviderKind::Anarlog => "anarlog",
         CaptureProviderKind::Recall => "recall",
         CaptureProviderKind::ZoomRtms => "zoom_rtms",
+        CaptureProviderKind::MicrosoftGraph => "microsoft_graph",
+        CaptureProviderKind::WebexMeetingsSdk => "webex_meetings_sdk",
     }
 }
 

--- a/enterprise/google-meet-worker/src/event_sink.rs
+++ b/enterprise/google-meet-worker/src/event_sink.rs
@@ -1,6 +1,8 @@
 use std::{collections::VecDeque, time::Duration};
 
-use anlg_meeting_capture::{BotState, CaptureEvent, CaptureProviderKind, MeetingPlatform};
+use anlg_meeting_capture::{
+    BotState, CaptureEvent, CaptureProviderKind, CaptureWorkerCheckpoint, MeetingReference,
+};
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use reqwest::StatusCode;
@@ -373,14 +375,7 @@ impl From<&WorkerLease> for WorkerLeaseIdentity {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WorkerCheckpoint {
-    pub job_id: String,
-    pub bot_id: String,
-    pub meeting_url: crate::GoogleMeetUrl,
-    pub state: BotState,
-    pub next_sequence: u64,
-}
+pub type WorkerCheckpoint = CaptureWorkerCheckpoint;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -397,13 +392,7 @@ struct WireCaptureJob {
     job_id: String,
     bot_id: String,
     provider: CaptureProviderKind,
-    meeting: WireMeetingReference,
-}
-
-#[derive(Deserialize)]
-struct WireMeetingReference {
-    platform: MeetingPlatform,
-    url: String,
+    meeting: MeetingReference,
 }
 
 async fn decode_checkpoint(
@@ -420,26 +409,18 @@ async fn decode_checkpoint(
     }
     validate_identifier(&checkpoint.job.bot_id, "checkpoint bot ID")
         .map_err(|_| CaptureEventSinkError::InvalidCheckpoint("bot ID"))?;
-    if checkpoint.job.provider != CaptureProviderKind::Anarlog {
-        return Err(CaptureEventSinkError::InvalidCheckpoint("capture provider"));
-    }
-    if checkpoint.job.meeting.platform != MeetingPlatform::GoogleMeet {
-        return Err(CaptureEventSinkError::InvalidCheckpoint("meeting platform"));
-    }
-    if checkpoint.state == BotState::Queued && checkpoint.next_sequence != 0
-        || checkpoint.state != BotState::Queued && checkpoint.next_sequence == 0
-    {
-        return Err(CaptureEventSinkError::InvalidCheckpoint("next sequence"));
-    }
-    let meeting_url = crate::GoogleMeetUrl::parse(&checkpoint.job.meeting.url)
-        .map_err(|_| CaptureEventSinkError::InvalidCheckpoint("meeting URL"))?;
-    Ok(WorkerCheckpoint {
+    let checkpoint = WorkerCheckpoint {
         job_id: checkpoint.job.job_id,
         bot_id: checkpoint.job.bot_id,
-        meeting_url,
+        provider: checkpoint.job.provider,
+        meeting: checkpoint.job.meeting,
         state: checkpoint.state,
         next_sequence: checkpoint.next_sequence,
-    })
+    };
+    checkpoint
+        .validate()
+        .map_err(|_| CaptureEventSinkError::InvalidCheckpoint("worker checkpoint"))?;
+    Ok(checkpoint)
 }
 
 async fn decode_bounded_json<T: serde::de::DeserializeOwned>(
@@ -905,7 +886,7 @@ mod tests {
         assert_eq!(checkpoint.job_id, "job-1");
         assert_eq!(checkpoint.bot_id, "bot-1");
         assert_eq!(
-            checkpoint.meeting_url.as_str(),
+            checkpoint.meeting.url,
             "https://meet.google.com/abc-defg-hij"
         );
         assert_eq!(checkpoint.state, BotState::Capturing);

--- a/enterprise/google-meet-worker/src/google_meet_runtime.rs
+++ b/enterprise/google-meet-worker/src/google_meet_runtime.rs
@@ -1,6 +1,8 @@
 use std::{error::Error, time::Duration};
 
-use anlg_meeting_capture::{CaptureEvent, CaptureEventPayload, TransitionError};
+use anlg_meeting_capture::{
+    CaptureEvent, CaptureEventPayload, CaptureProviderKind, MeetingPlatform, TransitionError,
+};
 use async_trait::async_trait;
 use chrono::Utc;
 use tokio::sync::mpsc;
@@ -70,6 +72,10 @@ where
 {
     type Error = GoogleMeetRuntimeError<S::Error>;
 
+    fn validate_checkpoint(&self, checkpoint: &WorkerCheckpoint) -> Result<(), Self::Error> {
+        google_meet_url(checkpoint).map(|_| ())
+    }
+
     async fn run(
         &mut self,
         checkpoint: &WorkerCheckpoint,
@@ -79,11 +85,11 @@ where
         if self.started {
             return Err(GoogleMeetRuntimeError::AlreadyStarted);
         }
+        let meeting_url = google_meet_url(checkpoint)?;
         self.started = true;
         send_event(&events, lifecycle.launch_started(Utc::now())?).await?;
 
-        let session =
-            MeetingSession::launch(self.chromium.clone(), &checkpoint.meeting_url).await?;
+        let session = MeetingSession::launch(self.chromium.clone(), &meeting_url).await?;
         self.session = Some(session);
 
         {
@@ -174,6 +180,21 @@ where
             })
         }
     }
+}
+
+fn google_meet_url<S>(
+    checkpoint: &WorkerCheckpoint,
+) -> Result<crate::GoogleMeetUrl, GoogleMeetRuntimeError<S>>
+where
+    S: Error + Send + Sync + 'static,
+{
+    if checkpoint.provider != CaptureProviderKind::Anarlog
+        || checkpoint.meeting.platform != MeetingPlatform::GoogleMeet
+    {
+        return Err(GoogleMeetRuntimeError::UnsupportedCheckpoint);
+    }
+    crate::GoogleMeetUrl::parse(&checkpoint.meeting.url)
+        .map_err(GoogleMeetRuntimeError::InvalidMeetingUrl)
 }
 
 impl<S> GoogleMeetRuntime<S>
@@ -303,6 +324,10 @@ where
 {
     #[error("Google Meet runtime can only be started once")]
     AlreadyStarted,
+    #[error("Google Meet runtime received a checkpoint for another provider or platform")]
+    UnsupportedCheckpoint,
+    #[error("Google Meet runtime received an invalid meeting URL")]
+    InvalidMeetingUrl(#[source] crate::CdpError),
     #[error("capture supervisor stopped accepting runtime events")]
     EventChannelClosed,
     #[error(transparent)]
@@ -331,7 +356,9 @@ where
 mod tests {
     use std::path::PathBuf;
 
-    use anlg_meeting_capture::{BotState, TranscriptSegment};
+    use anlg_meeting_capture::{
+        BotState, CaptureProviderKind, MeetingPlatform, MeetingReference, TranscriptSegment,
+    };
 
     use super::*;
 
@@ -444,6 +471,29 @@ mod tests {
             Err(GoogleMeetRuntimeConfigError::RuntimeMonitor(
                 RuntimeMonitorError::InvalidPollInterval
             ))
+        ));
+    }
+
+    #[test]
+    fn rejects_other_platforms_before_launching_the_browser() {
+        let runtime = GoogleMeetRuntime::new(config("Anarlog Notetaker"), UnusedSink).unwrap();
+        let checkpoint = WorkerCheckpoint {
+            job_id: "job-1".into(),
+            bot_id: "bot-1".into(),
+            provider: CaptureProviderKind::MicrosoftGraph,
+            meeting: MeetingReference {
+                platform: MeetingPlatform::MicrosoftTeams,
+                url: "https://teams.microsoft.com/l/meetup-join/test".into(),
+                external_id: None,
+                calendar_event_id: None,
+            },
+            state: BotState::Queued,
+            next_sequence: 0,
+        };
+
+        assert!(matches!(
+            runtime.validate_checkpoint(&checkpoint),
+            Err(GoogleMeetRuntimeError::UnsupportedCheckpoint)
         ));
     }
 

--- a/enterprise/google-meet-worker/src/supervisor.rs
+++ b/enterprise/google-meet-worker/src/supervisor.rs
@@ -49,6 +49,10 @@ impl CaptureJobControlPlane for ControlPlaneEventSink {
 pub trait CaptureJobRuntime: Send {
     type Error: Error + Send + Sync + 'static;
 
+    fn validate_checkpoint(&self, _checkpoint: &WorkerCheckpoint) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     async fn run(
         &mut self,
         checkpoint: &WorkerCheckpoint,
@@ -137,6 +141,9 @@ where
         if *shutdown.borrow() {
             return Ok(CaptureJobSupervisorOutcome::ShutdownBeforeClaim);
         }
+        self.runtime
+            .validate_checkpoint(&checkpoint)
+            .map_err(CaptureJobSupervisorError::RuntimeValidation)?;
 
         self.control_plane
             .claim(&self.worker_id, &self.lease_id)
@@ -338,6 +345,8 @@ where
     ControlPlane(#[source] C),
     #[error("capture runtime cleanup failed")]
     Cleanup(#[source] R),
+    #[error("capture runtime rejected the worker checkpoint")]
+    RuntimeValidation(#[source] R),
     #[error("capture runtime produced cleanup output after entering a terminal state")]
     CleanupOutputAfterTerminal,
     #[error("capture runtime cleanup cannot produce lifecycle events")]
@@ -446,7 +455,7 @@ mod tests {
         ) -> Result<(), Self::Error> {
             assert_eq!(checkpoint.job_id, "job-a");
             assert_eq!(
-                checkpoint.meeting_url.as_str(),
+                checkpoint.meeting.url,
                 "https://meet.google.com/abc-defg-hij"
             );
             events
@@ -524,8 +533,13 @@ mod tests {
         WorkerCheckpoint {
             job_id: "job-a".into(),
             bot_id: "bot-a".into(),
-            meeting_url: crate::GoogleMeetUrl::parse("https://meet.google.com/abc-defg-hij")
-                .unwrap(),
+            provider: anlg_meeting_capture::CaptureProviderKind::Anarlog,
+            meeting: anlg_meeting_capture::MeetingReference {
+                platform: anlg_meeting_capture::MeetingPlatform::GoogleMeet,
+                url: "https://meet.google.com/abc-defg-hij".into(),
+                external_id: None,
+                calendar_event_id: None,
+            },
             state,
             next_sequence,
         }

--- a/enterprise/google-meet-worker/tests/live_google_meet.rs
+++ b/enterprise/google-meet-worker/tests/live_google_meet.rs
@@ -64,7 +64,13 @@ async fn captures_a_live_google_meet_and_cleans_up() -> Result<(), Box<dyn std::
     let checkpoint = WorkerCheckpoint {
         job_id: "live-google-meet-job".into(),
         bot_id: "live-google-meet-bot".into(),
-        meeting_url,
+        provider: anlg_meeting_capture::CaptureProviderKind::Anarlog,
+        meeting: anlg_meeting_capture::MeetingReference {
+            platform: anlg_meeting_capture::MeetingPlatform::GoogleMeet,
+            url: meeting_url.as_str().into(),
+            external_id: None,
+            calendar_event_id: None,
+        },
         state: BotState::Queued,
         next_sequence: 0,
     };

--- a/enterprise/meeting-sdk-bridge-worker/Cargo.toml
+++ b/enterprise/meeting-sdk-bridge-worker/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "anarlog-enterprise-meeting-sdk-bridge-worker"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+
+[dependencies]
+anlg-meeting-capture.workspace = true
+
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["io-util", "macros", "process", "rt", "sync", "time"] }

--- a/enterprise/meeting-sdk-bridge-worker/src/lib.rs
+++ b/enterprise/meeting-sdk-bridge-worker/src/lib.rs
@@ -1,0 +1,433 @@
+use std::{ffi::OsString, path::PathBuf, process::Stdio, time::Duration};
+
+use anlg_meeting_capture::{
+    BotState, CaptureEvent, MeetingSdkBridgeCommand, MeetingSdkBridgeError, MeetingSdkBridgeEvent,
+    MeetingSdkBridgeEventPayload, MeetingSdkBridgeNormalizer, MeetingSdkBridgeStart,
+};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
+    process::{Child, ChildStdin, ChildStdout, Command},
+    sync::{mpsc, watch},
+};
+
+const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(15);
+const DEFAULT_MAX_LINE_BYTES: usize = 256 * 1024;
+
+#[derive(Clone)]
+pub struct MeetingSdkBridgeProcessConfig {
+    pub executable: PathBuf,
+    pub args: Vec<OsString>,
+    pub environment: Vec<(OsString, OsString)>,
+    pub startup_timeout: Duration,
+    pub shutdown_timeout: Duration,
+    pub max_line_bytes: usize,
+}
+
+impl MeetingSdkBridgeProcessConfig {
+    pub fn new(executable: impl Into<PathBuf>) -> Self {
+        Self {
+            executable: executable.into(),
+            args: Vec::new(),
+            environment: Vec::new(),
+            startup_timeout: DEFAULT_STARTUP_TIMEOUT,
+            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
+            max_line_bytes: DEFAULT_MAX_LINE_BYTES,
+        }
+    }
+
+    pub fn validate(self) -> Result<Self, MeetingSdkBridgeProcessConfigError> {
+        if !self.executable.is_absolute() {
+            return Err(MeetingSdkBridgeProcessConfigError::ExecutableMustBeAbsolute);
+        }
+        if self.startup_timeout.is_zero() || self.startup_timeout > Duration::from_secs(120) {
+            return Err(MeetingSdkBridgeProcessConfigError::InvalidStartupTimeout);
+        }
+        if self.shutdown_timeout.is_zero() || self.shutdown_timeout > Duration::from_secs(60) {
+            return Err(MeetingSdkBridgeProcessConfigError::InvalidShutdownTimeout);
+        }
+        if !(1024..=4 * 1024 * 1024).contains(&self.max_line_bytes) {
+            return Err(MeetingSdkBridgeProcessConfigError::InvalidMaxLineBytes);
+        }
+        Ok(self)
+    }
+}
+
+impl std::fmt::Debug for MeetingSdkBridgeProcessConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MeetingSdkBridgeProcessConfig")
+            .field("executable", &self.executable)
+            .field("argument_count", &self.args.len())
+            .field(
+                "environment",
+                &self
+                    .environment
+                    .iter()
+                    .map(|(key, _)| key)
+                    .collect::<Vec<_>>(),
+            )
+            .field("startup_timeout", &self.startup_timeout)
+            .field("shutdown_timeout", &self.shutdown_timeout)
+            .field("max_line_bytes", &self.max_line_bytes)
+            .finish()
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum MeetingSdkBridgeProcessConfigError {
+    #[error("meeting SDK bridge executable path must be absolute")]
+    ExecutableMustBeAbsolute,
+    #[error("meeting SDK bridge startup timeout must be between one nanosecond and 120 seconds")]
+    InvalidStartupTimeout,
+    #[error("meeting SDK bridge shutdown timeout must be between one nanosecond and 60 seconds")]
+    InvalidShutdownTimeout,
+    #[error("meeting SDK bridge line limit must be between 1 KiB and 4 MiB")]
+    InvalidMaxLineBytes,
+}
+
+pub struct MeetingSdkBridgeWorker {
+    child: Child,
+    stdin: BufWriter<ChildStdin>,
+    stdout: BufReader<ChildStdout>,
+    normalizer: MeetingSdkBridgeNormalizer,
+    job_id: String,
+    shutdown_timeout: Duration,
+    max_line_bytes: usize,
+}
+
+impl MeetingSdkBridgeWorker {
+    pub async fn launch(
+        config: MeetingSdkBridgeProcessConfig,
+        start: MeetingSdkBridgeStart,
+    ) -> Result<(Self, CaptureEvent), MeetingSdkBridgeWorkerError> {
+        let config = config.validate()?;
+        start.validate()?;
+        let normalizer = MeetingSdkBridgeNormalizer::new(&start.checkpoint)?;
+        let job_id = start.checkpoint.job_id.clone();
+        let mut child = Command::new(&config.executable)
+            .args(&config.args)
+            .env_clear()
+            .envs(config.environment.iter().map(|(key, value)| (key, value)))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true)
+            .spawn()?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or(MeetingSdkBridgeWorkerError::MissingStdin)?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or(MeetingSdkBridgeWorkerError::MissingStdout)?;
+        let mut worker = Self {
+            child,
+            stdin: BufWriter::new(stdin),
+            stdout: BufReader::new(stdout),
+            normalizer,
+            job_id,
+            shutdown_timeout: config.shutdown_timeout,
+            max_line_bytes: config.max_line_bytes,
+        };
+        worker
+            .send_command(&MeetingSdkBridgeCommand::Start(start))
+            .await?;
+        let ready = tokio::time::timeout(config.startup_timeout, worker.read_event())
+            .await
+            .map_err(|_| MeetingSdkBridgeWorkerError::StartupTimeout)??;
+        if !matches!(ready.payload, MeetingSdkBridgeEventPayload::Ready) {
+            worker.terminate().await;
+            return Err(MeetingSdkBridgeWorkerError::ReadyRequired);
+        }
+        let ready = worker.normalizer.accept(ready, chrono::Utc::now())?;
+        Ok((worker, ready))
+    }
+
+    pub async fn run(
+        mut self,
+        events: mpsc::Sender<CaptureEvent>,
+        mut shutdown: watch::Receiver<bool>,
+    ) -> Result<MeetingSdkBridgeWorkerOutcome, MeetingSdkBridgeWorkerError> {
+        if *shutdown.borrow() {
+            self.send_command(&MeetingSdkBridgeCommand::Stop {
+                job_id: self.job_id.clone(),
+            })
+            .await?;
+            return self.drain_shutdown(events).await;
+        }
+        loop {
+            tokio::select! {
+                event = self.read_event() => {
+                    let event = self.normalizer.accept(event?, chrono::Utc::now())?;
+                    let terminal = event_is_terminal(&event);
+                    events.send(event).await.map_err(|_| MeetingSdkBridgeWorkerError::EventReceiverClosed)?;
+                    if terminal {
+                        let state = self.normalizer.state();
+                        self.wait_or_terminate().await?;
+                        return Ok(MeetingSdkBridgeWorkerOutcome::Terminal(state));
+                    }
+                }
+                changed = shutdown.changed() => {
+                    if changed.is_err() || *shutdown.borrow() {
+                        self.send_command(&MeetingSdkBridgeCommand::Stop {
+                            job_id: self.job_id.clone(),
+                        }).await?;
+                        return self.drain_shutdown(events).await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn drain_shutdown(
+        &mut self,
+        events: mpsc::Sender<CaptureEvent>,
+    ) -> Result<MeetingSdkBridgeWorkerOutcome, MeetingSdkBridgeWorkerError> {
+        let result = tokio::time::timeout(self.shutdown_timeout, async {
+            loop {
+                let event = self.read_event().await?;
+                let event = self.normalizer.accept(event, chrono::Utc::now())?;
+                let terminal = event_is_terminal(&event);
+                events
+                    .send(event)
+                    .await
+                    .map_err(|_| MeetingSdkBridgeWorkerError::EventReceiverClosed)?;
+                if terminal {
+                    return Ok::<_, MeetingSdkBridgeWorkerError>(
+                        MeetingSdkBridgeWorkerOutcome::Terminal(self.normalizer.state()),
+                    );
+                }
+            }
+        })
+        .await;
+        match result {
+            Ok(result) => {
+                self.wait_or_terminate().await?;
+                result
+            }
+            Err(_) => {
+                self.terminate().await;
+                Err(MeetingSdkBridgeWorkerError::ShutdownTimeout)
+            }
+        }
+    }
+
+    async fn send_command(
+        &mut self,
+        command: &MeetingSdkBridgeCommand,
+    ) -> Result<(), MeetingSdkBridgeWorkerError> {
+        let mut encoded = serde_json::to_vec(command)?;
+        if encoded.len() > self.max_line_bytes {
+            return Err(MeetingSdkBridgeWorkerError::LineTooLarge);
+        }
+        encoded.push(b'\n');
+        self.stdin.write_all(&encoded).await?;
+        self.stdin.flush().await?;
+        Ok(())
+    }
+
+    async fn read_event(&mut self) -> Result<MeetingSdkBridgeEvent, MeetingSdkBridgeWorkerError> {
+        let line = read_line_bounded(&mut self.stdout, self.max_line_bytes).await?;
+        serde_json::from_slice(&line).map_err(Into::into)
+    }
+
+    async fn wait_or_terminate(&mut self) -> Result<(), MeetingSdkBridgeWorkerError> {
+        match tokio::time::timeout(self.shutdown_timeout, self.child.wait()).await {
+            Ok(Ok(status)) if status.success() => Ok(()),
+            Ok(Ok(status)) => Err(MeetingSdkBridgeWorkerError::SidecarFailed(status.code())),
+            Ok(Err(error)) => Err(error.into()),
+            Err(_) => {
+                self.terminate().await;
+                Err(MeetingSdkBridgeWorkerError::ShutdownTimeout)
+            }
+        }
+    }
+
+    async fn terminate(&mut self) {
+        let _ = self.child.kill().await;
+        let _ = self.child.wait().await;
+    }
+}
+
+fn event_is_terminal(event: &CaptureEvent) -> bool {
+    matches!(
+        &event.payload,
+        anlg_meeting_capture::CaptureEventPayload::Lifecycle(transition)
+            if transition.to.is_terminal()
+    )
+}
+
+async fn read_line_bounded<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut BufReader<R>,
+    max_line_bytes: usize,
+) -> Result<Vec<u8>, MeetingSdkBridgeWorkerError> {
+    let mut line = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return Err(MeetingSdkBridgeWorkerError::SidecarExited);
+        }
+        let take = available
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(available.len(), |index| index + 1);
+        if line.len().saturating_add(take) > max_line_bytes.saturating_add(1) {
+            return Err(MeetingSdkBridgeWorkerError::LineTooLarge);
+        }
+        line.extend_from_slice(&available[..take]);
+        reader.consume(take);
+        if line.last() == Some(&b'\n') {
+            line.pop();
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+            if line.is_empty() {
+                return Err(MeetingSdkBridgeWorkerError::EmptyLine);
+            }
+            return Ok(line);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MeetingSdkBridgeWorkerOutcome {
+    Terminal(BotState),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MeetingSdkBridgeWorkerError {
+    #[error(transparent)]
+    Config(#[from] MeetingSdkBridgeProcessConfigError),
+    #[error(transparent)]
+    Protocol(#[from] MeetingSdkBridgeError),
+    #[error("meeting SDK bridge I/O failed")]
+    Io(#[from] std::io::Error),
+    #[error("meeting SDK bridge JSON is invalid")]
+    Json(#[from] serde_json::Error),
+    #[error("meeting SDK bridge process did not expose stdin")]
+    MissingStdin,
+    #[error("meeting SDK bridge process did not expose stdout")]
+    MissingStdout,
+    #[error("meeting SDK bridge process did not become ready before the deadline")]
+    StartupTimeout,
+    #[error("meeting SDK bridge first event must be ready")]
+    ReadyRequired,
+    #[error("meeting SDK bridge process exited before a complete event")]
+    SidecarExited,
+    #[error("meeting SDK bridge process exited unsuccessfully with code {0:?}")]
+    SidecarFailed(Option<i32>),
+    #[error("meeting SDK bridge process did not stop before the deadline")]
+    ShutdownTimeout,
+    #[error("meeting SDK bridge line exceeded the configured size limit")]
+    LineTooLarge,
+    #[error("meeting SDK bridge emitted an empty line")]
+    EmptyLine,
+    #[error("capture event receiver closed")]
+    EventReceiverClosed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anlg_meeting_capture::{
+        CaptureProviderKind, CaptureWorkerCheckpoint, MeetingPlatform, MeetingReference,
+    };
+    use tokio::io::AsyncWriteExt;
+
+    #[test]
+    fn requires_an_absolute_executable_and_bounded_limits() {
+        assert!(matches!(
+            MeetingSdkBridgeProcessConfig::new("relative-sidecar").validate(),
+            Err(MeetingSdkBridgeProcessConfigError::ExecutableMustBeAbsolute)
+        ));
+        assert!(
+            MeetingSdkBridgeProcessConfig::new("/opt/anarlog/teams-bridge")
+                .validate()
+                .is_ok()
+        );
+
+        let mut config = MeetingSdkBridgeProcessConfig::new("/opt/anarlog/teams-bridge");
+        config.args.push("argument-secret".into());
+        config
+            .environment
+            .push(("TEAMS_CLIENT_SECRET".into(), "environment-secret".into()));
+        let debug = format!("{config:?}");
+        assert!(debug.contains("TEAMS_CLIENT_SECRET"));
+        assert!(!debug.contains("argument-secret"));
+        assert!(!debug.contains("environment-secret"));
+    }
+
+    #[tokio::test]
+    async fn reads_only_complete_bounded_ndjson_records() {
+        let (mut writer, reader) = tokio::io::duplex(64);
+        writer.write_all(b"{\"ok\":true}\n").await.unwrap();
+        let mut reader = BufReader::new(reader);
+        assert_eq!(
+            read_line_bounded(&mut reader, 32).await.unwrap(),
+            br#"{"ok":true}"#
+        );
+
+        let (mut writer, reader) = tokio::io::duplex(64);
+        writer.write_all(b"0123456789\n").await.unwrap();
+        let mut reader = BufReader::new(reader);
+        assert!(matches!(
+            read_line_bounded(&mut reader, 4).await,
+            Err(MeetingSdkBridgeWorkerError::LineTooLarge)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn supervises_a_versioned_teams_sdk_sidecar_to_terminal_state() {
+        let checkpoint = CaptureWorkerCheckpoint {
+            job_id: "job-1".into(),
+            bot_id: "bot-1".into(),
+            provider: CaptureProviderKind::MicrosoftGraph,
+            meeting: MeetingReference {
+                platform: MeetingPlatform::MicrosoftTeams,
+                url: "https://teams.microsoft.com/l/meetup-join/test".into(),
+                external_id: None,
+                calendar_event_id: None,
+            },
+            state: BotState::Queued,
+            next_sequence: 0,
+        };
+        let start = MeetingSdkBridgeStart::new(checkpoint, "Anarlog Notetaker").unwrap();
+        let mut config = MeetingSdkBridgeProcessConfig::new("/bin/sh");
+        config.args = vec![
+            "-c".into(),
+            r#"read -r start
+printf '%s\n' \
+'{"protocolVersion":1,"sequence":0,"platform":"microsoft_teams","provider":"microsoft_graph","payload":{"type":"ready"}}' \
+'{"protocolVersion":1,"sequence":1,"platform":"microsoft_teams","provider":"microsoft_graph","payload":{"type":"joined"}}' \
+'{"protocolVersion":1,"sequence":2,"platform":"microsoft_teams","provider":"microsoft_graph","payload":{"type":"capturing"}}' \
+'{"protocolVersion":1,"sequence":3,"platform":"microsoft_teams","provider":"microsoft_graph","payload":{"type":"terminal","data":{"state":"completed","reason":{"kind":"meeting_ended","retryable":false}}}}'"#.into(),
+        ];
+
+        let (worker, ready) = MeetingSdkBridgeWorker::launch(config, start).await.unwrap();
+        assert!(matches!(
+            ready.payload,
+            anlg_meeting_capture::CaptureEventPayload::Lifecycle(ref transition)
+                if transition.to == BotState::Launching
+        ));
+        let (events_tx, mut events_rx) = mpsc::channel(8);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        assert_eq!(
+            worker.run(events_tx, shutdown_rx).await.unwrap(),
+            MeetingSdkBridgeWorkerOutcome::Terminal(BotState::Completed)
+        );
+        let mut states = Vec::new();
+        while let Ok(event) = events_rx.try_recv() {
+            if let anlg_meeting_capture::CaptureEventPayload::Lifecycle(transition) = event.payload
+            {
+                states.push(transition.to);
+            }
+        }
+        assert_eq!(
+            states,
+            vec![BotState::Joined, BotState::Capturing, BotState::Completed]
+        );
+    }
+}

--- a/enterprise/zoom-rtms-worker/Cargo.toml
+++ b/enterprise/zoom-rtms-worker/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "anarlog-enterprise-zoom-rtms-worker"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+
+[dependencies]
+anlg-meeting-capture.workspace = true
+
+futures-util.workspace = true
+hmac.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2 = "0.10"
+thiserror.workspace = true
+tokio = { workspace = true, features = ["macros", "net", "rt", "sync", "time"] }
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
+url.workspace = true

--- a/enterprise/zoom-rtms-worker/src/lib.rs
+++ b/enterprise/zoom-rtms-worker/src/lib.rs
@@ -1,0 +1,5 @@
+mod protocol;
+mod session;
+
+pub use protocol::*;
+pub use session::*;

--- a/enterprise/zoom-rtms-worker/src/protocol.rs
+++ b/enterprise/zoom-rtms-worker/src/protocol.rs
@@ -1,0 +1,723 @@
+use std::{fmt::Write as _, time::Duration};
+
+use anlg_meeting_capture::{Speaker, TranscriptSegment};
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::Sha256;
+use url::Url;
+
+pub const SIGNALING_HANDSHAKE_REQUEST: u8 = 1;
+pub const SIGNALING_HANDSHAKE_RESPONSE: u8 = 2;
+pub const MEDIA_HANDSHAKE_REQUEST: u8 = 3;
+pub const MEDIA_HANDSHAKE_RESPONSE: u8 = 4;
+pub const CLIENT_READY_ACK: u8 = 7;
+pub const KEEP_ALIVE_REQUEST: u8 = 12;
+pub const KEEP_ALIVE_RESPONSE: u8 = 13;
+pub const TRANSCRIPT_DATA: u8 = 17;
+pub const TRANSCRIPT_MEDIA_TYPE: u8 = 8;
+pub const RTMS_PROTOCOL_VERSION: u8 = 1;
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub struct ZoomRtmsCredentials {
+    client_id: String,
+    client_secret: String,
+}
+
+impl ZoomRtmsCredentials {
+    pub fn new(
+        client_id: impl Into<String>,
+        client_secret: impl Into<String>,
+    ) -> Result<Self, ZoomRtmsConfigError> {
+        let client_id = client_id.into();
+        let client_secret = client_secret.into();
+        validate_secret(&client_id).map_err(|()| ZoomRtmsConfigError::InvalidClientId)?;
+        validate_secret(&client_secret).map_err(|()| ZoomRtmsConfigError::InvalidClientSecret)?;
+        Ok(Self {
+            client_id,
+            client_secret,
+        })
+    }
+
+    pub fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    pub fn signature(&self, meeting_uuid: &str, stream_id: &str) -> String {
+        hmac_hex(
+            self.client_secret.as_bytes(),
+            format!("{},{meeting_uuid},{stream_id}", self.client_id).as_bytes(),
+        )
+    }
+}
+
+impl std::fmt::Debug for ZoomRtmsCredentials {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ZoomRtmsCredentials")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[REDACTED]")
+            .finish()
+    }
+}
+
+fn validate_secret(value: &str) -> Result<(), ()> {
+    if value.is_empty() || value.len() > 512 || value.chars().any(char::is_control) {
+        return Err(());
+    }
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ZoomRtmsConfigError {
+    #[error("Zoom RTMS client ID must contain 1-512 non-control characters")]
+    InvalidClientId,
+    #[error("Zoom RTMS client secret must contain 1-512 non-control characters")]
+    InvalidClientSecret,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZoomRtmsWebhookEvent {
+    UrlValidation { plain_token: String },
+    Started(ZoomRtmsStarted),
+    Stopped { meeting_uuid: String },
+    Interrupted { meeting_uuid: String },
+    Other { event: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZoomRtmsStarted {
+    pub meeting_uuid: String,
+    pub meeting_id: String,
+    pub stream_id: String,
+    pub signaling_url: Url,
+    pub event_timestamp_ms: u64,
+}
+
+impl ZoomRtmsWebhookEvent {
+    pub fn parse(body: &[u8]) -> Result<Self, ZoomRtmsProtocolError> {
+        let webhook: WebhookEnvelope = serde_json::from_slice(body)?;
+        match webhook.event.as_str() {
+            "endpoint.url_validation" => {
+                let payload: UrlValidationPayload = serde_json::from_value(webhook.payload)?;
+                validate_token(&payload.plain_token, "URL validation token")?;
+                Ok(Self::UrlValidation {
+                    plain_token: payload.plain_token,
+                })
+            }
+            "meeting.rtms_started" => {
+                let payload: StartedPayload = serde_json::from_value(webhook.payload)?;
+                let meeting_id = payload.meeting_id.into_string();
+                validate_token(&payload.meeting_uuid, "meeting UUID")?;
+                validate_token(&meeting_id, "meeting ID")?;
+                validate_token(&payload.rtms_stream_id, "RTMS stream ID")?;
+                let signaling_url = validate_websocket_url(&payload.server_urls)?;
+                Ok(Self::Started(ZoomRtmsStarted {
+                    meeting_uuid: payload.meeting_uuid,
+                    meeting_id,
+                    stream_id: payload.rtms_stream_id,
+                    signaling_url,
+                    event_timestamp_ms: webhook.event_ts,
+                }))
+            }
+            "meeting.rtms_stopped" | "meeting.rtms_interrupted" => {
+                let payload: TerminalPayload = serde_json::from_value(webhook.payload)?;
+                validate_token(&payload.meeting_uuid, "meeting UUID")?;
+                if webhook.event == "meeting.rtms_stopped" {
+                    Ok(Self::Stopped {
+                        meeting_uuid: payload.meeting_uuid,
+                    })
+                } else {
+                    Ok(Self::Interrupted {
+                        meeting_uuid: payload.meeting_uuid,
+                    })
+                }
+            }
+            _ => Ok(Self::Other {
+                event: webhook.event,
+            }),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct WebhookEnvelope {
+    event: String,
+    event_ts: u64,
+    payload: Value,
+}
+
+#[derive(Deserialize)]
+struct StartedPayload {
+    meeting_uuid: String,
+    meeting_id: StringOrU64,
+    rtms_stream_id: String,
+    server_urls: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UrlValidationPayload {
+    plain_token: String,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum StringOrU64 {
+    String(String),
+    Number(u64),
+}
+
+impl StringOrU64 {
+    fn into_string(self) -> String {
+        match self {
+            Self::String(value) => value,
+            Self::Number(value) => value.to_string(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct TerminalPayload {
+    meeting_uuid: String,
+}
+
+pub struct ZoomWebhookVerifier {
+    secret: String,
+    max_age: Duration,
+}
+
+impl ZoomWebhookVerifier {
+    pub fn new(
+        secret: impl Into<String>,
+        max_age: Duration,
+    ) -> Result<Self, ZoomWebhookVerificationError> {
+        let secret = secret.into();
+        if validate_secret(&secret).is_err() {
+            return Err(ZoomWebhookVerificationError::InvalidSecret);
+        }
+        if max_age.is_zero() || max_age > Duration::from_secs(60 * 60) {
+            return Err(ZoomWebhookVerificationError::InvalidMaxAge);
+        }
+        Ok(Self { secret, max_age })
+    }
+
+    pub fn verify(
+        &self,
+        timestamp: &str,
+        signature: &str,
+        body: &[u8],
+        now_unix_seconds: u64,
+    ) -> Result<(), ZoomWebhookVerificationError> {
+        let timestamp_seconds = timestamp
+            .parse::<u64>()
+            .map_err(|_| ZoomWebhookVerificationError::InvalidTimestamp)?;
+        if timestamp_seconds > now_unix_seconds.saturating_add(60) {
+            return Err(ZoomWebhookVerificationError::TimestampInFuture);
+        }
+        if now_unix_seconds.saturating_sub(timestamp_seconds) > self.max_age.as_secs() {
+            return Err(ZoomWebhookVerificationError::StaleTimestamp);
+        }
+        let provided = signature
+            .strip_prefix("v0=")
+            .ok_or(ZoomWebhookVerificationError::InvalidSignature)?;
+        let provided =
+            decode_hex_digest(provided).ok_or(ZoomWebhookVerificationError::InvalidSignature)?;
+        let mut mac = HmacSha256::new_from_slice(self.secret.as_bytes())
+            .expect("HMAC accepts keys of every size");
+        mac.update(format!("v0:{timestamp}:").as_bytes());
+        mac.update(body);
+        mac.verify_slice(&provided)
+            .map_err(|_| ZoomWebhookVerificationError::SignatureMismatch)
+    }
+
+    pub fn validation_response(
+        &self,
+        plain_token: impl Into<String>,
+    ) -> Result<ZoomWebhookValidationResponse, ZoomWebhookVerificationError> {
+        let plain_token = plain_token.into();
+        if validate_secret(&plain_token).is_err() {
+            return Err(ZoomWebhookVerificationError::InvalidPlainToken);
+        }
+        Ok(ZoomWebhookValidationResponse {
+            encrypted_token: hmac_hex(self.secret.as_bytes(), plain_token.as_bytes()),
+            plain_token,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZoomWebhookValidationResponse {
+    pub plain_token: String,
+    pub encrypted_token: String,
+}
+
+impl std::fmt::Debug for ZoomWebhookVerifier {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ZoomWebhookVerifier")
+            .field("secret", &"[REDACTED]")
+            .field("max_age", &self.max_age)
+            .finish()
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ZoomWebhookVerificationError {
+    #[error("Zoom webhook secret must contain 1-512 non-control characters")]
+    InvalidSecret,
+    #[error("Zoom webhook maximum age must be between one second and one hour")]
+    InvalidMaxAge,
+    #[error("Zoom webhook URL validation token must contain 1-512 non-control characters")]
+    InvalidPlainToken,
+    #[error("Zoom webhook timestamp is invalid")]
+    InvalidTimestamp,
+    #[error("Zoom webhook timestamp is in the future")]
+    TimestampInFuture,
+    #[error("Zoom webhook timestamp is stale")]
+    StaleTimestamp,
+    #[error("Zoom webhook signature is malformed")]
+    InvalidSignature,
+    #[error("Zoom webhook signature does not match")]
+    SignatureMismatch,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SignalingHandshake<'a> {
+    msg_type: u8,
+    protocol_version: u8,
+    sequence: u64,
+    meeting_uuid: &'a str,
+    rtms_stream_id: &'a str,
+    signature: String,
+    buffer_data: bool,
+}
+
+impl<'a> SignalingHandshake<'a> {
+    pub fn new(started: &'a ZoomRtmsStarted, credentials: &ZoomRtmsCredentials) -> Self {
+        Self {
+            msg_type: SIGNALING_HANDSHAKE_REQUEST,
+            protocol_version: RTMS_PROTOCOL_VERSION,
+            sequence: 0,
+            meeting_uuid: &started.meeting_uuid,
+            rtms_stream_id: &started.stream_id,
+            signature: credentials.signature(&started.meeting_uuid, &started.stream_id),
+            buffer_data: true,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct MediaHandshake<'a> {
+    msg_type: u8,
+    protocol_version: u8,
+    sequence: u64,
+    meeting_uuid: &'a str,
+    rtms_stream_id: &'a str,
+    signature: String,
+    media_type: u8,
+}
+
+impl<'a> MediaHandshake<'a> {
+    pub fn transcripts(started: &'a ZoomRtmsStarted, credentials: &ZoomRtmsCredentials) -> Self {
+        Self {
+            msg_type: MEDIA_HANDSHAKE_REQUEST,
+            protocol_version: RTMS_PROTOCOL_VERSION,
+            sequence: 0,
+            meeting_uuid: &started.meeting_uuid,
+            rtms_stream_id: &started.stream_id,
+            signature: credentials.signature(&started.meeting_uuid, &started.stream_id),
+            media_type: TRANSCRIPT_MEDIA_TYPE,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SignalingMessage {
+    HandshakeAccepted { transcript_url: Url },
+    KeepAlive { timestamp: u64 },
+    Other { message_type: u64 },
+}
+
+impl SignalingMessage {
+    pub fn parse(text: &str) -> Result<Self, ZoomRtmsProtocolError> {
+        let message: WireMessage = serde_json::from_str(text)?;
+        match message.msg_type {
+            value if value == u64::from(SIGNALING_HANDSHAKE_RESPONSE) => {
+                if message.status_code != Some(0) {
+                    return Err(ZoomRtmsProtocolError::HandshakeRejected {
+                        scope: "signaling",
+                        status_code: message.status_code,
+                        reason: message.reason.unwrap_or_default(),
+                    });
+                }
+                let url = message
+                    .media_server
+                    .and_then(|server| server.server_urls.transcript)
+                    .ok_or(ZoomRtmsProtocolError::MissingTranscriptUrl)?;
+                Ok(Self::HandshakeAccepted {
+                    transcript_url: validate_websocket_url(&url)?,
+                })
+            }
+            value if value == u64::from(KEEP_ALIVE_REQUEST) => Ok(Self::KeepAlive {
+                timestamp: message
+                    .timestamp
+                    .ok_or(ZoomRtmsProtocolError::MissingKeepAliveTimestamp)?,
+            }),
+            message_type => Ok(Self::Other { message_type }),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum MediaMessage {
+    HandshakeAccepted,
+    KeepAlive { timestamp: u64 },
+    Transcript(ZoomRtmsTranscript),
+    Other { message_type: u64 },
+}
+
+impl MediaMessage {
+    pub fn parse(text: &str) -> Result<Self, ZoomRtmsProtocolError> {
+        let message: WireMessage = serde_json::from_str(text)?;
+        match message.msg_type {
+            value if value == u64::from(MEDIA_HANDSHAKE_RESPONSE) => {
+                if message.status_code != Some(0) {
+                    return Err(ZoomRtmsProtocolError::HandshakeRejected {
+                        scope: "media",
+                        status_code: message.status_code,
+                        reason: message.reason.unwrap_or_default(),
+                    });
+                }
+                Ok(Self::HandshakeAccepted)
+            }
+            value if value == u64::from(KEEP_ALIVE_REQUEST) => Ok(Self::KeepAlive {
+                timestamp: message
+                    .timestamp
+                    .ok_or(ZoomRtmsProtocolError::MissingKeepAliveTimestamp)?,
+            }),
+            value if value == u64::from(TRANSCRIPT_DATA) => {
+                let content = message
+                    .content
+                    .ok_or(ZoomRtmsProtocolError::MissingTranscriptContent)?;
+                validate_transcript(&content)?;
+                Ok(Self::Transcript(content))
+            }
+            message_type => Ok(Self::Other { message_type }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ZoomRtmsTranscript {
+    pub user_id: u64,
+    pub user_name: String,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub timestamp: u64,
+    pub language: u16,
+    pub data: String,
+}
+
+impl ZoomRtmsTranscript {
+    pub fn into_segment(self, origin_ms: u64, sequence: u64) -> TranscriptSegment {
+        TranscriptSegment {
+            id: format!("zoom-rtms-segment-{sequence}"),
+            sequence,
+            start_ms: self.start_time.saturating_sub(origin_ms),
+            end_ms: Some(self.end_time.saturating_sub(origin_ms)),
+            text: self.data,
+            speaker: Some(Speaker {
+                id: format!("zoom-user-{}", self.user_id),
+                display_name: Some(self.user_name),
+                participant_id: Some(self.user_id.to_string()),
+            }),
+            is_final: true,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct WireMessage {
+    msg_type: u64,
+    status_code: Option<i64>,
+    reason: Option<String>,
+    timestamp: Option<u64>,
+    media_server: Option<WireMediaServer>,
+    content: Option<ZoomRtmsTranscript>,
+}
+
+#[derive(Deserialize)]
+struct WireMediaServer {
+    server_urls: WireMediaUrls,
+}
+
+#[derive(Deserialize)]
+struct WireMediaUrls {
+    transcript: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct KeepAliveResponse {
+    msg_type: u8,
+    timestamp: u64,
+}
+
+impl KeepAliveResponse {
+    pub fn new(timestamp: u64) -> Self {
+        Self {
+            msg_type: KEEP_ALIVE_RESPONSE,
+            timestamp,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ClientReady<'a> {
+    msg_type: u8,
+    rtms_stream_id: &'a str,
+}
+
+impl<'a> ClientReady<'a> {
+    pub fn new(stream_id: &'a str) -> Self {
+        Self {
+            msg_type: CLIENT_READY_ACK,
+            rtms_stream_id: stream_id,
+        }
+    }
+}
+
+fn validate_websocket_url(value: &str) -> Result<Url, ZoomRtmsProtocolError> {
+    let url = Url::parse(value).map_err(ZoomRtmsProtocolError::InvalidWebsocketUrl)?;
+    if url.scheme() != "wss"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(ZoomRtmsProtocolError::UnsafeWebsocketUrl);
+    }
+    Ok(url)
+}
+
+fn validate_token(value: &str, field: &'static str) -> Result<(), ZoomRtmsProtocolError> {
+    if value.is_empty() || value.len() > 512 || value.chars().any(char::is_control) {
+        return Err(ZoomRtmsProtocolError::InvalidWebhookField(field));
+    }
+    Ok(())
+}
+
+fn validate_transcript(value: &ZoomRtmsTranscript) -> Result<(), ZoomRtmsProtocolError> {
+    if value.user_name.is_empty()
+        || value.user_name.len() > 1024
+        || value.user_name.chars().any(char::is_control)
+        || value.data.trim().is_empty()
+        || value.data.len() > 64 * 1024
+        || value.end_time < value.start_time
+    {
+        return Err(ZoomRtmsProtocolError::InvalidTranscript);
+    }
+    Ok(())
+}
+
+fn hmac_hex(key: &[u8], message: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts keys of every size");
+    mac.update(message);
+    let bytes = mac.finalize().into_bytes();
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut encoded, "{byte:02x}").expect("writing to a string cannot fail");
+    }
+    encoded
+}
+
+fn decode_hex_digest(value: &str) -> Option<[u8; 32]> {
+    if value.len() != 64 {
+        return None;
+    }
+    let mut output = [0_u8; 32];
+    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        output[index] = (hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?;
+    }
+    Some(output)
+}
+
+fn hex_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        _ => None,
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ZoomRtmsProtocolError {
+    #[error("invalid Zoom RTMS JSON message")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid Zoom RTMS WebSocket URL")]
+    InvalidWebsocketUrl(#[source] url::ParseError),
+    #[error("Zoom RTMS WebSocket URLs must use wss without credentials or fragments")]
+    UnsafeWebsocketUrl,
+    #[error("invalid Zoom RTMS webhook field: {0}")]
+    InvalidWebhookField(&'static str),
+    #[error("Zoom RTMS {scope} handshake was rejected with status {status_code:?}: {reason}")]
+    HandshakeRejected {
+        scope: &'static str,
+        status_code: Option<i64>,
+        reason: String,
+    },
+    #[error("Zoom RTMS signaling handshake omitted the transcript media URL")]
+    MissingTranscriptUrl,
+    #[error("Zoom RTMS keep-alive request omitted its timestamp")]
+    MissingKeepAliveTimestamp,
+    #[error("Zoom RTMS transcript message omitted its content")]
+    MissingTranscriptContent,
+    #[error("Zoom RTMS transcript content is invalid")]
+    InvalidTranscript,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn started_body(server_url: &str) -> Vec<u8> {
+        started_body_with_meeting_id(server_url, serde_json::json!("123456789"))
+    }
+
+    fn started_body_with_meeting_id(server_url: &str, meeting_id: Value) -> Vec<u8> {
+        serde_json::json!({
+            "event": "meeting.rtms_started",
+            "event_ts": 1_727_384_100_000_u64,
+            "payload": {
+                "meeting_uuid": "meeting-uuid",
+                "meeting_id": meeting_id,
+                "rtms_stream_id": "stream-id",
+                "server_urls": server_url
+            }
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[test]
+    fn verifies_webhooks_without_exposing_the_secret() {
+        let verifier =
+            ZoomWebhookVerifier::new("webhook-secret", Duration::from_secs(300)).unwrap();
+        let body = started_body("wss://rtms.zoom.us/signaling");
+        let timestamp = "1727384100";
+        let signature = format!(
+            "v0={}",
+            hmac_hex(
+                b"webhook-secret",
+                [format!("v0:{timestamp}:").as_bytes(), body.as_slice()]
+                    .concat()
+                    .as_slice()
+            )
+        );
+
+        verifier
+            .verify(timestamp, &signature, &body, 1_727_384_101)
+            .unwrap();
+        assert!(matches!(
+            verifier.verify(
+                timestamp,
+                "v0=0000000000000000000000000000000000000000000000000000000000000000",
+                &body,
+                1_727_384_101
+            ),
+            Err(ZoomWebhookVerificationError::SignatureMismatch)
+        ));
+        assert!(!format!("{verifier:?}").contains("webhook-secret"));
+    }
+
+    #[test]
+    fn parses_and_answers_zoom_url_validation_challenges() {
+        let body = serde_json::json!({
+            "event": "endpoint.url_validation",
+            "event_ts": 1_727_384_100_000_u64,
+            "payload": { "plainToken": "plain-token" }
+        })
+        .to_string();
+        assert!(matches!(
+            ZoomRtmsWebhookEvent::parse(body.as_bytes()).unwrap(),
+            ZoomRtmsWebhookEvent::UrlValidation { plain_token } if plain_token == "plain-token"
+        ));
+
+        let response = ZoomWebhookVerifier::new("webhook-secret", Duration::from_secs(300))
+            .unwrap()
+            .validation_response("plain-token")
+            .unwrap();
+        assert_eq!(response.plain_token, "plain-token");
+        assert_eq!(response.encrypted_token.len(), 64);
+        assert_eq!(
+            serde_json::to_value(response).unwrap()["encryptedToken"]
+                .as_str()
+                .unwrap()
+                .len(),
+            64
+        );
+    }
+
+    #[test]
+    fn rejects_stale_webhooks_and_unsafe_server_urls() {
+        let verifier = ZoomWebhookVerifier::new("webhook-secret", Duration::from_secs(60)).unwrap();
+        assert!(matches!(
+            verifier.verify(
+                "100",
+                "v0=0000000000000000000000000000000000000000000000000000000000000000",
+                b"{}",
+                1000
+            ),
+            Err(ZoomWebhookVerificationError::StaleTimestamp)
+        ));
+        assert!(matches!(
+            ZoomRtmsWebhookEvent::parse(&started_body("ws://127.0.0.1/signaling")),
+            Err(ZoomRtmsProtocolError::UnsafeWebsocketUrl)
+        ));
+    }
+
+    #[test]
+    fn builds_zoom_handshakes_and_parses_attributed_transcripts() {
+        let ZoomRtmsWebhookEvent::Started(started) =
+            ZoomRtmsWebhookEvent::parse(&started_body_with_meeting_id(
+                "wss://rtms.zoom.us/signaling",
+                serde_json::json!(123456789_u64),
+            ))
+            .unwrap()
+        else {
+            panic!("expected started event")
+        };
+        assert_eq!(started.meeting_id, "123456789");
+        let credentials = ZoomRtmsCredentials::new("client-id", "client-secret").unwrap();
+        let signaling =
+            serde_json::to_value(SignalingHandshake::new(&started, &credentials)).unwrap();
+        assert_eq!(signaling["msg_type"], SIGNALING_HANDSHAKE_REQUEST);
+        assert_eq!(signaling["meeting_uuid"], "meeting-uuid");
+        assert_eq!(signaling["signature"].as_str().unwrap().len(), 64);
+
+        assert!(matches!(
+            SignalingMessage::parse(
+                r#"{"msg_type":2,"status_code":0,"media_server":{"server_urls":{"transcript":"wss://rtms.zoom.us/transcript"}}}"#
+            )
+            .unwrap(),
+            SignalingMessage::HandshakeAccepted { .. }
+        ));
+        let MediaMessage::Transcript(transcript) = MediaMessage::parse(
+            r#"{"msg_type":17,"content":{"user_id":19778240,"user_name":"John Smith","start_time":1727384100000,"end_time":1727384310000,"timestamp":1727384349000,"language":9,"data":"Hi, hello world!"}}"#,
+        )
+        .unwrap()
+        else {
+            panic!("expected transcript")
+        };
+        let segment = transcript.into_segment(started.event_timestamp_ms, 4);
+        assert_eq!(segment.sequence, 4);
+        assert_eq!(segment.start_ms, 0);
+        assert_eq!(segment.end_ms, Some(210_000));
+        assert_eq!(
+            segment.speaker.unwrap().participant_id.as_deref(),
+            Some("19778240")
+        );
+    }
+}

--- a/enterprise/zoom-rtms-worker/src/session.rs
+++ b/enterprise/zoom-rtms-worker/src/session.rs
@@ -1,0 +1,264 @@
+use std::time::Duration;
+
+use anlg_meeting_capture::TranscriptSegment;
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::{mpsc, watch};
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream, connect_async,
+    tungstenite::{Message, Utf8Bytes},
+};
+
+use crate::{
+    ClientReady, KeepAliveResponse, MediaHandshake, MediaMessage, SignalingHandshake,
+    SignalingMessage, ZoomRtmsCredentials, ZoomRtmsProtocolError, ZoomRtmsStarted,
+};
+
+const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
+const DEFAULT_MAX_MESSAGE_BYTES: usize = 256 * 1024;
+
+type ZoomWebSocket = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ZoomRtmsSessionConfig {
+    pub handshake_timeout: Duration,
+    pub max_message_bytes: usize,
+}
+
+impl Default for ZoomRtmsSessionConfig {
+    fn default() -> Self {
+        Self {
+            handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
+            max_message_bytes: DEFAULT_MAX_MESSAGE_BYTES,
+        }
+    }
+}
+
+impl ZoomRtmsSessionConfig {
+    pub fn validate(self) -> Result<Self, ZoomRtmsSessionConfigError> {
+        if self.handshake_timeout.is_zero() || self.handshake_timeout > Duration::from_secs(60) {
+            return Err(ZoomRtmsSessionConfigError::InvalidHandshakeTimeout);
+        }
+        if !(1024..=4 * 1024 * 1024).contains(&self.max_message_bytes) {
+            return Err(ZoomRtmsSessionConfigError::InvalidMaxMessageBytes);
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ZoomRtmsSessionConfigError {
+    #[error("Zoom RTMS handshake timeout must be between one nanosecond and 60 seconds")]
+    InvalidHandshakeTimeout,
+    #[error("Zoom RTMS message limit must be between 1 KiB and 4 MiB")]
+    InvalidMaxMessageBytes,
+}
+
+pub struct ZoomRtmsSession {
+    signaling: ZoomWebSocket,
+    media: ZoomWebSocket,
+    started: ZoomRtmsStarted,
+    max_message_bytes: usize,
+    next_segment_sequence: u64,
+}
+
+impl ZoomRtmsSession {
+    pub async fn connect(
+        credentials: &ZoomRtmsCredentials,
+        started: ZoomRtmsStarted,
+        config: ZoomRtmsSessionConfig,
+    ) -> Result<Self, ZoomRtmsSessionError> {
+        let config = config.validate()?;
+        let (mut signaling, _) = connect_async(started.signaling_url.as_str()).await?;
+        send_json(
+            &mut signaling,
+            &SignalingHandshake::new(&started, credentials),
+        )
+        .await?;
+        let transcript_url = tokio::time::timeout(config.handshake_timeout, async {
+            loop {
+                let text = next_text(&mut signaling, config.max_message_bytes, "signaling").await?;
+                match SignalingMessage::parse(&text)? {
+                    SignalingMessage::HandshakeAccepted { transcript_url } => {
+                        break Ok::<_, ZoomRtmsSessionError>(transcript_url);
+                    }
+                    SignalingMessage::KeepAlive { timestamp } => {
+                        send_json(&mut signaling, &KeepAliveResponse::new(timestamp)).await?;
+                    }
+                    SignalingMessage::Other { .. } => {}
+                }
+            }
+        })
+        .await
+        .map_err(|_| ZoomRtmsSessionError::HandshakeTimeout("signaling"))??;
+
+        let (mut media, _) = connect_async(transcript_url.as_str()).await?;
+        send_json(
+            &mut media,
+            &MediaHandshake::transcripts(&started, credentials),
+        )
+        .await?;
+        tokio::time::timeout(config.handshake_timeout, async {
+            loop {
+                let text = next_text(&mut media, config.max_message_bytes, "media").await?;
+                match MediaMessage::parse(&text)? {
+                    MediaMessage::HandshakeAccepted => {
+                        send_json(&mut signaling, &ClientReady::new(&started.stream_id)).await?;
+                        break Ok::<_, ZoomRtmsSessionError>(());
+                    }
+                    MediaMessage::KeepAlive { timestamp } => {
+                        send_json(&mut media, &KeepAliveResponse::new(timestamp)).await?;
+                    }
+                    MediaMessage::Transcript(_) | MediaMessage::Other { .. } => {}
+                }
+            }
+        })
+        .await
+        .map_err(|_| ZoomRtmsSessionError::HandshakeTimeout("media"))??;
+
+        Ok(Self {
+            signaling,
+            media,
+            started,
+            max_message_bytes: config.max_message_bytes,
+            next_segment_sequence: 0,
+        })
+    }
+
+    pub async fn stream_transcripts(
+        &mut self,
+        transcripts: mpsc::Sender<TranscriptSegment>,
+        mut shutdown: watch::Receiver<bool>,
+    ) -> Result<ZoomRtmsSessionOutcome, ZoomRtmsSessionError> {
+        loop {
+            tokio::select! {
+                message = next_text(&mut self.signaling, self.max_message_bytes, "signaling") => {
+                    let text = message?;
+                    if let SignalingMessage::KeepAlive { timestamp } = SignalingMessage::parse(&text)? {
+                        send_json(&mut self.signaling, &KeepAliveResponse::new(timestamp)).await?;
+                    }
+                }
+                message = next_text(&mut self.media, self.max_message_bytes, "media") => {
+                    let text = message?;
+                    match MediaMessage::parse(&text)? {
+                        MediaMessage::KeepAlive { timestamp } => {
+                            send_json(&mut self.media, &KeepAliveResponse::new(timestamp)).await?;
+                        }
+                        MediaMessage::Transcript(transcript) => {
+                            let sequence = self.next_segment_sequence;
+                            self.next_segment_sequence = self.next_segment_sequence
+                                .checked_add(1)
+                                .ok_or(ZoomRtmsSessionError::SequenceExhausted)?;
+                            transcripts
+                                .send(transcript.into_segment(self.started.event_timestamp_ms, sequence))
+                                .await
+                                .map_err(|_| ZoomRtmsSessionError::TranscriptReceiverClosed)?;
+                        }
+                        MediaMessage::HandshakeAccepted | MediaMessage::Other { .. } => {}
+                    }
+                }
+                changed = shutdown.changed() => {
+                    if changed.is_err() || *shutdown.borrow() {
+                        self.close().await;
+                        return Ok(ZoomRtmsSessionOutcome::StoppedByRequest);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn close(&mut self) {
+        let _ = self.media.close(None).await;
+        let _ = self.signaling.close(None).await;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZoomRtmsSessionOutcome {
+    StoppedByRequest,
+}
+
+async fn send_json<T: serde::Serialize>(
+    socket: &mut ZoomWebSocket,
+    value: &T,
+) -> Result<(), ZoomRtmsSessionError> {
+    let text = serde_json::to_string(value)?;
+    socket.send(Message::Text(Utf8Bytes::from(text))).await?;
+    Ok(())
+}
+
+async fn next_text(
+    socket: &mut ZoomWebSocket,
+    max_message_bytes: usize,
+    scope: &'static str,
+) -> Result<String, ZoomRtmsSessionError> {
+    loop {
+        match socket.next().await {
+            Some(Ok(Message::Text(text))) => {
+                if text.len() > max_message_bytes {
+                    return Err(ZoomRtmsSessionError::MessageTooLarge);
+                }
+                return Ok(text.to_string());
+            }
+            Some(Ok(Message::Ping(payload))) => socket.send(Message::Pong(payload)).await?,
+            Some(Ok(Message::Pong(_))) => {}
+            Some(Ok(Message::Close(_))) | None => {
+                return Err(ZoomRtmsSessionError::ConnectionClosed(scope));
+            }
+            Some(Ok(Message::Binary(_))) => {
+                return Err(ZoomRtmsSessionError::UnexpectedBinaryMessage);
+            }
+            Some(Ok(Message::Frame(_))) => {}
+            Some(Err(error)) => return Err(error.into()),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ZoomRtmsSessionError {
+    #[error(transparent)]
+    Config(#[from] ZoomRtmsSessionConfigError),
+    #[error(transparent)]
+    Websocket(#[from] tokio_tungstenite::tungstenite::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Protocol(#[from] ZoomRtmsProtocolError),
+    #[error("Zoom RTMS {0} handshake timed out")]
+    HandshakeTimeout(&'static str),
+    #[error("Zoom RTMS {0} connection closed")]
+    ConnectionClosed(&'static str),
+    #[error("Zoom RTMS message exceeded the configured size limit")]
+    MessageTooLarge,
+    #[error("Zoom RTMS transcript connection sent an unexpected binary message")]
+    UnexpectedBinaryMessage,
+    #[error("Zoom RTMS transcript receiver closed")]
+    TranscriptReceiverClosed,
+    #[error("Zoom RTMS transcript sequence was exhausted")]
+    SequenceExhausted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_session_limits() {
+        assert!(ZoomRtmsSessionConfig::default().validate().is_ok());
+        assert!(matches!(
+            ZoomRtmsSessionConfig {
+                handshake_timeout: Duration::ZERO,
+                ..ZoomRtmsSessionConfig::default()
+            }
+            .validate(),
+            Err(ZoomRtmsSessionConfigError::InvalidHandshakeTimeout)
+        ));
+        assert!(matches!(
+            ZoomRtmsSessionConfig {
+                max_message_bytes: 512,
+                ..ZoomRtmsSessionConfig::default()
+            }
+            .validate(),
+            Err(ZoomRtmsSessionConfigError::InvalidMaxMessageBytes)
+        ));
+    }
+}


### PR DESCRIPTION
Adds shared fail-closed worker checkpoints and SDK bridge contracts, a native Rust Zoom RTMS transcript transport, and a supervised process boundary for Microsoft Teams and Webex SDK sidecars. Keeps the existing Google Meet runtime provider-checked and unchanged for hosted jobs.

Validation:
- `cargo test --locked -p meeting-capture`
- enterprise workspace tests against OrbStack Postgres
- root and enterprise `cargo check --locked`
- strict root and enterprise clippy
- `pnpm fmt:check`