### PR TITLE
fix(updater2): prune update cache and install at open reliably

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19431,6 +19431,7 @@ dependencies = [
  "tauri-plugin-store2",
  "tauri-plugin-updater",
  "tauri-specta",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/plugins/updater2/Cargo.toml
+++ b/plugins/updater2/Cargo.toml
@@ -12,6 +12,7 @@ tauri-plugin = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 specta-typescript = { workspace = true }
+tempfile = { workspace = true }
 
 [dependencies]
 tauri-plugin-store2 = { workspace = true }

--- a/plugins/updater2/src/ext.rs
+++ b/plugins/updater2/src/ext.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::LazyLock};
+use std::{
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
 
 use tauri::Manager;
 use tauri_plugin_store2::Store2PluginExt;
@@ -120,6 +123,10 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Updater2<'a, R, M> {
         let updater = self.manager.updater()?;
         let update = updater.check().await?;
         let version = update.map(|u| u.version);
+
+        // install_and_relaunch never returns, so this periodic check is the
+        // only place stale cached bins can be cleaned up.
+        prune_cached_updates(self.manager, version.as_deref());
 
         if let Some(version) = &version {
             if self.has_cached_update(version) {
@@ -255,15 +262,97 @@ impl<R: tauri::Runtime, T: tauri::Manager<R>> Updater2PluginExt<R> for T {
     }
 }
 
-fn get_cache_path<R: tauri::Runtime, M: tauri::Manager<R>>(
-    manager: &M,
-    version: &str,
-) -> Option<PathBuf> {
-    let dir = manager
+fn get_updates_dir<R: tauri::Runtime, M: tauri::Manager<R>>(manager: &M) -> Option<PathBuf> {
+    manager
         .app_handle()
         .path()
         .app_cache_dir()
         .ok()
-        .map(|p: PathBuf| p.join("updates"))?;
-    Some(dir.join(format!("{}.bin", version)))
+        .map(|p: PathBuf| p.join("updates"))
+}
+
+fn get_cache_path<R: tauri::Runtime, M: tauri::Manager<R>>(
+    manager: &M,
+    version: &str,
+) -> Option<PathBuf> {
+    Some(get_updates_dir(manager)?.join(format!("{}.bin", version)))
+}
+
+fn prune_cached_updates<R: tauri::Runtime, M: tauri::Manager<R>>(manager: &M, keep: Option<&str>) {
+    if let Some(dir) = get_updates_dir(manager) {
+        prune_updates_dir(&dir, keep);
+    }
+}
+
+fn prune_updates_dir(dir: &Path, keep: Option<&str>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("bin") {
+            continue;
+        }
+        if keep.is_some() && path.file_stem().and_then(|s| s.to_str()) == keep {
+            continue;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => tracing::info!("pruned_cached_update: {:?}", path),
+            Err(e) => tracing::warn!("failed_to_prune_cached_update: {:?}: {}", path, e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prune_updates_dir;
+
+    fn write_bins(dir: &std::path::Path, versions: &[&str]) {
+        for v in versions {
+            std::fs::write(dir.join(format!("{v}.bin")), b"update").unwrap();
+        }
+    }
+
+    #[test]
+    fn prune_keeps_only_the_kept_version() {
+        let dir = tempfile::tempdir().unwrap();
+        write_bins(dir.path(), &["1.4.1", "1.4.2", "1.4.8"]);
+
+        prune_updates_dir(dir.path(), Some("1.4.8"));
+
+        assert!(dir.path().join("1.4.8.bin").exists());
+        assert!(!dir.path().join("1.4.1.bin").exists());
+        assert!(!dir.path().join("1.4.2.bin").exists());
+    }
+
+    #[test]
+    fn prune_without_keep_removes_all_bins() {
+        let dir = tempfile::tempdir().unwrap();
+        write_bins(dir.path(), &["1.4.1", "1.4.2"]);
+
+        prune_updates_dir(dir.path(), None);
+
+        assert!(!dir.path().join("1.4.1.bin").exists());
+        assert!(!dir.path().join("1.4.2.bin").exists());
+    }
+
+    #[test]
+    fn prune_ignores_non_bin_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_bins(dir.path(), &["1.4.1"]);
+        std::fs::write(dir.path().join("notes.txt"), b"keep").unwrap();
+
+        prune_updates_dir(dir.path(), None);
+
+        assert!(dir.path().join("notes.txt").exists());
+        assert!(!dir.path().join("1.4.1.bin").exists());
+    }
+
+    #[test]
+    fn prune_missing_dir_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+
+        prune_updates_dir(&dir.path().join("does-not-exist"), Some("1.4.8"));
+    }
 }

--- a/plugins/updater2/src/lib.rs
+++ b/plugins/updater2/src/lib.rs
@@ -53,12 +53,9 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
 
             let handle = app.clone();
             tauri::async_runtime::spawn(async move {
-                let mut install_cached_update = true;
+                let mut install_at_open = true;
                 loop {
-                    let deferred = check_and_download(&handle, install_cached_update).await;
-                    if !deferred {
-                        install_cached_update = false;
-                    }
+                    install_at_open = check_and_download(&handle, install_at_open).await;
                     tokio::time::sleep(std::time::Duration::from_secs(30 * 60)).await;
                 }
             });
@@ -68,11 +65,13 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
         .build()
 }
 
-// Returns true when deferred because a meeting is active, so the caller keeps
-// the cached-install intent for the next tick.
+// Takes the install-at-open intent and returns it for the next tick. A
+// completed pass installs (which restarts the app) and consumes the intent;
+// a meeting deferral or a transient check/download failure (e.g. network not
+// up yet at login) preserves it so a later tick can still install.
 async fn check_and_download<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
-    install_cached_update: bool,
+    install_at_open: bool,
 ) -> bool {
     if cfg!(debug_assertions) {
         return false;
@@ -93,7 +92,7 @@ async fn check_and_download<R: tauri::Runtime>(
     // being recorded; the next 30-minute tick retries after the meeting.
     if updater2.meeting_active() {
         tracing::info!("automatic_update_deferred_meeting_active");
-        return true;
+        return install_at_open;
     }
 
     let version = match updater2.check().await {
@@ -101,17 +100,17 @@ async fn check_and_download<R: tauri::Runtime>(
         Ok(None) => return false,
         Err(e) => {
             tracing::error!("update_check_failed: {}", e);
-            return false;
+            return install_at_open;
         }
     };
 
     // A meeting may have started while the check was in flight.
     if updater2.meeting_active() {
         tracing::info!("automatic_update_deferred_meeting_active");
-        return true;
+        return install_at_open;
     }
 
-    if install_cached_update && updater2.has_cached_update(&version) {
+    if install_at_open && updater2.has_cached_update(&version) {
         if let Err(e) = updater2.install_and_relaunch(&version).await {
             tracing::error!("cached_update_install_failed: {}", e);
         }
@@ -120,7 +119,23 @@ async fn check_and_download<R: tauri::Runtime>(
 
     if let Err(e) = updater2.download(&version).await {
         tracing::error!("update_download_failed: {}", e);
+        return install_at_open;
     }
+
+    // With frequent releases the cached version is rarely still the latest by
+    // the next open, so deferring the install to the next session would
+    // re-download forever and never install anything. Install as soon as the
+    // at-open download completes instead.
+    if install_at_open {
+        if updater2.meeting_active() {
+            tracing::info!("automatic_update_deferred_meeting_active");
+            return true;
+        }
+        if let Err(e) = updater2.install_and_relaunch(&version).await {
+            tracing::error!("downloaded_update_install_failed: {}", e);
+        }
+    }
+
     false
 }
 


### PR DESCRIPTION
Stale cached update bins accumulated forever (8 bins, ~1.6GB observed in `~/Library/Caches/com.hyprnote.stable/updates/`) because `install_and_relaunch` never returns, so nothing ever pruned the cache — and the install-at-open path only fired when the cached version was still the latest, so with frequent releases every open downloaded a newer version and installed nothing. A single failed first-tick check (e.g. network not up at login) also permanently disabled auto-install for the session.

- `check()` now prunes every cached `.bin` except the latest version, or all of them when already up to date (`prune_cached_updates` in ext.rs)
- `check_and_download` keeps the install-at-open intent across transient check/download failures instead of clearing it after one failed tick
- the first successful pass installs right after its at-open download completes (meeting guard re-checked after the download) instead of deferring to the next session, which never installed under frequent releases; mid-session ticks still only download, never restart
- unit tests for the prune helper (new `tempfile` dev-dependency)

Install-on-quit was considered for the timing gap but rejected: it would need exit hooks plus a live network version-check during shutdown, while installing right after the at-open download reuses the existing validated `install_and_relaunch` path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automatic update install timing and cache deletion in the desktop app; incorrect pruning or install logic could block updates or trigger unexpected restarts, though meeting guards and existing `install_and_relaunch` validation remain in place.
> 
> **Overview**
> Fixes **updater2** automatic updates so cached `.bin` files do not grow without bound and install-at-open actually completes under frequent releases.
> 
> **Cache pruning:** Each `check()` now deletes stale cached update bins in the app cache `updates` folder, keeping only the latest reported version (or removing all when already up to date). This runs on the periodic check because `install_and_relaunch` never returns.
> 
> **Install-at-open behavior:** `check_and_download` renames and threads an `install_at_open` flag across ticks. Meeting deferrals and transient check/download failures no longer permanently drop install intent for the session. On the first successful at-open pass, it installs immediately after download (with a post-download meeting guard) instead of waiting for the next session—mid-session ticks still only download, not restart.
> 
> Adds unit tests for `prune_updates_dir` and a `tempfile` dev-dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738efa7d65309d8c338f9dffef1bcce4510326b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->