### PR TITLE
fix(desktop): show migration progress and block second launches

### DIFF
--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -125,7 +125,7 @@ fn parse_env_flag(value: String) -> Result<bool, String> {
     }
 }
 
-fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
+pub(crate) fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
     let data_dir = dirs::data_dir()?;
     let default_dir = anlg_storage::global::compute_default_base(identifier)?;
     let identifier_dir = data_dir.join(identifier);

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod db;
 mod embedded_cli;
 mod ext;
 mod search_index;
+mod startup;
 mod store;
 mod supervisor;
 
@@ -142,16 +143,34 @@ pub async fn main() {
     let context = tauri::generate_context!();
     let identifier = context.config().identifier.clone();
 
+    // The single-instance plugin only starts with the builder, which is too
+    // late to keep a second launch from racing an in-flight startup migration.
+    let launch_lock = match startup::acquire_launch_lock(&identifier) {
+        startup::LaunchLockState::Acquired(lock) => Some(lock),
+        startup::LaunchLockState::HeldByAnotherProcess => {
+            startup::exit_for_already_running_instance()
+        }
+        startup::LaunchLockState::Unavailable(reason) => {
+            eprintln!("starting without the launch lock: {reason}");
+            None
+        }
+    };
+
     let (root_supervisor_ctx, root_supervisor_handle) =
         match supervisor::spawn_root_supervisor().await {
             Some((ctx, handle)) => (Some(ctx), Some(handle)),
             None => (None, None),
         };
 
+    let startup_indicator = startup::SlowStartupIndicator::show_after_delay();
     let db = match open_desktop_db(&identifier).await {
         Ok(db) => db,
-        Err(error) => exit_after_startup_failure(&identifier, &error),
+        Err(error) => {
+            startup_indicator.dismiss();
+            exit_after_startup_failure(&identifier, &error)
+        }
     };
+    startup_indicator.dismiss();
     let crash_reporting_enabled = load_crash_reporting_consent(&db).await;
 
     let sentry_client = {
@@ -418,6 +437,9 @@ pub async fn main() {
         Ok(app) => app,
         Err(error) => exit_after_startup_failure(&identifier, &error),
     };
+
+    // The single-instance plugin took over when the builder finished.
+    drop(launch_lock);
 
     match get_onboarding_flag() {
         None => {}

--- a/apps/desktop/src-tauri/src/startup.rs
+++ b/apps/desktop/src-tauri/src/startup.rs
@@ -1,0 +1,167 @@
+use std::fs::TryLockError;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+const LAUNCH_LOCK_FILENAME: &str = "launch.lock";
+const SLOW_STARTUP_INDICATOR_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
+
+// Startup migrations can hold the database for minutes before any window or
+// plugin exists, so single-instance semantics are enforced with an OS file
+// lock that is held from process start until the single-instance plugin is
+// initialized. The OS releases it automatically if the process dies.
+pub struct LaunchLock {
+    _file: std::fs::File,
+}
+
+pub enum LaunchLockState {
+    Acquired(LaunchLock),
+    HeldByAnotherProcess,
+    Unavailable(String),
+}
+
+pub fn acquire_launch_lock(identifier: &str) -> LaunchLockState {
+    let Some(dir) = crate::db::desktop_db_dir(identifier) else {
+        return LaunchLockState::Unavailable(
+            "application data directory is unavailable".to_string(),
+        );
+    };
+    if let Err(error) = std::fs::create_dir_all(&dir) {
+        return LaunchLockState::Unavailable(format!(
+            "failed to create application data directory: {error}"
+        ));
+    }
+    lock_launch_file(&dir.join(LAUNCH_LOCK_FILENAME))
+}
+
+fn lock_launch_file(path: &Path) -> LaunchLockState {
+    let file = match std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) => {
+            return LaunchLockState::Unavailable(format!(
+                "failed to open {}: {error}",
+                path.display()
+            ));
+        }
+    };
+
+    match file.try_lock() {
+        Ok(()) => LaunchLockState::Acquired(LaunchLock { _file: file }),
+        Err(TryLockError::WouldBlock) => LaunchLockState::HeldByAnotherProcess,
+        Err(TryLockError::Error(error)) => {
+            LaunchLockState::Unavailable(format!("failed to lock {}: {error}", path.display()))
+        }
+    }
+}
+
+pub fn exit_for_already_running_instance() -> ! {
+    eprintln!("another Anarlog process holds the launch lock; exiting");
+
+    #[cfg(target_os = "macos")]
+    {
+        let alert = "display alert \"Anarlog is already starting\" message \"Another Anarlog process is preparing your data, possibly finishing an update. The app will open automatically when it is ready.\" buttons {\"OK\"} default button \"OK\"";
+        let _ = std::process::Command::new("/usr/bin/osascript")
+            .args(["-e", alert])
+            .spawn();
+    }
+
+    std::process::exit(0);
+}
+
+// Database migrations run before the webview or dock icon exists, so a long
+// migration makes the app look dead. After a short delay this shows a native
+// alert (spawned osascript, matching the startup-failure alerts) that is
+// killed as soon as the database is ready.
+pub struct SlowStartupIndicator {
+    state: Arc<Mutex<IndicatorState>>,
+}
+
+struct IndicatorState {
+    dismissed: bool,
+    child: Option<std::process::Child>,
+}
+
+impl SlowStartupIndicator {
+    pub fn show_after_delay() -> Self {
+        let state = Arc::new(Mutex::new(IndicatorState {
+            dismissed: false,
+            child: None,
+        }));
+
+        {
+            let state = state.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(SLOW_STARTUP_INDICATOR_DELAY);
+                let mut state = state.lock().unwrap();
+                if state.dismissed {
+                    return;
+                }
+                state.child = spawn_indicator_alert();
+            });
+        }
+
+        Self { state }
+    }
+
+    pub fn dismiss(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.dismissed = true;
+        if let Some(mut child) = state.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn spawn_indicator_alert() -> Option<std::process::Child> {
+    let alert = "display alert \"Updating your data\" message \"Anarlog is updating your data. This can take several minutes for a large library.\\n\\nPlease keep Anarlog running; it will open automatically when the update finishes.\" buttons {\"OK\"} default button \"OK\"";
+    std::process::Command::new("/usr/bin/osascript")
+        .args(["-e", alert])
+        .spawn()
+        .ok()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn spawn_indicator_alert() -> Option<std::process::Child> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launch_lock_excludes_a_second_holder_until_released() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(LAUNCH_LOCK_FILENAME);
+
+        let first = lock_launch_file(&path);
+        assert!(matches!(first, LaunchLockState::Acquired(_)));
+
+        assert!(matches!(
+            lock_launch_file(&path),
+            LaunchLockState::HeldByAnotherProcess
+        ));
+
+        drop(first);
+        assert!(matches!(
+            lock_launch_file(&path),
+            LaunchLockState::Acquired(_)
+        ));
+    }
+
+    #[test]
+    fn dismissing_before_the_delay_prevents_the_indicator() {
+        let indicator = SlowStartupIndicator::show_after_delay();
+        indicator.dismiss();
+
+        let state = indicator.state.lock().unwrap();
+        assert!(state.dismissed);
+        assert!(state.child.is_none());
+    }
+}


