### PR TITLE
Skip empty meeting import step during onboarding

### DIFF
--- a/apps/desktop/src/imports/screen.test.tsx
+++ b/apps/desktop/src/imports/screen.test.tsx
@@ -83,7 +83,11 @@ import { MEETING_IMPORT_PROVIDERS } from "./providers";
 import { MeetingImportScreen } from "./screen";
 
 function renderImports(
-  props: { compact?: boolean; secondaryAction?: ReactNode } = {},
+  props: {
+    compact?: boolean;
+    onNoSourcesDetected?: () => void;
+    secondaryAction?: ReactNode;
+  } = {},
 ) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -267,5 +271,38 @@ describe("MeetingImportScreen", () => {
     renderImports();
 
     expect(await screen.findByText("No apps found.")).toBeTruthy();
+  });
+
+  it("reports when detection finishes without finding any apps", async () => {
+    const onNoSourcesDetected = vi.fn();
+    mockDetected([]);
+
+    renderImports({ onNoSourcesDetected });
+
+    await waitFor(() => {
+      expect(onNoSourcesDetected).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("does not report an empty result while detection is pending", async () => {
+    const onNoSourcesDetected = vi.fn();
+    mocks.detectImportSources.mockReturnValue(new Promise(() => {}));
+
+    renderImports({ onNoSourcesDetected });
+
+    expect(
+      await screen.findByText("Checking installed meeting assistants…"),
+    ).toBeTruthy();
+    expect(onNoSourcesDetected).not.toHaveBeenCalled();
+  });
+
+  it("does not report an empty result when detection fails", async () => {
+    const onNoSourcesDetected = vi.fn();
+    mocks.detectImportSources.mockRejectedValue(new Error("Detection failed"));
+
+    renderImports({ onNoSourcesDetected });
+
+    expect(await screen.findByText("Detection failed")).toBeTruthy();
+    expect(onNoSourcesDetected).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/imports/screen.tsx
+++ b/apps/desktop/src/imports/screen.tsx
@@ -13,7 +13,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { open as selectFiles } from "@tauri-apps/plugin-dialog";
-import { type ReactNode, useRef } from "react";
+import { type ReactNode, useEffect, useRef } from "react";
 
 import { commands as importerCommands } from "@anlg/plugin-importer";
 import { Button } from "@anlg/ui/components/ui/button";
@@ -85,10 +85,12 @@ function ProviderIcon({
 export function MeetingImportScreen({
   compact = false,
   onContinue,
+  onNoSourcesDetected,
   secondaryAction,
 }: {
   compact?: boolean;
   onContinue?: () => void;
+  onNoSourcesDetected?: () => void;
   secondaryAction?: ReactNode;
 }) {
   const { t } = useLingui();
@@ -113,6 +115,24 @@ export function MeetingImportScreen({
     .sort((left, right) => left.name.localeCompare(right.name));
   const displayedProviders = [...directProviders, ...fileProviders];
   const detectionSettled = !detectionQuery.isLoading && !detectionQuery.error;
+
+  useEffect(() => {
+    if (
+      detectionQuery.isFetching ||
+      detectionQuery.error ||
+      detectionQuery.data?.length !== 0
+    ) {
+      return;
+    }
+
+    onNoSourcesDetected?.();
+  }, [
+    detectionQuery.data,
+    detectionQuery.error,
+    detectionQuery.isFetching,
+    onNoSourcesDetected,
+  ]);
+
   const connectedProviders = directProviders;
   const credentialQueries = useQueries({
     queries: connectedProviders.map((provider) =>

--- a/apps/desktop/src/onboarding/imports.tsx
+++ b/apps/desktop/src/onboarding/imports.tsx
@@ -15,6 +15,7 @@ export function ImportSection({
     <MeetingImportScreen
       compact
       onContinue={onContinue}
+      onNoSourcesDetected={onSkip}
       secondaryAction={
         <OnboardingButton
           variant="secondary"


### PR DESCRIPTION
## Summary
- notify onboarding when meeting app detection completes with zero sources
- automatically advance only after a successful empty detection
- keep pending and failed detections visible
- add regression coverage for empty, pending, and failed detection

## Testing
- `pnpm -F desktop exec vitest run src/imports/screen.test.tsx`
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop i18n:check`

## Local environment notes
- `pnpm -F desktop test` was attempted twice; the Windows runner hit unrelated 5-second UI-test timeouts under full-suite parallelism, while the focused import suite passes 10/10.
- The touched files pass `oxfmt --check`; the repository-wide dprint wrapper cannot launch its configured pnpm/Swift subprocesses in this bundled Windows shell.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UX only; callback is gated on successful empty detection and does not touch auth or import logic.
> 
> **Overview**
> **Meeting import** now exposes an optional `onNoSourcesDetected` callback that runs after meeting-app detection finishes successfully with zero installed sources. The callback is **not** invoked while detection is still in progress or when detection errors.
> 
> Onboarding wires this to **`onSkip`**, so users with no detectable meeting assistants automatically advance past the import step instead of staying on an empty screen (manual **Skip for now** remains unchanged).
> 
> Regression tests cover the success-empty, pending, and failed detection paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b844657585317354a88adbc726ce68436d785b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->