### PR TITLE
docs(changelog): add desktop 1.4.10 release notes

### DIFF
--- a/packages/changelog/content/1.4.10.md
+++ b/packages/changelog/content/1.4.10.md
@@ -1,0 +1,82 @@
+---
+date: "2026-08-18"
+summary: "Anarlog 1.4.10 adds summary length control, voice input and meeting prep in chat, a Windows application toolbar, Microsoft sign-in, and major idle CPU and memory reductions, plus signed APT installs on Linux."
+---
+
+## Summaries and chat
+
+- Choose how detailed AI summaries should be with the new **Crisp**,
+  **Balanced**, and **Detailed** modes in Settings → Meetings
+- Dictate into chat with the new microphone control: short recordings are
+  transcribed and inserted into your draft
+- Ask chat to prepare agendas and talking points before a meeting; proposals
+  go into the meeting memo with the same diff review as summary edits
+- Approve or decline a proposed summary edit directly on the chat message that
+  suggested it, keep the progress indicator visible while chat runs tools, and
+  scroll long context chip rows instead of losing them
+
+## Performance
+
+- Use far less CPU and memory while idle: background work now wakes only when
+  something is actually due instead of running on constant timers
+- Start faster and stay lighter during meetings, with app code loaded on
+  demand, much smaller encrypted transcript storage, and long transcripts
+  rendered only as you scroll
+
+## Windows
+
+- Work from a new application toolbar with File, Edit, View, and Help menus,
+  the sidebar toggle, and minimize, maximize, and close controls built into
+  the title bar
+
+## macOS
+
+- Follow system light and dark appearance changes natively, while an explicit
+  Light or Dark choice stays pinned regardless of the OS theme
+- Pick from five new artwork Dock icons — Field Journal, Notepad, Stone,
+  Typewriter Key, and Walnut — in Appearance → App icon
+- Recover automatically when the app window reopens unresponsive instead of
+  staying stuck on a frozen page
+- Repair cloud sync Keychain access from a guided prompt when macOS blocks the
+  recovery key, then resume syncing right away
+
+## Sign-in, accounts, and billing
+
+- Sign in with Microsoft alongside Google and GitHub
+- Change your account email from Settings → Account
+- Connect calendars with your signed-in desktop account so a different browser
+  login can no longer trigger a false upgrade prompt, and see specific
+  guidance when a connection fails from a blocked pop-up, connection limit, or
+  provider rejection
+- Retry billing verification when it fails instead of seeing a wrong paywall,
+  and stop getting duplicate "open app" prompts after signing in from the
+  browser
+
+## Meetings and recording
+
+- Keep manual speaker corrections applied during live transcription instead
+  of them disappearing until the recording is saved
+- Keep the sync indicator out of the way during meetings while sync
+  intentionally waits for the recording to finish
+- Keep contact suggestions from calendar events fully on-device, with no
+  model calls involved
+
+## Linux
+
+- Install and update Anarlog through the new signed APT repository on amd64
+  and arm64
+
+## Other improvements
+
+- Sign in to the Anarlog CLI without opening the desktop app using
+  `anarlog auth login`
+- Quit safely from the tray: **Hide** closes the window while **Quit
+  Completely…** asks for confirmation before stopping background work
+- Control Dock and taskbar attention with a single **Bounce app icon** setting
+- Skip the meeting import step automatically during onboarding when no meeting
+  assistants are installed, and see the welcome demo prompt without clipping
+- Team workspaces now require Anarlog Pro to create or manage; existing
+  workspaces stay reachable and you can still join, leave, or delete them
+- Enjoy tidier Team and Developers settings, tighter header icons, a visible
+  template picker chevron in narrow windows, and a shared-note chat launcher
+  that matches the in-app design


### PR DESCRIPTION
Cover desktop user-facing changes since desktop_v1.4.9: summary length
modes, chat voice input and memo prep, Windows application toolbar,
Microsoft sign-in, idle CPU/memory reductions, macOS appearance and
Keychain repair fixes, and the signed Linux APT repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or application code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.10.md`**, the user-facing release notes for desktop **1.4.10** (dated 2026-08-18), following the same front matter and section layout as prior entries like `1.4.9.md`.
> 
> The new post documents shipped changes since **1.4.9**: summary length modes, chat voice input and meeting prep, Windows title-bar toolbar, Microsoft sign-in, idle performance work, macOS appearance/icons/Keychain recovery, meeting/recording fixes, signed Linux APT, CLI auth, tray quit behavior, team Pro gating, and assorted UI polish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3f2639cc320b356a8d3e5f6e6ddbd4b1143ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->