### PR TITLE
fix(stripe): apply each entitlement snapshot in one transaction

### DIFF
--- a/apps/stripe/src/scripts/entitlement-snapshot.test.ts
+++ b/apps/stripe/src/scripts/entitlement-snapshot.test.ts
@@ -1,0 +1,173 @@
+import { expect, test } from "bun:test";
+import type Stripe from "stripe";
+
+import {
+  applyEntitlementSnapshot,
+  type SnapshotClient,
+  type SnapshotPool,
+} from "./entitlement-snapshot";
+
+function entitlement(lookupKey: string): Stripe.Entitlements.ActiveEntitlement {
+  return {
+    id: `ent_${lookupKey}`,
+    object: "entitlements.active_entitlement",
+    livemode: false,
+    feature: `feat_${lookupKey}`,
+    lookup_key: lookupKey,
+  } as Stripe.Entitlements.ActiveEntitlement;
+}
+
+function fakePool(
+  options: { failOn?: (sql: string, call: number) => boolean } = {},
+) {
+  const calls: Array<{ sql: string; params?: unknown[] }> = [];
+  let released = 0;
+  let connects = 0;
+
+  const client: SnapshotClient = {
+    async query(sql: string, params?: unknown[]) {
+      const call = calls.length;
+      calls.push({ sql, params });
+      if (options.failOn?.(sql, call)) {
+        throw new Error(`injected failure: ${sql.slice(0, 24)}`);
+      }
+      return { rowCount: sql.startsWith("DELETE") ? 2 : 1 };
+    },
+    release() {
+      released++;
+    },
+  };
+
+  const pool: SnapshotPool = {
+    async connect() {
+      connects++;
+      return client;
+    },
+  };
+
+  return {
+    pool,
+    calls,
+    kinds: () => calls.map(({ sql }) => sql.split(/[ \n]/, 1)[0]),
+    released: () => released,
+    connects: () => connects,
+  };
+}
+
+test("commits deletion, upserts, and last_synced_at in one transaction", async () => {
+  const db = fakePool();
+
+  const result = await applyEntitlementSnapshot(db.pool, "cus_1", [
+    entitlement("pro"),
+    entitlement("teams"),
+  ]);
+
+  expect(db.kinds()).toEqual([
+    "BEGIN",
+    "DELETE",
+    "INSERT",
+    "INSERT",
+    "UPDATE",
+    "COMMIT",
+  ]);
+  expect(db.calls[1]?.params).toEqual(["cus_1", ["pro", "teams"]]);
+  expect(db.calls[4]?.sql).toContain("stripe.customers SET last_synced_at");
+  expect(result).toEqual({ updated: 2, deleted: 2, hasError: false });
+  expect(db.released()).toBe(1);
+});
+
+test("empty snapshots use the same transaction path and delete everything", async () => {
+  const db = fakePool();
+
+  const result = await applyEntitlementSnapshot(db.pool, "cus_1", []);
+
+  expect(db.kinds()).toEqual(["BEGIN", "DELETE", "UPDATE", "COMMIT"]);
+  expect(db.calls[1]?.params).toEqual(["cus_1", []]);
+  expect(result).toEqual({ updated: 0, deleted: 2, hasError: false });
+});
+
+test("rolls back when stale deletion fails", async () => {
+  const db = fakePool({ failOn: (sql) => sql.startsWith("DELETE") });
+
+  await expect(
+    applyEntitlementSnapshot(db.pool, "cus_1", [entitlement("pro")]),
+  ).rejects.toThrow("injected failure");
+
+  expect(db.kinds()).toEqual(["BEGIN", "DELETE", "ROLLBACK"]);
+  expect(db.released()).toBe(1);
+});
+
+test("rolls back a partially applied upsert batch", async () => {
+  let inserts = 0;
+  const db = fakePool({
+    failOn: (sql) => sql.startsWith("INSERT") && ++inserts === 2,
+  });
+
+  await expect(
+    applyEntitlementSnapshot(db.pool, "cus_1", [
+      entitlement("pro"),
+      entitlement("teams"),
+    ]),
+  ).rejects.toThrow("injected failure");
+
+  expect(db.kinds()).toEqual([
+    "BEGIN",
+    "DELETE",
+    "INSERT",
+    "INSERT",
+    "ROLLBACK",
+  ]);
+});
+
+test("rolls back when the last_synced_at update fails", async () => {
+  const db = fakePool({ failOn: (sql) => sql.startsWith("UPDATE") });
+
+  await expect(
+    applyEntitlementSnapshot(db.pool, "cus_1", [entitlement("pro")]),
+  ).rejects.toThrow("injected failure");
+
+  expect(db.kinds()).toEqual([
+    "BEGIN",
+    "DELETE",
+    "INSERT",
+    "UPDATE",
+    "ROLLBACK",
+  ]);
+  expect(db.kinds()).not.toContain("COMMIT");
+});
+
+test("releases the connection even when rollback itself fails", async () => {
+  const db = fakePool({
+    failOn: (sql) => sql.startsWith("DELETE") || sql.startsWith("ROLLBACK"),
+  });
+
+  await expect(
+    applyEntitlementSnapshot(db.pool, "cus_1", [entitlement("pro")]),
+  ).rejects.toThrow("injected failure: DELETE");
+
+  expect(db.released()).toBe(1);
+});
+
+test("concurrent customers each get their own connection and transaction", async () => {
+  const clients: Array<ReturnType<typeof fakePool>> = [];
+  const pool: SnapshotPool = {
+    async connect() {
+      const db = fakePool();
+      clients.push(db);
+      return db.pool.connect();
+    },
+  };
+
+  const [first, second] = await Promise.all([
+    applyEntitlementSnapshot(pool, "cus_1", [entitlement("pro")]),
+    applyEntitlementSnapshot(pool, "cus_2", []),
+  ]);
+
+  expect(first.hasError).toBe(false);
+  expect(second.hasError).toBe(false);
+  expect(clients).toHaveLength(2);
+  for (const db of clients) {
+    expect(db.kinds()[0]).toBe("BEGIN");
+    expect(db.kinds().at(-1)).toBe("COMMIT");
+  }
+});

