### PR TITLE
docs(changelog): cover late 1.4.10 desktop changes

### DIFF
--- a/packages/changelog/content/1.4.10.md
+++ b/packages/changelog/content/1.4.10.md
@@ -77,6 +77,11 @@ summary: "Anarlog 1.4.10 adds summary length control, voice input and meeting pr
   assistants are installed, and see the welcome demo prompt without clipping
 - Team workspaces now require Anarlog Pro to create or manage; existing
   workspaces stay reachable and you can still join, leave, or delete them
-- Enjoy tidier Team and Developers settings, tighter header icons, a visible
+- Manage your team from a cleaner Team settings page: switch workspaces from
+  an always-visible selector, rename the workspace with the new pencil
+  control, and resend pending invitations
+- Follow initial cloud sync from the sidebar sync indicator instead of a
+  toast, with a notification still confirming when the first sync completes
+- Enjoy tidier Developers settings, tighter header icons, a visible
   template picker chevron in narrow windows, and a shared-note chat launcher
   that matches the in-app design


### PR DESCRIPTION
The 1.4.10 release notes were merged before two desktop changes landed.
Add entries for the reworked Team settings workspace controls
(always-visible selector, pencil rename, invitation resend) and the
removal of the initial cloud sync toast in favor of the sidebar
indicator, and narrow the old tidier-settings bullet accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or product behavior changes.
> 
> **Overview**
> Updates **1.4.10** release notes for two desktop UX changes that landed after the initial changelog merge.
> 
> Adds bullets for the reworked **Team** settings page (always-visible workspace selector, pencil rename, resend pending invitations) and for **initial cloud sync** feedback moving from a toast to the sidebar sync indicator, while still noting the completion notification.
> 
> Narrows the previous “tidier settings” bullet so it no longer claims Team improvements—those are covered separately—and only mentions Developers settings, header icons, template picker chevron, and the shared-note chat launcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc8d8ec09b5dcc3a67ef55a178b9d1688b66bfda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->