### PR TITLE
refactor(meeting-capture): share exact enterprise capture wire structs

### DIFF
--- a/crates/meeting-capture/src/lib.rs
+++ b/crates/meeting-capture/src/lib.rs
@@ -3,6 +3,7 @@ mod lifecycle;
 mod metadata;
 mod model;
 mod provider;
+pub mod wire;
 mod worker;
 
 pub use adapter::*;

--- a/crates/meeting-capture/src/wire.rs
+++ b/crates/meeting-capture/src/wire.rs
@@ -1,0 +1,180 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{BotState, CaptureEvent, CaptureProviderKind, MeetingReference};
+
+// Exact capture protocol wire shapes shared by the enterprise control plane
+// (server) and capture workers (clients). Serialization only: retries, HTTP
+// clients, storage, and domain behavior stay with each consumer.
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CaptureJob {
+    pub workspace_id: String,
+    pub job_id: String,
+    pub bot_id: String,
+    pub owner_user_id: String,
+    pub requesting_actor_id: String,
+    pub session_id: String,
+    pub session_title: String,
+    pub provider: CaptureProviderKind,
+    pub meeting: MeetingReference,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CaptureJobLease {
+    pub worker_id: String,
+    pub lease_id: String,
+    pub epoch: u64,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CaptureJobLeaseIdentity {
+    pub worker_id: String,
+    pub lease_id: String,
+    pub epoch: u64,
+}
+
+impl From<&CaptureJobLease> for CaptureJobLeaseIdentity {
+    fn from(lease: &CaptureJobLease) -> Self {
+        Self {
+            worker_id: lease.worker_id.clone(),
+            lease_id: lease.lease_id.clone(),
+            epoch: lease.epoch,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CaptureJobCheckpoint {
+    pub job: CaptureJob,
+    pub state: BotState,
+    pub next_sequence: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClaimCaptureJobRequest {
+    pub worker_id: String,
+    pub lease_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RenewCaptureJobLeaseRequest {
+    pub lease: CaptureJobLeaseIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AppendCaptureEventRequest {
+    pub lease: CaptureJobLeaseIdentity,
+    pub event: CaptureEvent,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MeetingPlatform;
+
+    fn lease() -> CaptureJobLease {
+        CaptureJobLease {
+            worker_id: "worker-a".to_string(),
+            lease_id: "lease-a".to_string(),
+            epoch: 3,
+            expires_at: "2026-08-18T00:05:00Z".parse().unwrap(),
+        }
+    }
+
+    #[test]
+    fn lease_round_trips_the_exact_wire_shape() {
+        let json = serde_json::json!({
+            "workerId": "worker-a",
+            "leaseId": "lease-a",
+            "epoch": 3,
+            "expiresAt": "2026-08-18T00:05:00Z",
+        });
+
+        let parsed: CaptureJobLease = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(parsed, lease());
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+    }
+
+    #[test]
+    fn lease_identity_derives_from_a_lease() {
+        let identity = CaptureJobLeaseIdentity::from(&lease());
+        assert_eq!(
+            serde_json::to_value(&identity).unwrap(),
+            serde_json::json!({
+                "workerId": "worker-a",
+                "leaseId": "lease-a",
+                "epoch": 3,
+            })
+        );
+    }
+
+    #[test]
+    fn claim_and_renew_requests_round_trip() {
+        let claim = ClaimCaptureJobRequest {
+            worker_id: "worker-a".to_string(),
+            lease_id: "lease-a".to_string(),
+        };
+        let claim_json = serde_json::json!({
+            "workerId": "worker-a",
+            "leaseId": "lease-a",
+        });
+        assert_eq!(serde_json::to_value(&claim).unwrap(), claim_json);
+        assert_eq!(
+            serde_json::from_value::<ClaimCaptureJobRequest>(claim_json).unwrap(),
+            claim
+        );
+
+        let renew = RenewCaptureJobLeaseRequest {
+            lease: CaptureJobLeaseIdentity::from(&lease()),
+        };
+        let renew_json = serde_json::to_value(&renew).unwrap();
+        assert_eq!(renew_json["lease"]["epoch"], 3);
+        assert_eq!(
+            serde_json::from_value::<RenewCaptureJobLeaseRequest>(renew_json).unwrap(),
+            renew
+        );
+    }
+
+    #[test]
+    fn checkpoint_round_trips_with_the_full_job() {
+        let checkpoint = CaptureJobCheckpoint {
+            job: CaptureJob {
+                workspace_id: "workspace-a".to_string(),
+                job_id: "job-a".to_string(),
+                bot_id: "bot-a".to_string(),
+                owner_user_id: "owner-a".to_string(),
+                requesting_actor_id: "actor-a".to_string(),
+                session_id: "session-a".to_string(),
+                session_title: "Weekly sync".to_string(),
+                provider: CaptureProviderKind::Anarlog,
+                meeting: MeetingReference {
+                    platform: MeetingPlatform::GoogleMeet,
+                    url: "https://meet.google.com/abc-defg-hij".to_string(),
+                    external_id: None,
+                    calendar_event_id: None,
+                },
+                created_at: "2026-08-18T00:00:00Z".parse().unwrap(),
+            },
+            state: BotState::Queued,
+            next_sequence: 7,
+        };
+
+        let json = serde_json::to_value(&checkpoint).unwrap();
+        assert_eq!(json["job"]["workspaceId"], "workspace-a");
+        assert_eq!(json["nextSequence"], 7);
+        assert_eq!(
+            serde_json::from_value::<CaptureJobCheckpoint>(json).unwrap(),
+            checkpoint
+        );
+    }
+}

--- a/enterprise/control-plane/src/capture.rs
+++ b/enterprise/control-plane/src/capture.rs
@@ -1,23 +1,14 @@
-use anlg_meeting_capture::{BotState, CaptureEvent, CaptureProviderKind, MeetingReference};
+use anlg_meeting_capture::{BotState, CaptureProviderKind, MeetingReference};
+// The exact capture wire contract is owned by the shared MIT-layer module and
+// used unchanged by the control plane and every capture worker.
+pub use anlg_meeting_capture::wire::{
+    AppendCaptureEventRequest, CaptureJob, CaptureJobCheckpoint, CaptureJobLease,
+    CaptureJobLeaseIdentity, ClaimCaptureJobRequest, RenewCaptureJobLeaseRequest,
+};
 use anlg_session_ingest::SessionIngestEnvelope;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct CaptureJob {
-    pub workspace_id: String,
-    pub job_id: String,
-    pub bot_id: String,
-    pub owner_user_id: String,
-    pub requesting_actor_id: String,
-    pub session_id: String,
-    pub session_title: String,
-    pub provider: CaptureProviderKind,
-    pub meeting: MeetingReference,
-    pub created_at: DateTime<Utc>,
-}
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -27,14 +18,6 @@ pub struct CaptureJobStatus {
     pub state: BotState,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CaptureJobCheckpoint {
-    pub job: CaptureJob,
-    pub state: BotState,
-    pub next_sequence: u64,
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct CaptureDispatch {
     pub workspace_id: String,
@@ -42,23 +25,6 @@ pub struct CaptureDispatch {
     pub provider: CaptureProviderKind,
     pub dispatch_id: String,
     pub payload: Value,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CaptureJobLease {
-    pub worker_id: String,
-    pub lease_id: String,
-    pub epoch: u64,
-    pub expires_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct CaptureJobLeaseIdentity {
-    pub worker_id: String,
-    pub lease_id: String,
-    pub epoch: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -82,24 +48,4 @@ pub struct CreateCaptureJobRequest {
     pub provider: CaptureProviderKind,
     pub meeting: MeetingReference,
     pub created_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct ClaimCaptureJobRequest {
-    pub worker_id: String,
-    pub lease_id: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct RenewCaptureJobLeaseRequest {
-    pub lease: CaptureJobLeaseIdentity,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct AppendCaptureEventRequest {
-    pub lease: CaptureJobLeaseIdentity,
-    pub event: CaptureEvent,
 }

--- a/enterprise/control-plane/tests/compose-smoke.sh
+++ b/enterprise/control-plane/tests/compose-smoke.sh
@@ -57,6 +57,22 @@ create_status=$(curl \
     "$base_url/v1/workspaces/workspace-a/capture-jobs/job-a")
 test "$create_status" = 201
 
+# Appending events requires an active worker lease, so claim the job first
+# and thread the returned lease identity through the append payload.
+claim_response=$(curl \
+    --connect-timeout 3 \
+    --max-time 10 \
+    --fail \
+    --silent \
+    --show-error \
+    --request POST \
+    --header "Authorization: Bearer $token" \
+    --header 'Content-Type: application/json' \
+    --data '{"workerId":"worker-a","leaseId":"lease-a"}' \
+    "$base_url/v1/workspaces/workspace-a/capture-jobs/job-a/claim")
+lease_epoch=$(printf '%s' "$claim_response" | sed -n 's/.*"epoch":\([0-9][0-9]*\).*/\1/p')
+test -n "$lease_epoch"
+
 append_status=$(curl \
     --connect-timeout 3 \
     --max-time 10 \
@@ -66,7 +82,7 @@ append_status=$(curl \
     --request POST \
     --header "Authorization: Bearer $token" \
     --header 'Content-Type: application/json' \
-    --data '{"event":{"id":"event-0","bot_id":"bot-a","sequence":0,"occurred_at":"2026-08-17T00:00:01Z","payload":{"type":"lifecycle","data":{"from":"queued","to":"launching"}},"metadata":{}}}' \
+    --data '{"lease":{"workerId":"worker-a","leaseId":"lease-a","epoch":'"$lease_epoch"'},"event":{"id":"event-0","bot_id":"bot-a","sequence":0,"occurred_at":"2026-08-17T00:00:01Z","payload":{"type":"lifecycle","data":{"from":"queued","to":"launching"}},"metadata":{}}}' \
     "$base_url/v1/workspaces/workspace-a/capture-jobs/job-a/events")
 test "$append_status" = 200
 

--- a/enterprise/google-meet-worker/src/event_sink.rs
+++ b/enterprise/google-meet-worker/src/event_sink.rs
@@ -1,12 +1,17 @@
 use std::{collections::VecDeque, time::Duration};
 
-use anlg_meeting_capture::{
-    BotState, CaptureEvent, CaptureProviderKind, CaptureWorkerCheckpoint, MeetingReference,
+use anlg_meeting_capture::{CaptureEvent, CaptureWorkerCheckpoint};
+// The exact capture wire contract is owned by the shared MIT-layer module;
+// this sink only adds HTTP, retries, and validation on top of it.
+pub use anlg_meeting_capture::wire::CaptureJobLease as WorkerLease;
+use anlg_meeting_capture::wire::{
+    AppendCaptureEventRequest, CaptureJobCheckpoint, CaptureJobLeaseIdentity,
+    ClaimCaptureJobRequest, RenewCaptureJobLeaseRequest,
 };
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use reqwest::StatusCode;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use url::Url;
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
@@ -203,8 +208,8 @@ impl ControlPlaneEventSink {
         validate_identifier(&lease_id, "lease ID")
             .map_err(|_| CaptureEventSinkError::InvalidLeaseIdentity("lease ID"))?;
         let request = ClaimCaptureJobRequest {
-            worker_id: &worker_id,
-            lease_id: &lease_id,
+            worker_id: worker_id.clone(),
+            lease_id: lease_id.clone(),
         };
         let lease = self
             .send_lease_request(self.claim_endpoint.clone(), &request)
@@ -221,8 +226,9 @@ impl ControlPlaneEventSink {
             .await
             .clone()
             .ok_or(CaptureEventSinkError::LeaseRequired)?;
-        let identity = WorkerLeaseIdentity::from(&current);
-        let request = RenewCaptureJobLeaseRequest { lease: &identity };
+        let request = RenewCaptureJobLeaseRequest {
+            lease: CaptureJobLeaseIdentity::from(&current),
+        };
         let renewed = match self
             .send_lease_request(self.lease_endpoint.clone(), &request)
             .await
@@ -294,10 +300,9 @@ impl CaptureEventSink for ControlPlaneEventSink {
             .await
             .clone()
             .ok_or(CaptureEventSinkError::LeaseRequired)?;
-        let identity = WorkerLeaseIdentity::from(&lease);
         let request = AppendCaptureEventRequest {
-            lease: &identity,
-            event,
+            lease: CaptureJobLeaseIdentity::from(&lease),
+            event: event.clone(),
         };
         let mut retry_delay = self.retry.initial_delay;
         for attempt in 1..=self.retry.max_attempts {
@@ -329,78 +334,14 @@ impl CaptureEventSink for ControlPlaneEventSink {
     }
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct AppendCaptureEventRequest<'a> {
-    lease: &'a WorkerLeaseIdentity,
-    event: &'a CaptureEvent,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ClaimCaptureJobRequest<'a> {
-    worker_id: &'a str,
-    lease_id: &'a str,
-}
-
-#[derive(Serialize)]
-struct RenewCaptureJobLeaseRequest<'a> {
-    lease: &'a WorkerLeaseIdentity,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct WorkerLease {
-    pub worker_id: String,
-    pub lease_id: String,
-    pub epoch: u64,
-    pub expires_at: chrono::DateTime<chrono::Utc>,
-}
-
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct WorkerLeaseIdentity {
-    worker_id: String,
-    lease_id: String,
-    epoch: u64,
-}
-
-impl From<&WorkerLease> for WorkerLeaseIdentity {
-    fn from(lease: &WorkerLease) -> Self {
-        Self {
-            worker_id: lease.worker_id.clone(),
-            lease_id: lease.lease_id.clone(),
-            epoch: lease.epoch,
-        }
-    }
-}
-
 pub type WorkerCheckpoint = CaptureWorkerCheckpoint;
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct WireCaptureJobCheckpoint {
-    job: WireCaptureJob,
-    state: BotState,
-    next_sequence: u64,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct WireCaptureJob {
-    workspace_id: String,
-    job_id: String,
-    bot_id: String,
-    provider: CaptureProviderKind,
-    meeting: MeetingReference,
-}
 
 async fn decode_checkpoint(
     response: reqwest::Response,
     expected_workspace_id: &str,
     expected_job_id: &str,
 ) -> Result<WorkerCheckpoint, CaptureEventSinkError> {
-    let checkpoint: WireCaptureJobCheckpoint = decode_bounded_json(response).await?;
+    let checkpoint: CaptureJobCheckpoint = decode_bounded_json(response).await?;
     if checkpoint.job.workspace_id != expected_workspace_id {
         return Err(CaptureEventSinkError::InvalidCheckpoint("workspace ID"));
     }
@@ -582,6 +523,7 @@ mod tests {
     };
 
     use super::*;
+    use anlg_meeting_capture::BotState;
 
     fn event(sequence: u64) -> CaptureEvent {
         CaptureEvent {


### PR DESCRIPTION
Capture lease/request/checkpoint serialization was defined in the
enterprise control plane and manually mirrored (with drift) in the
Google Meet worker, and the compose smoke test omitted the required
lease on event append. Move the serialization-only capture protocol
structs into a wire module in the MIT-layer meeting-capture crate (per
the enterprise layering rule) with JSON round-trip fixtures; the
control plane re-exports them unchanged and the worker consumes them in
place of its local mirrors, keeping retries, HTTP, and validation
local. The compose smoke test now claims the job and threads the
returned lease identity through the append payload. (ANLG-272)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared serialization contract between control plane and capture workers; drift fixes are intended but any serde mismatch could break job claim, lease renew, or event append at runtime.
> 
> **Overview**
> Centralizes the **capture control-plane ↔ worker JSON contract** in a new `anlg_meeting_capture::wire` module so the enterprise control plane and Google Meet worker no longer maintain parallel, drifting serde types.
> 
> The shared module defines jobs, leases, checkpoints, and claim/renew/append request bodies (`camelCase`, `deny_unknown_fields`) plus JSON round-trip tests. The control plane **re-exports** those types unchanged; the worker **drops** its local wire mirrors and uses the shared structs (with `CaptureJobLease` aliased as `WorkerLease`), while HTTP/retry/validation stay in the worker. The compose smoke test now **claims** a job and includes the returned **lease identity** on event append, matching the real API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f7c7707bce2a777d6e1d9841dd13cc38a5a168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->