### PR TITLE
feat(desktop): drop initial cloud sync toast for corner indicator

### DIFF
--- a/apps/desktop/src/auth/cloudsync-progress.test.ts
+++ b/apps/desktop/src/auth/cloudsync-progress.test.ts
@@ -1,4 +1,3 @@
-import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -19,7 +18,6 @@ vi.mock("@anlg/plugin-notification", () => ({
 import {
   startCloudsyncInitialSyncProgress,
   stopCloudsyncInitialSyncProgress,
-  useCloudsyncInitialSyncProgress,
 } from "./cloudsync-progress";
 
 function cloudsyncStatus(lastSyncAtMs: number | null) {
@@ -59,28 +57,22 @@ describe("CloudSync initial sync progress", () => {
 
   afterEach(() => {
     stopCloudsyncInitialSyncProgress();
-    cleanup();
     vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
-  it("shows progress and sends a notification when initial sync completes", async () => {
+  it("sends a notification when initial sync completes", async () => {
     mocks.getCloudsyncStatus
       .mockResolvedValueOnce(cloudsyncStatus(null))
       .mockResolvedValueOnce(cloudsyncStatus(123));
-    const progress = renderHook(() => useCloudsyncInitialSyncProgress());
 
-    act(() => startCloudsyncInitialSyncProgress("user-1"));
+    startCloudsyncInitialSyncProgress("user-1");
 
-    expect(progress.result.current).toEqual({
-      state: "syncing",
-      toastId: "cloudsync-initial-sync-user-1",
-      userId: "user-1",
-    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mocks.showNotification).not.toHaveBeenCalled();
 
-    await act(() => vi.advanceTimersByTimeAsync(2_000));
+    await vi.advanceTimersByTimeAsync(2_000);
 
-    expect(progress.result.current).toEqual({ state: "idle" });
     expect(
       localStorage.getItem("anarlog:cloudsync_initial_sync_completed:user-1"),
     ).toBe("1");
@@ -93,16 +85,15 @@ describe("CloudSync initial sync progress", () => {
     );
   });
 
-  it("does not restart progress after completion was persisted", () => {
+  it("does not restart monitoring after completion was persisted", () => {
     localStorage.setItem(
       "anarlog:cloudsync_initial_sync_completed:user-1",
       "1",
     );
-    const progress = renderHook(() => useCloudsyncInitialSyncProgress());
 
-    act(() => startCloudsyncInitialSyncProgress("user-1"));
+    startCloudsyncInitialSyncProgress("user-1");
 
-    expect(progress.result.current).toEqual({ state: "idle" });
     expect(mocks.getCloudsyncStatus).not.toHaveBeenCalled();
+    expect(mocks.showNotification).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/auth/cloudsync-progress.ts
+++ b/apps/desktop/src/auth/cloudsync-progress.ts
@@ -1,18 +1,11 @@
-import { useSyncExternalStore } from "react";
-
 import { getCloudsyncStatus } from "@anlg/plugin-db";
 import { commands as notificationCommands } from "@anlg/plugin-notification";
 
 const POLL_INTERVAL_MS = 2_000;
 const COMPLETED_KEY_PREFIX = "anarlog:cloudsync_initial_sync_completed:";
 
-type CloudsyncInitialSyncProgress =
-  | { state: "idle" }
-  | { state: "syncing"; toastId: string; userId: string };
-
 let monitorGeneration = 0;
-let snapshot: CloudsyncInitialSyncProgress = { state: "idle" };
-const listeners = new Set<() => void>();
+let monitoredUserId: string | null = null;
 
 function completionKey(userId: string) {
   return `${COMPLETED_KEY_PREFIX}${userId}`;
@@ -32,16 +25,6 @@ function markCompleted(userId: string) {
   } catch {
     // The completion notification may repeat after restart if storage is unavailable.
   }
-}
-
-function setSnapshot(next: CloudsyncInitialSyncProgress) {
-  snapshot = next;
-  listeners.forEach((listener) => listener());
-}
-
-function subscribe(listener: () => void) {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
 }
 
 function sleep(ms: number) {
@@ -87,7 +70,7 @@ async function monitorInitialSync(userId: string, activeGeneration: number) {
 
       if (status.last_sync_at_ms !== null) {
         markCompleted(userId);
-        setSnapshot({ state: "idle" });
+        monitoredUserId = null;
         await showCompletionNotification(userId);
         return;
       }
@@ -97,7 +80,7 @@ async function monitorInitialSync(userId: string, activeGeneration: number) {
         !status.running &&
         status.last_error_kind !== null
       ) {
-        setSnapshot({ state: "idle" });
+        monitoredUserId = null;
         return;
       }
     } catch {
@@ -113,30 +96,16 @@ export function startCloudsyncInitialSyncProgress(userId: string) {
     return;
   }
 
-  if (snapshot.state === "syncing" && snapshot.userId === userId) {
+  if (monitoredUserId === userId) {
     return;
   }
 
   const activeGeneration = ++monitorGeneration;
-  setSnapshot({
-    state: "syncing",
-    toastId: `cloudsync-initial-sync-${userId}`,
-    userId,
-  });
+  monitoredUserId = userId;
   void monitorInitialSync(userId, activeGeneration);
 }
 
 export function stopCloudsyncInitialSyncProgress() {
   monitorGeneration += 1;
-  if (snapshot.state !== "idle") {
-    setSnapshot({ state: "idle" });
-  }
-}
-
-export function useCloudsyncInitialSyncProgress() {
-  return useSyncExternalStore(
-    subscribe,
-    () => snapshot,
-    () => snapshot,
-  );
+  monitoredUserId = null;
 }

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -11,7 +11,6 @@ import type { ToastType } from "./types";
 import { useDismissedToasts } from "./useDismissedToasts";
 
 import { useAuth } from "~/auth";
-import { useCloudsyncInitialSyncProgress } from "~/auth/cloudsync-progress";
 import { useNotifications } from "~/contexts/notifications";
 import { useDesktopUpdateControl } from "~/main/update-banner";
 import { useConfigValues } from "~/shared/config";
@@ -28,7 +27,6 @@ import { useListener } from "~/stt/contexts";
 
 export function ToastNotifications() {
   const auth = useAuth();
-  const cloudsyncProgress = useCloudsyncInitialSyncProgress();
   const { dismissToast, isDismissed } = useDismissedToasts();
   const [sessionDismissedToastIds, setSessionDismissedToastIds] = useState(
     () => new Set<string>(),
@@ -149,10 +147,6 @@ export function ToastNotifications() {
         isAiIntelligenceTabActive,
         isBatchTranscribingInActiveTranscriptTab,
         isLiveMeetingActive,
-        cloudsyncInitialSyncToastId:
-          cloudsyncProgress.state === "syncing"
-            ? cloudsyncProgress.toastId
-            : null,
         hasActiveDownload,
         downloadingModel,
         activeDownloads,
@@ -174,7 +168,6 @@ export function ToastNotifications() {
       isAiIntelligenceTabActive,
       isBatchTranscribingInActiveTranscriptTab,
       isLiveMeetingActive,
-      cloudsyncProgress,
       hasActiveDownload,
       downloadingModel,
       activeDownloads,

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -17,7 +17,6 @@ const baseParams = {
   isAiIntelligenceTabActive: false,
   isBatchTranscribingInActiveTranscriptTab: false,
   isLiveMeetingActive: false,
-  cloudsyncInitialSyncToastId: null,
   hasActiveDownload: false,
   downloadingModel: null,
   activeDownloads: [],
@@ -161,21 +160,6 @@ describe("sidebar toast registry", () => {
 
     expect(toast?.id).toBe("local-stt-loading");
     expect(toast?.description).toBe("Starting transcription...");
-  });
-
-  it("keeps initial cloud sync condition-bound", () => {
-    const toast = getToastToShow(
-      createToastRegistry({
-        ...baseParams,
-        cloudsyncInitialSyncToastId: "cloudsync-initial-sync-user-1",
-      }),
-      () => false,
-    );
-
-    expect(toast?.id).toBe("cloudsync-initial-sync-user-1");
-    expect(toast?.description).toBe("Syncing your data in the background...");
-    expect(toast?.lifecycle).toEqual({ type: "condition-bound" });
-    expect(toast?.loading).toBe(true);
   });
 
   it("renders the pro upgrade toast without an icon", () => {

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -24,7 +24,6 @@ type ToastRegistryParams = {
   isAiIntelligenceTabActive: boolean;
   isBatchTranscribingInActiveTranscriptTab: boolean;
   isLiveMeetingActive: boolean;
-  cloudsyncInitialSyncToastId: string | null;
   hasActiveDownload: boolean;
   downloadingModel: string | null;
   activeDownloads: DownloadProgress[];
@@ -54,7 +53,6 @@ export function createToastRegistry({
   isAiIntelligenceTabActive,
   isBatchTranscribingInActiveTranscriptTab,
   isLiveMeetingActive,
-  cloudsyncInitialSyncToastId,
   hasActiveDownload,
   downloadingModel,
   activeDownloads,
@@ -87,15 +85,6 @@ export function createToastRegistry({
         loading: true,
       },
       condition: () => hasActiveDownload,
-    },
-    {
-      toast: {
-        id: cloudsyncInitialSyncToastId ?? "cloudsync-initial-sync",
-        description: "Syncing your data in the background...",
-        lifecycle: { type: "condition-bound" },
-        loading: true,
-      },
-      condition: () => cloudsyncInitialSyncToastId !== null,
     },
     ...(updateToast
       ? [


### PR DESCRIPTION
The sidebar sync-status indicator already shows sync activity, so the "Syncing your data in the background..." toast duplicated it as redundant noise during initial CloudSync.

Notable changes:
- Remove the cloudsync-initial-sync entry and its toastId param from the sidebar toast registry.
- Stop subscribing to initial-sync progress in the toast host component.
- Slim cloudsync-progress down to the poll loop that fires the "Cloud sync complete" native notification, dropping the now-unused React external store and toastId plumbing; its test moves from .tsx to .ts.

Verified with dprint, desktop typecheck, the full desktop test suite, and oxlint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only change in desktop toasts and internal progress state; completion notification and localStorage completion flags are unchanged.
> 
> **Overview**
> Removes the **"Syncing your data in the background..."** sidebar toast during initial CloudSync, since sync activity is already shown elsewhere (e.g. the sidebar sync indicator).
> 
> The toast registry no longer takes `cloudsyncInitialSyncToastId` or registers that condition-bound loading toast; `ToastNotifications` stops wiring in cloudsync progress for UI.
> 
> **`cloudsync-progress`** is trimmed to background polling plus the **"Cloud sync complete"** native notification: the React `useSyncExternalStore` hook, syncing snapshot, and toast IDs are gone in favor of a simple `monitoredUserId` guard. Tests drop React Testing Library and assert notification/localStorage behavior only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524f466a72a82278a17e2025b646261660d06547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->