### PR TITLE
Add a Codex-inspired application toolbar for the Windows desktop shell.

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -1,3 +1,4 @@
+import { platform } from "@tauri-apps/plugin-os";
 import {
   type CSSProperties,
   type WheelEvent as ReactWheelEvent,
@@ -79,6 +80,7 @@ export function ClassicMainBody({
     useState(false);
   const [noteFilter, setNoteFilter] = useState<SidebarNoteFilter>("mine");
   const showWindowControlsGutter = useWindowControlsGutter();
+  const showSidebarToggleInBody = getRuntimePlatform() !== "windows";
   leftSidebarPanelConstraintsRef.current = leftSidebarPanelConstraints;
 
   const isOnboarding = currentTab?.type === "onboarding";
@@ -406,6 +408,7 @@ export function ClassicMainBody({
           currentSessionId={currentSessionId}
           noteFilter={noteFilter}
           sidebarExpanded
+          showSidebarToggle={showSidebarToggleInBody}
           showIgnoredTimelineEvents={showIgnoredTimelineEvents}
           onNewNote={createNewNote}
           onNoteFilterChange={setNoteFilter}
@@ -444,6 +447,7 @@ export function ClassicMainBody({
               currentSessionId={currentSessionId}
               noteFilter={noteFilter}
               sidebarExpanded={false}
+              showSidebarToggle={showSidebarToggleInBody}
               showIgnoredTimelineEvents={showIgnoredTimelineEvents}
               onNewNote={createNewNote}
               onNoteFilterChange={setNoteFilter}
@@ -567,4 +571,12 @@ export function ClassicMainBody({
       </ResizablePanelGroup>
     </div>
   );
+}
+
+function getRuntimePlatform() {
+  try {
+    return platform();
+  } catch {
+    return null;
+  }
 }

--- a/apps/desktop/src/main/shell-frame.test.tsx
+++ b/apps/desktop/src/main/shell-frame.test.tsx
@@ -3,9 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   currentTab: { type: "empty" } as { type: string } | null,
+  platform: "macos" as "macos" | "windows",
   leftsidebar: {
     expanded: true,
   },
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => mocks.platform,
 }));
 
 vi.mock("./body", () => ({
@@ -14,6 +19,10 @@ vi.mock("./body", () => ({
       {showSyncStatus ? <div data-testid="sync-status-indicator" /> : null}
     </div>
   ),
+}));
+
+vi.mock("./windows-title-bar", () => ({
+  WindowsTitleBar: () => <div data-testid="windows-title-bar" />,
 }));
 
 vi.mock("~/shared/main", () => ({
@@ -64,7 +73,22 @@ describe("ClassicMainShellFrame", () => {
 
   beforeEach(() => {
     mocks.currentTab = { type: "empty" };
+    mocks.platform = "macos";
     mocks.leftsidebar.expanded = true;
+  });
+
+  it("places the custom title bar above the shell on Windows", () => {
+    mocks.platform = "windows";
+
+    render(<ClassicMainShellFrame />);
+
+    const titleBar = screen.getByTestId("windows-title-bar");
+    const scaffold = screen.getByTestId("main-shell-scaffold");
+
+    expect(titleBar.compareDocumentPosition(scaffold)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(titleBar.parentElement?.className).toContain("flex-col");
   });
 
   it("uses left-edge main surface chrome while the sidebar timeline is expanded", () => {

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -1,7 +1,9 @@
+import { platform } from "@tauri-apps/plugin-os";
 import { memo } from "react";
 
 import { ClassicMainBody } from "./body";
 import { resolveMainSurfaceChrome } from "./main-surface-chrome";
+import { WindowsTitleBar } from "./windows-title-bar";
 
 import { useShell } from "~/contexts/shell";
 import { MainShellBodyFrame, MainShellScaffold } from "~/shared/main";
@@ -33,7 +35,7 @@ export function ClassicMainShellFrame() {
     showSidebarTimelineChrome,
   });
 
-  return (
+  const shell = (
     <MainShellScaffold
       edgeToEdge={isOnboarding}
       mainSurfaceChrome={isOnboarding ? undefined : mainSurfaceChrome}
@@ -41,6 +43,17 @@ export function ClassicMainShellFrame() {
       <ClassicMainBodyHost showSyncStatus={showSyncStatus} />
       <ToastNotifications />
     </MainShellScaffold>
+  );
+
+  if (platform() !== "windows") {
+    return shell;
+  }
+
+  return (
+    <div className="bg-background flex h-full min-h-0 flex-col">
+      <WindowsTitleBar />
+      <div className="min-h-0 flex-1">{shell}</div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/main/sidebar-timeline-chrome.tsx
+++ b/apps/desktop/src/main/sidebar-timeline-chrome.tsx
@@ -21,6 +21,7 @@ export const SidebarTimelineChromeWithUpcomingMeeting = memo(
     onSearch,
     onToggleSidebar,
     sidebarExpanded,
+    showSidebarToggle = true,
     showIgnoredTimelineEvents,
   }: {
     currentSessionId?: string;
@@ -30,6 +31,7 @@ export const SidebarTimelineChromeWithUpcomingMeeting = memo(
     onSearch: () => void;
     onToggleSidebar: () => void;
     sidebarExpanded: boolean;
+    showSidebarToggle?: boolean;
     showIgnoredTimelineEvents: boolean;
   }) {
     const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus({
@@ -49,6 +51,7 @@ export const SidebarTimelineChromeWithUpcomingMeeting = memo(
         onSearch={onSearch}
         onToggleSidebar={onToggleSidebar}
         sidebarExpanded={sidebarExpanded}
+        showSidebarToggle={showSidebarToggle}
       />
     );
   },
@@ -62,6 +65,7 @@ function SidebarTimelineChrome({
   onSearch,
   onToggleSidebar,
   sidebarExpanded,
+  showSidebarToggle,
 }: {
   hasUpcomingMeeting: boolean;
   noteFilter: SidebarNoteFilter;
@@ -70,6 +74,7 @@ function SidebarTimelineChrome({
   onSearch: () => void;
   onToggleSidebar: () => void;
   sidebarExpanded: boolean;
+  showSidebarToggle: boolean;
 }) {
   const collapsedBadge = !sidebarExpanded
     ? hasUpcomingMeeting
@@ -80,17 +85,25 @@ function SidebarTimelineChrome({
   return (
     <div data-tauri-drag-region className="flex w-full items-center">
       <div data-tauri-drag-region className="flex items-center gap-0">
-        <LeftSurfaceChromeButton
-          ariaLabel={sidebarExpanded ? "Hide sidebar" : "Show sidebar"}
-          badge={collapsedBadge}
-          onClick={onToggleSidebar}
-        >
-          {sidebarExpanded ? (
-            <SidebarSimple size={16} />
-          ) : (
-            <Sidebar size={16} />
-          )}
-        </LeftSurfaceChromeButton>
+        {showSidebarToggle ? (
+          <LeftSurfaceChromeButton
+            ariaLabel={sidebarExpanded ? "Hide sidebar" : "Show sidebar"}
+            badge={collapsedBadge}
+            onClick={onToggleSidebar}
+          >
+            {sidebarExpanded ? (
+              <SidebarSimple size={16} />
+            ) : (
+              <Sidebar size={16} />
+            )}
+          </LeftSurfaceChromeButton>
+        ) : (
+          <span
+            aria-hidden="true"
+            data-tauri-drag-region
+            className="size-7 shrink-0"
+          />
+        )}
         {sidebarExpanded ? (
           <>
             <LeftSurfaceChromeButton ariaLabel="Search" onClick={onSearch}>

--- a/apps/desktop/src/main/windows-title-bar.test.tsx
+++ b/apps/desktop/src/main/windows-title-bar.test.tsx
@@ -1,0 +1,136 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  close: vi.fn().mockResolvedValue(undefined),
+  createNewNote: vi.fn(),
+  isFullscreen: vi.fn().mockResolvedValue(false),
+  isMaximized: vi.fn().mockResolvedValue(false),
+  minimize: vi.fn().mockResolvedValue(undefined),
+  onResized: vi.fn().mockResolvedValue(vi.fn()),
+  openNew: vi.fn(),
+  openUrl: vi.fn().mockResolvedValue({ status: "ok", data: null }),
+  setFullscreen: vi.fn().mockResolvedValue(undefined),
+  toggleExpanded: vi.fn(),
+  toggleMaximize: vi.fn().mockResolvedValue(undefined),
+  currentTab: { type: "empty" } as { id?: string; type: string },
+  leftSidebarExpanded: true,
+  upcomingMeetingStatus: null as null | { itemKey: string },
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    close: mocks.close,
+    isFullscreen: mocks.isFullscreen,
+    isMaximized: mocks.isMaximized,
+    minimize: mocks.minimize,
+    onResized: mocks.onResized,
+    setFullscreen: mocks.setFullscreen,
+    toggleMaximize: mocks.toggleMaximize,
+  }),
+}));
+
+vi.mock("@anlg/plugin-opener2", () => ({
+  commands: { openUrl: mocks.openUrl },
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: () => ({
+    leftsidebar: {
+      expanded: mocks.leftSidebarExpanded,
+      toggleExpanded: mocks.toggleExpanded,
+    },
+  }),
+}));
+
+vi.mock("~/shared/useNewNote", () => ({
+  useNewNote: () => mocks.createNewNote,
+}));
+
+vi.mock("~/sidebar/timeline/upcoming-meeting", () => ({
+  useSidebarUpcomingMeetingStatus: () => mocks.upcomingMeetingStatus,
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: (
+    selector: (state: {
+      currentTab: typeof mocks.currentTab;
+      openNew: typeof mocks.openNew;
+    }) => unknown,
+  ) => selector({ currentTab: mocks.currentTab, openNew: mocks.openNew }),
+}));
+
+import { WindowsTitleBar } from "./windows-title-bar";
+
+describe("WindowsTitleBar", () => {
+  beforeEach(() => {
+    mocks.close.mockClear();
+    mocks.createNewNote.mockClear();
+    mocks.isFullscreen.mockClear();
+    mocks.isMaximized.mockClear();
+    mocks.isMaximized.mockResolvedValue(false);
+    mocks.minimize.mockClear();
+    mocks.onResized.mockClear();
+    mocks.openNew.mockClear();
+    mocks.openUrl.mockClear();
+    mocks.setFullscreen.mockClear();
+    mocks.toggleExpanded.mockClear();
+    mocks.toggleMaximize.mockClear();
+    mocks.currentTab = { type: "empty" };
+    mocks.leftSidebarExpanded = true;
+    mocks.upcomingMeetingStatus = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the sidebar and application menus in the draggable title bar", async () => {
+    render(<WindowsTitleBar />);
+
+    const titleBar = screen.getByTestId("windows-title-bar");
+
+    expect(titleBar.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "File" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Edit" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "View" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Help" })).toBeTruthy();
+
+    await waitFor(() => expect(mocks.isMaximized).toHaveBeenCalledOnce());
+  });
+
+  it("connects the sidebar and native window controls", () => {
+    render(<WindowsTitleBar />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Minimize" }));
+    fireEvent.click(screen.getByRole("button", { name: "Maximize" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(mocks.toggleExpanded).toHaveBeenCalledOnce();
+    expect(mocks.minimize).toHaveBeenCalledOnce();
+    expect(mocks.toggleMaximize).toHaveBeenCalledOnce();
+    expect(mocks.close).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the collapsed-sidebar upcoming meeting badge", () => {
+    mocks.leftSidebarExpanded = false;
+    mocks.upcomingMeetingStatus = { itemKey: "session-upcoming" };
+
+    render(<WindowsTitleBar />);
+
+    const toggle = screen.getByRole("button", { name: "Show sidebar" });
+    expect(
+      toggle.querySelector(
+        "[data-testid='collapsed-sidebar-upcoming-meeting-badge']",
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/main/windows-title-bar.tsx
+++ b/apps/desktop/src/main/windows-title-bar.tsx
@@ -1,0 +1,316 @@
+import { Sidebar, SidebarSimple } from "@phosphor-icons/react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useCallback, useRef, useState } from "react";
+
+import { commands as openerCommands } from "@anlg/plugin-opener2";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@anlg/ui/components/ui/dropdown-menu";
+import { cn } from "@anlg/utils";
+
+import { LeftSurfaceChromeButton } from "./sidebar-timeline-chrome";
+
+import { useShell } from "~/contexts/shell";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+import { useNewNote } from "~/shared/useNewNote";
+import { useSidebarUpcomingMeetingStatus } from "~/sidebar/timeline/upcoming-meeting";
+import { useTabs } from "~/store/zustand/tabs";
+
+const appWindow = getCurrentWindow();
+
+export function WindowsTitleBar() {
+  const { leftsidebar } = useShell();
+  const currentTab = useTabs((state) => state.currentTab);
+  const openNew = useTabs((state) => state.openNew);
+  const createNewNote = useNewNote();
+  const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus();
+  const [isMaximized, setIsMaximized] = useState(false);
+  const editTargetRef = useRef<HTMLElement | null>(null);
+  const currentSessionId =
+    currentTab?.type === "sessions" ? currentTab.id : undefined;
+  const showUpcomingMeetingBadge =
+    !leftsidebar.expanded &&
+    !!upcomingMeetingStatus &&
+    (!currentSessionId ||
+      upcomingMeetingStatus.itemKey !== `session-${currentSessionId}`);
+
+  const syncMaximized = useCallback(() => {
+    void appWindow
+      .isMaximized()
+      .then(setIsMaximized)
+      .catch(() => setIsMaximized(false));
+  }, []);
+
+  useMountEffect(() => {
+    let cancelled = false;
+    let unlistenResize: (() => void) | undefined;
+
+    const sync = () => {
+      if (!cancelled) {
+        syncMaximized();
+      }
+    };
+
+    sync();
+    void appWindow
+      .onResized(sync)
+      .then((unlisten) => {
+        if (cancelled) {
+          unlisten();
+          return;
+        }
+
+        unlistenResize = unlisten;
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+      unlistenResize?.();
+    };
+  });
+
+  const rememberEditTarget = useCallback(() => {
+    editTargetRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+  }, []);
+  const runEditCommand = useCallback((command: string) => {
+    const editTarget = editTargetRef.current;
+    if (editTarget?.isConnected) {
+      editTarget.focus();
+    }
+
+    document.execCommand(command);
+  }, []);
+  const toggleFullscreen = useCallback(async () => {
+    const isFullscreen = await appWindow.isFullscreen();
+    await appWindow.setFullscreen(!isFullscreen);
+  }, []);
+  const toggleMaximize = useCallback(async () => {
+    await appWindow.toggleMaximize();
+    syncMaximized();
+  }, [syncMaximized]);
+
+  return (
+    <header
+      data-tauri-drag-region
+      data-testid="windows-title-bar"
+      className="border-border/60 bg-background flex h-10 shrink-0 items-stretch border-b"
+    >
+      <div
+        data-tauri-drag-region
+        className="flex min-w-0 flex-1 items-center pl-2"
+      >
+        <LeftSurfaceChromeButton
+          ariaLabel={leftsidebar.expanded ? "Hide sidebar" : "Show sidebar"}
+          badge={showUpcomingMeetingBadge ? "upcomingMeeting" : null}
+          onClick={leftsidebar.toggleExpanded}
+        >
+          {leftsidebar.expanded ? (
+            <SidebarSimple size={16} />
+          ) : (
+            <Sidebar size={16} />
+          )}
+        </LeftSurfaceChromeButton>
+        <nav
+          aria-label="Application menu"
+          className="ml-2 flex h-full items-center"
+          role="menubar"
+        >
+          <TitleBarMenu label="File" onPointerDown={rememberEditTarget}>
+            <DropdownMenuItem onSelect={createNewNote}>
+              New Note
+              <DropdownMenuShortcut>Ctrl+N</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() =>
+                openNew({ type: "settings", state: { tab: "app" } })
+              }
+            >
+              Settings
+              <DropdownMenuShortcut>Ctrl+,</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => void appWindow.close()}>
+              Close
+              <DropdownMenuShortcut>Alt+F4</DropdownMenuShortcut>
+            </DropdownMenuItem>
+          </TitleBarMenu>
+          <TitleBarMenu label="Edit" onPointerDown={rememberEditTarget}>
+            <DropdownMenuItem onSelect={() => runEditCommand("undo")}>
+              Undo
+              <DropdownMenuShortcut>Ctrl+Z</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => runEditCommand("redo")}>
+              Redo
+              <DropdownMenuShortcut>Ctrl+Y</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => runEditCommand("cut")}>
+              Cut
+              <DropdownMenuShortcut>Ctrl+X</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => runEditCommand("copy")}>
+              Copy
+              <DropdownMenuShortcut>Ctrl+C</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => runEditCommand("paste")}>
+              Paste
+              <DropdownMenuShortcut>Ctrl+V</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => runEditCommand("selectAll")}>
+              Select All
+              <DropdownMenuShortcut>Ctrl+A</DropdownMenuShortcut>
+            </DropdownMenuItem>
+          </TitleBarMenu>
+          <TitleBarMenu label="View" onPointerDown={rememberEditTarget}>
+            <DropdownMenuItem onSelect={leftsidebar.toggleExpanded}>
+              {leftsidebar.expanded ? "Hide Sidebar" : "Show Sidebar"}
+              <DropdownMenuShortcut>Ctrl+\</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => void toggleFullscreen()}>
+              Full Screen
+              <DropdownMenuShortcut>F11</DropdownMenuShortcut>
+            </DropdownMenuItem>
+          </TitleBarMenu>
+          <TitleBarMenu label="Help" onPointerDown={rememberEditTarget}>
+            <DropdownMenuItem
+              onSelect={() =>
+                void openerCommands.openUrl("https://docs.anarlog.so", null)
+              }
+            >
+              Documentation
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() =>
+                void openerCommands.openUrl("https://anarlog.so/discord", null)
+              }
+            >
+              Report a Bug
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() =>
+                void openerCommands.openUrl("https://anarlog.so/discord", null)
+              }
+            >
+              Suggest a Feature
+            </DropdownMenuItem>
+          </TitleBarMenu>
+        </nav>
+        <div data-tauri-drag-region className="min-w-4 flex-1" />
+      </div>
+      <div className="flex shrink-0" data-tauri-drag-region="false">
+        <WindowControlButton
+          ariaLabel="Minimize"
+          onClick={() => void appWindow.minimize()}
+        >
+          <span className="h-px w-2.5 bg-current" />
+        </WindowControlButton>
+        <WindowControlButton
+          ariaLabel={isMaximized ? "Restore" : "Maximize"}
+          onClick={() => void toggleMaximize()}
+        >
+          {isMaximized ? <RestoreIcon /> : <MaximizeIcon />}
+        </WindowControlButton>
+        <WindowControlButton
+          ariaLabel="Close"
+          close
+          onClick={() => void appWindow.close()}
+        >
+          <span className="relative size-3">
+            <span className="absolute top-[5.5px] left-0 h-px w-3 rotate-45 bg-current" />
+            <span className="absolute top-[5.5px] left-0 h-px w-3 -rotate-45 bg-current" />
+          </span>
+        </WindowControlButton>
+      </div>
+    </header>
+  );
+}
+
+function TitleBarMenu({
+  children,
+  label,
+  onPointerDown,
+}: {
+  children: React.ReactNode;
+  label: string;
+  onPointerDown: () => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          data-tauri-drag-region="false"
+          role="menuitem"
+          className={cn([
+            "text-muted-foreground h-7 rounded-md px-2.5 text-sm",
+            "hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground",
+            "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
+          ])}
+          onPointerDown={onPointerDown}
+        >
+          {label}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        sideOffset={1}
+        className="w-56 rounded-lg"
+      >
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function WindowControlButton({
+  ariaLabel,
+  children,
+  close = false,
+  onClick,
+}: {
+  ariaLabel: string;
+  children: React.ReactNode;
+  close?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      data-tauri-drag-region="false"
+      className={cn([
+        "text-foreground flex h-10 w-[46px] items-center justify-center transition-colors",
+        close
+          ? "hover:bg-[#c42b1c] hover:text-white"
+          : "hover:bg-foreground/10",
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden focus-visible:ring-inset",
+      ])}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+function MaximizeIcon() {
+  return <span className="size-2.5 border border-current" />;
+}
+
+function RestoreIcon() {
+  return (
+    <span className="relative size-3">
+      <span className="absolute top-0.5 right-0 size-2 border border-current" />
+      <span className="bg-background absolute bottom-0.5 left-0 size-2 border border-current" />
+    </span>
+  );
+}

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -375,37 +375,19 @@ describe("ClassicMainBody", () => {
   it.each([
     {
       expanded: true,
-      platform: "windows",
-      platformName: "Windows",
       sidebarState: "expanded",
       toggleLabel: "Hide sidebar",
     },
     {
       expanded: false,
-      platform: "windows",
-      platformName: "Windows",
-      sidebarState: "collapsed",
-      toggleLabel: "Show sidebar",
-    },
-    {
-      expanded: true,
-      platform: "linux",
-      platformName: "Linux",
-      sidebarState: "expanded",
-      toggleLabel: "Hide sidebar",
-    },
-    {
-      expanded: false,
-      platform: "linux",
-      platformName: "Linux",
       sidebarState: "collapsed",
       toggleLabel: "Show sidebar",
     },
   ] as const)(
-    "uses the 8px fallback gutter on $platformName with the sidebar $sidebarState",
-    async ({ expanded, platform, toggleLabel }) => {
+    "uses the 8px fallback gutter on Linux with the sidebar $sidebarState",
+    async ({ expanded, toggleLabel }) => {
       mocks.leftSidebarExpanded = expanded;
-      mocks.platform = platform;
+      mocks.platform = "linux";
 
       render(<ClassicMainBody />);
 
@@ -417,6 +399,37 @@ describe("ClassicMainBody", () => {
       await waitFor(() => {
         expect(chromeFrame?.className).toContain("pl-2");
       });
+      expect(chromeFrame?.className).not.toContain("pl-[76px]");
+      expect(mocks.isFullscreen).not.toHaveBeenCalled();
+      expect(mocks.resizeListeners).toHaveLength(0);
+    },
+  );
+
+  it.each([
+    ["expanded", true],
+    ["collapsed", false],
+  ])(
+    "leaves the sidebar toggle to the Windows title bar while %s",
+    async (_state, expanded) => {
+      mocks.leftSidebarExpanded = expanded;
+      mocks.platform = "windows";
+
+      render(<ClassicMainBody />);
+
+      const chromeFrame = expanded
+        ? document.querySelector<HTMLElement>("[data-sidebar-timeline-header]")
+        : document.querySelector<HTMLElement>(
+            "[data-left-sidebar-chrome] > div",
+          );
+
+      await waitFor(() => {
+        expect(chromeFrame?.className).toContain("pl-2");
+      });
+      expect(
+        screen.queryByRole("button", {
+          name: expanded ? "Hide sidebar" : "Show sidebar",
+        }),
+      ).toBeNull();
       expect(chromeFrame?.className).not.toContain("pl-[76px]");
       expect(mocks.isFullscreen).not.toHaveBeenCalled();
       expect(mocks.resizeListeners).toHaveLength(0);

--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -206,7 +206,12 @@ impl AppWindow {
                 .title_bar_style(tauri::TitleBarStyle::Overlay);
         }
 
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(target_os = "windows")]
+        {
+            builder = builder.decorations(!matches!(self, Self::Main));
+        }
+
+        #[cfg(target_os = "linux")]
         {
             builder = builder.decorations(true);
         }
@@ -268,7 +273,10 @@ impl WindowImpl for AppWindow {
             }
         };
 
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(target_os = "windows")]
+        window.set_decorations(!matches!(self, Self::Main))?;
+
+        #[cfg(target_os = "linux")]
         window.set_decorations(true)?;
 
         Ok(window)


### PR DESCRIPTION
## Summary
- add a Windows-only custom title bar with sidebar, File, Edit, View, and Help controls
- wire native minimize, maximize/restore, close, and fullscreen behavior
- move the sidebar toggle into the title bar on Windows while preserving its meeting badge
- keep native decorations unchanged for Linux, macOS, and auxiliary windows

## Validation
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/` (0 errors)
- 67 focused Vitest tests passed
- full desktop suite: 3,115 passed; 8 timeout flakes passed when rerun standalone
- `cargo check -p tauri-plugin-windows`
- direct oxfmt and rustfmt checks

## Local environment limitations
- full desktop Rust check could not run because `libclang.dll` is unavailable
- the plugin unit-test binary could not launch due to `STATUS_ENTRYPOINT_NOT_FOUND`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches window decoration policy and primary shell layout on Windows only; incorrect decoration or drag-region handling could affect resizing, closing, or menu/edit focus, but scope is platform-gated with solid test coverage.
> 
> **Overview**
> Adds a **Windows-only** custom application title bar above the main shell, with sidebar toggle (including collapsed upcoming-meeting badge), **File / Edit / View / Help** menus, and in-app **minimize, maximize/restore, and close** controls wired to Tauri window APIs.
> 
> On Windows, the **main** window is created **without native decorations** so the custom bar can own the frame; **note/composer** and **Linux/macOS** behavior stay on native chrome. The sidebar toggle is **removed from the timeline header in the body** on Windows (spacer only) so it lives solely in the title bar, with tests covering shell layout and gutter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3283807e25c57e2729c186fdb15e92ae0f387ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->