### PR TITLE
refactor(skills): generate the published Anarlog skill from one source

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
       - run: >-
           node --test
           scripts/desktop-release-provenance.test.mjs
+          scripts/publish-anarlog-skill.test.mjs
           scripts/repack-linux-appimage.test.mjs
           scripts/verify-linux-audio-qa-run.test.mjs
           scripts/verify-linux-audio-qa-evidence.test.mjs

--- a/.github/workflows/cli_ci.yaml
+++ b/.github/workflows/cli_ci.yaml
@@ -134,6 +134,7 @@ jobs:
           awk 'NR > 1 && $0 == "---" { found = 1; exit } END { if (!found) exit 1 }' skills/anarlog/SKILL.md
           test "$(readlink docs/.mintlify/skills)" = "../../skills"
           test -f docs/.mintlify/skills/anarlog/SKILL.md
+          node scripts/publish-anarlog-skill.mjs --check
           skill_list="$(npx --yes skills@1.5.16 add . --list)"
           echo "$skill_list"
           grep -q 'anarlog' <<<"$skill_list"

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -20,7 +20,9 @@ Never query or modify Anarlog's SQLite database directly. The CLI and MCP server
 1. List recent meetings or search by a short title fragment.
 2. Use a meeting ID returned by the search. Never guess one.
 3. Get the meeting before requesting its transcript. Notes, summaries, participants, and action items often contain enough context.
