### PR TITLE
refactor(desktop): project update UI from one discriminated state

### DIFF
--- a/apps/desktop/src/main/update-banner.test.tsx
+++ b/apps/desktop/src/main/update-banner.test.tsx
@@ -95,7 +95,7 @@ vi.mock("@anlg/plugin-updater2", () => ({
   },
 }));
 
-import { useDesktopUpdateControl } from "./update-banner";
+import { resolveUpdateState, useDesktopUpdateControl } from "./update-banner";
 
 import { useDevtoolsOtaPreview } from "~/store/zustand/devtools-ota-preview";
 
@@ -354,6 +354,39 @@ describe("useDesktopUpdateControl", () => {
     expect(screen.getByTestId("progress").textContent).toBe("0.58");
     expect(downloadMock).not.toHaveBeenCalled();
   });
+
+  it("shows a bounded download when progress arrives before availability", async () => {
+    renderUpdateControl();
+
+    await waitFor(() =>
+      expect(eventHandlers.updateDownloadProgress).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      eventHandlers.updateDownloadProgress?.({
+        payload: {
+          version: "1.0.34",
+          chunk_length: 25,
+          content_length: 100,
+        },
+      });
+    });
+
+    expect(screen.getByTestId("status").textContent).toBe("downloading");
+    expect(screen.getByTestId("progress").textContent).toBe("0.25");
+
+    act(() => {
+      eventHandlers.updateDownloadProgress?.({
+        payload: {
+          version: "1.0.34",
+          chunk_length: 75,
+          content_length: 100,
+        },
+      });
+    });
+
+    expect(screen.getByTestId("progress").textContent).toBe("1");
+  });
 });
 
 function renderUpdateControl() {
@@ -393,3 +426,66 @@ function renderWithQueryClient(ui: ReactNode) {
     <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
   );
 }
+
+describe("resolveUpdateState", () => {
+  it("projects the check result when no event arrived", () => {
+    expect(resolveUpdateState(null, null, null)).toEqual({ kind: "none" });
+    expect(
+      resolveUpdateState(null, { version: "1.0.34", ready: false }, null),
+    ).toEqual({ kind: "available", version: "1.0.34" });
+    expect(
+      resolveUpdateState(null, { version: "1.0.34", ready: true }, null),
+    ).toEqual({ kind: "ready", version: "1.0.34" });
+  });
+
+  it("upgrades an available event to ready when the check says downloaded", () => {
+    expect(
+      resolveUpdateState(
+        { kind: "available", version: "1.0.34" },
+        { version: "1.0.34", ready: true },
+        null,
+      ),
+    ).toEqual({ kind: "ready", version: "1.0.34" });
+    expect(
+      resolveUpdateState(
+        { kind: "available", version: "1.0.34" },
+        { version: "1.0.35", ready: true },
+        null,
+      ),
+    ).toEqual({ kind: "available", version: "1.0.34" });
+  });
+
+  it("keeps event precedence over the check for active and failed states", () => {
+    const downloading = {
+      kind: "downloading" as const,
+      version: "1.0.34",
+      downloadedBytes: 10,
+      contentLength: 100,
+    };
+    expect(
+      resolveUpdateState(downloading, { version: "1.0.35", ready: true }, null),
+    ).toEqual(downloading);
+
+    const failed = {
+      kind: "failed" as const,
+      version: "1.0.34",
+      errorMessage: "boom",
+    };
+    expect(
+      resolveUpdateState(failed, { version: "1.0.34", ready: true }, null),
+    ).toEqual(failed);
+  });
+
+  it("suppresses acknowledged versions from the check but not events", () => {
+    expect(
+      resolveUpdateState(null, { version: "1.0.34", ready: true }, "1.0.34"),
+    ).toEqual({ kind: "none" });
+    expect(
+      resolveUpdateState(
+        { kind: "available", version: "1.0.34" },
+        { version: "1.0.34", ready: true },
+        "1.0.34",
+      ),
+    ).toEqual({ kind: "available", version: "1.0.34" });
+  });
+});

--- a/apps/desktop/src/main/update-banner.tsx
+++ b/apps/desktop/src/main/update-banner.tsx
@@ -27,24 +27,60 @@ export type DesktopUpdateControl = {
   installUpdate: () => void;
 };
 
