### PR TITLE
refactor(qa): share one Linux audio QA policy between producer and verifier

### DIFF
--- a/scripts/qa/linux-audio-qa-policy.json
+++ b/scripts/qa/linux-audio-qa-policy.json
@@ -1,0 +1,21 @@
+{
+  "$comment": "Single policy for the Linux audio QA scenario: the Python track verifier (scripts/qa/verify_linux_audio_tracks.py) produces analysis evidence with these thresholds and phase rules, and the release evidence verifier (scripts/verify-linux-audio-qa-evidence.mjs) enforces the same values, so producer and verifier cannot silently disagree.",
+  "policyVersion": 1,
+  "phaseSchemaVersion": 1,
+  "requiredPhases": ["both", "mic_only", "system_only"],
+  "minPhaseDurationSeconds": 5,
+  "thresholds": {
+    "duration_delta_seconds_max": 0.15,
+    "mic_active_rms_min": 0.0002,
+    "speaker_active_rms_min": 0.001,
+    "system_tone_amplitude_min": 0.0005,
+    "mic_pilot_amplitude_min": 0.0002,
+    "mic_isolation_db_min": 12.0,
+    "speaker_isolation_db_min": 15.0,
+    "system_tone_isolation_db_min": 18.0,
+    "mic_pilot_isolation_db_min": 6.0,
+    "cross_channel_isolation_db_min": 12.0,
+    "clipped_fraction_max": 0.001,
+    "recording_tail_tolerance_seconds": 0.5
+  }
+}

--- a/scripts/qa/verify_linux_audio_tracks.py
+++ b/scripts/qa/verify_linux_audio_tracks.py
@@ -20,20 +20,15 @@ class WavTrack:
         return len(self.samples) / self.sample_rate
 
 
-THRESHOLDS = {
-    "duration_delta_seconds_max": 0.15,
-    "mic_active_rms_min": 0.0002,
-    "speaker_active_rms_min": 0.001,
-    "system_tone_amplitude_min": 0.0005,
-    "mic_pilot_amplitude_min": 0.0002,
-    "mic_isolation_db_min": 12.0,
-    "speaker_isolation_db_min": 15.0,
-    "system_tone_isolation_db_min": 18.0,
-    "mic_pilot_isolation_db_min": 6.0,
-    "cross_channel_isolation_db_min": 12.0,
-    "clipped_fraction_max": 0.001,
-    "recording_tail_tolerance_seconds": 0.5,
-}
+# Shared with scripts/verify-linux-audio-qa-evidence.mjs so the producer and
+# release verifier apply identical thresholds and phase rules.
+POLICY = json.loads(
+    (Path(__file__).with_name("linux-audio-qa-policy.json")).read_text()
+)
+THRESHOLDS = POLICY["thresholds"]
+REQUIRED_PHASES = frozenset(POLICY["requiredPhases"])
+MIN_PHASE_DURATION_SECONDS = float(POLICY["minPhaseDurationSeconds"])
+PHASE_SCHEMA_VERSION = POLICY["phaseSchemaVersion"]
 
 
 def parse_args() -> argparse.Namespace:
@@ -139,7 +134,7 @@ def decode_samples(data: bytes, audio_format: int, bits_per_sample: int) -> list
 
 def load_phases(path: Path) -> tuple[dict[str, dict[str, float]], float]:
     payload = json.loads(path.read_text())
-    if payload.get("schema_version") != 1:
+    if payload.get("schema_version") != PHASE_SCHEMA_VERSION:
         raise ValueError("unsupported phase schema")
     if payload.get("no_aec") is not True:
         raise ValueError("phase evidence must declare no_aec=true")
@@ -147,15 +142,15 @@ def load_phases(path: Path) -> tuple[dict[str, dict[str, float]], float]:
     phases: dict[str, dict[str, float]] = {}
     for phase in payload.get("phases", []):
         name = phase.get("name")
-        if name not in {"mic_only", "system_only", "both"}:
+        if name not in REQUIRED_PHASES:
             continue
         start = float(phase["start_seconds"])
         end = float(phase["end_seconds"])
-        if end - start < 5.0:
+        if end - start < MIN_PHASE_DURATION_SECONDS:
             raise ValueError(f"{name} phase is too short for deterministic analysis")
         phases[name] = {"start": start, "end": end}
 
