### PR TITLE
ci: migrate Linux runners from Depot to free GitHub-hosted runners

### DIFF
--- a/.github/actions/install_desktop_deps/action.yaml
+++ b/.github/actions/install_desktop_deps/action.yaml
@@ -16,6 +16,8 @@ runs:
     - if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /usr/local/share/powershell 2> /dev/null || true
+        df -h /
         if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
           sudo sed -i \
             's|http://us-east-1.ec2.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \

--- a/.github/workflows/bot_cd.yaml
+++ b/.github/workflows/bot_cd.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     concurrency: bot-fly-deploy
     steps:

--- a/.github/workflows/bot_ci.yaml
+++ b/.github/workflows/bot_ci.yaml
@@ -5,7 +5,7 @@ on:
       - apps/bot/**
 jobs:
   ci:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/chrome_cd.yaml
+++ b/.github/workflows/chrome_cd.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   zip:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm_install

--- a/.github/workflows/chrome_ci.yaml
+++ b/.github/workflows/chrome_ci.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   chrome_ci:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm_install

--- a/.github/workflows/cli_ci.yaml
+++ b/.github/workflows/cli_ci.yaml
@@ -62,12 +62,15 @@ concurrency:
 
 jobs:
   cli-ci:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
+      - run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /usr/local/share/powershell 2> /dev/null || true
+          df -h /
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -343,14 +343,14 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - runner: depot-ubuntu-24.04-8
+          - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             rust_platform: linux-x86_64
             artifact_name: x64
             debian_arch: amd64
             file_arch: x86-64
             docker_arch: amd64
-          - runner: depot-ubuntu-24.04-arm-8
+          - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             rust_platform: linux-aarch64
             artifact_name: arm64

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -389,7 +389,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: depot-ubuntu-24.04-8
+          - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             rust_platform: linux-x86_64
             artifact_name: x64
@@ -397,7 +397,7 @@ jobs:
             file_arch: x86-64
             docker_arch: amd64
             cloudsync_arch: x86_64
-          - runner: depot-ubuntu-24.04-arm-8
+          - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             rust_platform: linux-aarch64
             artifact_name: arm64

--- a/.github/workflows/desktop_e2e.yaml
+++ b/.github/workflows/desktop_e2e.yaml
@@ -7,7 +7,7 @@ concurrency:
 
 jobs:
   e2e-linux:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/desktop_linux_audio_qa.yaml
+++ b/.github/workflows/desktop_linux_audio_qa.yaml
@@ -119,11 +119,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: depot-ubuntu-24.04-8
+          - runner: ubuntu-24.04
             artifact_arch: x64
             public_platform: debian-x86_64
             debian_arch: amd64
-          - runner: depot-ubuntu-24.04-arm-8
+          - runner: ubuntu-24.04-arm
             artifact_arch: arm64
             public_platform: debian-aarch64
             debian_arch: arm64

--- a/.github/workflows/extensions_cd.yaml
+++ b/.github/workflows/extensions_cd.yaml
@@ -7,7 +7,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2

--- a/.github/workflows/fmt.yaml
+++ b/.github/workflows/fmt.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 jobs:
   fmt:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 jobs:
   lint:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -81,10 +81,13 @@ jobs:
             --no-bundler
 
   android_build:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+      - run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /usr/local/share/powershell 2> /dev/null || true
+          df -h /
       - uses: ./.github/actions/pnpm_install
       - uses: ./.github/actions/rust_install
         with:

--- a/.github/workflows/pro_api_e2e.yaml
+++ b/.github/workflows/pro_api_e2e.yaml
@@ -22,9 +22,12 @@ on:
 jobs:
   pro-transcription:
     name: Pro transcription API
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+      - run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /usr/local/share/powershell 2> /dev/null || true
+          df -h /
       - uses: ./.github/actions/rust_install
         with:
           platform: linux
@@ -42,9 +45,12 @@ jobs:
 
   pro-intelligence:
     name: Pro intelligence API
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+      - run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /usr/local/share/powershell 2> /dev/null || true
+          df -h /
       - uses: ./.github/actions/rust_install
         with:
           platform: linux

--- a/.github/workflows/stripe_cd.yaml
+++ b/.github/workflows/stripe_cd.yaml
@@ -21,7 +21,7 @@ jobs:
 
   deploy:
     needs: compute-version
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     concurrency: stripe-fly-deploy
     permissions:

--- a/.github/workflows/web_cd.yaml
+++ b/.github/workflows/web_cd.yaml
@@ -21,7 +21,7 @@ jobs:
 
   deploy:
     needs: compute-version
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     concurrency: web-netlify-deploy
     steps:

--- a/.github/workflows/web_ci.yaml
+++ b/.github/workflows/web_ci.yaml
@@ -15,7 +15,7 @@ on:
       - packages/**
 jobs:
   ci:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm_install

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   zizmor:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write
       contents: read


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Since this repo is public/open-source, **standard GitHub-hosted runners are free and unlimited** (confirmed against GitHub's 2026 docs). Depot is being paid for something GitHub provides for free here, so this migrates all Linux CI/CD off Depot.

## What changed

- **All `depot-ubuntu-*` runners → free GitHub-hosted runners:**
  - `depot-ubuntu-24.04-8` / `depot-ubuntu-24.04-4` → `ubuntu-24.04`
  - `depot-ubuntu-24.04-arm-8` → `ubuntu-24.04-arm` (free arm64 for public repos)
  - Covers: `fmt`, `lint`, `zizmor`, `web_ci`/`web_cd`, `cli_ci`, `api`-adjacent, `chrome_*`, `bot_*`, `stripe_cd`, `extensions_cd`, `pro_api_e2e`, `desktop_ci` (linux), `desktop_cd` (linux), `desktop_e2e` (linux), `desktop_linux_audio_qa`, `mobile_ci` (android).
- **Disk cleanup added to heavy Rust/Tauri/Android jobs.** Free runners have a **14 GB disk**; a debug `cargo test -p desktop` / `tauri build` can approach that. A small step removes preinstalled bloat (Android SDK*, .NET, GHC, CodeQL, PowerShell), freeing ~15–19 GB. Added via the shared `install_desktop_deps` action (Linux branch → covers desktop CI/CD/e2e Linux) and directly to `mobile_ci` android, `cli_ci`, and `pro_api_e2e`.
  - *The Android SDK is preserved in the `android_build` job (it needs it); removed elsewhere.

## Deliberately NOT in this PR

- **macOS jobs stay on Depot** (`desktop_ci` macos, `desktop_cd` macos, `desktop_e2e` macos, `mobile_ci` ios+watchos, `desktop_swift`). Free macOS runners are M1 **3-core / 7 GB RAM / 14 GB disk** — tight for Xcode + Tauri. These should move in a follow-up **after one validation run** confirms they fit.
- **No trigger/QA-scope changes.** This is purely a runner swap; moving heavy builds off per-PR to nightly/release is a separate discussion.

## Tradeoffs

- Free standard runners are smaller (4 vCPU vs Depot 8) and cap concurrency on public repos, so wall-clock will increase somewhat. No per-minute cost on public repos.
- Depot's remote cache is lost; jobs rely on the existing `Swatinem/rust-cache` in `rust_install` (10 GB/repo Actions cache cap applies).

## Validation

- All 19 workflow/action files parse as valid YAML and pass `dprint check`.
- Only intended `depot-macos-*` references remain; zero `depot-ubuntu` references left.
- Each disk-cleanup step prints `df -h /` so the first runs will show real free space on the new runners.

Recommended: run `desktop_ci` and `mobile_ci` (android) on this PR to confirm the Linux builds fit under 14 GB before merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4dbd805-bd1d-4a62-84a5-295f69efdaf2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4dbd805-bd1d-4a62-84a5-295f69efdaf2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