-type UpdateEventState = {
-  status: UpdateBannerStatus;
-  version: string;
-  downloadedBytes: number;
-  contentLength: number | null;
-  errorMessage: string | null;
-};
+// One discriminated state with only variant-valid fields: updater events,
+// mutations, and the periodic check all reduce into it, and the visible
+// control is derived from it in a single precedence pass.
+export type UpdateState =
+  | { kind: "none" }
+  | { kind: "available"; version: string }
+  | {
+      kind: "downloading";
+      version: string;
+      downloadedBytes: number;
+      contentLength: number | null;
+    }
+  | { kind: "ready"; version: string }
+  | { kind: "failed"; version: string; errorMessage: string };
+
+type UpdateEvent = Exclude<UpdateState, { kind: "none" }>;
 
 type UpdateCheckState = {
   version: string;
   ready: boolean;
 } | null;
 
+export function resolveUpdateState(
+  event: UpdateEvent | null,
+  check: UpdateCheckState,
+  acknowledgedVersion: string | null,
+): UpdateState {
+  const checked = check && check.version !== acknowledgedVersion ? check : null;
+
+  if (event) {
+    if (
+      event.kind === "available" &&
+      checked?.version === event.version &&
+      checked.ready
+    ) {
+      return { kind: "ready", version: event.version };
+    }
+    return event;
+  }
+
+  if (checked) {
+    return checked.ready
+      ? { kind: "ready", version: checked.version }
+      : { kind: "available", version: checked.version };
+  }
+
+  return { kind: "none" };
+}
+
 const UPDATE_CHECK_QUERY_KEY = ["updater2", "check"] as const;
 const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000;
 
 export function useDesktopUpdateControl(): DesktopUpdateControl {
-  const [eventState, setEventState] = useState<UpdateEventState | null>(null);
+  const [eventState, setEventState] = useState<UpdateEvent | null>(null);
   const [acknowledgedVersion, setAcknowledgedVersion] = useState<string | null>(
     null,
   );
@@ -71,60 +107,42 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
       ] = await Promise.all([
         updaterEvents.updateAvailableEvent.listen(({ payload }) => {
           setEventState((current) =>
-            current?.version === payload.version &&
-            (current.status === "downloading" ||
-              current.status === "ready" ||
-              current.status === "failed")
+            current?.version === payload.version && current.kind !== "available"
               ? current
-              : {
-                  status: "available",
-                  version: payload.version,
-                  downloadedBytes: 0,
-                  contentLength: null,
-                  errorMessage: null,
-                },
+              : { kind: "available", version: payload.version },
           );
         }),
         updaterEvents.updateDownloadingEvent.listen(({ payload }) => {
           setEventState({
-            status: "downloading",
+            kind: "downloading",
             version: payload.version,
             downloadedBytes: 0,
             contentLength: null,
-            errorMessage: null,
           });
         }),
         updaterEvents.updateDownloadProgressEvent.listen(({ payload }) => {
           setEventState((current) => {
             const downloadedBytes =
-              current?.version === payload.version
+              current?.kind === "downloading" &&
+              current.version === payload.version
                 ? current.downloadedBytes + payload.chunk_length
                 : payload.chunk_length;
 
             return {
-              status: "downloading",
+              kind: "downloading",
               version: payload.version,
               downloadedBytes,
               contentLength: payload.content_length,
-              errorMessage: null,
             };
           });
         }),
         updaterEvents.updateReadyEvent.listen(({ payload }) => {
-          setEventState({
-            status: "ready",
-            version: payload.version,
-            downloadedBytes: 0,
-            contentLength: null,
-            errorMessage: null,
-          });
+          setEventState({ kind: "ready", version: payload.version });
         }),
         updaterEvents.updateDownloadFailedEvent.listen(({ payload }) => {
           setEventState({
-            status: "failed",
+            kind: "failed",
             version: payload.version,
-            downloadedBytes: 0,
-            contentLength: null,
             errorMessage: "Failed to download update.",
           });
         }),
@@ -170,7 +188,7 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
 
       if (!version) {
         setEventState((current) =>
-          current?.status === "available" ? null : current,
+          current?.kind === "available" ? null : current,
         );
         return null;
       }
@@ -181,7 +199,7 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
       };
 
       setEventState((current) =>
-        current?.status === "available" && current.version !== version
+        current?.kind === "available" && current.version !== version
           ? null
           : current,
       );
@@ -198,33 +216,22 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
       unwrapResult(await updaterCommands.download(version)),
     onMutate: (version) => {
       setEventState({
-        status: "downloading",
+        kind: "downloading",
         version,
         downloadedBytes: 0,
         contentLength: null,
-        errorMessage: null,
       });
     },
     onError: (error, version) => {
       setEventState({
-        status: "failed",
+        kind: "failed",
         version,
-        downloadedBytes: 0,
-        contentLength: null,
         errorMessage: readErrorMessage(error),
       });
     },
     onSuccess: (_data, version) => {
       setEventState((current) =>
-        current?.status === "ready"
-          ? current
-          : {
-              status: "ready",
-              version,
-              downloadedBytes: 0,
-              contentLength: null,
-              errorMessage: null,
-            },
+        current?.kind === "ready" ? current : { kind: "ready", version },
       );
     },
   });