-    missing = {"mic_only", "system_only", "both"} - phases.keys()
+    missing = REQUIRED_PHASES - phases.keys()
     if missing:
         raise ValueError(f"missing phase evidence: {', '.join(sorted(missing))}")
 

--- a/scripts/verify-linux-audio-qa-evidence.mjs
+++ b/scripts/verify-linux-audio-qa-evidence.mjs
@@ -1,6 +1,16 @@
+import { readFileSync } from "node:fs";
 import { lstat, readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+
+// Shared with scripts/qa/verify_linux_audio_tracks.py so the producer and
+// release verifier apply identical thresholds and phase rules.
+export const linuxAudioQaPolicy = JSON.parse(
+  readFileSync(
+    new URL("./qa/linux-audio-qa-policy.json", import.meta.url),
+    "utf8",
+  ),
+);
 
 const APPLICATION = "fastrepl/hyprnote2";
 const SOURCE_WORKFLOW = ".github/workflows/desktop_cd.yaml";
@@ -18,20 +28,7 @@ const ARCHITECTURES = [
 ];
 const ANALYSIS_SCOPE =
   "Virtual microphone/system routing, capture, separation, and persistence with NO_AEC=1. This result makes no AEC claim.";
-const ANALYSIS_THRESHOLDS = {
-  duration_delta_seconds_max: 0.15,
-  mic_active_rms_min: 0.0002,
-  speaker_active_rms_min: 0.001,
-  system_tone_amplitude_min: 0.0005,
-  mic_pilot_amplitude_min: 0.0002,
-  mic_isolation_db_min: 12,
-  speaker_isolation_db_min: 15,
-  system_tone_isolation_db_min: 18,
-  mic_pilot_isolation_db_min: 6,
-  cross_channel_isolation_db_min: 12,
-  clipped_fraction_max: 0.001,
-  recording_tail_tolerance_seconds: 0.5,
-};
+const ANALYSIS_THRESHOLDS = linuxAudioQaPolicy.thresholds;
 const ANALYSIS_METRICS = [
   "mic_duration_seconds",
   "speaker_duration_seconds",
@@ -330,20 +327,21 @@ async function verifyArchitecture({
       Number.isFinite(phase.start_seconds) &&
       typeof phase?.end_seconds === "number" &&
       Number.isFinite(phase.end_seconds) &&
-      phase.end_seconds - phase.start_seconds >= 5,
+      phase.end_seconds - phase.start_seconds >=
+        linuxAudioQaPolicy.minPhaseDurationSeconds,
   );
   const latestPhaseEnd = Math.max(
     ...phaseList.map((phase) => phase?.end_seconds ?? Number.POSITIVE_INFINITY),
   );
   invariant(
-    phases.schema_version === 1 &&
+    phases.schema_version === linuxAudioQaPolicy.phaseSchemaVersion &&
       phases.no_aec === true &&
       typeof phases.recording_stop_seconds === "number" &&
       Number.isFinite(phases.recording_stop_seconds) &&
       validIntervals &&
       phases.recording_stop_seconds > latestPhaseEnd &&
       JSON.stringify(phaseNames) ===
-        JSON.stringify(["both", "mic_only", "system_only"]),
+        JSON.stringify([...linuxAudioQaPolicy.requiredPhases].sort()),
     `Linux ${architecture.artifactArch} phase evidence is invalid`,
   );
 

--- a/scripts/verify-linux-audio-qa-evidence.test.mjs
+++ b/scripts/verify-linux-audio-qa-evidence.test.mjs
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rename, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rename, writeFile, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { verifyLinuxAudioQaEvidence } from "./verify-linux-audio-qa-evidence.mjs";
+import {
+  linuxAudioQaPolicy,
+  verifyLinuxAudioQaEvidence,
+} from "./verify-linux-audio-qa-evidence.mjs";
 
 const version = "1.4.0";
 const candidateSha = "0123456789abcdef0123456789abcdef01234567";
@@ -28,20 +31,7 @@ const architectures = {
     assetId: "asset-arm64",
   },
 };
-const thresholds = {
-  duration_delta_seconds_max: 0.15,
-  mic_active_rms_min: 0.0002,
-  speaker_active_rms_min: 0.001,
-  system_tone_amplitude_min: 0.0005,
-  mic_pilot_amplitude_min: 0.0002,
-  mic_isolation_db_min: 12,
-  speaker_isolation_db_min: 15,
-  system_tone_isolation_db_min: 18,
-  mic_pilot_isolation_db_min: 6,
-  cross_channel_isolation_db_min: 12,
-  clipped_fraction_max: 0.001,
-  recording_tail_tolerance_seconds: 0.5,
-};
+const thresholds = linuxAudioQaPolicy.thresholds;
 const metricNames = [
   "mic_duration_seconds",
   "speaker_duration_seconds",
@@ -292,6 +282,68 @@ test("rejects a basename decoy outside the exact evidence path", async () => {
       audioQaRunId,
     }),
     /x64 evidence is missing .*provenance\.json/,
+  );
+});
+
+test("python producer and node verifier read the same policy artifact", async () => {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const pythonPolicy = JSON.parse(
+    (
+      await promisify(execFile)("python3", [
+        "-c",
+        [
+          "import importlib.util, json",
+          "spec = importlib.util.spec_from_file_location('v', 'scripts/qa/verify_linux_audio_tracks.py')",
+          "module = importlib.util.module_from_spec(spec)",
+          "spec.loader.exec_module(module)",
+          "print(json.dumps({'thresholds': module.THRESHOLDS, 'requiredPhases': sorted(module.REQUIRED_PHASES), 'minPhaseDurationSeconds': module.MIN_PHASE_DURATION_SECONDS, 'phaseSchemaVersion': module.PHASE_SCHEMA_VERSION}))",
+        ].join("\n"),
+      ])
+    ).stdout,
+  );
+
+  assert.deepEqual(pythonPolicy.thresholds, linuxAudioQaPolicy.thresholds);
+  assert.deepEqual(
+    pythonPolicy.requiredPhases,
+    [...linuxAudioQaPolicy.requiredPhases].sort(),
+  );
+  assert.equal(
+    pythonPolicy.minPhaseDurationSeconds,
+    linuxAudioQaPolicy.minPhaseDurationSeconds,
+  );
+  assert.equal(
+    pythonPolicy.phaseSchemaVersion,
+    linuxAudioQaPolicy.phaseSchemaVersion,
+  );
+});
+
+test("rejects analysis thresholds that deviate from the shared policy", async () => {
+  const fixture = await createFixture();
+  const root = path.join(
+    fixture.evidenceDir,
+    "x64",
+    "qa-artifacts",
+    "linux-x64",
+  );
+  const analysis = JSON.parse(
+    await readFile(path.join(root, "analysis.json"), "utf8"),
+  );
+  analysis.thresholds = {
+    ...analysis.thresholds,
+    mic_isolation_db_min: analysis.thresholds.mic_isolation_db_min - 1,
+  };
+  await writeFile(path.join(root, "analysis.json"), JSON.stringify(analysis));
+
+  await assert.rejects(
+    verifyLinuxAudioQaEvidence({
+      ...fixture,
+      version,
+      candidateSha,
+      dryRunId,
+      audioQaRunId,
+    }),
+    /audio analysis did not pass/,
   );
 });
 


