### PR TITLE
ci: fast checks per PR, batch heavy builds to main/nightly/release

### DIFF
--- a/.github/workflows/api_ci.yaml
+++ b/.github/workflows/api_ci.yaml
@@ -22,6 +22,11 @@ on:
       - crates/api-sync/**
       - crates/llm-proxy/**
       - crates/transcribe-proxy/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/bot_ci.yaml
+++ b/.github/workflows/bot_ci.yaml
@@ -3,6 +3,11 @@ on:
   pull_request:
     paths:
       - apps/bot/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-24.04

--- a/.github/workflows/chrome_ci.yaml
+++ b/.github/workflows/chrome_ci.yaml
@@ -19,6 +19,10 @@ on:
       - .github/actions/pnpm_install/**
       - .github/workflows/chrome_ci.yaml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chrome_ci:
     runs-on: ubuntu-24.04

--- a/.github/workflows/db_ci.yaml
+++ b/.github/workflows/db_ci.yaml
@@ -10,6 +10,10 @@ on:
     paths:
       - supabase/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -1,6 +1,8 @@
 # https://github.com/tauri-apps/tauri-action/blob/3013cac/examples/test-build-only.yml
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * *"
   push:
     branches:
       - main
@@ -27,9 +29,27 @@ on:
       - crates/**
       - Cargo.toml
       - Cargo.lock
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  macos_ci:
+  js_ci:
     if: ${{ !startsWith(github.head_ref || '', 'blog/') }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: ./.github/actions/pnpm_install
+      - run: pnpm -F ui build
+      - run: pnpm -F desktop typecheck
+      - run: pnpm -F desktop test
+
+  macos_ci:
+    if: ${{ github.event_name != 'pull_request' && !startsWith(github.head_ref || '', 'blog/') }}
     defaults:
       run:
         shell: bash
@@ -171,7 +191,7 @@ jobs:
             plugins/db/permissions/schemas/schema.json
 
   windows_ci:
-    if: ${{ !startsWith(github.head_ref || '', 'blog/') }}
+    if: ${{ github.event_name != 'pull_request' && !startsWith(github.head_ref || '', 'blog/') }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -388,23 +408,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - runner: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
-            rust_platform: linux-x86_64
-            artifact_name: x64
-            debian_arch: amd64
-            file_arch: x86-64
-            docker_arch: amd64
-            cloudsync_arch: x86_64
-          - runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            rust_platform: linux-aarch64
-            artifact_name: arm64
-            debian_arch: arm64
-            file_arch: ARM aarch64
-            docker_arch: arm64
-            cloudsync_arch: aarch64
+        include: ${{ github.event_name == 'pull_request' && fromJSON('[{"runner":"ubuntu-24.04","target":"x86_64-unknown-linux-gnu","rust_platform":"linux-x86_64","artifact_name":"x64","debian_arch":"amd64","file_arch":"x86-64","docker_arch":"amd64","cloudsync_arch":"x86_64"}]') || fromJSON('[{"runner":"ubuntu-24.04","target":"x86_64-unknown-linux-gnu","rust_platform":"linux-x86_64","artifact_name":"x64","debian_arch":"amd64","file_arch":"x86-64","docker_arch":"amd64","cloudsync_arch":"x86_64"},{"runner":"ubuntu-24.04-arm","target":"aarch64-unknown-linux-gnu","rust_platform":"linux-aarch64","artifact_name":"arm64","debian_arch":"arm64","file_arch":"ARM aarch64","docker_arch":"arm64","cloudsync_arch":"aarch64"}]') }}
     runs-on: ${{ matrix.runner }}
     defaults:
       run:
@@ -614,7 +618,7 @@ jobs:
       - run: pnpm -F desktop i18n:check
 
   desktop_swift:
-    if: ${{ !startsWith(github.head_ref || '', 'blog/') }}
+    if: ${{ github.event_name != 'pull_request' && !startsWith(github.head_ref || '', 'blog/') }}
     runs-on: depot-macos-15
     defaults:
       run:
@@ -629,6 +633,7 @@ jobs:
   ci:
     if: always()
     needs: [
+      js_ci,
       macos_ci,
       windows_ci,
       linux_ci,

--- a/.github/workflows/fmt.yaml
+++ b/.github/workflows/fmt.yaml
@@ -6,6 +6,11 @@ on:
       - main
       - .github/workflows/fmt.yaml
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fmt:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -2,6 +2,8 @@ name: mobile_ci
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * *"
   push:
     branches:
       - main
@@ -42,13 +44,26 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: "1"
   EXPO_NO_GIT_STATUS: "1"
   SENTRY_DISABLE_AUTO_UPLOAD: "true"
 
 jobs:
+  mobile_checks:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pnpm_install
+      - run: pnpm -F @anlg/mobile typecheck
+      - run: pnpm -F @anlg/mobile test
+
   watchos_build:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: depot-macos-26
     timeout-minutes: 30
     steps:
@@ -64,6 +79,7 @@ jobs:
             build
 
   ios_build:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: depot-macos-26
     timeout-minutes: 45
     steps:
@@ -81,6 +97,7 @@ jobs:
             --no-bundler
 
   android_build:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
@@ -107,7 +124,7 @@ jobs:
 
   mobile_ci:
     if: always()
-    needs: [watchos_build, ios_build, android_build]
+    needs: [mobile_checks, watchos_build, ios_build, android_build]
     runs-on: ubuntu-latest
     steps:
       - run: exit 1

--- a/.github/workflows/pro_api_e2e.yaml
+++ b/.github/workflows/pro_api_e2e.yaml
@@ -2,6 +2,8 @@ name: Pro API E2E
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * *"
   push:
     branches:
       - main
@@ -11,13 +13,9 @@ on:
       - crates/owhisper-client/**
       - crates/soniox/**
       - crates/transcribe-proxy/**
-  pull_request:
-    paths:
-      - .github/workflows/pro_api_e2e.yaml
-      - crates/llm-proxy/**
-      - crates/owhisper-client/**
-      - crates/soniox/**
-      - crates/transcribe-proxy/**
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pro-transcription:

--- a/.github/workflows/web_ci.yaml
+++ b/.github/workflows/web_ci.yaml
@@ -13,6 +13,11 @@ on:
     paths:
       - apps/web/**
       - packages/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-24.04

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -3,6 +3,10 @@ on:
     branches: ["main"]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     runs-on: ubuntu-24.04

--- a/RELEASE_AUDIT.md
+++ b/RELEASE_AUDIT.md
@@ -1,0 +1,50 @@
+# Release audit
+
+Heavy, cross-platform verification is deliberately **not** run on every PR. It is
+batched into a short audit performed just before cutting a release. This keeps
+per-PR feedback fast (so the Bugbot → fix → push loop stays cheap) while the real
+"moment of truth" happens once, on purpose.
+
+## CI model
+
+- **Per PR (fast lane, Linux only):** lint, format, typecheck, unit/integration
+  tests, and Linux `cargo check`/`cargo test`. Deduplicated via
+  `concurrency: cancel-in-progress`, so rapid pushes cancel superseded runs.
+- **On merge to `main` + nightly (`schedule`):** the full desktop matrix
+  (macOS, Windows, Linux arm64, Swift) and the mobile native builds
+  (iOS, watchOS, Android). Nightly catches platform breakage within a day and
+  attributes it to a small window — keeping the release audit a clean diff review
+  rather than a regression hunt.
+- **Release (this audit):** full builds + signing + real-hardware QA.
+
+## Audit checklist
+
+Run these before publishing a stable desktop release.
+
+1. **Read the cumulative diff since the last version.**
+   `git diff <last-stable-tag>..main -- apps/desktop/src-tauri plugins crates apps/desktop/src`
+   (see the `diff` task in `Taskfile.yaml`). Polish from first principles:
+   simplify, delete dead code, reconcile inconsistencies introduced across PRs.
+
+2. **Confirm the heavy suites are green** on the release candidate:
+   - `desktop_ci` and `mobile_ci` — trigger via `workflow_dispatch` on the
+     candidate (or confirm the latest nightly on `main` passed).
+   - `pro_api_e2e` — nightly/dispatch (live provider APIs).
+
+3. **Build + sign all platforms** via `desktop_cd` (`staging` first, then
+   `stable`). This produces the signed macOS/Windows/Linux artifacts.
+
+4. **Real-hardware QA** (cannot run in CI/Cloud Agent):
+   - Critical Pro user journey on a Mac — follow `.agents/skills/qa-critical-ux`.
+   - Linux system-audio capture — `desktop_linux_audio_qa` against the candidate.
+
+5. **Changelog** — add the entry via `.agents/skills/new-changelog`.
+
+6. **Cut the release** — follow `.agents/skills/release-new-version`.
+
+## Notes
+
+- Anything that fails incidentally but is out of scope for the release gate is
+  tracked in Linear, not patched into the candidate (see `qa-critical-ux`).
+- macOS/iOS/watchOS/Windows verification requires real Apple/Windows machines;
+  the Linux Cloud Agent covers authoring + Linux-native checks only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Per-PR CI currently reruns the full multi-platform build suite on every push, so the Bugbot → fix → push loop is expensive. This moves expensive verification off the fast-feedback path and batches it into merge/nightly/release, keeping per-PR feedback quick.

**Stacked on [#6917](https://github.com/fastrepl/anarlog/pull/6917)** (the Depot→GitHub runner migration) since both touch the same workflows — base this on that branch; retarget to `main` once #6917 merges.

## What changed

**1. Cancel superseded runs** — added `concurrency: { group: <workflow>-<ref>, cancel-in-progress: true }` to the CI workflows that lacked it (`desktop_ci`, `mobile_ci`, `api_ci`, `web_ci`, `fmt`, `lint`, `zizmor`, `chrome_ci`, `bot_ci`, `db_ci`, `pro_api_e2e`). Pushing 5 times now cancels the first 4 runs instead of running all 5.

**2. `desktop_ci` — fast lane on PRs, heavy on main/nightly/dispatch:**
- New `js_ci` (Linux): `pnpm -F ui build` + desktop `typecheck` + `test` (previously only ran inside the macOS job). Verified these pass on Linux.
- `linux_ci`: conditional matrix — **x64 only on PRs**, x64 + arm64 otherwise.
- `macos_ci`, `windows_ci`, `desktop_swift`: gated to `github.event_name != 'pull_request'`.
- Added a nightly `schedule` and `js_ci` to the `ci` aggregation gate.

**3. `mobile_ci` — fast lane on PRs:**
- New `mobile_checks` (Linux): `pnpm -F @anlg/mobile typecheck` + `test`.
- `watchos_build`, `ios_build`, `android_build`: gated off PRs → main/nightly/dispatch.

**4. `pro_api_e2e`** (hits live provider APIs): removed the `pull_request` trigger → runs on `push:main` + nightly + dispatch.

**5. `RELEASE_AUDIT.md`** — documents the model (per-PR fast lane / nightly on `main` / deliberate pre-release audit) and a checklist that ties into the existing `qa-critical-ux`, `desktop_cd`, `desktop_linux_audio_qa`, `new-changelog`, and `release-new-version` skills/workflows.

## Result

- **PRs run:** lint, fmt, typecheck, unit/integration tests, Linux `cargo check`/`cargo test` (x64) — minutes, deduped.
- **`main` + nightly run:** full desktop matrix (macOS/Windows/Linux arm64/Swift) + mobile native builds. Nightly catches platform breakage within a day so the release audit stays a clean diff review.
- **Release:** full builds + real-hardware QA, done deliberately.

The required `ci` / `mobile_ci` aggregation gates still run on every PR and pass when heavy jobs are skipped (`skipped` ≠ `failure`).

## Validation & caveats

- All workflows parse as valid YAML and pass `dprint check`.
- I can't execute GitHub Actions from here, so the trigger logic (skip-on-PR gates, conditional matrix, aggregation with skipped needs) should get one real run to confirm — open this PR (fast lane only should fire) and dispatch `desktop_ci`/`mobile_ci` once to confirm the full suite still runs on non-PR events.
- Draft-gating was intentionally left out: with the fast lane + cancel-in-progress, per-PR CI is already cheap, and the Bugbot loop happens on *ready* PRs (where draft-gating wouldn't apply). Easy to add later if you want zero CI on drafts.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4dbd805-bd1d-4a62-84a5-295f69efdaf2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4dbd805-bd1d-4a62-84a5-295f69efdaf2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

