### PR TITLE
ANLG-249: Surface synced files in mobile notes

### DIFF
--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -23,13 +23,22 @@ import { AudioChip } from "@/components/audio-chip";
 import { EditorAccessory } from "@/components/editor-accessory";
 import { HandoffCard } from "@/components/handoff-card";
 import { ListeningSheet } from "@/components/listening-sheet";
+import { NoteAttachmentCard } from "@/components/note-attachment-card";
 import { RemoteAudioCard } from "@/components/remote-audio-card";
 import { Card } from "@/components/ui/card";
 import { IconButton } from "@/components/ui/icon-button";
 import { Colors, Spacing, Typography } from "@/constants/theme";
 import { useSessionAudio } from "@/data/audio-catalog";
+import {
+  type NoteAttachment,
+  useNoteAttachments,
+} from "@/data/note-attachment-catalog";
 import { insertCapturedNoteAttachmentMarkdown } from "@/data/note-attachment-model";
 import { pickAndCatalogNoteAttachment } from "@/data/note-attachments";
+import {
+  restoreNoteAttachmentFromCloud,
+  shareNoteAttachment,
+} from "@/data/restore-note-attachment";
 import {
   restoreSessionAudioFromCloud,
   restoreSessionAudioFromPicker,
@@ -230,6 +239,7 @@ export default function NoteScreen() {
   }>();
   const { data, isLoading } = useSessionDetail(id);
   const audio = useSessionAudio(id);
+  const noteAttachments = useNoteAttachments(id);
   const transcripts = useSessionTranscripts(id);
   const transcription = useTranscriptionState(id);
   const [listening, setListening] = useState(listen === "1");
@@ -240,12 +250,30 @@ export default function NoteScreen() {
   const [restoringAudio, setRestoringAudio] = useState(false);
   const audioRestoreBusyRef = useRef(false);
   const audioRestoreControllerRef = useRef<AbortController | null>(null);
+  const attachmentActionBusyRef = useRef(false);
+  const attachmentRestoreControllerRef = useRef<AbortController | null>(null);
+  const [attachmentActionId, setAttachmentActionId] = useState<string | null>(
+    null,
+  );
+  const [attachmentActionError, setAttachmentActionError] = useState<{
+    attachmentId: string;
+    message: string;
+  } | null>(null);
   const screenActiveRef = useRef(true);
   const localAudioFile = audio.data?.localRelativePath
     ? new File(Paths.document, "sessions", id, audio.data.localRelativePath)
     : null;
   const localAudioAvailable =
     audio.data?.availableLocally === true && localAudioFile?.exists === true;
+  const localNoteAttachments = noteAttachments.map((attachment) => {
+    const file = attachment.localRelativePath
+      ? new File(Paths.document, "sessions", id, attachment.localRelativePath)
+      : null;
+    return {
+      attachment,
+      file: file?.exists === true ? file : null,
+    };
+  });
 
   const dataRef = useRef(data);
   dataRef.current = data;
@@ -308,6 +336,7 @@ export default function NoteScreen() {
     return () => {
       screenActiveRef.current = false;
       audioRestoreControllerRef.current?.abort();
+      attachmentRestoreControllerRef.current?.abort();
       flush();
     };
   });
@@ -454,6 +483,88 @@ export default function NoteScreen() {
     }
   };
 