@@ -236,47 +243,29 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
     },
     onError: (error, version) => {
       setEventState({
-        status: "failed",
+        kind: "failed",
         version,
-        downloadedBytes: 0,
-        contentLength: null,
         errorMessage: readErrorMessage(error),
       });
     },
   });
 
-  const checkedUpdate =
-    updateCheck.data && updateCheck.data.version !== acknowledgedVersion
-      ? updateCheck.data
+  const state = useMemo(
+    () =>
+      resolveUpdateState(
+        eventState,
+        updateCheck.data ?? null,
+        acknowledgedVersion,
+      ),
+    [eventState, updateCheck.data, acknowledgedVersion],
+  );
+  const status = state.kind === "none" ? null : state.kind;
+  const version = state.kind === "none" ? null : state.version;
+  const progress =
+    state.kind === "downloading" && state.contentLength
+      ? Math.max(0, Math.min(1, state.downloadedBytes / state.contentLength))
       : null;
-  const version = eventState?.version ?? checkedUpdate?.version ?? null;
-  const eventStatus =
-    eventState?.status === "available" &&
-    checkedUpdate?.version === eventState.version &&
-    checkedUpdate.ready
-      ? "ready"
-      : eventState?.status;
-  const status: UpdateBannerStatus | null = eventStatus
-    ? eventStatus
-    : checkedUpdate
-      ? checkedUpdate.ready
-        ? "ready"
-        : "available"
-      : null;
-  const progress = useMemo(() => {
-    if (
-      !eventState ||
-      eventState.status !== "downloading" ||
-      !eventState.contentLength
-    ) {
-      return null;
-    }
-
-    return Math.max(
-      0,
-      Math.min(1, eventState.downloadedBytes / eventState.contentLength),
-    );
-  }, [eventState]);
+  const errorMessage = state.kind === "failed" ? state.errorMessage : null;
 
   const handleDownload = useCallback(() => {
     if (!version) {
@@ -320,7 +309,7 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
     status,
     version,
     progress,
-    errorMessage: eventState?.errorMessage ?? null,
+    errorMessage,
     downloadStarting,
     installing,
     downloadUpdate: handleDownload,


### PR DESCRIPTION
The update banner hook combined a status field with nullable
version/progress/error, separate check state, acknowledgement, and
mutation booleans, reconciled through nested precedence expressions.
Updater events, download/install mutations, and the periodic check now
reduce into one discriminated UpdateState
(None | Available | Downloading | Ready | Failed) carrying only
variant-valid fields, and a single exported resolveUpdateState
precedence function derives the existing DesktopUpdateControl view —
event states win over the check, an available event upgrades to ready
when the check reports the download present, and acknowledged versions
suppress only the check. Visible behavior, devtools preview, and
progress accumulation are unchanged. Adds precedence-matrix unit tests
and an out-of-order progress-before-availability sequence test.
(ANLG-271)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop update-banner refactor with behavior locked by existing and new unit tests; no auth, data, or infra changes.
> 
> **Overview**
> Refactors **`useDesktopUpdateControl`** so updater events, mutations, and the periodic check all feed a single discriminated **`UpdateState`** (`none` | `available` | `downloading` | `ready` | `failed`) instead of a loose status plus nullable fields reconciled inline.
> 
> Adds exported **`resolveUpdateState`** to merge live events, check results, and acknowledged versions in one precedence pass: events win over the check (including **downloading** / **failed**), an **available** event upgrades to **ready** when the check reports the same version downloaded, and acknowledged versions hide only check-driven UI—not event-driven state. The hook derives status, version, progress, and errors from that resolved state; event handlers are simplified to set variant-shaped payloads (e.g. progress can enter **downloading** without a prior **available** event).
> 
> Tests add a **`resolveUpdateState`** matrix and a hook case for **download progress arriving before availability**, with progress clamped to 0–1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2fb83be777e414f33fbbfbd85e69d0c080f9b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->