### PR TITLE
feat(desktop): install the bundled CLI automatically at startup

### DIFF
--- a/apps/desktop/src-tauri/src/embedded_cli.rs
+++ b/apps/desktop/src-tauri/src/embedded_cli.rs
@@ -94,6 +94,30 @@ pub fn check<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -> EmbeddedCl
     }
 }
 
+// Missing also covers a symlink left behind by a previous app version, so this
+// keeps the installed CLI current across updates. Conflict is left alone: the
+// user put something else at the install path and a background task must not
+// replace it.
+pub fn spawn_auto_install<R: tauri::Runtime>(app_handle: tauri::AppHandle<R>) {
+    tauri::async_runtime::spawn_blocking(move || {
+        if check(&app_handle).state != EmbeddedCliState::Missing {
+            return;
+        }
+
+        match install(&app_handle) {
+            Ok(status) if status.state == EmbeddedCliState::Installed => {
+                tracing::info!(install_path = %status.install_path, "auto_installed_embedded_cli");
+            }
+            Ok(status) => {
+                tracing::warn!(state = ?status.state, "embedded_cli_auto_install_incomplete");
+            }
+            Err(error) => {
+                tracing::warn!(%error, "embedded_cli_auto_install_failed");
+            }
+        }
+    });
+}
+
 pub fn install<R: tauri::Runtime, T: tauri::Manager<R>>(
     manager: &T,
 ) -> Result<EmbeddedCliStatus, String> {

--- a/apps/desktop/src-tauri/src/embedded_cli.rs
+++ b/apps/desktop/src-tauri/src/embedded_cli.rs
@@ -100,8 +100,29 @@ pub fn check<R: tauri::Runtime, T: tauri::Manager<R>>(manager: &T) -> EmbeddedCl
 // replace it.
 pub fn spawn_auto_install<R: tauri::Runtime>(app_handle: tauri::AppHandle<R>) {
     tauri::async_runtime::spawn_blocking(move || {
-        if check(&app_handle).state != EmbeddedCliState::Missing {
+        let status = check(&app_handle);
+        if status.state != EmbeddedCliState::Missing {
             return;
+        }
+
+        // On Windows, Missing also covers a binary that is present but absent
+        // from the user PATH. Rewriting the binary on every launch would churn
+        // it forever when the PATH registry write keeps failing, so only the
+        // PATH entry is repaired.
+        #[cfg(target_os = "windows")]
+        {
+            let install_path = PathBuf::from(&status.install_path);
+            if std::fs::symlink_metadata(&install_path).is_ok_and(|metadata| metadata.is_file()) {
+                match add_windows_cli_to_path(&install_path) {
+                    Ok(()) => {
+                        tracing::info!(install_path = %status.install_path, "auto_repaired_embedded_cli_path");
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "embedded_cli_auto_path_repair_failed");
+                    }
+                }
+                return;
+            }
         }
 
         match install(&app_handle) {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -428,7 +428,9 @@ pub async fn main() {
                 }
             }
 
-            search_index::spawn(app_handle, db.clone());
+            search_index::spawn(app_handle.clone(), db.clone());
+
+            embedded_cli::spawn_auto_install(app_handle);
 
             Ok(())
         })


### PR DESCRIPTION
Users previously had to click Install in Developers settings to get the
Anarlog CLI, even though the binary already ships inside the app bundle.
Spawn a background task during app setup that installs the CLI whenever
its status is missing, which also covers symlinks left pointing at a
previous app version, so new users get the CLI on first launch and
existing installs stay current across updates. Conflicting files at the
install path are left untouched, and failures only log a warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Startup now mutates the CLI install path and Windows user PATH via existing install helpers, but conflict detection and PATH-only repair limit unintended overwrites.
> 
> **Overview**
> **Startup now installs the bundled Anarlog CLI in the background** when `check` reports **Missing**, so new installs get the command without using Developers settings and macOS/Linux installs can refresh stale symlinks after app updates. **Conflict** paths are skipped so an unrelated file at the install location is never overwritten.
> 
> On **Windows**, **Missing** can mean the binary exists but is not on the user PATH; in that case auto-install only calls **`add_windows_cli_to_path`** instead of copying the executable again, avoiding churn if registry updates keep failing.
> 
> App **setup** invokes **`embedded_cli::spawn_auto_install`** (blocking pool) alongside search index startup; success and failures are **info/warn** logs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9cf6d61595a22ca8d37c537df1eaf0f9310993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->