+  const handleDownloadAttachment = async (attachment: NoteAttachment) => {
+    const accessToken = auth.session?.access_token;
+    if (
+      attachmentActionBusyRef.current ||
+      !attachment.cloudObjectKey ||
+      !accessToken ||
+      !env.supabaseUrl
+    ) {
+      return;
+    }
+    attachmentActionBusyRef.current = true;
+    const controller = new AbortController();
+    attachmentRestoreControllerRef.current = controller;
+    setAttachmentActionId(attachment.attachmentId);
+    setAttachmentActionError(null);
+    try {
+      await restoreNoteAttachmentFromCloud(id, attachment, {
+        accessToken,
+        apiBaseUrl: env.apiUrl,
+        supabaseUrl: env.supabaseUrl,
+        signal: controller.signal,
+      });
+      captureAnalytics("file_downloaded", {
+        entry_point: "mobile_note_attachment",
+        file_type: "attachment",
+        size_bytes: attachment.sizeBytes,
+      });
+    } catch (error) {
+      if (!controller.signal.aborted && screenActiveRef.current) {
+        captureOperationalError(error, {
+          operation: "note_attachment_cloud_restore",
+        });
+        setAttachmentActionError({
+          attachmentId: attachment.attachmentId,
+          message:
+            error instanceof Error
+              ? error.message
+              : "The file could not be downloaded to this phone.",
+        });
+      }
+    } finally {
+      if (attachmentRestoreControllerRef.current === controller) {
+        attachmentRestoreControllerRef.current = null;
+      }
+      attachmentActionBusyRef.current = false;
+      if (screenActiveRef.current) setAttachmentActionId(null);
+    }
+  };
+
+  const handleShareAttachment = async (
+    attachment: NoteAttachment,
+    uri: string,
+  ) => {
+    if (attachmentActionBusyRef.current) return;
+    attachmentActionBusyRef.current = true;
+    setAttachmentActionId(attachment.attachmentId);
+    setAttachmentActionError(null);
+    try {
+      await shareNoteAttachment(uri, attachment);
+      captureAnalytics("file_shared", {
+        entry_point: "mobile_note_attachment",
+        file_type: "attachment",
+      });
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "note_attachment_share",
+      });
+      if (screenActiveRef.current) {
+        setAttachmentActionError({
+          attachmentId: attachment.attachmentId,
+          message:
+            error instanceof Error
+              ? error.message
+              : "The file could not be shared.",
+        });
+      }
+    } finally {
+      attachmentActionBusyRef.current = false;
+      if (screenActiveRef.current) setAttachmentActionId(null);
+    }
+  };
+
   const handleDelete = async () => {
     const confirmed = await confirmDestructive(
       `Delete "${data?.title || "Untitled"}"?`,
@@ -569,6 +680,35 @@ export default function NoteScreen() {
                 ))}
               </ScrollView>
             </Card>
