### PR TITLE
refactor(openai-transcription): pair realtime event types with payloads

### DIFF
--- a/crates/openai-transcription/src/realtime.rs
+++ b/crates/openai-transcription/src/realtime.rs
@@ -1,13 +1,34 @@
 use crate::batch::{TranscriptionLogprob, TranscriptionUsage};
 use serde::{Deserialize, Serialize};
 
+// Every outbound event variant owns its payload, so a caller cannot pair a
+// valid wire type with the wrong body. The serde tag reproduces the exact
+// OpenAI realtime `type` strings.
 #[derive(Debug, Clone, Serialize)]
-pub struct SessionUpdateEvent {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub event_id: Option<String>,
-    #[serde(rename = "type")]
-    pub event_type: ClientEventType,
-    pub session: SessionConfig,
+#[serde(tag = "type")]
+pub enum ClientEvent {
+    #[serde(rename = "session.update")]
+    SessionUpdate {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        event_id: Option<String>,
+        session: SessionConfig,
+    },
+    #[serde(rename = "input_audio_buffer.append")]
+    InputAudioBufferAppend {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        event_id: Option<String>,
+        audio: String,
+    },
+    #[serde(rename = "input_audio_buffer.commit")]
+    InputAudioBufferCommit {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        event_id: Option<String>,
+    },
+    #[serde(rename = "input_audio_buffer.clear")]
+    InputAudioBufferClear {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        event_id: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -83,43 +104,6 @@ pub struct TurnDetectionConfig {
     pub prefix_padding_ms: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub silence_duration_ms: Option<u32>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct InputAudioBufferAppendEvent {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub event_id: Option<String>,
-    #[serde(rename = "type")]
-    pub event_type: ClientEventType,
-    pub audio: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct InputAudioBufferCommitEvent {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub event_id: Option<String>,
-    #[serde(rename = "type")]
-    pub event_type: ClientEventType,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct InputAudioBufferClearEvent {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub event_id: Option<String>,
-    #[serde(rename = "type")]
-    pub event_type: ClientEventType,
-}
-
-#[derive(Debug, Clone, Copy, Serialize)]
-pub enum ClientEventType {
-    #[serde(rename = "session.update")]
-    SessionUpdate,
-    #[serde(rename = "input_audio_buffer.append")]
-    InputAudioBufferAppend,
-    #[serde(rename = "input_audio_buffer.commit")]
-    InputAudioBufferCommit,
-    #[serde(rename = "input_audio_buffer.clear")]
-    InputAudioBufferClear,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -273,9 +257,8 @@ mod tests {
 
     #[test]
     fn session_update_serializes_expected_shape() {
-        let json = serde_json::to_value(SessionUpdateEvent {
+        let json = serde_json::to_value(ClientEvent::SessionUpdate {
             event_id: Some("event-123".to_string()),
-            event_type: ClientEventType::SessionUpdate,
             session: SessionConfig {
                 session_type: SessionType::Transcription,
                 audio: Some(AudioConfig {
@@ -330,6 +313,35 @@ mod tests {
         assert_eq!(
             json["session"]["audio"]["input"]["turn_detection"]["idle_timeout_ms"],
             5_000
+        );
+    }
+
+    #[test]
+    fn audio_buffer_events_serialize_expected_wire_shapes() {
+        assert_eq!(
+            serde_json::to_value(ClientEvent::InputAudioBufferAppend {
+                event_id: None,
+                audio: "cGNtMTY=".to_string(),
+            })
+            .unwrap(),
+            serde_json::json!({
+                "type": "input_audio_buffer.append",
+                "audio": "cGNtMTY=",
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(ClientEvent::InputAudioBufferCommit { event_id: None }).unwrap(),
+            serde_json::json!({ "type": "input_audio_buffer.commit" })
+        );
+        assert_eq!(
+            serde_json::to_value(ClientEvent::InputAudioBufferClear {
+                event_id: Some("event-9".to_string()),
+            })
+            .unwrap(),
+            serde_json::json!({
+                "type": "input_audio_buffer.clear",
+                "event_id": "event-9",
+            })
         );
     }
 

--- a/crates/owhisper-client/src/adapter/openai/live.rs
+++ b/crates/owhisper-client/src/adapter/openai/live.rs
@@ -1,8 +1,7 @@
 use anlg_ws_client::client::Message;
 use openai_transcription::realtime::{
-    AudioConfig, AudioFormat, AudioFormatType, AudioInputConfig, ClientEventType,
-    InputAudioBufferAppendEvent, InputAudioBufferCommitEvent, ServerEvent, SessionConfig,
-    SessionInclude, SessionType, SessionUpdateEvent, TranscriptionConfig, TurnDetectionConfig,
+    AudioConfig, AudioFormat, AudioFormatType, AudioInputConfig, ClientEvent, ServerEvent,
+    SessionConfig, SessionInclude, SessionType, TranscriptionConfig, TurnDetectionConfig,
     TurnDetectionType,
 };
 use owhisper_interface::ListenParams;
@@ -85,9 +84,8 @@ impl RealtimeSttAdapter for OpenAIAdapter {
             input_sample_rate,
             crate::providers::Provider::OpenAI.default_live_sample_rate(),
         );
-        let event = InputAudioBufferAppendEvent {
+        let event = ClientEvent::InputAudioBufferAppend {
             event_id: None,
-            event_type: ClientEventType::InputAudioBufferAppend,
             audio: base64::engine::general_purpose::STANDARD.encode(audio),
         };
         Message::Text(serde_json::to_string(&event).unwrap().into())
@@ -118,9 +116,8 @@ impl RealtimeSttAdapter for OpenAIAdapter {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .input_sample_rate = params.sample_rate;
 
-        let event = SessionUpdateEvent {
+        let event = ClientEvent::SessionUpdate {
             event_id: None,
-            event_type: ClientEventType::SessionUpdate,
             session: SessionConfig {
                 session_type: SessionType::Transcription,
                 audio: Some(AudioConfig {
@@ -167,10 +164,7 @@ impl RealtimeSttAdapter for OpenAIAdapter {
     }
 
     fn finalize_message(&self) -> Message {
-        let event = InputAudioBufferCommitEvent {
-            event_id: None,
-            event_type: ClientEventType::InputAudioBufferCommit,
-        };
+        let event = ClientEvent::InputAudioBufferCommit { event_id: None };
         Message::Text(serde_json::to_string(&event).unwrap().into())
     }
 


### PR DESCRIPTION
Outbound realtime events carried an independent ClientEventType field,
so a caller could serialize the wrong payload under a valid event name.
Replace the four event structs and the type enum with one serde-tagged
ClientEvent enum whose variants own their payloads, preserving the
exact OpenAI realtime type strings and field shapes; the OpenAI live
adapter (the sole construction path) now builds variants directly.
Adds per-variant JSON wire-shape tests alongside the existing session
update and server event coverage. (ANLG-277)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with serde wire-shape tests; no protocol or runtime behavior change beyond compile-time safety.
> 
> **Overview**
> Replaces separate outbound realtime event structs plus a standalone `ClientEventType` with a single **`ClientEvent`** enum (`#[serde(tag = "type")]`) so each variant owns its payload and wire `type` strings stay aligned with OpenAI’s API.
> 
> The **OpenAI live adapter** now builds `ClientEvent::SessionUpdate`, `InputAudioBufferAppend`, and `InputAudioBufferCommit` directly instead of pairing structs with a type enum. Serialization shape is unchanged.
> 
> Adds unit tests that assert JSON wire shapes for append, commit, and clear buffer events; existing session-update serialization tests use the new enum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab64b95bd766d40f17570fcf3430f34b3464579f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->