### PR TITLE
fix(db-app): repair torn e2ee payload-hash migration on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4542,6 +4542,7 @@ name = "db-app"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "cloudsync",
  "db-core",
  "db-migrate",
  "e2ee",
@@ -4549,6 +4550,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "uuid",

--- a/crates/db-app/Cargo.toml
+++ b/crates/db-app/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anlg-cloudsync = { workspace = true }
 anlg-db-core = { workspace = true }
 anlg-db-migrate = { workspace = true }
 anlg-e2ee = { workspace = true }
@@ -21,4 +22,5 @@ default = []
 cli = []
 
 [dev-dependencies]
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -402,6 +402,7 @@ const E2EE_PAYLOAD_HASH_LOCAL_STATE_ALTER: &str =
 pub enum AppSchemaError {
     Migrate(anlg_db_migrate::MigrateError),
     Sqlx(sqlx::Error),
+    Cloudsync(anlg_cloudsync::Error),
     CloudsyncWorkspace(CloudsyncWorkspaceError),
     SharedSessionCacheRepair(&'static str),
     AttachmentTransferJobsRepair(&'static str),
@@ -414,6 +415,7 @@ impl std::fmt::Display for AppSchemaError {
         match self {
             Self::Migrate(error) => write!(f, "{error}"),
             Self::Sqlx(error) => write!(f, "{error}"),
+            Self::Cloudsync(error) => write!(f, "{error}"),
             Self::CloudsyncWorkspace(error) => write!(f, "{error}"),
             Self::SharedSessionCacheRepair(error) => write!(f, "{error}"),
             Self::AttachmentTransferJobsRepair(error) => write!(f, "{error}"),
@@ -443,12 +445,18 @@ impl From<CloudsyncWorkspaceError> for AppSchemaError {
     }
 }
 
+impl From<anlg_cloudsync::Error> for AppSchemaError {
+    fn from(error: anlg_cloudsync::Error) -> Self {
+        Self::Cloudsync(error)
+    }
+}
+
 pub async fn prepare_schema(db: &anlg_db_core::Db) -> Result<(), AppSchemaError> {
     let templates_missing_before_migration = !templates_table_exists(db.pool()).await?;
     adopt_legacy_mobile_schema_migration(db.pool()).await?;
     repair_legacy_shared_session_cache_migration(db.pool()).await?;
     repair_legacy_attachment_transfer_jobs_migration(db.pool()).await?;
-    repair_torn_e2ee_payload_hash_local_state_migration(db.pool()).await?;
+    repair_torn_e2ee_payload_hash_local_state_migration(db).await?;
     anlg_db_migrate::migrate(db, schema()).await?;
     repair_missing_core_tables(db.pool(), templates_missing_before_migration).await?;
     backfill_session_share_activation(db.pool()).await?;
@@ -941,8 +949,9 @@ async fn repair_legacy_shared_session_cache_migration(
 // the ALTER left the column dropped, some views/triggers missing, and no
 // history row. The re-run then dies on the ALTER with "no such column".
 async fn repair_torn_e2ee_payload_hash_local_state_migration(
-    pool: &sqlx::SqlitePool,
+    db: &anlg_db_core::Db,
 ) -> Result<(), AppSchemaError> {
+    let pool = db.pool();
     let migration_table_exists: bool = sqlx::query_scalar(
         "SELECT EXISTS(
             SELECT 1 FROM sqlite_master
@@ -983,6 +992,17 @@ async fn repair_torn_e2ee_payload_hash_local_state_migration(
         return Ok(());
     }
 
+    // The torn run died after cloudsync_begin_alter and the committed DROP
+    // COLUMN but before cloudsync_commit_alter, so the CloudSync schema hash
+    // for e2ee_records still describes the dropped column. Redo the alter
+    // window around the repair so commit_alter records the current schema;
+    // otherwise sync fails with a schema-hash mismatch after the unbrick.
+    let cloudsync_alter = db.cloudsync_enabled()
+        && anlg_db_core::cloudsync_is_enabled_on(&mut *transaction, "e2ee_records").await?;
+    if cloudsync_alter {
+        anlg_db_core::cloudsync_begin_alter_on(&mut *transaction, "e2ee_records").await?;
+    }
+
     sqlx::raw_sql(sqlx::AssertSqlSafe(repair_sql.as_str()))
         .execute(&mut *transaction)
         .await?;
@@ -997,6 +1017,10 @@ async fn repair_torn_e2ee_payload_hash_local_state_migration(
     .bind(current_migration_checksum.as_slice())
     .execute(&mut *transaction)
     .await?;
+
+    if cloudsync_alter {
+        anlg_db_core::cloudsync_commit_alter_on(&mut *transaction, "e2ee_records").await?;
+    }
 
     transaction.commit().await?;
     Ok(())

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -392,6 +392,11 @@ const LEGACY_ATTACHMENT_TRANSFER_JOBS_CHECKSUM: &str = "fd846a54c653d8e737371a95
 const CURRENT_ATTACHMENT_TRANSFER_JOBS_CHECKSUM: &str = "9250233e7b51b83bb74ef4e4af159a9c2bbc753ee64751cac8316968b66bb1b2e0e224770d8b63a631350183dc81c2e0";
 const LEGACY_ATTACHMENT_TRANSFER_JOBS_SCHEMA_CHECKSUM: &str = "5702d2831ccfe75bfca957aa6d37cacc54347090c0d106aaaa9c3af124fcf7e57e49b0432ad5191ff3075f2d9d489916";
 const CURRENT_ATTACHMENT_TRANSFER_JOBS_SCHEMA_CHECKSUM: &str = "3beb182b60f84e0f53ae6069fc7a6e4ba28e51e87d37e4fda7e5ab9b8e8ca713bd43bb8bd79100c6116a4d23dfff55ef";
+const E2EE_PAYLOAD_HASH_LOCAL_STATE_MIGRATION_VERSION: i64 = 20260816100100;
+const E2EE_REPLICA_PAYLOAD_HASHES_MIGRATION_VERSION: i64 = 20260816100000;
+const CURRENT_E2EE_PAYLOAD_HASH_LOCAL_STATE_CHECKSUM: &str = "1e0da0d8b5a524adf12cf1bb5a9c3910f922c9c2e7feb9c1f2704c4b093af41b50519083546409fe55a0d9d9f6f12f5a";
+const E2EE_PAYLOAD_HASH_LOCAL_STATE_ALTER: &str =
+    "ALTER TABLE e2ee_records DROP COLUMN payload_hash;";
 
 #[derive(Debug)]
 pub enum AppSchemaError {
@@ -400,6 +405,7 @@ pub enum AppSchemaError {
     CloudsyncWorkspace(CloudsyncWorkspaceError),
     SharedSessionCacheRepair(&'static str),
     AttachmentTransferJobsRepair(&'static str),
+    E2eePayloadHashLocalStateRepair(&'static str),
     LegacyMobileSchema(&'static str),
 }
 
@@ -411,6 +417,7 @@ impl std::fmt::Display for AppSchemaError {
             Self::CloudsyncWorkspace(error) => write!(f, "{error}"),
             Self::SharedSessionCacheRepair(error) => write!(f, "{error}"),
             Self::AttachmentTransferJobsRepair(error) => write!(f, "{error}"),
+            Self::E2eePayloadHashLocalStateRepair(error) => write!(f, "{error}"),
             Self::LegacyMobileSchema(error) => write!(f, "{error}"),
         }
     }
@@ -441,6 +448,7 @@ pub async fn prepare_schema(db: &anlg_db_core::Db) -> Result<(), AppSchemaError>
     adopt_legacy_mobile_schema_migration(db.pool()).await?;
     repair_legacy_shared_session_cache_migration(db.pool()).await?;
     repair_legacy_attachment_transfer_jobs_migration(db.pool()).await?;
+    repair_torn_e2ee_payload_hash_local_state_migration(db.pool()).await?;
     anlg_db_migrate::migrate(db, schema()).await?;
     repair_missing_core_tables(db.pool(), templates_missing_before_migration).await?;
     backfill_session_share_activation(db.pool()).await?;
@@ -926,6 +934,96 @@ async fn repair_legacy_shared_session_cache_migration(
 
     transaction.commit().await?;
     Ok(())
+}
+
+// Builds of 1.4.10 without the transactional CloudsyncAlter runner executed
+// this migration statement-by-statement with autocommit, so a force-quit after
+// the ALTER left the column dropped, some views/triggers missing, and no
+// history row. The re-run then dies on the ALTER with "no such column".
+async fn repair_torn_e2ee_payload_hash_local_state_migration(
+    pool: &sqlx::SqlitePool,
+) -> Result<(), AppSchemaError> {
+    let migration_table_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM sqlite_master
+            WHERE type = 'table' AND name = '_sqlx_migrations'
+        )",
+    )
+    .fetch_one(pool)
+    .await?;
+    if !migration_table_exists {
+        return Ok(());
+    }
+    if !e2ee_payload_hash_migration_is_torn(pool).await? {
+        return Ok(());
+    }
+
+    let migration_sql =
+        include_str!("../migrations/20260816100100_e2ee_payload_hash_local_state.sql");
+    let current_migration_checksum = migration_checksum(migration_sql);
+    if checksum_hex(&current_migration_checksum) != CURRENT_E2EE_PAYLOAD_HASH_LOCAL_STATE_CHECKSUM {
+        return Err(AppSchemaError::E2eePayloadHashLocalStateRepair(
+            "compiled e2ee payload-hash migration has an unexpected checksum",
+        ));
+    }
+
+    // The replica-hash triggers are created without IF EXISTS in the shipped
+    // migration; the torn run may have gotten far enough to create them.
+    let repair_sql = format!(
+        "DROP TRIGGER IF EXISTS e2ee_replica_payload_hash_insert;
+         DROP TRIGGER IF EXISTS e2ee_replica_payload_hash_update;
+         DROP TRIGGER IF EXISTS e2ee_replica_payload_hash_delete;
+         {}",
+        migration_sql.replace(E2EE_PAYLOAD_HASH_LOCAL_STATE_ALTER, ""),
+    );
+
+    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    if !e2ee_payload_hash_migration_is_torn(&mut *transaction).await? {
+        transaction.commit().await?;
+        return Ok(());
+    }
+
+    sqlx::raw_sql(sqlx::AssertSqlSafe(repair_sql.as_str()))
+        .execute(&mut *transaction)
+        .await?;
+
+    sqlx::query(
+        "INSERT INTO _sqlx_migrations (
+            version, description, success, checksum, execution_time
+         ) VALUES (?, ?, 1, ?, 0)",
+    )
+    .bind(E2EE_PAYLOAD_HASH_LOCAL_STATE_MIGRATION_VERSION)
+    .bind("e2ee_payload_hash_local_state")
+    .bind(current_migration_checksum.as_slice())
+    .execute(&mut *transaction)
+    .await?;
+
+    transaction.commit().await?;
+    Ok(())
+}
+
+async fn e2ee_payload_hash_migration_is_torn<'e, E>(executor: E) -> Result<bool, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
+    sqlx::query_scalar(
+        "SELECT NOT EXISTS(
+            SELECT 1 FROM _sqlx_migrations WHERE version = ?
+        )
+        AND EXISTS(
+            SELECT 1 FROM _sqlx_migrations WHERE version = ? AND success = 1
+        )
+        AND EXISTS(
+            SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'e2ee_records'
+        )
+        AND NOT EXISTS(
+            SELECT 1 FROM pragma_table_info('e2ee_records') WHERE name = 'payload_hash'
+        )",
+    )
+    .bind(E2EE_PAYLOAD_HASH_LOCAL_STATE_MIGRATION_VERSION)
+    .bind(E2EE_REPLICA_PAYLOAD_HASHES_MIGRATION_VERSION)
+    .fetch_one(executor)
+    .await
 }
 
 async fn shared_session_cache_column_exists(

--- a/crates/db-app/src/schema_tests/encrypted_replica.rs
+++ b/crates/db-app/src/schema_tests/encrypted_replica.rs
@@ -1060,3 +1060,126 @@ async fn e2ee_dirty_triggers_apply_to_initialized_cloudsync_tables() {
     .unwrap();
     assert_eq!(generation, 1);
 }
+
+async fn e2ee_schema_objects(db: &Db) -> Vec<(String, String, String)> {
+    sqlx::query_as(
+        "SELECT type, name, sql FROM sqlite_master
+         WHERE type IN ('view', 'trigger') AND name LIKE 'e2ee_%'
+         ORDER BY type, name",
+    )
+    .fetch_all(db.pool())
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn torn_e2ee_payload_hash_local_state_migration_is_repaired() {
+    let migration_sql =
+        include_str!("../../migrations/20260816100100_e2ee_payload_hash_local_state.sql");
+    let clean_db = test_db().await;
+
+    // A pre-transactional 1.4.10 runner force-quit mid-migration leaves the
+    // column dropped with no history row: either nothing recreated yet, or
+    // some views/triggers (including a non-IF-EXISTS trigger) already back.
+    for cut_marker in [
+        "CREATE VIEW e2ee_local_state_resolved",
+        "CREATE TRIGGER e2ee_replica_payload_hash_update",
+    ] {
+        let db = Db::connect_memory_plain().await.unwrap();
+        anlg_db_migrate::migrate(
+            &db,
+            anlg_db_migrate::DbSchema {
+                steps: migration_steps_before("20260816100100_e2ee_payload_hash_local_state"),
+                validate_cloudsync_table: cloudsync_alter_guard_required,
+            },
+        )
+        .await
+        .unwrap();
+
+        let cut = migration_sql.find(cut_marker).unwrap();
+        sqlx::raw_sql(sqlx::AssertSqlSafe(&migration_sql[..cut]))
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        prepare_schema(&db).await.unwrap();
+
+        let (success, checksum): (bool, Vec<u8>) = sqlx::query_as(
+            "SELECT success, checksum FROM _sqlx_migrations WHERE version = 20260816100100",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert!(success);
+        assert_eq!(checksum, migration_checksum(migration_sql));
+
+        let payload_hash_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(
+                SELECT 1 FROM pragma_table_info('e2ee_records') WHERE name = 'payload_hash'
+            )",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert!(!payload_hash_exists);
+
+        assert_eq!(
+            e2ee_schema_objects(&db).await,
+            e2ee_schema_objects(&clean_db).await
+        );
+    }
+}
+
+#[tokio::test]
+async fn e2ee_payload_hash_repair_ignores_databases_before_the_column_existed() {
+    let db = Db::connect_memory_plain().await.unwrap();
+    anlg_db_migrate::migrate(
+        &db,
+        anlg_db_migrate::DbSchema {
+            steps: migration_steps_before("20260815100300_e2ee_record_payload_hash"),
+            validate_cloudsync_table: cloudsync_alter_guard_required,
+        },
+    )
+    .await
+    .unwrap();
+
+    repair_torn_e2ee_payload_hash_local_state_migration(db.pool())
+        .await
+        .unwrap();
+
+    let row_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM _sqlx_migrations WHERE version = 20260816100100)",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert!(
+        !row_exists,
+        "repair must not pre-record an unapplied migration"
+    );
+
+    prepare_schema(&db).await.unwrap();
+}
+
+#[tokio::test]
+async fn e2ee_payload_hash_repair_leaves_cleanly_migrated_databases_alone() {
+    let db = test_db().await;
+    let before = e2ee_schema_objects(&db).await;
+    let checksum_before: Vec<u8> =
+        sqlx::query_scalar("SELECT checksum FROM _sqlx_migrations WHERE version = 20260816100100")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+
+    repair_torn_e2ee_payload_hash_local_state_migration(db.pool())
+        .await
+        .unwrap();
+
+    let checksum_after: Vec<u8> =
+        sqlx::query_scalar("SELECT checksum FROM _sqlx_migrations WHERE version = 20260816100100")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(checksum_before, checksum_after);
+    assert_eq!(before, e2ee_schema_objects(&db).await);
+}

--- a/crates/db-app/src/schema_tests/encrypted_replica.rs
+++ b/crates/db-app/src/schema_tests/encrypted_replica.rs
@@ -1130,6 +1130,116 @@ async fn torn_e2ee_payload_hash_local_state_migration_is_repaired() {
     }
 }
 
+// The prebuilt sqlite-sync extension only ships for these targets.
+#[cfg(any(
+    all(test, target_os = "macos", target_arch = "aarch64"),
+    all(test, target_os = "macos", target_arch = "x86_64"),
+    all(test, target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+    all(test, target_os = "linux", target_env = "gnu", target_arch = "x86_64"),
+    all(
+        test,
+        target_os = "linux",
+        target_env = "musl",
+        target_arch = "aarch64"
+    ),
+    all(test, target_os = "linux", target_env = "musl", target_arch = "x86_64"),
+    all(test, target_os = "windows", target_arch = "x86_64"),
+))]
+#[tokio::test]
+async fn torn_e2ee_payload_hash_repair_refreshes_the_cloudsync_schema_hash() {
+    async fn open_cloudsync_db(path: &std::path::Path) -> Db {
+        Db::open(anlg_db_core::DbOpenOptions {
+            storage: anlg_db_core::DbStorage::Local(path),
+            cloudsync_enabled: true,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(1),
+        })
+        .await
+        .unwrap()
+    }
+
+    async fn migrate_until_before_torn_step(db: &Db) {
+        anlg_db_migrate::migrate(
+            db,
+            anlg_db_migrate::DbSchema {
+                steps: migration_steps_before("20260816100100_e2ee_payload_hash_local_state"),
+                validate_cloudsync_table: cloudsync_alter_guard_required,
+            },
+        )
+        .await
+        .unwrap();
+        db.cloudsync_init("e2ee_records", None, None).await.unwrap();
+    }
+
+    async fn latest_cloudsync_schema_hash(db: &Db) -> i64 {
+        sqlx::query_scalar("SELECT hash FROM cloudsync_schema_versions ORDER BY seq DESC LIMIT 1")
+            .fetch_one(db.pool())
+            .await
+            .unwrap()
+    }
+
+    let migration_sql =
+        include_str!("../../migrations/20260816100100_e2ee_payload_hash_local_state.sql");
+
+    // Reference: the same migration applied through the CloudsyncAlter runner
+    // records the schema hash of the post-drop e2ee_records table.
+    let clean_dir = tempfile::tempdir().unwrap();
+    let clean_hash = {
+        let db = open_cloudsync_db(&clean_dir.path().join("app.db")).await;
+        migrate_until_before_torn_step(&db).await;
+        prepare_schema(&db).await.unwrap();
+        let hash = latest_cloudsync_schema_hash(&db).await;
+        db.pool().close().await;
+        hash
+    };
+
+    // Torn 1.4.10 run: cloudsync_begin_alter dropped the change-tracking
+    // triggers, the ALTER plus part of the DDL committed, and the process died
+    // before cloudsync_commit_alter recorded the post-drop schema hash.
+    let torn_dir = tempfile::tempdir().unwrap();
+    let torn_path = torn_dir.path().join("app.db");
+    {
+        let db = open_cloudsync_db(&torn_path).await;
+        migrate_until_before_torn_step(&db).await;
+
+        let mut conn = db.pool().acquire().await.unwrap();
+        anlg_db_core::cloudsync_begin_alter_on(&mut *conn, "e2ee_records")
+            .await
+            .unwrap();
+        let cut = migration_sql
+            .find("CREATE VIEW e2ee_local_state_resolved")
+            .unwrap();
+        sqlx::raw_sql(sqlx::AssertSqlSafe(&migration_sql[..cut]))
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        sqlx::query("RELEASE SAVEPOINT cloudsync_alter")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        drop(conn);
+        db.pool().close().await;
+    }
+
+    let db = open_cloudsync_db(&torn_path).await;
+    let stale_hash = latest_cloudsync_schema_hash(&db).await;
+    assert_ne!(stale_hash, clean_hash, "torn setup must leave a stale hash");
+
+    prepare_schema(&db).await.unwrap();
+
+    let repaired: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM _sqlx_migrations WHERE version = 20260816100100 AND success = 1
+        )",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert!(repaired);
+    assert_eq!(latest_cloudsync_schema_hash(&db).await, clean_hash);
+}
+
 #[tokio::test]
 async fn e2ee_payload_hash_repair_ignores_databases_before_the_column_existed() {
     let db = Db::connect_memory_plain().await.unwrap();
@@ -1143,7 +1253,7 @@ async fn e2ee_payload_hash_repair_ignores_databases_before_the_column_existed() 
     .await
     .unwrap();
 
-    repair_torn_e2ee_payload_hash_local_state_migration(db.pool())
+    repair_torn_e2ee_payload_hash_local_state_migration(&db)
         .await
         .unwrap();
 
@@ -1171,7 +1281,7 @@ async fn e2ee_payload_hash_repair_leaves_cleanly_migrated_databases_alone() {
             .await
             .unwrap();
 
-    repair_torn_e2ee_payload_hash_local_state_migration(db.pool())
+    repair_torn_e2ee_payload_hash_local_state_migration(&db)
         .await
         .unwrap();
 


### PR DESCRIPTION
Pre-transactional 1.4.10 builds ran 20260816100100 statement-by-statement
with autocommit on cloudsync-enabled databases; a force-quit mid-way left
the payload_hash column dropped with no _sqlx_migrations row, so the
re-run bricked startup on "no such column".

Add repair_torn_e2ee_payload_hash_local_state_migration to prepare_schema:
when the history row is absent, the prior migration is applied, and the
column is already gone, finish the remaining idempotent DDL (skipping the
ALTER, dropping the non-IF-EXISTS replica-hash triggers first) and record
the migration, all in one transaction. The shipped migration SQL is
untouched to preserve checksums for cleanly migrated databases; a pinned
checksum guards the SQL surgery. Schema tests cover two torn shapes plus
no-op behavior on older and healthy databases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches encrypted-replica schema, migration history, and CloudSync alter bookkeeping at startup; incorrect detection could skip needed migrations or alter sync state, but guards and tests target a narrow torn-state fingerprint.
> 
> **Overview**
> Fixes **startup brick** on databases where pre-transactional 1.4.10 runs left migration `20260816100100` half-applied: `payload_hash` already dropped on `e2ee_records` but no `_sqlx_migrations` row, so a normal re-run fails on the `ALTER`.
> 
> **`prepare_schema`** now runs **`repair_torn_e2ee_payload_hash_local_state_migration`** before `migrate`. When the torn fingerprint matches (prior step applied, local-state row missing, column gone), it finishes the migration in one transaction: drops replica-hash triggers that may already exist, replays the shipped SQL **without** the `DROP COLUMN`, inserts the migration history row with a **pinned checksum**, and on CloudSync-enabled DBs wraps the work in **`cloudsync_begin_alter` / `commit_alter`** so `e2ee_records` schema hash matches post-repair state.
> 
> Adds **`AppSchemaError`** variants for cloudsync and repair failures, **`anlg-cloudsync`** + **`tempfile`** deps, and schema tests for two torn DDL cut points, CloudSync hash refresh, and no-op paths on older or healthy DBs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c1aa7a8eb8f4fbe48aa3c6b7d007dc629e8666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->