### PR TITLE
fix(llm-proxy): buffer SSE frames across network chunk boundaries

### DIFF
--- a/crates/llm-proxy/src/handler/streaming.rs
+++ b/crates/llm-proxy/src/handler/streaming.rs
@@ -68,6 +68,10 @@ pub(super) async fn handle_stream_response(
             }
         }
 
+        if analytics.is_some() {
+            provider.finish_stream(&mut accumulator);
+        }
+
         if let Some(generation_id) = accumulator.generation_id {
                 stream_span.record("gen_ai.response.id", generation_id.as_str());
                 if let Some(model) = accumulator.model.as_deref() {

--- a/crates/llm-proxy/src/provider/mod.rs
+++ b/crates/llm-proxy/src/provider/mod.rs
@@ -15,11 +15,16 @@ pub struct GenerationMetadata {
     pub output_tokens: u32,
 }
 
+// Bounds the partial-frame buffer so a malformed stream without newlines
+// cannot grow it indefinitely; analytics parsing is best-effort.
+const MAX_PENDING_STREAM_BYTES: usize = 1024 * 1024;
+
 pub struct StreamAccumulator {
     pub generation_id: Option<String>,
     pub model: Option<String>,
     pub input_tokens: u32,
     pub output_tokens: u32,
+    pending: Vec<u8>,
 }
 
 impl Default for StreamAccumulator {
@@ -35,6 +40,37 @@ impl StreamAccumulator {
             model: None,
             input_tokens: 0,
             output_tokens: 0,
+            pending: Vec::new(),
+        }
+    }
+
+    pub(crate) fn buffer_bytes(&mut self, chunk: &[u8]) {
+        self.pending.extend_from_slice(chunk);
+    }
+
+    // Splitting at b'\n' is UTF-8 safe: continuation bytes are >= 0x80, so a
+    // newline byte can never be part of a multibyte character.
+    pub(crate) fn next_complete_line(&mut self) -> Option<Vec<u8>> {
+        let newline = self.pending.iter().position(|byte| *byte == b'\n')?;
+        let mut line: Vec<u8> = self.pending.drain(..=newline).collect();
+        line.pop();
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+        Some(line)
+    }
+
+    pub(crate) fn take_pending_line(&mut self) -> Vec<u8> {
+        let mut line = std::mem::take(&mut self.pending);
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+        line
+    }
+
+    pub(crate) fn drop_oversized_pending(&mut self) {
+        if self.pending.len() > MAX_PENDING_STREAM_BYTES {
+            self.pending.clear();
         }
     }
 }
@@ -66,6 +102,12 @@ pub trait Provider: Send + Sync {
     fn parse_response(&self, body: &[u8]) -> Result<GenerationMetadata, ProviderError>;
 
     fn parse_stream_chunk(&self, chunk: &[u8], accumulator: &mut StreamAccumulator);
+
+    // Called once after the upstream stream ends so providers can parse data
+    // buffered from a final frame that arrived without a trailing newline.
+    fn finish_stream(&self, accumulator: &mut StreamAccumulator) {
+        let _ = accumulator;
+    }
 
     fn fetch_cost(
         &self,

--- a/crates/llm-proxy/src/provider/openrouter.rs
+++ b/crates/llm-proxy/src/provider/openrouter.rs
@@ -38,6 +38,39 @@ struct OpenRouterResponse {
     pub usage: Option<UsageInfo>,
 }
 
+fn parse_sse_data_line(line: &str, accumulator: &mut StreamAccumulator) {
+    let Some(data) = line.strip_prefix("data: ") else {
+        return;
+    };
+
+    if data.trim() == "[DONE]" {
+        return;
+    }
+
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(data) else {
+        return;
+    };
+
+    if accumulator.generation_id.is_none() {
+        accumulator.generation_id = parsed.get("id").and_then(|v| v.as_str()).map(String::from);
+    }
+
+    if accumulator.model.is_none() {
+        accumulator.model = parsed
+            .get("model")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+    }
+
+    if let Some(usage) = parsed
+        .get("usage")
+        .and_then(|u| serde_json::from_value::<UsageInfo>(u.clone()).ok())
+    {
+        accumulator.input_tokens = usage.input_tokens();
+        accumulator.output_tokens = usage.output_tokens();
+    }
+}
+
 impl Provider for OpenRouterProvider {
     fn name(&self) -> &str {
         "openrouter"
@@ -92,42 +125,19 @@ impl Provider for OpenRouterProvider {
     }
 
     fn parse_stream_chunk(&self, chunk: &[u8], accumulator: &mut StreamAccumulator) {
-        let Ok(text) = std::str::from_utf8(chunk) else {
-            return;
-        };
-
-        for line in text.lines() {
-            let Some(data) = line.strip_prefix("data: ") else {
-                continue;
-            };
-
-            if data.trim() == "[DONE]" {
-                continue;
+        accumulator.buffer_bytes(chunk);
+        while let Some(line) = accumulator.next_complete_line() {
+            if let Ok(line) = std::str::from_utf8(&line) {
+                parse_sse_data_line(line, accumulator);
             }
+        }
+        accumulator.drop_oversized_pending();
+    }
 
-            let Ok(parsed) = serde_json::from_str::<serde_json::Value>(data) else {
-                continue;
-            };
-
-            if accumulator.generation_id.is_none() {
-                accumulator.generation_id =
-                    parsed.get("id").and_then(|v| v.as_str()).map(String::from);
-            }
-
-            if accumulator.model.is_none() {
-                accumulator.model = parsed
-                    .get("model")
-                    .and_then(|v| v.as_str())
-                    .map(String::from);
-            }
-
-            if let Some(usage) = parsed
-                .get("usage")
-                .and_then(|u| serde_json::from_value::<UsageInfo>(u.clone()).ok())
-            {
-                accumulator.input_tokens = usage.input_tokens();
-                accumulator.output_tokens = usage.output_tokens();
-            }
+    fn finish_stream(&self, accumulator: &mut StreamAccumulator) {
+        let line = accumulator.take_pending_line();
+        if let Ok(line) = std::str::from_utf8(&line) {
+            parse_sse_data_line(line, accumulator);
         }
     }
 
@@ -182,6 +192,81 @@ impl Provider for OpenRouterProvider {
 mod tests {
     use super::*;
     use crate::types::{ChatMessage, Role};
+
+    const STREAM_FIXTURE: &str = concat!(
+        ": OPENROUTER PROCESSING\n\n",
+        "data: {\"id\":\"gen-1\",\"model\":\"provider/モデル-1\"}\n\n",
+        "data: {\"id\":\"gen-ignored\",\"choices\":[{\"delta\":{\"content\":\"héllo\"}}]}\n\n",
+        "data: {\"id\":\"gen-1\",\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":42}}\n\n",
+        "data: [DONE]\n\n",
+    );
+
+    fn assert_fixture_result(accumulator: &StreamAccumulator) {
+        assert_eq!(accumulator.generation_id.as_deref(), Some("gen-1"));
+        assert_eq!(accumulator.model.as_deref(), Some("provider/モデル-1"));
+        assert_eq!(accumulator.input_tokens, 11);
+        assert_eq!(accumulator.output_tokens, 42);
+    }
+
+    #[test]
+    fn stream_parsing_handles_whole_payload_in_one_chunk() {
+        let provider = OpenRouterProvider::default();
+        let mut accumulator = StreamAccumulator::new();
+        provider.parse_stream_chunk(STREAM_FIXTURE.as_bytes(), &mut accumulator);
+        provider.finish_stream(&mut accumulator);
+        assert_fixture_result(&accumulator);
+    }
+
+    // Feeding one byte at a time exercises every possible chunk boundary,
+    // including splits inside multibyte UTF-8 characters and JSON tokens.
+    #[test]
+    fn stream_parsing_is_invariant_to_chunk_boundaries() {
+        let provider = OpenRouterProvider::default();
+        let mut accumulator = StreamAccumulator::new();
+        for byte in STREAM_FIXTURE.as_bytes() {
+            provider.parse_stream_chunk(std::slice::from_ref(byte), &mut accumulator);
+        }
+        provider.finish_stream(&mut accumulator);
+        assert_fixture_result(&accumulator);
+    }
+
+    #[test]
+    fn stream_parsing_is_invariant_to_every_two_chunk_split() {
+        let provider = OpenRouterProvider::default();
+        let bytes = STREAM_FIXTURE.as_bytes();
+        for split in 0..=bytes.len() {
+            let mut accumulator = StreamAccumulator::new();
+            provider.parse_stream_chunk(&bytes[..split], &mut accumulator);
+            provider.parse_stream_chunk(&bytes[split..], &mut accumulator);
+            provider.finish_stream(&mut accumulator);
+            assert_fixture_result(&accumulator);
+        }
+    }
+
+    #[test]
+    fn stream_parsing_flushes_final_frame_without_trailing_newline() {
+        let provider = OpenRouterProvider::default();
+        let mut accumulator = StreamAccumulator::new();
+        provider.parse_stream_chunk(
+            b"data: {\"id\":\"gen-9\",\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":7}}",
+            &mut accumulator,
+        );
+        assert!(accumulator.generation_id.is_none());
+        provider.finish_stream(&mut accumulator);
+        assert_eq!(accumulator.generation_id.as_deref(), Some("gen-9"));
+        assert_eq!(accumulator.input_tokens, 3);
+        assert_eq!(accumulator.output_tokens, 7);
+    }
+
+    #[test]
+    fn stream_parsing_handles_crlf_lines_split_across_chunks() {
+        let provider = OpenRouterProvider::default();
+        let mut accumulator = StreamAccumulator::new();
+        provider.parse_stream_chunk(b"data: {\"id\":\"gen-2\"}\r", &mut accumulator);
+        provider.parse_stream_chunk(b"\ndata: [DONE]\r\n", &mut accumulator);
+        provider.finish_stream(&mut accumulator);
+        assert_eq!(accumulator.generation_id.as_deref(), Some("gen-2"));
+    }
 
     #[test]
     fn build_request_replaces_model_with_openrouter_models() {


### PR DESCRIPTION
The OpenRouter stream parser ran from_utf8 and lines() on each raw
network chunk, so SSE frames split across chunks (mid-line, mid-JSON,
or mid multibyte character) were silently dropped and usage/cost
assembly could be wrong. StreamAccumulator now carries a bounded
pending-byte buffer between chunks; the parser drains only complete
lines per chunk and a new defaulted Provider::finish_stream flushes a
final frame that arrives without a trailing newline at EOF. Adds
byte-by-byte and every-two-chunk-split invariance tests plus CRLF,
[DONE], comment, and EOF-flush coverage. (ANLG-260)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches streaming analytics and token/cost assembly paths; behavior change is localized to best-effort parsing with a bounded buffer, but wrong usage data could still affect billing/observability if edge cases remain.
> 
> **Overview**
> Fixes **incorrect or missing streaming analytics** when OpenRouter SSE arrives split across TCP chunks. Parsing no longer assumes each network chunk is a complete UTF-8 string with whole lines.
> 
> **`StreamAccumulator`** now keeps a **bounded pending byte buffer** (1 MiB cap) between chunks, drains only **complete lines** per chunk, and supports **CRLF** line endings. **`Provider::finish_stream`** (default no-op) flushes a **final `data:` line without a trailing newline** after the upstream stream ends; the streaming handler calls it when analytics is enabled.
> 
> **OpenRouter** moves SSE `data:` parsing into **`parse_sse_data_line`** and wires **`parse_stream_chunk`** / **`finish_stream`** through the buffer. Adds tests for single-chunk payloads, byte-by-byte and every two-chunk split invariance, EOF flush, and CRLF splits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60811ff06127282ce89a06621a9bb23b47c2096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->