### PR TITLE
ANLG-212: dispatch Zoom RTMS webhooks

### DIFF
--- a/enterprise/Cargo.lock
+++ b/enterprise/Cargo.lock
@@ -55,18 +55,21 @@ version = "0.1.0"
 dependencies = [
  "agent-access",
  "anarlog-enterprise-google-meet-worker",
+ "anarlog-enterprise-zoom-rtms-worker",
  "anyhow",
  "async-trait",
  "axum",
  "chrono",
  "db-app",
  "db-core",
+ "hmac",
  "http",
  "meeting-capture",
  "reqwest",
  "serde",
  "serde_json",
  "session-ingest",
+ "sha2 0.10.9",
  "sha2 0.11.0",
  "sqlx",
  "thiserror",
@@ -3170,6 +3173,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/enterprise/control-plane/Cargo.toml
+++ b/enterprise/control-plane/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license-file.workspace = true
 
 [dependencies]
+anarlog-enterprise-zoom-rtms-worker = { path = "../zoom-rtms-worker" }
 anlg-meeting-capture.workspace = true
 anlg-session-ingest.workspace = true
 
@@ -29,5 +30,7 @@ anlg-agent-access.workspace = true
 anlg-db-app.workspace = true
 anlg-db-core.workspace = true
 anlg-session-ingest = { workspace = true, features = ["apply"] }
+hmac.workspace = true
 reqwest.workspace = true
+sha2-legacy = { package = "sha2", version = "0.10" }
 tower = { workspace = true, features = ["util"] }

--- a/enterprise/control-plane/README.md
+++ b/enterprise/control-plane/README.md
@@ -60,9 +60,15 @@ See the official [`infisical run` documentation](https://infisical.com/docs/cli/
 | `ANARLOG_ENTERPRISE_WORKSPACE_TOKENS` | Yes | JSON object mapping workspace IDs to bearer tokens. At least one unique token of 32–512 bytes is required. |
 | `ANARLOG_ENTERPRISE_BIND_ADDRESS` | No | Listener address. Defaults to `0.0.0.0:8080`; the image sets the same value. |
 | `ANARLOG_ENTERPRISE_DATABASE_MAX_CONNECTIONS` | No | PostgreSQL pool size from 1–100. Defaults to `10`. |
+| `ANARLOG_ENTERPRISE_ZOOM_CLIENT_ID` | Together | Zoom RTMS app client ID. |
+| `ANARLOG_ENTERPRISE_ZOOM_CLIENT_SECRET` | Together | Zoom RTMS app client secret. |
+| `ANARLOG_ENTERPRISE_ZOOM_WEBHOOK_SECRET` | Together | Zoom webhook secret used to verify signed request bodies. |
+| `ANARLOG_ENTERPRISE_ZOOM_ACCOUNT_WORKSPACES` | Together | JSON object mapping signed Zoom account IDs to configured workspace IDs. |
 | `RUST_LOG` | No | Standard tracing filter. Defaults to request and service information. No telemetry is exported. |
 
 `GET /health/live` is process-only liveness. `GET /health/ready` checks PostgreSQL. Capture and delivery routes require `Authorization: Bearer <token>` and reject a token used against any workspace other than its configured workspace.
+
+The four Zoom variables are optional as a group. When all are absent, `/webhooks/zoom` is not mounted and the control plane boots with its minimal database and workspace-auth configuration. If any Zoom variable is set, all four must be valid or startup fails. `ANARLOG_ENTERPRISE_ZOOM_ACCOUNT_WORKSPACES` may reference only workspaces present in `ANARLOG_ENTERPRISE_WORKSPACE_TOKENS`. Infisical should inject these values at process start; the service does not fetch, persist, or log provider credentials.
 
 Capture workers create a durable job with `POST /v1/workspaces/{workspace_id}/capture-jobs/{job_id}`, claim it through `/claim`, and renew the returned 60-second fencing lease through `/lease`. Every new event appended to `/events` must carry that lease identity. An expired lease can be reclaimed with a higher epoch, which prevents the prior worker from advancing the job; an identical already-persisted event remains safe to replay. Event IDs and zero-based sequences are idempotency keys. Each accepted event atomically advances the PostgreSQL checkpoint and publishes a delivery revision, while conflicting IDs, sequences, lifecycle transitions, or stale leases fail closed.
 

--- a/enterprise/control-plane/migrations/0004_capture_dispatches.sql
+++ b/enterprise/control-plane/migrations/0004_capture_dispatches.sql
@@ -1,0 +1,21 @@
+ALTER TABLE capture_jobs
+    ADD COLUMN dispatch_id TEXT,
+    ADD COLUMN dispatch_payload JSONB,
+    ADD COLUMN dispatch_accepted_at TIMESTAMPTZ,
+    ADD CONSTRAINT capture_jobs_dispatch_shape CHECK (
+        (
+            dispatch_id IS NULL
+            AND dispatch_payload IS NULL
+            AND dispatch_accepted_at IS NULL
+        )
+        OR (
+            dispatch_id IS NOT NULL
+            AND length(dispatch_id) BETWEEN 1 AND 512
+            AND dispatch_payload IS NOT NULL
+            AND dispatch_accepted_at IS NOT NULL
+        )
+    );
+
+CREATE UNIQUE INDEX capture_jobs_provider_dispatch
+    ON capture_jobs (provider, dispatch_id)
+    WHERE dispatch_id IS NOT NULL;

--- a/enterprise/control-plane/src/api.rs
+++ b/enterprise/control-plane/src/api.rs
@@ -3,6 +3,7 @@ use std::{sync::Arc, time::Duration};
 use anlg_session_ingest::{AcknowledgeRequest, AcknowledgeResponse, DeliveryPage, SessionRead};
 use axum::{
     Json, Router,
+    body::Bytes,
     extract::{DefaultBodyLimit, Path, Query, State},
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
@@ -19,6 +20,7 @@ use crate::{
         RenewCaptureJobLeaseRequest,
     },
     store::{ControlPlaneStore, StoreError},
+    zoom::{ZoomDispatchError, ZoomWebhookError, ZoomWebhookOutcome, ZoomWebhookService},
 };
 
 const MAX_REQUEST_BYTES: usize = 256 * 1024;
@@ -30,6 +32,7 @@ const CAPTURE_LEASE_DURATION: Duration = Duration::from_secs(60);
 pub struct AppState {
     store: Arc<dyn ControlPlaneStore>,
     authenticator: Arc<dyn WorkspaceAuthenticator>,
+    zoom: Option<Arc<ZoomWebhookService>>,
 }
 
 impl AppState {
@@ -40,12 +43,18 @@ impl AppState {
         Self {
             store,
             authenticator,
+            zoom: None,
         }
+    }
+
+    pub fn with_zoom(mut self, zoom: Arc<ZoomWebhookService>) -> Self {
+        self.zoom = Some(zoom);
+        self
     }
 }
 
 pub fn router(state: AppState) -> Router {
-    Router::new()
+    let mut router = Router::new()
         .route("/health/live", get(liveness))
         .route("/health/ready", get(readiness))
         .route(
@@ -75,10 +84,48 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/v1/workspaces/{workspace_id}/sessions/{job_id}",
             get(read_session),
-        )
+        );
+    if state.zoom.is_some() {
+        router = router.route("/webhooks/zoom", post(zoom_webhook));
+    }
+    router
         .layer(DefaultBodyLimit::max(MAX_REQUEST_BYTES))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
+}
+
+async fn zoom_webhook(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, ApiError> {
+    let service = state.zoom.as_ref().ok_or_else(ApiError::not_found)?;
+    let timestamp = headers
+        .get("x-zm-request-timestamp")
+        .and_then(|value| value.to_str().ok());
+    let signature = headers
+        .get("x-zm-signature")
+        .and_then(|value| value.to_str().ok());
+    match service
+        .handle(timestamp, signature, body.as_ref())
+        .await
+        .map_err(ApiError::from_zoom)?
+    {
+        ZoomWebhookOutcome::Validation(response) => Ok(Json(response).into_response()),
+        ZoomWebhookOutcome::Accepted(outcome) => Ok((
+            StatusCode::OK,
+            Json(ZoomWebhookAccepted {
+                status: if outcome.started {
+                    "started"
+                } else {
+                    "already_running"
+                },
+                job_id: outcome.job_id,
+            }),
+        )
+            .into_response()),
+        ZoomWebhookOutcome::Ignored => Ok(StatusCode::NO_CONTENT.into_response()),
+    }
 }
 
 async fn read_capture_checkpoint(
@@ -381,6 +428,13 @@ struct HealthResponse {
     status: &'static str,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ZoomWebhookAccepted {
+    status: &'static str,
+    job_id: String,
+}
+
 struct ApiError {
     status: StatusCode,
     code: &'static str,
@@ -425,6 +479,44 @@ impl ApiError {
         }
     }
 
+    fn not_found() -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: "not_found",
+            message: "the requested route was not found",
+            authenticate: false,
+        }
+    }
+
+    fn from_zoom(error: ZoomWebhookError) -> Self {
+        match error {
+            ZoomWebhookError::MissingHeaders | ZoomWebhookError::Verification(_) => Self {
+                status: StatusCode::UNAUTHORIZED,
+                code: "invalid_zoom_signature",
+                message: "the Zoom webhook signature is invalid",
+                authenticate: false,
+            },
+            ZoomWebhookError::Protocol(_) => Self::bad_request(
+                "invalid_zoom_webhook",
+                "the Zoom webhook payload is invalid",
+            ),
+            ZoomWebhookError::Dispatch(ZoomDispatchError::NotFound) => Self::not_found(),
+            ZoomWebhookError::Dispatch(ZoomDispatchError::Unavailable(error)) => {
+                tracing::error!(error = %error, "Zoom webhook dispatch failed");
+                Self {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    code: "zoom_dispatch_unavailable",
+                    message: "the Zoom capture worker could not accept the event",
+                    authenticate: false,
+                }
+            }
+            ZoomWebhookError::InvalidSystemClock => {
+                tracing::error!("system clock is before Unix epoch");
+                Self::internal()
+            }
+        }
+    }
+
     fn from_store(error: StoreError) -> Self {
         match error {
             StoreError::NotFound => Self {
@@ -449,6 +541,12 @@ impl ApiError {
                 status: StatusCode::CONFLICT,
                 code: "capture_bot_conflict",
                 message: "capture bot is already assigned to a different job",
+                authenticate: false,
+            },
+            StoreError::CaptureExternalIdConflict => Self {
+                status: StatusCode::CONFLICT,
+                code: "capture_external_id_conflict",
+                message: "capture provider identity matches more than one queued job",
                 authenticate: false,
             },
             StoreError::CaptureEventConflict | StoreError::CaptureSequenceConflict { .. } => Self {

--- a/enterprise/control-plane/src/capture.rs
+++ b/enterprise/control-plane/src/capture.rs
@@ -2,6 +2,7 @@ use anlg_meeting_capture::{BotState, CaptureEvent, CaptureProviderKind, MeetingR
 use anlg_session_ingest::SessionIngestEnvelope;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -32,6 +33,15 @@ pub struct CaptureJobCheckpoint {
     pub job: CaptureJob,
     pub state: BotState,
     pub next_sequence: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CaptureDispatch {
+    pub workspace_id: String,
+    pub job_id: String,
+    pub provider: CaptureProviderKind,
+    pub dispatch_id: String,
+    pub payload: Value,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/enterprise/control-plane/src/config.rs
+++ b/enterprise/control-plane/src/config.rs
@@ -1,11 +1,18 @@
 use std::{collections::BTreeMap, env, net::SocketAddr, time::Duration};
 
+use anarlog_enterprise_zoom_rtms_worker::{ZoomRtmsCredentials, ZoomWebhookVerifier};
 use serde::Deserialize;
 
 pub const DATABASE_URL_ENV: &str = "ANARLOG_ENTERPRISE_DATABASE_URL";
 pub const WORKSPACE_TOKENS_ENV: &str = "ANARLOG_ENTERPRISE_WORKSPACE_TOKENS";
 pub const BIND_ADDRESS_ENV: &str = "ANARLOG_ENTERPRISE_BIND_ADDRESS";
 pub const DATABASE_MAX_CONNECTIONS_ENV: &str = "ANARLOG_ENTERPRISE_DATABASE_MAX_CONNECTIONS";
+pub const ZOOM_CLIENT_ID_ENV: &str = "ANARLOG_ENTERPRISE_ZOOM_CLIENT_ID";
+pub const ZOOM_CLIENT_SECRET_ENV: &str = "ANARLOG_ENTERPRISE_ZOOM_CLIENT_SECRET";
+pub const ZOOM_WEBHOOK_SECRET_ENV: &str = "ANARLOG_ENTERPRISE_ZOOM_WEBHOOK_SECRET";
+pub const ZOOM_ACCOUNT_WORKSPACES_ENV: &str = "ANARLOG_ENTERPRISE_ZOOM_ACCOUNT_WORKSPACES";
+
+const ZOOM_WEBHOOK_MAX_AGE: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Clone)]
 pub struct Config {
@@ -14,15 +21,51 @@ pub struct Config {
     pub database_max_connections: u32,
     pub database_acquire_timeout: Duration,
     pub workspace_tokens: BTreeMap<String, String>,
+    pub zoom: Option<ZoomConfig>,
+}
+
+#[derive(Clone)]
+pub struct ZoomConfig {
+    credentials: ZoomRtmsCredentials,
+    verifier: ZoomWebhookVerifier,
+    account_workspaces: BTreeMap<String, String>,
+}
+
+impl ZoomConfig {
+    pub fn credentials(&self) -> &ZoomRtmsCredentials {
+        &self.credentials
+    }
+
+    pub fn verifier(&self) -> &ZoomWebhookVerifier {
+        &self.verifier
+    }
+
+    pub fn workspace_for_account(&self, account_id: &str) -> Option<&str> {
+        self.account_workspaces.get(account_id).map(String::as_str)
+    }
+}
+
+#[derive(Default)]
+pub struct ZoomConfigValues {
+    pub client_id: Option<String>,
+    pub client_secret: Option<String>,
+    pub webhook_secret: Option<String>,
+    pub account_workspaces: Option<String>,
 }
 
 impl Config {
     pub fn from_env() -> Result<Self, ConfigError> {
-        Self::from_values(
+        Self::from_values_with_zoom(
             required_env(DATABASE_URL_ENV)?,
             env::var(BIND_ADDRESS_ENV).ok(),
             env::var(DATABASE_MAX_CONNECTIONS_ENV).ok(),
             required_env(WORKSPACE_TOKENS_ENV)?,
+            ZoomConfigValues {
+                client_id: env::var(ZOOM_CLIENT_ID_ENV).ok(),
+                client_secret: env::var(ZOOM_CLIENT_SECRET_ENV).ok(),
+                webhook_secret: env::var(ZOOM_WEBHOOK_SECRET_ENV).ok(),
+                account_workspaces: env::var(ZOOM_ACCOUNT_WORKSPACES_ENV).ok(),
+            },
         )
     }
 
@@ -31,6 +74,22 @@ impl Config {
         bind_address: Option<String>,
         database_max_connections: Option<String>,
         workspace_tokens: String,
+    ) -> Result<Self, ConfigError> {
+        Self::from_values_with_zoom(
+            database_url,
+            bind_address,
+            database_max_connections,
+            workspace_tokens,
+            ZoomConfigValues::default(),
+        )
+    }
+
+    pub fn from_values_with_zoom(
+        database_url: String,
+        bind_address: Option<String>,
+        database_max_connections: Option<String>,
+        workspace_tokens: String,
+        zoom: ZoomConfigValues,
     ) -> Result<Self, ConfigError> {
         if !database_url.starts_with("postgres://") && !database_url.starts_with("postgresql://") {
             return Err(ConfigError::InvalidDatabaseUrl);
@@ -52,6 +111,7 @@ impl Config {
             .map_err(|_| ConfigError::InvalidWorkspaceTokens)?
             .0;
         validate_workspace_tokens(&workspace_tokens)?;
+        let zoom = parse_zoom_config(zoom, &workspace_tokens)?;
 
         Ok(Self {
             database_url,
@@ -59,6 +119,7 @@ impl Config {
             database_max_connections,
             database_acquire_timeout: Duration::from_secs(10),
             workspace_tokens,
+            zoom,
         })
     }
 }
@@ -66,6 +127,10 @@ impl Config {
 #[derive(Deserialize)]
 #[serde(transparent)]
 struct WorkspaceTokens(BTreeMap<String, String>);
+
+#[derive(Deserialize)]
+#[serde(transparent)]
+struct ZoomAccountWorkspaces(BTreeMap<String, String>);
 
 fn required_env(name: &'static str) -> Result<String, ConfigError> {
     env::var(name).map_err(|_| ConfigError::Missing(name))
@@ -93,6 +158,68 @@ fn validate_workspace_tokens(
     Ok(())
 }
 
+fn parse_zoom_config(
+    values: ZoomConfigValues,
+    workspace_tokens: &BTreeMap<String, String>,
+) -> Result<Option<ZoomConfig>, ConfigError> {
+    let present = [
+        values.client_id.is_some(),
+        values.client_secret.is_some(),
+        values.webhook_secret.is_some(),
+        values.account_workspaces.is_some(),
+    ];
+    if present.iter().all(|present| !present) {
+        return Ok(None);
+    }
+    if present.iter().any(|present| !present) {
+        return Err(ConfigError::IncompleteZoomConfiguration);
+    }
+
+    let credentials = ZoomRtmsCredentials::new(
+        values
+            .client_id
+            .expect("complete configuration has a client ID"),
+        values
+            .client_secret
+            .expect("complete configuration has a client secret"),
+    )
+    .map_err(|_| ConfigError::InvalidZoomCredentials)?;
+    let verifier = ZoomWebhookVerifier::new(
+        values
+            .webhook_secret
+            .expect("complete configuration has a webhook secret"),
+        ZOOM_WEBHOOK_MAX_AGE,
+    )
+    .map_err(|_| ConfigError::InvalidZoomWebhookSecret)?;
+    let account_workspaces = serde_json::from_str::<ZoomAccountWorkspaces>(
+        &values
+            .account_workspaces
+            .expect("complete configuration has an account registry"),
+    )
+    .map_err(|_| ConfigError::InvalidZoomAccountWorkspaces)?
+    .0;
+    if account_workspaces.is_empty() {
+        return Err(ConfigError::EmptyZoomAccountWorkspaces);
+    }
+    for (account_id, workspace_id) in &account_workspaces {
+        if account_id.is_empty()
+            || account_id.len() > 256
+            || account_id.chars().any(char::is_control)
+        {
+            return Err(ConfigError::InvalidZoomAccountId);
+        }
+        if !workspace_tokens.contains_key(workspace_id) {
+            return Err(ConfigError::UnknownZoomWorkspace(workspace_id.clone()));
+        }
+    }
+
+    Ok(Some(ZoomConfig {
+        credentials,
+        verifier,
+        account_workspaces,
+    }))
+}
+
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum ConfigError {
     #[error("missing required configuration: {0}")]
@@ -111,6 +238,24 @@ pub enum ConfigError {
     InvalidWorkspaceId(String),
     #[error("bearer token for workspace {0} must contain between 32 and 512 bytes")]
     InvalidWorkspaceToken(String),
+    #[error(
+        "Zoom integration requires {ZOOM_CLIENT_ID_ENV}, {ZOOM_CLIENT_SECRET_ENV}, {ZOOM_WEBHOOK_SECRET_ENV}, and {ZOOM_ACCOUNT_WORKSPACES_ENV} together"
+    )]
+    IncompleteZoomConfiguration,
+    #[error("Zoom client credentials are invalid")]
+    InvalidZoomCredentials,
+    #[error("Zoom webhook credentials are invalid")]
+    InvalidZoomWebhookSecret,
+    #[error(
+        "{ZOOM_ACCOUNT_WORKSPACES_ENV} must be a JSON object of Zoom account IDs to workspace IDs"
+    )]
+    InvalidZoomAccountWorkspaces,
+    #[error("{ZOOM_ACCOUNT_WORKSPACES_ENV} must contain at least one Zoom account")]
+    EmptyZoomAccountWorkspaces,
+    #[error("{ZOOM_ACCOUNT_WORKSPACES_ENV} contains an invalid Zoom account ID")]
+    InvalidZoomAccountId,
+    #[error("Zoom account registry references an unconfigured workspace: {0}")]
+    UnknownZoomWorkspace(String),
 }
 
 #[cfg(test)]
@@ -132,6 +277,7 @@ mod tests {
         assert_eq!(config.bind_address, "0.0.0.0:8080".parse().unwrap());
         assert_eq!(config.database_max_connections, 10);
         assert_eq!(config.workspace_tokens["workspace-a"], TOKEN);
+        assert!(config.zoom.is_none());
     }
 
     #[test]
@@ -166,5 +312,69 @@ mod tests {
             ConfigError::InvalidWorkspaceToken("workspace-a".into())
         );
         assert!(!error.to_string().contains("short-secret"));
+    }
+
+    #[test]
+    fn enables_zoom_only_with_a_complete_workspace_scoped_registry() {
+        let config = Config::from_values_with_zoom(
+            "postgres://localhost/anarlog".into(),
+            None,
+            None,
+            format!(r#"{{"workspace-a":"{TOKEN}"}}"#),
+            ZoomConfigValues {
+                client_id: Some("zoom-client".into()),
+                client_secret: Some("zoom-client-secret".into()),
+                webhook_secret: Some("zoom-webhook-secret".into()),
+                account_workspaces: Some(r#"{"account-a":"workspace-a"}"#.into()),
+            },
+        )
+        .unwrap();
+
+        let zoom = config.zoom.unwrap();
+        assert_eq!(zoom.workspace_for_account("account-a"), Some("workspace-a"));
+        assert_eq!(zoom.workspace_for_account("account-b"), None);
+        assert!(!format!("{:?}", zoom.credentials()).contains("zoom-client-secret"));
+        assert!(!format!("{:?}", zoom.verifier()).contains("zoom-webhook-secret"));
+    }
+
+    #[test]
+    fn rejects_partial_zoom_configuration_without_weakening_core_startup() {
+        let error = Config::from_values_with_zoom(
+            "postgres://localhost/anarlog".into(),
+            None,
+            None,
+            format!(r#"{{"workspace-a":"{TOKEN}"}}"#),
+            ZoomConfigValues {
+                client_id: Some("zoom-client".into()),
+                ..ZoomConfigValues::default()
+            },
+        )
+        .err()
+        .unwrap();
+
+        assert_eq!(error, ConfigError::IncompleteZoomConfiguration);
+    }
+
+    #[test]
+    fn rejects_zoom_accounts_mapped_to_an_unconfigured_workspace() {
+        let error = Config::from_values_with_zoom(
+            "postgres://localhost/anarlog".into(),
+            None,
+            None,
+            format!(r#"{{"workspace-a":"{TOKEN}"}}"#),
+            ZoomConfigValues {
+                client_id: Some("zoom-client".into()),
+                client_secret: Some("zoom-client-secret".into()),
+                webhook_secret: Some("zoom-webhook-secret".into()),
+                account_workspaces: Some(r#"{"account-a":"workspace-b"}"#.into()),
+            },
+        )
+        .err()
+        .unwrap();
+
+        assert_eq!(
+            error,
+            ConfigError::UnknownZoomWorkspace("workspace-b".into())
+        );
     }
 }

--- a/enterprise/control-plane/src/lib.rs
+++ b/enterprise/control-plane/src/lib.rs
@@ -6,6 +6,7 @@ pub mod capture;
 pub mod config;
 pub mod projector;
 pub mod store;
+pub mod zoom;
 
 use std::{future::Future, sync::Arc};
 
@@ -14,6 +15,7 @@ use auth::StaticTokenAuthenticator;
 use config::Config;
 use store::PostgresStore;
 use tokio::net::TcpListener;
+use zoom::{ZoomCaptureDispatcher, ZoomWebhookService};
 
 pub async fn run(config: Config) -> anyhow::Result<()> {
     let state = configured_state(&config).await?;
@@ -45,10 +47,21 @@ pub async fn configured_state(config: &Config) -> anyhow::Result<api::AppState> 
         .migrate()
         .await
         .context("failed to apply database migrations")?;
-    Ok(api::AppState::new(
-        store.into_shared(),
-        Arc::new(authenticator),
-    ))
+    let store = store.into_shared();
+    let mut state = api::AppState::new(store.clone(), Arc::new(authenticator));
+    if let Some(zoom) = &config.zoom {
+        let dispatcher = Arc::new(ZoomCaptureDispatcher::new(
+            store,
+            zoom.credentials().clone(),
+        ));
+        dispatcher
+            .recover_pending()
+            .await
+            .context("failed to recover durable Zoom dispatches")?;
+        dispatcher.clone().spawn_recovery();
+        state = state.with_zoom(Arc::new(ZoomWebhookService::new(zoom.clone(), dispatcher)));
+    }
+    Ok(state)
 }
 
 pub async fn serve(

--- a/enterprise/control-plane/src/store.rs
+++ b/enterprise/control-plane/src/store.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use anlg_meeting_capture::{BotState, CaptureEvent, CaptureEventPayload};
+use anlg_meeting_capture::{BotState, CaptureEvent, CaptureEventPayload, CaptureProviderKind};
 use anlg_session_ingest::{
     AcknowledgeRequest, DeliveryItem, DeliveryPage, SessionIngestEnvelope, SessionRead,
 };
@@ -10,8 +10,8 @@ use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 
 use crate::{
     capture::{
-        CaptureJob, CaptureJobCheckpoint, CaptureJobLease, CaptureJobLeaseIdentity,
-        CaptureJobStatus, ProjectionPublication,
+        CaptureDispatch, CaptureJob, CaptureJobCheckpoint, CaptureJobLease,
+        CaptureJobLeaseIdentity, CaptureJobStatus, ProjectionPublication,
     },
     projector,
 };
@@ -29,6 +29,32 @@ pub trait ControlPlaneStore: Send + Sync {
         workspace_id: &str,
         job_id: &str,
     ) -> Result<CaptureJobCheckpoint, StoreError>;
+
+    async fn find_dispatchable_capture_checkpoint(
+        &self,
+        workspace_id: &str,
+        provider: CaptureProviderKind,
+        external_ids: &[String],
+    ) -> Result<CaptureJobCheckpoint, StoreError>;
+
+    async fn save_capture_dispatch(&self, dispatch: &CaptureDispatch) -> Result<(), StoreError>;
+
+    async fn list_capture_dispatches(
+        &self,
+        provider: CaptureProviderKind,
+    ) -> Result<Vec<CaptureDispatch>, StoreError>;
+
+    async fn find_capture_dispatch(
+        &self,
+        provider: CaptureProviderKind,
+        dispatch_id: &str,
+    ) -> Result<CaptureDispatch, StoreError>;
+
+    async fn next_capture_transcript_sequence(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+    ) -> Result<u64, StoreError>;
 
     async fn claim_capture_job(
         &self,
@@ -235,16 +261,220 @@ impl ControlPlaneStore for PostgresStore {
         .fetch_optional(&self.pool)
         .await?
         .ok_or(StoreError::NotFound)?;
-        let state = parse_enum(&row.try_get::<String, _>("state")?)?;
-        let next_sequence = row
-            .try_get::<i64, _>("last_sequence")?
-            .checked_add(1)
-            .ok_or(StoreError::OutOfRange("capture event sequence"))?;
-        Ok(CaptureJobCheckpoint {
-            job: capture_job(row)?,
-            state,
-            next_sequence: from_i64(next_sequence, "capture event sequence")?,
-        })
+        capture_checkpoint(row)
+    }
+
+    async fn find_dispatchable_capture_checkpoint(
+        &self,
+        workspace_id: &str,
+        provider: CaptureProviderKind,
+        external_ids: &[String],
+    ) -> Result<CaptureJobCheckpoint, StoreError> {
+        if external_ids.is_empty() {
+            return Err(StoreError::NotFound);
+        }
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                workspace_id,
+                job_id,
+                bot_id,
+                owner_user_id,
+                requesting_actor_id,
+                session_id,
+                session_title,
+                provider,
+                meeting,
+                state,
+                last_sequence,
+                created_at
+            FROM capture_jobs
+            WHERE workspace_id = $1
+              AND provider = $2
+              AND state = 'queued'
+              AND meeting->>'external_id' = ANY($3)
+            ORDER BY created_at ASC, job_id ASC
+            LIMIT 2
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(enum_name(provider)?)
+        .bind(external_ids)
+        .fetch_all(&self.pool)
+        .await?;
+        match rows.len() {
+            0 => Err(StoreError::NotFound),
+            1 => capture_checkpoint(rows.into_iter().next().expect("row exists")),
+            _ => Err(StoreError::CaptureExternalIdConflict),
+        }
+    }
+
+    async fn save_capture_dispatch(&self, dispatch: &CaptureDispatch) -> Result<(), StoreError> {
+        let provider = enum_name(dispatch.provider)?;
+        let mut transaction = self.pool.begin().await?;
+        let row = sqlx::query(
+            r#"
+            SELECT provider, state, dispatch_id, dispatch_payload
+            FROM capture_jobs
+            WHERE workspace_id = $1 AND job_id = $2
+            FOR UPDATE
+            "#,
+        )
+        .bind(&dispatch.workspace_id)
+        .bind(&dispatch.job_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or(StoreError::NotFound)?;
+        if parse_enum::<BotState>(&row.try_get::<String, _>("state")?)?.is_terminal() {
+            return Err(StoreError::CaptureJobTerminal);
+        }
+        if row.try_get::<String, _>("provider")? != provider {
+            return Err(StoreError::InvalidCaptureEvent(
+                "capture dispatch belongs to a different provider".into(),
+            ));
+        }
+        let current_id = row.try_get::<Option<String>, _>("dispatch_id")?;
+        let current_payload = row.try_get::<Option<serde_json::Value>, _>("dispatch_payload")?;
+        if current_id.as_deref() == Some(dispatch.dispatch_id.as_str()) {
+            if current_payload.as_ref() != Some(&dispatch.payload) {
+                sqlx::query(
+                    r#"
+                    UPDATE capture_jobs
+                    SET
+                        dispatch_payload = $3,
+                        dispatch_accepted_at = clock_timestamp()
+                    WHERE workspace_id = $1 AND job_id = $2
+                    "#,
+                )
+                .bind(&dispatch.workspace_id)
+                .bind(&dispatch.job_id)
+                .bind(&dispatch.payload)
+                .execute(&mut *transaction)
+                .await?;
+            }
+            transaction.commit().await?;
+            return Ok(());
+        }
+        if current_id.is_some() || current_payload.is_some() {
+            return Err(StoreError::CaptureDispatchConflict);
+        }
+        sqlx::query(
+            r#"
+            UPDATE capture_jobs
+            SET
+                dispatch_id = $3,
+                dispatch_payload = $4,
+                dispatch_accepted_at = clock_timestamp()
+            WHERE workspace_id = $1 AND job_id = $2
+            "#,
+        )
+        .bind(&dispatch.workspace_id)
+        .bind(&dispatch.job_id)
+        .bind(&dispatch.dispatch_id)
+        .bind(&dispatch.payload)
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    async fn list_capture_dispatches(
+        &self,
+        provider: CaptureProviderKind,
+    ) -> Result<Vec<CaptureDispatch>, StoreError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT workspace_id, job_id, provider, dispatch_id, dispatch_payload
+            FROM capture_jobs
+            WHERE provider = $1
+              AND dispatch_id IS NOT NULL
+              AND state NOT IN ('completed', 'failed', 'canceled')
+            ORDER BY dispatch_accepted_at ASC, workspace_id ASC, job_id ASC
+            "#,
+        )
+        .bind(enum_name(provider)?)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                Ok(CaptureDispatch {
+                    workspace_id: row.try_get("workspace_id")?,
+                    job_id: row.try_get("job_id")?,
+                    provider: parse_enum(&row.try_get::<String, _>("provider")?)?,
+                    dispatch_id: row.try_get("dispatch_id")?,
+                    payload: row.try_get("dispatch_payload")?,
+                })
+            })
+            .collect()
+    }
+
+    async fn find_capture_dispatch(
+        &self,
+        provider: CaptureProviderKind,
+        dispatch_id: &str,
+    ) -> Result<CaptureDispatch, StoreError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT workspace_id, job_id, provider, dispatch_id, dispatch_payload
+            FROM capture_jobs
+            WHERE provider = $1
+              AND dispatch_id = $2
+              AND state NOT IN ('completed', 'failed', 'canceled')
+            ORDER BY dispatch_accepted_at ASC, workspace_id ASC, job_id ASC
+            LIMIT 2
+            "#,
+        )
+        .bind(enum_name(provider)?)
+        .bind(dispatch_id)
+        .fetch_all(&self.pool)
+        .await?;
+        match rows.len() {
+            0 => Err(StoreError::NotFound),
+            1 => {
+                let row = rows.into_iter().next().expect("row exists");
+                Ok(CaptureDispatch {
+                    workspace_id: row.try_get("workspace_id")?,
+                    job_id: row.try_get("job_id")?,
+                    provider: parse_enum(&row.try_get::<String, _>("provider")?)?,
+                    dispatch_id: row.try_get("dispatch_id")?,
+                    payload: row.try_get("dispatch_payload")?,
+                })
+            }
+            _ => Err(StoreError::CaptureDispatchConflict),
+        }
+    }
+
+    async fn next_capture_transcript_sequence(
+        &self,
+        workspace_id: &str,
+        job_id: &str,
+    ) -> Result<u64, StoreError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT event
+            FROM capture_events
+            WHERE workspace_id = $1
+              AND job_id = $2
+              AND event->'payload'->>'type' = 'transcript'
+            "#,
+        )
+        .bind(workspace_id)
+        .bind(job_id)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut next_sequence = 0;
+        for row in rows {
+            let event = serde_json::from_value::<CaptureEvent>(row.try_get("event")?)?;
+            if let CaptureEventPayload::Transcript(transcript) = event.payload {
+                next_sequence = next_sequence.max(
+                    transcript
+                        .sequence
+                        .checked_add(1)
+                        .ok_or(StoreError::OutOfRange("transcript sequence"))?,
+                );
+            }
+        }
+        Ok(next_sequence)
     }
 
     async fn claim_capture_job(
@@ -567,7 +797,19 @@ impl ControlPlaneStore for PostgresStore {
                 state = $3,
                 terminal_reason = $4,
                 last_sequence = $5,
-                updated_at = $6
+                updated_at = $6,
+                dispatch_id = CASE
+                    WHEN $3 IN ('completed', 'failed', 'canceled') THEN NULL
+                    ELSE dispatch_id
+                END,
+                dispatch_payload = CASE
+                    WHEN $3 IN ('completed', 'failed', 'canceled') THEN NULL
+                    ELSE dispatch_payload
+                END,
+                dispatch_accepted_at = CASE
+                    WHEN $3 IN ('completed', 'failed', 'canceled') THEN NULL
+                    ELSE dispatch_accepted_at
+                END
             WHERE workspace_id = $1 AND job_id = $2
             "#,
         )
@@ -799,6 +1041,19 @@ fn capture_job(row: sqlx::postgres::PgRow) -> Result<CaptureJob, StoreError> {
     })
 }
 
+fn capture_checkpoint(row: sqlx::postgres::PgRow) -> Result<CaptureJobCheckpoint, StoreError> {
+    let state = parse_enum(&row.try_get::<String, _>("state")?)?;
+    let next_sequence = row
+        .try_get::<i64, _>("last_sequence")?
+        .checked_add(1)
+        .ok_or(StoreError::OutOfRange("capture event sequence"))?;
+    Ok(CaptureJobCheckpoint {
+        job: capture_job(row)?,
+        state,
+        next_sequence: from_i64(next_sequence, "capture event sequence")?,
+    })
+}
+
 async fn read_publication(
     transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     workspace_id: &str,
@@ -887,8 +1142,12 @@ pub enum StoreError {
     CaptureJobConflict,
     #[error("capture bot is already assigned to a different job")]
     CaptureBotConflict,
+    #[error("capture provider identity matches more than one dispatchable job")]
+    CaptureExternalIdConflict,
     #[error("capture event id or sequence already exists with different content")]
     CaptureEventConflict,
+    #[error("capture job already has a different durable dispatch")]
+    CaptureDispatchConflict,
     #[error("capture event sequence conflict: expected {expected}, got {actual}")]
     CaptureSequenceConflict { expected: u64, actual: u64 },
     #[error("capture job is already terminal")]

--- a/enterprise/control-plane/src/zoom.rs
+++ b/enterprise/control-plane/src/zoom.rs
@@ -1,0 +1,2242 @@
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use anarlog_enterprise_zoom_rtms_worker::{
+    ZoomRtmsCredentials, ZoomRtmsSession, ZoomRtmsSessionConfig, ZoomRtmsSessionError,
+    ZoomRtmsSessionOutcome, ZoomRtmsStarted, ZoomRtmsTerminal, ZoomRtmsWebhookEvent,
+    ZoomWebhookValidationResponse, ZoomWebhookVerificationError,
+};
+use anlg_meeting_capture::{
+    BotState, CaptureEvent, CaptureEventPayload, CaptureProviderKind, ProviderMetadata,
+    TerminalReason, TerminalReasonKind, TransitionError,
+};
+use async_trait::async_trait;
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+use tokio::sync::{Mutex, mpsc, oneshot, watch};
+
+use crate::{
+    capture::{CaptureDispatch, CaptureJobCheckpoint, CaptureJobLeaseIdentity},
+    config::ZoomConfig,
+    store::{ControlPlaneStore, StoreError},
+};
+
+const CAPTURE_LEASE_DURATION: Duration = Duration::from_secs(60);
+const CAPTURE_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(20);
+const TRANSCRIPT_CHANNEL_CAPACITY: usize = 32;
+const STORE_RETRY_ATTEMPTS: usize = 3;
+const STORE_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(25);
+const STORE_RETRY_MAX_DELAY: Duration = Duration::from_millis(100);
+const DISPATCH_RECOVERY_INTERVAL: Duration = Duration::from_secs(20);
+const STOP_WEBHOOK_GRACE_PERIOD: Duration = Duration::from_secs(2);
+const RECONNECT_BASE_DELAY: Duration = Duration::from_secs(3);
+const RECONNECT_MAX_DELAY: Duration = Duration::from_secs(30);
+const RECONNECT_WINDOW: Duration = Duration::from_secs(55);
+const PENDING_STOP_TTL: Duration = Duration::from_secs(5 * 60);
+const MAX_PENDING_STOPS: usize = 1024;
+
+static WORKER_NONCE: AtomicU64 = AtomicU64::new(0);
+
+#[async_trait]
+pub trait ZoomWebhookDispatcher: Send + Sync {
+    async fn start(
+        &self,
+        workspace_id: &str,
+        started: ZoomRtmsStarted,
+    ) -> Result<ZoomDispatchOutcome, ZoomDispatchError>;
+
+    async fn stop(
+        &self,
+        terminal: &ZoomRtmsTerminal,
+        reason: ZoomStopReason,
+    ) -> Result<(), ZoomDispatchError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZoomDispatchOutcome {
+    pub job_id: String,
+    pub started: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZoomStopReason {
+    Stopped,
+    Interrupted,
+}
+
+impl ZoomStopReason {
+    fn merge(self, other: Self) -> Self {
+        if self == Self::Stopped || other == Self::Stopped {
+            Self::Stopped
+        } else {
+            Self::Interrupted
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ZoomDispatchError {
+    #[error("no dispatchable capture job matches the Zoom meeting")]
+    NotFound,
+    #[error("Zoom capture dispatch is unavailable")]
+    Unavailable(#[source] StoreError),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ZoomWebhookOutcome {
+    Validation(ZoomWebhookValidationResponse),
+    Accepted(ZoomDispatchOutcome),
+    Ignored,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ZoomWebhookError {
+    #[error("Zoom webhook headers are missing")]
+    MissingHeaders,
+    #[error(transparent)]
+    Verification(#[from] ZoomWebhookVerificationError),
+    #[error(transparent)]
+    Protocol(#[from] anarlog_enterprise_zoom_rtms_worker::ZoomRtmsProtocolError),
+    #[error(transparent)]
+    Dispatch(#[from] ZoomDispatchError),
+    #[error("system clock is before the Unix epoch")]
+    InvalidSystemClock,
+}
+
+#[derive(Clone)]
+pub struct ZoomWebhookService {
+    config: ZoomConfig,
+    dispatcher: Arc<dyn ZoomWebhookDispatcher>,
+}
+
+impl ZoomWebhookService {
+    pub fn new(config: ZoomConfig, dispatcher: Arc<dyn ZoomWebhookDispatcher>) -> Self {
+        Self { config, dispatcher }
+    }
+
+    pub async fn handle(
+        &self,
+        timestamp: Option<&str>,
+        signature: Option<&str>,
+        body: &[u8],
+    ) -> Result<ZoomWebhookOutcome, ZoomWebhookError> {
+        let timestamp = timestamp.ok_or(ZoomWebhookError::MissingHeaders)?;
+        let signature = signature.ok_or(ZoomWebhookError::MissingHeaders)?;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| ZoomWebhookError::InvalidSystemClock)?
+            .as_secs();
+        self.handle_at(timestamp, signature, body, now).await
+    }
+
+    pub async fn handle_at(
+        &self,
+        timestamp: &str,
+        signature: &str,
+        body: &[u8],
+        now_unix_seconds: u64,
+    ) -> Result<ZoomWebhookOutcome, ZoomWebhookError> {
+        self.config
+            .verifier()
+            .verify(timestamp, signature, body, now_unix_seconds)?;
+        match ZoomRtmsWebhookEvent::parse(body)? {
+            ZoomRtmsWebhookEvent::UrlValidation { plain_token } => {
+                Ok(ZoomWebhookOutcome::Validation(
+                    self.config.verifier().validation_response(plain_token)?,
+                ))
+            }
+            ZoomRtmsWebhookEvent::Started(started) => {
+                let Some(workspace_id) = self.config.workspace_for_account(&started.account_id)
+                else {
+                    return Ok(ZoomWebhookOutcome::Ignored);
+                };
+                match self.dispatcher.start(workspace_id, started).await {
+                    Ok(outcome) => Ok(ZoomWebhookOutcome::Accepted(outcome)),
+                    Err(ZoomDispatchError::NotFound) => Ok(ZoomWebhookOutcome::Ignored),
+                    Err(error) => Err(error.into()),
+                }
+            }
+            ZoomRtmsWebhookEvent::Stopped(terminal) => {
+                self.dispatcher
+                    .stop(&terminal, ZoomStopReason::Stopped)
+                    .await?;
+                Ok(ZoomWebhookOutcome::Ignored)
+            }
+            ZoomRtmsWebhookEvent::Interrupted(terminal) => {
+                self.dispatcher
+                    .stop(&terminal, ZoomStopReason::Interrupted)
+                    .await?;
+                Ok(ZoomWebhookOutcome::Ignored)
+            }
+            ZoomRtmsWebhookEvent::Other { .. } => Ok(ZoomWebhookOutcome::Ignored),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ZoomCaptureDispatcher {
+    store: Arc<dyn ControlPlaneStore>,
+    credentials: ZoomRtmsCredentials,
+    registry: Arc<Mutex<ZoomCaptureRegistry>>,
+}
+
+#[derive(Default)]
+struct ZoomCaptureRegistry {
+    tasks: HashMap<String, ZoomCaptureTask>,
+    pending_stops: HashMap<String, PendingZoomStop>,
+}
+
+struct ZoomCaptureTask {
+    workspace_id: String,
+    job_id: String,
+    meeting_uuid: String,
+    commands: mpsc::UnboundedSender<ZoomCaptureCommand>,
+}
+
+struct PendingZoomStop {
+    meeting_uuid: String,
+    reason: ZoomStopReason,
+    received_at: Instant,
+}
+
+enum ZoomCaptureCommand {
+    Stop(ZoomStopReason),
+    Restart {
+        started: ZoomRtmsStarted,
+        accepted: oneshot::Sender<()>,
+    },
+}
+
+enum ZoomCaptureInstruction {
+    Stop(ZoomStopReason),
+    Restart(ZoomRtmsStarted),
+}
+
+impl ZoomCaptureRegistry {
+    fn prune_pending_stops(&mut self, now: Instant) {
+        self.pending_stops
+            .retain(|_, stop| now.saturating_duration_since(stop.received_at) <= PENDING_STOP_TTL);
+    }
+}
+
+fn accept_zoom_command(command: ZoomCaptureCommand) -> Option<ZoomCaptureInstruction> {
+    match command {
+        ZoomCaptureCommand::Stop(reason) => Some(ZoomCaptureInstruction::Stop(reason)),
+        ZoomCaptureCommand::Restart { started, accepted } => accepted
+            .send(())
+            .ok()
+            .map(|()| ZoomCaptureInstruction::Restart(started)),
+    }
+}
+
+fn try_receive_zoom_instruction(
+    commands: &mut mpsc::UnboundedReceiver<ZoomCaptureCommand>,
+) -> Result<Option<ZoomCaptureInstruction>, ZoomCaptureWorkerError> {
+    loop {
+        match commands.try_recv() {
+            Ok(command) => {
+                if let Some(instruction) = accept_zoom_command(command) {
+                    return Ok(Some(instruction));
+                }
+            }
+            Err(mpsc::error::TryRecvError::Empty) => return Ok(None),
+            Err(mpsc::error::TryRecvError::Disconnected) => {
+                return Err(ZoomCaptureWorkerError::ControlChannelClosed);
+            }
+        }
+    }
+}
+
+async fn receive_zoom_instruction(
+    commands: &mut mpsc::UnboundedReceiver<ZoomCaptureCommand>,
+) -> Result<ZoomCaptureInstruction, ZoomCaptureWorkerError> {
+    loop {
+        let command = commands
+            .recv()
+            .await
+            .ok_or(ZoomCaptureWorkerError::ControlChannelClosed)?;
+        if let Some(instruction) = accept_zoom_command(command) {
+            return Ok(instruction);
+        }
+    }
+}
+
+impl ZoomCaptureDispatcher {
+    pub fn new(store: Arc<dyn ControlPlaneStore>, credentials: ZoomRtmsCredentials) -> Self {
+        Self {
+            store,
+            credentials,
+            registry: Arc::new(Mutex::new(ZoomCaptureRegistry::default())),
+        }
+    }
+
+    pub async fn recover_pending(&self) -> Result<(), ZoomDispatchError> {
+        let dispatches = self
+            .store
+            .list_capture_dispatches(CaptureProviderKind::ZoomRtms)
+            .await
+            .map_err(dispatch_store_error)?;
+        for dispatch in dispatches {
+            let workspace_id = dispatch.workspace_id.clone();
+            let job_id = dispatch.job_id.clone();
+            if let Err(error) = self.recover_dispatch(dispatch).await {
+                tracing::error!(%workspace_id, %job_id, error = %error, "failed to recover durable Zoom dispatch");
+            }
+        }
+        Ok(())
+    }
+
+    async fn recover_dispatch(&self, dispatch: CaptureDispatch) -> Result<(), ZoomDispatchError> {
+        let started = serde_json::from_value::<ZoomRtmsStarted>(dispatch.payload)
+            .map_err(StoreError::from)
+            .map_err(dispatch_store_error)?;
+        if started.stream_id != dispatch.dispatch_id {
+            return Err(ZoomDispatchError::Unavailable(
+                StoreError::InvalidCaptureEvent(
+                    "durable Zoom dispatch ID does not match its payload".into(),
+                ),
+            ));
+        }
+        let checkpoint = match self
+            .store
+            .read_capture_checkpoint(&dispatch.workspace_id, &dispatch.job_id)
+            .await
+        {
+            Ok(checkpoint) => checkpoint,
+            Err(StoreError::NotFound) | Err(StoreError::CaptureJobTerminal) => return Ok(()),
+            Err(error) => return Err(dispatch_store_error(error)),
+        };
+        validate_checkpoint(&checkpoint, &started).map_err(|_| {
+            ZoomDispatchError::Unavailable(StoreError::InvalidCaptureEvent(
+                "durable Zoom dispatch does not match its capture checkpoint".into(),
+            ))
+        })?;
+        self.start_checkpoint(&dispatch.workspace_id, checkpoint, started)
+            .await?;
+        Ok(())
+    }
+
+    pub fn spawn_recovery(self: Arc<Self>) {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval_at(
+                tokio::time::Instant::now() + DISPATCH_RECOVERY_INTERVAL,
+                DISPATCH_RECOVERY_INTERVAL,
+            );
+            loop {
+                interval.tick().await;
+                if let Err(error) = self.recover_pending().await {
+                    tracing::error!(error = %error, "failed to recover durable Zoom dispatches");
+                }
+            }
+        });
+    }
+
+    async fn start_checkpoint(
+        &self,
+        workspace_id: &str,
+        checkpoint: CaptureJobCheckpoint,
+        started: ZoomRtmsStarted,
+    ) -> Result<ZoomDispatchOutcome, ZoomDispatchError> {
+        {
+            let mut registry = self.registry.lock().await;
+            registry.prune_pending_stops(Instant::now());
+            if let Some(task) = registry.tasks.get(&started.stream_id) {
+                if task.commands.is_closed() {
+                    registry.tasks.remove(&started.stream_id);
+                } else {
+                    return Ok(ZoomDispatchOutcome {
+                        job_id: task.job_id.clone(),
+                        started: false,
+                    });
+                }
+            }
+        }
+        let (worker_id, lease_id) = worker_lease_ids(&checkpoint.job.job_id, &started.stream_id);
+        let lease = match self
+            .store
+            .claim_capture_job(
+                workspace_id,
+                &checkpoint.job.job_id,
+                &worker_id,
+                &lease_id,
+                CAPTURE_LEASE_DURATION,
+            )
+            .await
+        {
+            Ok(lease) => lease,
+            Err(StoreError::CaptureLeaseUnavailable) | Err(StoreError::CaptureJobTerminal) => {
+                return Ok(ZoomDispatchOutcome {
+                    job_id: checkpoint.job.job_id,
+                    started: false,
+                });
+            }
+            Err(error) => return Err(dispatch_store_error(error)),
+        };
+        let lease = CaptureJobLeaseIdentity {
+            worker_id: lease.worker_id,
+            lease_id: lease.lease_id,
+            epoch: lease.epoch,
+        };
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let stream_id = started.stream_id.clone();
+        let pending_stop = {
+            let mut registry = self.registry.lock().await;
+            let pending_stop = registry.pending_stops.remove(&stream_id);
+            registry.tasks.insert(
+                stream_id.clone(),
+                ZoomCaptureTask {
+                    workspace_id: workspace_id.to_string(),
+                    job_id: checkpoint.job.job_id.clone(),
+                    meeting_uuid: started.meeting_uuid.clone(),
+                    commands: command_tx.clone(),
+                },
+            );
+            pending_stop
+        };
+        if let Some(pending) = pending_stop
+            && pending.meeting_uuid == started.meeting_uuid
+        {
+            let _ = command_tx.send(ZoomCaptureCommand::Stop(pending.reason));
+        }
+
+        let store = self.store.clone();
+        let credentials = self.credentials.clone();
+        let registry = self.registry.clone();
+        let cleanup_commands = command_tx.clone();
+        let job_id = checkpoint.job.job_id.clone();
+        let response_job_id = job_id.clone();
+        let workspace_id = workspace_id.to_string();
+        tokio::spawn(async move {
+            let result = run_zoom_capture(
+                store,
+                &workspace_id,
+                checkpoint,
+                lease,
+                credentials,
+                started,
+                command_rx,
+            )
+            .await;
+            if let Err(error) = result {
+                tracing::error!(%workspace_id, %job_id, error = %error, "Zoom RTMS capture worker stopped");
+            }
+            let mut registry = registry.lock().await;
+            if registry
+                .tasks
+                .get(&stream_id)
+                .is_some_and(|task| task.commands.same_channel(&cleanup_commands))
+            {
+                registry.tasks.remove(&stream_id);
+            }
+        });
+
+        Ok(ZoomDispatchOutcome {
+            job_id: response_job_id,
+            started: true,
+        })
+    }
+}
+
+#[async_trait]
+impl ZoomWebhookDispatcher for ZoomCaptureDispatcher {
+    async fn start(
+        &self,
+        workspace_id: &str,
+        started: ZoomRtmsStarted,
+    ) -> Result<ZoomDispatchOutcome, ZoomDispatchError> {
+        let active = {
+            let mut registry = self.registry.lock().await;
+            registry.prune_pending_stops(Instant::now());
+            registry.tasks.get(&started.stream_id).map(|task| {
+                (
+                    task.workspace_id.clone(),
+                    task.job_id.clone(),
+                    task.meeting_uuid.clone(),
+                    task.commands.clone(),
+                )
+            })
+        };
+        if let Some((active_workspace_id, job_id, meeting_uuid, commands)) = active {
+            if active_workspace_id != workspace_id || meeting_uuid != started.meeting_uuid {
+                return Err(ZoomDispatchError::Unavailable(
+                    StoreError::InvalidCaptureEvent(
+                        "active Zoom stream does not match its signed webhook".into(),
+                    ),
+                ));
+            }
+            let checkpoint = self
+                .store
+                .read_capture_checkpoint(workspace_id, &job_id)
+                .await
+                .map_err(dispatch_store_error)?;
+            validate_checkpoint(&checkpoint, &started).map_err(|_| {
+                ZoomDispatchError::Unavailable(StoreError::InvalidCaptureEvent(
+                    "active Zoom dispatch does not match its signed webhook".into(),
+                ))
+            })?;
+            self.store
+                .save_capture_dispatch(&capture_dispatch(workspace_id, &job_id, &started)?)
+                .await
+                .map_err(dispatch_store_error)?;
+            let (accepted_tx, accepted_rx) = oneshot::channel();
+            if commands
+                .send(ZoomCaptureCommand::Restart {
+                    started: started.clone(),
+                    accepted: accepted_tx,
+                })
+                .is_ok()
+                && accepted_rx.await.is_ok()
+            {
+                return Ok(ZoomDispatchOutcome {
+                    job_id,
+                    started: false,
+                });
+            }
+            let mut registry = self.registry.lock().await;
+            if registry
+                .tasks
+                .get(&started.stream_id)
+                .is_some_and(|task| task.commands.same_channel(&commands))
+            {
+                registry.tasks.remove(&started.stream_id);
+            }
+        }
+
+        let existing_dispatch = self
+            .store
+            .find_capture_dispatch(CaptureProviderKind::ZoomRtms, &started.stream_id)
+            .await;
+        match existing_dispatch {
+            Ok(dispatch) => {
+                if dispatch.workspace_id != workspace_id {
+                    return Err(ZoomDispatchError::NotFound);
+                }
+                let checkpoint = self
+                    .store
+                    .read_capture_checkpoint(&dispatch.workspace_id, &dispatch.job_id)
+                    .await
+                    .map_err(dispatch_store_error)?;
+                validate_checkpoint(&checkpoint, &started).map_err(|_| {
+                    ZoomDispatchError::Unavailable(StoreError::InvalidCaptureEvent(
+                        "durable Zoom dispatch does not match its signed webhook".into(),
+                    ))
+                })?;
+                self.store
+                    .save_capture_dispatch(&capture_dispatch(
+                        &dispatch.workspace_id,
+                        &dispatch.job_id,
+                        &started,
+                    )?)
+                    .await
+                    .map_err(dispatch_store_error)?;
+                return self
+                    .start_checkpoint(&dispatch.workspace_id, checkpoint, started)
+                    .await;
+            }
+            Err(StoreError::NotFound) => {}
+            Err(error) => return Err(dispatch_store_error(error)),
+        }
+
+        let mut external_ids = vec![started.meeting_id.clone()];
+        if started.meeting_uuid != started.meeting_id {
+            external_ids.push(started.meeting_uuid.clone());
+        }
+        let checkpoint = self
+            .store
+            .find_dispatchable_capture_checkpoint(
+                workspace_id,
+                CaptureProviderKind::ZoomRtms,
+                &external_ids,
+            )
+            .await
+            .map_err(dispatch_store_error)?;
+        validate_checkpoint(&checkpoint, &started).map_err(|_| {
+            ZoomDispatchError::Unavailable(StoreError::InvalidCaptureEvent(
+                "Zoom capture checkpoint does not match its signed webhook".into(),
+            ))
+        })?;
+        let dispatch = capture_dispatch(workspace_id, &checkpoint.job.job_id, &started)?;
+        self.store
+            .save_capture_dispatch(&dispatch)
+            .await
+            .map_err(dispatch_store_error)?;
+        self.start_checkpoint(workspace_id, checkpoint, started)
+            .await
+    }
+
+    async fn stop(
+        &self,
+        terminal: &ZoomRtmsTerminal,
+        reason: ZoomStopReason,
+    ) -> Result<(), ZoomDispatchError> {
+        let active = {
+            let mut registry = self.registry.lock().await;
+            registry.prune_pending_stops(Instant::now());
+            registry.tasks.get(&terminal.stream_id).and_then(|task| {
+                (task.meeting_uuid == terminal.meeting_uuid).then(|| task.commands.clone())
+            })
+        };
+        if let Some(commands) = active
+            && commands.send(ZoomCaptureCommand::Stop(reason)).is_ok()
+        {
+            return Ok(());
+        }
+
+        let dispatch = match self
+            .store
+            .find_capture_dispatch(CaptureProviderKind::ZoomRtms, &terminal.stream_id)
+            .await
+        {
+            Ok(dispatch) => dispatch,
+            Err(StoreError::NotFound) => return Ok(()),
+            Err(error) => return Err(dispatch_store_error(error)),
+        };
+        let started = serde_json::from_value::<ZoomRtmsStarted>(dispatch.payload)
+            .map_err(StoreError::from)
+            .map_err(dispatch_store_error)?;
+        if started.meeting_uuid != terminal.meeting_uuid {
+            return Ok(());
+        }
+
+        let mut registry = self.registry.lock().await;
+        let now = Instant::now();
+        registry.prune_pending_stops(now);
+        if let Some(task) = registry.tasks.get(&terminal.stream_id) {
+            if task.meeting_uuid == terminal.meeting_uuid {
+                let _ = task.commands.send(ZoomCaptureCommand::Stop(reason));
+            }
+            return Ok(());
+        }
+        if let Some(pending) = registry.pending_stops.get_mut(&terminal.stream_id) {
+            if pending.meeting_uuid == terminal.meeting_uuid {
+                pending.reason = pending.reason.merge(reason);
+                pending.received_at = now;
+            }
+            return Ok(());
+        }
+        if registry.pending_stops.len() >= MAX_PENDING_STOPS {
+            return Err(ZoomDispatchError::Unavailable(StoreError::OutOfRange(
+                "pending Zoom stop capacity",
+            )));
+        }
+        registry.pending_stops.insert(
+            terminal.stream_id.clone(),
+            PendingZoomStop {
+                meeting_uuid: terminal.meeting_uuid.clone(),
+                reason,
+                received_at: now,
+            },
+        );
+        Ok(())
+    }
+}
+
+fn capture_dispatch(
+    workspace_id: &str,
+    job_id: &str,
+    started: &ZoomRtmsStarted,
+) -> Result<CaptureDispatch, ZoomDispatchError> {
+    Ok(CaptureDispatch {
+        workspace_id: workspace_id.to_string(),
+        job_id: job_id.to_string(),
+        provider: CaptureProviderKind::ZoomRtms,
+        dispatch_id: started.stream_id.clone(),
+        payload: serde_json::to_value(started)
+            .map_err(StoreError::from)
+            .map_err(dispatch_store_error)?,
+    })
+}
+
+fn dispatch_store_error(error: StoreError) -> ZoomDispatchError {
+    match error {
+        StoreError::NotFound => ZoomDispatchError::NotFound,
+        error => ZoomDispatchError::Unavailable(error),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_zoom_capture(
+    store: Arc<dyn ControlPlaneStore>,
+    workspace_id: &str,
+    checkpoint: CaptureJobCheckpoint,
+    lease: CaptureJobLeaseIdentity,
+    credentials: ZoomRtmsCredentials,
+    mut started: ZoomRtmsStarted,
+    mut commands: mpsc::UnboundedReceiver<ZoomCaptureCommand>,
+) -> Result<(), ZoomCaptureWorkerError> {
+    let mut events = ZoomCaptureEvents::resume(&checkpoint)?;
+    if events.state == BotState::Stopping {
+        return persist_zoom_stop(
+            store.as_ref(),
+            workspace_id,
+            &checkpoint.job.job_id,
+            &lease,
+            &mut events,
+        )
+        .await;
+    }
+    let mut reconnect = None;
+    loop {
+        if let Some(state) = reconnect.as_mut() {
+            let reconnect_result = wait_for_zoom_reconnect(
+                store.as_ref(),
+                workspace_id,
+                &checkpoint.job.job_id,
+                &lease,
+                &mut commands,
+                state,
+            )
+            .await;
+            let reconnect_command = match reconnect_result {
+                Ok(command) => command,
+                Err(error) => {
+                    return fail_zoom_capture(
+                        store.as_ref(),
+                        workspace_id,
+                        &checkpoint.job.job_id,
+                        &lease,
+                        &mut events,
+                        error,
+                    )
+                    .await;
+                }
+            };
+            match reconnect_command {
+                Some(ZoomCaptureInstruction::Stop(ZoomStopReason::Stopped)) => {
+                    return persist_zoom_stop(
+                        store.as_ref(),
+                        workspace_id,
+                        &checkpoint.job.job_id,
+                        &lease,
+                        &mut events,
+                    )
+                    .await;
+                }
+                Some(ZoomCaptureInstruction::Stop(ZoomStopReason::Interrupted)) => {
+                    schedule_zoom_interruption(&mut reconnect);
+                    continue;
+                }
+                Some(ZoomCaptureInstruction::Restart(restarted)) => {
+                    started = restarted;
+                    reconnect = Some(ZoomReconnectState::immediate());
+                    continue;
+                }
+                None => {}
+            }
+        }
+
+        let transcript_sequence = match store
+            .next_capture_transcript_sequence(workspace_id, &checkpoint.job.job_id)
+            .await
+        {
+            Ok(sequence) => sequence,
+            Err(error) => {
+                return fail_zoom_capture(
+                    store.as_ref(),
+                    workspace_id,
+                    &checkpoint.job.job_id,
+                    &lease,
+                    &mut events,
+                    error.into(),
+                )
+                .await;
+            }
+        };
+        let mut connected = false;
+        let result = run_zoom_session(
+            store.as_ref(),
+            workspace_id,
+            &checkpoint.job.job_id,
+            &lease,
+            &credentials,
+            started.clone(),
+            transcript_sequence,
+            &mut commands,
+            &mut events,
+            &mut connected,
+        )
+        .await;
+        if connected {
+            reconnect = None;
+        }
+
+        let command = match result {
+            Ok(ZoomSessionRunOutcome::Command(command)) => Some(command),
+            Ok(ZoomSessionRunOutcome::Session(ZoomRtmsSessionOutcome::StoppedByRequest)) => {
+                return Err(ZoomCaptureWorkerError::ControlChannelClosed);
+            }
+            Err(error) => {
+                if !connected && reconnect.is_some() && error.can_reconnect() {
+                    continue;
+                }
+                let command = if error.can_reconcile_with_stop() {
+                    tokio::time::timeout(
+                        STOP_WEBHOOK_GRACE_PERIOD,
+                        receive_zoom_instruction(&mut commands),
+                    )
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                } else {
+                    None
+                };
+                if command.is_none() {
+                    return fail_zoom_capture(
+                        store.as_ref(),
+                        workspace_id,
+                        &checkpoint.job.job_id,
+                        &lease,
+                        &mut events,
+                        error,
+                    )
+                    .await;
+                }
+                command
+            }
+        };
+
+        match command.expect("Zoom session command exists") {
+            ZoomCaptureInstruction::Stop(ZoomStopReason::Stopped) => {
+                return persist_zoom_stop(
+                    store.as_ref(),
+                    workspace_id,
+                    &checkpoint.job.job_id,
+                    &lease,
+                    &mut events,
+                )
+                .await;
+            }
+            ZoomCaptureInstruction::Stop(ZoomStopReason::Interrupted) => {
+                schedule_zoom_interruption(&mut reconnect);
+            }
+            ZoomCaptureInstruction::Restart(restarted) => {
+                started = restarted;
+                reconnect = Some(ZoomReconnectState::immediate());
+            }
+        }
+    }
+}
+
+async fn fail_zoom_capture(
+    store: &dyn ControlPlaneStore,
+    workspace_id: &str,
+    job_id: &str,
+    lease: &CaptureJobLeaseIdentity,
+    events: &mut ZoomCaptureEvents,
+    error: ZoomCaptureWorkerError,
+) -> Result<(), ZoomCaptureWorkerError> {
+    if !events.state.is_terminal() {
+        let failed = events.transition(
+            BotState::Failed,
+            Some(TerminalReason {
+                kind: TerminalReasonKind::ProviderError,
+                message: Some("Zoom RTMS worker exited before the stream stopped".into()),
+                retryable: true,
+            }),
+        )?;
+        if let Err(store_error) = append(store, workspace_id, job_id, lease, events, failed).await {
+            tracing::warn!(%workspace_id, %job_id, error = %store_error, "failed to persist Zoom worker terminal state");
+        }
+    }
+    Err(error)
+}
+
+struct ZoomReconnectState {
+    deadline: tokio::time::Instant,
+    attempt: u32,
+    immediate: bool,
+}
+
+impl ZoomReconnectState {
+    fn backoff() -> Self {
+        Self {
+            deadline: tokio::time::Instant::now() + RECONNECT_WINDOW,
+            attempt: 0,
+            immediate: false,
+        }
+    }
+
+    fn immediate() -> Self {
+        Self {
+            immediate: true,
+            ..Self::backoff()
+        }
+    }
+}
+
+fn schedule_zoom_interruption(reconnect: &mut Option<ZoomReconnectState>) {
+    if reconnect.is_none() {
+        *reconnect = Some(ZoomReconnectState::backoff());
+    }
+}
+
+async fn wait_for_zoom_reconnect(
+    store: &dyn ControlPlaneStore,
+    workspace_id: &str,
+    job_id: &str,
+    lease: &CaptureJobLeaseIdentity,
+    commands: &mut mpsc::UnboundedReceiver<ZoomCaptureCommand>,
+    reconnect: &mut ZoomReconnectState,
+) -> Result<Option<ZoomCaptureInstruction>, ZoomCaptureWorkerError> {
+    renew_lease(store, workspace_id, job_id, lease).await?;
+    let now = tokio::time::Instant::now();
+    if now >= reconnect.deadline {
+        return Err(ZoomCaptureWorkerError::ReconnectWindowExpired);
+    }
+    let delay = if reconnect.immediate {
+        reconnect.immediate = false;
+        Duration::ZERO
+    } else {
+        let multiplier = 1_u32
+            .checked_shl(reconnect.attempt.min(31))
+            .unwrap_or(u32::MAX);
+        reconnect.attempt = reconnect.attempt.saturating_add(1);
+        RECONNECT_BASE_DELAY
+            .saturating_mul(multiplier)
+            .min(RECONNECT_MAX_DELAY)
+    };
+    let sleep_until = (now + delay).min(reconnect.deadline);
+    tokio::select! {
+        _ = tokio::time::sleep_until(sleep_until) => {
+            if tokio::time::Instant::now() >= reconnect.deadline {
+                Err(ZoomCaptureWorkerError::ReconnectWindowExpired)
+            } else {
+                Ok(None)
+            }
+        }
+        command = receive_zoom_instruction(commands) => command.map(Some),
+    }
+}
+
+async fn persist_zoom_stop(
+    store: &dyn ControlPlaneStore,
+    workspace_id: &str,
+    job_id: &str,
+    lease: &CaptureJobLeaseIdentity,
+    events: &mut ZoomCaptureEvents,
+) -> Result<(), ZoomCaptureWorkerError> {
+    if events.state == BotState::Queued {
+        let event = events.transition(
+            BotState::Canceled,
+            Some(TerminalReason {
+                kind: TerminalReasonKind::StoppedByRequest,
+                message: None,
+                retryable: false,
+            }),
+        )?;
+        append(store, workspace_id, job_id, lease, events, event).await
+    } else {
+        if events.state != BotState::Stopping {
+            let event = events.transition(BotState::Stopping, None)?;
+            append(store, workspace_id, job_id, lease, events, event).await?;
+        }
+        let event = events.transition(
+            BotState::Completed,
+            Some(TerminalReason {
+                kind: TerminalReasonKind::MeetingEnded,
+                message: None,
+                retryable: false,
+            }),
+        )?;
+        append(store, workspace_id, job_id, lease, events, event).await
+    }
+}
+
+enum ZoomSessionRunOutcome {
+    Command(ZoomCaptureInstruction),
+    Session(ZoomRtmsSessionOutcome),
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_zoom_session(
+    store: &dyn ControlPlaneStore,
+    workspace_id: &str,
+    job_id: &str,
+    lease: &CaptureJobLeaseIdentity,
+    credentials: &ZoomRtmsCredentials,
+    started: ZoomRtmsStarted,
+    transcript_sequence: u64,
+    commands: &mut mpsc::UnboundedReceiver<ZoomCaptureCommand>,
+    events: &mut ZoomCaptureEvents,
+    connected: &mut bool,
+) -> Result<ZoomSessionRunOutcome, ZoomCaptureWorkerError> {
+    if let Some(command) = try_receive_zoom_instruction(commands)? {
+        return Ok(ZoomSessionRunOutcome::Command(command));
+    }
+    if events.state == BotState::Queued {
+        let event = events.transition(BotState::Launching, None)?;
+        append(store, workspace_id, job_id, lease, events, event).await?;
+    }
+    if !matches!(
+        events.state,
+        BotState::Launching | BotState::Joined | BotState::Capturing
+    ) {
+        return Err(ZoomCaptureWorkerError::InvalidCheckpoint);
+    }
+    let mut connection = Box::pin(ZoomRtmsSession::connect(
+        credentials,
+        started,
+        ZoomRtmsSessionConfig {
+            initial_segment_sequence: transcript_sequence,
+            ..ZoomRtmsSessionConfig::default()
+        },
+    ));
+    let mut session = tokio::select! {
+        result = &mut connection => result?,
+        command = receive_zoom_instruction(commands) => {
+            return command.map(ZoomSessionRunOutcome::Command);
+        }
+    };
+    drop(connection);
+    *connected = true;
+    if let Some(command) = try_receive_zoom_instruction(commands)? {
+        session.shutdown().await;
+        return Ok(ZoomSessionRunOutcome::Command(command));
+    }
+    if events.state == BotState::Launching {
+        let event = events.transition(BotState::Joined, None)?;
+        append(store, workspace_id, job_id, lease, events, event).await?;
+    }
+    if let Some(command) = try_receive_zoom_instruction(commands)? {
+        session.shutdown().await;
+        return Ok(ZoomSessionRunOutcome::Command(command));
+    }
+    if events.state == BotState::Joined {
+        let event = events.transition(BotState::Capturing, None)?;
+        append(store, workspace_id, job_id, lease, events, event).await?;
+    }
+
+    let (transcript_tx, mut transcript_rx) = mpsc::channel(TRANSCRIPT_CHANNEL_CAPACITY);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let mut stream = tokio::spawn(async move {
+        let result = session.stream_transcripts(transcript_tx, shutdown_rx).await;
+        session.shutdown().await;
+        result
+    });
+    let mut renewals = tokio::time::interval_at(
+        tokio::time::Instant::now() + CAPTURE_LEASE_RENEW_INTERVAL,
+        CAPTURE_LEASE_RENEW_INTERVAL,
+    );
+    let mut transcripts_open = true;
+    let result = async {
+        let outcome = loop {
+            tokio::select! {
+                result = &mut stream => {
+                    break ZoomSessionRunOutcome::Session(
+                        result.map_err(ZoomCaptureWorkerError::StreamTask)??
+                    );
+                }
+                command = receive_zoom_instruction(commands) => {
+                    let command = command?;
+                    let _ = shutdown_tx.send(true);
+                    let outcome = (&mut stream)
+                        .await
+                        .map_err(ZoomCaptureWorkerError::StreamTask)??;
+                    debug_assert_eq!(outcome, ZoomRtmsSessionOutcome::StoppedByRequest);
+                    break ZoomSessionRunOutcome::Command(command);
+                }
+                transcript = transcript_rx.recv(), if transcripts_open => {
+                    if let Some(transcript) = transcript {
+                        let event = events.payload(CaptureEventPayload::Transcript(transcript))?;
+                        append(store, workspace_id, job_id, lease, events, event).await?;
+                    } else {
+                        transcripts_open = false;
+                    }
+                }
+                _ = renewals.tick() => {
+                    renew_lease(store, workspace_id, job_id, lease).await?;
+                }
+            }
+        };
+        while let Ok(transcript) = transcript_rx.try_recv() {
+            let event = events.payload(CaptureEventPayload::Transcript(transcript))?;
+            append(store, workspace_id, job_id, lease, events, event).await?;
+        }
+        Ok(outcome)
+    }
+    .await;
+    if result.is_err() && !stream.is_finished() {
+        stream.abort();
+        let _ = stream.await;
+    }
+    result
+}
+
+async fn append(
+    store: &dyn ControlPlaneStore,
+    workspace_id: &str,
+    job_id: &str,
+    lease: &CaptureJobLeaseIdentity,
+    events: &mut ZoomCaptureEvents,
+    event: CaptureEvent,
+) -> Result<(), ZoomCaptureWorkerError> {
+    let mut retry_delay = STORE_RETRY_INITIAL_DELAY;
+    for attempt in 1..=STORE_RETRY_ATTEMPTS {
+        match store
+            .append_capture_event(workspace_id, job_id, lease, &event)
+            .await
+        {
+            Ok(_) => {
+                events.commit(&event)?;
+                return Ok(());
+            }
+            Err(error) if attempt < STORE_RETRY_ATTEMPTS && retryable_store_error(&error) => {
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = retry_delay.saturating_mul(2).min(STORE_RETRY_MAX_DELAY);
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    unreachable!("store retry policy always performs at least one attempt")
+}
+
+async fn renew_lease(
+    store: &dyn ControlPlaneStore,
+    workspace_id: &str,
+    job_id: &str,
+    lease: &CaptureJobLeaseIdentity,
+) -> Result<(), ZoomCaptureWorkerError> {
+    let mut retry_delay = STORE_RETRY_INITIAL_DELAY;
+    for attempt in 1..=STORE_RETRY_ATTEMPTS {
+        match store
+            .renew_capture_job_lease(workspace_id, job_id, lease, CAPTURE_LEASE_DURATION)
+            .await
+        {
+            Ok(_) => return Ok(()),
+            Err(error) if attempt < STORE_RETRY_ATTEMPTS && retryable_store_error(&error) => {
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = retry_delay.saturating_mul(2).min(STORE_RETRY_MAX_DELAY);
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    unreachable!("store retry policy always performs at least one attempt")
+}
+
+fn retryable_store_error(error: &StoreError) -> bool {
+    matches!(error, StoreError::Database(_))
+}
+
+struct ZoomCaptureEvents {
+    bot_id: String,
+    state: BotState,
+    next_sequence: u64,
+}
+
+impl ZoomCaptureEvents {
+    fn resume(checkpoint: &CaptureJobCheckpoint) -> Result<Self, ZoomCaptureWorkerError> {
+        if checkpoint.state.is_terminal() || checkpoint.state == BotState::WaitingForAdmission {
+            return Err(ZoomCaptureWorkerError::InvalidCheckpoint);
+        }
+        Ok(Self {
+            bot_id: checkpoint.job.bot_id.clone(),
+            state: checkpoint.state,
+            next_sequence: checkpoint.next_sequence,
+        })
+    }
+
+    fn transition(
+        &self,
+        next: BotState,
+        reason: Option<TerminalReason>,
+    ) -> Result<CaptureEvent, ZoomCaptureWorkerError> {
+        let transition = self.state.transition_to(next, reason)?;
+        self.payload(CaptureEventPayload::Lifecycle(transition))
+    }
+
+    fn payload(
+        &self,
+        payload: CaptureEventPayload,
+    ) -> Result<CaptureEvent, ZoomCaptureWorkerError> {
+        let sequence = self.next_sequence;
+        self.next_sequence
+            .checked_add(1)
+            .ok_or(ZoomCaptureWorkerError::SequenceExhausted)?;
+        Ok(CaptureEvent {
+            id: format!("capture-event-{sequence}"),
+            bot_id: self.bot_id.clone(),
+            sequence,
+            occurred_at: Utc::now(),
+            payload,
+            metadata: ProviderMetadata::default(),
+        })
+    }
+
+    fn commit(&mut self, event: &CaptureEvent) -> Result<(), ZoomCaptureWorkerError> {
+        if event.bot_id != self.bot_id || event.sequence != self.next_sequence {
+            return Err(ZoomCaptureWorkerError::InvalidCheckpoint);
+        }
+        if let CaptureEventPayload::Lifecycle(transition) = &event.payload {
+            if transition.from != self.state {
+                return Err(ZoomCaptureWorkerError::InvalidCheckpoint);
+            }
+            self.state = transition.to;
+        }
+        self.next_sequence = self
+            .next_sequence
+            .checked_add(1)
+            .ok_or(ZoomCaptureWorkerError::SequenceExhausted)?;
+        Ok(())
+    }
+}
+
+fn validate_checkpoint(
+    checkpoint: &CaptureJobCheckpoint,
+    started: &ZoomRtmsStarted,
+) -> Result<(), ZoomCaptureWorkerError> {
+    let worker = anlg_meeting_capture::CaptureWorkerCheckpoint {
+        job_id: checkpoint.job.job_id.clone(),
+        bot_id: checkpoint.job.bot_id.clone(),
+        provider: checkpoint.job.provider,
+        meeting: checkpoint.job.meeting.clone(),
+        state: checkpoint.state,
+        next_sequence: checkpoint.next_sequence,
+    };
+    worker
+        .validate()
+        .map_err(|_| ZoomCaptureWorkerError::InvalidCheckpoint)?;
+    let external_id = checkpoint
+        .job
+        .meeting
+        .external_id
+        .as_deref()
+        .ok_or(ZoomCaptureWorkerError::InvalidCheckpoint)?;
+    if checkpoint.job.provider != CaptureProviderKind::ZoomRtms
+        || (external_id != started.meeting_id && external_id != started.meeting_uuid)
+    {
+        return Err(ZoomCaptureWorkerError::InvalidCheckpoint);
+    }
+    Ok(())
+}
+
+fn worker_lease_ids(job_id: &str, stream_id: &str) -> (String, String) {
+    let nonce = WORKER_NONCE.fetch_add(1, Ordering::Relaxed);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let process_id = std::process::id();
+    let digest = Sha256::digest(
+        format!("{job_id}\0{stream_id}\0{process_id}\0{timestamp}\0{nonce}").as_bytes(),
+    );
+    let suffix = digest
+        .iter()
+        .take(16)
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    (
+        format!("zoom-worker-{suffix}"),
+        format!("zoom-lease-{suffix}"),
+    )
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ZoomCaptureWorkerError {
+    #[error("Zoom capture checkpoint is invalid")]
+    InvalidCheckpoint,
+    #[error("Zoom capture event sequence was exhausted")]
+    SequenceExhausted,
+    #[error(transparent)]
+    Transition(#[from] TransitionError),
+    #[error(transparent)]
+    Session(#[from] ZoomRtmsSessionError),
+    #[error("Zoom RTMS stream task stopped unexpectedly")]
+    StreamTask(#[source] tokio::task::JoinError),
+    #[error("Zoom RTMS capture control channel closed")]
+    ControlChannelClosed,
+    #[error("Zoom RTMS reconnect window expired")]
+    ReconnectWindowExpired,
+    #[error(transparent)]
+    Store(#[from] StoreError),
+}
+
+impl ZoomCaptureWorkerError {
+    fn can_reconcile_with_stop(&self) -> bool {
+        matches!(
+            self,
+            Self::Session(ZoomRtmsSessionError::ConnectionClosed(_))
+        )
+    }
+
+    fn can_reconnect(&self) -> bool {
+        matches!(
+            self,
+            Self::Session(
+                ZoomRtmsSessionError::Websocket(_)
+                    | ZoomRtmsSessionError::HandshakeTimeout(_)
+                    | ZoomRtmsSessionError::ConnectionClosed(_)
+            )
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capture::{CaptureJob, CaptureJobLease, CaptureJobStatus, ProjectionPublication};
+    use anlg_meeting_capture::{MeetingPlatform, MeetingReference};
+    use anlg_session_ingest::{AcknowledgeRequest, DeliveryPage, SessionRead};
+    use std::sync::{Mutex as StdMutex, atomic::AtomicUsize};
+    use tokio::sync::Notify;
+
+    struct TestStore {
+        checkpoint: CaptureJobCheckpoint,
+        events: StdMutex<Vec<CaptureEvent>>,
+        dispatches: StdMutex<Vec<CaptureDispatch>>,
+        append_failures_remaining: AtomicUsize,
+        launching: Notify,
+        terminal: Notify,
+    }
+
+    impl TestStore {
+        fn new(checkpoint: CaptureJobCheckpoint) -> Self {
+            Self {
+                checkpoint,
+                events: StdMutex::new(Vec::new()),
+                dispatches: StdMutex::new(Vec::new()),
+                append_failures_remaining: AtomicUsize::new(0),
+                launching: Notify::new(),
+                terminal: Notify::new(),
+            }
+        }
+
+        fn with_append_failures(checkpoint: CaptureJobCheckpoint, failures: usize) -> Self {
+            let store = Self::new(checkpoint);
+            store
+                .append_failures_remaining
+                .store(failures, Ordering::SeqCst);
+            store
+        }
+    }
+
+    #[async_trait]
+    impl ControlPlaneStore for TestStore {
+        async fn readiness(&self) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        async fn create_capture_job(
+            &self,
+            job: &CaptureJob,
+        ) -> Result<CaptureJobStatus, StoreError> {
+            Ok(CaptureJobStatus {
+                job_id: job.job_id.clone(),
+                created: true,
+                state: BotState::Queued,
+            })
+        }
+
+        async fn read_capture_checkpoint(
+            &self,
+            _workspace_id: &str,
+            _job_id: &str,
+        ) -> Result<CaptureJobCheckpoint, StoreError> {
+            Ok(self.checkpoint.clone())
+        }
+
+        async fn find_dispatchable_capture_checkpoint(
+            &self,
+            workspace_id: &str,
+            provider: CaptureProviderKind,
+            external_ids: &[String],
+        ) -> Result<CaptureJobCheckpoint, StoreError> {
+            let external_id = self.checkpoint.job.meeting.external_id.as_ref().unwrap();
+            if workspace_id == self.checkpoint.job.workspace_id
+                && provider == self.checkpoint.job.provider
+                && external_ids.contains(external_id)
+            {
+                Ok(self.checkpoint.clone())
+            } else {
+                Err(StoreError::NotFound)
+            }
+        }
+
+        async fn save_capture_dispatch(
+            &self,
+            dispatch: &CaptureDispatch,
+        ) -> Result<(), StoreError> {
+            let mut current = self.dispatches.lock().unwrap();
+            if let Some(existing) = current
+                .iter_mut()
+                .find(|existing| existing.job_id == dispatch.job_id)
+            {
+                return if existing.dispatch_id == dispatch.dispatch_id {
+                    *existing = dispatch.clone();
+                    Ok(())
+                } else {
+                    Err(StoreError::CaptureDispatchConflict)
+                };
+            }
+            current.push(dispatch.clone());
+            Ok(())
+        }
+
+        async fn list_capture_dispatches(
+            &self,
+            provider: CaptureProviderKind,
+        ) -> Result<Vec<CaptureDispatch>, StoreError> {
+            Ok(self
+                .dispatches
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|dispatch| dispatch.provider == provider)
+                .cloned()
+                .collect())
+        }
+
+        async fn find_capture_dispatch(
+            &self,
+            provider: CaptureProviderKind,
+            dispatch_id: &str,
+        ) -> Result<CaptureDispatch, StoreError> {
+            self.dispatches
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|dispatch| {
+                    dispatch.provider == provider && dispatch.dispatch_id == dispatch_id
+                })
+                .cloned()
+                .ok_or(StoreError::NotFound)
+        }
+
+        async fn next_capture_transcript_sequence(
+            &self,
+            _workspace_id: &str,
+            _job_id: &str,
+        ) -> Result<u64, StoreError> {
+            self.events
+                .lock()
+                .unwrap()
+                .iter()
+                .filter_map(|event| match &event.payload {
+                    CaptureEventPayload::Transcript(transcript) => Some(transcript.sequence),
+                    _ => None,
+                })
+                .try_fold(0, |next_sequence, sequence| {
+                    Ok(next_sequence.max(
+                        sequence
+                            .checked_add(1)
+                            .ok_or(StoreError::OutOfRange("transcript sequence"))?,
+                    ))
+                })
+        }
+
+        async fn claim_capture_job(
+            &self,
+            _workspace_id: &str,
+            _job_id: &str,
+            worker_id: &str,
+            lease_id: &str,
+            lease_duration: Duration,
+        ) -> Result<CaptureJobLease, StoreError> {
+            Ok(CaptureJobLease {
+                worker_id: worker_id.into(),
+                lease_id: lease_id.into(),
+                epoch: 1,
+                expires_at: Utc::now() + chrono::Duration::from_std(lease_duration).unwrap(),
+            })
+        }
+
+        async fn renew_capture_job_lease(
+            &self,
+            _workspace_id: &str,
+            _job_id: &str,
+            lease: &CaptureJobLeaseIdentity,
+            lease_duration: Duration,
+        ) -> Result<CaptureJobLease, StoreError> {
+            Ok(CaptureJobLease {
+                worker_id: lease.worker_id.clone(),
+                lease_id: lease.lease_id.clone(),
+                epoch: lease.epoch,
+                expires_at: Utc::now() + chrono::Duration::from_std(lease_duration).unwrap(),
+            })
+        }
+
+        async fn append_capture_event(
+            &self,
+            _workspace_id: &str,
+            _job_id: &str,
+            _lease: &CaptureJobLeaseIdentity,
+            event: &CaptureEvent,
+        ) -> Result<ProjectionPublication, StoreError> {
+            if self
+                .append_failures_remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err(StoreError::Database(sqlx::Error::PoolTimedOut));
+            }
+            let mut events = self.events.lock().unwrap();
+            events.push(event.clone());
+            let envelope = crate::projector::project(&self.checkpoint.job, &events)
+                .map_err(|error| StoreError::InvalidCaptureEvent(error.to_string()))?;
+            let finalized = envelope.finalized;
+            let revision = envelope.revision;
+            let content_hash = crate::projector::content_hash(&envelope)?;
+            if matches!(
+                &event.payload,
+                CaptureEventPayload::Lifecycle(transition) if transition.to == BotState::Launching
+            ) {
+                self.launching.notify_one();
+            }
+            if matches!(
+                &event.payload,
+                CaptureEventPayload::Lifecycle(transition) if transition.to.is_terminal()
+            ) {
+                self.dispatches.lock().unwrap().clear();
+                self.terminal.notify_one();
+            }
+            Ok(ProjectionPublication {
+                job_id: self.checkpoint.job.job_id.clone(),
+                revision,
+                finalized,
+                content_hash,
+                envelope,
+            })
+        }
+
+        async fn list_deliveries(
+            &self,
+            _workspace_id: &str,
+            _consumer_id: &str,
+            after: u64,
+            _limit: u16,
+        ) -> Result<DeliveryPage, StoreError> {
+            Ok(DeliveryPage {
+                items: Vec::new(),
+                next_cursor: after,
+                has_more: false,
+            })
+        }
+
+        async fn acknowledge(
+            &self,
+            _workspace_id: &str,
+            _job_id: &str,
+            _request: &AcknowledgeRequest,
+        ) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        async fn read_session(
+            &self,
+            _workspace_id: &str,
+            _job_id: &str,
+        ) -> Result<SessionRead, StoreError> {
+            Err(StoreError::NotFound)
+        }
+    }
+
+    fn zoom_checkpoint(external_id: &str) -> CaptureJobCheckpoint {
+        CaptureJobCheckpoint {
+            job: CaptureJob {
+                workspace_id: "workspace-a".into(),
+                job_id: "job-a".into(),
+                bot_id: "bot-a".into(),
+                owner_user_id: "owner-a".into(),
+                requesting_actor_id: "actor-a".into(),
+                session_id: "session-a".into(),
+                session_title: "Zoom".into(),
+                provider: CaptureProviderKind::ZoomRtms,
+                meeting: MeetingReference {
+                    platform: MeetingPlatform::Zoom,
+                    url: "https://zoom.us/j/123".into(),
+                    external_id: Some(external_id.into()),
+                    calendar_event_id: None,
+                },
+                created_at: Utc::now(),
+            },
+            state: BotState::Queued,
+            next_sequence: 0,
+        }
+    }
+
+    async fn terminal_state_after_pending_stops(reasons: &[ZoomStopReason]) -> BotState {
+        let store = Arc::new(TestStore::new(zoom_checkpoint("123")));
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+        let started = ZoomRtmsStarted {
+            account_id: "account-a".into(),
+            meeting_uuid: "meeting-uuid".into(),
+            meeting_id: "123".into(),
+            stream_id: "stream-id".into(),
+            signaling_url: "wss://127.0.0.1:1/signaling".parse().unwrap(),
+            event_timestamp_ms: 1,
+        };
+        store
+            .save_capture_dispatch(&capture_dispatch("workspace-a", "job-a", &started).unwrap())
+            .await
+            .unwrap();
+        let terminal = ZoomRtmsTerminal {
+            meeting_uuid: "meeting-uuid".into(),
+            stream_id: "stream-id".into(),
+            event_timestamp_ms: 1,
+        };
+        for reason in reasons {
+            dispatcher.stop(&terminal, *reason).await.unwrap();
+        }
+        dispatcher.start("workspace-a", started).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), store.terminal.notified())
+            .await
+            .expect("worker did not persist the pending terminal state");
+        let events = store.events.lock().unwrap();
+        match &events.last().unwrap().payload {
+            CaptureEventPayload::Lifecycle(transition) => transition.to,
+            _ => panic!("expected a terminal lifecycle event"),
+        }
+    }
+
+    #[test]
+    fn creates_valid_unique_lease_identities() {
+        let first = worker_lease_ids("job-a", "stream-a");
+        let second = worker_lease_ids("job-a", "stream-a");
+
+        assert_ne!(first, second);
+        for value in [first.0, first.1, second.0, second.1] {
+            assert!(value.len() <= 128);
+            assert!(
+                value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || b"-_.".contains(&byte))
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_interruptions_keep_the_original_reconnect_deadline() {
+        let mut reconnect = None;
+        schedule_zoom_interruption(&mut reconnect);
+        let deadline = reconnect.as_ref().unwrap().deadline;
+        reconnect.as_mut().unwrap().attempt = 3;
+
+        schedule_zoom_interruption(&mut reconnect);
+
+        let reconnect = reconnect.unwrap();
+        assert_eq!(reconnect.deadline, deadline);
+        assert_eq!(reconnect.attempt, 3);
+    }
+
+    #[test]
+    fn rejects_a_signed_meeting_that_does_not_match_the_job() {
+        let checkpoint = zoom_checkpoint("123");
+        let started = ZoomRtmsStarted {
+            account_id: "account-a".into(),
+            meeting_uuid: "uuid-b".into(),
+            meeting_id: "456".into(),
+            stream_id: "stream-a".into(),
+            signaling_url: "wss://rtms.zoom.us/signaling".parse().unwrap(),
+            event_timestamp_ms: 1,
+        };
+
+        assert!(validate_checkpoint(&checkpoint, &started).is_err());
+    }
+
+    #[test]
+    fn only_connection_close_errors_can_reconcile_with_a_clean_stop() {
+        assert!(
+            ZoomCaptureWorkerError::Session(ZoomRtmsSessionError::ConnectionClosed("media"))
+                .can_reconcile_with_stop()
+        );
+        assert!(
+            !ZoomCaptureWorkerError::Session(ZoomRtmsSessionError::TranscriptBackpressure)
+                .can_reconcile_with_stop()
+        );
+    }
+
+    #[tokio::test]
+    async fn skips_a_corrupt_dispatch_and_recovers_the_next_after_registry_loss() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let store = Arc::new(TestStore::new(zoom_checkpoint("123")));
+        let started = ZoomRtmsStarted {
+            account_id: "account-a".into(),
+            meeting_uuid: "meeting-uuid".into(),
+            meeting_id: "123".into(),
+            stream_id: "stream-id".into(),
+            signaling_url: format!("wss://{address}/signaling").parse().unwrap(),
+            event_timestamp_ms: 1,
+        };
+        store
+            .save_capture_dispatch(&CaptureDispatch {
+                workspace_id: "workspace-a".into(),
+                job_id: "job-a".into(),
+                provider: CaptureProviderKind::ZoomRtms,
+                dispatch_id: started.stream_id.clone(),
+                payload: serde_json::to_value(&started).unwrap(),
+            })
+            .await
+            .unwrap();
+        store.dispatches.lock().unwrap().insert(
+            0,
+            CaptureDispatch {
+                workspace_id: "workspace-corrupt".into(),
+                job_id: "job-corrupt".into(),
+                provider: CaptureProviderKind::ZoomRtms,
+                dispatch_id: "stream-corrupt".into(),
+                payload: serde_json::json!({"invalid": true}),
+            },
+        );
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+
+        dispatcher.recover_pending().await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), store.terminal.notified())
+            .await
+            .expect("recovered worker did not terminalize");
+        let states = store
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match &event.payload {
+                CaptureEventPayload::Lifecycle(transition) => Some(transition.to),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(states, vec![BotState::Launching, BotState::Failed]);
+        assert!(store.dispatches.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn claims_and_hands_a_zoom_job_to_the_background_worker() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let store = Arc::new(TestStore::new(zoom_checkpoint("123")));
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+        let outcome = dispatcher
+            .start(
+                "workspace-a",
+                ZoomRtmsStarted {
+                    account_id: "account-a".into(),
+                    meeting_uuid: "meeting-uuid".into(),
+                    meeting_id: "123".into(),
+                    stream_id: "stream-id".into(),
+                    signaling_url: format!("wss://{address}/signaling").parse().unwrap(),
+                    event_timestamp_ms: 1,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.job_id, "job-a");
+        assert!(outcome.started);
+        tokio::time::timeout(Duration::from_secs(5), store.terminal.notified())
+            .await
+            .expect("worker did not persist its terminal state");
+        let events = store.events.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            &events[0].payload,
+            CaptureEventPayload::Lifecycle(transition) if transition.to == BotState::Launching
+        ));
+        assert!(matches!(
+            &events[1].payload,
+            CaptureEventPayload::Lifecycle(transition) if transition.to == BotState::Failed
+        ));
+        assert_eq!(events[0].sequence, 0);
+        assert_eq!(events[1].sequence, 1);
+    }
+
+    #[tokio::test]
+    async fn applies_a_signed_stop_that_arrives_before_start_dispatch_finishes() {
+        let store = Arc::new(TestStore::new(zoom_checkpoint("123")));
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+        let started = ZoomRtmsStarted {
+            account_id: "account-a".into(),
+            meeting_uuid: "meeting-uuid".into(),
+            meeting_id: "123".into(),
+            stream_id: "stream-id".into(),
+            signaling_url: "wss://127.0.0.1:1/signaling".parse().unwrap(),
+            event_timestamp_ms: 1,
+        };
+        store
+            .save_capture_dispatch(&capture_dispatch("workspace-a", "job-a", &started).unwrap())
+            .await
+            .unwrap();
+        dispatcher
+            .stop(
+                &ZoomRtmsTerminal {
+                    meeting_uuid: "meeting-uuid".into(),
+                    stream_id: "stream-id".into(),
+                    event_timestamp_ms: 1,
+                },
+                ZoomStopReason::Stopped,
+            )
+            .await
+            .unwrap();
+        dispatcher.start("workspace-a", started).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), store.terminal.notified())
+            .await
+            .expect("worker did not persist the early stop");
+        let events = store.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0].payload,
+            CaptureEventPayload::Lifecycle(transition) if transition.to == BotState::Canceled
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_terminal_stop_wins_over_an_interruption_in_either_order() {
+        let stopped_then_interrupted = terminal_state_after_pending_stops(&[
+            ZoomStopReason::Stopped,
+            ZoomStopReason::Interrupted,
+        ])
+        .await;
+        let interrupted_then_stopped = terminal_state_after_pending_stops(&[
+            ZoomStopReason::Interrupted,
+            ZoomStopReason::Stopped,
+        ])
+        .await;
+
+        assert_eq!(stopped_then_interrupted, BotState::Canceled);
+        assert_eq!(interrupted_then_stopped, BotState::Canceled);
+    }
+
+    #[tokio::test]
+    async fn unknown_terminal_events_do_not_consume_pending_capacity() {
+        let store = Arc::new(TestStore::new(zoom_checkpoint("123")));
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+        for index in 0..=MAX_PENDING_STOPS {
+            dispatcher
+                .stop(
+                    &ZoomRtmsTerminal {
+                        meeting_uuid: format!("unknown-meeting-{index}"),
+                        stream_id: format!("unknown-stream-{index}"),
+                        event_timestamp_ms: 1,
+                    },
+                    ZoomStopReason::Stopped,
+                )
+                .await
+                .unwrap();
+        }
+        assert!(dispatcher.registry.lock().await.pending_stops.is_empty());
+
+        let started = ZoomRtmsStarted {
+            account_id: "account-a".into(),
+            meeting_uuid: "meeting-uuid".into(),
+            meeting_id: "123".into(),
+            stream_id: "stream-id".into(),
+            signaling_url: "wss://127.0.0.1:1/signaling".parse().unwrap(),
+            event_timestamp_ms: 1,
+        };
+        store
+            .save_capture_dispatch(&capture_dispatch("workspace-a", "job-a", &started).unwrap())
+            .await
+            .unwrap();
+        dispatcher
+            .stop(
+                &ZoomRtmsTerminal {
+                    meeting_uuid: started.meeting_uuid.clone(),
+                    stream_id: started.stream_id.clone(),
+                    event_timestamp_ms: 2,
+                },
+                ZoomStopReason::Stopped,
+            )
+            .await
+            .unwrap();
+        assert_eq!(dispatcher.registry.lock().await.pending_stops.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn interruption_keeps_the_capture_non_terminal_until_a_stop_arrives() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let _ = accepted_tx.send(());
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            drop(stream);
+        });
+        let store = Arc::new(TestStore::new(zoom_checkpoint("123")));
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+        let terminal = ZoomRtmsTerminal {
+            meeting_uuid: "meeting-uuid".into(),
+            stream_id: "stream-id".into(),
+            event_timestamp_ms: 2,
+        };
+        dispatcher
+            .start(
+                "workspace-a",
+                ZoomRtmsStarted {
+                    account_id: "account-a".into(),
+                    meeting_uuid: terminal.meeting_uuid.clone(),
+                    meeting_id: "123".into(),
+                    stream_id: terminal.stream_id.clone(),
+                    signaling_url: format!("wss://{address}/signaling").parse().unwrap(),
+                    event_timestamp_ms: 1,
+                },
+            )
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), accepted_rx)
+            .await
+            .expect("worker did not begin connecting")
+            .unwrap();
+
+        dispatcher
+            .stop(&terminal, ZoomStopReason::Interrupted)
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(!store.dispatches.lock().unwrap().is_empty());
+        assert!(store.events.lock().unwrap().iter().all(|event| {
+            !matches!(
+                &event.payload,
+                CaptureEventPayload::Lifecycle(transition) if transition.to.is_terminal()
+            )
+        }));
+
+        dispatcher
+            .stop(&terminal, ZoomStopReason::Stopped)
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), store.terminal.notified())
+            .await
+            .expect("worker did not persist the final stop");
+        server.abort();
+        let states = store
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match &event.payload {
+                CaptureEventPayload::Lifecycle(transition) => Some(transition.to),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            states,
+            vec![BotState::Launching, BotState::Stopping, BotState::Completed]
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_start_refreshes_the_dispatch_and_reconnects_immediately() {
+        let first_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let first_address = first_listener.local_addr().unwrap();
+        let second_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let second_address = second_listener.local_addr().unwrap();
+        let (first_tx, first_rx) = tokio::sync::oneshot::channel();
+        let first_server = tokio::spawn(async move {
+            let (stream, _) = first_listener.accept().await.unwrap();
+            let _ = first_tx.send(());
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            drop(stream);
+        });
+        let (second_tx, second_rx) = tokio::sync::oneshot::channel();
+        let second_server = tokio::spawn(async move {
+            let (stream, _) = second_listener.accept().await.unwrap();
+            let _ = second_tx.send(());
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            drop(stream);
+        });
+        let store = Arc::new(TestStore::new(zoom_checkpoint("123")));
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+        let mut started = ZoomRtmsStarted {
+            account_id: "account-a".into(),
+            meeting_uuid: "meeting-uuid".into(),
+            meeting_id: "123".into(),
+            stream_id: "stream-id".into(),
+            signaling_url: format!("wss://{first_address}/signaling").parse().unwrap(),
+            event_timestamp_ms: 1,
+        };
+        dispatcher
+            .start("workspace-a", started.clone())
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), first_rx)
+            .await
+            .expect("worker did not use the initial RTMS server")
+            .unwrap();
+
+        started.signaling_url = format!("wss://{second_address}/signaling").parse().unwrap();
+        started.event_timestamp_ms = 2;
+        let outcome = dispatcher
+            .start("workspace-a", started.clone())
+            .await
+            .unwrap();
+        assert!(!outcome.started);
+        tokio::time::timeout(Duration::from_secs(2), second_rx)
+            .await
+            .expect("worker did not reconnect to the refreshed RTMS server")
+            .unwrap();
+        let dispatch = store.dispatches.lock().unwrap().first().cloned().unwrap();
+        assert_eq!(dispatch.payload, serde_json::to_value(&started).unwrap());
+
+        dispatcher
+            .stop(
+                &ZoomRtmsTerminal {
+                    meeting_uuid: started.meeting_uuid,
+                    stream_id: started.stream_id,
+                    event_timestamp_ms: 3,
+                },
+                ZoomStopReason::Stopped,
+            )
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), store.terminal.notified())
+            .await
+            .expect("worker did not stop after reconnecting");
+        first_server.abort();
+        second_server.abort();
+    }
+
+    #[tokio::test]
+    async fn restart_is_not_acknowledged_by_a_tearing_down_registry_task() {
+        let store = Arc::new(TestStore::new(zoom_checkpoint("123")));
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+        let started = ZoomRtmsStarted {
+            account_id: "account-a".into(),
+            meeting_uuid: "meeting-uuid".into(),
+            meeting_id: "123".into(),
+            stream_id: "stream-id".into(),
+            signaling_url: "wss://127.0.0.1:1/signaling".parse().unwrap(),
+            event_timestamp_ms: 1,
+        };
+        let (commands, mut receiver) = mpsc::unbounded_channel();
+        dispatcher.registry.lock().await.tasks.insert(
+            started.stream_id.clone(),
+            ZoomCaptureTask {
+                workspace_id: "workspace-a".into(),
+                job_id: "job-a".into(),
+                meeting_uuid: started.meeting_uuid.clone(),
+                commands,
+            },
+        );
+        let teardown = tokio::spawn(async move {
+            let command = receiver.recv().await.unwrap();
+            assert!(matches!(command, ZoomCaptureCommand::Restart { .. }));
+        });
+
+        let outcome = dispatcher
+            .start("workspace-a", started.clone())
+            .await
+            .unwrap();
+
+        teardown.await.unwrap();
+        assert!(outcome.started);
+        assert_eq!(outcome.job_id, "job-a");
+        dispatcher
+            .stop(
+                &ZoomRtmsTerminal {
+                    meeting_uuid: started.meeting_uuid,
+                    stream_id: started.stream_id,
+                    event_timestamp_ms: 2,
+                },
+                ZoomStopReason::Stopped,
+            )
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), store.terminal.notified())
+            .await
+            .expect("replacement worker did not receive the stop");
+    }
+
+    #[tokio::test]
+    async fn store_failures_terminalize_the_job_instead_of_abandoning_it() {
+        let store = Arc::new(TestStore::with_append_failures(
+            zoom_checkpoint("123"),
+            STORE_RETRY_ATTEMPTS,
+        ));
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+        dispatcher
+            .start(
+                "workspace-a",
+                ZoomRtmsStarted {
+                    account_id: "account-a".into(),
+                    meeting_uuid: "meeting-uuid".into(),
+                    meeting_id: "123".into(),
+                    stream_id: "stream-id".into(),
+                    signaling_url: "wss://127.0.0.1:1/signaling".parse().unwrap(),
+                    event_timestamp_ms: 1,
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), store.terminal.notified())
+            .await
+            .expect("worker abandoned the job after a store failure");
+        let events = store.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].sequence, 0);
+        assert!(matches!(
+            &events[0].payload,
+            CaptureEventPayload::Lifecycle(transition) if transition.to == BotState::Failed
+        ));
+    }
+
+    #[tokio::test]
+    async fn signed_stop_cancels_an_in_progress_connection() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let _ = accepted_tx.send(());
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            drop(stream);
+        });
+        let store = Arc::new(TestStore::new(zoom_checkpoint("123")));
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+        dispatcher
+            .start(
+                "workspace-a",
+                ZoomRtmsStarted {
+                    account_id: "account-a".into(),
+                    meeting_uuid: "meeting-uuid".into(),
+                    meeting_id: "123".into(),
+                    stream_id: "stream-id".into(),
+                    signaling_url: format!("wss://{address}/signaling").parse().unwrap(),
+                    event_timestamp_ms: 1,
+                },
+            )
+            .await
+            .unwrap();
+        let dispatch = store.dispatches.lock().unwrap().first().cloned().unwrap();
+        assert_eq!(dispatch.workspace_id, "workspace-a");
+        assert_eq!(dispatch.job_id, "job-a");
+        assert_eq!(dispatch.dispatch_id, "stream-id");
+        tokio::time::timeout(Duration::from_secs(2), store.launching.notified())
+            .await
+            .expect("worker did not enter launching");
+        tokio::time::timeout(Duration::from_secs(2), accepted_rx)
+            .await
+            .expect("worker did not begin connecting")
+            .unwrap();
+        dispatcher
+            .stop(
+                &ZoomRtmsTerminal {
+                    meeting_uuid: "meeting-uuid".into(),
+                    stream_id: "stream-id".into(),
+                    event_timestamp_ms: 2,
+                },
+                ZoomStopReason::Stopped,
+            )
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), store.terminal.notified())
+            .await
+            .expect("worker did not cancel its pending connection");
+        assert!(store.dispatches.lock().unwrap().is_empty());
+        server.abort();
+        let states = store
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match &event.payload {
+                CaptureEventPayload::Lifecycle(transition) => Some(transition.to),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            states,
+            vec![BotState::Launching, BotState::Stopping, BotState::Completed]
+        );
+    }
+
+    #[tokio::test]
+    async fn signed_stop_wins_when_the_socket_closes_first() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let store = Arc::new(TestStore::new(zoom_checkpoint("123")));
+        let dispatcher = ZoomCaptureDispatcher::new(
+            store.clone(),
+            ZoomRtmsCredentials::new("client-id", "client-secret").unwrap(),
+        );
+        dispatcher
+            .start(
+                "workspace-a",
+                ZoomRtmsStarted {
+                    account_id: "account-a".into(),
+                    meeting_uuid: "meeting-uuid".into(),
+                    meeting_id: "123".into(),
+                    stream_id: "stream-id".into(),
+                    signaling_url: format!("wss://{address}/signaling").parse().unwrap(),
+                    event_timestamp_ms: 1,
+                },
+            )
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), store.launching.notified())
+            .await
+            .expect("worker did not enter launching");
+        dispatcher
+            .stop(
+                &ZoomRtmsTerminal {
+                    meeting_uuid: "meeting-uuid".into(),
+                    stream_id: "stream-id".into(),
+                    event_timestamp_ms: 2,
+                },
+                ZoomStopReason::Stopped,
+            )
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), store.terminal.notified())
+            .await
+            .expect("worker did not persist the signed stop");
+        let states = store
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match &event.payload {
+                CaptureEventPayload::Lifecycle(transition) => Some(transition.to),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            states,
+            vec![BotState::Launching, BotState::Stopping, BotState::Completed]
+        );
+    }
+}

--- a/enterprise/control-plane/tests/api.rs
+++ b/enterprise/control-plane/tests/api.rs
@@ -4,21 +4,30 @@ use anarlog_enterprise_control_plane::{
     api::{AppState, router},
     auth::StaticTokenAuthenticator,
     capture::{
-        CaptureJob, CaptureJobCheckpoint, CaptureJobLease, CaptureJobLeaseIdentity,
-        CaptureJobStatus, ProjectionPublication,
+        CaptureDispatch, CaptureJob, CaptureJobCheckpoint, CaptureJobLease,
+        CaptureJobLeaseIdentity, CaptureJobStatus, ProjectionPublication,
     },
+    config::{Config, ZoomConfigValues},
     serve,
     store::{ControlPlaneStore, StoreError},
+    zoom::{
+        ZoomDispatchError, ZoomDispatchOutcome, ZoomStopReason, ZoomWebhookDispatcher,
+        ZoomWebhookService,
+    },
 };
 use anarlog_enterprise_google_meet_worker::{ControlPlaneEventSink, ControlPlaneEventSinkConfig};
-use anlg_meeting_capture::{BotState, CaptureEvent};
+use anarlog_enterprise_zoom_rtms_worker::{ZoomRtmsStarted, ZoomRtmsTerminal};
+use anlg_meeting_capture::{BotState, CaptureEvent, CaptureProviderKind};
 use anlg_session_ingest::{AcknowledgeRequest, DeliveryPage, SessionRead};
 use async_trait::async_trait;
 use axum::{
     body::{Body, to_bytes},
     http::{Method, Request, StatusCode, header},
 };
+use hmac::{Hmac, Mac};
 use serde_json::Value;
+use sha2_legacy::Sha256;
+use std::sync::Mutex;
 use tokio::{net::TcpListener, sync::oneshot, time::Duration};
 use tower::ServiceExt;
 
@@ -27,6 +36,38 @@ const TOKEN_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
 struct MemoryStore {
     ready: bool,
+}
+
+#[derive(Default)]
+struct RecordingZoomDispatcher {
+    starts: Mutex<Vec<(String, ZoomRtmsStarted)>>,
+    stops: Mutex<Vec<(ZoomRtmsTerminal, ZoomStopReason)>>,
+}
+
+#[async_trait]
+impl ZoomWebhookDispatcher for RecordingZoomDispatcher {
+    async fn start(
+        &self,
+        workspace_id: &str,
+        started: ZoomRtmsStarted,
+    ) -> Result<ZoomDispatchOutcome, ZoomDispatchError> {
+        let mut starts = self.starts.lock().unwrap();
+        let first_delivery = starts.is_empty();
+        starts.push((workspace_id.into(), started));
+        Ok(ZoomDispatchOutcome {
+            job_id: "job-zoom-a".into(),
+            started: first_delivery,
+        })
+    }
+
+    async fn stop(
+        &self,
+        terminal: &ZoomRtmsTerminal,
+        reason: ZoomStopReason,
+    ) -> Result<(), ZoomDispatchError> {
+        self.stops.lock().unwrap().push((terminal.clone(), reason));
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -60,6 +101,42 @@ impl ControlPlaneStore for MemoryStore {
             state: BotState::Capturing,
             next_sequence: 7,
         })
+    }
+
+    async fn find_dispatchable_capture_checkpoint(
+        &self,
+        _workspace_id: &str,
+        _provider: CaptureProviderKind,
+        _external_ids: &[String],
+    ) -> Result<CaptureJobCheckpoint, StoreError> {
+        Err(StoreError::NotFound)
+    }
+
+    async fn save_capture_dispatch(&self, _dispatch: &CaptureDispatch) -> Result<(), StoreError> {
+        Ok(())
+    }
+
+    async fn list_capture_dispatches(
+        &self,
+        _provider: CaptureProviderKind,
+    ) -> Result<Vec<CaptureDispatch>, StoreError> {
+        Ok(Vec::new())
+    }
+
+    async fn find_capture_dispatch(
+        &self,
+        _provider: CaptureProviderKind,
+        _dispatch_id: &str,
+    ) -> Result<CaptureDispatch, StoreError> {
+        Err(StoreError::NotFound)
+    }
+
+    async fn next_capture_transcript_sequence(
+        &self,
+        _workspace_id: &str,
+        _job_id: &str,
+    ) -> Result<u64, StoreError> {
+        Ok(0)
     }
 
     async fn claim_capture_job(
@@ -144,6 +221,26 @@ fn state(ready: bool) -> AppState {
     AppState::new(Arc::new(MemoryStore { ready }), Arc::new(authenticator))
 }
 
+fn state_with_zoom(dispatcher: Arc<RecordingZoomDispatcher>) -> AppState {
+    let config = Config::from_values_with_zoom(
+        "postgres://localhost/anarlog".into(),
+        None,
+        None,
+        format!(r#"{{"workspace-a":"{TOKEN_A}","workspace-b":"{TOKEN_B}"}}"#),
+        ZoomConfigValues {
+            client_id: Some("zoom-client".into()),
+            client_secret: Some("zoom-client-secret".into()),
+            webhook_secret: Some("zoom-webhook-secret".into()),
+            account_workspaces: Some(r#"{"account-a":"workspace-a"}"#.into()),
+        },
+    )
+    .unwrap();
+    state(true).with_zoom(Arc::new(ZoomWebhookService::new(
+        config.zoom.unwrap(),
+        dispatcher,
+    )))
+}
+
 #[tokio::test]
 async fn exposes_database_independent_liveness_and_fail_closed_readiness() {
     let app = router(state(false));
@@ -160,6 +257,115 @@ async fn exposes_database_independent_liveness_and_fail_closed_readiness() {
 
     assert_eq!(live.status(), StatusCode::OK);
     assert_eq!(ready.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn mounts_zoom_webhooks_only_when_complete_configuration_is_present() {
+    let body = zoom_started_body("account-a");
+    let disabled = router(state(true))
+        .oneshot(zoom_request(&body, true))
+        .await
+        .unwrap();
+    assert_eq!(disabled.status(), StatusCode::NOT_FOUND);
+
+    let dispatcher = Arc::new(RecordingZoomDispatcher::default());
+    let enabled = router(state_with_zoom(dispatcher.clone()));
+    let missing_signature = enabled
+        .clone()
+        .oneshot(
+            Request::post("/webhooks/zoom")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let invalid_signature = enabled
+        .clone()
+        .oneshot(zoom_request(&body, false))
+        .await
+        .unwrap();
+    let accepted = enabled
+        .clone()
+        .oneshot(zoom_request(&body, true))
+        .await
+        .unwrap();
+    let retried = enabled.oneshot(zoom_request(&body, true)).await.unwrap();
+
+    assert_eq!(missing_signature.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(invalid_signature.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(accepted.status(), StatusCode::OK);
+    assert_eq!(retried.status(), StatusCode::OK);
+    assert_eq!(
+        response_json(accepted).await,
+        serde_json::json!({
+            "status": "started",
+            "jobId": "job-zoom-a"
+        })
+    );
+    assert_eq!(
+        response_json(retried).await,
+        serde_json::json!({
+            "status": "already_running",
+            "jobId": "job-zoom-a"
+        })
+    );
+    let starts = dispatcher.starts.lock().unwrap();
+    assert_eq!(starts.len(), 2);
+    assert_eq!(starts[0].0, "workspace-a");
+    assert_eq!(starts[0].1.account_id, "account-a");
+    assert_eq!(starts[0].1.meeting_id, "123456789");
+}
+
+#[tokio::test]
+async fn validates_zoom_challenges_and_ignores_unregistered_accounts() {
+    let dispatcher = Arc::new(RecordingZoomDispatcher::default());
+    let app = router(state_with_zoom(dispatcher.clone()));
+    let validation_body = serde_json::json!({
+        "event": "endpoint.url_validation",
+        "event_ts": 1,
+        "payload": { "plainToken": "plain-token" }
+    })
+    .to_string();
+    let validation = app
+        .clone()
+        .oneshot(zoom_request(&validation_body, true))
+        .await
+        .unwrap();
+    assert_eq!(validation.status(), StatusCode::OK);
+    let validation = response_json(validation).await;
+    assert_eq!(validation["plainToken"], "plain-token");
+    assert_eq!(validation["encryptedToken"].as_str().unwrap().len(), 64);
+
+    let ignored = app
+        .oneshot(zoom_request(&zoom_started_body("account-b"), true))
+        .await
+        .unwrap();
+    assert_eq!(ignored.status(), StatusCode::NO_CONTENT);
+    assert!(dispatcher.starts.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn hands_signed_zoom_terminal_events_to_the_running_worker_registry() {
+    let dispatcher = Arc::new(RecordingZoomDispatcher::default());
+    let app = router(state_with_zoom(dispatcher.clone()));
+    let body = serde_json::json!({
+        "event": "meeting.rtms_interrupted",
+        "event_ts": 1,
+        "payload": {
+            "meeting_uuid": "meeting-uuid",
+            "rtms_stream_id": "stream-id"
+        }
+    })
+    .to_string();
+
+    let response = app.oneshot(zoom_request(&body, true)).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let stops = dispatcher.stops.lock().unwrap();
+    assert_eq!(stops.len(), 1);
+    assert_eq!(stops[0].0.stream_id, "stream-id");
+    assert_eq!(stops[0].1, ZoomStopReason::Interrupted);
 }
 
 #[tokio::test]
@@ -425,6 +631,49 @@ fn json_request(method: Method, path: &str, token: Option<&str>, body: &Value) -
 async fn response_json(response: axum::response::Response) -> Value {
     let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
     serde_json::from_slice(&body).unwrap()
+}
+
+fn zoom_started_body(account_id: &str) -> String {
+    serde_json::json!({
+        "event": "meeting.rtms_started",
+        "event_ts": 1,
+        "payload": {
+            "account_id": account_id,
+            "meeting_uuid": "meeting-uuid",
+            "meeting_id": 123456789,
+            "rtms_stream_id": "stream-id",
+            "server_urls": "wss://rtms.zoom.us/signaling"
+        }
+    })
+    .to_string()
+}
+
+fn zoom_request(body: &str, valid_signature: bool) -> Request<Body> {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .to_string();
+    let mut mac = Hmac::<Sha256>::new_from_slice(if valid_signature {
+        b"zoom-webhook-secret"
+    } else {
+        b"wrong-webhook-secret"
+    })
+    .unwrap();
+    mac.update(format!("v0:{timestamp}:").as_bytes());
+    mac.update(body.as_bytes());
+    let signature = mac
+        .finalize()
+        .into_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Request::post("/webhooks/zoom")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("x-zm-request-timestamp", timestamp)
+        .header("x-zm-signature", format!("v0={signature}"))
+        .body(Body::from(body.to_string()))
+        .unwrap()
 }
 
 fn capture_job() -> CaptureJob {

--- a/enterprise/control-plane/tests/postgres.rs
+++ b/enterprise/control-plane/tests/postgres.rs
@@ -6,15 +6,22 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use anarlog_enterprise_control_plane::{api::router, config::Config, configured_state, serve};
+use anarlog_enterprise_control_plane::{
+    api::router,
+    capture::{CaptureDispatch, CaptureJob},
+    config::Config,
+    configured_state, serve,
+    store::{ControlPlaneStore, PostgresStore, StoreError},
+};
 use anarlog_enterprise_google_meet_worker::{
     CaptureJobRuntime, CaptureJobSupervisor, CaptureJobSupervisorConfig,
     CaptureJobSupervisorOutcome, ControlPlaneEventSink, ControlPlaneEventSinkConfig,
     WorkerCheckpoint, WorkerLifecycle,
 };
 use anlg_meeting_capture::{
-    BotState, CaptureEvent, CaptureEventPayload, Participant, RecordingChunk, Speaker,
-    TerminalReason, TerminalReasonKind, TranscriptSegment,
+    BotState, CaptureEvent, CaptureEventPayload, CaptureProviderKind, MeetingPlatform,
+    MeetingReference, Participant, RecordingChunk, Speaker, TerminalReason, TerminalReasonKind,
+    TranscriptSegment,
 };
 use async_trait::async_trait;
 use axum::{
@@ -148,6 +155,16 @@ async fn migrates_postgres_and_enforces_workspace_delivery() {
     .unwrap();
 
     let app = router(state);
+    let zoom_disabled = app
+        .clone()
+        .oneshot(
+            Request::post("/webhooks/zoom")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(zoom_disabled.status(), StatusCode::NOT_FOUND);
     let list_path =
         format!("/v1/workspaces/{workspace_id}/session-envelopes?consumerId=device-a&after=0");
     let listed = app
@@ -188,6 +205,184 @@ async fn migrates_postgres_and_enforces_workspace_delivery() {
         .await
         .unwrap();
     assert_eq!(wrong_workspace.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn resolves_dispatchable_zoom_jobs_by_workspace_and_external_identity() {
+    let Ok(database_url) = std::env::var(TEST_DATABASE_URL_ENV) else {
+        return;
+    };
+    let suffix = format!(
+        "{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let workspace_id = format!("workspace-zoom-{suffix}");
+    let job_id = format!("job-zoom-{suffix}");
+    let external_id = format!("meeting-{suffix}");
+    let store = PostgresStore::connect(&database_url, 2, Duration::from_secs(10))
+        .await
+        .unwrap();
+    store.migrate().await.unwrap();
+    store
+        .create_capture_job(&CaptureJob {
+            workspace_id: workspace_id.clone(),
+            job_id: job_id.clone(),
+            bot_id: format!("bot-zoom-{suffix}"),
+            owner_user_id: "owner-a".into(),
+            requesting_actor_id: "actor-a".into(),
+            session_id: format!("session-zoom-{suffix}"),
+            session_title: "Zoom dispatch".into(),
+            provider: CaptureProviderKind::ZoomRtms,
+            meeting: MeetingReference {
+                platform: MeetingPlatform::Zoom,
+                url: "https://zoom.us/j/123456789".into(),
+                external_id: Some(external_id.clone()),
+                calendar_event_id: None,
+            },
+            created_at: chrono::Utc::now(),
+        })
+        .await
+        .unwrap();
+
+    let checkpoint = store
+        .find_dispatchable_capture_checkpoint(
+            &workspace_id,
+            CaptureProviderKind::ZoomRtms,
+            &["unrelated-uuid".into(), external_id],
+        )
+        .await
+        .unwrap();
+    assert_eq!(checkpoint.job.job_id, job_id);
+    assert_eq!(checkpoint.state, BotState::Queued);
+    let stream_id = "s".repeat(512);
+    let mut dispatch = CaptureDispatch {
+        workspace_id: workspace_id.clone(),
+        job_id: job_id.clone(),
+        provider: CaptureProviderKind::ZoomRtms,
+        dispatch_id: stream_id.clone(),
+        payload: serde_json::json!({
+            "account_id": "account-a",
+            "meeting_uuid": "meeting-uuid",
+            "meeting_id": "123456789",
+            "stream_id": stream_id,
+            "signaling_url": "wss://rtms.zoom.us/signaling",
+            "event_timestamp_ms": 1
+        }),
+    };
+    store.save_capture_dispatch(&dispatch).await.unwrap();
+    store.save_capture_dispatch(&dispatch).await.unwrap();
+    assert_eq!(
+        store
+            .find_capture_dispatch(CaptureProviderKind::ZoomRtms, &stream_id)
+            .await
+            .unwrap(),
+        dispatch
+    );
+    dispatch.payload["signaling_url"] = serde_json::json!("wss://rtms2.zoom.us/signaling");
+    dispatch.payload["event_timestamp_ms"] = serde_json::json!(2);
+    store.save_capture_dispatch(&dispatch).await.unwrap();
+    assert_eq!(
+        store
+            .list_capture_dispatches(CaptureProviderKind::ZoomRtms)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|candidate| candidate.job_id == job_id),
+        Some(dispatch.clone())
+    );
+    let mut conflicting = dispatch.clone();
+    conflicting.dispatch_id.push_str("-other");
+    assert!(matches!(
+        store.save_capture_dispatch(&conflicting).await,
+        Err(StoreError::CaptureDispatchConflict)
+    ));
+    assert!(matches!(
+        store
+            .find_dispatchable_capture_checkpoint(
+                "another-workspace",
+                CaptureProviderKind::ZoomRtms,
+                &[checkpoint.job.meeting.external_id.clone().unwrap()],
+            )
+            .await,
+        Err(StoreError::NotFound)
+    ));
+    let lease = store
+        .claim_capture_job(
+            &workspace_id,
+            &job_id,
+            "worker-a",
+            "lease-a",
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+    let lease_identity = anarlog_enterprise_control_plane::capture::CaptureJobLeaseIdentity {
+        worker_id: lease.worker_id,
+        lease_id: lease.lease_id,
+        epoch: lease.epoch,
+    };
+    store
+        .append_capture_event(
+            &workspace_id,
+            &job_id,
+            &lease_identity,
+            &CaptureEvent {
+                id: format!("event-transcript-{suffix}"),
+                bot_id: checkpoint.job.bot_id.clone(),
+                sequence: 0,
+                occurred_at: chrono::Utc::now(),
+                payload: CaptureEventPayload::Transcript(TranscriptSegment {
+                    id: format!("segment-{suffix}"),
+                    sequence: 41,
+                    start_ms: 0,
+                    end_ms: Some(1),
+                    text: "before reconnect".into(),
+                    speaker: None,
+                    is_final: true,
+                }),
+                metadata: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .next_capture_transcript_sequence(&workspace_id, &job_id)
+            .await
+            .unwrap(),
+        42
+    );
+    store
+        .append_capture_event(
+            &workspace_id,
+            &job_id,
+            &lease_identity,
+            &lifecycle(
+                &checkpoint.job.bot_id,
+                1,
+                BotState::Queued,
+                BotState::Failed,
+                Some(TerminalReason {
+                    kind: TerminalReasonKind::ProviderError,
+                    message: None,
+                    retryable: true,
+                }),
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(
+        store
+            .list_capture_dispatches(CaptureProviderKind::ZoomRtms)
+            .await
+            .unwrap()
+            .into_iter()
+            .all(|candidate| candidate.job_id != job_id)
+    );
 }
 
 #[tokio::test]

--- a/enterprise/zoom-rtms-worker/Cargo.toml
+++ b/enterprise/zoom-rtms-worker/Cargo.toml
@@ -15,4 +15,4 @@ sha2 = "0.10"
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "rt", "sync", "time"] }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
-url.workspace = true
+url = { workspace = true, features = ["serde"] }

--- a/enterprise/zoom-rtms-worker/src/protocol.rs
+++ b/enterprise/zoom-rtms-worker/src/protocol.rs
@@ -20,6 +20,7 @@ pub const RTMS_PROTOCOL_VERSION: u8 = 1;
 
 type HmacSha256 = Hmac<Sha256>;
 
+#[derive(Clone)]
 pub struct ZoomRtmsCredentials {
     client_id: String,
     client_secret: String,
@@ -81,17 +82,26 @@ pub enum ZoomRtmsConfigError {
 pub enum ZoomRtmsWebhookEvent {
     UrlValidation { plain_token: String },
     Started(ZoomRtmsStarted),
-    Stopped { meeting_uuid: String },
-    Interrupted { meeting_uuid: String },
+    Stopped(ZoomRtmsTerminal),
+    Interrupted(ZoomRtmsTerminal),
     Other { event: String },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ZoomRtmsStarted {
+    pub account_id: String,
     pub meeting_uuid: String,
     pub meeting_id: String,
     pub stream_id: String,
     pub signaling_url: Url,
+    pub event_timestamp_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZoomRtmsTerminal {
+    pub meeting_uuid: String,
+    pub stream_id: String,
     pub event_timestamp_ms: u64,
 }
 
@@ -109,11 +119,13 @@ impl ZoomRtmsWebhookEvent {
             "meeting.rtms_started" => {
                 let payload: StartedPayload = serde_json::from_value(webhook.payload)?;
                 let meeting_id = payload.meeting_id.into_string();
+                validate_token(&payload.account_id, "account ID")?;
                 validate_token(&payload.meeting_uuid, "meeting UUID")?;
                 validate_token(&meeting_id, "meeting ID")?;
                 validate_token(&payload.rtms_stream_id, "RTMS stream ID")?;
                 let signaling_url = validate_websocket_url(&payload.server_urls)?;
                 Ok(Self::Started(ZoomRtmsStarted {
+                    account_id: payload.account_id,
                     meeting_uuid: payload.meeting_uuid,
                     meeting_id,
                     stream_id: payload.rtms_stream_id,
@@ -124,14 +136,16 @@ impl ZoomRtmsWebhookEvent {
             "meeting.rtms_stopped" | "meeting.rtms_interrupted" => {
                 let payload: TerminalPayload = serde_json::from_value(webhook.payload)?;
                 validate_token(&payload.meeting_uuid, "meeting UUID")?;
+                validate_token(&payload.rtms_stream_id, "RTMS stream ID")?;
+                let terminal = ZoomRtmsTerminal {
+                    meeting_uuid: payload.meeting_uuid,
+                    stream_id: payload.rtms_stream_id,
+                    event_timestamp_ms: webhook.event_ts,
+                };
                 if webhook.event == "meeting.rtms_stopped" {
-                    Ok(Self::Stopped {
-                        meeting_uuid: payload.meeting_uuid,
-                    })
+                    Ok(Self::Stopped(terminal))
                 } else {
-                    Ok(Self::Interrupted {
-                        meeting_uuid: payload.meeting_uuid,
-                    })
+                    Ok(Self::Interrupted(terminal))
                 }
             }
             _ => Ok(Self::Other {
@@ -150,6 +164,7 @@ struct WebhookEnvelope {
 
 #[derive(Deserialize)]
 struct StartedPayload {
+    account_id: String,
     meeting_uuid: String,
     meeting_id: StringOrU64,
     rtms_stream_id: String,
@@ -181,8 +196,10 @@ impl StringOrU64 {
 #[derive(Deserialize)]
 struct TerminalPayload {
     meeting_uuid: String,
+    rtms_stream_id: String,
 }
 
+#[derive(Clone)]
 pub struct ZoomWebhookVerifier {
     secret: String,
     max_age: Duration,
@@ -591,6 +608,7 @@ mod tests {
             "event": "meeting.rtms_started",
             "event_ts": 1_727_384_100_000_u64,
             "payload": {
+                "account_id": "account-id",
                 "meeting_uuid": "meeting-uuid",
                 "meeting_id": meeting_id,
                 "rtms_stream_id": "stream-id",
@@ -690,6 +708,7 @@ mod tests {
             panic!("expected started event")
         };
         assert_eq!(started.meeting_id, "123456789");
+        assert_eq!(started.account_id, "account-id");
         let credentials = ZoomRtmsCredentials::new("client-id", "client-secret").unwrap();
         let signaling =
             serde_json::to_value(SignalingHandshake::new(&started, &credentials)).unwrap();

--- a/enterprise/zoom-rtms-worker/src/session.rs
+++ b/enterprise/zoom-rtms-worker/src/session.rs
@@ -22,6 +22,7 @@ type ZoomWebSocket = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 pub struct ZoomRtmsSessionConfig {
     pub handshake_timeout: Duration,
     pub max_message_bytes: usize,
+    pub initial_segment_sequence: u64,
 }
 
 impl Default for ZoomRtmsSessionConfig {
@@ -29,6 +30,7 @@ impl Default for ZoomRtmsSessionConfig {
         Self {
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
             max_message_bytes: DEFAULT_MAX_MESSAGE_BYTES,
+            initial_segment_sequence: 0,
         }
     }
 }
@@ -120,7 +122,7 @@ impl ZoomRtmsSession {
             media,
             started,
             max_message_bytes: config.max_message_bytes,
-            next_segment_sequence: 0,
+            next_segment_sequence: config.initial_segment_sequence,
         })
     }
 
@@ -148,17 +150,17 @@ impl ZoomRtmsSession {
                             self.next_segment_sequence = self.next_segment_sequence
                                 .checked_add(1)
                                 .ok_or(ZoomRtmsSessionError::SequenceExhausted)?;
-                            transcripts
-                                .send(transcript.into_segment(self.started.event_timestamp_ms, sequence))
-                                .await
-                                .map_err(|_| ZoomRtmsSessionError::TranscriptReceiverClosed)?;
+                            enqueue_transcript(
+                                &transcripts,
+                                transcript.into_segment(self.started.event_timestamp_ms, sequence),
+                            )?;
                         }
                         MediaMessage::HandshakeAccepted | MediaMessage::Other { .. } => {}
                     }
                 }
                 changed = shutdown.changed() => {
                     if changed.is_err() || *shutdown.borrow() {
-                        self.close().await;
+                        self.shutdown().await;
                         return Ok(ZoomRtmsSessionOutcome::StoppedByRequest);
                     }
                 }
@@ -166,10 +168,22 @@ impl ZoomRtmsSession {
         }
     }
 
-    async fn close(&mut self) {
+    pub async fn shutdown(&mut self) {
         let _ = self.media.close(None).await;
         let _ = self.signaling.close(None).await;
     }
+}
+
+fn enqueue_transcript(
+    transcripts: &mpsc::Sender<TranscriptSegment>,
+    transcript: TranscriptSegment,
+) -> Result<(), ZoomRtmsSessionError> {
+    transcripts
+        .try_send(transcript)
+        .map_err(|error| match error {
+            mpsc::error::TrySendError::Full(_) => ZoomRtmsSessionError::TranscriptBackpressure,
+            mpsc::error::TrySendError::Closed(_) => ZoomRtmsSessionError::TranscriptReceiverClosed,
+        })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -233,6 +247,8 @@ pub enum ZoomRtmsSessionError {
     UnexpectedBinaryMessage,
     #[error("Zoom RTMS transcript receiver closed")]
     TranscriptReceiverClosed,
+    #[error("Zoom RTMS transcript persistence exceeded its bounded buffer")]
+    TranscriptBackpressure,
     #[error("Zoom RTMS transcript sequence was exhausted")]
     SequenceExhausted,
 }
@@ -240,6 +256,18 @@ pub enum ZoomRtmsSessionError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn transcript(sequence: u64) -> TranscriptSegment {
+        TranscriptSegment {
+            id: format!("segment-{sequence}"),
+            sequence,
+            start_ms: 0,
+            end_ms: Some(1),
+            text: "hello".into(),
+            speaker: None,
+            is_final: true,
+        }
+    }
 
     #[test]
     fn validates_session_limits() {
@@ -259,6 +287,17 @@ mod tests {
             }
             .validate(),
             Err(ZoomRtmsSessionConfigError::InvalidMaxMessageBytes)
+        ));
+    }
+
+    #[test]
+    fn fails_fast_when_transcript_persistence_falls_behind() {
+        let (transcripts, _receiver) = mpsc::channel(1);
+        enqueue_transcript(&transcripts, transcript(0)).unwrap();
+
+        assert!(matches!(
+            enqueue_transcript(&transcripts, transcript(1)),
+            Err(ZoomRtmsSessionError::TranscriptBackpressure)
         ));
     }
 }


### PR DESCRIPTION
## Summary
- keep Zoom RTMS configuration optional as a complete group
- mount a raw-body verified webhook only when configured
- map signed Zoom accounts to workspaces and dispatch fenced capture jobs
- persist normalized lifecycle and transcript events through the control plane
- add Axum, worker-handoff, and Postgres lookup coverage

## Validation
- cargo test --workspace with OrbStack Postgres
- cargo clippy --workspace --all-targets -- -D warnings
- affected dprint check
- license boundary checks

## Live QA
- real Zoom RTMS smoke remains blocked on Marketplace credentials and a disposable meeting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new path spanning webhook verification, Postgres dispatch state, background workers, and capture leases; misconfiguration or dispatch bugs could start wrong jobs or drop transcripts.
> 
> **Overview**
> Adds **optional Zoom RTMS** to the enterprise control plane: when all four Zoom env vars are set, startup wires a signed **`POST /webhooks/zoom`** handler and maps Zoom account IDs to workspaces; otherwise the route stays unmounted.
> 
> Verified webhooks drive **`ZoomCaptureDispatcher`**, which matches queued **`ZoomRtms`** jobs by meeting external ID, **persists durable dispatches** on `capture_jobs` (new migration), claims a fenced lease, and runs an in-process RTMS worker that streams transcripts and lifecycle events through the existing capture append path. Startup **recovers** pending dispatches; stop/interrupt/reconnect and early-stop races are handled in the new `zoom` module.
> 
> The **`zoom-rtms-worker`** crate gains richer webhook parsing (`account_id`, terminal events keyed by stream ID), configurable transcript sequence offsets, and bounded transcript delivery with explicit backpressure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11bbf5ce5d8ebc77839a58dc850a5bba0042d766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->