### PR TITLE
ANLG-249: Preserve attachment IDs in Markdown

### DIFF
--- a/packages/editor/src/markdown.test.ts
+++ b/packages/editor/src/markdown.test.ts
@@ -758,6 +758,32 @@ describe("fileAttachment round-trip", () => {
     );
   });
 
+  test("round-trips a portable attachment id without a local URL", () => {
+    const attachmentId = "9cfb2f08-a02f-41cf-a13e-07f36b87ef2b";
+    const markdown = json2md({
+      type: "doc",
+      content: [
+        {
+          type: "fileAttachment",
+          attrs: { attachmentId, name: "report.pdf" },
+        },
+      ],
+    });
+
+    expect(markdown).toBe(`[report.pdf](attachment://${attachmentId})`);
+    const attachment = md2json(markdown).content?.[0];
+    expect(attachment?.type).toBe("fileAttachment");
+    expect(attachment?.attrs?.attachmentId).toBe(attachmentId);
+    expect(attachment?.attrs?.src).toBeNull();
+  });
+
+  test("does not accept a path as a portable attachment id", () => {
+    const parsed = md2json("[report.pdf](attachment://../report.pdf)");
+    expect(parsed.content?.some((node) => node.type === "fileAttachment")).toBe(
+      false,
+    );
+  });
+
   test("round-trips two file attachments without leaking URL tail", () => {
     const doc: JSONContent = {
       type: "doc",

--- a/packages/editor/src/markdown/parser.ts
+++ b/packages/editor/src/markdown/parser.ts
@@ -366,7 +366,6 @@ function fileAttachmentPlugin(md: MarkdownIt) {
       const max = state.eMarks[startLine];
       const line = state.src.slice(pos, max);
 
-      // [name](asset://localhost/...) with balanced parens in the URL
       if (!line.startsWith("[")) return false;
 
       const closeBracket = line.indexOf("](");
@@ -376,8 +375,11 @@ function fileAttachmentPlugin(md: MarkdownIt) {
       if (name.includes("]")) return false;
 
       const urlStart = closeBracket + 2;
-      const PREFIX = "asset://localhost/";
-      if (!line.startsWith(PREFIX, urlStart)) return false;
+      const assetPrefix = "asset://localhost/";
+      const portablePrefix = "attachment://";
+      const isAssetUrl = line.startsWith(assetPrefix, urlStart);
+      const isPortableUrl = line.startsWith(portablePrefix, urlStart);
+      if (!isAssetUrl && !isPortableUrl) return false;
 
       let depth = 1;
       let i = urlStart;
@@ -394,9 +396,21 @@ function fileAttachmentPlugin(md: MarkdownIt) {
       if (silent) return true;
 
       const url = line.slice(urlStart, i);
+      const attachmentId = isPortableUrl
+        ? url.slice(portablePrefix.length)
+        : null;
+      if (
+        attachmentId !== null &&
+        !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(
+          attachmentId,
+        )
+      ) {
+        return false;
+      }
       const token = state.push("file_attachment", "", 0);
       token.attrSet("name", name);
-      token.attrSet("src", url);
+      if (attachmentId) token.attrSet("attachment-id", attachmentId);
+      else token.attrSet("src", url);
       token.map = [startLine, startLine + 1];
       token.content = line;
       state.line = startLine + 1;
@@ -586,7 +600,7 @@ export function getParser(): MarkdownParser {
     file_attachment: {
       node: "fileAttachment",
       getAttrs: (tok) => ({
-        attachmentId: null,
+        attachmentId: tok.attrGet("attachment-id"),
         name: tok.attrGet("name") ?? "",
         mimeType: "",
         src: tok.attrGet("src"),

--- a/packages/editor/src/markdown/serializer.ts
+++ b/packages/editor/src/markdown/serializer.ts
@@ -257,9 +257,14 @@ export function getSerializer(): MarkdownSerializer {
 
       fileAttachment(state, node) {
         const name = node.attrs.name || "file";
-        const src = (node.attrs.src || "")
-          .replace(/\(/g, "%28")
-          .replace(/\)/g, "%29");
+        const attachmentId = node.attrs.attachmentId || "";
+        const source =
+          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(
+            attachmentId,
+          )
+            ? `attachment://${attachmentId}`
+            : node.attrs.src || "";
+        const src = source.replace(/\(/g, "%28").replace(/\)/g, "%29");
         state.write(`[${name}](${src})`);
         state.closeBlock(node);
       },


### PR DESCRIPTION
## Summary
- parse portable `attachment://` links into editor attachment nodes
- serialize attachment nodes back to stable Markdown links
- require canonical UUIDv4 attachment identities and reject malformed attachment URLs

## Validation
- `pnpm -F @anlg/editor test` (192 passed)
- `pnpm -F @anlg/editor typecheck`
- targeted Markdown attachment tests (41 passed)
- targeted dprint and oxlint

Linear: [ANLG-249](https://linear.app/fastrepl-inc/issue/ANLG-249/bring-encrypted-attachment-byte-sync-to-mobile)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to editor Markdown parse/serialize for file attachments; UUID validation reduces misuse of attachment URLs without changing auth or storage.
> 
> **Overview**
> **File attachments in Markdown can now use stable `attachment://<uuid>` links** instead of only local `asset://localhost/...` URLs, so notes can reference encrypted/synced attachments without embedding device paths.
> 
> The **serializer** writes `[name](attachment://…)` when a `fileAttachment` node has a canonical **UUIDv4** `attachmentId`; otherwise it still emits `asset://` from `src`. The **parser** accepts both schemes, maps portable links to `attachmentId` (with `src` unset), and **rejects** non-UUID values (e.g. `attachment://../report.pdf`) so path-like strings are not treated as attachments. **Tests** cover round-trip and rejection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6140051ebf3ade5700ac7ea1a7fef810d3468e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->