### PR TITLE
refactor(cli-process): make StreamProcess own child lifecycle and shutdown

### DIFF
--- a/crates/amp/src/exec.rs
+++ b/crates/amp/src/exec.rs
@@ -2,12 +2,12 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Stdio;
 
-use anlg_cli_process::{spawn_streaming_lines, spawn_with_retry};
+use anlg_cli_process::{StreamProcess, spawn_streaming_lines, spawn_with_retry};
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::Error;
-use crate::events::{EventStream, NormalizedInput, ThreadEvent};
+use crate::events::{NormalizedInput, ThreadEvent};
 use crate::options::AmpMode;
 #[derive(Debug, Clone)]
 pub(crate) struct AmpExec {
@@ -15,10 +15,7 @@ pub(crate) struct AmpExec {
     env_override: Option<BTreeMap<String, String>>,
 }
 
-pub(crate) struct AmpExecRun {
-    pub events: EventStream,
-    pub shutdown: CancellationToken,
-}
+pub(crate) type AmpExecRun = StreamProcess<ThreadEvent, Error>;
 
 pub(crate) struct AmpExecArgs {
     pub input: NormalizedInput,
@@ -79,14 +76,9 @@ impl AmpExec {
             NormalizedInput::Text(text) => text,
             NormalizedInput::StreamJson(text) => text,
         };
-        let stream = spawn_streaming_lines(child, Some(prompt), args.cancellation_token, |line| {
+        spawn_streaming_lines(child, Some(prompt), args.cancellation_token, |line| {
             let value = serde_json::from_str::<serde_json::Value>(&line)?;
-            Ok(ThreadEvent::try_from(value)?)
-        })?;
-
-        Ok(AmpExecRun {
-            events: stream.events,
-            shutdown: stream.shutdown,
+            ThreadEvent::try_from(value).map_err(Error::from)
         })
     }
 

--- a/crates/amp/src/thread.rs
+++ b/crates/amp/src/thread.rs
@@ -3,7 +3,6 @@ use std::task::{Context, Poll};
 
 use futures_util::Stream;
 use futures_util::StreamExt;
-use tokio_util::sync::CancellationToken;
 
 use crate::error::Error;
 use crate::events::{Input, RunStreamedResult, ThreadEvent, Turn};
@@ -98,10 +97,9 @@ impl Thread {
 
         Ok(RunStreamedResult {
             events: Box::pin(ManagedEventStream {
-                inner: stream.events,
+                inner: stream,
                 _settings_file: settings_file,
                 thread_id: self.id.clone(),
-                shutdown: stream.shutdown,
             }),
         })
     }
@@ -151,11 +149,12 @@ impl Thread {
     }
 }
 
+// Dropping the inner StreamProcess shuts the child down, so no explicit Drop
+// is needed here.
 struct ManagedEventStream {
-    inner: crate::events::EventStream,
+    inner: crate::exec::AmpExecRun,
     _settings_file: Option<SettingsFile>,
     thread_id: Arc<Mutex<Option<String>>>,
-    shutdown: CancellationToken,
 }
 
 impl Stream for ManagedEventStream {
@@ -165,12 +164,12 @@ impl Stream for ManagedEventStream {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        match self.inner.as_mut().poll_next(cx) {
+        match std::pin::Pin::new(&mut self.inner).poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
-                if let Some(thread_id) = event.session_id().map(ToOwned::to_owned) {
-                    if let Ok(mut guard) = self.thread_id.lock() {
-                        *guard = Some(thread_id);
-                    }
+                if let Some(thread_id) = event.session_id().map(ToOwned::to_owned)
+                    && let Ok(mut guard) = self.thread_id.lock()
+                {
+                    *guard = Some(thread_id);
                 }
                 Poll::Ready(Some(Ok(event)))
             }
@@ -179,25 +178,18 @@ impl Stream for ManagedEventStream {
     }
 }
 
-impl Drop for ManagedEventStream {
-    fn drop(&mut self) {
-        self.shutdown.cancel();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
     use std::fs;
     use std::path::PathBuf;
-    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use futures_util::StreamExt;
     use tokio::runtime::Builder;
     use tokio_util::sync::CancellationToken;
 
-    use super::{Amp, ManagedEventStream};
+    use super::Amp;
     use crate::error::Error;
     use crate::options::{AmpMode, AmpOptions, ThreadOptions, TurnOptions};
 
@@ -266,17 +258,40 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"T-99","is_erro
     }
 
     #[test]
-    fn dropping_managed_event_stream_cancels_shutdown_token() {
-        let shutdown = CancellationToken::new();
-        let stream = ManagedEventStream {
-            inner: Box::pin(futures_util::stream::empty()),
-            _settings_file: None,
-            thread_id: Arc::new(Mutex::new(None)),
-            shutdown: shutdown.clone(),
-        };
+    fn dropping_the_event_stream_kills_the_child() {
+        let runtime = runtime();
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let pid_file = temp_dir.path().join("pid.txt");
+        let script = write_fake_amp_script(
+            &temp_dir,
+            r#"
+printf '%s' "$$" > "$PID_FILE"
+printf '%s\n' '{"type":"system","subtype":"init","cwd":"/tmp","session_id":"T-drop","tools":[],"mcp_servers":[]}'
+while :; do sleep 1; done
+"#,
+        );
 
-        drop(stream);
-        assert!(shutdown.is_cancelled());
+        let thread = test_amp(script, env_map([("PID_FILE", pid_file.clone())])).start_thread(
+            ThreadOptions {
+                mode: Some(AmpMode::Rush),
+                working_directory: None,
+            },
+        );
+
+        let streamed = runtime
+            .block_on(thread.run_streamed("hello", TurnOptions::default()))
+            .expect("stream");
+        let mut events = streamed.events;
+        let first = runtime.block_on(async { events.next().await.expect("first event") });
+        assert!(first.is_ok());
+
+        runtime.block_on(async {
+            drop(events);
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        });
+
+        let pid = fs::read_to_string(pid_file).expect("pid file");
+        assert!(!process_exists(pid.trim()));
     }
 
     #[test]

--- a/crates/claude/src/error.rs
+++ b/crates/claude/src/error.rs
@@ -23,3 +23,25 @@ pub enum Error {
     #[error("mutex poisoned")]
     Poisoned,
 }
+
+impl From<anlg_cli_process::ProcessError> for Error {
+    fn from(value: anlg_cli_process::ProcessError) -> Self {
+        match value {
+            anlg_cli_process::ProcessError::MissingStdout => Self::MissingStdout,
+            anlg_cli_process::ProcessError::StdoutRead(error) => Self::StdoutRead(error),
+            anlg_cli_process::ProcessError::Wait(error) => Self::Wait(error),
+            anlg_cli_process::ProcessError::Kill(error) => Self::Kill(error),
+            anlg_cli_process::ProcessError::ProcessFailed { detail } => {
+                Self::ProcessFailed { detail }
+            }
+            anlg_cli_process::ProcessError::Cancelled => Self::Cancelled,
+            // Claude runs with stdin null, so stdin failures cannot occur.
+            anlg_cli_process::ProcessError::MissingStdin => Self::ProcessFailed {
+                detail: "process missing stdin".to_string(),
+            },
+            anlg_cli_process::ProcessError::StdinWrite(error) => Self::ProcessFailed {
+                detail: format!("failed to write process stdin: {error}"),
+            },
+        }
+    }
+}

--- a/crates/claude/src/exec.rs
+++ b/crates/claude/src/exec.rs
@@ -2,19 +2,13 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Stdio;
 
-use tokio::io::BufReader;
 use tokio::process::Command;
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
-use anlg_cli_process::{
-    MAX_PROCESS_STDOUT_BYTES, MAX_PROCESS_STDOUT_LINE_BYTES, collect_stderr, read_line_with_limit,
-    read_text_with_limit, spawn_stderr_reader, spawn_with_retry,
-};
+use anlg_cli_process::{StreamProcess, run_to_string, spawn_streaming_lines, spawn_with_retry};
 
 use crate::error::Error;
-use crate::events::{ClaudeEvent, EventStream};
+use crate::events::ClaudeEvent;
 use crate::options::{PermissionMode, SettingSource};
 
 #[derive(Debug, Clone)]
@@ -57,10 +51,7 @@ enum OutputFormat {
     StreamJson,
 }
 
-pub(crate) struct ClaudeExecStream {
-    pub events: EventStream,
-    pub shutdown: CancellationToken,
-}
+pub(crate) type ClaudeExecStream = StreamProcess<ClaudeEvent, Error>;
 
 impl ClaudeExec {
     pub(crate) fn new(
@@ -87,61 +78,8 @@ impl ClaudeExec {
         }
 
         let mut command = self.build_command(&args, OutputFormat::Json)?;
-        let mut child = spawn_with_retry(&mut command).map_err(Error::Spawn)?;
-        let stdout = child.stdout.take().ok_or(Error::MissingStdout)?;
-        let stderr = child.stderr.take();
-        let cancellation_token = args.cancellation_token;
-        let stderr_task = stderr.map(spawn_stderr_reader);
-        let read_stdout = async {
-            read_text_with_limit(stdout, MAX_PROCESS_STDOUT_BYTES)
-                .await
-                .map_err(Error::StdoutRead)
-        };
-
-        let stdout_result = match cancellation_token.as_ref() {
-            Some(token) => tokio::select! {
-                _ = token.cancelled() => {
-                    kill_child(&mut child).await?;
-                    let _ = collect_stderr(stderr_task).await;
-                    return Err(Error::Cancelled);
-                }
-                result = read_stdout => {
-                    result
-                }
-            },
-            None => read_stdout.await,
-        };
-        let stdout_text = match stdout_result {
-            Ok(output) => output,
-            Err(error) => {
-                kill_child(&mut child).await?;
-                let _ = collect_stderr(stderr_task).await;
-                return Err(error);
-            }
-        };
-
-        let status = match cancellation_token.as_ref() {
-            Some(token) => tokio::select! {
-                _ = token.cancelled() => {
-                    kill_child(&mut child).await?;
-                    let _ = collect_stderr(stderr_task).await;
-                    return Err(Error::Cancelled);
-                }
-                status = child.wait() => status.map_err(Error::Wait)?,
-            },
-            None => child.wait().await.map_err(Error::Wait)?,
-        };
-
-        let stderr_output = collect_stderr(stderr_task).await;
-        if !status.success() {
-            let detail = if let Some(code) = status.code() {
-                format!("code {code}: {}", stderr_output.trim())
-            } else {
-                stderr_output.trim().to_string()
-            };
-            return Err(Error::ProcessFailed { detail });
-        }
-
+        let child = spawn_with_retry(&mut command).map_err(Error::Spawn)?;
+        let stdout_text = run_to_string(child, args.cancellation_token).await?;
         Ok(serde_json::from_str(stdout_text.trim())?)
     }
 
@@ -155,104 +93,10 @@ impl ClaudeExec {
         }
 
         let mut command = self.build_command(&args, OutputFormat::StreamJson)?;
-        let mut child = spawn_with_retry(&mut command).map_err(Error::Spawn)?;
-        let stdout = child.stdout.take().ok_or(Error::MissingStdout)?;
-        let stderr = child.stderr.take();
-        let cancellation_token = args.cancellation_token;
-        let shutdown = CancellationToken::new();
-        let task_shutdown = shutdown.clone();
-        let stderr_task = stderr.map(spawn_stderr_reader);
-        let (tx, rx) = mpsc::channel(64);
-
-        tokio::spawn(async move {
-            let result = async {
-                let mut lines = BufReader::new(stdout);
-                loop {
-                    let next_line = async {
-                        read_line_with_limit(&mut lines, MAX_PROCESS_STDOUT_LINE_BYTES)
-                            .await
-                            .map_err(Error::StdoutRead)
-                    };
-                    let line = match cancellation_token.as_ref() {
-                        Some(token) => tokio::select! {
-                            _ = token.cancelled() => {
-                                kill_child(&mut child).await?;
-                                let _ = collect_stderr(stderr_task).await;
-                                return Err(Error::Cancelled);
-                            }
-                            _ = task_shutdown.cancelled() => {
-                                kill_child(&mut child).await?;
-                                let _ = collect_stderr(stderr_task).await;
-                                return Ok(());
-                            }
-                            line = next_line => match line {
-                                Ok(line) => line,
-                                Err(error) => {
-                                    kill_child(&mut child).await?;
-                                    let _ = collect_stderr(stderr_task).await;
-                                    return Err(error);
-                                }
-                            },
-                        },
-                        None => tokio::select! {
-                            _ = task_shutdown.cancelled() => {
-                                kill_child(&mut child).await?;
-                                let _ = collect_stderr(stderr_task).await;
-                                return Ok(());
-                            }
-                            line = next_line => match line {
-                                Ok(line) => line,
-                                Err(error) => {
-                                    kill_child(&mut child).await?;
-                                    let _ = collect_stderr(stderr_task).await;
-                                    return Err(error);
-                                }
-                            },
-                        },
-                    };
-
-                    let Some(line) = line else {
-                        break;
-                    };
-
-                    let event = match serde_json::from_str(&line) {
-                        Ok(value) => ClaudeEvent::from_value(value),
-                        Err(error) => {
-                            kill_child(&mut child).await?;
-                            let _ = collect_stderr(stderr_task).await;
-                            return Err(error.into());
-                        }
-                    };
-                    if tx.send(Ok(event)).await.is_err() {
-                        kill_child(&mut child).await?;
-                        let _ = collect_stderr(stderr_task).await;
-                        return Ok(());
-                    }
-                }
-
-                let status = child.wait().await.map_err(Error::Wait)?;
-                let stderr_output = collect_stderr(stderr_task).await;
-                if !status.success() {
-                    let detail = if let Some(code) = status.code() {
-                        format!("code {code}: {}", stderr_output.trim())
-                    } else {
-                        stderr_output.trim().to_string()
-                    };
-                    return Err(Error::ProcessFailed { detail });
-                }
-
-                Ok(())
-            }
-            .await;
-
-            if let Err(error) = result {
-                let _ = tx.send(Err(error)).await;
-            }
-        });
-
-        Ok(ClaudeExecStream {
-            events: Box::pin(ReceiverStream::new(rx)),
-            shutdown,
+        let child = spawn_with_retry(&mut command).map_err(Error::Spawn)?;
+        spawn_streaming_lines(child, None, args.cancellation_token, |line| {
+            let value = serde_json::from_str(&line)?;
+            Ok(ClaudeEvent::from_value(value))
         })
     }
 
@@ -409,21 +253,6 @@ fn serde_variant<T: serde::Serialize>(value: &T) -> String {
         .ok()
         .and_then(|value| value.as_str().map(ToOwned::to_owned))
         .unwrap_or_default()
-}
-
-async fn kill_child(child: &mut tokio::process::Child) -> Result<(), Error> {
-    if child.try_wait().map_err(Error::Wait)?.is_some() {
-        return Ok(());
-    }
-
-    match child.kill().await {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::InvalidInput => {}
-        Err(error) => return Err(Error::Kill(error)),
-    }
-
-    child.wait().await.map_err(Error::Wait)?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/claude/src/session.rs
+++ b/crates/claude/src/session.rs
@@ -9,7 +9,6 @@ use crate::events::{
 };
 use crate::exec::{ClaudeExec, ClaudeExecArgs, SessionMode};
 use crate::options::{ClaudeOptions, SessionOptions, TurnOptions};
-use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone)]
 pub struct Claude {
@@ -85,9 +84,8 @@ impl Session {
             .run_streamed(self.exec_args(prompt.into(), turn_options))?;
         Ok(RunStreamedResult {
             events: Box::pin(ManagedEventStream {
-                inner: stream.events,
+                inner: stream,
                 session_id: self.id.clone(),
-                shutdown: stream.shutdown,
             }),
         })
     }
@@ -147,10 +145,11 @@ impl Session {
     }
 }
 
+// Dropping the inner StreamProcess shuts the child down, so no explicit Drop
+// is needed here.
 struct ManagedEventStream {
-    inner: crate::events::EventStream,
+    inner: crate::exec::ClaudeExecStream,
     session_id: Arc<Mutex<Option<String>>>,
-    shutdown: CancellationToken,
 }
 
 impl Stream for ManagedEventStream {
@@ -160,7 +159,7 @@ impl Stream for ManagedEventStream {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        match self.inner.as_mut().poll_next(cx) {
+        match std::pin::Pin::new(&mut self.inner).poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
                 if let Some(session_id) = event.session_id.clone() {
                     if let Ok(mut guard) = self.session_id.lock() {
@@ -171,12 +170,6 @@ impl Stream for ManagedEventStream {
             }
             other => other,
         }
-    }
-}
-
-impl Drop for ManagedEventStream {
-    fn drop(&mut self) {
-        self.shutdown.cancel();
     }
 }
 

--- a/crates/cli-process/src/lib.rs
+++ b/crates/cli-process/src/lib.rs
@@ -35,9 +35,35 @@ pub enum ProcessError {
     Cancelled,
 }
 
+// One handle owns the spawned child and its event stream: polling yields the
+// parsed events, cancel() requests shutdown explicitly, and dropping the
+// handle also shuts the child down, so the child can never be orphaned.
 pub struct StreamProcess<T, E> {
-    pub events: EventStream<T, E>,
-    pub shutdown: CancellationToken,
+    events: EventStream<T, E>,
+    shutdown: CancellationToken,
+}
+
+impl<T, E> StreamProcess<T, E> {
+    pub fn cancel(&self) {
+        self.shutdown.cancel();
+    }
+}
+
+impl<T, E> Stream for StreamProcess<T, E> {
+    type Item = Result<T, E>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.get_mut().events.as_mut().poll_next(cx)
+    }
+}
+
+impl<T, E> Drop for StreamProcess<T, E> {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+    }
 }
 
 pub fn spawn_with_retry(command: &mut tokio::process::Command) -> std::io::Result<Child> {
@@ -473,6 +499,73 @@ mod tests {
         let result =
             spawn_streaming_lines::<String, ProcessError, _>(child, None, Some(cancellation), Ok);
         assert!(matches!(result, Err(ProcessError::Cancelled)));
+        tokio::time::sleep(std::time::Duration::from_millis(350)).await;
+        assert!(!marker.exists());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn streams_complete_on_eof_and_drain_all_output() {
+        let mut command = tokio::process::Command::new("sh");
+        command
+            .args(["-c", "printf 'one\ntwo\nthree\n'"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let child = command.spawn().unwrap();
+
+        let stream =
+            spawn_streaming_lines::<String, ProcessError, _>(child, None, None, Ok).unwrap();
+        let lines: Vec<_> = futures_util::StreamExt::collect::<Vec<_>>(stream)
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(lines, ["one", "two", "three"]);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn dropping_the_stream_handle_kills_the_child() {
+        let marker = std::env::temp_dir().join(format!(
+            "cli-process-drop-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let child = delayed_marker_child(&marker);
+
+        let stream =
+            spawn_streaming_lines::<String, ProcessError, _>(child, None, None, Ok).unwrap();
+        drop(stream);
+        tokio::time::sleep(std::time::Duration::from_millis(350)).await;
+        assert!(!marker.exists());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn explicit_cancel_kills_the_child_and_ends_the_stream() {
+        let marker = std::env::temp_dir().join(format!(
+            "cli-process-explicit-cancel-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let child = delayed_marker_child(&marker);
+
+        let mut stream =
+            spawn_streaming_lines::<String, ProcessError, _>(child, None, None, Ok).unwrap();
+        stream.cancel();
+        // Explicit shutdown ends the stream without an error event.
+        while futures_util::StreamExt::next(&mut stream)
+            .await
+            .transpose()
+            .unwrap()
+            .is_some()
+        {}
         tokio::time::sleep(std::time::Duration::from_millis(350)).await;
         assert!(!marker.exists());
     }

--- a/crates/codex/src/exec.rs
+++ b/crates/codex/src/exec.rs
@@ -2,13 +2,13 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Stdio;
 
-use anlg_cli_process::{spawn_streaming_lines, spawn_with_retry};
+use anlg_cli_process::{StreamProcess, spawn_streaming_lines, spawn_with_retry};
 use serde::Serialize;
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::Error;
-use crate::events::{EventStream, ThreadEvent};
+use crate::events::ThreadEvent;
 use crate::options::{ApprovalMode, ModelReasoningEffort, SandboxMode, WebSearchMode};
 
 const INTERNAL_ORIGINATOR_ENV: &str = "CODEX_INTERNAL_ORIGINATOR_OVERRIDE";
@@ -41,10 +41,7 @@ pub(crate) struct CodexExecArgs {
     pub cancellation_token: Option<CancellationToken>,
 }
 
-pub(crate) struct CodexExecRun {
-    pub events: EventStream,
-    pub shutdown: CancellationToken,
-}
+pub(crate) type CodexExecRun = StreamProcess<ThreadEvent, Error>;
 
 impl CodexExec {
     pub(crate) fn new(
@@ -91,13 +88,8 @@ impl CodexExec {
 
         let child = spawn_with_retry(&mut command).map_err(Error::Spawn)?;
         let prompt = args.input;
-        let stream = spawn_streaming_lines(child, Some(prompt), args.cancellation_token, |line| {
+        spawn_streaming_lines(child, Some(prompt), args.cancellation_token, |line| {
             Ok(serde_json::from_str::<ThreadEvent>(&line)?)
-        })?;
-
-        Ok(CodexExecRun {
-            events: stream.events,
-            shutdown: stream.shutdown,
         })
     }
 

--- a/crates/codex/src/thread.rs
+++ b/crates/codex/src/thread.rs
@@ -9,7 +9,6 @@ use crate::events::{Input, RunStreamedResult, ThreadEvent, Turn};
 use crate::exec::{CodexExec, CodexExecArgs};
 use crate::options::{CodexOptions, ThreadOptions, TurnOptions};
 use crate::output_schema::{OutputSchemaFile, create_output_schema_file};
-use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone)]
 pub struct Codex {
@@ -109,10 +108,9 @@ impl Thread {
         })?;
         Ok(RunStreamedResult {
             events: Box::pin(ManagedEventStream {
-                inner: stream.events,
+                inner: stream,
                 _output_schema: output_schema,
                 thread_id: self.id.clone(),
-                shutdown: stream.shutdown,
             }),
         })
     }
@@ -165,11 +163,12 @@ impl Thread {
     }
 }
 
+// Dropping the inner StreamProcess shuts the child down, so no explicit Drop
+// is needed here.
 struct ManagedEventStream {
-    inner: crate::events::EventStream,
+    inner: crate::exec::CodexExecRun,
     _output_schema: Option<OutputSchemaFile>,
     thread_id: Arc<Mutex<Option<String>>>,
-    shutdown: CancellationToken,
 }
 
 impl Stream for ManagedEventStream {
@@ -179,7 +178,7 @@ impl Stream for ManagedEventStream {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        match self.inner.as_mut().poll_next(cx) {
+        match std::pin::Pin::new(&mut self.inner).poll_next(cx) {
             Poll::Ready(Some(Ok(ThreadEvent::ThreadStarted { thread_id }))) => {
                 let thread_id = thread_id.clone();
                 if let Ok(mut guard) = self.thread_id.lock() {
@@ -189,12 +188,6 @@ impl Stream for ManagedEventStream {
             }
             other => other,
         }
-    }
-}
-
-impl Drop for ManagedEventStream {
-    fn drop(&mut self) {
-        self.shutdown.cancel();
     }
 }
 

--- a/crates/opencode/src/exec.rs
+++ b/crates/opencode/src/exec.rs
@@ -2,12 +2,12 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Stdio;
 
-use anlg_cli_process::spawn_streaming_lines;
+use anlg_cli_process::{StreamProcess, spawn_streaming_lines};
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::Error;
-use crate::events::{Event, EventStream};
+use crate::events::Event;
 
 #[derive(Debug, Clone)]
 pub(crate) struct OpencodeExec {
@@ -30,10 +30,7 @@ pub(crate) struct OpencodeExecArgs {
     pub cancellation_token: Option<CancellationToken>,
 }
 
-pub(crate) struct OpencodeExecRun {
-    pub events: EventStream,
-    pub shutdown: CancellationToken,
-}
+pub(crate) type OpencodeExecRun = StreamProcess<Event, Error>;
 
 impl OpencodeExec {
     pub(crate) fn new(
@@ -68,13 +65,8 @@ impl OpencodeExec {
         }
 
         let child = command.spawn().map_err(Error::Spawn)?;
-        let stream = spawn_streaming_lines(child, None, args.cancellation_token, |line| {
+        spawn_streaming_lines(child, None, args.cancellation_token, |line| {
             Ok(serde_json::from_str::<Event>(&line)?)
-        })?;
-
-        Ok(OpencodeExecRun {
-            events: stream.events,
-            shutdown: stream.shutdown,
         })
     }
 

--- a/crates/opencode/src/session.rs
+++ b/crates/opencode/src/session.rs
@@ -3,7 +3,6 @@ use std::task::{Context, Poll};
 
 use futures_util::Stream;
 use futures_util::StreamExt;
-use tokio_util::sync::CancellationToken;
 
 use crate::error::Error;
 use crate::events::{Event, Input, RunStreamedResult, SessionTurn};
@@ -105,9 +104,8 @@ impl Session {
 
         Ok(RunStreamedResult {
             events: Box::pin(ManagedEventStream {
-                inner: stream.events,
+                inner: stream,
                 session_id: self.id.clone(),
-                shutdown: stream.shutdown,
             }),
         })
     }
@@ -128,10 +126,11 @@ impl Session {
     }
 }
 
+// Dropping the inner StreamProcess shuts the child down, so no explicit Drop
+// is needed here.
 struct ManagedEventStream {
-    inner: crate::events::EventStream,
+    inner: crate::exec::OpencodeExecRun,
     session_id: Arc<Mutex<Option<String>>>,
-    shutdown: CancellationToken,
 }
 
 impl Stream for ManagedEventStream {
@@ -141,22 +140,16 @@ impl Stream for ManagedEventStream {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        match self.inner.as_mut().poll_next(cx) {
+        match std::pin::Pin::new(&mut self.inner).poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
-                if let Some(session_id) = event.session_id() {
-                    if let Ok(mut guard) = self.session_id.lock() {
-                        *guard = Some(session_id.to_string());
-                    }
+                if let Some(session_id) = event.session_id()
+                    && let Ok(mut guard) = self.session_id.lock()
+                {
+                    *guard = Some(session_id.to_string());
                 }
                 Poll::Ready(Some(Ok(event)))
             }
             other => other,
         }
-    }
-}
-
-impl Drop for ManagedEventStream {
-    fn drop(&mut self) {
-        self.shutdown.cancel();
     }
 }


### PR DESCRIPTION
StreamProcess exposed separate events and shutdown fields, so every
wrapper (amp, codex, opencode, claude) implemented its own Drop to
cancel the token, and Claude duplicated the whole streaming/JSON
orchestration in exec.rs. StreamProcess now implements Stream and Drop
itself: polling yields events, cancel() requests explicit shutdown, and
dropping the handle shuts the child down so it can never be orphaned.
The four wrappers embed the handle and lose their custom Drop impls,
and Claude's run_json/run_streamed are now thin calls to run_to_string
and spawn_streaming_lines with Claude-specific JSON parsing and a
ProcessError-to-Error conversion. Adds cli-process tests for EOF
output draining, drop-kills-child, and explicit cancellation, plus an
end-to-end drop test in amp; existing Claude parse/cancellation/stderr
regressions keep passing. (ANLG-269)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all agent SDKs terminate subprocesses on drop/cancel; behavior is intentional and well-tested but touches shared process orchestration used on every streamed turn.
> 
> **Overview**
> **`StreamProcess`** in `anlg_cli_process` now owns the child and parsed event stream as one handle: it implements **`Stream`** for polling events, **`cancel()`** for explicit shutdown, and **`Drop`** to kill the child so callers cannot leave processes running.
> 
> The **amp**, **codex**, **opencode**, and **claude** exec layers type their run handles as **`StreamProcess<…>`** and return **`spawn_streaming_lines`** (or **`run_to_string`** for Claude JSON) directly instead of exposing separate `events` and `shutdown` fields. Session/thread **`ManagedEventStream`** wrappers embed that handle and **drop their own `Drop` impls** that used to cancel a shutdown token.
> 
> **Claude** removes a large block of duplicated stdout/stderr/cancellation logic from `exec.rs` in favor of the shared helpers, plus a **`ProcessError` → `Error`** mapping. **Tests** add cli-process coverage for EOF line draining, drop-kills-child, and explicit cancel, and amp replaces a token-only drop test with an end-to-end child termination check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 662943696f88ea35aac1e28be77e11665bfb1260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->