### PR TITLE
refactor(desktop): preindex past-note relationships before ranking

### DIFF
--- a/apps/desktop/src/session/insights/past-notes.test.ts
+++ b/apps/desktop/src/session/insights/past-notes.test.ts
@@ -211,6 +211,166 @@ describe("buildPastSessionNotes", () => {
   });
 });
 
+describe("past note relationship indexing", () => {
+  function session(_id: string, createdAt: string) {
+    return {
+      title: "Weekly Product Sync",
+      created_at: createdAt,
+      event_json: "",
+      raw_md: "",
+    };
+  }
+
+  it("keeps duplicate participant rows and names deduplicated", () => {
+    const data = makeData({
+      sessions: {
+        current: session("current", "2026-06-03T10:00:00.000Z"),
+        previous: session("previous", "2026-05-28T10:00:00.000Z"),
+      },
+      mapping_session_participant: {
+        current_alex: {
+          session_id: "current",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+          name: "Alex",
+        },
+        current_alex_again: {
+          session_id: "current",
+          human_id: "alex",
+          user_id: "self",
+          source: "manual",
+          name: "Alex Kim",
+        },
+        previous_alex: {
+          session_id: "previous",
+          human_id: "alex",
+          user_id: "self",
+          source: "auto",
+          name: "",
+        },
+      },
+      enhanced_notes: {
+        previous_summary: {
+          session_id: "previous",
+          content: "Alex committed to send pricing by Friday.",
+          position: 0,
+        },
+      },
+    });
+
+    const result = buildPastSessionNotes(data, "current", "self");
+
+    expect(result.notes).toHaveLength(1);
+    // The last non-empty name for a human wins, exactly once.
+    expect(result.notes[0]?.participantNames).toEqual(["Alex Kim"]);
+  });
+
+  it("skips candidates with no participants or notes without failing", () => {
+    const data = makeData({
+      sessions: {
+        current: session("current", "2026-06-03T10:00:00.000Z"),
+        no_relations: session("no_relations", "2026-05-28T10:00:00.000Z"),
+      },
+    });
+
+    const result = buildPastSessionNotes(data, "current", "self");
+
+    expect(result.notes).toEqual([]);
+    expect(result.requests).toEqual([]);
+  });
+
+  it("keeps insertion order for recency ties", () => {
+    const data = makeData({
+      sessions: {
+        current: session("current", "2026-06-03T10:00:00.000Z"),
+        tie_a: session("tie_a", "2026-05-28T10:00:00.000Z"),
+        tie_b: session("tie_b", "2026-05-28T10:00:00.000Z"),
+      },
+      enhanced_notes: {
+        a: { session_id: "tie_a", content: "Summary A", position: 0 },
+        b: { session_id: "tie_b", content: "Summary B", position: 0 },
+      },
+    });
+
+    const result = buildPastSessionNotes(data, "current", "self");
+
+    expect(result.notes.map((note) => note.sessionId)).toEqual([
+      "tie_a",
+      "tie_b",
+    ]);
+  });
+
+  it("visits each participant and note row a bounded number of times", () => {
+    const sessions: Record<string, ReturnType<typeof session>> = {
+      current: session("current", "2026-06-03T10:00:00.000Z"),
+    };
+    const participants: Record<string, Record<string, unknown>> = {
+      current_p: {
+        session_id: "current",
+        human_id: "human-0",
+        user_id: "self",
+        source: "auto",
+        name: "Human 0",
+      },
+    };
+    const notes: Record<string, Record<string, unknown>> = {};
+    for (let index = 0; index < 200; index += 1) {
+      const id = `past-${index}`;
+      sessions[id] = session(
+        id,
+        `2026-05-${String((index % 27) + 1).padStart(2, "0")}T10:00:00.000Z`,
+      );
+      participants[`${id}_p`] = {
+        session_id: id,
+        human_id: `human-${index % 20}`,
+        user_id: "self",
+        source: "auto",
+        name: `Human ${index % 20}`,
+      };
+      notes[`${id}_n`] = {
+        session_id: id,
+        content: `Summary ${index}`,
+        position: 0,
+      };
+    }
+
+    const data = makeData({
+      sessions,
+      mapping_session_participant: participants,
+      enhanced_notes: notes,
+    });
+    let participantVisits = 0;
+    let noteVisits = 0;
+    const countingRows = <T>(rows: T[], count: () => void): T[] =>
+      new Proxy(rows, {
+        get(target, property, receiver) {
+          if (typeof property === "string" && /^\d+$/.test(property)) {
+            count();
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+    const counted: PastSessionNotesData = {
+      ...data,
+      participants: countingRows(data.participants, () => {
+        participantVisits += 1;
+      }),
+      enhancedNotes: countingRows(data.enhancedNotes, () => {
+        noteVisits += 1;
+      }),
+    };
+
+    const result = buildPastSessionNotes(counted, "current", "self");
+
+    expect(result.notes).toHaveLength(8);
+    // One indexing pass (plus small constant-factor iteration overhead)
+    // instead of a rescan per candidate session.
+    expect(participantVisits).toBeLessThanOrEqual(data.participants.length * 4);
+    expect(noteVisits).toBeLessThanOrEqual(data.enhancedNotes.length * 4);
+  });
+});
+
 describe("buildSessionKeyFactsStatements", () => {
   it("copies workspace ownership from the parent session", () => {
     const statements = buildSessionKeyFactsStatements(

--- a/apps/desktop/src/session/insights/past-notes.ts
+++ b/apps/desktop/src/session/insights/past-notes.ts
@@ -318,11 +318,20 @@ export function buildPastSessionNotes(
     return { notes: [], missing: [], requests: [] };
   }
 
-  const currentParticipantIds = getSessionParticipantIds(
-    data.participants,
-    sessionId,
-    userId,
-  );
+  // One indexing pass over the collections; the candidate loop below then
+  // performs direct lookups instead of rescanning every row per session.
+  const participantsBySession = groupBySession(data.participants);
+  const notesBySession = groupBySession(data.enhancedNotes);
+  const namesByHumanId = new Map<string, string>();
+  for (const participant of data.participants) {
+    if (participant.name.trim()) {
+      namesByHumanId.set(participant.human_id, participant.name.trim());
+    }
+  }
+  const participantIdsFor = (id: string) =>
+    getSessionParticipantIds(participantsBySession.get(id) ?? [], userId);
+
+  const currentParticipantIds = participantIdsFor(sessionId);
   const currentEvent = getSessionEvent(currentSession);
   const currentSeriesId = getRecurrenceSeriesId(currentEvent);
   const currentTitleKey = getSessionTitleKey(currentSession);
@@ -353,11 +362,7 @@ export function buildPastSessionNotes(
     }
 
     const candidateEvent = getSessionEvent(candidateSession);
-    const candidateParticipantIds = getSessionParticipantIds(
-      data.participants,
-      candidateSessionId,
-      userId,
-    );
+    const candidateParticipantIds = participantIdsFor(candidateSessionId);
     if (
       !isRelatedPastSession({
         currentParticipantIds,
@@ -372,8 +377,7 @@ export function buildPastSessionNotes(
     }
 
     const source = getSessionKeyFactsSource(
-      data.enhancedNotes,
-      candidateSessionId,
+      notesBySession.get(candidateSessionId) ?? [],
     );
     if (!source) {
       continue;
@@ -389,7 +393,7 @@ export function buildPastSessionNotes(
     );
     const ownerUserId = getSessionUserId(candidateSession, userId);
     const participantNames = getSessionParticipantNames(
-      data.participants,
+      namesByHumanId,
       new Set([...currentParticipantIds, ...candidateParticipantIds]),
     );
     const request = {
@@ -619,13 +623,25 @@ function getSavedKeyFacts(
   return row.content.trim();
 }
 
+function groupBySession<T extends { session_id: string }>(
+  rows: T[],
+): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const row of rows) {
+    const group = groups.get(row.session_id);
+    if (group) {
+      group.push(row);
+    } else {
+      groups.set(row.session_id, [row]);
+    }
+  }
+  return groups;
+}
+
 function getSessionKeyFactsSource(
   enhancedNotes: PastEnhancedNoteRow[],
-  sessionId: string,
 ): string | null {
-  const summaries = enhancedNotes.filter(
-    (note) => note.session_id === sessionId && note.content.trim(),
-  );
+  const summaries = enhancedNotes.filter((note) => note.content.trim());
 
   summaries.sort((a, b) => a.position - b.position);
   const summaryText = cleanSourceText(
@@ -657,17 +673,12 @@ function truncateAtWord(text: string, maxLength: number): string {
 
 function getSessionParticipantIds(
   participants: PastParticipantRow[],
-  sessionId: string,
   userId: string | null,
 ): Set<string> {
   const participantIds = new Set<string>();
 
   for (const mapping of participants) {
-    if (
-      mapping.session_id !== sessionId ||
-      mapping.source === "excluded" ||
-      !mapping.human_id
-    ) {
+    if (mapping.source === "excluded" || !mapping.human_id) {
       continue;
     }
 
@@ -687,15 +698,9 @@ function getSessionParticipantIds(
 }
 
 function getSessionParticipantNames(
-  participants: PastParticipantRow[],
+  namesByHumanId: Map<string, string>,
   participantIds: Set<string>,
 ): string[] {
-  const namesByHumanId = new Map<string, string>();
-  for (const participant of participants) {
-    if (participant.name.trim()) {
-      namesByHumanId.set(participant.human_id, participant.name.trim());
-    }
-  }
   const seen = new Set<string>();
   const names: string[] = [];
 


### PR DESCRIPTION
buildPastSessionNotes rescanned and re-sorted the full participant and
note collections for every candidate session (participant IDs, key-fact
sources, and a fresh name map per candidate), multiplying work with
data size. Build local indexes once — participants and notes grouped by
session plus one human-to-name map — and do direct lookups in the
candidate loop, keeping the public result shape, persistence queries,
stable ordering, and last-non-empty-name semantics unchanged. Adds
output-equivalence tests for duplicate participants, candidates with
missing relations, and recency ties, plus a 200-session dataset that
counts row visits through a proxy to assert bounded scans without
wall-clock thresholds. (ANLG-268)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal algorithm refactor in session insights with no API or persistence changes; risk is mainly behavioral drift, which the new tests target.
> 
> **Overview**
> **`buildPastSessionNotes`** no longer rescans full participant and enhanced-note arrays for every candidate session. It builds **`participantsBySession`**, **`notesBySession`**, and a single **`namesByHumanId`** map up front, then uses per-session slices and map lookups in the candidate loop.
> 
> Helpers are narrowed to match: **`getSessionParticipantIds`** takes only that session’s rows (no `sessionId` filter inside), **`getSessionKeyFactsSource`** works on a pre-filtered note list, and **`getSessionParticipantNames`** reads from the shared name map instead of rebuilding it per candidate. Output shape, ordering, and “last non-empty name wins” behavior are intended to stay the same.
> 
> New tests cover duplicate participant rows, empty relation edge cases, recency tie ordering, and a 200-session proxy that caps how often participant/note rows are visited during indexing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb95b04468f4a226a56e7259e355e09b76b2f13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->