### PR TITLE
fix(editor): ignore stale async mention search results

### DIFF
--- a/packages/editor/src/widgets/mention.test.tsx
+++ b/packages/editor/src/widgets/mention.test.tsx
@@ -1,0 +1,129 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { type MentionItem, useMentionSearch } from "./mention";
+
+function deferredSearch() {
+  const pending = new Map<
+    string,
+    {
+      resolve: (items: MentionItem[]) => void;
+      reject: (error: Error) => void;
+    }
+  >();
+  const handleSearch = (query: string) =>
+    new Promise<MentionItem[]>((resolve, reject) => {
+      pending.set(query, { resolve, reject });
+    });
+  return { pending, handleSearch };
+}
+
+function item(id: string): MentionItem {
+  return { id, type: "human", label: id };
+}
+
+afterEach(cleanup);
+
+describe("useMentionSearch", () => {
+  it("ignores an older search resolving after a newer one", async () => {
+    const { pending, handleSearch } = deferredSearch();
+    const { result, rerender } = renderHook(
+      ({ query }) => useMentionSearch(true, query, handleSearch),
+      { initialProps: { query: "a" } },
+    );
+
+    rerender({ query: "ab" });
+    await act(async () => {
+      pending.get("ab")!.resolve([item("newer")]);
+    });
+    expect(result.current.items.map((i) => i.id)).toEqual(["newer"]);
+
+    await act(async () => {
+      pending.get("a")!.resolve([item("older")]);
+    });
+    expect(result.current.items.map((i) => i.id)).toEqual(["newer"]);
+  });
+
+  it("ignores an older search rejecting after a newer one resolved", async () => {
+    const { pending, handleSearch } = deferredSearch();
+    const { result, rerender } = renderHook(
+      ({ query }) => useMentionSearch(true, query, handleSearch),
+      { initialProps: { query: "a" } },
+    );
+
+    rerender({ query: "ab" });
+    await act(async () => {
+      pending.get("ab")!.resolve([item("newer")]);
+    });
+
+    await act(async () => {
+      pending.get("a")!.reject(new Error("slow failure"));
+    });
+    expect(result.current.items.map((i) => i.id)).toEqual(["newer"]);
+  });
+
+  it("does not repopulate after the mention is dismissed or cleared", async () => {
+    const { pending, handleSearch } = deferredSearch();
+    const { result, rerender } = renderHook(
+      ({ active, query }: { active: boolean; query: string | undefined }) =>
+        useMentionSearch(active, query, handleSearch),
+      { initialProps: { active: true, query: "a" } },
+    );
+
+    rerender({ active: false, query: undefined });
+    expect(result.current.items).toEqual([]);
+
+    await act(async () => {
+      pending.get("a")!.resolve([item("stale")]);
+    });
+    expect(result.current.items).toEqual([]);
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it("ignores a search resolving after unmount", async () => {
+    const { pending, handleSearch } = deferredSearch();
+    const { unmount } = renderHook(() =>
+      useMentionSearch(true, "a", handleSearch),
+    );
+
+    unmount();
+    await act(async () => {
+      pending.get("a")!.resolve([item("stale")]);
+    });
+  });
+
+  it("resets the selection when fresh results arrive", async () => {
+    const { pending, handleSearch } = deferredSearch();
+    const { result, rerender } = renderHook(
+      ({ query }) => useMentionSearch(true, query, handleSearch),
+      { initialProps: { query: "a" } },
+    );
+
+    await act(async () => {
+      pending.get("a")!.resolve([item("one"), item("two")]);
+    });
+    act(() => {
+      result.current.setSelectedIndex(1);
+    });
+    expect(result.current.selectedIndex).toBe(1);
+
+    rerender({ query: "ab" });
+    await act(async () => {
+      pending.get("ab")!.resolve([item("three")]);
+    });
+    expect(result.current.selectedIndex).toBe(0);
+    expect(result.current.items.map((i) => i.id)).toEqual(["three"]);
+  });
+
+  it("caps results at five items", async () => {
+    const { pending, handleSearch } = deferredSearch();
+    const { result } = renderHook(() =>
+      useMentionSearch(true, "a", handleSearch),
+    );
+
+    await act(async () => {
+      pending.get("a")!.resolve(["1", "2", "3", "4", "5", "6", "7"].map(item));
+    });
+    expect(result.current.items).toHaveLength(5);
+  });
+});

--- a/packages/editor/src/widgets/mention.tsx
+++ b/packages/editor/src/widgets/mention.tsx
@@ -73,11 +73,48 @@ export function findMention(
 }
 
 // ---------------------------------------------------------------------------
+// Mention search state
+// ---------------------------------------------------------------------------
+// Exported for tests: a slow older search must never overwrite the results of
+// a newer one, repopulate a dismissed popup, or update after unmount.
+export function useMentionSearch(
+  active: boolean,
+  query: string | undefined,
+  handleSearch: (query: string) => Promise<MentionItem[]>,
+) {
+  const [items, setItems] = useState<MentionItem[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    if (!active || query === undefined) {
+      setItems([]);
+      setSelectedIndex(0);
+      return;
+    }
+
+    let stale = false;
+    handleSearch(query)
+      .then((results) => {
+        if (stale) return;
+        setItems(results.slice(0, 5));
+        setSelectedIndex(0);
+      })
+      .catch(() => {
+        if (stale) return;
+        setItems([]);
+      });
+    return () => {
+      stale = true;
+    };
+  }, [active, query, handleSearch]);
+
+  return { items, selectedIndex, setSelectedIndex };
+}
+
+// ---------------------------------------------------------------------------
 // Mention popup
 // ---------------------------------------------------------------------------
 export function MentionSuggestion({ config }: { config: MentionConfig }) {
-  const [items, setItems] = useState<MentionItem[]>([]);
-  const [selectedIndex, setSelectedIndex] = useState(0);
   const [dismissedFrom, setDismissedFrom] = useState<number | null>(null);
   const popupRef = useRef<HTMLDivElement>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
@@ -90,6 +127,12 @@ export function MentionSuggestion({ config }: { config: MentionConfig }) {
   const dismissed =
     mentionState !== null && dismissedFrom === mentionState.from;
   const active = mentionState !== null && !dismissed;
+
+  const { items, selectedIndex, setSelectedIndex } = useMentionSearch(
+    active,
+    mentionState?.query,
+    config.handleSearch,
+  );
 
   if (!active && selectedIndex !== 0) {
     setSelectedIndex(0);
@@ -184,24 +227,6 @@ export function MentionSuggestion({ config }: { config: MentionConfig }) {
     cleanupRef.current = autoUpdate(referenceEl, popup, update);
     update();
   });
-
-  useEffect(() => {
-    if (!active) {
-      setItems([]);
-      setSelectedIndex(0);
-      return;
-    }
-
-    config
-      .handleSearch(mentionState!.query)
-      .then((results) => {
-        setItems(results.slice(0, 5));
-        setSelectedIndex(0);
-      })
-      .catch(() => {
-        setItems([]);
-      });
-  }, [active, mentionState?.query, config]);
 
   if (!active || items.length === 0) return null;
 


### PR DESCRIPTION
Every handleSearch promise applied its result unconditionally, so a
slow older query could overwrite results for a newer query, repopulate
a dismissed popup, or set state after unmount. Extract the search state
into useMentionSearch, which marks each in-flight request stale from
the effect cleanup and ignores stale resolve and reject completions;
only the current active query can mutate suggestion state. Adds
out-of-order resolution, stale rejection, dismissal/clear, unmount,
selection-reset, and result-cap tests. (ANLG-262)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized editor mention UX fix with test coverage; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a race where **any** completed `handleSearch` promise could update mention suggestion state, so slower or late responses could show wrong results, reopen a dismissed popup, or update after unmount.
> 
> Mention async search is moved into an exported **`useMentionSearch`** hook. Each effect run marks prior in-flight work **stale** on cleanup and only the current `active` + `query` may apply resolve/reject handlers; results stay capped at five and selection resets when new results land. **`MentionSuggestion`** wires the hook in place of the old inline `useEffect`.
> 
> Adds **`mention.test.tsx`** with deferred-search tests for out-of-order resolve/reject, dismiss/clear, unmount, selection reset, and the five-item cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37fbbf0d658f8c7311c6e74b5d1d5bbb3189dd81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->