### PR TITLE
feat(web): polish account page

### DIFF
--- a/apps/web/src/functions/account-shares.ts
+++ b/apps/web/src/functions/account-shares.ts
@@ -100,6 +100,20 @@ export const listMyManagedShares = createServerFn({ method: "GET" }).handler(
   },
 );
 
+export const deleteMyShare = createServerFn({ method: "POST" })
+  .inputValidator(z.object({ shareId: z.string().uuid() }))
+  .handler(async ({ data }) => {
+    const supabase = getSupabaseServerClient();
+    const { error } = await supabase.rpc("delete_session_share", {
+      p_share_id: data.shareId,
+    });
+
+    if (error) {
+      return { success: false as const, message: error.message };
+    }
+    return { success: true as const };
+  });
+
 export const restrictMyShare = createServerFn({ method: "POST" })
   .inputValidator(z.object({ shareId: z.string().uuid() }))
   .handler(async ({ data }) => {

--- a/apps/web/src/routes/_view/app/-account-api-keys.tsx
+++ b/apps/web/src/routes/_view/app/-account-api-keys.tsx
@@ -1,12 +1,19 @@
+import { Check, Copy } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 
-import { listKeys, revokeKey } from "@anlg/api-client";
+import { createKey, listKeys, revokeKey } from "@anlg/api-client";
+import type { CreatedApiKey } from "@anlg/api-client";
+
+import { authInputClassName } from "@/components/auth-shell";
 
 import { getAuthorizedApiClient } from "./-account-api";
 import { useAccountSession } from "./-account-session";
 import {
   accountCardClassName,
   accountPillDangerClassName,
+  accountPillPrimaryClassName,
+  accountPillSecondaryClassName,
 } from "./-account-ui";
 
 const apiKeysQueryKey = ["account-api-keys"];
@@ -14,6 +21,10 @@ const apiKeysQueryKey = ["account-api-keys"];
 export function ApiKeysSection() {
   const queryClient = useQueryClient();
   const session = useAccountSession();
+  const [isCreating, setIsCreating] = useState(false);
+  const [newKeyName, setNewKeyName] = useState("");
+  const [createdKey, setCreatedKey] = useState<CreatedApiKey | null>(null);
+  const [copiedKey, setCopiedKey] = useState(false);
 
   const keysQuery = useQuery({
     queryKey: apiKeysQueryKey,
@@ -30,6 +41,40 @@ export function ApiKeysSection() {
     },
   });
 
+  const create = useMutation({
+    mutationFn: async (name: string) => {
+      const client = await getAuthorizedApiClient();
+      const { data, error } = await createKey({ client, body: { name } });
+      if (error || !data) {
+        throw new Error("Failed to create API key");
+      }
+      return data;
+    },
+    onSuccess: (data) => {
+      setCreatedKey(data);
+      setIsCreating(false);
+      setNewKeyName("");
+      queryClient.invalidateQueries({ queryKey: apiKeysQueryKey });
+    },
+  });
+
+  const handleCreateSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = newKeyName.trim();
+    if (name) {
+      create.mutate(name);
+    }
+  };
+
+  const handleCopyKey = async () => {
+    if (!createdKey) {
+      return;
+    }
+    await navigator.clipboard.writeText(createdKey.key);
+    setCopiedKey(true);
+    setTimeout(() => setCopiedKey(false), 2_000);
+  };
+
   const revoke = useMutation({
     mutationFn: async (keyId: string) => {
       const client = await getAuthorizedApiClient();
@@ -44,9 +89,102 @@ export function ApiKeysSection() {
   });
 
   const keys = keysQuery.data ?? [];
+  const isPro = session.data?.billing.isPro === true;
+  const showCreateControls =
+    isPro && !keysQuery.isPending && !session.isPending && !keysQuery.isError;
 
   return (
     <div className={accountCardClassName}>
+      {showCreateControls && (
+        <div className="border-b border-[#ede7dc] px-6 py-4 sm:px-8">
+          {isCreating ? (
+            <form
+              onSubmit={handleCreateSubmit}
+              className="flex flex-col gap-3 md:flex-row md:items-center"
+            >
+              <input
+                type="text"
+                value={newKeyName}
+                onChange={(e) => setNewKeyName(e.target.value)}
+                placeholder="Key name, e.g. my-script"
+                maxLength={100}
+                className={authInputClassName}
+                autoFocus
+              />
+              <div className="flex shrink-0 gap-2">
+                <button
+                  type="submit"
+                  disabled={create.isPending || !newKeyName.trim()}
+                  className={accountPillPrimaryClassName}
+                >
+                  {create.isPending ? "Creating..." : "Create"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsCreating(false);
+                    setNewKeyName("");
+                    create.reset();
+                  }}
+                  disabled={create.isPending}
+                  className={accountPillSecondaryClassName}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          ) : (
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-sm leading-6 text-[#756b5d]">
+                Keys let your own tools call the Anarlog Cloud API.
+              </p>
+              <button
+                onClick={() => {
+                  setCreatedKey(null);
+                  setIsCreating(true);
+                }}
+                className={accountPillSecondaryClassName}
+              >
+                Create key
+              </button>
+            </div>
+          )}
+          {create.isError && (
+            <p className="mt-3 text-sm text-red-600">
+              {create.error?.message || "Failed to create API key"}
+            </p>
+          )}
+        </div>
+      )}
+      {createdKey && (
+        <div className="border-b border-[#ede7dc] bg-[#fffaf0] px-6 py-4 sm:px-8">
+          <p className="text-sm font-medium text-[#181613]">
+            {createdKey.name} is ready. Copy the key now; it won't be shown
+            again.
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <code className="max-w-full overflow-x-auto rounded-lg border border-[#ede7dc] bg-white px-3 py-2 font-mono text-sm text-[#181613]">
+              {createdKey.key}
+            </code>
+            <button
+              onClick={handleCopyKey}
+              className={accountPillSecondaryClassName}
+            >
+              {copiedKey ? (
+                <>
+                  <Check className="mr-2 size-4" />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="mr-2 size-4" />
+                  Copy key
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
       {keysQuery.isPending || session.isPending ? (
         <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
           Checking your API keys...
@@ -59,9 +197,9 @@ export function ApiKeysSection() {
         <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
           {/* Listing keys is not plan-gated, so an empty list is the only
               signal a free user gets; creating one is Pro-only. */}
-          {session.data?.billing.isPro
-            ? "No API keys yet. Create one from the desktop app to use the Cloud API."
-            : "Cloud API keys come with Pro. Create and use them from the desktop app."}
+          {isPro
+            ? "No API keys yet. Create one to use the Cloud API."
+            : "Cloud API keys come with Pro."}
         </p>
       ) : (
         <ul className="divide-y divide-[#ede7dc]">

--- a/apps/web/src/routes/_view/app/-account-api-keys.tsx
+++ b/apps/web/src/routes/_view/app/-account-api-keys.tsx
@@ -52,6 +52,7 @@ export function ApiKeysSection() {
     },
     onSuccess: (data) => {
       setCreatedKey(data);
+      setCopiedKey(false);
       setIsCreating(false);
       setNewKeyName("");
       queryClient.invalidateQueries({ queryKey: apiKeysQueryKey });
@@ -141,6 +142,7 @@ export function ApiKeysSection() {
               <button
                 onClick={() => {
                   setCreatedKey(null);
+                  setCopiedKey(false);
                   setIsCreating(true);
                 }}
                 className={accountPillSecondaryClassName}

--- a/apps/web/src/routes/_view/app/-account-danger.tsx
+++ b/apps/web/src/routes/_view/app/-account-danger.tsx
@@ -2,12 +2,6 @@ import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@anlg/ui/components/ui/accordion";
 import { cn } from "@anlg/utils";
 
 import { deleteAccount } from "@/functions/billing";
@@ -36,76 +30,59 @@ export function DangerAreaSection() {
 
   return (
     <div className={accountCardClassName}>
-      <div className="px-6 py-2 sm:px-8">
-        <Accordion
-          type="single"
-          collapsible
-          onValueChange={(value) => {
-            if (!value) {
-              setShowDeleteConfirm(false);
-              deleteAccountMutation.reset();
-            }
-          }}
-        >
-          <AccordionItem value="delete-account" className="border-none">
-            <AccordionTrigger className="py-4 font-sans text-base font-medium text-red-700 hover:text-red-800 hover:no-underline">
-              Delete account
-            </AccordionTrigger>
-            <AccordionContent className="pb-6">
-              <div className="rounded-xl border border-red-200 bg-red-50 p-4">
-                <p className="text-sm leading-6 text-red-900">
-                  Anarlog is a local-first app. Your notes, transcripts, and
-                  meeting data stay on your device. Deleting your account only
-                  removes cloud-stored data.
+      <div className="p-6 sm:p-8">
+        <p className="text-base font-medium text-[#181613]">Delete account</p>
+        <div className="mt-4 rounded-xl border border-red-200 bg-red-50 p-4">
+          <p className="text-sm leading-6 text-red-900">
+            Anarlog is a local-first app. Your notes, transcripts, and meeting
+            data stay on your device. Deleting your account only removes
+            cloud-stored data.
+          </p>
+
+          {showDeleteConfirm ? (
+            <div className="mt-4 space-y-3">
+              <p className="text-sm text-red-800">
+                This permanently deletes your account and cloud data.
+              </p>
+
+              {deleteAccountMutation.isError && (
+                <p className="text-sm text-red-600">
+                  {deleteAccountMutation.error?.message ||
+                    "Failed to delete account"}
                 </p>
+              )}
 
-                {showDeleteConfirm ? (
-                  <div className="mt-4 space-y-3">
-                    <p className="text-sm text-red-800">
-                      This permanently deletes your account and cloud data.
-                    </p>
-
-                    {deleteAccountMutation.isError && (
-                      <p className="text-sm text-red-600">
-                        {deleteAccountMutation.error?.message ||
-                          "Failed to delete account"}
-                      </p>
-                    )}
-
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        onClick={() => deleteAccountMutation.mutate()}
-                        disabled={deleteAccountMutation.isPending}
-                        className="flex h-9 cursor-pointer items-center justify-center rounded-full bg-red-700 px-4 text-sm font-medium text-white transition-colors hover:bg-red-800 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {deleteAccountMutation.isPending
-                          ? "Deleting..."
-                          : "Yes, delete my account"}
-                      </button>
-                      <button
-                        onClick={() => {
-                          setShowDeleteConfirm(false);
-                          deleteAccountMutation.reset();
-                        }}
-                        disabled={deleteAccountMutation.isPending}
-                        className={accountPillDangerClassName}
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  <button
-                    onClick={() => setShowDeleteConfirm(true)}
-                    className={cn([accountPillDangerClassName, "mt-4"])}
-                  >
-                    Continue
-                  </button>
-                )}
+              <div className="flex flex-wrap gap-2">
+                <button
+                  onClick={() => deleteAccountMutation.mutate()}
+                  disabled={deleteAccountMutation.isPending}
+                  className="flex h-9 cursor-pointer items-center justify-center rounded-full bg-red-700 px-4 text-sm font-medium text-white transition-colors hover:bg-red-800 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {deleteAccountMutation.isPending
+                    ? "Deleting..."
+                    : "Yes, delete my account"}
+                </button>
+                <button
+                  onClick={() => {
+                    setShowDeleteConfirm(false);
+                    deleteAccountMutation.reset();
+                  }}
+                  disabled={deleteAccountMutation.isPending}
+                  className={accountPillDangerClassName}
+                >
+                  Cancel
+                </button>
               </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowDeleteConfirm(true)}
+              className={cn([accountPillDangerClassName, "mt-4"])}
+            >
+              Continue
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/routes/_view/app/-account-integrations.tsx
+++ b/apps/web/src/routes/_view/app/-account-integrations.tsx
@@ -1,7 +1,12 @@
+import { Icon } from "@iconify-icon/react";
+import { Plugs, PuzzlePiece } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
 
 import { listConnections } from "@anlg/api-client";
+import { OutlookIcon } from "@anlg/ui/components/icons/outlook";
+import { cn } from "@anlg/utils";
 
 import { getAuthorizedApiClient } from "./-account-api";
 import { useAccountSession } from "./-account-session";
@@ -18,6 +23,17 @@ const INTEGRATION_NAMES: Record<string, string> = {
   github: "GitHub",
   slack: "Slack",
   notion: "Notion",
+};
+
+const INTEGRATION_ICONS: Record<string, ReactNode> = {
+  "google-calendar": (
+    <Icon icon="logos:google-calendar" width="20" height="20" />
+  ),
+  outlook: <OutlookIcon size={20} />,
+  linear: <Icon icon="logos:linear-icon" width="20" height="20" />,
+  github: <Icon icon="logos:github-icon" width="20" height="20" />,
+  slack: <Icon icon="logos:slack-icon" width="20" height="20" />,
+  notion: <Icon icon="logos:notion-icon" width="20" height="20" />,
 };
 
 const connectionsQueryKey = ["account-integrations"];
@@ -69,17 +85,27 @@ export function IntegrationsSection() {
                 key={connection.connection_id}
                 className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between sm:px-8"
               >
-                <div>
-                  <p className="text-base font-medium text-[#181613]">
-                    {INTEGRATION_NAMES[connection.integration_id] ??
-                      connection.integration_id}
-                  </p>
-                  <p className="mt-1 text-sm leading-6 text-[#756b5d]">
-                    {hasError
-                      ? connection.last_error_description ||
-                        "Connection needs attention."
-                      : "Connected."}
-                  </p>
+                <div className="flex items-center gap-4">
+                  <span
+                    aria-hidden="true"
+                    className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-[#ede7dc] bg-[#fffaf0]"
+                  >
+                    {INTEGRATION_ICONS[connection.integration_id] ?? (
+                      <PuzzlePiece size={20} className="text-[#756b5d]" />
+                    )}
+                  </span>
+                  <div>
+                    <p className="text-base font-medium text-[#181613]">
+                      {INTEGRATION_NAMES[connection.integration_id] ??
+                        connection.integration_id}
+                    </p>
+                    <p className="mt-1 text-sm leading-6 text-[#756b5d]">
+                      {hasError
+                        ? connection.last_error_description ||
+                          "Connection needs attention."
+                        : "Connected."}
+                    </p>
+                  </div>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
                   {hasError && (
@@ -104,9 +130,14 @@ export function IntegrationsSection() {
                       connection_id: connection.connection_id,
                       action: "disconnect",
                     }}
-                    className={accountPillDangerClassName}
+                    aria-label={`Disconnect ${
+                      INTEGRATION_NAMES[connection.integration_id] ??
+                      connection.integration_id
+                    }`}
+                    title="Disconnect"
+                    className={cn([accountPillDangerClassName, "w-9 px-0"])}
                   >
-                    Disconnect
+                    <Plugs size={16} aria-hidden="true" />
                   </Link>
                 </div>
               </li>

--- a/apps/web/src/routes/_view/app/-account-profile-info.tsx
+++ b/apps/web/src/routes/_view/app/-account-profile-info.tsx
@@ -179,7 +179,10 @@ export function ProfileInfoSection({ email }: { email?: string }) {
 
         <div className="flex flex-col gap-4 border-t border-[#ede7dc] pt-4">
           {isEditingDetails ? (
-            <form onSubmit={handleDetailsSubmit} className="flex flex-col gap-4">
+            <form
+              onSubmit={handleDetailsSubmit}
+              className="flex flex-col gap-4"
+            >
               <DetailsField
                 label="Full name"
                 value={draftName}

--- a/apps/web/src/routes/_view/app/-account-profile-info.tsx
+++ b/apps/web/src/routes/_view/app/-account-profile-info.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { cn } from "@anlg/utils";
@@ -8,8 +8,9 @@ import {
   authNoticeClassName,
 } from "@/components/auth-shell";
 import { updateUserEmail } from "@/functions/auth";
+import { getSupabaseBrowserClient } from "@/functions/supabase";
 
-import { useAccountSession } from "./-account-session";
+import { accountSessionQueryKey, useAccountSession } from "./-account-session";
 import {
   accountCardClassName,
   accountPillPrimaryClassName,
@@ -20,7 +21,54 @@ export function ProfileInfoSection({ email }: { email?: string }) {
   const [isEditing, setIsEditing] = useState(false);
   const [newEmail, setNewEmail] = useState("");
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [isEditingDetails, setIsEditingDetails] = useState(false);
+  const [draftName, setDraftName] = useState("");
+  const [draftLinkedin, setDraftLinkedin] = useState("");
+  const [draftX, setDraftX] = useState("");
   const { data: accountSession } = useAccountSession();
+  const queryClient = useQueryClient();
+  const profile = accountSession?.profile;
+
+  const updateDetailsMutation = useMutation({
+    mutationFn: async (details: {
+      fullName: string | null;
+      linkedinUrl: string | null;
+      xHandle: string | null;
+    }) => {
+      const supabase = getSupabaseBrowserClient();
+      const { error } = await supabase.auth.updateUser({
+        data: {
+          full_name: details.fullName,
+          linkedin_url: details.linkedinUrl,
+          x_handle: details.xHandle,
+        },
+      });
+      if (error) {
+        throw new Error(error.message);
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: accountSessionQueryKey });
+      setIsEditingDetails(false);
+    },
+  });
+
+  const startEditingDetails = () => {
+    setDraftName(profile?.fullName ?? "");
+    setDraftLinkedin(profile?.linkedinUrl ?? "");
+    setDraftX(profile?.xHandle ?? "");
+    updateDetailsMutation.reset();
+    setIsEditingDetails(true);
+  };
+
+  const handleDetailsSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    updateDetailsMutation.mutate({
+      fullName: draftName.trim() || null,
+      linkedinUrl: normalizeLinkedinUrl(draftLinkedin),
+      xHandle: normalizeXHandle(draftX),
+    });
+  };
 
   const updateEmailMutation = useMutation({
     mutationFn: async (email: string) => {
@@ -129,6 +177,105 @@ export function ProfileInfoSection({ email }: { email?: string }) {
           </div>
         )}
 
+        <div className="flex flex-col gap-4 border-t border-[#ede7dc] pt-4">
+          {isEditingDetails ? (
+            <form onSubmit={handleDetailsSubmit} className="flex flex-col gap-4">
+              <DetailsField
+                label="Full name"
+                value={draftName}
+                onChange={setDraftName}
+                placeholder="Ada Lovelace"
+              />
+              <DetailsField
+                label="LinkedIn"
+                value={draftLinkedin}
+                onChange={setDraftLinkedin}
+                placeholder="linkedin.com/in/your-name"
+              />
+              <DetailsField
+                label="X"
+                value={draftX}
+                onChange={setDraftX}
+                placeholder="@yourhandle"
+              />
+              {updateDetailsMutation.isError && (
+                <p className="text-sm text-red-600">
+                  {updateDetailsMutation.error?.message ||
+                    "Failed to update profile"}
+                </p>
+              )}
+              <div className="flex justify-start gap-2 md:justify-end">
+                <button
+                  type="submit"
+                  disabled={updateDetailsMutation.isPending}
+                  className={accountPillPrimaryClassName}
+                >
+                  {updateDetailsMutation.isPending ? "Saving..." : "Save"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setIsEditingDetails(false)}
+                  disabled={updateDetailsMutation.isPending}
+                  className={accountPillSecondaryClassName}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          ) : (
+            <>
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <span className="text-sm font-medium text-[#756b5d]">
+                  Full name
+                </span>
+                <div className="flex flex-wrap items-center gap-3">
+                  <span className="text-base text-[#181613]">
+                    {profile?.fullName || "Not set"}
+                  </span>
+                  <button
+                    onClick={startEditingDetails}
+                    className={accountPillSecondaryClassName}
+                  >
+                    Edit
+                  </button>
+                </div>
+              </div>
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <span className="text-sm font-medium text-[#756b5d]">
+                  LinkedIn
+                </span>
+                {profile?.linkedinUrl ? (
+                  <a
+                    href={profile.linkedinUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-base text-[#181613] underline decoration-[#d9cdb8] underline-offset-4"
+                  >
+                    {profile.linkedinUrl.replace(/^https?:\/\/(www\.)?/, "")}
+                  </a>
+                ) : (
+                  <span className="text-base text-[#756b5d]">Not set</span>
+                )}
+              </div>
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <span className="text-sm font-medium text-[#756b5d]">X</span>
+                {profile?.xHandle ? (
+                  <a
+                    href={`https://x.com/${profile.xHandle}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-base text-[#181613] underline decoration-[#d9cdb8] underline-offset-4"
+                  >
+                    @{profile.xHandle}
+                  </a>
+                ) : (
+                  <span className="text-base text-[#756b5d]">Not set</span>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+
         {accountSession?.createdAt && (
           <div className="flex flex-col gap-3 border-t border-[#ede7dc] pt-4 md:flex-row md:items-center md:justify-between">
             <span className="text-sm font-medium text-[#756b5d]">
@@ -145,4 +292,57 @@ export function ProfileInfoSection({ email }: { email?: string }) {
       </div>
     </div>
   );
+}
+
+function DetailsField({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+}) {
+  return (
+    <label className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <span className="text-sm font-medium text-[#756b5d]">{label}</span>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={cn([authInputClassName, "md:max-w-[420px]"])}
+      />
+    </label>
+  );
+}
+
+function normalizeLinkedinUrl(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const bare = trimmed
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/\/+$/, "");
+  if (/^linkedin\.com\//i.test(bare)) {
+    return `https://www.${bare}`;
+  }
+  const handle = bare.replace(/^@/, "");
+  return `https://www.linkedin.com/in/${handle}`;
+}
+
+function normalizeXHandle(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const handle = trimmed
+    .replace(/^(https?:\/\/)?(www\.)?(x\.com|twitter\.com)\//i, "")
+    .replace(/^@/, "")
+    .replace(/\/+$/, "");
+  return handle || null;
 }

--- a/apps/web/src/routes/_view/app/-account-referrals.tsx
+++ b/apps/web/src/routes/_view/app/-account-referrals.tsx
@@ -136,7 +136,7 @@ export function ReferralSection({ ineligible }: { ineligible: boolean }) {
       <p className="border-t border-[#ede7dc] px-6 py-4 text-sm leading-6 text-[#756b5d] sm:px-8">
         {earnedRewards > 0
           ? `${earnedCredit} in referral credit earned.`
-          : "Your friend gets 30 days of Pro. You earn $15 after their first payment."}
+          : "You both get a month of Pro free. Your friend's starts right away, and yours kicks in after their first payment."}
       </p>
     </div>
   );

--- a/apps/web/src/routes/_view/app/-account-session.ts
+++ b/apps/web/src/routes/_view/app/-account-session.ts
@@ -21,7 +21,8 @@ export function useAccountSession() {
         return null;
       }
 
-      const metadata: Record<string, unknown> = session.user.user_metadata ?? {};
+      const metadata: Record<string, unknown> =
+        session.user.user_metadata ?? {};
       const metadataString = (key: string) => {
         const value = metadata[key];
         return typeof value === "string" && value.trim() ? value.trim() : null;

--- a/apps/web/src/routes/_view/app/-account-session.ts
+++ b/apps/web/src/routes/_view/app/-account-session.ts
@@ -21,11 +21,27 @@ export function useAccountSession() {
         return null;
       }
 
+      const metadata: Record<string, unknown> = session.user.user_metadata ?? {};
+      const metadataString = (key: string) => {
+        const value = metadata[key];
+        return typeof value === "string" && value.trim() ? value.trim() : null;
+      };
+
       return {
         billing: deriveBillingInfo(
           jwtDecode<SupabaseJwtPayload>(session.access_token),
         ),
         createdAt: session.user.created_at ?? null,
+        profile: {
+          // An explicit full_name (even cleared to null) wins; fall back to
+          // the OAuth-provided name only when the user never set one.
+          fullName:
+            "full_name" in metadata
+              ? metadataString("full_name")
+              : metadataString("name"),
+          linkedinUrl: metadataString("linkedin_url"),
+          xHandle: metadataString("x_handle"),
+        },
       };
     },
   });

--- a/apps/web/src/routes/_view/app/-account-shares.tsx
+++ b/apps/web/src/routes/_view/app/-account-shares.tsx
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import { useState } from "react";
 
 import {
+  deleteMyShare,
   listMyManagedShares,
   restrictMyShare,
 } from "@/functions/account-shares";
@@ -23,6 +25,9 @@ const sharesQueryKey = ["account-managed-shares"];
 
 export function SharedNotesSection() {
   const queryClient = useQueryClient();
+  const [confirmingShareId, setConfirmingShareId] = useState<string | null>(
+    null,
+  );
 
   const sharesQuery = useQuery({
     queryKey: sharesQueryKey,
@@ -46,6 +51,19 @@ export function SharedNotesSection() {
       }
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: sharesQueryKey });
+    },
+  });
+
+  const stopSharing = useMutation({
+    mutationFn: async (shareId: string) => {
+      const result = await deleteMyShare({ data: { shareId } });
+      if (!result.success) {
+        throw new Error(result.message);
+      }
+    },
+    onSuccess: () => {
+      setConfirmingShareId(null);
       queryClient.invalidateQueries({ queryKey: sharesQueryKey });
     },
   });
@@ -99,13 +117,31 @@ export function SharedNotesSection() {
                   <button
                     onClick={() => restrict.mutate(share.shareId)}
                     disabled={restrict.isPending}
-                    className={accountPillDangerClassName}
+                    className={accountPillSecondaryClassName}
                   >
                     {restrict.isPending && restrict.variables === share.shareId
                       ? "Restricting..."
                       : "Restrict"}
                   </button>
                 )}
+                <button
+                  onClick={() => {
+                    if (confirmingShareId === share.shareId) {
+                      stopSharing.mutate(share.shareId);
+                    } else {
+                      setConfirmingShareId(share.shareId);
+                    }
+                  }}
+                  disabled={stopSharing.isPending}
+                  className={accountPillDangerClassName}
+                >
+                  {stopSharing.isPending &&
+                  stopSharing.variables === share.shareId
+                    ? "Stopping..."
+                    : confirmingShareId === share.shareId
+                      ? "You sure?"
+                      : "Stop sharing"}
+                </button>
               </div>
             </li>
           ))}
@@ -114,6 +150,11 @@ export function SharedNotesSection() {
       {restrict.isError && (
         <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
           {restrict.error?.message || "Failed to restrict shared note"}
+        </p>
+      )}
+      {stopSharing.isError && (
+        <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
+          {stopSharing.error?.message || "Failed to stop sharing this note"}
         </p>
       )}
     </div>

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -1,4 +1,3 @@
-import { ArrowRight } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { jwtDecode } from "jwt-decode";
@@ -202,32 +201,6 @@ function Component() {
             </div>
           </section>
 
-          <section>
-            <article
-              className="overflow-hidden rounded-[3px] border border-[#eadfce] bg-[#fffaf0] px-7 py-9 shadow-[0_18px_50px_rgba(68,54,36,0.12)] sm:px-10 sm:py-12"
-              style={{
-                backgroundImage:
-                  "linear-gradient(115deg, rgba(255, 250, 240, 0.9), rgba(246, 236, 218, 0.82)), url('/textures/crumpled-paper.webp')",
-                backgroundPosition: "center",
-                backgroundSize: "cover",
-              }}
-            >
-              <h2 className="font-hand text-3xl leading-none font-semibold text-[#363029]">
-                Anarlog lives on your desktop
-              </h2>
-              <p className="mt-4 max-w-xl text-base leading-7 text-[#363029]">
-                Notes, transcripts, and integrations all live in the app, on
-                your device. Grab it if you haven't already.
-              </p>
-              <Link
-                to="/download/"
-                className="mt-6 inline-flex items-center gap-2 rounded-full bg-[#181613] px-5 py-3 text-sm font-medium text-white"
-              >
-                <span>Download for free</span>
-                <ArrowRight size={16} weight="bold" aria-hidden="true" />
-              </Link>
-            </article>
-          </section>
         </div>
       </div>
     </main>

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -200,7 +200,6 @@ function Component() {
               <DangerAreaSection />
             </div>
           </section>
-
         </div>
       </div>
     </main>

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -125,10 +125,6 @@ function Component() {
             <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Profile
             </h2>
-            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-              The email attached to your account, and how long you've been
-              around.
-            </p>
             <div className="mt-6">
               <ProfileInfoSection email={user?.email} />
             </div>
@@ -138,10 +134,6 @@ function Component() {
             <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Refer friends
             </h2>
-            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-              Give a month of Anarlog Pro and get a month when your friend
-              becomes a subscriber.
-            </p>
             <div className="mt-6">
               <ReferralSection ineligible={search.referral === "ineligible"} />
             </div>
@@ -151,10 +143,6 @@ function Component() {
             <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Your plan
             </h2>
-            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-              Billing runs through Stripe, and you can also manage it from the
-              desktop app.
-            </p>
             <div className="mt-6">
               <PlanSection />
             </div>
@@ -164,9 +152,6 @@ function Component() {
             <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Integrations
             </h2>
-            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-              Calendars and tools connected to Anarlog.
-            </p>
             <div className="mt-6">
               <IntegrationsSection />
             </div>
@@ -176,9 +161,6 @@ function Component() {
             <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Synced devices
             </h2>
-            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-              Anarlog syncs up to five devices. Remove one to free a slot.
-            </p>
             <div className="mt-6">
               <DevicesSection />
             </div>
@@ -188,10 +170,6 @@ function Component() {
             <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Shared notes
             </h2>
-            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-              Notes you've shared with others. Restricting a note turns off link
-              and public access.
-            </p>
             <div className="mt-6">
               <SharedNotesSection />
             </div>
@@ -201,9 +179,6 @@ function Component() {
             <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Cloud API keys
             </h2>
-            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-              Keys that let your own tools talk to the Anarlog Cloud API.
-            </p>
             <div className="mt-6">
               <ApiKeysSection />
             </div>
@@ -213,9 +188,6 @@ function Component() {
             <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Session controls
             </h2>
-            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-              Sign out quickly whenever you need to.
-            </p>
             <div className="mt-6">
               <AccountAccessSection />
             </div>
@@ -225,10 +197,6 @@ function Component() {
             <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
               Danger area
             </h2>
-            <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-              Account deletion lives here, tucked behind an extra deliberate
-              step.
-            </p>
             <div className="mt-6">
               <DangerAreaSection />
             </div>


### PR DESCRIPTION
Streamline the web account page so users can manage their profile, API keys, integrations, and shared notes without leaving it.

- Create Cloud API keys directly from the account page with an inline name form and a one-time key reveal banner with copy button
- Add editable full name, LinkedIn, and X fields to the profile section
- Allow revoking shared notes entirely via a two-step "Stop sharing" button (new deleteMyShare server fn wrapping the delete_session_share RPC); demote Restrict to a secondary pill
- Show brand icons per integration connection and replace the Disconnect text link with an icon button
- Render the danger area (Delete account) inline instead of behind an accordion
- Drop the download callout and redundant section descriptions; reword referral copy (both sides get a month of Pro free)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds API key creation and share deletion (RPC-backed destructive actions) plus client-side profile metadata updates; changes are scoped to account UI with existing auth patterns.
> 
> **Overview**
> **Expands self-serve account management** on the web: Pro users can **create Cloud API keys** in-page (name form, one-time reveal + copy) instead of being pointed at the desktop app. **Profile** gains editable full name, LinkedIn, and X via Supabase `user_metadata`, with session hook exposing `profile` and sensible `full_name` vs OAuth `name` fallback.
> 
> **Shared notes** add **`deleteMyShare`** (`delete_session_share` RPC) and a two-step **Stop sharing** control; **Restrict** moves to a secondary pill. **Integrations** show per-provider icons and an icon-only disconnect button with `aria-label`.
> 
> **Layout/copy tweaks:** delete account is **inline** (accordion removed); section blurbs and the desktop download promo are removed; referral footer copy now describes mutual Pro month.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cdade0317cf2e297c002d1695390d5c6ce07d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->