### PR TITLE
Ensure cloudsync-scoped schema changes run atom inside a single IMMEDIATE transaction, rolling back on failure and allowing retries.

### DIFF
--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -4,6 +4,8 @@ use anlg_db_core::Db;
 
 const DB_FILENAME: &str = "app.db";
 const DEFAULT_CLOUDSYNC_INTERVAL_MS: u64 = 30_000;
+const DB_OPEN_LOCK_RETRIES: u32 = 12;
+const DB_OPEN_LOCK_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
 
 pub async fn open_desktop_db(identifier: &str) -> Result<Arc<Db>, String> {
     let dir = desktop_db_dir(identifier)
@@ -12,11 +14,34 @@ pub async fn open_desktop_db(identifier: &str) -> Result<Arc<Db>, String> {
         .map_err(|error| format!("failed to create application data directory: {error}"))?;
 
     let db_path = dir.join(DB_FILENAME);
-    let db = tauri_plugin_db::open_app_db(Some(&db_path))
-        .await
-        .map_err(|error| format!("failed to open application database: {error}"))?;
+
+    // During an update relaunch the previous process can hold the database for
+    // several seconds while it flushes and exits; retry instead of failing the
+    // whole startup on a transient lock.
+    let mut attempts = 0u32;
+    let db = loop {
+        match tauri_plugin_db::open_app_db(Some(&db_path)).await {
+            Ok(db) => break db,
+            Err(error) if attempts < DB_OPEN_LOCK_RETRIES && is_transient_lock_error(&error) => {
+                attempts += 1;
+                eprintln!(
+                    "application database is locked by another process; \
+                     retrying ({attempts}/{DB_OPEN_LOCK_RETRIES}): {error}"
+                );
+                tokio::time::sleep(DB_OPEN_LOCK_RETRY_DELAY).await;
+            }
+            Err(error) => {
+                return Err(format!("failed to open application database: {error}"));
+            }
+        }
+    };
 
     Ok(Arc::new(db))
+}
+
+pub fn is_transient_lock_error(error: &impl std::fmt::Display) -> bool {
+    let message = error.to_string();
+    message.contains("database is locked") || message.contains("database table is locked")
 }
 
 pub fn cloudsync_runtime_config_from_env()
@@ -116,6 +141,19 @@ fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn transient_lock_errors_are_recognized() {
+        assert!(is_transient_lock_error(
+            &"error returned from database: (code: 5) database is locked"
+        ));
+        assert!(is_transient_lock_error(
+            &"error returned from database: (code: 6) database table is locked"
+        ));
+        assert!(!is_transient_lock_error(
+            &"unable to open database file: /tmp/app.db"
+        ));
+    }
 
     #[test]
     fn dev_uses_an_isolated_persistent_database() {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -161,6 +161,7 @@ fn create_audio_provider(_bundle_id: &str) -> std::sync::Arc<dyn anlg_audio_actu
 pub async fn main() {
     tauri::async_runtime::set(tokio::runtime::Handle::current());
     let context = tauri::generate_context!();
+    let identifier = context.config().identifier.clone();
 
     let (root_supervisor_ctx, root_supervisor_handle) =
         match supervisor::spawn_root_supervisor().await {
@@ -168,9 +169,9 @@ pub async fn main() {
             None => (None, None),
         };
 
-    let db = match open_desktop_db(&context.config().identifier).await {
+    let db = match open_desktop_db(&identifier).await {
         Ok(db) => db,
-        Err(error) => exit_after_startup_failure(&error),
+        Err(error) => exit_after_startup_failure(&identifier, &error),
     };
     let crash_reporting_enabled = load_crash_reporting_consent(&db).await;
 
@@ -436,7 +437,7 @@ pub async fn main() {
 
     let app = match app_result {
         Ok(app) => app,
-        Err(error) => exit_after_startup_failure(&error),
+        Err(error) => exit_after_startup_failure(&identifier, &error),
     };
 
     match get_onboarding_flag() {
@@ -479,7 +480,7 @@ pub async fn main() {
                 }
             }
             Ok(_) => {}
-            Err(error) => exit_after_startup_failure(&error),
+            Err(error) => exit_after_startup_failure(&identifier, &error),
         }
     }
 
@@ -540,23 +541,85 @@ fn startup_failure_message(error: &impl std::fmt::Display) -> String {
     format!("Anarlog failed to start: {error}")
 }
 
-fn exit_after_startup_failure(error: &impl std::fmt::Display) -> ! {
+fn exit_after_startup_failure(identifier: &str, error: &impl std::fmt::Display) -> ! {
     let message = startup_failure_message(error);
     eprintln!("{message}");
     tracing::error!(error = %error, "desktop startup failed");
-    sentry::capture_message(&message, sentry::Level::Error);
+    append_startup_failure_to_log(identifier, &message);
+    report_startup_failure_to_sentry(&message);
 
     #[cfg(target_os = "macos")]
     {
+        // Startup can fail before the database is reachable, so the alert text
+        // is fixed per failure class instead of embedding the error.
+        let alert = if db::is_transient_lock_error(error) {
+            "display alert \"Anarlog is not ready yet\" message \"Another Anarlog process is still using your data, possibly finishing an update. Your existing data was left unchanged. Please wait a moment and open Anarlog again.\" as critical buttons {\"OK\"} default button \"OK\""
+        } else {
+            "display alert \"Anarlog could not start\" message \"Your existing data was left unchanged. Please restart the app. If the problem continues, contact support.\" as critical buttons {\"OK\"} default button \"OK\""
+        };
         let _ = std::process::Command::new("/usr/bin/osascript")
-            .args([
-                "-e",
-                "display alert \"Anarlog could not start\" message \"Your existing data was left unchanged. Please restart the app. If the problem continues, contact support.\" as critical buttons {\"OK\"} default button \"OK\"",
-            ])
+            .args(["-e", alert])
             .spawn();
     }
 
     std::process::exit(1);
+}
+
+// Startup failures happen before the tracing plugin exists, so append directly
+// to the same log file support already asks users for.
+fn append_startup_failure_to_log(identifier: &str, message: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        use std::io::Write;
+
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let dir = home.join("Library/Logs").join(identifier);
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dir.join("app.log"))
+        else {
+            return;
+        };
+        let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ");
+        let _ = writeln!(file, "{timestamp} ERROR anarlog::startup: {message}");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (identifier, message);
+    }
+}
+
+// The main Sentry client is initialized after the database opens, so database
+// startup failures need their own short-lived client to be reported at all.
+fn report_startup_failure_to_sentry(message: &str) {
+    if let Some(client) = sentry::Hub::current().client() {
+        sentry::capture_message(message, sentry::Level::Error);
+        client.flush(Some(std::time::Duration::from_secs(3)));
+        return;
+    }
+
+    let Some(dsn) = option_env!("SENTRY_DSN") else {
+        return;
+    };
+    let guard = sentry::init((
+        dsn,
+        sentry::ClientOptions {
+            release: option_env!("APP_VERSION").map(|v| format!("anarlog-desktop@{}", v).into()),
+            auto_session_tracking: false,
+            before_send: Some(Arc::new(|event| {
+                tauri_plugin_tracing::redaction::sanitize_sentry_event(event)
+            })),
+            ..Default::default()
+        },
+    ));
+    sentry::capture_message(message, sentry::Level::Error);
+    guard.flush(Some(std::time::Duration::from_secs(3)));
 }
 
 fn get_onboarding_flag() -> Option<bool> {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -604,6 +604,9 @@ fn report_startup_failure_to_sentry(message: &str) {
         return;
     }
 
+    if std::env::var_os("ANARLOG_DISABLE_SENTRY").is_some() {
+        return;
+    }
     let Some(dsn) = option_env!("SENTRY_DSN") else {
         return;
     };

--- a/crates/db-migrate/src/migrate.rs
+++ b/crates/db-migrate/src/migrate.rs
@@ -257,15 +257,36 @@ impl Migrate for DbMigrateConnection<'_> {
 
                     let start = Instant::now();
 
-                    anlg_db_core::cloudsync_begin_alter_on(&mut *self.conn, cs_table)
-                        .await
-                        .map_err(cloudsync_error)?;
+                    // The alter window bypasses sqlx's per-migration transaction, so a
+                    // crash mid-way would otherwise leave a half-migrated schema with no
+                    // _sqlx_migrations row, and the re-run would fail on already-applied
+                    // DDL. Wrap it ourselves unless the step opts out.
+                    let wrap_in_transaction = !migration.no_tx;
+                    if wrap_in_transaction {
+                        sqlx::query("BEGIN IMMEDIATE")
+                            .execute(&mut *self.conn)
+                            .await
+                            .map_err(SqlxMigrateError::from)?;
+                    }
 
-                    execute_migration(&mut self.conn, migration).await?;
+                    let result =
+                        cloudsync_alter_migration(&mut self.conn, cs_table, migration).await;
 
-                    anlg_db_core::cloudsync_commit_alter_on(&mut *self.conn, cs_table)
-                        .await
-                        .map_err(cloudsync_error)?;
+                    match result {
+                        Ok(()) if wrap_in_transaction => {
+                            sqlx::query("COMMIT")
+                                .execute(&mut *self.conn)
+                                .await
+                                .map_err(SqlxMigrateError::from)?;
+                        }
+                        Ok(()) => {}
+                        Err(error) => {
+                            if wrap_in_transaction {
+                                let _ = sqlx::query("ROLLBACK").execute(&mut *self.conn).await;
+                            }
+                            return Err(error);
+                        }
+                    }
 
                     let elapsed = start.elapsed();
                     update_execution_time(&mut self.conn, migration.version, elapsed).await?;
@@ -283,6 +304,24 @@ impl Migrate for DbMigrateConnection<'_> {
     ) -> BoxFuture<'e, Result<Duration, SqlxMigrateError>> {
         <SqliteConnection as Migrate>::revert(&mut *self.conn, table_name, migration)
     }
+}
+
+async fn cloudsync_alter_migration(
+    conn: &mut SqliteConnection,
+    cs_table: &str,
+    migration: &Migration,
+) -> Result<(), SqlxMigrateError> {
+    anlg_db_core::cloudsync_begin_alter_on(&mut *conn, cs_table)
+        .await
+        .map_err(cloudsync_error)?;
+
+    execute_migration(&mut *conn, migration).await?;
+
+    anlg_db_core::cloudsync_commit_alter_on(&mut *conn, cs_table)
+        .await
+        .map_err(cloudsync_error)?;
+
+    Ok(())
 }
 
 async fn execute_migration(

--- a/crates/db-migrate/tests/e2e.rs
+++ b/crates/db-migrate/tests/e2e.rs
@@ -96,6 +96,26 @@ const CLOUDSYNC_ALTER_STEPS: &[MigrationStep] = &[
     },
 ];
 
+const ADD_SLUG_THEN_FAIL_SQL: &str = r#"
+ALTER TABLE widgets ADD COLUMN slug TEXT NOT NULL DEFAULT '';
+ALTER TABLE missing_table ADD COLUMN broken TEXT;
+"#;
+
+const CLOUDSYNC_FAILING_ALTER_STEPS: &[MigrationStep] = &[
+    MigrationStep {
+        id: "20260415030101_create_widgets",
+        scope: MigrationScope::Plain,
+        sql: CREATE_CLOUDSYNC_WIDGETS_SQL,
+    },
+    MigrationStep {
+        id: "20260415030102_add_slug",
+        scope: MigrationScope::CloudsyncAlter {
+            table_name: "widgets",
+        },
+        sql: ADD_SLUG_THEN_FAIL_SQL,
+    },
+];
+
 fn schema(steps: &'static [MigrationStep], validate_cloudsync_table: fn(&str) -> bool) -> DbSchema {
     DbSchema {
         steps,
@@ -326,5 +346,53 @@ async fn cloudsync_alter_scope_preserves_an_initialized_cloudsync_table() {
         anlg_db_core::cloudsync_is_enabled_on(db.pool(), "widgets")
             .await
             .unwrap()
+    );
+}
+
+#[cfg(any(
+    all(test, target_os = "macos", target_arch = "aarch64"),
+    all(test, target_os = "macos", target_arch = "x86_64"),
+    all(test, target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+    all(test, target_os = "linux", target_env = "gnu", target_arch = "x86_64"),
+    all(
+        test,
+        target_os = "linux",
+        target_env = "musl",
+        target_arch = "aarch64"
+    ),
+    all(test, target_os = "linux", target_env = "musl", target_arch = "x86_64"),
+    all(test, target_os = "windows", target_arch = "x86_64"),
+))]
+#[tokio::test]
+async fn failed_cloudsync_alter_leaves_no_partial_schema_and_can_be_retried() {
+    let db = Db::connect_memory().await.unwrap();
+
+    migrate(&db, schema(CLOUDSYNC_BASE_STEPS, widgets_synced))
+        .await
+        .unwrap();
+
+    db.cloudsync_init("widgets", None, None).await.unwrap();
+
+    migrate(&db, schema(CLOUDSYNC_FAILING_ALTER_STEPS, widgets_synced))
+        .await
+        .unwrap_err();
+
+    assert_eq!(applied_versions(&db).await, vec![20260415030101]);
+    assert_eq!(
+        widget_columns(&db).await,
+        vec!["id".to_string(), "name".to_string()]
+    );
+
+    migrate(&db, schema(CLOUDSYNC_ALTER_STEPS, widgets_synced))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        applied_versions(&db).await,
+        vec![20260415030101, 20260415030102]
+    );
+    assert_eq!(
+        widget_columns(&db).await,
+        vec!["id".to_string(), "name".to_string(), "slug".to_string()]
     );
 }


