### PR TITLE
feat(desktop): mark selected app icon with a spotlight shadow

### DIFF
--- a/apps/desktop/src/settings/appearance/app-icon.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.tsx
@@ -104,7 +104,7 @@ export function AppIconSelector() {
               className={cn([
                 "group text-foreground focus-visible:ring-ring focus-visible:ring-offset-background relative flex cursor-pointer items-center justify-center rounded-[22px] border bg-transparent p-0.5 transition-[border-color,scale] duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.98] disabled:cursor-wait",
                 selected
-                  ? "border-blue-500"
+                  ? "border-transparent"
                   : "border-border hover:border-foreground/30",
               ])}
               onClick={() => {
@@ -117,7 +117,22 @@ export function AppIconSelector() {
                 setAppIcon(option);
               }}
             >
-              <span className="flex size-16 overflow-hidden rounded-[18px]">
+              <span
+                aria-hidden
+                className={cn([
+                  "pointer-events-none absolute inset-x-2.5 bottom-0 h-2 rounded-full",
+                  "bg-black/35 blur-[6px] dark:bg-white/25",
+                  "transition-opacity duration-150",
+                  selected ? "opacity-100" : "opacity-0",
+                ])}
+              />
+              <span
+                className={cn([
+                  "flex size-16 overflow-hidden rounded-[18px]",
+                  "transition-transform duration-150",
+                  selected && "-translate-y-1",
+                ])}
+              >
                 {theme === "system" && hasDarkVariant ? (
                   <picture>
                     <source


### PR DESCRIPTION
The blue selection ring around app icon previews looked heavy next to the
artwork. Replace it with a spotlight treatment: the selected icon lifts
slightly and casts a soft elliptical ground shadow (a light glow in dark
mode), while unselected tiles keep their neutral border.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop settings UI-only styling in `app-icon.tsx` with no logic, auth, or data changes.
> 
> **Overview**
> **App icon** selection in appearance settings no longer uses a **blue border** on the selected tile. Selected state is shown with a **transparent** border, a slight **upward lift** on the preview, and a soft **elliptical ground shadow** (darker in light mode, lighter glow in dark mode) that fades in only when selected.
> 
> Unselected icons keep the neutral border and hover styling; behavior and accessibility (`role="radio"`, labels, Pro lock) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9624210451eefcac0622047b6fe3aefac9711f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->