### PR TITLE
refactor(pricing): make tier actions behavioral instead of label-driven

### DIFF
--- a/apps/desktop/src/settings/general/account.test.tsx
+++ b/apps/desktop/src/settings/general/account.test.tsx
@@ -25,6 +25,9 @@ const mocks = vi.hoisted(() => ({
     plan: "free",
     trialDaysRemaining: null as number | null,
   },
+  session: { user: { email: "john@example.com" } } as {
+    user: { email: string };
+  } | null,
 }));
 
 vi.mock("@anlg/plugin-analytics", () => ({
@@ -46,7 +49,7 @@ vi.mock("~/auth", () => ({
   useAuth: () => ({
     isRefreshingSession: false,
     refreshSession: vi.fn(),
-    session: { user: { email: "john@example.com" } },
+    session: mocks.session,
     signIn: mocks.signIn,
     signOut: mocks.signOut,
   }),
@@ -80,6 +83,7 @@ const renderAccount = () => {
 describe("SettingsAccount", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.session = { user: { email: "john@example.com" } };
     mocks.billing = {
       canStartTrial: { data: false, isPending: false },
       hasPaymentMethod: false,
@@ -163,6 +167,72 @@ describe("SettingsAccount", () => {
       days_remaining: 3,
       source: "settings",
     });
+  });
+
+  it("starts a cardless trial from the behavioral action variant", async () => {
+    mocks.billing = {
+      canStartTrial: { data: true, isPending: false },
+      hasPaymentMethod: false,
+      isPaid: false,
+      isTrialing: false,
+      plan: "free",
+      trialDaysRemaining: null,
+    };
+
+    renderAccount();
+
+    fireEvent.click(screen.getByRole("button", { name: "Start free trial" }));
+
+    await waitFor(() =>
+      expect(mocks.buildWebAppUrl).toHaveBeenCalledWith("/app/checkout", {
+        period: "monthly",
+        trial: "true",
+        source: "settings",
+      }),
+    );
+    expect(mocks.analyticsEvent).toHaveBeenCalledWith({
+      event: "trial_checkout_started",
+      plan: "pro",
+      period: "monthly",
+      source: "settings",
+    });
+  });
+
+  it("opens checkout for an upgrade when no trial is available", async () => {
+    renderAccount();
+
+    fireEvent.click(screen.getByRole("button", { name: "Get Pro" }));
+
+    await waitFor(() =>
+      expect(mocks.buildWebAppUrl).toHaveBeenCalledWith("/app/checkout", {
+        plan: "pro",
+        period: "monthly",
+        source: "settings",
+      }),
+    );
+    expect(mocks.analyticsEvent).toHaveBeenCalledWith({
+      event: "upgrade_clicked",
+      plan: "pro",
+      period: "monthly",
+      source: "settings",
+    });
+  });
+
+  it("asks guests to sign in instead of opening checkout", async () => {
+    mocks.session = null;
+
+    renderAccount();
+
+    expect(screen.queryByRole("button", { name: "Get Pro" })).toBeNull();
+    expect(screen.getByText("Current plan")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign in for Pro" }));
+
+    await waitFor(() => expect(mocks.signIn).toHaveBeenCalled());
+    expect(mocks.buildWebAppUrl).not.toHaveBeenCalledWith(
+      "/app/checkout",
+      expect.anything(),
+    );
   });
 
   it("renders the current plan as status once the trial has a payment method", () => {

--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -29,6 +29,17 @@ import { SettingsPageTitle } from "~/settings/page-title";
 import { DestructiveConfirmationDialog } from "~/shared/ui/destructive-confirmation-dialog";
 import { buildWebAppUrl } from "~/shared/utils";
 
+function tierActionLabel(action: NonNullable<TierAction>): string {
+  switch (action.kind) {
+    case "current":
+      return "Current plan";
+    case "startTrial":
+      return "Start free trial";
+    case "checkout":
+      return action.direction === "upgrade" ? "Get Pro" : "Switch to Pro";
+  }
+}
+
 export function SettingsAccount() {
   const { t } = useLingui();
   const auth = useAuth();
@@ -266,7 +277,7 @@ function PlanBillingSection({
   const renderAction = (action: TierAction, compact: boolean) => {
     if (action == null) return null;
 
-    if (action.style === "current") {
+    if (action.kind === "current") {
       if (needsPaymentMethod) {
         if (compact) {
           return (
@@ -295,24 +306,27 @@ function PlanBillingSection({
 
       if (compact) {
         return (
-          <span className="text-muted-foreground text-xs">{action.label}</span>
+          <span className="text-muted-foreground text-xs">
+            {tierActionLabel(action)}
+          </span>
         );
       }
 
       return (
         <div className="border-border bg-muted text-muted-foreground flex h-8 w-full items-center justify-center rounded-full border text-xs">
-          {action.label}
+          {tierActionLabel(action)}
         </div>
       );
     }
 
-    const isUpgrade = action.style === "upgrade";
+    const isUpgrade =
+      action.kind === "startTrial" || action.direction === "upgrade";
 
     const handleClick = async () => {
-      if (action.label === "Start free trial") {
+      if (action.kind === "startTrial") {
         void analyticsCommands.event({
           event: "trial_checkout_started",
-          plan: "pro",
+          plan: action.plan,
           period: "monthly",
           source: "settings",
         });
@@ -326,19 +340,17 @@ function PlanBillingSection({
         );
         return;
       }
-      const targetPlan = action.targetPlan;
-      if (!targetPlan) return;
 
       void analyticsCommands.event({
         event: "upgrade_clicked",
-        plan: targetPlan,
+        plan: action.plan,
         period: "monthly",
         source: "settings",
       });
 
       await openBillingUrl(() =>
         buildWebAppUrl("/app/checkout", {
-          plan: targetPlan,
+          plan: action.plan,
           period: "monthly",
           source: "settings",
         }),
@@ -346,7 +358,7 @@ function PlanBillingSection({
     };
 
     const isBusy = actionPending;
-    const label = action.label;
+    const label = tierActionLabel(action);
 
     if (compact) {
       return (
@@ -423,21 +435,23 @@ function GuestPlanSection({ onSignIn }: { onSignIn: () => Promise<void> }) {
   const renderAction = (action: TierAction, compact: boolean) => {
     if (action == null) return null;
 
-    if (action.style === "current") {
+    if (action.kind === "current") {
       if (compact) {
         return (
-          <span className="text-muted-foreground text-xs">{action.label}</span>
+          <span className="text-muted-foreground text-xs">
+            {tierActionLabel(action)}
+          </span>
         );
       }
 
       return (
         <div className="border-border bg-muted text-muted-foreground flex h-8 w-full items-center justify-center rounded-full border text-xs">
-          {action.label}
+          {tierActionLabel(action)}
         </div>
       );
     }
 
-    const label = action.targetPlan === "pro" ? t`Sign in for Pro` : t`Sign in`;
+    const label = action.plan === "pro" ? t`Sign in for Pro` : t`Sign in`;
 
     if (compact) {
       return (

--- a/apps/desktop/src/settings/general/tier-actions.test.ts
+++ b/apps/desktop/src/settings/general/tier-actions.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { getActionForTier, type PlanTier } from "@anlg/pricing";
+
+describe("getActionForTier", () => {
+  const cases: Array<{
+    tierId: PlanTier;
+    currentPlan: PlanTier;
+    canStartTrial: boolean;
+    expected: ReturnType<typeof getActionForTier>;
+  }> = [
+    {
+      tierId: "free",
+      currentPlan: "free",
+      canStartTrial: false,
+      expected: { kind: "current" },
+    },
+    {
+      tierId: "free",
+      currentPlan: "free",
+      canStartTrial: true,
+      expected: { kind: "current" },
+    },
+    {
+      tierId: "pro",
+      currentPlan: "pro",
+      canStartTrial: false,
+      expected: { kind: "current" },
+    },
+    {
+      tierId: "pro",
+      currentPlan: "pro",
+      canStartTrial: true,
+      expected: { kind: "current" },
+    },
+    {
+      tierId: "pro",
+      currentPlan: "free",
+      canStartTrial: true,
+      expected: { kind: "startTrial", plan: "pro" },
+    },
+    {
+      tierId: "pro",
+      currentPlan: "free",
+      canStartTrial: false,
+      expected: { kind: "checkout", plan: "pro", direction: "upgrade" },
+    },
+    {
+      tierId: "free",
+      currentPlan: "pro",
+      canStartTrial: false,
+      expected: null,
+    },
+    {
+      tierId: "free",
+      currentPlan: "pro",
+      canStartTrial: true,
+      expected: null,
+    },
+  ];
+
+  for (const { tierId, currentPlan, canStartTrial, expected } of cases) {
+    it(`resolves ${currentPlan} -> ${tierId} (trial: ${canStartTrial})`, () => {
+      expect(getActionForTier(tierId, currentPlan, canStartTrial)).toEqual(
+        expected,
+      );
+    });
+  }
+});

--- a/packages/pricing/src/tiers.ts
+++ b/packages/pricing/src/tiers.ts
@@ -5,13 +5,12 @@ export type PlanFeature = {
   tooltip?: string;
 };
 
+// Behavioral variants only: consumers render their own (translated) labels,
+// so no navigation or analytics decision can depend on display copy.
 export type TierAction =
-  | {
-      label: string;
-      style: "current" | "upgrade" | "downgrade";
-      targetPlan: "pro";
-    }
-  | { label: string; style: "current"; targetPlan?: undefined }
+  | { kind: "current" }
+  | { kind: "startTrial"; plan: "pro" }
+  | { kind: "checkout"; plan: "pro"; direction: "upgrade" | "downgrade" }
   | null;
 
 export interface PlanTierData {
@@ -135,25 +134,14 @@ export function getActionForTier(
   canStartTrial: boolean,
 ): TierAction {
   if (tierId === currentPlan) {
-    return { label: "Current plan", style: "current" };
+    return { kind: "current" };
   }
-
-  const direction =
-    TIER_ORDER[tierId] > TIER_ORDER[currentPlan] ? "upgrade" : "downgrade";
 
   if (currentPlan === "free") {
     if (tierId === "pro" && canStartTrial) {
-      return {
-        label: "Start free trial",
-        style: "upgrade",
-        targetPlan: "pro",
-      };
+      return { kind: "startTrial", plan: "pro" };
     }
-    return {
-      label: "Get Pro",
-      style: "upgrade",
-      targetPlan: "pro",
-    };
+    return { kind: "checkout", plan: "pro", direction: "upgrade" };
   }
 
   if (tierId === "free") {
@@ -161,8 +149,9 @@ export function getActionForTier(
   }
 
   return {
-    label: direction === "upgrade" ? "Upgrade to Pro" : "Switch to Pro",
-    style: direction,
-    targetPlan: tierId,
+    kind: "checkout",
+    plan: tierId,
+    direction:
+      TIER_ORDER[tierId] > TIER_ORDER[currentPlan] ? "upgrade" : "downgrade",
   };
 }


### PR DESCRIPTION
TierAction carried label/style/optional targetPlan and the desktop
account page decided to start a trial by comparing
action.label === "Start free trial", coupling behavior to display copy.
Model actions as Current, StartTrial { plan }, or
Checkout { plan, direction }; the desktop renders labels separately via
a presentation-side mapping, keeps the exact checkout query parameters
and analytics event names, and the guest path branches on the variant
instead of targetPlan. Adds table tests for every current/target/trial
combination and component tests asserting the trial and upgrade
checkout URLs, analytics payloads, and the guest sign-in path.
(ANLG-278)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of settings billing UI and shared pricing types with broad test coverage; no auth or payment-backend logic changes.
> 
> **Overview**
> **`TierAction`** in `@anlg/pricing` no longer carries button labels or `style`/`targetPlan`. Actions are **`current`**, **`startTrial` { plan }**, or **`checkout` { plan, direction }**, so checkout and analytics logic cannot depend on display copy.
> 
> The desktop **Account** settings page maps those variants to UI strings via **`tierActionLabel`**, branches clicks on **`action.kind`** (including guest **Sign in for Pro** via **`action.plan`**), and still emits the same checkout URLs and analytics events. **`getActionForTier`** is updated to return the new shapes.
> 
> **Tests** add a table-driven suite for every tier/current-plan/trial combination and component cases for trial checkout, upgrade checkout, and guest sign-in without opening checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49910b7a818846cde5aad9f497987a839482d519. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->