### PR TITLE
fix(desktop): keep transcript speaker labels aligned with text

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -127,6 +127,21 @@ describe("TranscriptViewer", () => {
     ).toBe("false");
   });
 
+  it("clips horizontal overflow so speaker labels stay aligned with text", () => {
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive={false}
+        scrollRef={createRef()}
+      />,
+    );
+
+    const container = document.querySelector("[data-transcript-container]");
+    expect(container?.className).toContain("overflow-x-clip");
+    expect(container?.className).toContain("min-w-0");
+  });
+
   it("keeps active transcript sessions pinned to the bottom", () => {
     render(
       <TranscriptViewer

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -290,7 +290,7 @@ export function TranscriptViewer({
         onClickCapture={handleSegmentSelection}
         onContextMenu={handleContextMenu}
         className={cn([
-          "flex h-full flex-col gap-8 overflow-x-hidden overflow-y-auto",
+          "flex h-full min-h-0 min-w-0 flex-col gap-8 overflow-x-clip overflow-y-auto",
           "scrollbar-hide",
           "scroll-pb-[calc(8rem+env(safe-area-inset-bottom))]",
           "pb-[calc(4rem+env(safe-area-inset-bottom))]",

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.test.tsx
@@ -30,6 +30,22 @@ describe("SegmentHeader", () => {
     expect(screen.queryByText("00:12 - 00:18")).toBeNull();
   });
 
+  it("keeps speaker labels in document flow with their text", () => {
+    const view = render(
+      <SegmentHeader
+        transcriptId="transcript-1"
+        sessionId="session-1"
+        label="J"
+        segment={createRemoteSegment(0)}
+      />,
+    );
+
+    const header = view.container.firstElementChild;
+    expect(header?.className).not.toContain("sticky");
+    expect(header?.className).not.toContain("-mx-3");
+    expect(header?.className).not.toContain("z-20");
+  });
+
   it("labels remote live segments as the unique other participant", () => {
     render(
       <SegmentHeader

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -18,8 +18,7 @@ export function SegmentHeader({
 }) {
   const colorVars = useSegmentColorVars(segment.key);
   const headerClassName = cn([
-    "bg-card sticky top-0 z-20",
-    "-mx-3 px-3 py-1",
+    "relative py-1",
     "text-xs font-light",
     "flex items-center gap-3",
     "[--segment-color:var(--segment-color-light)]",

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
@@ -102,7 +102,7 @@ export const SegmentRenderer = memo(
         data-segment-speaker-human-id={segment.key.speaker_human_id ?? ""}
         data-transcript-offset-ms={offsetMs}
         className={cn([
-          "-mx-2 rounded-lg px-2 transition-colors",
+          "rounded-lg px-2 transition-colors",
           "data-[transcript-selected=true]:bg-primary/10 data-[transcript-selected=true]:ring-primary/30 data-[transcript-selected=true]:ring-1",
         ])}
       >

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.test.tsx
@@ -97,7 +97,7 @@ describe("RenderTranscript", () => {
       />,
     );
 
-    expect(document.querySelectorAll("section").length).toBeLessThanOrEqual(20);
+    expect(document.querySelectorAll("section").length).toBeLessThanOrEqual(30);
     expect(
       document
         .querySelector("[data-transcript-virtual-total]")
@@ -259,7 +259,7 @@ describe("RenderTranscript", () => {
 
     renderTranscript();
 
-    expect(document.querySelectorAll("section").length).toBeLessThanOrEqual(20);
+    expect(document.querySelectorAll("section").length).toBeLessThanOrEqual(30);
     expect(
       document
         .querySelector("[data-transcript-virtual-total]")
@@ -308,7 +308,7 @@ describe("RenderTranscript", () => {
         "section[data-transcript-segment-id='segment-999']",
       ),
     ).toBeTruthy();
-    expect(document.querySelectorAll("section").length).toBeLessThanOrEqual(21);
+    expect(document.querySelectorAll("section").length).toBeLessThanOrEqual(30);
   });
 
   it("preserves visible segment nodes when incremental updates append", () => {
@@ -347,7 +347,7 @@ describe("RenderTranscript", () => {
     expect(
       document.querySelector("section[data-transcript-segment-id='segment-0']"),
     ).toBe(first);
-    expect(document.querySelectorAll("section").length).toBeLessThanOrEqual(20);
+    expect(document.querySelectorAll("section").length).toBeLessThanOrEqual(30);
   });
 });
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
@@ -321,7 +321,7 @@ const SegmentsList = memo(
       <div
         ref={virtual.listRef}
         data-transcript-virtual-total={segments.length}
-        className="relative"
+        className="relative w-full min-w-0 overflow-x-clip"
         style={{ height: virtual.totalHeight }}
       >
         {virtual.virtualItems.map(({ index, key, top }) => {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/virtual-segments.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/virtual-segments.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  estimateTranscriptRowHeight,
+  VirtualSegmentRow,
+} from "./virtual-segments";
+
+import type { Segment } from "~/stt/live-segment";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("estimateTranscriptRowHeight", () => {
+  it("keeps short speaker turns compact instead of reserving a large empty row", () => {
+    expect(
+      estimateTranscriptRowHeight(createSegment("Hi there."), 0),
+    ).toBeLessThan(80);
+    expect(estimateTranscriptRowHeight(createSegment(""), 1)).toBeLessThan(60);
+  });
+
+  it("grows with wrapped content instead of a flat minimum", () => {
+    const short = estimateTranscriptRowHeight(createSegment("Hi"), 0);
+    const long = estimateTranscriptRowHeight(
+      createSegment("word ".repeat(400).trim()),
+      0,
+    );
+    expect(long).toBeGreaterThan(short + 80);
+  });
+});
+
+describe("VirtualSegmentRow", () => {
+  it("positions rows with top offsets instead of transforms", () => {
+    const onMeasure = vi.fn();
+    const view = render(
+      <VirtualSegmentRow
+        rowKey="segment-1"
+        index={3}
+        top={240}
+        onMeasure={onMeasure}
+        onFocus={vi.fn()}
+        onBlur={vi.fn()}
+      >
+        <div>Speaker 1</div>
+      </VirtualSegmentRow>,
+    );
+
+    const row = view.container.querySelector(
+      "[data-transcript-virtual-index='3']",
+    );
+    expect(row).toBeInstanceOf(HTMLElement);
+    if (!(row instanceof HTMLElement)) {
+      throw new Error("expected virtual row");
+    }
+    expect(row.style.position).toBe("absolute");
+    expect(row.style.top).toBe("240px");
+    expect(row.style.width).toBe("100%");
+    expect(row.style.transform).toBe("");
+  });
+});
+
+function createSegment(text: string): Segment {
+  const words = text
+    ? text.split(/\s+/).map((word, index) => ({
+        id: `word-${index}`,
+        text: word,
+        start_ms: index * 100,
+        end_ms: index * 100 + 80,
+        channel: "MixedCapture" as const,
+        is_final: true,
+      }))
+    : [];
+
+  return {
+    id: "segment-1",
+    key: {
+      channel: "MixedCapture",
+      speaker_index: 0,
+      speaker_human_id: null,
+    },
+    start_ms: 0,
+    end_ms: Math.max(0, words.length * 100),
+    text,
+    words,
+  };
+}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/virtual-segments.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/virtual-segments.tsx
@@ -19,13 +19,28 @@ import {
 
 import type { Segment } from "~/stt/live-segment";
 
-const ESTIMATED_LINE_HEIGHT = 24;
+const ESTIMATED_LINE_HEIGHT = 22;
 const ESTIMATED_ROW_CHARS = 90;
-const ESTIMATED_ROW_CHROME = 64;
-const MINIMUM_ROW_HEIGHT = 88;
+const ESTIMATED_ROW_CHROME = 36;
 const SEGMENT_GAP = 16;
 const OVERSCAN_PX = 800;
 const FALLBACK_VIEWPORT_HEIGHT = 800;
+
+export function estimateTranscriptRowHeight(segment: Segment, index: number) {
+  const characterCount = segment.words.reduce(
+    (total, word) => total + word.text.length + 1,
+    0,
+  );
+  const lineCount =
+    characterCount === 0
+      ? 0
+      : Math.max(1, Math.ceil(characterCount / ESTIMATED_ROW_CHARS));
+  return (
+    ESTIMATED_ROW_CHROME +
+    lineCount * ESTIMATED_LINE_HEIGHT +
+    (index > 0 ? SEGMENT_GAP : 0)
+  );
+}
 
 export function useVirtualSegments({
   segments,
@@ -57,20 +72,9 @@ export function useVirtualSegments({
 
   const estimatedHeights = useMemo(
     () =>
-      segments.map((segment, index) => {
-        const characterCount = segment.words.reduce(
-          (total, word) => total + word.text.length + 1,
-          0,
-        );
-        const contentHeight =
-          ESTIMATED_ROW_CHROME +
-          Math.ceil(characterCount / ESTIMATED_ROW_CHARS) *
-            ESTIMATED_LINE_HEIGHT;
-        return (
-          Math.max(MINIMUM_ROW_HEIGHT, contentHeight) +
-          (index > 0 ? SEGMENT_GAP : 0)
-        );
-      }),
+      segments.map((segment, index) =>
+        estimateTranscriptRowHeight(segment, index),
+      ),
     [segments],
   );
   const offsets = useMemo(() => {
@@ -80,7 +84,7 @@ export function useVirtualSegments({
         values[index] +
           (measuredHeights.get(key) ??
             estimatedHeights[index] ??
-            MINIMUM_ROW_HEIGHT),
+            ESTIMATED_ROW_CHROME),
       );
     }
     return values;
@@ -321,8 +325,7 @@ export function VirtualSegmentRow({
       observerRef.current = null;
       if (!node) return;
 
-      const measure = () =>
-        onMeasure(rowKey, node.getBoundingClientRect().height);
+      const measure = () => onMeasure(rowKey, node.offsetHeight);
       measure();
       if (typeof ResizeObserver !== "undefined") {
         observerRef.current = new ResizeObserver(measure);
@@ -335,9 +338,8 @@ export function VirtualSegmentRow({
     () => ({
       left: 0,
       position: "absolute",
-      right: 0,
-      top: 0,
-      transform: `translateY(${top}px)`,
+      top,
+      width: "100%",
     }),
     [top],
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why it looked like a mess

Live transcript turns were virtualized in #6797 (`position: absolute` + `translateY`), but segment chrome still assumed a normal document flow:

1. **Sticky speaker headers** (`sticky top-0` + opaque `bg-card`) escaped transformed rows on WebKit, so names like `J` / `Speaker 1` floated away from their text.
2. **Full-bleed negative margins** (`-mx-3` / `-mx-2`) made the scroller wider than the viewport, which produced the bottom scrollbar and shifted blocks.
3. **An 88px minimum row height** reserved large empty slots for short live turns, so labels sat in a column of gaps with the actual words at the bottom.

## Fix

- Keep speaker labels in document flow with their text (no sticky overlay).
- Position virtual rows with `top` and measure `offsetHeight` instead of transformed bounding boxes.
- Estimate compact row heights for short turns.
- Clip horizontal overflow on the transcript scroller.

## Validation

- `pnpm exec dprint check` on changed transcript files
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/` (0 errors)
- `pnpm -F desktop test` — 3160 passed

Full-repo `pnpm fmt:check` was skipped here: this environment cannot run rustfmt/swiftformat.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6470d80-2108-462f-9ae3-f8613874f8a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6470d80-2108-462f-9ae3-f8613874f8a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