### PR DESCRIPTION
- Make desktop startup resilient to transient "database is locked" errors by retrying for to a minute and surface startup failures to logs Sentry immediately.

What changed- Wrap begin_alter / DDL / commit_alter in one transaction (honoring --no-transaction) and add rollback on failure.
- Add e2e confirming failed alters leave no partial schema and can retried.
- Update open_desktop_db to retry transient database-locked errors instead of failing startup.
- Initialize logging and a short-lived redacted S client early so startup failures recorded shown.
- Show a dedicated "finishing an update" alert when startup is blocked by a locked DB.

Why- Prevent partial/half-applied migrations that block retries and can corrupt runtime.
 Avoid startup failures during app update/relaunch races where the previous process still the DB, make those failures for debugging.

Risk- Changes affect migration and startup paths; tests added to verify/retry behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches critical startup and schema migration paths; behavior is constrained by retries, transactional alters, and new e2e coverage, but failures here still affect all users at launch or upgrade.
> 
> **Overview**
> Hardens **desktop startup** and **cloudsync-scoped migrations** against update/relaunch races and half-applied schema changes.
> 
> **Desktop:** `open_desktop_db` retries transient SQLite lock errors (up to ~1 minute) instead of failing immediately. Startup failures are appended to `app.log` on macOS, reported to Sentry via a short-lived client when the main client is not up yet, and show a dedicated “still using your data / finishing an update” alert when the failure is a lock.
> 
> **Migrations:** Cloudsync alter steps (`begin_alter` → DDL → `commit_alter`) run inside a single `BEGIN IMMEDIATE` transaction unless the step opts out with `--no-transaction`, with rollback on failure so a failed alter does not leave partial DDL without a `_sqlx_migrations` row. An e2e test confirms a failed alter can be retried cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ed4c86361162b66a007d1e9559ec159d9e205d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->