### PR DESCRIPTION
Startup migrations run before any window or plugin exists, so a long
migration looked like a dead app, and a second launch could race the
in-flight migration because single-instance only starts with the
builder.

Acquire an OS file lock next to the database before opening it: a
second launch shows a native alert and exits, and the lock is released
once the single-instance plugin takes over. While the database opens,
show a native "Updating your data" alert (spawned osascript, macOS)
after a few seconds and dismiss it as soon as the database is ready.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core desktop startup ordering and concurrency around database open/migrations; mis-handling the lock could block launches or allow brief races, but behavior degrades gracefully when the lock is unavailable.
> 
> **Overview**
> Adds **early single-instance protection** and **slow-startup feedback** while the desktop app opens the database and runs migrations—before any window or Tauri single-instance plugin is available.
> 
> A new `startup` module acquires an OS **file lock** (`launch.lock`) beside the app data directory as soon as `main` runs. A second process that cannot acquire the lock shows a native macOS alert and exits; the first process holds the lock until the Tauri builder finishes, then drops it so the existing single-instance plugin takes over. If the lock cannot be created, startup continues with a logged warning.
> 
> While `open_desktop_db` runs, a **slow startup indicator** starts a 3-second timer and, on macOS, spawns an “Updating your data” `osascript` alert if the DB is still not ready; it is dismissed (and the child process killed) when the DB opens or on startup failure. `desktop_db_dir` is exposed as `pub(crate)` so the lock path matches the database location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc86cfaf9f5507a79db72096d732003752c607f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->