--- a/apps/stripe/src/scripts/entitlement-snapshot.ts
+++ b/apps/stripe/src/scripts/entitlement-snapshot.ts
@@ -1,0 +1,82 @@
+import type Stripe from "stripe";
+
+export type SnapshotResult = {
+  updated: number;
+  deleted: number;
+  hasError: boolean;
+};
+
+type QueryResult = { rowCount: number | null };
+
+export type SnapshotClient = {
+  query(sql: string, params?: unknown[]): Promise<QueryResult>;
+  release(): void;
+};
+
+export type SnapshotPool = {
+  connect(): Promise<SnapshotClient>;
+};
+
+// Applies one customer's entitlement snapshot atomically: stale deletion,
+// every upsert, and the successful last_synced_at update commit or roll back
+// together. An empty snapshot takes the same path — `!= ALL('{}')` matches
+// every row, so all of the customer's entitlements are deleted.
+export async function applyEntitlementSnapshot(
+  pool: SnapshotPool,
+  customerId: string,
+  entitlements: Stripe.Entitlements.ActiveEntitlement[],
+): Promise<SnapshotResult> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const deleteResult = await client.query(
+      `DELETE FROM stripe.active_entitlements WHERE customer = $1 AND lookup_key != ALL($2)`,
+      [customerId, entitlements.map((e) => e.lookup_key)],
+    );
+
+    const now = new Date().toISOString();
+    for (const entitlement of entitlements) {
+      await client.query(
+        `INSERT INTO stripe.active_entitlements (id, object, livemode, feature, customer, lookup_key, last_synced_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT (customer, lookup_key) DO UPDATE SET
+           id = EXCLUDED.id,
+           object = EXCLUDED.object,
+           livemode = EXCLUDED.livemode,
+           feature = EXCLUDED.feature,
+           last_synced_at = EXCLUDED.last_synced_at`,
+        [
+          entitlement.id,
+          entitlement.object,
+          entitlement.livemode,
+          entitlement.feature,
+          customerId,
+          entitlement.lookup_key,
+          now,
+        ],
+      );
+    }
+
+    await client.query(
+      `UPDATE stripe.customers SET last_synced_at = $1 WHERE id = $2`,
+      [now, customerId],
+    );
+
+    await client.query("COMMIT");
+    return {
+      updated: entitlements.length,
+      deleted: deleteResult.rowCount ?? 0,
+      hasError: false,
+    };
+  } catch (error) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // Releasing a broken connection also aborts the transaction.
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/apps/stripe/src/scripts/stripe-sync-entitlements.ts
+++ b/apps/stripe/src/scripts/stripe-sync-entitlements.ts
@@ -12,6 +12,7 @@ import Stripe from "stripe";
 import { parseArgs } from "util";
 
 import { STRIPE_API_VERSION } from "../integration/stripe";
