### PR TITLE
Show calendar metadata instead of Join & record when meeting is over

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -975,6 +975,31 @@ describe("OuterHeader", () => {
     expect(mocks.startListening).not.toHaveBeenCalled();
   });
 
+  it("shows only the calendar metadata button when the session is recorded but ended_at is missing", () => {
+    mocks.sessionEvents = {
+      "session-1": {
+        title: "Design Review",
+        started_at: "2026-06-05T10:00:00.000Z",
+        meeting_link: "https://meet.google.com/abc-defg-hij",
+      },
+    };
+    mocks.hasTranscriptBySession = { "session-1": true };
+    mocks.nowMs = new Date("2026-06-05T10:31:00.000Z").getTime();
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    expect(screen.getByTestId("metadata-calendar-icon")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Join & record" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
+    expect(mocks.startListening).not.toHaveBeenCalled();
+  });
+
   it("shows transcript editing in the meeting-action slot after an ad hoc meeting", () => {
     mocks.hasTranscriptBySession = { "session-1": true };
     const onTranscriptEditModeChange = vi.fn();

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -193,6 +193,19 @@ function HeaderMeetingControl({
     );
   }
 
+  if (
+    !isRecording &&
+    sessionMode === "inactive" &&
+    sessionEvent &&
+    (hasTranscript || audioExists)
+  ) {
+    return (
+      <div className="shrink-0">
+        <MetadataButton sessionId={sessionId} />
+      </div>
+    );
+  }
+
   if (ended && !isRecording) {
     return (
       <div className="shrink-0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When a scheduled session is no longer recording and audio/transcript exists, the outer header now shows the calendar metadata icon instead of the “Join & record” pill (covers cases where `ended_at` is missing).

Tests:
- Updated `apps/desktop/src/session/components/outer-header/index.test.tsx` with a new case for sessions recorded without an `ended_at` timestamp.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7ee1a78-3298-49e8-8135-5f4dd1d7ce4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7ee1a78-3298-49e8-8135-5f4dd1d7ce4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

