### PR TITLE
fix(db-app): update import run outcome and migration state atomically

### DIFF
--- a/crates/db-app/src/legacy_import/run.rs
+++ b/crates/db-app/src/legacy_import/run.rs
@@ -152,6 +152,9 @@ pub async fn finish_legacy_import_run(
     pool: &SqlitePool,
     run_id: &str,
 ) -> Result<String, sqlx::Error> {
+    // One transaction: the run outcome and the migration-state control
+    // pointer must never diverge if the process dies between the writes.
+    let mut transaction = pool.begin().await?;
     let aggregate = sqlx::query(
         "SELECT
            COALESCE(SUM(discovered_count), 0) AS discovered_count,
@@ -164,7 +167,7 @@ pub async fn finish_legacy_import_run(
          WHERE run_id = ?",
     )
     .bind(run_id)
-    .fetch_one(pool)
+    .fetch_one(&mut *transaction)
     .await?;
 
     let skipped_count = aggregate.get::<i64, _>("skipped_count");
@@ -198,7 +201,7 @@ pub async fn finish_legacy_import_run(
     .bind(conflict_count)
     .bind(error_count)
     .bind(run_id)
-    .execute(pool)
+    .execute(&mut *transaction)
     .await?;
 
     sqlx::query(
@@ -219,8 +222,10 @@ pub async fn finish_legacy_import_run(
     .bind(status)
     .bind(status)
     .bind(run_id)
-    .execute(pool)
+    .execute(&mut *transaction)
     .await?;
+
+    transaction.commit().await?;
 
     Ok(status.to_string())
 }
@@ -230,6 +235,8 @@ pub async fn fail_legacy_import_run(
     run_id: &str,
     error: &str,
 ) -> Result<(), sqlx::Error> {
+    // One transaction, for the same reason as finish_legacy_import_run.
+    let mut transaction = pool.begin().await?;
     sqlx::query(
         "UPDATE migration_import_runs
          SET status = 'failed', error = ?, completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
@@ -237,7 +244,7 @@ pub async fn fail_legacy_import_run(
     )
     .bind(error)
     .bind(run_id)
-    .execute(pool)
+    .execute(&mut *transaction)
     .await?;
 
     sqlx::query(
@@ -251,8 +258,10 @@ pub async fn fail_legacy_import_run(
     .bind(run_id)
     .bind(error)
     .bind(run_id)
-    .execute(pool)
+    .execute(&mut *transaction)
     .await?;
+
+    transaction.commit().await?;
 
     Ok(())
 }

--- a/crates/db-app/src/legacy_import/tests.rs
+++ b/crates/db-app/src/legacy_import/tests.rs
@@ -505,6 +505,74 @@ async fn divergent_nonempty_documents_remain_conflicted_and_unchanged() {
 }
 
 #[tokio::test]
+async fn run_outcome_and_migration_state_pointer_stay_consistent() {
+    let db = test_db().await;
+    begin_run_with_session(&db, "run-1").await;
+
+    let status = finish_legacy_import_run(db.pool(), "run-1").await.unwrap();
+    let (latest_run_id, parity_verified, last_error): (String, bool, String) = sqlx::query_as(
+        "SELECT latest_run_id, parity_verified, last_error
+         FROM storage_migration_state WHERE id = 'legacy_v1'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(latest_run_id, "run-1");
+    assert_eq!(parity_verified, status == "completed");
+    let run_status: String =
+        sqlx::query_scalar("SELECT status FROM migration_import_runs WHERE id = 'run-1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(run_status, status);
+    assert_eq!(last_error.is_empty(), status == "completed");
+
+    begin_legacy_import_run(db.pool(), "run-2", "/vault", false)
+        .await
+        .unwrap();
+    fail_legacy_import_run(db.pool(), "run-2", "disk full")
+        .await
+        .unwrap();
+    let (latest_run_id, last_error): (String, String) = sqlx::query_as(
+        "SELECT latest_run_id, last_error
+         FROM storage_migration_state WHERE id = 'legacy_v1'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    let (run_status, run_error): (String, String) =
+        sqlx::query_as("SELECT status, error FROM migration_import_runs WHERE id = 'run-2'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(latest_run_id, "run-2");
+    assert_eq!(run_status, "failed");
+    assert_eq!(last_error, run_error);
+    assert_eq!(last_error, "disk full");
+}
+
+#[tokio::test]
+async fn dry_runs_never_touch_migration_state() {
+    let db = test_db().await;
+    begin_legacy_import_run(db.pool(), "dry-run-1", "/legacy", true)
+        .await
+        .unwrap();
+    fail_legacy_import_run(db.pool(), "dry-run-1", "dry failure")
+        .await
+        .unwrap();
+
+    let (latest_run_id, last_error): (String, String) = sqlx::query_as(
+        "SELECT latest_run_id, last_error
+         FROM storage_migration_state WHERE id = 'legacy_v1'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(latest_run_id, "");
+    assert_eq!(last_error, "");
+}
+
+#[tokio::test]
 async fn transcript_reconciliation_only_fills_an_empty_payload() {
     let db = test_db().await;
     begin_run_with_session(&db, "run-1").await;


### PR DESCRIPTION
finish_legacy_import_run and fail_legacy_import_run wrote the
migration_import_runs outcome and the storage_migration_state control
pointer as separate pool statements, so a crash between them could
leave the state row pointing at a run whose recorded outcome disagreed
with it. Both paths now run inside one transaction (begin already did),
so the run result and control pointer commit together. Adds tests
asserting the pointer, parity, and error fields always agree with the
referenced run after finish and fail, and that dry runs never touch
migration state. Consolidating the duplicated parity/error columns into
run-derived reads remains open on the ticket: parity is also set by the
external parity-marking flow, so that schema change needs its own
migration and consumer pass. (ANLG-279)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches migration control state and run finalization; behavior change is narrowly scoped to atomicity with no new SQL semantics beyond wrapping existing updates.
> 
> **Overview**
> **`finish_legacy_import_run`** and **`fail_legacy_import_run`** now run their aggregate/read, **`migration_import_runs`** update, and **`storage_migration_state`** control-pointer update inside a **single SQLite transaction** (with commit), matching the transactional pattern already used in **`begin_legacy_import_run`**. That prevents a crash between separate pool writes from leaving **`latest_run_id`**, **`parity_verified`**, or **`last_error`** out of sync with the run row’s status and error.
> 
> New tests assert **`storage_migration_state`** stays aligned with the referenced run after successful finish and after fail, and that **dry runs** still do not update migration state when finish/fail run (via the existing `dry_run = 0` guard on the state update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3664a41c5d037e06f40b77c39a6f8898e78548c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->