+import { applyEntitlementSnapshot } from "./entitlement-snapshot";
 
 const { values } = parseArgs({
   args: Bun.argv.slice(2),
@@ -140,130 +141,30 @@ const fetchCustomerEntitlements = (customerId: string) =>
     catch: (error) => error,
   }).pipe(Effect.retry(retryPolicy));
 
-const deleteAllEntitlements = (customerId: string) =>
+// One transaction per customer: stale deletion, upserts, and last_synced_at
+// commit together, so a failure cannot leave a partially applied snapshot.
+const applySnapshot = (
+  customerId: string,
+  entitlements: Stripe.Entitlements.ActiveEntitlement[],
+) =>
   Effect.tryPromise({
-    try: () =>
-      pool.query(`DELETE FROM stripe.active_entitlements WHERE customer = $1`, [
-        customerId,
-      ]),
+    try: () => applyEntitlementSnapshot(pool, customerId, entitlements),
     catch: (e) => new DbError(e instanceof Error ? e.message : String(e)),
   }).pipe(
-    Effect.map((result) => ({
-      updated: 0,
-      deleted: result.rowCount ?? 0,
-      hasError: false,
-    })),
     Effect.catchAll((e) =>
       Effect.gen(function* () {
         yield* Effect.logError(
-          `Failed to delete entitlements for ${customerId}: ${e.message}`,
+          `Failed to apply entitlement snapshot for ${customerId}: ${e.message}`,
         );
         return { updated: 0, deleted: 0, hasError: true };
       }),
     ),
   );
 
