### PR TITLE
chore(ci): drop legacy desktop_cd publish input

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -147,7 +147,6 @@ After the changelog merge and QA Gate pass on the same `main` SHA, verify
 gh workflow run desktop_cd.yaml \
   --ref main \
   -f channel=stable \
-  -f publish=false \
   -f version=<version>
 ```
 

--- a/.github/actions/trigger-workflow/action.yml
+++ b/.github/actions/trigger-workflow/action.yml
@@ -14,10 +14,6 @@ inputs:
   channel:
     description: Channel input for the workflow
     required: true
-  publish:
-    description: Legacy desktop CD compatibility input
-    required: false
-    default: "false"
   version:
     description: "Explicit stable version"
     required: false
@@ -41,7 +37,6 @@ runs:
       env:
         CHANNEL: ${{ inputs.channel }}
         GH_TOKEN: ${{ inputs.token }}
-        PUBLISH: ${{ inputs.publish }}
         REF: ${{ inputs.ref }}
         REPO: ${{ inputs.repo }}
         SHA: ${{ inputs.sha }}
@@ -55,7 +50,6 @@ runs:
           -f "ref=$REF"
           -f "inputs[channel]=$CHANNEL"
           -f "inputs[candidate_sha]=$SHA"
-          -F "inputs[publish]=$PUBLISH"
           -F "return_run_details=true"
         )
         if [[ -n "$VERSION" ]]; then

--- a/.github/workflows/command_dispatcher.yaml
+++ b/.github/workflows/command_dispatcher.yaml
@@ -46,7 +46,6 @@ jobs:
     uses: ./.github/workflows/handle_release.yaml
     with:
       channel: stable
-      publish: false
       version: ${{ needs.parse-stable-options.outputs.version }}
       issue_number: ${{ github.event.issue.number }}
       comment_id: ${{ github.event.comment.id }}

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -14,10 +14,6 @@ on:
         required: false
         type: string
         default: ""
-      publish:
-        description: "Legacy compatibility input; stable publication must use desktop_publish"
-        type: boolean
-        default: false
       include_linux:
         description: "Build and include Linux beta artifacts"
         type: boolean
@@ -58,11 +54,6 @@ jobs:
           git fetch --tags --force
       - if: ${{ inputs.channel == 'stable' }}
         run: |
-          if [[ "${{ inputs.publish }}" == "true" ]]; then
-            echo "::error::desktop_cd only builds stable candidates; publish through desktop_publish after QA"
-            exit 1
-          fi
-
           git fetch origin main --no-tags
 
           TARGET=$(git rev-parse HEAD)

--- a/.github/workflows/handle_release.yaml
+++ b/.github/workflows/handle_release.yaml
@@ -4,10 +4,6 @@ on:
       channel:
         required: true
         type: string
-      publish:
-        required: false
-        type: boolean
-        default: false
       version:
         required: true
         type: string
@@ -73,7 +69,6 @@ jobs:
           ref: ${{ steps.resolve.outputs.branch }}
           sha: ${{ steps.resolve.outputs.target_sha }}
           channel: ${{ inputs.channel }}
-          publish: ${{ inputs.publish }}
           version: ${{ inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}


### PR DESCRIPTION
The publish input on desktop_cd became a no-op when stable publication moved to desktop_publish: every dispatcher hardcoded false, and desktop_cd only read it to fail the run if it was ever set.

Notable changes:
- Remove the publish input and its stable-channel tripwire from desktop_cd.
- Stop sending inputs[publish] from the trigger-workflow action.
- Drop the publish pass-through in handle_release and command_dispatcher.
- Update the release-new-version skill command that still passed -f publish=false.

All senders and the input are removed in one change, so no dispatcher ever sends an input the workflow no longer declares.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and docs cleanup only; stable publish behavior is unchanged because publication already went through `desktop_publish`.
> 
> **Overview**
> Removes the legacy **`publish`** input from the desktop CD pipeline end to end. Stable releases are already built via **`desktop_cd`** and published only through **`desktop_publish`**; **`publish`** was unused (always false) except as a guard that failed if set to true.
> 
> **`desktop_cd.yaml`** no longer declares **`publish`** or the stable-channel check that rejected **`publish=true`**. The **`trigger-workflow`** composite action, **`handle_release`**, and **`command_dispatcher`** stop passing it. The **release-new-version** skill’s **`gh workflow run`** example drops **`-f publish=false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c820e76d8757a7e7f906355c6f1d84c94d14150b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->