### PR TITLE
ANLG-249: Add mobile attachment upload bridge

### DIFF
--- a/apps/mobile/src/db/client.ts
+++ b/apps/mobile/src/db/client.ts
@@ -81,6 +81,157 @@ export async function restoreAttachment(
   }
 }
 
+export type AttachmentUploadDescriptor = {
+  attachmentRef: string;
+  versionRef: string;
+  ciphertextSizeBytes: number;
+  formatVersion: number;
+};
+
+export type PreparedAttachmentUpload = {
+  cacheId: string;
+  ciphertextSha256: string;
+  ciphertextSizeBytes: number;
+};
+
+export async function describeAttachmentUpload(
+  jobId: string,
+  attemptCount: number,
+  signal?: AbortSignal,
+): Promise<AttachmentUploadDescriptor> {
+  try {
+    const value: unknown = JSON.parse(
+      await getBridge().describeAttachmentUpload(
+        jobId,
+        attemptCount,
+        signal ? { signal } : undefined,
+      ),
+    );
+    if (!value || typeof value !== "object") {
+      throw new Error("Unexpected attachment upload descriptor");
+    }
+    const descriptor = value as Record<string, unknown>;
+    if (
+      !isBlindAttachmentRef(descriptor.attachmentRef) ||
+      !isBlindAttachmentRef(descriptor.versionRef) ||
+      !isPositiveSafeInteger(descriptor.ciphertextSizeBytes) ||
+      descriptor.formatVersion !== 1
+    ) {
+      throw new Error("Unexpected attachment upload descriptor");
+    }
+    return descriptor as AttachmentUploadDescriptor;
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "attachment_upload_describe",
+    });
+    throw error;
+  }
+}
+
+export async function prepareAttachmentUpload(
+  input: {
+    jobId: string;
+    attemptCount: number;
+    objectId: string;
+    objectKey: string;
+  },
+  signal?: AbortSignal,
+): Promise<PreparedAttachmentUpload> {
+  try {
+    const value: unknown = JSON.parse(
+      await getBridge().prepareAttachmentUpload(
+        input.jobId,
+        input.attemptCount,
+        input.objectId,
+        input.objectKey,
+        signal ? { signal } : undefined,
+      ),
+    );
+    if (!value || typeof value !== "object") {
+      throw new Error("Unexpected prepared attachment upload");
+    }
+    const prepared = value as Record<string, unknown>;
+    if (
+      typeof prepared.cacheId !== "string" ||
+      !isUuidV4(prepared.cacheId) ||
+      typeof prepared.ciphertextSha256 !== "string" ||
+      !/^[0-9a-f]{64}$/.test(prepared.ciphertextSha256) ||
+      !isPositiveSafeInteger(prepared.ciphertextSizeBytes)
+    ) {
+      throw new Error("Unexpected prepared attachment upload");
+    }
+    return prepared as PreparedAttachmentUpload;
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "attachment_upload_prepare",
+    });
+    throw error;
+  }
+}
+
+export async function readAttachmentUploadRange(
+  input: {
+    jobId: string;
+    attemptCount: number;
+    cacheId: string;
+    start: number;
+    end: number;
+  },
+  signal?: AbortSignal,
+): Promise<Uint8Array> {
+  try {
+    return new Uint8Array(
+      await getBridge().readAttachmentUploadRange(
+        input.jobId,
+        input.attemptCount,
+        input.cacheId,
+        input.start,
+        input.end,
+        signal ? { signal } : undefined,
+      ),
+    );
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "attachment_upload_read",
+    });
+    throw error;
+  }
+}
+
+export async function cleanupAttachmentUploadCache(
+  input: { jobId: string; attemptCount: number; cacheId: string },
+  signal?: AbortSignal,
+): Promise<boolean> {
+  try {
+    return await getBridge().cleanupAttachmentUploadCache(
+      input.jobId,
+      input.attemptCount,
+      input.cacheId,
+      signal ? { signal } : undefined,
+    );
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "attachment_upload_cleanup",
+      level: "warning",
+    });
+    throw error;
+  }
+}
+
+function isBlindAttachmentRef(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{43}$/.test(value);
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isUuidV4(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(
+    value,
+  );
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }

--- a/crates/mobile-bridge/src/attachment.rs
+++ b/crates/mobile-bridge/src/attachment.rs
@@ -2,8 +2,10 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anlg_attachment_sync_core::{
-    CacheFileGuard, DownloadObject, TransferPaths, download_to_path, persist_staged_attachment,
-    private_cache_path, stage_attachment_restore, valid_sha256, validate_signed_download_url,
+    CacheFileGuard, DownloadObject, MAX_PLAINTEXT_BYTES, TransferPaths, download_to_path,
+    ensure_file_size, file_matches_cancellable_async, persist_staged_attachment,
+    private_cache_path, read_range, seal_attachment_to_cache, stage_attachment_restore,
+    valid_cache_id, valid_sha256, validate_range, validate_signed_download_url,
 };
 use anlg_e2ee::{
     AttachmentBlobCiphertextMetadata, AttachmentBlobContext, AttachmentBlobMetadata,
@@ -19,23 +21,23 @@ use crate::error::{BridgeError, attachment_error, serialization_error};
 const FORMAT_VERSION: u8 = 1;
 
 #[derive(Clone)]
-pub(crate) struct RestoreOperation {
+pub(crate) struct TransferOperation {
     cancellation: CancellationToken,
-    phase: Arc<Mutex<RestorePhase>>,
+    phase: Arc<Mutex<TransferPhase>>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum RestorePhase {
+enum TransferPhase {
     Running,
     Committing,
     Cancelled,
 }
 
-impl RestoreOperation {
+impl TransferOperation {
     pub(crate) fn new() -> Self {
         Self {
             cancellation: CancellationToken::new(),
-            phase: Arc::new(Mutex::new(RestorePhase::Running)),
+            phase: Arc::new(Mutex::new(TransferPhase::Running)),
         }
     }
 
@@ -43,15 +45,22 @@ impl RestoreOperation {
         &self.cancellation
     }
 
+    fn ensure_active(&self) -> Result<(), BridgeError> {
+        if self.cancellation.is_cancelled() {
+            return Err(attachment_error("attachment transfer was cancelled"));
+        }
+        Ok(())
+    }
+
     fn begin_commit(&self) -> Result<(), BridgeError> {
         let mut phase = self
             .phase
             .lock()
-            .map_err(|_| attachment_error("attachment restore state is unavailable"))?;
-        if *phase != RestorePhase::Running || self.cancellation.is_cancelled() {
-            return Err(attachment_error("attachment restore was cancelled"));
+            .map_err(|_| attachment_error("attachment transfer state is unavailable"))?;
+        if *phase != TransferPhase::Running || self.cancellation.is_cancelled() {
+            return Err(attachment_error("attachment transfer was cancelled"));
         }
-        *phase = RestorePhase::Committing;
+        *phase = TransferPhase::Committing;
         Ok(())
     }
 
@@ -60,17 +69,17 @@ impl RestoreOperation {
         let Ok(mut phase) = self.phase.lock() else {
             return true;
         };
-        if *phase != RestorePhase::Running {
+        if *phase != TransferPhase::Running {
             return false;
         }
-        *phase = RestorePhase::Cancelled;
+        *phase = TransferPhase::Cancelled;
         true
     }
 }
 
 #[derive(Clone)]
 pub(crate) struct AttachmentStorage {
-    documents_root: PathBuf,
+    sessions_root: PathBuf,
     transfer_paths: TransferPaths,
 }
 
@@ -78,20 +87,44 @@ impl AttachmentStorage {
     pub(crate) fn new(documents_root: String, cache_root: String) -> Result<Self, BridgeError> {
         let documents_root = canonical_directory(documents_root)?;
         let cache_root = canonical_directory(cache_root)?;
+        let sessions_root = documents_root.join("sessions");
+        std::fs::create_dir_all(&sessions_root).map_err(attachment_error)?;
+        if std::fs::canonicalize(&sessions_root).map_err(attachment_error)? != sessions_root {
+            return Err(attachment_error("attachment sessions path is invalid"));
+        }
         Ok(Self {
             transfer_paths: TransferPaths::new(cache_root, documents_root.clone()),
-            documents_root,
+            sessions_root,
         })
     }
 
     fn destination(&self, attachment: &AttachmentRecord) -> Result<PathBuf, BridgeError> {
         validate_session_id(&attachment.session_id)?;
         validate_audio_relative_path(&attachment.relative_path)?;
-        Ok(self
-            .documents_root
-            .join("sessions")
-            .join(&attachment.session_id)
-            .join(&attachment.relative_path))
+        let session_directory = self.session_directory(&attachment.session_id, true)?;
+        Ok(session_directory.join(&attachment.relative_path))
+    }
+
+    fn source(&self, attachment: &UploadRecord) -> Result<PathBuf, BridgeError> {
+        validate_session_id(&attachment.session_id)?;
+        validate_audio_relative_path(&attachment.relative_path)?;
+        let session_directory = self.session_directory(&attachment.session_id, false)?;
+        let source = session_directory.join(&attachment.relative_path);
+        if std::fs::canonicalize(&source).map_err(attachment_error)? != source {
+            return Err(attachment_error("attachment source path is invalid"));
+        }
+        Ok(source)
+    }
+
+    fn session_directory(&self, session_id: &str, create: bool) -> Result<PathBuf, BridgeError> {
+        let directory = self.sessions_root.join(session_id);
+        if create {
+            std::fs::create_dir_all(&directory).map_err(attachment_error)?;
+        }
+        if std::fs::canonicalize(&directory).map_err(attachment_error)? != directory {
+            return Err(attachment_error("attachment session path is invalid"));
+        }
+        Ok(directory)
     }
 }
 
@@ -131,12 +164,310 @@ struct AttachmentRecord {
     cloud_object_key: String,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UploadDescriptor {
+    attachment_ref: String,
+    version_ref: String,
+    ciphertext_size_bytes: u64,
+    format_version: u8,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PreparedUpload {
+    cache_id: String,
+    ciphertext_sha256: String,
+    ciphertext_size_bytes: u64,
+}
+
+pub(crate) struct PrepareUploadRequest {
+    pub(crate) job_id: String,
+    pub(crate) attempt_count: u32,
+    pub(crate) object_id: String,
+    pub(crate) object_key: String,
+}
+
+pub(crate) struct UploadRangeRequest {
+    pub(crate) job_id: String,
+    pub(crate) attempt_count: u32,
+    pub(crate) cache_id: String,
+    pub(crate) start: u32,
+    pub(crate) end: u32,
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct UploadRecord {
+    job_id: String,
+    attachment_id: String,
+    session_id: String,
+    workspace_id: String,
+    expected_sha256: String,
+    expected_size_bytes: i64,
+    ciphertext_sha256: String,
+    ciphertext_size_bytes: i64,
+    remote_object_id: String,
+    object_key: String,
+    cache_id: String,
+    phase: String,
+    relative_path: String,
+    source_type: String,
+    attachment_sha256: String,
+    attachment_size_bytes: i64,
+    cloud_sync_enabled: i64,
+}
+
+pub(crate) async fn describe_upload(
+    db: Arc<anlg_db_core::Db>,
+    e2ee_sync_hook: Arc<anlg_db_sync::E2eeSyncHook>,
+    job_id: String,
+    attempt_count: u32,
+    operation: TransferOperation,
+) -> Result<String, BridgeError> {
+    operation.ensure_active()?;
+    let record = load_upload_record(db.pool(), &job_id, attempt_count).await?;
+    let plaintext = validate_upload_record(&record)?;
+    let key = workspace_key(&e2ee_sync_hook, &record.workspace_id)?;
+    let descriptor = UploadDescriptor {
+        attachment_ref: key
+            .blind_attachment_backup_ref(&record.workspace_id, &record.attachment_id)
+            .map_err(attachment_error)?,
+        version_ref: key
+            .blind_attachment_backup_version_ref(
+                &record.workspace_id,
+                &record.attachment_id,
+                &plaintext,
+            )
+            .map_err(attachment_error)?,
+        ciphertext_size_bytes: key
+            .attachment_blob_ciphertext_size(
+                &record.workspace_id,
+                &record.attachment_id,
+                plaintext.size_bytes,
+            )
+            .map_err(attachment_error)?,
+        format_version: FORMAT_VERSION,
+    };
+    operation.ensure_active()?;
+    serde_json::to_string(&descriptor).map_err(serialization_error)
+}
+
+pub(crate) async fn prepare_upload(
+    db: Arc<anlg_db_core::Db>,
+    e2ee_sync_hook: Arc<anlg_db_sync::E2eeSyncHook>,
+    storage: AttachmentStorage,
+    request: PrepareUploadRequest,
+    operation: TransferOperation,
+) -> Result<String, BridgeError> {
+    operation.ensure_active()?;
+    validate_private_object_identity(&request.object_id, &request.object_key)?;
+    let record = load_upload_record(db.pool(), &request.job_id, request.attempt_count).await?;
+    let plaintext = validate_upload_record(&record)?;
+    let key = workspace_key(&e2ee_sync_hook, &record.workspace_id)?;
+    let ciphertext_size_bytes = key
+        .attachment_blob_ciphertext_size(
+            &record.workspace_id,
+            &record.attachment_id,
+            plaintext.size_bytes,
+        )
+        .map_err(attachment_error)?;
+    let cache_root = storage.transfer_paths.private_cache_root();
+    tokio::fs::create_dir_all(&cache_root)
+        .await
+        .map_err(attachment_error)?;
+
+    if record.remote_object_id == request.object_id
+        && record.object_key == request.object_key
+        && matches!(
+            record.phase.as_str(),
+            "ready" | "transferring" | "finalizing"
+        )
+        && valid_cache_id(&record.cache_id)
+        && valid_sha256(&record.ciphertext_sha256)
+        && u64::try_from(record.ciphertext_size_bytes).ok() == Some(ciphertext_size_bytes)
+    {
+        let cache_path =
+            private_cache_path(&cache_root, &record.cache_id).map_err(attachment_error)?;
+        if file_matches_cancellable_async(
+            cache_path,
+            ciphertext_size_bytes,
+            record.ciphertext_sha256.clone(),
+            operation.cancellation().clone(),
+        )
+        .await
+        .map_err(attachment_error)?
+        {
+            operation.ensure_active()?;
+            return serde_json::to_string(&PreparedUpload {
+                cache_id: record.cache_id,
+                ciphertext_sha256: record.ciphertext_sha256,
+                ciphertext_size_bytes,
+            })
+            .map_err(serialization_error);
+        }
+    }
+
+    let source_path = storage.source(&record)?;
+    ensure_file_size(&source_path, plaintext.size_bytes).map_err(attachment_error)?;
+    let cache_id = Uuid::new_v4().to_string();
+    let cache_path = private_cache_path(&cache_root, &cache_id).map_err(attachment_error)?;
+    let context = AttachmentBlobContext::new(
+        record.workspace_id.clone(),
+        record.attachment_id.clone(),
+        request.object_id.clone(),
+    )
+    .map_err(attachment_error)?;
+    let (metadata, cache_guard) =
+        seal_attachment_to_cache(key, context, source_path, cache_path, plaintext)
+            .await
+            .map_err(attachment_error)?;
+    operation.ensure_active()?;
+    let ciphertext_sha256 = metadata.ciphertext.sha256_hex();
+    operation.begin_commit()?;
+    let updated = sqlx::query(
+        "UPDATE attachment_transfer_jobs
+         SET remote_object_id = ?, object_key = ?, cache_id = ?,
+             ciphertext_sha256 = ?, ciphertext_size_bytes = ?, phase = 'ready',
+             last_error = '', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+         WHERE id = ? AND direction = 'upload' AND phase <> 'completed'
+           AND attachment_id = ? AND session_id = ? AND workspace_id = ?
+           AND expected_sha256 = ? AND expected_size_bytes = ?
+           AND remote_object_id = ? AND object_key = ?
+           AND cache_id = ? AND phase = ? AND attempt_count = ?",
+    )
+    .bind(&request.object_id)
+    .bind(&request.object_key)
+    .bind(&cache_id)
+    .bind(&ciphertext_sha256)
+    .bind(i64::try_from(metadata.ciphertext.size_bytes).map_err(attachment_error)?)
+    .bind(&record.job_id)
+    .bind(&record.attachment_id)
+    .bind(&record.session_id)
+    .bind(&record.workspace_id)
+    .bind(&record.expected_sha256)
+    .bind(record.expected_size_bytes)
+    .bind(&record.remote_object_id)
+    .bind(&record.object_key)
+    .bind(&record.cache_id)
+    .bind(&record.phase)
+    .bind(i64::from(request.attempt_count))
+    .execute(db.pool())
+    .await
+    .map_err(attachment_error)?;
+    if updated.rows_affected() != 1 {
+        return Err(attachment_error("attachment upload state changed"));
+    }
+    cache_guard.disarm();
+
+    if record.cache_id != cache_id && valid_cache_id(&record.cache_id) {
+        let old_path =
+            private_cache_path(&cache_root, &record.cache_id).map_err(attachment_error)?;
+        let _ = tokio::fs::remove_file(old_path).await;
+    }
+
+    serde_json::to_string(&PreparedUpload {
+        cache_id,
+        ciphertext_sha256,
+        ciphertext_size_bytes: metadata.ciphertext.size_bytes,
+    })
+    .map_err(serialization_error)
+}
+
+pub(crate) async fn read_upload_range(
+    db: Arc<anlg_db_core::Db>,
+    storage: AttachmentStorage,
+    request: UploadRangeRequest,
+    operation: TransferOperation,
+) -> Result<Vec<u8>, BridgeError> {
+    operation.ensure_active()?;
+    let start = u64::from(request.start);
+    let end = u64::from(request.end);
+    validate_range(start, end).map_err(attachment_error)?;
+    if !valid_cache_id(&request.cache_id) {
+        return Err(attachment_error("attachment upload cache is invalid"));
+    }
+    let record = load_upload_record(db.pool(), &request.job_id, request.attempt_count).await?;
+    validate_upload_record(&record)?;
+    if !matches!(
+        record.phase.as_str(),
+        "ready" | "transferring" | "finalizing"
+    ) || record.cache_id != request.cache_id
+        || !valid_sha256(&record.ciphertext_sha256)
+    {
+        return Err(attachment_error("attachment upload state is invalid"));
+    }
+    let size = u64::try_from(record.ciphertext_size_bytes).map_err(attachment_error)?;
+    if size == 0 || end > size {
+        return Err(attachment_error("attachment upload range is invalid"));
+    }
+    let path = private_cache_path(
+        &storage.transfer_paths.private_cache_root(),
+        &request.cache_id,
+    )
+    .map_err(attachment_error)?;
+    let bytes = read_range(path, start, end, size)
+        .await
+        .map_err(attachment_error)?;
+    operation.ensure_active()?;
+    Ok(bytes)
+}
+
+pub(crate) async fn cleanup_upload_cache(
+    db: Arc<anlg_db_core::Db>,
+    storage: AttachmentStorage,
+    job_id: String,
+    attempt_count: u32,
+    cache_id: String,
+    operation: TransferOperation,
+) -> Result<bool, BridgeError> {
+    operation.ensure_active()?;
+    validate_opaque_id(&job_id)?;
+    if attempt_count == 0 || !valid_cache_id(&cache_id) {
+        return Err(attachment_error("attachment upload cache is invalid"));
+    }
+    let current: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+           SELECT 1 FROM attachment_transfer_jobs
+           WHERE id = ? AND attempt_count = ? AND cache_id = ?
+         )",
+    )
+    .bind(&job_id)
+    .bind(i64::from(attempt_count))
+    .bind(&cache_id)
+    .fetch_one(db.pool())
+    .await
+    .map_err(attachment_error)?;
+    if !current {
+        return Ok(false);
+    }
+    operation.begin_commit()?;
+    let path = private_cache_path(&storage.transfer_paths.private_cache_root(), &cache_id)
+        .map_err(attachment_error)?;
+    let removed = match tokio::fs::remove_file(path).await {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => return Err(attachment_error(error)),
+    };
+    sqlx::query(
+        "UPDATE attachment_transfer_jobs
+         SET cache_id = '', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+         WHERE id = ? AND attempt_count = ? AND cache_id = ?",
+    )
+    .bind(&job_id)
+    .bind(i64::from(attempt_count))
+    .bind(&cache_id)
+    .execute(db.pool())
+    .await
+    .map_err(attachment_error)?;
+    Ok(removed)
+}
+
 pub(crate) async fn restore_attachment(
     db: Arc<anlg_db_core::Db>,
     e2ee_sync_hook: Arc<anlg_db_sync::E2eeSyncHook>,
     storage: AttachmentStorage,
     request_json: String,
-    operation: RestoreOperation,
+    operation: TransferOperation,
 ) -> Result<String, BridgeError> {
     let request: RestoreAttachmentRequest =
         serde_json::from_str(&request_json).map_err(|error| {
@@ -302,6 +633,97 @@ async fn load_attachment(
     .map_err(attachment_error)
 }
 
+async fn load_upload_record(
+    pool: &sqlx::SqlitePool,
+    job_id: &str,
+    attempt_count: u32,
+) -> Result<UploadRecord, BridgeError> {
+    validate_opaque_id(job_id)?;
+    if attempt_count == 0 {
+        return Err(attachment_error("attachment upload attempt is invalid"));
+    }
+    sqlx::query_as(
+        "SELECT
+           job.id AS job_id,
+           job.attachment_id,
+           job.session_id,
+           job.workspace_id,
+           job.expected_sha256,
+           job.expected_size_bytes,
+           job.ciphertext_sha256,
+           job.ciphertext_size_bytes,
+           job.remote_object_id,
+           job.object_key,
+           job.cache_id,
+           job.phase,
+           attachment.relative_path,
+           attachment.source_type,
+           attachment.sha256 AS attachment_sha256,
+           attachment.size_bytes AS attachment_size_bytes,
+           attachment.cloud_sync_enabled
+         FROM attachment_transfer_jobs AS job
+         JOIN session_attachments AS attachment
+           ON attachment.id = job.attachment_id
+          AND attachment.session_id = job.session_id
+          AND attachment.workspace_id = job.workspace_id
+          AND attachment.deleted_at IS NULL
+         JOIN attachment_local_state AS local
+           ON local.attachment_id = attachment.id
+          AND local.availability = 'present'
+         WHERE job.id = ? AND job.attempt_count = ?
+           AND job.direction = 'upload' AND job.phase <> 'completed'
+         LIMIT 1",
+    )
+    .bind(job_id)
+    .bind(i64::from(attempt_count))
+    .fetch_one(pool)
+    .await
+    .map_err(attachment_error)
+}
+
+fn validate_upload_record(
+    record: &UploadRecord,
+) -> Result<AttachmentBlobPlaintextMetadata, BridgeError> {
+    if record.job_id.is_empty()
+        || record.attachment_id != format!("session-audio:{}", record.session_id)
+        || record.workspace_id.is_empty()
+        || record.source_type != "session_audio"
+        || record.expected_sha256 != record.attachment_sha256
+        || record.expected_size_bytes != record.attachment_size_bytes
+        || record.cloud_sync_enabled != 1
+        || !valid_sha256(&record.expected_sha256)
+    {
+        return Err(attachment_error("attachment upload state is invalid"));
+    }
+    validate_session_id(&record.session_id)?;
+    validate_audio_relative_path(&record.relative_path)?;
+    let size_bytes = u64::try_from(record.expected_size_bytes).map_err(attachment_error)?;
+    if size_bytes == 0 || size_bytes > MAX_PLAINTEXT_BYTES {
+        return Err(attachment_error("attachment upload size is invalid"));
+    }
+    AttachmentBlobPlaintextMetadata::from_hex(size_bytes, &record.expected_sha256)
+        .map_err(attachment_error)
+}
+
+fn workspace_key(
+    hook: &anlg_db_sync::E2eeSyncHook,
+    workspace_id: &str,
+) -> Result<anlg_e2ee::WorkspaceKey, BridgeError> {
+    hook.workspace_key(workspace_id)
+        .ok_or_else(|| attachment_error("attachment workspace key is unavailable"))
+}
+
+fn validate_opaque_id(value: &str) -> Result<(), BridgeError> {
+    if value.is_empty()
+        || value.len() > 512
+        || value.trim() != value
+        || value.chars().any(char::is_control)
+    {
+        return Err(attachment_error("attachment identifier is invalid"));
+    }
+    Ok(())
+}
+
 fn validate_request(request: &RestoreAttachmentRequest) -> Result<(), BridgeError> {
     validate_session_id(&request.session_id)?;
     if request.attachment_id != format!("session-audio:{}", request.session_id)
@@ -419,13 +841,196 @@ mod tests {
 
     #[test]
     fn cancellation_cannot_interrupt_the_commit_phase() {
-        let cancelled = RestoreOperation::new();
+        let cancelled = TransferOperation::new();
         assert!(cancelled.cancel());
         assert!(cancelled.begin_commit().is_err());
 
-        let committing = RestoreOperation::new();
+        let committing = TransferOperation::new();
         committing.begin_commit().unwrap();
         assert!(!committing.cancel());
+    }
+
+    #[tokio::test]
+    async fn prepares_reads_and_cleans_an_encrypted_audio_upload() {
+        let directory = tempfile::tempdir().unwrap();
+        let documents = directory.path().join("documents");
+        let cache = directory.path().join("cache");
+        let db = Arc::new(
+            crate::db::open_app_db(&directory.path().join("app.db"), false)
+                .await
+                .unwrap(),
+        );
+        let recovery_key = anlg_e2ee::RecoveryKey::generate().unwrap();
+        let workspace_id = Uuid::new_v4().to_string();
+        let session_id = Uuid::new_v4().to_string();
+        let attachment_id = format!("session-audio:{session_id}");
+        let job_id = Uuid::new_v4().to_string();
+        let owner_id = Uuid::new_v4();
+        let object_id = Uuid::new_v4();
+        let object_key = format!("{owner_id}/{object_id}.anb1");
+        let plaintext = b"mobile upload recording";
+        let plaintext_sha256 = hex_digest(Sha256::digest(plaintext).as_slice());
+        let source_directory = documents.join("sessions").join(&session_id);
+        std::fs::create_dir_all(&source_directory).unwrap();
+        std::fs::write(source_directory.join("audio.wav"), plaintext).unwrap();
+        std::fs::create_dir_all(&cache).unwrap();
+
+        sqlx::query("INSERT INTO sessions (id, workspace_id) VALUES (?, ?)")
+            .bind(&session_id)
+            .bind(&workspace_id)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO session_attachments (
+               id, workspace_id, session_id, filename, relative_path,
+               content_type, size_bytes, sha256, cloud_object_key,
+               source_type, cloud_sync_enabled
+             ) VALUES (?, ?, ?, 'audio.wav', 'audio.wav', 'audio/wav', ?, ?, '',
+                       'session_audio', 1)",
+        )
+        .bind(&attachment_id)
+        .bind(&workspace_id)
+        .bind(&session_id)
+        .bind(i64::try_from(plaintext.len()).unwrap())
+        .bind(&plaintext_sha256)
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO attachment_local_state (
+               attachment_id, session_id, relative_path, availability
+             ) VALUES (?, ?, 'audio.wav', 'present')",
+        )
+        .bind(&attachment_id)
+        .bind(&session_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO attachment_transfer_jobs (
+               id, attachment_id, session_id, workspace_id, direction,
+               expected_sha256, expected_size_bytes, phase, attempt_count
+             ) VALUES (?, ?, ?, ?, 'upload', ?, ?, 'preparing', 1)",
+        )
+        .bind(&job_id)
+        .bind(&attachment_id)
+        .bind(&session_id)
+        .bind(&workspace_id)
+        .bind(&plaintext_sha256)
+        .bind(i64::try_from(plaintext.len()).unwrap())
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let hook = Arc::new(anlg_db_sync::E2eeSyncHook::default());
+        hook.set_personal_workspace(&workspace_id, &recovery_key)
+            .unwrap();
+        let storage = AttachmentStorage::new(
+            documents.to_string_lossy().into_owned(),
+            cache.to_string_lossy().into_owned(),
+        )
+        .unwrap();
+        let descriptor: serde_json::Value = serde_json::from_str(
+            &describe_upload(
+                Arc::clone(&db),
+                Arc::clone(&hook),
+                job_id.clone(),
+                1,
+                TransferOperation::new(),
+            )
+            .await
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(descriptor["formatVersion"], FORMAT_VERSION);
+        assert!(descriptor["attachmentRef"].as_str().unwrap().len() >= 32);
+        assert!(descriptor["versionRef"].as_str().unwrap().len() >= 32);
+
+        let prepared: serde_json::Value = serde_json::from_str(
+            &prepare_upload(
+                Arc::clone(&db),
+                hook,
+                storage.clone(),
+                PrepareUploadRequest {
+                    job_id: job_id.clone(),
+                    attempt_count: 1,
+                    object_id: object_id.to_string(),
+                    object_key,
+                },
+                TransferOperation::new(),
+            )
+            .await
+            .unwrap(),
+        )
+        .unwrap();
+        let cache_id = prepared["cacheId"].as_str().unwrap().to_string();
+        let ciphertext_size = prepared["ciphertextSizeBytes"].as_u64().unwrap();
+        assert_eq!(descriptor["ciphertextSizeBytes"], ciphertext_size);
+        let ciphertext = read_upload_range(
+            Arc::clone(&db),
+            storage.clone(),
+            UploadRangeRequest {
+                job_id: job_id.clone(),
+                attempt_count: 1,
+                cache_id: cache_id.clone(),
+                start: 0,
+                end: u32::try_from(ciphertext_size).unwrap(),
+            },
+            TransferOperation::new(),
+        )
+        .await
+        .unwrap();
+        let key = recovery_key.workspace_key(&workspace_id).unwrap();
+        let context =
+            AttachmentBlobContext::new(workspace_id, attachment_id, object_id.to_string()).unwrap();
+        let expected = AttachmentBlobMetadata {
+            version: FORMAT_VERSION,
+            plaintext: AttachmentBlobPlaintextMetadata::from_hex(
+                plaintext.len() as u64,
+                &plaintext_sha256,
+            )
+            .unwrap(),
+            ciphertext: AttachmentBlobCiphertextMetadata::from_hex(
+                ciphertext_size,
+                prepared["ciphertextSha256"].as_str().unwrap(),
+            )
+            .unwrap(),
+        };
+        let mut restored = Vec::new();
+        key.open_attachment_blob(
+            &context,
+            &mut std::io::Cursor::new(ciphertext),
+            &mut restored,
+            &expected,
+        )
+        .unwrap();
+        assert_eq!(restored, plaintext);
+
+        assert!(
+            cleanup_upload_cache(
+                Arc::clone(&db),
+                storage.clone(),
+                job_id.clone(),
+                1,
+                cache_id.clone(),
+                TransferOperation::new(),
+            )
+            .await
+            .unwrap()
+        );
+        assert!(
+            !private_cache_path(&storage.transfer_paths.private_cache_root(), &cache_id)
+                .unwrap()
+                .exists()
+        );
+        let current_cache_id: String =
+            sqlx::query_scalar("SELECT cache_id FROM attachment_transfer_jobs WHERE id = ?")
+                .bind(job_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert!(current_cache_id.is_empty());
     }
 
     #[tokio::test]
@@ -539,7 +1144,7 @@ mod tests {
                 hook,
                 storage,
                 request.to_string(),
-                RestoreOperation::new(),
+                TransferOperation::new(),
             )
             .await
             .unwrap(),

--- a/crates/mobile-bridge/src/lib.rs
+++ b/crates/mobile-bridge/src/lib.rs
@@ -153,7 +153,7 @@ impl MobileDbBridge {
                 })?,
             ))
         })?;
-        let operation = attachment::RestoreOperation::new();
+        let operation = attachment::TransferOperation::new();
         let handle = runtime.spawn(attachment::restore_attachment(
             db,
             e2ee_sync_hook,
@@ -167,6 +167,142 @@ impl MobileDbBridge {
         }
         .await;
         result.map_err(error::attachment_error)?
+    }
+
+    pub async fn describe_attachment_upload(
+        &self,
+        job_id: String,
+        attempt_count: u32,
+    ) -> Result<String, BridgeError> {
+        let (runtime, db, e2ee_sync_hook) = self.with_state(|state| {
+            Ok((
+                Arc::clone(&state.runtime),
+                Arc::clone(&state.db),
+                Arc::clone(&state.e2ee_sync_hook),
+            ))
+        })?;
+        let operation = attachment::TransferOperation::new();
+        let handle = runtime.spawn(attachment::describe_upload(
+            db,
+            e2ee_sync_hook,
+            job_id,
+            attempt_count,
+            operation.clone(),
+        ));
+        CancellableRuntimeTask {
+            handle: Box::pin(handle),
+            operation,
+        }
+        .await
+        .map_err(error::attachment_error)?
+    }
+
+    pub async fn prepare_attachment_upload(
+        &self,
+        job_id: String,
+        attempt_count: u32,
+        object_id: String,
+        object_key: String,
+    ) -> Result<String, BridgeError> {
+        let (runtime, db, e2ee_sync_hook, storage) = self.with_state(|state| {
+            Ok((
+                Arc::clone(&state.runtime),
+                Arc::clone(&state.db),
+                Arc::clone(&state.e2ee_sync_hook),
+                state.attachment_storage.clone().ok_or_else(|| {
+                    error::attachment_error("attachment storage is not configured")
+                })?,
+            ))
+        })?;
+        let operation = attachment::TransferOperation::new();
+        let handle = runtime.spawn(attachment::prepare_upload(
+            db,
+            e2ee_sync_hook,
+            storage,
+            attachment::PrepareUploadRequest {
+                job_id,
+                attempt_count,
+                object_id,
+                object_key,
+            },
+            operation.clone(),
+        ));
+        CancellableRuntimeTask {
+            handle: Box::pin(handle),
+            operation,
+        }
+        .await
+        .map_err(error::attachment_error)?
+    }
+
+    pub async fn read_attachment_upload_range(
+        &self,
+        job_id: String,
+        attempt_count: u32,
+        cache_id: String,
+        start: u32,
+        end: u32,
+    ) -> Result<Vec<u8>, BridgeError> {
+        let (runtime, db, storage) = self.with_state(|state| {
+            Ok((
+                Arc::clone(&state.runtime),
+                Arc::clone(&state.db),
+                state.attachment_storage.clone().ok_or_else(|| {
+                    error::attachment_error("attachment storage is not configured")
+                })?,
+            ))
+        })?;
+        let operation = attachment::TransferOperation::new();
+        let handle = runtime.spawn(attachment::read_upload_range(
+            db,
+            storage,
+            attachment::UploadRangeRequest {
+                job_id,
+                attempt_count,
+                cache_id,
+                start,
+                end,
+            },
+            operation.clone(),
+        ));
+        CancellableRuntimeTask {
+            handle: Box::pin(handle),
+            operation,
+        }
+        .await
+        .map_err(error::attachment_error)?
+    }
+
+    pub async fn cleanup_attachment_upload_cache(
+        &self,
+        job_id: String,
+        attempt_count: u32,
+        cache_id: String,
+    ) -> Result<bool, BridgeError> {
+        let (runtime, db, storage) = self.with_state(|state| {
+            Ok((
+                Arc::clone(&state.runtime),
+                Arc::clone(&state.db),
+                state.attachment_storage.clone().ok_or_else(|| {
+                    error::attachment_error("attachment storage is not configured")
+                })?,
+            ))
+        })?;
+        let operation = attachment::TransferOperation::new();
+        let handle = runtime.spawn(attachment::cleanup_upload_cache(
+            db,
+            storage,
+            job_id,
+            attempt_count,
+            cache_id,
+            operation.clone(),
+        ));
+        CancellableRuntimeTask {
+            handle: Box::pin(handle),
+            operation,
+        }
+        .await
+        .map_err(error::attachment_error)?
     }
 
     pub fn subscribe(
@@ -569,7 +705,7 @@ impl MobileDbBridge {
 
 struct CancellableRuntimeTask<T> {
     handle: std::pin::Pin<Box<tokio::task::JoinHandle<T>>>,
-    operation: attachment::RestoreOperation,
+    operation: attachment::TransferOperation,
 }
 
 impl<T> Future for CancellableRuntimeTask<T> {

--- a/packages/mobile-bridge-rn/cpp/generated/mobile_bridge.cpp
+++ b/packages/mobile-bridge-rn/cpp/generated/mobile_bridge.cpp
@@ -159,6 +159,12 @@ extern "C" {
         RustBuffer cloudsync_open_mode,
         RustCallStatus *uniffi_out_err
     );
+    /*handle*/ uint64_t uniffi_mobile_bridge_fn_method_mobiledbbridge_cleanup_attachment_upload_cache(
+        /*handle*/ uint64_t ptr,
+        RustBuffer job_id,
+        uint32_t attempt_count,
+        RustBuffer cache_id
+    );
     void uniffi_mobile_bridge_fn_method_mobiledbbridge_close(
         /*handle*/ uint64_t ptr,
         RustCallStatus *uniffi_out_err
@@ -222,6 +228,11 @@ extern "C" {
         RustBuffer recovery_key_code,
         RustCallStatus *uniffi_out_err
     );
+    /*handle*/ uint64_t uniffi_mobile_bridge_fn_method_mobiledbbridge_describe_attachment_upload(
+        /*handle*/ uint64_t ptr,
+        RustBuffer job_id,
+        uint32_t attempt_count
+    );
     RustBuffer uniffi_mobile_bridge_fn_method_mobiledbbridge_execute(
         /*handle*/ uint64_t ptr,
         RustBuffer sql,
@@ -248,6 +259,21 @@ extern "C" {
         /*handle*/ uint64_t ptr,
         RustBuffer recovery_key_code,
         RustCallStatus *uniffi_out_err
+    );
+    /*handle*/ uint64_t uniffi_mobile_bridge_fn_method_mobiledbbridge_prepare_attachment_upload(
+        /*handle*/ uint64_t ptr,
+        RustBuffer job_id,
+        uint32_t attempt_count,
+        RustBuffer object_id,
+        RustBuffer object_key
+    );
+    /*handle*/ uint64_t uniffi_mobile_bridge_fn_method_mobiledbbridge_read_attachment_upload_range(
+        /*handle*/ uint64_t ptr,
+        RustBuffer job_id,
+        uint32_t attempt_count,
+        RustBuffer cache_id,
+        uint32_t start,
+        uint32_t end
     );
     /*handle*/ uint64_t uniffi_mobile_bridge_fn_method_mobiledbbridge_restore_attachment(
         /*handle*/ uint64_t ptr,
@@ -491,6 +517,8 @@ extern "C" {
         /*handle*/ uint64_t handle,
         RustCallStatus *uniffi_out_err
     );
+    uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_cleanup_attachment_upload_cache(
+    );
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_close(
     );
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_cloudsync_init(
@@ -515,6 +543,8 @@ extern "C" {
     );
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_configure_e2ee_replica(
     );
+    uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_describe_attachment_upload(
+    );
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute(
     );
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_proxy(
@@ -524,6 +554,10 @@ extern "C" {
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key(
     );
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(
+    );
+    uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_prepare_attachment_upload(
+    );
+    uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_read_attachment_upload_range(
     );
     uint16_t uniffi_mobile_bridge_checksum_method_mobiledbbridge_restore_attachment(
     );
@@ -2567,6 +2601,14 @@ NativeMobileBridge::NativeMobileBridge(
             return this->cpp_uniffi_mobile_bridge_fn_constructor_mobiledbbridge_open(rt, thisVal, args, count);
         }
     );
+    props["ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_cleanup_attachment_upload_cache"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_cleanup_attachment_upload_cache"),
+        4,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_cleanup_attachment_upload_cache(rt, thisVal, args, count);
+        }
+    );
     props["ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_close"] = jsi::Function::createFromHostFunction(
         rt,
         jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_close"),
@@ -2663,6 +2705,14 @@ NativeMobileBridge::NativeMobileBridge(
             return this->cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_configure_e2ee_replica(rt, thisVal, args, count);
         }
     );
+    props["ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_describe_attachment_upload"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_describe_attachment_upload"),
+        3,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_describe_attachment_upload(rt, thisVal, args, count);
+        }
+    );
     props["ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute"] = jsi::Function::createFromHostFunction(
         rt,
         jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute"),
@@ -2701,6 +2751,22 @@ NativeMobileBridge::NativeMobileBridge(
         2,
         [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
             return this->cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_prepare_attachment_upload"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_prepare_attachment_upload"),
+        5,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_prepare_attachment_upload(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_read_attachment_upload_range"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_read_attachment_upload_range"),
+        6,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_read_attachment_upload_range(rt, thisVal, args, count);
         }
     );
     props["ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_restore_attachment"] = jsi::Function::createFromHostFunction(
@@ -3167,6 +3233,14 @@ NativeMobileBridge::NativeMobileBridge(
             return this->cpp_ffi_mobile_bridge_rust_future_complete_void(rt, thisVal, args, count);
         }
     );
+    props["ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cleanup_attachment_upload_cache"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cleanup_attachment_upload_cache"),
+        0,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cleanup_attachment_upload_cache(rt, thisVal, args, count);
+        }
+    );
     props["ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_close"] = jsi::Function::createFromHostFunction(
         rt,
         jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_close"),
@@ -3263,6 +3337,14 @@ NativeMobileBridge::NativeMobileBridge(
             return this->cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_configure_e2ee_replica(rt, thisVal, args, count);
         }
     );
+    props["ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_describe_attachment_upload"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_describe_attachment_upload"),
+        0,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_describe_attachment_upload(rt, thisVal, args, count);
+        }
+    );
     props["ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute"] = jsi::Function::createFromHostFunction(
         rt,
         jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute"),
@@ -3301,6 +3383,22 @@ NativeMobileBridge::NativeMobileBridge(
         0,
         [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
             return this->cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_prepare_attachment_upload"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_prepare_attachment_upload"),
+        0,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_prepare_attachment_upload(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_read_attachment_upload_range"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_read_attachment_upload_range"),
+        0,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_read_attachment_upload_range(rt, thisVal, args, count);
         }
     );
     props["ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_restore_attachment"] = jsi::Function::createFromHostFunction(
@@ -3582,6 +3680,13 @@ jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_constructor_mobiledbb
 
         return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker, value);
 }
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_cleanup_attachment_upload_cache(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_mobile_bridge_fn_method_mobiledbbridge_cleanup_attachment_upload_cache(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1]), uniffi_jsi::Bridging<uint32_t>::fromJs(rt, callInvoker, args[2]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[3])
+        );
+
+
+        return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker, value);
+}
 jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_close(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         RustCallStatus status = uniffi::mobile_bridge::Bridging<RustCallStatus>::rustSuccess(rt);
         uniffi_mobile_bridge_fn_method_mobiledbbridge_close(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]),
@@ -3702,6 +3807,13 @@ jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge
 
         return uniffi::mobile_bridge::Bridging<RustBuffer>::toJs(rt, callInvoker, value);
 }
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_describe_attachment_upload(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_mobile_bridge_fn_method_mobiledbbridge_describe_attachment_upload(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1]), uniffi_jsi::Bridging<uint32_t>::fromJs(rt, callInvoker, args[2])
+        );
+
+
+        return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker, value);
+}
 jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         RustCallStatus status = uniffi::mobile_bridge::Bridging<RustCallStatus>::rustSuccess(rt);
         auto value = uniffi_mobile_bridge_fn_method_mobiledbbridge_execute(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[2]),
@@ -3751,6 +3863,20 @@ jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge
 
 
         return uniffi::mobile_bridge::Bridging<RustBuffer>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_prepare_attachment_upload(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_mobile_bridge_fn_method_mobiledbbridge_prepare_attachment_upload(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1]), uniffi_jsi::Bridging<uint32_t>::fromJs(rt, callInvoker, args[2]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[3]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[4])
+        );
+
+
+        return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_read_attachment_upload_range(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_mobile_bridge_fn_method_mobiledbbridge_read_attachment_upload_range(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1]), uniffi_jsi::Bridging<uint32_t>::fromJs(rt, callInvoker, args[2]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[3]), uniffi_jsi::Bridging<uint32_t>::fromJs(rt, callInvoker, args[4]), uniffi_jsi::Bridging<uint32_t>::fromJs(rt, callInvoker, args[5])
+        );
+
+
+        return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker, value);
 }
 jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_restore_attachment(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         auto value = uniffi_mobile_bridge_fn_method_mobiledbbridge_restore_attachment(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), uniffi::mobile_bridge::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1])
@@ -4228,6 +4354,13 @@ jsi::Value NativeMobileBridge::cpp_ffi_mobile_bridge_rust_future_complete_void(j
 
         return jsi::Value::undefined();
 }
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cleanup_attachment_upload_cache(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_mobile_bridge_checksum_method_mobiledbbridge_cleanup_attachment_upload_cache(
+        );
+
+
+        return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
 jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_close(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         auto value = uniffi_mobile_bridge_checksum_method_mobiledbbridge_close(
         );
@@ -4312,6 +4445,13 @@ jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledb
 
         return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
 }
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_describe_attachment_upload(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_mobile_bridge_checksum_method_mobiledbbridge_describe_attachment_upload(
+        );
+
+
+        return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
 jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         auto value = uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute(
         );
@@ -4342,6 +4482,20 @@ jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledb
 }
 jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         auto value = uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(
+        );
+
+
+        return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_prepare_attachment_upload(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_mobile_bridge_checksum_method_mobiledbbridge_prepare_attachment_upload(
+        );
+
+
+        return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeMobileBridge::cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_read_attachment_upload_range(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_mobile_bridge_checksum_method_mobiledbbridge_read_attachment_upload_range(
         );
 
 

--- a/packages/mobile-bridge-rn/cpp/generated/mobile_bridge.hpp
+++ b/packages/mobile-bridge-rn/cpp/generated/mobile_bridge.hpp
@@ -25,6 +25,7 @@ class NativeMobileBridge : public jsi::HostObject {
     jsi::Value cpp_uniffi_mobile_bridge_fn_clone_mobiledbbridge(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_free_mobiledbbridge(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_constructor_mobiledbbridge_open(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_cleanup_attachment_upload_cache(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_close(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_cloudsync_init(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_cloudsync_network_init(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
@@ -37,11 +38,14 @@ class NativeMobileBridge : public jsi::HostObject {
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_configure_attachment_storage(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_configure_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_configure_e2ee_replica(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_describe_attachment_upload(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute_proxy(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute_transaction(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_generate_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_inspect_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_prepare_attachment_upload(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_read_attachment_upload_range(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_restore_attachment(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_start_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_fn_method_mobiledbbridge_stop_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
@@ -100,6 +104,7 @@ class NativeMobileBridge : public jsi::HostObject {
     jsi::Value cpp_ffi_mobile_bridge_rust_future_cancel_void(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_ffi_mobile_bridge_rust_future_free_void(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_ffi_mobile_bridge_rust_future_complete_void(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cleanup_attachment_upload_cache(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_close(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cloudsync_init(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cloudsync_network_init(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
@@ -112,11 +117,14 @@ class NativeMobileBridge : public jsi::HostObject {
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_configure_attachment_storage(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_configure_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_configure_e2ee_replica(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_describe_attachment_upload(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_proxy(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_transaction(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_prepare_attachment_upload(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_read_attachment_upload_range(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_restore_attachment(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_start_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_mobile_bridge_checksum_method_mobiledbbridge_stop_cloudsync(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);

--- a/packages/mobile-bridge-rn/src/generated/mobile_bridge-ffi.ts
+++ b/packages/mobile-bridge-rn/src/generated/mobile_bridge-ffi.ts
@@ -188,6 +188,12 @@ interface NativeModuleInterface {
     cloudsyncOpenMode: Uint8Array,
     uniffi_out_err: UniffiRustCallStatus,
   ): bigint;
+  ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_cleanup_attachment_upload_cache(
+    uniffiSelf: bigint,
+    jobId: Uint8Array,
+    attemptCount: number,
+    cacheId: Uint8Array,
+  ): bigint;
   ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_close(
     uniffiSelf: bigint,
     uniffi_out_err: UniffiRustCallStatus,
@@ -251,6 +257,11 @@ interface NativeModuleInterface {
     recoveryKeyCode: Uint8Array,
     uniffi_out_err: UniffiRustCallStatus,
   ): Uint8Array;
+  ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_describe_attachment_upload(
+    uniffiSelf: bigint,
+    jobId: Uint8Array,
+    attemptCount: number,
+  ): bigint;
   ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_execute(
     uniffiSelf: bigint,
     sql: Uint8Array,
@@ -278,6 +289,21 @@ interface NativeModuleInterface {
     recoveryKeyCode: Uint8Array,
     uniffi_out_err: UniffiRustCallStatus,
   ): Uint8Array;
+  ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_prepare_attachment_upload(
+    uniffiSelf: bigint,
+    jobId: Uint8Array,
+    attemptCount: number,
+    objectId: Uint8Array,
+    objectKey: Uint8Array,
+  ): bigint;
+  ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_read_attachment_upload_range(
+    uniffiSelf: bigint,
+    jobId: Uint8Array,
+    attemptCount: number,
+    cacheId: Uint8Array,
+    start: number,
+    end: number,
+  ): bigint;
   ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_restore_attachment(
     uniffiSelf: bigint,
     requestJson: Uint8Array,
@@ -314,6 +340,7 @@ interface NativeModuleInterface {
   ): void;
   ubrn_ffi_mobile_bridge_uniffi_contract_version(): number;
   ubrn_uniffi_mobile_bridge_checksum_constructor_mobiledbbridge_open(): number;
+  ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cleanup_attachment_upload_cache(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_close(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cloudsync_init(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cloudsync_network_init(): number;
@@ -326,11 +353,14 @@ interface NativeModuleInterface {
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_configure_attachment_storage(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_configure_cloudsync(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_configure_e2ee_replica(): number;
+  ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_describe_attachment_upload(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_proxy(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute_transaction(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_generate_e2ee_recovery_key(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key(): number;
+  ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_prepare_attachment_upload(): number;
+  ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_read_attachment_upload_range(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_restore_attachment(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_start_cloudsync(): number;
   ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_stop_cloudsync(): number;

--- a/packages/mobile-bridge-rn/src/generated/mobile_bridge.ts
+++ b/packages/mobile-bridge-rn/src/generated/mobile_bridge.ts
@@ -19,11 +19,14 @@ import {
   type UniffiReferenceHolder,
   type UniffiRustCallStatus,
   AbstractFfiConverterByteArray,
+  FfiConverterArrayBuffer,
+  FfiConverterBool,
   FfiConverterInt32,
   FfiConverterInt64,
   FfiConverterObject,
   FfiConverterObjectWithCallbacks,
   FfiConverterOptional,
+  FfiConverterUInt32,
   FfiConverterUInt8,
   RustBuffer,
   UniffiAbstractObject,
@@ -928,6 +931,12 @@ const uniffiCallbackInterfaceQueryEventListener: {
 };
 
 export interface MobileDbBridgeLike {
+  cleanupAttachmentUploadCache(
+    jobId: string,
+    attemptCount: number,
+    cacheId: string,
+    asyncOpts_?: { signal: AbortSignal },
+  ) /*throws*/ : Promise<boolean>;
   close() /*throws*/ : void;
   cloudsyncInit(
     tableName: string,
@@ -955,6 +964,11 @@ export interface MobileDbBridgeLike {
     witnessAccessToken: string,
     recoveryKeyCode: string,
   ) /*throws*/ : string;
+  describeAttachmentUpload(
+    jobId: string,
+    attemptCount: number,
+    asyncOpts_?: { signal: AbortSignal },
+  ) /*throws*/ : Promise<string>;
   execute(sql: string, paramsJson: string) /*throws*/ : string;
   executeProxy(
     sql: string,
@@ -964,6 +978,21 @@ export interface MobileDbBridgeLike {
   executeTransaction(statementsJson: string) /*throws*/ : string;
   generateE2eeRecoveryKey() /*throws*/ : string;
   inspectE2eeRecoveryKey(recoveryKeyCode: string) /*throws*/ : string;
+  prepareAttachmentUpload(
+    jobId: string,
+    attemptCount: number,
+    objectId: string,
+    objectKey: string,
+    asyncOpts_?: { signal: AbortSignal },
+  ) /*throws*/ : Promise<string>;
+  readAttachmentUploadRange(
+    jobId: string,
+    attemptCount: number,
+    cacheId: string,
+    start: number,
+    end: number,
+    asyncOpts_?: { signal: AbortSignal },
+  ) /*throws*/ : Promise<ArrayBuffer>;
   restoreAttachment(
     requestJson: string,
     asyncOpts_?: { signal: AbortSignal },
@@ -1019,6 +1048,53 @@ export class MobileDbBridge
         /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
       ),
     );
+  }
+
+  async cleanupAttachmentUploadCache(
+    jobId: string,
+    attemptCount: number,
+    cacheId: string,
+    asyncOpts_?: { signal: AbortSignal },
+  ): Promise<boolean> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+      return await uniffiRustCallAsync(
+        /*rustCaller:*/ uniffiCaller,
+        /*rustFutureFunc:*/ () => {
+          return nativeModule().ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_cleanup_attachment_upload_cache(
+            uniffiTypeMobileDbBridgeObjectFactory.clonePointer(this),
+            FfiConverterString.lower(jobId, nativeModule().rustbuffer_alloc),
+            FfiConverterUInt32.lower(
+              attemptCount,
+              nativeModule().rustbuffer_alloc,
+            ),
+            FfiConverterString.lower(cacheId, nativeModule().rustbuffer_alloc),
+          );
+        },
+        /*pollFunc:*/ nativeModule().ubrn_ffi_mobile_bridge_rust_future_poll_i8,
+        /*cancelFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_cancel_i8,
+        /*completeFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_complete_i8,
+        /*freeFunc:*/ nativeModule().ubrn_ffi_mobile_bridge_rust_future_free_i8,
+        // Async returns always go through the JS-side converter: the
+        // FFI symbol returns the future handle (u64), and the user-level
+        // RustBuffer comes back via the shared `rust_future_complete_*`
+        // export. The bytes the runtime hands back must be deserialized
+        // here using the per-callable return-type converter.
+        /*liftFunc:*/ FfiConverterBool.lift.bind(FfiConverterBool),
+        /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+        /*asyncOpts:*/ asyncOpts_,
+        /*errorHandler:*/ FfiConverterTypeBridgeError.lift.bind(
+          FfiConverterTypeBridgeError,
+        ),
+      );
+    } catch (__error: any) {
+      if (uniffiIsDebug && __error instanceof Error) {
+        __error.stack = __stack;
+      }
+      throw __error;
+    }
   }
 
   close(): void /*throws*/ {
@@ -1301,6 +1377,53 @@ export class MobileDbBridge
     );
   }
 
+  async describeAttachmentUpload(
+    jobId: string,
+    attemptCount: number,
+    asyncOpts_?: { signal: AbortSignal },
+  ): Promise<string> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+      return await uniffiRustCallAsync(
+        /*rustCaller:*/ uniffiCaller,
+        /*rustFutureFunc:*/ () => {
+          return nativeModule().ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_describe_attachment_upload(
+            uniffiTypeMobileDbBridgeObjectFactory.clonePointer(this),
+            FfiConverterString.lower(jobId, nativeModule().rustbuffer_alloc),
+            FfiConverterUInt32.lower(
+              attemptCount,
+              nativeModule().rustbuffer_alloc,
+            ),
+          );
+        },
+        /*pollFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_poll_rust_buffer,
+        /*cancelFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_cancel_rust_buffer,
+        /*completeFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_complete_rust_buffer,
+        /*freeFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_free_rust_buffer,
+        // Async returns always go through the JS-side converter: the
+        // FFI symbol returns the future handle (u64), and the user-level
+        // RustBuffer comes back via the shared `rust_future_complete_*`
+        // export. The bytes the runtime hands back must be deserialized
+        // here using the per-callable return-type converter.
+        /*liftFunc:*/ FfiConverterString.lift.bind(FfiConverterString),
+        /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+        /*asyncOpts:*/ asyncOpts_,
+        /*errorHandler:*/ FfiConverterTypeBridgeError.lift.bind(
+          FfiConverterTypeBridgeError,
+        ),
+      );
+    } catch (__error: any) {
+      if (uniffiIsDebug && __error instanceof Error) {
+        __error.stack = __stack;
+      }
+      throw __error;
+    }
+  }
+
   execute(sql: string, paramsJson: string): string /*throws*/ {
     return ((__rb: Uint8Array) => {
       try {
@@ -1437,6 +1560,115 @@ export class MobileDbBridge
         /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
       ),
     );
+  }
+
+  async prepareAttachmentUpload(
+    jobId: string,
+    attemptCount: number,
+    objectId: string,
+    objectKey: string,
+    asyncOpts_?: { signal: AbortSignal },
+  ): Promise<string> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+      return await uniffiRustCallAsync(
+        /*rustCaller:*/ uniffiCaller,
+        /*rustFutureFunc:*/ () => {
+          return nativeModule().ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_prepare_attachment_upload(
+            uniffiTypeMobileDbBridgeObjectFactory.clonePointer(this),
+            FfiConverterString.lower(jobId, nativeModule().rustbuffer_alloc),
+            FfiConverterUInt32.lower(
+              attemptCount,
+              nativeModule().rustbuffer_alloc,
+            ),
+            FfiConverterString.lower(objectId, nativeModule().rustbuffer_alloc),
+            FfiConverterString.lower(
+              objectKey,
+              nativeModule().rustbuffer_alloc,
+            ),
+          );
+        },
+        /*pollFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_poll_rust_buffer,
+        /*cancelFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_cancel_rust_buffer,
+        /*completeFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_complete_rust_buffer,
+        /*freeFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_free_rust_buffer,
+        // Async returns always go through the JS-side converter: the
+        // FFI symbol returns the future handle (u64), and the user-level
+        // RustBuffer comes back via the shared `rust_future_complete_*`
+        // export. The bytes the runtime hands back must be deserialized
+        // here using the per-callable return-type converter.
+        /*liftFunc:*/ FfiConverterString.lift.bind(FfiConverterString),
+        /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+        /*asyncOpts:*/ asyncOpts_,
+        /*errorHandler:*/ FfiConverterTypeBridgeError.lift.bind(
+          FfiConverterTypeBridgeError,
+        ),
+      );
+    } catch (__error: any) {
+      if (uniffiIsDebug && __error instanceof Error) {
+        __error.stack = __stack;
+      }
+      throw __error;
+    }
+  }
+
+  async readAttachmentUploadRange(
+    jobId: string,
+    attemptCount: number,
+    cacheId: string,
+    start: number,
+    end: number,
+    asyncOpts_?: { signal: AbortSignal },
+  ): Promise<ArrayBuffer> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+      return await uniffiRustCallAsync(
+        /*rustCaller:*/ uniffiCaller,
+        /*rustFutureFunc:*/ () => {
+          return nativeModule().ubrn_uniffi_mobile_bridge_fn_method_mobiledbbridge_read_attachment_upload_range(
+            uniffiTypeMobileDbBridgeObjectFactory.clonePointer(this),
+            FfiConverterString.lower(jobId, nativeModule().rustbuffer_alloc),
+            FfiConverterUInt32.lower(
+              attemptCount,
+              nativeModule().rustbuffer_alloc,
+            ),
+            FfiConverterString.lower(cacheId, nativeModule().rustbuffer_alloc),
+            FfiConverterUInt32.lower(start, nativeModule().rustbuffer_alloc),
+            FfiConverterUInt32.lower(end, nativeModule().rustbuffer_alloc),
+          );
+        },
+        /*pollFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_poll_rust_buffer,
+        /*cancelFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_cancel_rust_buffer,
+        /*completeFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_complete_rust_buffer,
+        /*freeFunc:*/ nativeModule()
+          .ubrn_ffi_mobile_bridge_rust_future_free_rust_buffer,
+        // Async returns always go through the JS-side converter: the
+        // FFI symbol returns the future handle (u64), and the user-level
+        // RustBuffer comes back via the shared `rust_future_complete_*`
+        // export. The bytes the runtime hands back must be deserialized
+        // here using the per-callable return-type converter.
+        /*liftFunc:*/ FfiConverterArrayBuffer.lift.bind(
+          FfiConverterArrayBuffer,
+        ),
+        /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+        /*asyncOpts:*/ asyncOpts_,
+        /*errorHandler:*/ FfiConverterTypeBridgeError.lift.bind(
+          FfiConverterTypeBridgeError,
+        ),
+      );
+    } catch (__error: any) {
+      if (uniffiIsDebug && __error instanceof Error) {
+        __error.stack = __stack;
+      }
+      throw __error;
+    }
   }
 
   async restoreAttachment(
@@ -1689,6 +1921,14 @@ function uniffiEnsureInitialized() {
     );
   }
   if (
+    nativeModule().ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_cleanup_attachment_upload_cache() !==
+    52166
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      "uniffi_mobile_bridge_checksum_method_mobiledbbridge_cleanup_attachment_upload_cache",
+    );
+  }
+  if (
     nativeModule().ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_close() !==
     15884
   ) {
@@ -1785,6 +2025,14 @@ function uniffiEnsureInitialized() {
     );
   }
   if (
+    nativeModule().ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_describe_attachment_upload() !==
+    11264
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      "uniffi_mobile_bridge_checksum_method_mobiledbbridge_describe_attachment_upload",
+    );
+  }
+  if (
     nativeModule().ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_execute() !==
     59785
   ) {
@@ -1822,6 +2070,22 @@ function uniffiEnsureInitialized() {
   ) {
     throw new UniffiInternalError.ApiChecksumMismatch(
       "uniffi_mobile_bridge_checksum_method_mobiledbbridge_inspect_e2ee_recovery_key",
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_prepare_attachment_upload() !==
+    3525
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      "uniffi_mobile_bridge_checksum_method_mobiledbbridge_prepare_attachment_upload",
+    );
+  }
+  if (
+    nativeModule().ubrn_uniffi_mobile_bridge_checksum_method_mobiledbbridge_read_attachment_upload_range() !==
+    21328
+  ) {
+    throw new UniffiInternalError.ApiChecksumMismatch(
+      "uniffi_mobile_bridge_checksum_method_mobiledbbridge_read_attachment_upload_range",
     );
   }
   if (


### PR DESCRIPTION
## Summary
- add cancellable mobile bridge operations to describe, prepare, range-read, and clean encrypted attachment uploads
- bind upload work to the canonical local attachment/job version and reject symlinked or non-canonical audio paths
- generate React Native bindings and expose validated TypeScript wrappers for the next mobile transfer-runner slice
- cover the native flow end to end by sealing, range-reading, decrypting, and cleaning an encrypted recording cache

## Validation
- `cargo test --locked -p mobile-bridge` (21 passed)
- `cargo check --locked -p mobile-bridge`
- `cargo clippy --locked -p mobile-bridge --all-targets --no-deps -- -D warnings`
- `cargo fmt -p mobile-bridge -- --check`
- `pnpm -F @anlg/mobile test` (84 passed)
- `pnpm -F @anlg/mobile typecheck`
- `pnpm -F @anlg/mobile-bridge typecheck`
- `pnpm fmt:check`
- `cargo xtask mobile-bridge ios` (device and both simulator architectures)
- generic iOS Release build

Interactive simulator/device QA was intentionally skipped for this non-release native transport slice. Local Android build was unavailable because this machine has no Android NDK; CI is the authoritative Android build.

Linear: ANLG-249