### PR TITLE
fix(desktop): stop recentering the main window after every update

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -118,27 +118,6 @@ fn should_force_quit() -> bool {
     false
 }
 
-fn versions_indicate_update(previous: Option<&str>, current: Option<&str>) -> bool {
-    matches!(
-        (previous, current),
-        (Some(previous), Some(current)) if !previous.is_empty() && previous != current
-    )
-}
-
-fn should_recenter_after_update(app: &tauri::AppHandle<tauri::Wry>) -> bool {
-    use tauri_plugin_updater2::Updater2PluginExt;
-
-    let previous = match app.updater2().get_last_seen_version() {
-        Ok(previous) => previous,
-        Err(error) => {
-            tracing::warn!(%error, "failed to read the previous app version during startup");
-            return false;
-        }
-    };
-
-    versions_indicate_update(previous.as_deref(), app.config().version.as_deref())
-}
-
 fn create_audio_provider(_bundle_id: &str) -> std::sync::Arc<dyn anlg_audio_actual::AudioProvider> {
     #[cfg(any(feature = "dev", feature = "devtools"))]
     {
@@ -470,18 +449,8 @@ pub async fn main() {
         }
     }
 
-    {
-        let app_handle = app.handle().clone();
-        let recenter_after_update = should_recenter_after_update(&app_handle);
-        match AppWindow::Main.show(&app_handle) {
-            Ok(window) if recenter_after_update => {
-                if let Err(error) = AppWindow::Main.center_on_primary(&app_handle, &window) {
-                    tracing::warn!(%error, "failed to recenter the main window after an update");
-                }
-            }
-            Ok(_) => {}
-            Err(error) => exit_after_startup_failure(&identifier, &error),
-        }
+    if let Err(error) = AppWindow::Main.show(app.handle()) {
+        exit_after_startup_failure(&identifier, &error);
     }
 
     #[cfg(target_os = "macos")]
@@ -692,15 +661,6 @@ mod test {
             message,
             "Anarlog failed to start: legacy import did not pass parity verification"
         );
-    }
-
-    #[test]
-    fn recenters_after_the_app_version_changes() {
-        assert!(versions_indicate_update(Some("1.4.7"), Some("1.4.8")));
-        assert!(!versions_indicate_update(Some("1.4.8"), Some("1.4.8")));
-        assert!(!versions_indicate_update(None, Some("1.4.8")));
-        assert!(!versions_indicate_update(Some(""), Some("1.4.8")));
-        assert!(!versions_indicate_update(Some("1.4.7"), None));
     }
 
     #[test]

--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -57,41 +57,6 @@ impl std::str::FromStr for AppWindow {
 }
 
 impl AppWindow {
-    pub fn center_on_primary(
-        &self,
-        app: &tauri::AppHandle<tauri::Wry>,
-        window: &tauri::WebviewWindow<tauri::Wry>,
-    ) -> Result<(), crate::Error> {
-        if !matches!(self, Self::Main) {
-            return Ok(());
-        }
-
-        use tauri::PhysicalPosition;
-
-        let Some(monitor) = app.primary_monitor()? else {
-            return Ok(());
-        };
-        let window_scale_factor = window.scale_factor()?;
-        let window_size = window
-            .outer_size()?
-            .to_logical::<f64>(window_scale_factor)
-            .to_physical::<u32>(monitor.scale_factor());
-        let work_area = monitor.work_area();
-        let window_frame = WindowFrame::new(
-            0.0,
-            0.0,
-            f64::from(window_size.width),
-            f64::from(window_size.height),
-        );
-        let work_area = WindowFrame::from_physical(work_area.position, work_area.size);
-        let (x, y) = centered_window_position(window_frame, work_area);
-
-        window.set_position(PhysicalPosition::new(x, y))?;
-        tracing::info!("main_window_centered_on_primary");
-
-        Ok(())
-    }
-
     pub(crate) fn ensure_visible(
         &self,
         app: &tauri::AppHandle<tauri::Wry>,


### PR DESCRIPTION
Every app update recentered the main window on the primary display, discarding the user's saved position — with frequent releases this reset the window on most launches. ensure_visible already recenters when the saved frame is actually unreachable, so the blunt version-change recenter is redundant. Remove should_recenter_after_update, versions_indicate_update, and the now-unused AppWindow::center_on_primary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop window startup behavior change; existing off-screen recovery via `ensure_visible` remains on the show path.
> 
> **Overview**
> Removes **version-based main-window recentering** on desktop startup so updates no longer override the user’s saved window position.
> 
> Startup now only calls `AppWindow::Main.show` without comparing the previous and current app version via `updater2`. Deleted helpers include `should_recenter_after_update`, `versions_indicate_update`, and `AppWindow::center_on_primary`, along with their unit tests.
> 
> **`ensure_visible`** still runs when the main window is shown and recenters only when the saved frame has no accessible titlebar on any monitor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 627bc9422d40b1c3a0d954128190928d3aafe35a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->