### PR TITLE
fix(desktop): prevent startup white screen from blocked init tasks

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -49,6 +49,7 @@ import { listenerStore } from "./store/zustand/listener/instance";
 
 const toolRegistry = createToolRegistry();
 const queryClient = new QueryClient();
+const STARTUP_TASK_TIMEOUT_MS = 10_000;
 
 const router = createRouter({
   routeTree,
@@ -146,23 +147,6 @@ async function enableReactScanInDev() {
 }
 
 async function renderApp() {
-  if (isMainWindow) {
-    await refreshLegacySettingsSnapshots().catch((error) => {
-      captureOperationalError(error, {
-        operation: "legacy_settings_refresh",
-      });
-    });
-    await initializeApplicationSettings().catch((error) => {
-      captureOperationalError(error, {
-        operation: "application_settings_initialize",
-      });
-    });
-    await migratePlaintextAiProviderApiKeys().catch((error) => {
-      captureOperationalError(error, {
-        operation: "ai_credentials_migrate",
-      });
-    });
-  }
   await Promise.all([bootstrapThemeFromSettings(), enableReactScanInDev()]);
   const root = ReactDOM.createRoot(rootElement);
   root.render(
@@ -170,8 +154,51 @@ async function renderApp() {
       <AppRoot />
     </StrictMode>,
   );
+  runMainWindowStartupTasks();
 }
 
 if (!rootElement.innerHTML) {
   void renderApp();
+}
+
+function runMainWindowStartupTasks() {
+  if (!isMainWindow) {
+    return;
+  }
+
+  void runStartupTask(
+    "legacy_settings_refresh",
+    refreshLegacySettingsSnapshots,
+  );
+  void runStartupTask(
+    "application_settings_initialize",
+    initializeApplicationSettings,
+  );
+  void runStartupTask(
+    "ai_credentials_migrate",
+    migratePlaintextAiProviderApiKeys,
+  );
+}
+
+async function runStartupTask(
+  operation: string,
+  task: () => Promise<void>,
+): Promise<void> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+  await new Promise<void>((resolve, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new Error(`startup operation timed out: ${operation}`));
+    }, STARTUP_TASK_TIMEOUT_MS);
+
+    void task().then(resolve, reject);
+  })
+    .catch((error) => {
+      captureOperationalError(error, { operation });
+    })
+    .finally(() => {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- render the desktop React root as soon as theme bootstrapping finishes instead of waiting for main-window startup tasks
- move legacy settings snapshot refresh, application settings initialization, and plaintext AI key migration off the render-critical path
- wrap each post-render startup task with a 10s timeout guard and operational error capture so stalled tasks cannot keep the app on a blank screen

## Validation
- `pnpm exec dprint fmt apps/desktop/src/main.tsx`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop typecheck`
- `pnpm -F desktop test`

## Notes
- attempted full-repo formatting checks (`pnpm exec dprint fmt` and `pnpm fmt:check`) but this environment is missing required Swift formatting binaries and has a broken Rust toolchain install state, causing unrelated formatter failures outside this change scope.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adaeb403-cfa0-42eb-9ddb-c4e9b24d01fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adaeb403-cfa0-42eb-9ddb-c4e9b24d01fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