+          )}
+          {localNoteAttachments.length > 0 && (
+            <View style={styles.attachments}>
+              <Text style={styles.attachmentLabel}>Files</Text>
+              {localNoteAttachments.map(({ attachment, file }) => (
+                <NoteAttachmentCard
+                  key={attachment.attachmentId}
+                  availableLocally={file !== null}
+                  cloudAvailable={Boolean(
+                    attachment.cloudObjectKey &&
+                    auth.session?.access_token &&
+                    env.supabaseUrl,
+                  )}
+                  errorMessage={
+                    attachmentActionError?.attachmentId ===
+                    attachment.attachmentId
+                      ? attachmentActionError.message
+                      : null
+                  }
+                  filename={attachment.filename}
+                  loading={attachmentActionId === attachment.attachmentId}
+                  onDownload={() => void handleDownloadAttachment(attachment)}
+                  onShare={() => {
+                    if (file) void handleShareAttachment(attachment, file.uri);
+                  }}
+                  sizeBytes={attachment.sizeBytes}
+                />
+              ))}
+            </View>
           )}
           <Text style={styles.noteLabel}>Notes</Text>
           {!data.plainEditable && (
@@ -688,6 +828,15 @@ const styles = StyleSheet.create({
     ...Typography.body,
     color: Colors.ink,
     marginBottom: Spacing.sm,
+  },
+  attachments: {
+    gap: Spacing.sm,
+    marginHorizontal: Spacing.lg,
+    marginTop: Spacing.md,
+  },
+  attachmentLabel: {
+    ...Typography.captionStrong,
+    color: Colors.muted,
   },
   noteLabel: {
     marginHorizontal: Spacing.lg,

--- a/apps/mobile/src/components/note-attachment-card.tsx
+++ b/apps/mobile/src/components/note-attachment-card.tsx
@@ -1,0 +1,100 @@
+import { Ionicons } from "@expo/vector-icons";
+import { StyleSheet, Text, View } from "react-native";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Colors, Spacing, Typography } from "@/constants/theme";
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${bytes} B`;
+}
+
+export function NoteAttachmentCard({
+  availableLocally,
+  cloudAvailable,
+  errorMessage,
+  filename,
+  loading,
+  onDownload,
+  onShare,
+  sizeBytes,
+}: {
+  availableLocally: boolean;
+  cloudAvailable: boolean;
+  errorMessage: string | null;
+  filename: string;
+  loading: boolean;
+  onDownload: () => void;
+  onShare: () => void;
+  sizeBytes: number;
+}) {
+  return (
+    <Card style={styles.card} tone="muted">
+      <View style={styles.icon}>
+        <Ionicons
+          name={availableLocally ? "document-attach-outline" : "cloud-outline"}
+          size={18}
+          color={Colors.muted}
+        />
+      </View>
+      <View style={styles.copy}>
+        <Text numberOfLines={1} style={styles.title}>
+          {filename}
+        </Text>
+        <Text style={styles.description}>
+          {availableLocally
+            ? formatBytes(sizeBytes)
+            : cloudAvailable
+              ? `${formatBytes(sizeBytes)} · Available from sync`
+              : `${formatBytes(sizeBytes)} · Waiting for sync`}
+        </Text>
+        {errorMessage && <Text style={styles.error}>{errorMessage}</Text>}
+      </View>
+      <Button
+        disabled={!availableLocally && !cloudAvailable}
+        label={
+          availableLocally ? "Share" : cloudAvailable ? "Download" : "Pending"
+        }
+        loading={loading}
+        onPress={availableLocally ? onShare : onDownload}
+        size="small"
+        variant={availableLocally ? "outline" : "primary"}
+      />
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.sm,
+    padding: Spacing.sm,
+  },
+  icon: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  copy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  title: {
+    ...Typography.captionStrong,
+    color: Colors.ink,
+  },
+  description: {
+    marginTop: 2,
+    ...Typography.caption,
+    color: Colors.muted,
+  },
+  error: {
+    marginTop: Spacing.xs,
+    ...Typography.caption,
+    color: Colors.destructive,
+  },
+});

--- a/apps/mobile/src/data/note-attachment-catalog-model.ts
+++ b/apps/mobile/src/data/note-attachment-catalog-model.ts
@@ -1,0 +1,96 @@
+export type NoteAttachmentRow = {
+  id: string;
+  source_id: string;
+  filename: string;
+  relative_path: string;
+  content_type: string;
+  size_bytes: number;
+  sha256: string;
+  created_at: string;
+  available_locally: number;
+  local_relative_path: string;
+  cloud_object_key: string;
+};
+
+export type NoteAttachment = {
+  attachmentId: string;
+  sourceId: string;
+  filename: string;
+  relativePath: string;
+  contentType: string;
+  sizeBytes: number;
+  sha256: string;
+  createdAt: string;
+  availableLocally: boolean;
+  localRelativePath: string | null;
+  cloudObjectKey: string | null;
+};
+
+const MAX_ATTACHMENT_BYTES = 512 * 1024 * 1024;
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+export function mapNoteAttachmentRows(
+  rows: NoteAttachmentRow[],
+): NoteAttachment[] {
+  return rows.flatMap((row) => {
+    if (
+      !UUID_V4_PATTERN.test(row.id) ||
+      !validBasename(row.source_id) ||
+      !validBasename(row.filename) ||
+      row.relative_path !== `attachments/${row.source_id}` ||
+      !Number.isSafeInteger(row.size_bytes) ||
+      row.size_bytes <= 0 ||
+      row.size_bytes > MAX_ATTACHMENT_BYTES ||
+      !SHA256_PATTERN.test(row.sha256) ||
+      !validContentType(row.content_type)
+    ) {
+      return [];
+    }
+    const availableLocally =
+      row.available_locally === 1 &&
+      row.local_relative_path === row.relative_path;
+    return [
+      {
+        attachmentId: row.id,
+        sourceId: row.source_id,
+        filename: row.filename,
+        relativePath: row.relative_path,
+        contentType: row.content_type,
+        sizeBytes: row.size_bytes,
+        sha256: row.sha256,
+        createdAt: row.created_at,
+        availableLocally,
+        localRelativePath: availableLocally ? row.local_relative_path : null,
+        cloudObjectKey: row.cloud_object_key || null,
+      },
+    ];
+  });
+}
+
+function validBasename(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= 1024 &&
+    value.trim() === value &&
+    !value.includes("/") &&
+    !value.includes("\\") &&
+    value !== "." &&
+    value !== ".." &&
+    !hasControlCharacter(value)
+  );
+}
+
+function validContentType(value: string): boolean {
+  return (
+    value.length <= 512 && value.trim() === value && !hasControlCharacter(value)
+  );
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}

--- a/apps/mobile/src/data/note-attachment-catalog.test.mjs
+++ b/apps/mobile/src/data/note-attachment-catalog.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mapNoteAttachmentRows } from "./note-attachment-catalog-model.ts";
+
+const row = {
+  id: "2c617e36-a3b9-49aa-a240-19c3aa542f50",
+  source_id: "9cfb2f08-a02f-41cf-a13e-07f36b87ef2b",
+  filename: "product brief.pdf",
+  relative_path: "attachments/9cfb2f08-a02f-41cf-a13e-07f36b87ef2b",
+  content_type: "application/pdf",
+  size_bytes: 42,
+  sha256: "a".repeat(64),
+  created_at: "2026-08-17T00:00:00.000Z",
+  available_locally: 1,
+  local_relative_path: "attachments/9cfb2f08-a02f-41cf-a13e-07f36b87ef2b",
+  cloud_object_key:
+    "e8d8149f-af6a-4c14-8b91-066fa196187c/02425e17-c452-41c9-869c-196d09f75c91.anb1",
+};
+
+test("maps a local note attachment to its canonical device path", () => {
+  assert.deepEqual(mapNoteAttachmentRows([row]), [
+    {
+      attachmentId: "2c617e36-a3b9-49aa-a240-19c3aa542f50",
+      sourceId: "9cfb2f08-a02f-41cf-a13e-07f36b87ef2b",
+      filename: "product brief.pdf",
+      relativePath: "attachments/9cfb2f08-a02f-41cf-a13e-07f36b87ef2b",
+      contentType: "application/pdf",
+      sizeBytes: 42,
+      sha256: "a".repeat(64),
+      createdAt: "2026-08-17T00:00:00.000Z",
+      availableLocally: true,
+      localRelativePath: "attachments/9cfb2f08-a02f-41cf-a13e-07f36b87ef2b",
+      cloudObjectKey:
+        "e8d8149f-af6a-4c14-8b91-066fa196187c/02425e17-c452-41c9-869c-196d09f75c91.anb1",
+    },
+  ]);
+});
+
+test("does not expose a mismatched local path", () => {
+  const [attachment] = mapNoteAttachmentRows([
+    { ...row, local_relative_path: "attachments/other" },
+  ]);
+  assert.equal(attachment.availableLocally, false);
+  assert.equal(attachment.localRelativePath, null);
+});
+
+test("drops attachment metadata with an unsafe canonical path", () => {
+  assert.deepEqual(
+    mapNoteAttachmentRows([
+      {
+        ...row,
+        source_id: "../product brief.pdf",
+        relative_path: "attachments/../product brief.pdf",
+      },
+    ]),
+    [],
+  );
+});

--- a/apps/mobile/src/data/note-attachment-catalog.ts
+++ b/apps/mobile/src/data/note-attachment-catalog.ts
@@ -1,0 +1,40 @@
+import { useLiveQuery } from "@/db";
+
+import {
+  mapNoteAttachmentRows,
+  type NoteAttachment,
+  type NoteAttachmentRow,
+} from "./note-attachment-catalog-model";
+
+export type { NoteAttachment } from "./note-attachment-catalog-model";
+
+const NOTE_ATTACHMENTS_SQL = `
+SELECT
+  attachment.id,
+  attachment.source_id,
+  attachment.filename,
+  attachment.relative_path,
+  attachment.content_type,
+  attachment.size_bytes,
+  attachment.sha256,
+  attachment.created_at,
+  CASE WHEN local_state.availability = 'present' THEN 1 ELSE 0 END AS available_locally,
+  COALESCE(local_state.relative_path, '') AS local_relative_path,
+  attachment.cloud_object_key
+FROM session_attachments AS attachment
+LEFT JOIN attachment_local_state AS local_state
+  ON local_state.attachment_id = attachment.id
+WHERE attachment.session_id = ?
+  AND attachment.source_type = 'note_upload'
+  AND attachment.deleted_at IS NULL
+ORDER BY attachment.created_at, attachment.id
+`;
+
+export function useNoteAttachments(sessionId: string): NoteAttachment[] {
+  const { data } = useLiveQuery<NoteAttachmentRow, NoteAttachment[]>({
+    sql: NOTE_ATTACHMENTS_SQL,
+    params: [sessionId],
+    mapRows: mapNoteAttachmentRows,
+  });
+  return data ?? [];
+}

--- a/apps/mobile/src/data/restore-note-attachment.ts
+++ b/apps/mobile/src/data/restore-note-attachment.ts
@@ -1,0 +1,72 @@
+import { Directory, File, Paths } from "expo-file-system";
+import * as Sharing from "expo-sharing";
+
+import { requestAttachmentBackupDownload } from "@/data/attachment-backup-client";
+import type { NoteAttachment } from "@/data/note-attachment-catalog";
+import { restoreAttachment } from "@/db/client";
+
+export async function restoreNoteAttachmentFromCloud(
+  sessionId: string,
+  attachment: NoteAttachment,
+  input: {
+    accessToken: string;
+    apiBaseUrl: string;
+    supabaseUrl: string;
+    signal?: AbortSignal;
+  },
+): Promise<void> {
+  if (!attachment.cloudObjectKey) {
+    throw new Error("This file has not finished syncing to the cloud.");
+  }
+  const download = await requestAttachmentBackupDownload({
+    accessToken: input.accessToken,
+    apiBaseUrl: input.apiBaseUrl,
+    objectKey: attachment.cloudObjectKey,
+    signal: input.signal,
+  });
+  const restored = await restoreAttachment(
+    {
+      sessionId,
+      attachmentId: attachment.attachmentId,
+      objectId: download.objectId,
+      objectKey: download.objectKey,
+      signedUrl: download.signedUrl,
+      supabaseUrl: input.supabaseUrl,
+      ciphertextSha256: download.ciphertextSha256,
+      ciphertextSizeBytes: download.ciphertextSizeBytes,
+      formatVersion: download.formatVersion,
+    },
+    input.signal,
+  );
+  if (
+    restored.attachmentId !== attachment.attachmentId ||
+    restored.sessionId !== sessionId ||
+    restored.relativePath !== attachment.relativePath ||
+    restored.sha256 !== attachment.sha256 ||
+    restored.sizeBytes !== attachment.sizeBytes
+  ) {
+    throw new Error("The restored file did not match this note.");
+  }
+}
+
+export async function shareNoteAttachment(
+  uri: string,
+  attachment: NoteAttachment,
+): Promise<void> {
+  if (!(await Sharing.isAvailableAsync())) {
+    throw new Error("Sharing is not available on this device.");
+  }
+  const directory = new Directory(
+    Paths.cache,
+    "note-attachment-shares",
+    attachment.attachmentId,
+  );
+  directory.create({ intermediates: true, idempotent: true });
+  const staged = new File(directory, attachment.filename);
+  if (staged.exists) staged.delete();
+  await new File(uri).copy(staged);
+  await Sharing.shareAsync(staged.uri, {
+    dialogTitle: `Share ${attachment.filename}`,
+    mimeType: attachment.contentType || "application/octet-stream",
+  });
+}


### PR DESCRIPTION
## Summary
- surface canonical `note_upload` attachments in a Files section on mobile notes
- distinguish local, cloud-downloadable, and pending-sync states truthfully
- download encrypted files through the native verified restore path and share local files through the system sheet
- stage shares under the original filename so opaque canonical storage IDs never leak into the user-facing file name
- filter unsafe or malformed synced attachment rows before constructing device paths

## Validation
- `pnpm -F @anlg/mobile test` (95 passed)
- `pnpm exec oxlint --quiet --format=github` on all changed mobile source files
- `pnpm exec dprint fmt apps/mobile/src/data/restore-note-attachment.ts`
- `pnpm fmt:check`

`pnpm -F @anlg/mobile typecheck` reports only the four pre-existing unrelated workspace errors in `live-transcription-model.ts`, `session-detail.ts`, `timeline.ts`, and `sync/identity.ts`.

Linear: [ANLG-249](https://linear.app/fastrepl-inc/issue/ANLG-249/bring-encrypted-attachment-byte-sync-to-mobile)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches encrypted cloud restore and local file paths for user attachments; validation reduces path-traversal risk but download/share still handle sensitive user files.
> 
> **Overview**
> Mobile notes now show a **Files** section for synced `note_upload` attachments, with UI that reflects whether each file is on-device, downloadable from cloud sync, or still pending.
> 
> A new live-query catalog maps `session_attachments` rows through strict validation (canonical paths, size/hash checks) so unsafe metadata never becomes device paths. **Download** uses the existing encrypted backup restore path and verifies restored bytes against catalog metadata; **Share** copies into cache under the original filename before opening the system share sheet.
> 
> The note screen wires busy state, per-attachment errors, abort on unmount, and analytics for download/share—parallel to how remote session audio restore already works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb817748853e43593e0a98a94e3d759aefd35e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->