### PR TITLE
fix(web): explain first email-change confirmation instead of erroring

### DIFF
--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -488,6 +488,16 @@ export const exchangeOtpToken = createServerFn({ method: "POST" })
       type: data.type,
     });
 
+    // Secure email change: the first of the two confirmations is accepted
+    // without a session; only the second one completes the change.
+    if (!error && !authData.session && data.type === "email_change") {
+      return {
+        success: false,
+        pendingEmailChange: true,
+        error: "Waiting for the confirmation from your other email address.",
+      };
+    }
+
     if (error || !authData.session) {
       return { success: false, error: error?.message || "Unknown error" };
     }

--- a/apps/web/src/routes/confirm-auth.tsx
+++ b/apps/web/src/routes/confirm-auth.tsx
@@ -49,6 +49,7 @@ function Component() {
   const search = Route.useSearch();
   const navigate = useNavigate();
   const [errorMessage, setErrorMessage] = useState("");
+  const [noticeMessage, setNoticeMessage] = useState("");
   const context = resolveAuthFlowContext({
     flow: search.flow,
     scheme: search.scheme,
@@ -67,6 +68,12 @@ function Component() {
       }),
     onSuccess: (result) => {
       if (!result.success) {
+        if ("pendingEmailChange" in result && result.pendingEmailChange) {
+          setNoticeMessage(
+            "This link is confirmed. To finish changing your email, click the link in the email sent to your other address.",
+          );
+          return;
+        }
         setErrorMessage(result.error);
         return;
       }
@@ -123,17 +130,25 @@ function Component() {
           </p>
         )}
 
-        <button
-          type="button"
-          onClick={() => {
-            setErrorMessage("");
-            confirmMutation.mutate();
-          }}
-          disabled={confirmMutation.isPending}
-          className={authPrimaryButtonClassName}
-        >
-          {confirmMutation.isPending ? "Confirming..." : "Continue"}
-        </button>
+        {noticeMessage && (
+          <p className="text-center text-sm leading-6 text-[#756b5d]">
+            {noticeMessage}
+          </p>
+        )}
+
+        {!noticeMessage && (
+          <button
+            type="button"
+            onClick={() => {
+              setErrorMessage("");
+              confirmMutation.mutate();
+            }}
+            disabled={confirmMutation.isPending}
+            className={authPrimaryButtonClassName}
+          >
+            {confirmMutation.isPending ? "Confirming..." : "Continue"}
+          </button>
+        )}
 
         <Link
           to="/auth/"


### PR DESCRIPTION
With secure email change, verifying the first of the two confirmation
links succeeds without returning a session, and exchangeOtpToken
reported that state as 'Unknown error' on /confirm-auth.

Return a pendingEmailChange flag from exchangeOtpToken for that case and
show a neutral notice pointing to the other address's email, hiding the
Continue button so the consumed token is not resubmitted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small auth UX change for a specific OTP edge case; no change to session issuance or email-change completion logic beyond clearer handling of the first confirmation.
> 
> **Overview**
> **Fixes misleading “Unknown error” when users confirm the first step of secure email change.**
> 
> `exchangeOtpToken` now treats a successful `email_change` OTP verification with **no session** as an expected intermediate state and returns `pendingEmailChange` with a clear message instead of falling through to the generic failure path.
> 
> On `/confirm-auth`, that response shows a **neutral notice** to check the other inbox and **hides the Continue button** so the already-used token is not submitted again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e45abaad847b5df1baf45f3bc13127f6bbb207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->