### PR TITLE
feat(desktop): install the Anarlog skill into coding agents

### DIFF
--- a/apps/desktop/src-tauri/src/agent_skills.rs
+++ b/apps/desktop/src-tauri/src/agent_skills.rs
@@ -1,0 +1,193 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+const SKILL_DIR_NAME: &str = "anarlog";
+
+// The published skill package from `skills/anarlog`, embedded at build time so
+// installs work offline and always match the running app version.
+const SKILL_FILES: &[(&str, &str)] = &[
+    (
+        "SKILL.md",
+        include_str!("../../../../skills/anarlog/SKILL.md"),
+    ),
+    (
+        "references/cli.md",
+        include_str!("../../../../skills/anarlog/references/cli.md"),
+    ),
+    (
+        "references/errors.md",
+        include_str!("../../../../skills/anarlog/references/errors.md"),
+    ),
+    (
+        "references/mcp.md",
+        include_str!("../../../../skills/anarlog/references/mcp.md"),
+    ),
+    (
+        "references/setup.md",
+        include_str!("../../../../skills/anarlog/references/setup.md"),
+    ),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillAgent {
+    ClaudeCode,
+    Codex,
+    Cursor,
+    Opencode,
+}
+
+const AGENTS: [SkillAgent; 4] = [
+    SkillAgent::ClaudeCode,
+    SkillAgent::Codex,
+    SkillAgent::Cursor,
+    SkillAgent::Opencode,
+];
+
+impl SkillAgent {
+    fn display_name(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "Claude Code",
+            Self::Codex => "Codex",
+            Self::Cursor => "Cursor",
+            Self::Opencode => "OpenCode",
+        }
+    }
+
+    // The config directory doubles as the detection signal: it only exists
+    // once the agent has been used on this machine.
+    fn config_dir(self, home: &Path) -> PathBuf {
+        match self {
+            Self::ClaudeCode => home.join(".claude"),
+            Self::Codex => home.join(".codex"),
+            Self::Cursor => home.join(".cursor"),
+            Self::Opencode => home.join(".config").join("opencode"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillAgentStatus {
+    pub agent: SkillAgent,
+    pub display_name: String,
+    pub detected: bool,
+    pub installed: bool,
+    pub skill_path: String,
+}
+
+pub fn list() -> Result<Vec<SkillAgentStatus>, String> {
+    let home = home_dir()?;
+    Ok(AGENTS
+        .into_iter()
+        .map(|agent| status(agent, &home))
+        .collect())
+}
+
+pub fn install(agent: SkillAgent) -> Result<SkillAgentStatus, String> {
+    let home = home_dir()?;
+    if !agent.config_dir(&home).is_dir() {
+        return Err(format!(
+            "{} was not found on this machine.",
+            agent.display_name()
+        ));
+    }
+
+    install_at(&skill_dir(agent, &home))?;
+    Ok(status(agent, &home))
+}
+
+fn home_dir() -> Result<PathBuf, String> {
+    dirs::home_dir().ok_or_else(|| "Anarlog could not find your home directory.".to_string())
+}
+
+fn skill_dir(agent: SkillAgent, home: &Path) -> PathBuf {
+    agent.config_dir(home).join("skills").join(SKILL_DIR_NAME)
+}
+
+fn status(agent: SkillAgent, home: &Path) -> SkillAgentStatus {
+    let skill_dir = skill_dir(agent, home);
+    SkillAgentStatus {
+        agent,
+        display_name: agent.display_name().to_string(),
+        detected: agent.config_dir(home).is_dir(),
+        installed: skill_dir.join("SKILL.md").is_file(),
+        skill_path: skill_dir.display().to_string(),
+    }
+}
+
+fn install_at(skill_dir: &Path) -> Result<(), String> {
+    for (relative_path, content) in SKILL_FILES {
+        let target = skill_dir.join(relative_path);
+        let parent = target
+            .parent()
+            .ok_or_else(|| "The skill install path is invalid.".to_string())?;
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("Could not create {}: {error}", parent.display()))?;
+        std::fs::write(&target, content)
+            .map_err(|error| format!("Could not write {}: {error}", target.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embeds_the_complete_skill_package() {
+        assert!(SKILL_FILES.iter().any(|(path, _)| *path == "SKILL.md"));
+        for (path, content) in SKILL_FILES {
+            assert!(!content.trim().is_empty(), "{path} is empty");
+        }
+    }
+
+    #[test]
+    fn install_writes_every_skill_file() {
+        let home = tempfile::tempdir().unwrap();
+        let skill_dir = skill_dir(SkillAgent::ClaudeCode, home.path());
+
+        install_at(&skill_dir).unwrap();
+
+        for (relative_path, content) in SKILL_FILES {
+            assert_eq!(
+                std::fs::read_to_string(skill_dir.join(relative_path)).unwrap(),
+                *content
+            );
+        }
+    }
+
+    #[test]
+    fn reinstall_overwrites_stale_content() {
+        let home = tempfile::tempdir().unwrap();
+        let skill_dir = skill_dir(SkillAgent::Codex, home.path());
+        install_at(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "outdated").unwrap();
+
+        install_at(&skill_dir).unwrap();
+
+        assert_ne!(
+            std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap(),
+            "outdated"
+        );
+    }
+
+    #[test]
+    fn status_reports_detection_and_installation_separately() {
+        let home = tempfile::tempdir().unwrap();
+
+        let missing = status(SkillAgent::Cursor, home.path());
+        assert!(!missing.detected);
+        assert!(!missing.installed);
+
+        std::fs::create_dir_all(SkillAgent::Cursor.config_dir(home.path())).unwrap();
+        let detected = status(SkillAgent::Cursor, home.path());
+        assert!(detected.detected);
+        assert!(!detected.installed);
+
+        install_at(&skill_dir(SkillAgent::Cursor, home.path())).unwrap();
+        let installed = status(SkillAgent::Cursor, home.path());
+        assert!(installed.installed);
+    }
+}

--- a/apps/desktop/src-tauri/src/agent_skills.rs
+++ b/apps/desktop/src-tauri/src/agent_skills.rs
@@ -62,9 +62,20 @@ impl SkillAgent {
             Self::ClaudeCode => home.join(".claude"),
             Self::Codex => home.join(".codex"),
             Self::Cursor => home.join(".cursor"),
-            Self::Opencode => home.join(".config").join("opencode"),
+            Self::Opencode => {
+                opencode_config_dir(home, std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from))
+            }
         }
     }
+}
+
+// OpenCode resolves its config root from XDG_CONFIG_HOME before falling back
+// to ~/.config; a relative value is ignored per the XDG spec.
+fn opencode_config_dir(home: &Path, xdg_config_home: Option<PathBuf>) -> PathBuf {
+    xdg_config_home
+        .filter(|path| path.is_absolute())
+        .unwrap_or_else(|| home.join(".config"))
+        .join("opencode")
 }
 
 #[derive(Debug, Clone, Serialize, specta::Type)]
@@ -170,6 +181,24 @@ mod tests {
         assert_ne!(
             std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap(),
             "outdated"
+        );
+    }
+
+    #[test]
+    fn opencode_config_dir_honors_xdg_config_home() {
+        let home = Path::new("/home/user");
+
+        assert_eq!(
+            opencode_config_dir(home, None),
+            Path::new("/home/user/.config/opencode")
+        );
+        assert_eq!(
+            opencode_config_dir(home, Some(PathBuf::from("/custom/config"))),
+            Path::new("/custom/config/opencode")
+        );
+        assert_eq!(
+            opencode_config_dir(home, Some(PathBuf::from("relative/config"))),
+            Path::new("/home/user/.config/opencode")
         );
     }
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,4 +1,8 @@
-use crate::{AppExt, embedded_cli::EmbeddedCliStatus};
+use crate::{
+    AppExt,
+    agent_skills::{SkillAgent, SkillAgentStatus},
+    embedded_cli::EmbeddedCliStatus,
+};
 
 const STAGING_BUNDLE_ID: &str = "com.hyprnote.staging";
 
@@ -132,6 +136,18 @@ pub async fn install_embedded_cli<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
 ) -> Result<EmbeddedCliStatus, String> {
     crate::embedded_cli::install(&app)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn list_skill_agents() -> Result<Vec<SkillAgentStatus>, String> {
+    crate::agent_skills::list()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn install_agent_skill(agent: SkillAgent) -> Result<SkillAgentStatus, String> {
+    crate::agent_skills::install(agent)
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod agent_skills;
 mod agents;
 mod appearance;
 mod commands;
@@ -610,6 +611,8 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::set_crash_reporting_enabled,
             commands::check_embedded_cli::<tauri::Wry>,
             commands::install_embedded_cli::<tauri::Wry>,
+            commands::list_skill_agents,
+            commands::install_agent_skill,
         ])
         .error_handling(tauri_specta::ErrorHandlingMode::Result)
 }

--- a/apps/desktop/src/settings/developers/cli.tsx
+++ b/apps/desktop/src/settings/developers/cli.tsx
@@ -5,6 +5,8 @@ import { Button } from "@anlg/ui/components/ui/button";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 import { cn } from "@anlg/utils";
 
+import { SkillsRow } from "./skills";
+
 import { commands, type EmbeddedCliStatus } from "~/types/tauri.gen";
 
 const CLI_STATUS_QUERY_KEY = ["embedded-cli-status"] as const;
@@ -154,6 +156,7 @@ function CliSection({
           </div>
         </div>
         <McpRow status={status} />
+        <SkillsRow />
       </div>
     </section>
   );

--- a/apps/desktop/src/settings/developers/index.test.tsx
+++ b/apps/desktop/src/settings/developers/index.test.tsx
@@ -12,6 +12,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   checkEmbeddedCli: vi.fn(),
   installEmbeddedCli: vi.fn(),
+  listSkillAgents: vi.fn(),
+  installAgentSkill: vi.fn(),
   showDevtool: vi.fn(),
   devtoolsPanelShow: vi.fn(),
   toastError: vi.fn(),
@@ -37,8 +39,34 @@ vi.mock("~/types/tauri.gen", () => ({
   commands: {
     checkEmbeddedCli: mocks.checkEmbeddedCli,
     installEmbeddedCli: mocks.installEmbeddedCli,
+    listSkillAgents: mocks.listSkillAgents,
+    installAgentSkill: mocks.installAgentSkill,
     showDevtool: mocks.showDevtool,
   },
+}));
+
+vi.mock("@anlg/ui/components/ui/dropdown-menu", () => ({
+  AppFloatingPanel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 vi.mock("@anlg/plugin-windows", () => ({
@@ -130,6 +158,9 @@ describe("SettingsDevelopers", () => {
   beforeEach(() => {
     mocks.checkEmbeddedCli.mockReset();
     mocks.installEmbeddedCli.mockReset();
+    mocks.listSkillAgents.mockReset();
+    mocks.listSkillAgents.mockResolvedValue({ status: "ok", data: [] });
+    mocks.installAgentSkill.mockReset();
     mocks.showDevtool.mockReset();
     mocks.showDevtool.mockResolvedValue(false);
     mocks.devtoolsPanelShow.mockReset();
@@ -409,6 +440,152 @@ describe("SettingsDevelopers", () => {
     fireEvent.click(screen.getByRole("button", { name: "Upgrade to Pro" }));
 
     expect(mocks.billing.upgradeToPro).toHaveBeenCalledOnce();
+  });
+
+  it("installs the skill into every detected agent from one action", async () => {
+    mocks.checkEmbeddedCli.mockResolvedValue({
+      status: "ok",
+      data: {
+        supported: false,
+        commandName: "anarlog",
+        installPath: "/Users/test/.local/bin/anarlog",
+        state: "unsupported",
+        details: "Unavailable.",
+      },
+    });
+    mocks.listSkillAgents.mockResolvedValue({
+      status: "ok",
+      data: [
+        {
+          agent: "claude_code",
+          displayName: "Claude Code",
+          detected: true,
+          installed: true,
+          skillPath: "/Users/test/.claude/skills/anarlog",
+        },
+        {
+          agent: "codex",
+          displayName: "Codex",
+          detected: true,
+          installed: false,
+          skillPath: "/Users/test/.codex/skills/anarlog",
+        },
+        {
+          agent: "cursor",
+          displayName: "Cursor",
+          detected: false,
+          installed: false,
+          skillPath: "/Users/test/.cursor/skills/anarlog",
+        },
+        {
+          agent: "opencode",
+          displayName: "OpenCode",
+          detected: true,
+          installed: false,
+          skillPath: "/Users/test/.config/opencode/skills/anarlog",
+        },
+      ],
+    });
+    mocks.installAgentSkill.mockImplementation((agent: string) =>
+      Promise.resolve({
+        status: "ok",
+        data: {
+          agent,
+          displayName: agent,
+          detected: true,
+          installed: true,
+          skillPath: `/Users/test/${agent}`,
+        },
+      }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SettingsDevelopers />
+      </QueryClientProvider>,
+    );
+
+    const cursorItem = await screen.findByRole("button", { name: "Cursor" });
+    expect(cursorItem.hasAttribute("disabled")).toBe(true);
+    const installedIcon = screen.getByLabelText("Skill installed");
+    expect(installedIcon.closest("button")?.textContent).toContain(
+      "Claude Code",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Install to all agents" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.installAgentSkill).toHaveBeenCalledTimes(3),
+    );
+    expect(mocks.installAgentSkill).toHaveBeenCalledWith("claude_code");
+    expect(mocks.installAgentSkill).toHaveBeenCalledWith("codex");
+    expect(mocks.installAgentSkill).toHaveBeenCalledWith("opencode");
+    expect(mocks.installAgentSkill).not.toHaveBeenCalledWith("cursor");
+    await waitFor(() =>
+      expect(mocks.toastSuccess).toHaveBeenCalledWith(
+        "Anarlog skill added to 3 agents",
+      ),
+    );
+  });
+
+  it("reports a single-agent skill install by agent name", async () => {
+    mocks.checkEmbeddedCli.mockResolvedValue({
+      status: "ok",
+      data: {
+        supported: false,
+        commandName: "anarlog",
+        installPath: "/Users/test/.local/bin/anarlog",
+        state: "unsupported",
+        details: "Unavailable.",
+      },
+    });
+    mocks.listSkillAgents.mockResolvedValue({
+      status: "ok",
+      data: [
+        {
+          agent: "codex",
+          displayName: "Codex",
+          detected: true,
+          installed: false,
+          skillPath: "/Users/test/.codex/skills/anarlog",
+        },
+      ],
+    });
+    mocks.installAgentSkill.mockResolvedValue({
+      status: "ok",
+      data: {
+        agent: "codex",
+        displayName: "Codex",
+        detected: true,
+        installed: true,
+        skillPath: "/Users/test/.codex/skills/anarlog",
+      },
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SettingsDevelopers />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Codex" }));
+
+    await waitFor(() =>
+      expect(mocks.installAgentSkill).toHaveBeenCalledWith("codex"),
+    );
+    await waitFor(() =>
+      expect(mocks.toastSuccess).toHaveBeenCalledWith(
+        "Anarlog skill added to Codex",
+      ),
+    );
   });
 
   it("hides the devtools section when devtools are disabled", async () => {

--- a/apps/desktop/src/settings/developers/skills.tsx
+++ b/apps/desktop/src/settings/developers/skills.tsx
@@ -1,0 +1,125 @@
+import { CaretDown, Check, CircleNotch } from "@phosphor-icons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { Button } from "@anlg/ui/components/ui/button";
+import {
+  AppFloatingPanel,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@anlg/ui/components/ui/dropdown-menu";
+import { sonnerToast } from "@anlg/ui/components/ui/toast";
+
+import { commands, type SkillAgent } from "~/types/tauri.gen";
+
+const SKILL_AGENTS_QUERY_KEY = ["skill-agents"] as const;
+
+async function loadSkillAgents() {
+  const result = await commands.listSkillAgents();
+  if (result.status === "error") {
+    throw new Error(result.error);
+  }
+  return result.data;
+}
+
+async function installSkill(agent: SkillAgent) {
+  const result = await commands.installAgentSkill(agent);
+  if (result.status === "error") {
+    throw new Error(result.error);
+  }
+  return result.data;
+}
+
+export function SkillsRow() {
+  const queryClient = useQueryClient();
+  const agentsQuery = useQuery({
+    queryKey: SKILL_AGENTS_QUERY_KEY,
+    queryFn: loadSkillAgents,
+  });
+  const installMutation = useMutation({
+    mutationFn: async (agents: SkillAgent[]) => {
+      const statuses = [];
+      for (const agent of agents) {
+        statuses.push(await installSkill(agent));
+      }
+      return statuses;
+    },
+    onSuccess: (statuses) => {
+      void queryClient.invalidateQueries({ queryKey: SKILL_AGENTS_QUERY_KEY });
+      sonnerToast.success(
+        statuses.length === 1
+          ? `Anarlog skill added to ${statuses[0].displayName}`
+          : `Anarlog skill added to ${statuses.length} agents`,
+      );
+    },
+    onError: (error) => {
+      void queryClient.invalidateQueries({ queryKey: SKILL_AGENTS_QUERY_KEY });
+      sonnerToast.error(error.message);
+    },
+  });
+
+  const agents = agentsQuery.data ?? [];
+  const detected = agents.filter((agent) => agent.detected);
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <h3 className="text-sm font-medium">Agent skills</h3>
+        <p className="text-muted-foreground mt-1 text-xs">
+          Teach coding agents when and how to use the Anarlog CLI and MCP
+        </p>
+      </div>
+      <div className="flex shrink-0 gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={agents.length === 0 || installMutation.isPending}
+            >
+              {installMutation.isPending ? (
+                <CircleNotch className="size-3.5 animate-spin" />
+              ) : (
+                <>
+                  Add skill to…
+                  <CaretDown className="size-3.5" />
+                </>
+              )}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent variant="app" align="end" className="w-52">
+            <AppFloatingPanel className="p-1">
+              <DropdownMenuItem
+                disabled={detected.length === 0}
+                onClick={() =>
+                  installMutation.mutate(detected.map((agent) => agent.agent))
+                }
+              >
+                Install to all agents
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              {agents.map((agent) => (
+                <DropdownMenuItem
+                  key={agent.agent}
+                  disabled={!agent.detected}
+                  onClick={() => installMutation.mutate([agent.agent])}
+                >
+                  {agent.displayName}
+                  {agent.installed && (
+                    <Check
+                      aria-label="Skill installed"
+                      className="ml-auto size-3.5"
+                    />
+                  )}
+                </DropdownMenuItem>
+              ))}
+            </AppFloatingPanel>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/types/tauri.gen.ts
+++ b/apps/desktop/src/types/tauri.gen.ts
@@ -118,6 +118,22 @@ async installEmbeddedCli() : Promise<Result<EmbeddedCliStatus, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async listSkillAgents() : Promise<Result<SkillAgentStatus[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_skill_agents") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async installAgentSkill(agent: SkillAgent) : Promise<Result<SkillAgentStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("install_agent_skill", { agent }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -133,6 +149,8 @@ async installEmbeddedCli() : Promise<Result<EmbeddedCliStatus, string>> {
 
 export type EmbeddedCliState = "installed" | "missing" | "conflict" | "unsupported" | "resource_missing"
 export type EmbeddedCliStatus = { supported: boolean; commandName: string; installPath: string; state: EmbeddedCliState; details: string | null }
+export type SkillAgent = "claude_code" | "codex" | "cursor" | "opencode"
+export type SkillAgentStatus = { agent: SkillAgent; displayName: string; detected: boolean; installed: boolean; skillPath: string }
 
 /** tauri-specta globals **/
 


### PR DESCRIPTION
Installing the public Anarlog skill previously required npx or manual
copying, so most users never taught their agents about Anarlog. Add an
Agent skills row to Developers settings with an Add skill to... menu
that installs the skill into Claude Code, Codex, Cursor, or OpenCode
individually or all detected agents at once, matching each agent's
~/<config>/skills/anarlog convention. The skill package from
skills/anarlog is embedded at build time so installs work offline and
track the running app version; agents are detected via their config
directories and undetected ones are disabled in the menu.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only write skill markdown under the user's existing agent config directories; no auth or cloud behavior, with behavior covered by unit and UI tests.
> 
> **Overview**
> Users can install the **Anarlog agent skill** from **Developers → CLI & MCP** without `npx` or manual copying. A new **Agent skills** row exposes **Add skill to…** with per-agent choices (Claude Code, Codex, Cursor, OpenCode) and **Install to all agents** for every detected install.
> 
> The desktop app **embeds** the `skills/anarlog` package at build time and writes it under each agent's `skills/anarlog` path. **Detection** treats an agent as present when its config directory exists; undetected agents stay disabled in the menu, and installs show a check when `SKILL.md` is already there. **OpenCode** resolves its config root via `XDG_CONFIG_HOME` when set to an absolute path.
> 
> Rust exposes `list_skill_agents` and `install_agent_skill`; the frontend loads status with React Query and reinstalls overwrite stale files. Tests cover bulk vs single install toasts and the Rust install/detection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc9055100318f1ea70a17e2d37e10c1b2389fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->