### PR TITLE
ANLG-250: Restore clean mobile TypeScript validation

### DIFF
--- a/apps/mobile/src/data/timeline.ts
+++ b/apps/mobile/src/data/timeline.ts
@@ -6,6 +6,7 @@ import {
   buildSessionList,
   mapTimelineRows,
   nextTimelineRefreshAt,
+  type SessionListItem,
   type TimelineRow,
   type TimelineSession,
 } from "./timeline-model";

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "strict": true,
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Summary
- allow explicit TypeScript import extensions in the no-emit Expo package so Node's native TypeScript test runner and `tsc` agree
- restore the missing `SessionListItem` type import in the mobile timeline hook
- return the mobile package to a clean typecheck baseline

## Validation
- `pnpm exec dprint fmt`
- `pnpm fmt:check`
- `pnpm -F @anlg/mobile typecheck`
- `pnpm -F @anlg/mobile test` (95 passed)
- `pnpm exec oxlint --quiet --format=github apps/mobile/src/`

Linear: [ANLG-250](https://linear.app/fastrepl-inc/issue/ANLG-250/restore-clean-mobile-typescript-validation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and type-only import changes with no runtime behavior impact.
> 
> **Overview**
> Restores a clean **`pnpm -F @anlg/mobile typecheck`** baseline with two small config/import fixes.
> 
> **`apps/mobile/tsconfig.json`** enables **`allowImportingTsExtensions`** so `tsc` accepts the explicit **`.ts`** import paths already used by Node’s native TypeScript test runner (e.g. `*.test.mjs` importing `./foo.ts`), keeping the compiler aligned with how those tests resolve modules.
> 
> **`apps/mobile/src/data/timeline.ts`** re-imports **`SessionListItem`** from `./timeline-model` so **`useTimelineSessions`**’s return type typechecks again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29c2c01717b3b76ba4394e1f5f8543092b5a1a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->