-const syncEntitlements = (
-  customerId: string,
-  entitlements: Stripe.Entitlements.ActiveEntitlement[],
-) =>
-  Effect.gen(function* () {
-    const activeLookupKeys = entitlements.map((e) => e.lookup_key);
-
-    const deleteResult = yield* Effect.tryPromise({
-      try: () =>
-        pool.query(
-          `DELETE FROM stripe.active_entitlements WHERE customer = $1 AND lookup_key != ALL($2)`,
-          [customerId, activeLookupKeys],
-        ),
-      catch: (e) => new DbError(e instanceof Error ? e.message : String(e)),
-    }).pipe(
-      Effect.catchAll((e) =>
-        Effect.gen(function* () {
-          yield* Effect.logError(
-            `Failed to delete stale entitlements for ${customerId}: ${e.message}`,
-          );
-          return null;
-        }),
-      ),
-    );
-
-    if (deleteResult === null) {
-      return { updated: 0, deleted: 0, hasError: true };
-    }
-
-    const deleteCount = deleteResult.rowCount ?? 0;
-
-    for (const entitlement of entitlements) {
-      const upsertResult = yield* Effect.tryPromise({
-        try: () =>
-          pool.query(
-            `INSERT INTO stripe.active_entitlements (id, object, livemode, feature, customer, lookup_key, last_synced_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
-             ON CONFLICT (customer, lookup_key) DO UPDATE SET
-               id = EXCLUDED.id,
-               object = EXCLUDED.object,
-               livemode = EXCLUDED.livemode,
-               feature = EXCLUDED.feature,
-               last_synced_at = EXCLUDED.last_synced_at`,
-            [
-              entitlement.id,
-              entitlement.object,
-              entitlement.livemode,
-              entitlement.feature,
-              customerId,
-              entitlement.lookup_key,
-              new Date().toISOString(),
-            ],
-          ),
-        catch: (e) => new DbError(e instanceof Error ? e.message : String(e)),
-      }).pipe(
-        Effect.catchAll((e) =>
-          Effect.gen(function* () {
-            yield* Effect.logError(
-              `Failed to upsert entitlement for ${customerId}: ${e.message}`,
-            );
-            return null;
-          }),
-        ),
-      );
-
-      if (upsertResult === null) {
-        return { updated: 0, deleted: deleteCount, hasError: true };
-      }
-    }
-
-    return {
-      updated: entitlements.length,
-      deleted: deleteCount,
-      hasError: false,
-    };
-  });
-
-const updateCustomerLastSyncedAt = (customerId: string) =>
-  Effect.tryPromise({
-    try: () =>
-      pool.query(
-        `UPDATE stripe.customers SET last_synced_at = $1 WHERE id = $2`,
-        [new Date().toISOString(), customerId],
-      ),
-    catch: (e) => new DbError(e instanceof Error ? e.message : String(e)),
-  }).pipe(Effect.catchAll(() => Effect.void));
-
 const processCustomer = (customerId: string) =>
   Effect.gen(function* () {
     const entitlements = yield* fetchCustomerEntitlements(customerId);
-
-    const result =
-      entitlements.length === 0
-        ? yield* deleteAllEntitlements(customerId)
-        : yield* syncEntitlements(customerId, entitlements);
-
-    if (!result.hasError) {
-      yield* updateCustomerLastSyncedAt(customerId);
-    }
-
-    return result;
+    return yield* applySnapshot(customerId, entitlements);
   }).pipe(
     Effect.catchAll((error) =>
       Effect.gen(function* () {


### PR DESCRIPTION
The entitlement sync script deleted stale rows, ran individual upserts,
and updated last_synced_at as separate pool queries, so a failure
partway through left a partially applied customer snapshot. Extract
applyEntitlementSnapshot, which runs stale deletion, every upsert, and
the last_synced_at update on one connection inside BEGIN/COMMIT with
rollback on any failure; empty snapshots take the same path since
!= ALL('{}') deletes every row. last_synced_at now changes only on
commit. Adds failure-injection tests for delete/upsert/timestamp
rollback, empty snapshots, rollback-failure release, and concurrent
customers. (ANLG-261)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Stripe entitlement rows and customer sync timestamps are written; failures now roll back entirely instead of leaving partial state, which is safer but affects billing/feature data consistency on errors.
> 
> **Overview**
> The entitlement sync script used separate pool queries for stale deletes, per-row upserts, and `last_synced_at`, so a mid-sync failure could leave a customer’s DB state half-applied.
> 
> This PR introduces **`applyEntitlementSnapshot`**, which runs stale deletion (`lookup_key != ALL($2)`), all upserts, and the customer **`last_synced_at`** update on one connection inside **BEGIN/COMMIT**, with rollback on any error. Empty Stripe snapshots use the same path (empty array deletes every entitlement row). **`last_synced_at` is only written on successful commit**, not after partial work.
> 
> The sync script drops the old `deleteAllEntitlements` / `syncEntitlements` / `updateCustomerLastSyncedAt` split and calls the helper via Effect. New Bun tests cover happy path, empty snapshots, rollback on delete/upsert/update failures, connection release when rollback fails, and isolated transactions per concurrent customer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d32321242dcbfaac47f4de8b69bd595c9d8162ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->