### PR TITLE
fix(updater2): keep the install-at-open intent when the install fails

### DIFF
--- a/plugins/updater2/src/lib.rs
+++ b/plugins/updater2/src/lib.rs
@@ -67,8 +67,8 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
 
 // Takes the install-at-open intent and returns it for the next tick. A
 // completed pass installs (which restarts the app) and consumes the intent;
-// a meeting deferral or a transient check/download failure (e.g. network not
-// up yet at login) preserves it so a later tick can still install.
+// a meeting deferral or a transient check/download/install failure (e.g.
+// network not up yet at login) preserves it so a later tick can still install.
 async fn check_and_download<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     install_at_open: bool,
@@ -110,9 +110,13 @@ async fn check_and_download<R: tauri::Runtime>(
         return install_at_open;
     }
 
+    // install_and_relaunch re-checks the release feed before applying the bin,
+    // so it can fail transiently just like check/download; keep the intent so
+    // a later tick retries instead of disabling auto-install for the session.
     if install_at_open && updater2.has_cached_update(&version) {
         if let Err(e) = updater2.install_and_relaunch(&version).await {
             tracing::error!("cached_update_install_failed: {}", e);
+            return true;
         }
         return false;
     }
@@ -133,6 +137,7 @@ async fn check_and_download<R: tauri::Runtime>(
         }
         if let Err(e) = updater2.install_and_relaunch(&version).await {
             tracing::error!("downloaded_update_install_failed: {}", e);
+            return true;
         }
     }
 


### PR DESCRIPTION
Follow-up to #6897 addressing the Bugbot finding that landed with the
merge: install_and_relaunch re-checks the release feed before applying
the cached bin, so a transient network failure (or a newer release
landing mid-download) cleared install_at_open and disabled
auto-install for the whole session.

- return the intent when the cached-update install fails so a later
  tick retries
- same for the install right after an at-open download completes
- matches how transient check/download failures are already handled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change in the background updater loop; only affects retry behavior after install errors, not the install implementation itself.
> 
> **Overview**
> Fixes a regression where a failed **install-at-open** attempt cleared the session flag and stopped automatic installs until the next app launch.
> 
> In `check_and_download`, **`install_and_relaunch`** failures (cached update path and install-right-after-download path) now **return `true`** so the 30-minute loop keeps retrying, consistent with transient check/download errors. Comments note that install re-checks the release feed and can fail transiently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752e075c304fe96d78952ea971c98dbc67cfcf90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->