-4. Request recurring history only when the task needs earlier meetings in the same series.
+4. Ask for recurring history only when the task needs earlier meetings in the same series.
+
+See [CLI commands](https://docs.anarlog.so/reference/cli) and [MCP tools](https://docs.anarlog.so/reference/mcp).
 
 ## Keep context bounded
 
@@ -37,4 +39,4 @@ Never query or modify Anarlog's SQLite database directly. The CLI and MCP server
 - CLI export can create a file. Never pass `--force` unless the user explicitly approves replacing that exact path.
 - If search results are ambiguous, ask the user to choose a meeting.
 
-See the [CLI reference](https://docs.anarlog.so/reference/cli), [MCP reference](https://docs.anarlog.so/reference/mcp), and [error guide](https://docs.anarlog.so/reference/errors).
+For setup and failures, see [setup](https://docs.anarlog.so/agents/overview) and [errors](https://docs.anarlog.so/reference/errors).

--- a/scripts/publish-anarlog-skill.mjs
+++ b/scripts/publish-anarlog-skill.mjs
@@ -1,0 +1,62 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// skills/anarlog/SKILL.md is the sole authored workflow. This script
+// deterministically publishes docs/skill.md from it, rewriting only the
+// package-relative reference links to their public documentation URLs, so any
+// other drift between the two files fails CI (--check).
+export const CANONICAL_SKILL_PATH = "skills/anarlog/SKILL.md";
+export const PUBLISHED_SKILL_PATH = "docs/skill.md";
+
+export const REFERENCE_LINK_REWRITES = {
+  "references/cli.md": "https://docs.anarlog.so/reference/cli",
+  "references/mcp.md": "https://docs.anarlog.so/reference/mcp",
+  "references/errors.md": "https://docs.anarlog.so/reference/errors",
+  "references/setup.md": "https://docs.anarlog.so/agents/overview",
+};
+
+export function publishSkill(canonical) {
+  let published = canonical;
+  for (const [reference, url] of Object.entries(REFERENCE_LINK_REWRITES)) {
+    published = published.split(`](${reference})`).join(`](${url})`);
+  }
+
+  const unrewritten = published.match(/\]\(references\/[^)]*\)/);
+  if (unrewritten) {
+    throw new Error(
+      `SKILL.md links to ${unrewritten[0]} which has no public URL mapping`,
+    );
+  }
+  return published;
+}
+
+function main() {
+  const check = process.argv.includes("--check");
+  const canonical = readFileSync(CANONICAL_SKILL_PATH, "utf8");
+  const published = publishSkill(canonical);
+
+  if (check) {
+    const current = readFileSync(PUBLISHED_SKILL_PATH, "utf8");
+    if (current !== published) {
+      console.error(
+        `${PUBLISHED_SKILL_PATH} drifted from ${CANONICAL_SKILL_PATH}; run: node scripts/publish-anarlog-skill.mjs`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`${PUBLISHED_SKILL_PATH} matches ${CANONICAL_SKILL_PATH}`);
+    return;
+  }
+
+  writeFileSync(PUBLISHED_SKILL_PATH, published);
+  console.log(`Published ${PUBLISHED_SKILL_PATH} from ${CANONICAL_SKILL_PATH}`);
+}
+
+const isMain = process.argv[1]
+  ? import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+  : false;
+
+if (isMain) {
+  main();
+}

--- a/scripts/publish-anarlog-skill.test.mjs
+++ b/scripts/publish-anarlog-skill.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  CANONICAL_SKILL_PATH,
+  PUBLISHED_SKILL_PATH,
+  publishSkill,
+  REFERENCE_LINK_REWRITES,
+} from "./publish-anarlog-skill.mjs";
+
+test("published skill equals the canonical skill after only link rewrites", async () => {
+  const canonical = await readFile(CANONICAL_SKILL_PATH, "utf8");
+  const published = await readFile(PUBLISHED_SKILL_PATH, "utf8");
+
+  assert.equal(published, publishSkill(canonical));
+});
+
+test("the transformation changes nothing but the defined reference links", async () => {
+  const canonical = await readFile(CANONICAL_SKILL_PATH, "utf8");
+  let restored = publishSkill(canonical);
+  for (const [reference, url] of Object.entries(REFERENCE_LINK_REWRITES)) {
+    restored = restored.split(`](${url})`).join(`](${reference})`);
+  }
+
+  assert.equal(restored, canonical);
+});
+
+test("non-link drift in the published mirror is detected", async () => {
+  const canonical = await readFile(CANONICAL_SKILL_PATH, "utf8");
+  const published = await readFile(PUBLISHED_SKILL_PATH, "utf8");
+
+  assert.notEqual(
+    publishSkill(canonical.replace("read-only", "writable")),
+    published,
+  );
+});
+
+test("reference links without a public mapping fail publishing", () => {
+  assert.throws(
+    () => publishSkill("see [new page](references/new-page.md)"),
+    /no public URL mapping/,
+  );
+});


### PR DESCRIPTION
skills/anarlog/SKILL.md and docs/skill.md duplicated the public
workflow guidance and had already drifted (reworded recurring-history
step, dropped in-context reference links, and a rewritten closing
line). SKILL.md is now the sole authored workflow: a small publish
script deterministically regenerates docs/skill.md, rewriting only the
package-relative reference links to their public documentation URLs
(reference/cli, reference/mcp, reference/errors, agents/overview), and
a --check mode in cli_ci fails on drift. Tests prove the published
output equals the canonical input under only the defined link
transformation, that the transformation is reversible, and that
unmapped reference links are refused; the discoverability and Mintlify
checks are unchanged. (ANLG-283)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI guardrails only; no runtime, auth, or data-path changes.
> 
> **Overview**
> **`skills/anarlog/SKILL.md` is now the only hand-edited agent workflow**; `docs/skill.md` is treated as a published mirror, not a second copy to maintain by hand.
> 
> A new **`scripts/publish-anarlog-skill.mjs`** reads the canonical skill and writes `docs/skill.md` by rewriting only `references/*.md` links to fixed `docs.anarlog.so` URLs. **`--check`** fails CI if the mirror has any other drift. **`publish-anarlog-skill.test.mjs`** locks in parity, reversibility of link rewrites, and rejection of unmapped reference links.
> 
> **CI** runs the new tests in the main workflow and **`node scripts/publish-anarlog-skill.mjs --check`** in `cli_ci` alongside the existing skill/Mintlify checks. **`docs/skill.md`** is refreshed so its wording and in-doc links align with the canonical skill (including recurring-history wording and CLI/MCP/setup/error links).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6544743bfb997a474369561bad41bdc7769fc642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->