### PR DESCRIPTION
Thresholds and phase rules for the Linux audio QA scenario were
duplicated between the Python track verifier and the release evidence
verifier, so the producer and verifier could silently disagree. Both
now read scripts/qa/linux-audio-qa-policy.json — thresholds, required
phases, minimum phase duration, and phase schema version — keeping
language-specific I/O and schema adapters local. Adds a cross-language
parity test that loads the Python module and compares its policy values
against the Node verifier's, plus a fixture proving analysis evidence
with deviating thresholds is rejected. (ANLG-275)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> QA/release-gate tooling only; behavior is intended to stay equivalent while removing duplicate policy definitions.
> 
> **Overview**
> Linux audio QA **thresholds and phase rules** were duplicated in the Python track analyzer and the Node release evidence verifier, so the two sides could drift apart without anyone noticing.
> 
> This PR introduces **`scripts/qa/linux-audio-qa-policy.json`** as the single policy (thresholds, required phases, minimum phase duration, phase schema version). **`verify_linux_audio_tracks.py`** and **`verify-linux-audio-qa-evidence.mjs`** both load that file instead of inlining the same constants.
> 
> Tests now pull thresholds from the shared policy, add a **cross-language parity check** (Python module vs Node `linuxAudioQaPolicy`), and assert that **`analysis.json` with thresholds that don’t match the policy** fails verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f288fa70a04944c4d468c88af220c1a244e933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->