### PR TITLE
fix(model-manager): eliminate lock inversion between get and monitor

### DIFF
--- a/crates/model-manager/src/builder.rs
+++ b/crates/model-manager/src/builder.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 
 use tokio::sync::{Mutex, RwLock, watch};
 
+use crate::manager::ManagerState;
 use crate::{ModelLoader, ModelManager};
 
 const DEFAULT_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(60);
@@ -68,8 +69,7 @@ impl<M: ModelLoader> ModelManagerBuilder<M> {
         let manager = ModelManager {
             registry: Arc::new(RwLock::new(self.models)),
             default_model: Arc::new(RwLock::new(self.default_model)),
-            active: Arc::new(Mutex::new(None)),
-            last_activity: Arc::new(Mutex::new(None)),
+            state: Arc::new(Mutex::new(ManagerState::default())),
             inactivity_timeout,
             _drop_guard: Arc::new(DropGuard { shutdown_tx }),
         };

--- a/crates/model-manager/src/lib.rs
+++ b/crates/model-manager/src/lib.rs
@@ -114,6 +114,95 @@ mod tests {
         assert!(Arc::ptr_eq(&m1, &m3));
     }
 
+    struct GatedModel;
+
+    static GATE: std::sync::OnceLock<(
+        std::sync::Arc<std::sync::Barrier>,
+        std::sync::Arc<std::sync::Barrier>,
+    )> = std::sync::OnceLock::new();
+    static GATED_LOADS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+    fn gate() -> &'static (
+        std::sync::Arc<std::sync::Barrier>,
+        std::sync::Arc<std::sync::Barrier>,
+    ) {
+        GATE.get_or_init(|| {
+            (
+                std::sync::Arc::new(std::sync::Barrier::new(2)),
+                std::sync::Arc::new(std::sync::Barrier::new(2)),
+            )
+        })
+    }
+
+    impl ModelLoader for GatedModel {
+        type Error = MockError;
+
+        fn load(_path: &Path) -> Result<Self, Self::Error> {
+            if GATED_LOADS.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                let (enter, exit) = gate();
+                enter.wait();
+                exit.wait();
+            }
+            Ok(GatedModel)
+        }
+    }
+
+    // Regression for the lock inversion between get() and the inactivity
+    // monitor: get() held `active` then `last_activity` while the monitor
+    // acquired them in the opposite order. This drives both paths into the
+    // former deadlock interleaving with barriers instead of timing sleeps.
+    #[tokio::test(start_paused = true)]
+    async fn concurrent_get_and_monitor_eviction_do_not_deadlock() {
+        let path = temp_model_path();
+        let mgr = ModelManager::<GatedModel>::builder()
+            .inactivity_timeout(Duration::from_millis(100))
+            .check_interval(Duration::from_millis(100))
+            .register("a", path)
+            .build();
+
+        let (enter, exit) = gate();
+
+        let mgr1 = mgr.clone();
+        let g1 = tokio::spawn(async move { mgr1.get(Some("a")).await });
+
+        // Wait until the first load is running, i.e. get() holds its lock(s).
+        let enter = std::sync::Arc::clone(enter);
+        tokio::task::spawn_blocking(move || enter.wait())
+            .await
+            .unwrap();
+
+        // Fire a monitor tick with the eviction condition satisfied so it
+        // queues on the manager state while get() still holds it.
+        tokio::time::advance(Duration::from_millis(150)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        let mgr2 = mgr.clone();
+        let g2 = tokio::spawn(async move { mgr2.get(Some("a")).await });
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        let exit = std::sync::Arc::clone(exit);
+        tokio::task::spawn_blocking(move || exit.wait())
+            .await
+            .unwrap();
+
+        // Under the old two-lock layout this interleaving deadlocked; the
+        // paused clock auto-advances into the timeout instead of hanging.
+        let joined = tokio::time::timeout(Duration::from_secs(300), async {
+            g1.await.unwrap().unwrap();
+            g2.await.unwrap().unwrap();
+        })
+        .await;
+
+        assert!(
+            joined.is_ok(),
+            "get() and the inactivity monitor deadlocked"
+        );
+    }
+
     #[tokio::test(start_paused = true)]
     async fn access_after_timeout_before_monitor_tick_reloads() {
         let path = temp_model_path();

--- a/crates/model-manager/src/manager.rs
+++ b/crates/model-manager/src/manager.rs
@@ -10,11 +10,26 @@ pub(crate) struct ActiveModel<M> {
     pub(crate) model: Arc<M>,
 }
 
+// Single lock for both fields: `get()` and the inactivity monitor previously
+// acquired two separate mutexes in opposite orders, which could deadlock.
+pub(crate) struct ManagerState<M> {
+    pub(crate) active: Option<ActiveModel<M>>,
+    pub(crate) last_activity: Option<tokio::time::Instant>,
+}
+
+impl<M> Default for ManagerState<M> {
+    fn default() -> Self {
+        Self {
+            active: None,
+            last_activity: None,
+        }
+    }
+}
+
 pub struct ModelManager<M: ModelLoader> {
     pub(crate) registry: Arc<RwLock<HashMap<String, PathBuf>>>,
     pub(crate) default_model: Arc<RwLock<Option<String>>>,
-    pub(crate) active: Arc<Mutex<Option<ActiveModel<M>>>>,
-    pub(crate) last_activity: Arc<Mutex<Option<tokio::time::Instant>>>,
+    pub(crate) state: Arc<Mutex<ManagerState<M>>>,
     pub(crate) inactivity_timeout: Duration,
     pub(crate) _drop_guard: Arc<DropGuard>,
 }
@@ -24,8 +39,7 @@ impl<M: ModelLoader> Clone for ModelManager<M> {
         Self {
             registry: Arc::clone(&self.registry),
             default_model: Arc::clone(&self.default_model),
-            active: Arc::clone(&self.active),
-            last_activity: Arc::clone(&self.last_activity),
+            state: Arc::clone(&self.state),
             inactivity_timeout: self.inactivity_timeout,
             _drop_guard: Arc::clone(&self._drop_guard),
         }
@@ -60,9 +74,9 @@ impl<M: ModelLoader> ModelManager<M> {
         let mut reg = self.registry.write().await;
         reg.remove(name);
 
-        let mut active = self.active.lock().await;
-        if active.as_ref().is_some_and(|a| a.name == name) {
-            *active = None;
+        let mut state = self.state.lock().await;
+        if state.active.as_ref().is_some_and(|a| a.name == name) {
+            state.active = None;
         }
     }
 
@@ -91,22 +105,26 @@ impl<M: ModelLoader> ModelManager<M> {
             return Err(Error::ModelFileNotFound(path.display().to_string()));
         }
 
-        let mut active = self.active.lock().await;
-        let mut last_activity = self.last_activity.lock().await;
+        // Held across the load on purpose: concurrent gets for the same model
+        // must not load it twice.
+        let mut state = self.state.lock().await;
         let now = tokio::time::Instant::now();
 
-        if last_activity.is_some_and(|t| now.duration_since(t) > self.inactivity_timeout) {
-            *active = None;
+        if state
+            .last_activity
+            .is_some_and(|t| now.duration_since(t) > self.inactivity_timeout)
+        {
+            state.active = None;
         }
-        *last_activity = Some(now);
+        state.last_activity = Some(now);
 
-        if let Some(ref a) = *active
+        if let Some(ref a) = state.active
             && a.name == resolved
         {
             return Ok(Arc::clone(&a.model));
         }
 
-        *active = None;
+        state.active = None;
 
         let model = tokio::task::spawn_blocking(move || M::load(&path))
             .await
@@ -114,7 +132,7 @@ impl<M: ModelLoader> ModelManager<M> {
             .map_err(|e| Error::Load(Box::new(e)))?;
 
         let model = Arc::new(model);
-        *active = Some(ActiveModel {
+        state.active = Some(ActiveModel {
             name: resolved,
             model: Arc::clone(&model),
         });
@@ -127,7 +145,7 @@ impl<M: ModelLoader> ModelManager<M> {
     }
 
     async fn update_activity(&self) {
-        *self.last_activity.lock().await = Some(tokio::time::Instant::now());
+        self.state.lock().await.last_activity = Some(tokio::time::Instant::now());
     }
 
     pub(crate) fn spawn_monitor(
@@ -135,8 +153,7 @@ impl<M: ModelLoader> ModelManager<M> {
         check_interval: Duration,
         mut shutdown_rx: watch::Receiver<()>,
     ) {
-        let active = Arc::clone(&self.active);
-        let last_activity = Arc::clone(&self.last_activity);
+        let state = Arc::clone(&self.state);
         let inactivity_timeout = self.inactivity_timeout;
 
         tokio::spawn(async move {
@@ -147,11 +164,11 @@ impl<M: ModelLoader> ModelManager<M> {
                 tokio::select! {
                     _ = shutdown_rx.changed() => break,
                     _ = interval.tick() => {
-                        let last = last_activity.lock().await;
-                        if let Some(t) = *last
+                        let mut state = state.lock().await;
+                        if let Some(t) = state.last_activity
                             && t.elapsed() > inactivity_timeout
                         {
-                            *active.lock().await = None;
+                            state.active = None;
                         }
                     }
                 }


### PR DESCRIPTION
get() locked active then last_activity while the inactivity monitor
locked them in the opposite order, so concurrent model access and
eviction ticks could deadlock. Merge both fields into one
mutex-protected ManagerState so a single lock order exists by
construction; the public API and eviction behavior are unchanged.
Add a barrier-driven regression that deterministically reproduces the
old deadlock interleaving (fails on the two-lock layout, passes now).
(ANLG-253)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core concurrency in model loading/eviction; behavior is intended to be unchanged but lock scope during load affects all concurrent access paths.
> 
> **Overview**
> Fixes a **deadlock** when model `get()` runs concurrently with the inactivity eviction monitor. `get()` used to lock `active` then `last_activity`, while the monitor locked them in the opposite order.
> 
> **`active` and `last_activity` are merged into one `ManagerState` protected by a single mutex**, so every path uses the same lock order. Public API and eviction semantics are unchanged; `get()` still holds the lock across `spawn_blocking` load so duplicate loads cannot happen.
> 
> Adds a **barrier-driven regression test** (`GatedModel` + `concurrent_get_and_monitor_eviction_do_not_deadlock`) that forces the old interleaving deterministically instead of relying on sleeps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff92c53a605f2a84ec4dce2a1c6b595c7669b5f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->