### PR TITLE
fix(desktop): query canonical document kinds for past-note insights

### DIFF
--- a/apps/desktop/src/devtools-panel/recurring-notes.ts
+++ b/apps/desktop/src/devtools-panel/recurring-notes.ts
@@ -276,7 +276,7 @@ function buildSessionStatements({
     buildDocumentStatement({
       id: `${sessionId}:summary`,
       sessionId,
-      kind: "enhanced_note",
+      kind: "summary",
       title: "Summary",
       body: rawMd,
       ownerUserId,
@@ -367,7 +367,7 @@ function buildDocumentStatement({
 }: {
   id: string;
   sessionId: string;
-  kind: "note" | "enhanced_note";
+  kind: "note" | "summary";
   title: string;
   body: string;
   ownerUserId: string;

--- a/apps/desktop/src/session/insights/past-notes.test.tsx
+++ b/apps/desktop/src/session/insights/past-notes.test.tsx
@@ -4,6 +4,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   data: null as ReturnType<typeof makeData> | null,
+  documents: null as Array<{
+    session_id: string;
+    kind: string;
+    body: string;
+    sort_order: number;
+    deleted_at: string | null;
+  }> | null,
   executeTransaction: vi.fn(
     (_statements: Array<{ sql: string; params: unknown[] }>) =>
       Promise.resolve([1]),
@@ -48,12 +55,28 @@ vi.mock("~/db", () => ({
       enhancedNotes: [],
       keyFacts: {},
     };
+    // Mirrors the canonical enhanced-document predicate so fixture rows with
+    // other kinds or a deleted_at exercise the same filtering as SQLite.
+    const enhancedRows = () =>
+      hoisted.documents
+        ? hoisted.documents
+            .filter(
+              (row) =>
+                ["summary", "template_output"].includes(row.kind) &&
+                row.deleted_at === null,
+            )
+            .map((row) => ({
+              session_id: row.session_id,
+              content: row.body,
+              position: row.sort_order,
+            }))
+        : data.enhancedNotes;
     const rows = options.sql.includes("FROM sessions")
       ? Object.values(data.sessions)
       : options.sql.includes("FROM session_participants")
         ? data.participants
-        : options.sql.includes("kind = 'enhanced_note'")
-          ? data.enhancedNotes
+        : options.sql.includes("kind IN ('summary', 'template_output')")
+          ? enhancedRows()
           : Object.values(data.keyFacts);
     return { data: options.mapRows(rows) };
   },
@@ -72,6 +95,7 @@ import {
 
 beforeEach(() => {
   hoisted.data = null;
+  hoisted.documents = null;
   hoisted.executeTransaction.mockClear();
   hoisted.generateText.mockReset();
   hoisted.toastError.mockReset();
@@ -255,6 +279,89 @@ describe("insights regeneration", () => {
     expect(statements[1].sql).toContain("INSERT INTO session_documents");
     expect(statements[1].sql).toContain("ON CONFLICT(id) DO UPDATE");
     consoleError.mockRestore();
+  });
+
+  it("feeds insights only from live summary and template_output documents", async () => {
+    hoisted.data = makeData({
+      sessions: {
+        current: {
+          title: "Weekly Product Sync",
+          created_at: "2026-06-03T10:00:00.000Z",
+          event_json: "",
+        },
+        previous: {
+          title: "Weekly Product Sync",
+          created_at: "2026-05-28T10:00:00.000Z",
+          event_json: "",
+        },
+      },
+      mapping_session_participant: {
+        current_alex: {
+          session_id: "current",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+        previous_alex: {
+          session_id: "previous",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+        },
+      },
+    });
+    hoisted.documents = [
+      {
+        session_id: "previous",
+        kind: "note",
+        body: "Raw note text must not feed insights.",
+        sort_order: 0,
+        deleted_at: null,
+      },
+      {
+        session_id: "previous",
+        kind: "summary",
+        body: "Deleted summary must not feed insights.",
+        sort_order: 1,
+        deleted_at: "2026-06-01T00:00:00.000Z",
+      },
+    ];
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result, rerender } = renderHook(
+      () => usePastSessionNotes("current", { enabled: true }),
+      { wrapper },
+    );
+    expect(result.current.hasPastNotes).toBe(false);
+
+    hoisted.documents = [
+      ...hoisted.documents,
+      {
+        session_id: "previous",
+        kind: "summary",
+        body: "Alex committed to send pricing by Friday.",
+        sort_order: 2,
+        deleted_at: null,
+      },
+      {
+        session_id: "previous",
+        kind: "template_output",
+        body: "Follow-up template output.",
+        sort_order: 3,
+        deleted_at: null,
+      },
+    ];
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.hasPastNotes).toBe(true);
+    });
+    expect(result.current.notes.map((note) => note.sessionId)).toEqual([
+      "previous",
+    ]);
   });
 });
 

--- a/apps/desktop/src/session/insights/past-notes.ts
+++ b/apps/desktop/src/session/insights/past-notes.ts
@@ -271,7 +271,7 @@ function usePastSessionNotesData(enabled: boolean): PastSessionNotesData {
         body AS content,
         sort_order AS position
       FROM session_documents
-      WHERE kind = 'enhanced_note' AND deleted_at IS NULL
+      WHERE kind IN ('summary', 'template_output') AND deleted_at IS NULL
       ORDER BY session_id, sort_order, created_at, id
     `,
     enabled,


### PR DESCRIPTION
The past-note insight query filtered session_documents on
kind = 'enhanced_note', a kind production never persists (enhanced
documents are stored as 'summary' or 'template_output', and the
TinyBase->SQLite migration never wrote a legacy enhanced_note kind), so
related-meeting insights silently found no source material. Switch the
query to the canonical kinds, align the devtools recurring-notes seeder
so fixtures exercise the production path, and rework the test mock to a
documents table that applies the real kind/deleted_at predicate with
coverage for summary, template_output, ordinary note, and deleted rows.
The UI task-source kind "enhanced_note" is a separate vocabulary and is
unchanged. (ANLG-257)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted query and fixture fix for insights source selection; no auth or data-migration changes.
> 
> **Overview**
> **Related-meeting insights** were loading past session source text from `session_documents` with `kind = 'enhanced_note'`, which production never writes (enhanced content is stored as **`summary`** or **`template_output`**). That mismatch caused insights to find no source material and stay empty.
> 
> The live query in `past-notes.ts` now filters on **`summary`** and **`template_output`** with `deleted_at IS NULL`. Devtools recurring-notes seeding writes a **`summary`** document instead of **`enhanced_note`** so local fixtures match production. Tests use a **`documents`** fixture and the same kind/deleted predicate, including coverage that raw **`note`** rows and deleted summaries are excluded while live summary and template output enable past notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d8f311ffe39e14ea42e89ee32aad100e94759ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->