### PR TITLE
ANLG-249: Attach files from the mobile editor

### DIFF
--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -28,7 +28,7 @@ import { Card } from "@/components/ui/card";
 import { IconButton } from "@/components/ui/icon-button";
 import { Colors, Spacing, Typography } from "@/constants/theme";
 import { useSessionAudio } from "@/data/audio-catalog";
-import { insertNoteAttachmentMarkdown } from "@/data/note-attachment-model";
+import { insertCapturedNoteAttachmentMarkdown } from "@/data/note-attachment-model";
 import { pickAndCatalogNoteAttachment } from "@/data/note-attachments";
 import {
   restoreSessionAudioFromCloud,
@@ -112,6 +112,7 @@ function BodyEditor({
   };
 
   const handleFormat = (format: EditorFormat) => {
+    if (attaching) return;
     const formatted = applyEditorFormat(
       textRef.current,
       selectionRef.current,
@@ -137,7 +138,8 @@ function BodyEditor({
   const handleAttach = async () => {
     if (attachControllerRef.current) return;
     const controller = new AbortController();
-    const selection = { ...selectionRef.current };
+    const capturedText = textRef.current;
+    const capturedSelection = { ...selectionRef.current };
     attachControllerRef.current = controller;
     setAttaching(true);
     try {
@@ -149,11 +151,12 @@ function BodyEditor({
       ) {
         return;
       }
-      const inserted = insertNoteAttachmentMarkdown(
-        textRef.current,
-        selection,
-        attachment.markdown,
-      );
+      const inserted = insertCapturedNoteAttachmentMarkdown({
+        capturedText,
+        capturedSelection,
+        currentText: textRef.current,
+        markdown: attachment.markdown,
+      });
       textRef.current = inserted.text;
       bodyFormatRef.current = "markdown";
       selectionRef.current = inserted.selection;
@@ -178,7 +181,7 @@ function BodyEditor({
         ref={inputRef}
         style={styles.body}
         multiline
-        editable={editable}
+        editable={editable && !attaching}
         inputAccessoryViewID={Platform.OS === "ios" ? accessoryId : undefined}
         defaultValue={defaultValue}
         value={nativeOverride?.text}

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -4,6 +4,7 @@ import * as Linking from "expo-linking";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useRef, useState } from "react";
 import {
+  Alert,
   InputAccessoryView,
   Keyboard,
   Platform,
@@ -27,6 +28,8 @@ import { Card } from "@/components/ui/card";
 import { IconButton } from "@/components/ui/icon-button";
 import { Colors, Spacing, Typography } from "@/constants/theme";
 import { useSessionAudio } from "@/data/audio-catalog";
+import { insertNoteAttachmentMarkdown } from "@/data/note-attachment-model";
+import { pickAndCatalogNoteAttachment } from "@/data/note-attachments";
 import {
   restoreSessionAudioFromCloud,
   restoreSessionAudioFromPicker,
@@ -51,16 +54,20 @@ function BodyEditor({
   defaultBodyFormat,
   defaultValue,
   editable,
+  onAttach,
   onChangeText,
+  onCommit,
 }: {
   accessoryId: string;
   defaultBodyFormat: "prosemirror_json" | "markdown";
   defaultValue: string;
   editable: boolean;
+  onAttach: (signal: AbortSignal) => Promise<{ markdown: string } | null>;
   onChangeText: (
     body: string,
     bodyFormat: "prosemirror_json" | "markdown",
   ) => void;
+  onCommit: () => void;
 }) {
   const inputRef = useRef<TextInput>(null);
   const textRef = useRef(defaultValue);
@@ -73,6 +80,17 @@ function BodyEditor({
     selection: { start: number; end: number };
   }>();
   const [androidKeyboardVisible, setAndroidKeyboardVisible] = useState(false);
+  const [attaching, setAttaching] = useState(false);
+  const attachControllerRef = useRef<AbortController | null>(null);
+  const editorActiveRef = useRef(true);
+
+  useMountEffect(() => {
+    editorActiveRef.current = true;
+    return () => {
+      editorActiveRef.current = false;
+      attachControllerRef.current?.abort();
+    };
+  });
 
   useMountEffect(() => {
     if (Platform.OS !== "android") return;
@@ -116,6 +134,44 @@ function BodyEditor({
     Keyboard.dismiss();
   };
 
+  const handleAttach = async () => {
+    if (attachControllerRef.current) return;
+    const controller = new AbortController();
+    const selection = { ...selectionRef.current };
+    attachControllerRef.current = controller;
+    setAttaching(true);
+    try {
+      const attachment = await onAttach(controller.signal);
+      if (
+        !attachment ||
+        controller.signal.aborted ||
+        !editorActiveRef.current
+      ) {
+        return;
+      }
+      const inserted = insertNoteAttachmentMarkdown(
+        textRef.current,
+        selection,
+        attachment.markdown,
+      );
+      textRef.current = inserted.text;
+      bodyFormatRef.current = "markdown";
+      selectionRef.current = inserted.selection;
+      setNativeOverride(inserted);
+      onChangeText(inserted.text, "markdown");
+      onCommit();
+      inputRef.current?.focus();
+      requestAnimationFrame(() => {
+        if (editorActiveRef.current) setNativeOverride(undefined);
+      });
+    } finally {
+      if (attachControllerRef.current === controller) {
+        attachControllerRef.current = null;
+      }
+      if (editorActiveRef.current) setAttaching(false);
+    }
+  };
+
   return (
     <>
       <TextInput
@@ -141,6 +197,8 @@ function BodyEditor({
           backgroundColor={Colors.background}
         >
           <EditorAccessory
+            attaching={attaching}
+            onAttach={() => void handleAttach()}
             onFormat={handleFormat}
             onDismiss={handleDismissKeyboard}
           />
@@ -149,6 +207,8 @@ function BodyEditor({
       {Platform.OS === "android" && editable && androidKeyboardVisible && (
         <View style={styles.androidAccessory}>
           <EditorAccessory
+            attaching={attaching}
+            onAttach={() => void handleAttach()}
             onFormat={handleFormat}
             onDismiss={handleDismissKeyboard}
           />
@@ -365,6 +425,32 @@ export default function NoteScreen() {
     }
   };
 
+  const handleAttachFile = async (
+    signal: AbortSignal,
+  ): Promise<{ markdown: string } | null> => {
+    try {
+      const result = await pickAndCatalogNoteAttachment(id, signal);
+      if (result.status === "cancelled") return null;
+      captureAnalytics("file_uploaded", {
+        entry_point: "mobile_note_attachment",
+        file_type: "attachment",
+      });
+      return { markdown: result.markdown };
+    } catch (error) {
+      if (signal.aborted) return null;
+      captureOperationalError(error, {
+        operation: "note_attachment_import",
+      });
+      Alert.alert(
+        "Couldn’t attach file",
+        error instanceof Error
+          ? error.message
+          : "The selected file could not be attached.",
+      );
+      return null;
+    }
+  };
+
   const handleDelete = async () => {
     const confirmed = await confirmDestructive(
       `Delete "${data?.title || "Untitled"}"?`,
@@ -499,7 +585,9 @@ export default function NoteScreen() {
             defaultBodyFormat={data.bodyFormat}
             defaultValue={data.noteText}
             editable={data.plainEditable}
+            onAttach={handleAttachFile}
             onChangeText={(body, bodyFormat) => onEdit({ body, bodyFormat })}
+            onCommit={flush}
           />
         </View>
       )}

--- a/apps/mobile/src/components/editor-accessory.tsx
+++ b/apps/mobile/src/components/editor-accessory.tsx
@@ -37,9 +37,13 @@ function FormatButton({
 }
 
 export function EditorAccessory({
+  attaching,
+  onAttach,
   onFormat,
   onDismiss,
 }: {
+  attaching: boolean;
+  onAttach: () => void;
   onFormat: (format: EditorFormat) => void;
   onDismiss: () => void;
 }) {
@@ -53,6 +57,20 @@ export function EditorAccessory({
           keyboardShouldPersistTaps="always"
           showsHorizontalScrollIndicator={false}
         >
+          <Pressable
+            accessibilityLabel="Attach file"
+            accessibilityRole="button"
+            disabled={attaching}
+            hitSlop={2}
+            onPress={onAttach}
+            style={({ pressed }) => [
+              styles.button,
+              attaching && styles.buttonDisabled,
+              pressed && styles.buttonPressed,
+            ]}
+          >
+            <Ionicons name="attach-outline" size={24} color={Colors.ink} />
+          </Pressable>
           <FormatButton
             accessibilityLabel="Heading"
             format="heading"
@@ -154,6 +172,9 @@ const styles = StyleSheet.create({
   },
   buttonPressed: {
     backgroundColor: Colors.accentSurface,
+  },
+  buttonDisabled: {
+    opacity: 0.45,
   },
   heading: {
     fontSize: 20,

--- a/apps/mobile/src/components/editor-accessory.tsx
+++ b/apps/mobile/src/components/editor-accessory.tsx
@@ -14,11 +14,13 @@ import type { EditorFormat } from "@/lib/editor-format";
 
 function FormatButton({
   accessibilityLabel,
+  disabled,
   format,
   onPress,
   children,
 }: {
   accessibilityLabel: string;
+  disabled: boolean;
   format: EditorFormat;
   onPress: (format: EditorFormat) => void;
   children: ReactNode;
@@ -27,9 +29,15 @@ function FormatButton({
     <Pressable
       accessibilityLabel={accessibilityLabel}
       accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
       hitSlop={2}
       onPress={() => onPress(format)}
-      style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+      style={({ pressed }) => [
+        styles.button,
+        disabled && styles.buttonDisabled,
+        pressed && styles.buttonPressed,
+      ]}
     >
       {children}
     </Pressable>
@@ -73,6 +81,7 @@ export function EditorAccessory({
           </Pressable>
           <FormatButton
             accessibilityLabel="Heading"
+            disabled={attaching}
             format="heading"
             onPress={onFormat}
           >
@@ -80,6 +89,7 @@ export function EditorAccessory({
           </FormatButton>
           <FormatButton
             accessibilityLabel="Bold"
+            disabled={attaching}
             format="bold"
             onPress={onFormat}
           >
@@ -87,6 +97,7 @@ export function EditorAccessory({
           </FormatButton>
           <FormatButton
             accessibilityLabel="Italic"
+            disabled={attaching}
             format="italic"
             onPress={onFormat}
           >
@@ -94,6 +105,7 @@ export function EditorAccessory({
           </FormatButton>
           <FormatButton
             accessibilityLabel="Bulleted list"
+            disabled={attaching}
             format="bullet"
             onPress={onFormat}
           >
@@ -101,6 +113,7 @@ export function EditorAccessory({
           </FormatButton>
           <FormatButton
             accessibilityLabel="Checklist"
+            disabled={attaching}
             format="checklist"
             onPress={onFormat}
           >

--- a/apps/mobile/src/data/file-sha256.ts
+++ b/apps/mobile/src/data/file-sha256.ts
@@ -7,7 +7,7 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted) {
     throw signal.reason instanceof Error
       ? signal.reason
-      : new Error("Audio verification was cancelled");
+      : new Error("File verification was cancelled");
   }
 }
 
@@ -27,7 +27,7 @@ export async function hashFileSha256(
   try {
     const expectedSize = handle.size;
     if (expectedSize === null || expectedSize <= 0) {
-      throw new Error("Audio file is empty or unavailable");
+      throw new Error("File is empty or unavailable");
     }
 
     handle.offset = 0;
@@ -41,7 +41,7 @@ export async function hashFileSha256(
         Math.min(CHUNK_BYTES, expectedSize - sizeBytes),
       );
       if (bytes.length === 0) {
-        throw new Error("Audio file ended before its reported size");
+        throw new Error("File ended before its reported size");
       }
       digest.update(bytes);
       sizeBytes += bytes.length;
@@ -55,7 +55,7 @@ export async function hashFileSha256(
     }
 
     if (sizeBytes !== expectedSize) {
-      throw new Error("Audio file changed while it was being verified");
+      throw new Error("File changed while it was being verified");
     }
 
     return { sha256: digest.hex(), sizeBytes };

--- a/apps/mobile/src/data/note-attachment-model.test.mjs
+++ b/apps/mobile/src/data/note-attachment-model.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  insertCapturedNoteAttachmentMarkdown,
   insertNoteAttachmentMarkdown,
   portableNoteAttachmentMarkdown,
   requireNoteAttachmentFilename,
@@ -13,6 +14,25 @@ test("builds a portable attachment link with a safe label", () => {
   assert.equal(
     portableNoteAttachmentMarkdown(attachmentId, "plan [final].pdf"),
     `[plan (final).pdf](attachment://${attachmentId})`,
+  );
+});
+
+test("appends safely when the note changes during attachment import", () => {
+  const markdown = portableNoteAttachmentMarkdown(attachmentId, "plan.pdf");
+  assert.deepEqual(
+    insertCapturedNoteAttachmentMarkdown({
+      capturedText: "beforeafter",
+      capturedSelection: { start: 6, end: 6 },
+      currentText: "beforeafter changed",
+      markdown,
+    }),
+    {
+      text: `beforeafter changed\n${markdown}`,
+      selection: {
+        start: `beforeafter changed\n${markdown}`.length,
+        end: `beforeafter changed\n${markdown}`.length,
+      },
+    },
   );
 });
 

--- a/apps/mobile/src/data/note-attachment-model.test.mjs
+++ b/apps/mobile/src/data/note-attachment-model.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  insertNoteAttachmentMarkdown,
+  portableNoteAttachmentMarkdown,
+  requireNoteAttachmentFilename,
+} from "./note-attachment-model.ts";
+
+const attachmentId = "9cfb2f08-a02f-41cf-a13e-07f36b87ef2b";
+
+test("builds a portable attachment link with a safe label", () => {
+  assert.equal(
+    portableNoteAttachmentMarkdown(attachmentId, "plan [final].pdf"),
+    `[plan (final).pdf](attachment://${attachmentId})`,
+  );
+});
+
+test("rejects path-like attachment names", () => {
+  for (const filename of ["", "../plan.pdf", "folder/plan.pdf", "bad\nname"]) {
+    assert.throws(() => requireNoteAttachmentFilename(filename));
+  }
+});
+
+test("inserts the attachment on its own Markdown line", () => {
+  const markdown = portableNoteAttachmentMarkdown(attachmentId, "plan.pdf");
+  assert.deepEqual(
+    insertNoteAttachmentMarkdown("beforeafter", { start: 6, end: 6 }, markdown),
+    {
+      text: `before\n${markdown}\nafter`,
+      selection: {
+        start: `before\n${markdown}\n`.length,
+        end: `before\n${markdown}\n`.length,
+      },
+    },
+  );
+});

--- a/apps/mobile/src/data/note-attachment-model.ts
+++ b/apps/mobile/src/data/note-attachment-model.ts
@@ -54,3 +54,20 @@ export function insertNoteAttachmentMarkdown(
     selection: { start: nextCursor, end: nextCursor },
   };
 }
+
+export function insertCapturedNoteAttachmentMarkdown(input: {
+  capturedText: string;
+  capturedSelection: { start: number; end: number };
+  currentText: string;
+  markdown: string;
+}): { text: string; selection: { start: number; end: number } } {
+  const selection =
+    input.currentText === input.capturedText
+      ? input.capturedSelection
+      : { start: input.currentText.length, end: input.currentText.length };
+  return insertNoteAttachmentMarkdown(
+    input.currentText,
+    selection,
+    input.markdown,
+  );
+}

--- a/apps/mobile/src/data/note-attachment-model.ts
+++ b/apps/mobile/src/data/note-attachment-model.ts
@@ -1,0 +1,56 @@
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+export function requireNoteAttachmentFilename(value: string): string {
+  if (
+    value.length === 0 ||
+    value.length > 1024 ||
+    value.trim() !== value ||
+    hasControlCharacter(value) ||
+    value.includes("/") ||
+    value.includes("\\") ||
+    value === "." ||
+    value === ".."
+  ) {
+    throw new Error("The selected file has an unsupported name.");
+  }
+  return value;
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}
+
+export function portableNoteAttachmentMarkdown(
+  attachmentId: string,
+  filename: string,
+): string {
+  if (!UUID_V4_PATTERN.test(attachmentId)) {
+    throw new Error("The attachment identifier is invalid.");
+  }
+  const label = requireNoteAttachmentFilename(filename)
+    .replaceAll("[", "(")
+    .replaceAll("]", ")");
+  return `[${label}](attachment://${attachmentId})`;
+}
+
+export function insertNoteAttachmentMarkdown(
+  text: string,
+  selection: { start: number; end: number },
+  markdown: string,
+): { text: string; selection: { start: number; end: number } } {
+  const cursor = Math.max(0, Math.min(text.length, selection.end));
+  const before = text.slice(0, cursor);
+  const after = text.slice(cursor);
+  const prefix = before === "" || before.endsWith("\n") ? "" : "\n";
+  const suffix = after === "" || after.startsWith("\n") ? "" : "\n";
+  const insertion = `${prefix}${markdown}${suffix}`;
+  const nextCursor = cursor + insertion.length;
+  return {
+    text: before + insertion + after,
+    selection: { start: nextCursor, end: nextCursor },
+  };
+}

--- a/apps/mobile/src/data/note-attachments.ts
+++ b/apps/mobile/src/data/note-attachments.ts
@@ -1,0 +1,165 @@
+import { getDocumentAsync } from "expo-document-picker";
+import { Directory, File, FileMode, Paths } from "expo-file-system";
+
+import { requestMobileAttachmentUploads } from "@/attachment-sync/upload-runner";
+import { hashFileSha256 } from "@/data/file-sha256";
+import {
+  portableNoteAttachmentMarkdown,
+  requireNoteAttachmentFilename,
+} from "@/data/note-attachment-model";
+import { executeTransaction } from "@/db";
+import { id, nowIso } from "@/lib/ids";
+
+const MAX_ATTACHMENT_BYTES = 512 * 1024 * 1024;
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+export async function pickAndCatalogNoteAttachment(
+  sessionId: string,
+  signal?: AbortSignal,
+): Promise<
+  | { status: "cancelled" }
+  | {
+      status: "attached";
+      attachmentId: string;
+      filename: string;
+      markdown: string;
+    }
+> {
+  if (!UUID_V4_PATTERN.test(sessionId)) {
+    throw new Error("The meeting identifier is invalid.");
+  }
+  const result = await getDocumentAsync({
+    type: "*/*",
+    multiple: false,
+    copyToCacheDirectory: true,
+  });
+  if (result.canceled) return { status: "cancelled" };
+  throwIfAborted(signal);
+
+  const asset = result.assets[0];
+  const filename = requireNoteAttachmentFilename(asset.name);
+  if (typeof asset.size === "number" && asset.size > MAX_ATTACHMENT_BYTES) {
+    throw new Error("Attachments must be 512 MB or smaller.");
+  }
+  const attachmentId = id();
+  const relativePath = `attachments/${attachmentId}`;
+  const directory = new Directory(
+    Paths.document,
+    "sessions",
+    sessionId,
+    "attachments",
+  );
+  directory.create({ intermediates: true, idempotent: true });
+  const destination = new File(directory, attachmentId);
+
+  try {
+    await new File(asset.uri).copy(destination);
+    const verified = await hashFileSha256(
+      { open: () => destination.open(FileMode.ReadOnly) },
+      signal,
+    );
+    if (verified.sizeBytes > MAX_ATTACHMENT_BYTES) {
+      throw new Error("Attachments must be 512 MB or smaller.");
+    }
+    const contentType = validContentType(asset.mimeType)
+      ? asset.mimeType
+      : "application/octet-stream";
+    const now = nowIso();
+    const transferJobId = id();
+    const [inserted = 0, localized = 0, queued = 0] = await executeTransaction([
+      {
+        sql: `
+            INSERT INTO session_attachments (
+              id, workspace_id, session_id, filename, relative_path,
+              content_type, size_bytes, sha256, storage_kind,
+              cloud_object_key, source_type, source_id, metadata_json,
+              cloud_sync_enabled, created_at, updated_at, deleted_at
+            )
+            SELECT ?, workspace_id, id, ?, ?, ?, ?, ?, 'local_file', '',
+              'note_upload', ?, '{}', 1, ?, ?, NULL
+            FROM sessions
+            WHERE id = ? AND deleted_at IS NULL
+          `,
+        params: [
+          attachmentId,
+          filename,
+          relativePath,
+          contentType,
+          verified.sizeBytes,
+          verified.sha256,
+          attachmentId,
+          now,
+          now,
+          sessionId,
+        ],
+        expectedRowsAffected: 1,
+      },
+      {
+        sql: `
+            INSERT INTO attachment_local_state (
+              attachment_id, session_id, relative_path, availability, updated_at
+            )
+            SELECT id, session_id, relative_path, 'present', ?
+            FROM session_attachments
+            WHERE id = ? AND session_id = ? AND deleted_at IS NULL
+          `,
+        params: [now, attachmentId, sessionId],
+        expectedRowsAffected: 1,
+      },
+      {
+        sql: `
+            INSERT INTO attachment_transfer_jobs (
+              id, attachment_id, session_id, workspace_id, direction,
+              expected_sha256, expected_size_bytes
+            )
+            SELECT ?, id, session_id, workspace_id, 'upload', sha256, size_bytes
+            FROM session_attachments
+            WHERE id = ? AND session_id = ? AND cloud_sync_enabled = 1
+              AND deleted_at IS NULL
+          `,
+        params: [transferJobId, attachmentId, sessionId],
+        expectedRowsAffected: 1,
+      },
+    ]);
+    if (inserted !== 1 || localized !== 1 || queued !== 1) {
+      throw new Error("The attachment could not be added to this meeting.");
+    }
+    requestMobileAttachmentUploads();
+    return {
+      status: "attached",
+      attachmentId,
+      filename,
+      markdown: portableNoteAttachmentMarkdown(attachmentId, filename),
+    };
+  } catch (error) {
+    try {
+      if (destination.exists) destination.delete();
+    } catch {}
+    throw error;
+  }
+}
+
+function validContentType(value: string | null | undefined): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 512 &&
+    value.trim() === value &&
+    !hasControlCharacter(value)
+  );
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw signal.reason instanceof Error
+    ? signal.reason
+    : new Error("Attachment import was cancelled.");
+}


### PR DESCRIPTION
## Summary
- add a file picker action to the mobile editor toolbar
- copy selected files into the canonical session attachment directory and stream their SHA-256 digest
- atomically catalog canonical metadata, truthful local state, and durable encrypted upload work
- insert a portable attachment link at the current editor selection and flush the note save

## Validation
- `pnpm -F @anlg/mobile test` (91 passed at this stack point)
- targeted dprint and oxlint
- generic iOS Release simulator build
- mobile typecheck reports only the four pre-existing unrelated workspace errors

Linear: [ANLG-249](https://linear.app/fastrepl-inc/issue/ANLG-249/bring-encrypted-attachment-byte-sync-to-mobile)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New local file I/O, SQLite attachment rows, and note body mutation; mitigated by validation, transactional cataloging, and tests aligned with existing audio attachment flow.
> 
> **Overview**
> Adds **file attachment** to the mobile note editor: a toolbar **attach** control opens the system document picker, catalogs the file for the session, and inserts a portable `attachment://` markdown link at the caret (with an immediate note **flush**).
> 
> **`pickAndCatalogNoteAttachment`** copies the pick into the session attachment directory, verifies **SHA-256** (with abort support), enforces a **512 MB** cap and safe filenames, then runs a single transaction to record `session_attachments`, local state, and an upload job before kicking **`requestMobileAttachmentUploads`**. **`note-attachment-model`** builds sanitized link markdown and handles insertion when the note text changes during import.
> 
> While import runs, the editor and formatting controls are **disabled**; unmount **aborts** in-flight work. **`hashFileSha256`** error copy is generalized from audio-only wording. Unit tests cover link building, line insertion, and filename rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af657963c97cc6528057536077819faba55f2664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->