### PR TITLE
Add reset button to disable Intelligence providers

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr "Resend invitation"
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr "Reset"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -2577,6 +2577,7 @@ msgid "Resend invitation"
 msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
+#: src/settings/ai/shared/index.tsx
 msgid "Reset"
 msgstr ""
 

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@iconify-icon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { ArrowSquareOut } from "@phosphor-icons/react";
+import { ArrowSquareOut, CircleNotch } from "@phosphor-icons/react";
 import { type AnyFieldApi, useForm } from "@tanstack/react-form";
 import { useMutation, useQueries } from "@tanstack/react-query";
 import { type ReactNode, useMemo, useState } from "react";
@@ -39,8 +39,10 @@ import {
   repairKeychainAccess,
   useAiProviders,
   useAiProvidersState,
+  useClearAiProvider,
   useSetAiProvider,
 } from "~/settings/providers";
+import { setSettingValues } from "~/settings/queries";
 import { SettingsAlertToast } from "~/shared/ui/settings-alert";
 
 export * from "./anarlog-cloud-button";
@@ -249,6 +251,7 @@ export function NonAnarlogProviderCard({
     providerType,
     config.id,
   );
+  const clearProvider = useClearAiProvider(providerType, config.id);
   const [hasUnresolvedKeychainError, setHasUnresolvedKeychainError] =
     useState(false);
   const [isKeychainRecoveryInProgress, setIsKeychainRecoveryInProgress] =
@@ -326,6 +329,40 @@ export function NonAnarlogProviderCard({
     ? t`Unlock your login Keychain in the macOS prompt. Anarlog will retry saving this API key automatically.`
     : (repairMutation.error?.message ??
       t`macOS cannot access your login Keychain. Repairing briefly locks it and asks for your Mac password before Anarlog retries this API key.`);
+  const hasStoredConfig =
+    Boolean(provider?.api_key?.trim()) ||
+    Boolean(
+      provider?.base_url?.trim() &&
+      provider.base_url.trim() !== (config.baseUrl ?? "").trim(),
+    );
+
+  const handleReset = async () => {
+    if (clearProvider.isPending) {
+      return;
+    }
+
+    try {
+      await clearProvider.mutateAsync();
+
+      if (currentProvider === config.id) {
+        await setSettingValues(
+          providerType === "llm"
+            ? { current_llm_provider: "", current_llm_model: "" }
+            : { current_stt_provider: "", current_stt_model: "" },
+        );
+      }
+
+      form.reset({
+        type: providerType,
+        base_url: config.baseUrl ?? "",
+        api_key: "",
+      });
+      setHasUnresolvedKeychainError(false);
+      providerMutation.reset();
+    } catch {
+      return;
+    }
+  };
 
   return (
     <AccordionItem
@@ -463,6 +500,31 @@ export function NonAnarlogProviderCard({
                 </div>
               </details>
             )}
+          {hasStoredConfig ? (
+            <button
+              type="button"
+              onClick={() => void handleReset()}
+              disabled={clearProvider.isPending}
+              className={cn([
+                "inline-flex cursor-pointer items-center gap-1 self-start text-xs",
+                "text-muted-foreground hover:text-foreground transition-colors",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+              ])}
+            >
+              {clearProvider.isPending ? (
+                <CircleNotch
+                  className="size-3 animate-spin"
+                  aria-hidden="true"
+                />
+              ) : null}
+              <Trans>Reset</Trans>
+            </button>
+          ) : null}
+          {clearProvider.error && (
+            <p className="text-destructive text-xs">
+              {clearProvider.error.message}
+            </p>
+          )}
           {providerMutation.error &&
             !isKeychainAccessError(providerMutation.error) && (
               <p className="text-destructive text-xs">

--- a/apps/desktop/src/settings/providers.test.ts
+++ b/apps/desktop/src/settings/providers.test.ts
@@ -44,6 +44,7 @@ vi.mock("~/db/write-queue", () => ({
 }));
 
 import {
+  clearAiProvider,
   getStoredAiProvider,
   isKeychainAccessError,
   loadSecureAiProviderApiKeys,
@@ -179,6 +180,53 @@ describe("SQLite AI providers", () => {
       "stt:deepgram",
       "new-key",
     );
+  });
+
+  it("clears stored provider credentials and deletes the SQLite row", async () => {
+    mocks.execute.mockResolvedValueOnce([
+      {
+        id: "ai_provider:llm:google",
+        value_json: JSON.stringify({
+          type: "llm",
+          base_url: "https://generativelanguage.googleapis.com/v1beta",
+          api_key: "",
+        }),
+      },
+      {
+        id: "legacy_settings_document",
+        value_json: JSON.stringify({
+          ai: {
+            llm: {
+              google: {
+                base_url: "https://generativelanguage.googleapis.com/v1beta",
+                api_key: "legacy-key",
+              },
+            },
+          },
+        }),
+      },
+    ]);
+    mocks.getSecret.mockResolvedValueOnce({
+      status: "ok",
+      data: "gemini-key",
+    });
+
+    await clearAiProvider("llm", "google");
+
+    expect(mocks.deleteSecret).toHaveBeenCalledWith(
+      "ai-provider-api-keys",
+      "llm:google",
+    );
+    const deleteStatement = mocks.executeTransaction.mock.calls[0][0].find(
+      (candidate: { sql: string }) =>
+        candidate.sql.includes("DELETE FROM app_settings"),
+    )!;
+    expect(deleteStatement.params[0]).toBe("ai_provider:llm:google");
+    const legacyUpdate = mocks.executeTransaction.mock.calls[0][0].find(
+      (candidate: { params: unknown[] }) =>
+        candidate.params.includes("legacy_settings_document"),
+    )!;
+    expect(String(legacyUpdate.params[0])).not.toContain("google");
   });
 
   it("retries partial writes without dropping a concurrent field", async () => {

--- a/apps/desktop/src/settings/providers.ts
+++ b/apps/desktop/src/settings/providers.ts
@@ -207,6 +207,85 @@ export function useSetAiProvider(type: AiProviderType, providerId: string) {
   });
 }
 
+export function clearAiProvider(
+  type: AiProviderType,
+  providerId: string,
+): Promise<void> {
+  const storageId = providerStorageId(type, providerId);
+  return enqueueDatabaseWrite(storageId, async () => {
+    const previousApiKey = await getProviderApiKey(type, providerId);
+
+    try {
+      await setProviderApiKey(type, providerId, "");
+
+      const rows = await liveQueryClient.execute<AppSettingRow>(
+        `
+          SELECT id, value_json
+          FROM app_settings
+          WHERE id IN (?, ?)
+        `,
+        [storageId, LEGACY_SETTINGS_ID],
+      );
+      const direct = rows.find((row) => row.id === storageId);
+      const legacyRow = rows.find((row) => row.id === LEGACY_SETTINGS_ID);
+      const now = new Date().toISOString();
+      const statements: Array<{ sql: string; params: unknown[] }> = [];
+
+      if (direct) {
+        statements.push({
+          sql: `
+            DELETE FROM app_settings
+            WHERE id = ? AND value_json = ?
+          `,
+          params: [storageId, direct.value_json],
+        });
+      }
+
+      const clearedLegacy = removeLegacyProvider(
+        legacyRow?.value_json,
+        type,
+        providerId,
+      );
+      if (legacyRow && clearedLegacy) {
+        statements.push({
+          sql: `
+            UPDATE app_settings
+            SET value_json = ?, updated_at = ?
+            WHERE id = ?
+          `,
+          params: [clearedLegacy, now, LEGACY_SETTINGS_ID],
+        });
+      }
+
+      if (statements.length > 0) {
+        await executeTransaction(statements);
+      }
+    } catch (error) {
+      await setProviderApiKey(type, providerId, previousApiKey ?? "");
+      throw error;
+    }
+  });
+}
+
+export function useClearAiProvider(type: AiProviderType, providerId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["clear-ai-provider", type, providerId],
+    mutationFn: () => clearAiProvider(type, providerId),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["ai-provider-api-keys", type],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["default-ai-selection", type],
+        }),
+      ]);
+    },
+  });
+}
+
 export async function loadSecureAiProviderApiKeys(
   providerRowIds: string[],
   type: AiProviderType,
@@ -462,6 +541,28 @@ function redactLegacyProviderApiKey(
     }
 
     provider.api_key = "";
+    return JSON.stringify(document);
+  } catch {
+    return null;
+  }
+}
+
+function removeLegacyProvider(
+  valueJson: string | undefined,
+  type: AiProviderType,
+  providerId: string,
+): string | null {
+  if (!valueJson) return null;
+
+  try {
+    const document = JSON.parse(valueJson) as Record<string, unknown>;
+    const ai = parseObjectValue(document.ai);
+    const providers = parseObjectValue(ai[type]);
+    if (!(providerId in providers)) {
+      return null;
+    }
+
+    delete providers[providerId];
     return JSON.stringify(document);
   } catch {
     return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users who configure an Intelligence provider (e.g. Gemini) had no way to go back to a clean, unconfigured state. Once an API key was saved, the form validation blocked clearing it manually, and the active provider selection stayed locked in.

This adds a **Reset** button to each API-key provider card in Intelligence and Transcription settings. Reset:

- Deletes the stored API key from the keychain
- Removes the provider configuration from SQLite (including legacy settings)
- Clears `current_llm_provider` / `current_llm_model` (or STT equivalents) when the reset provider is currently selected
- Resets the form back to defaults

The button uses muted text styling (not a CTA) and appears only when the provider has stored credentials.

## Test plan

- [x] `pnpm -F desktop test src/settings/providers.test.ts`
- [x] `pnpm -F desktop typecheck`
- [ ] Configure Gemini (or any BYOK LLM provider) with an API key, confirm Reset clears credentials and removes the active selection
- [ ] Confirm the "Language model needed" toast reappears after reset (expected until a provider is configured again)
- [ ] Confirm Reset works for transcription providers too
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fba38bb8-a164-4c5a-8b24-0ced76004bdf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fba38bb8-a164-4c5a-8b24-0ced76004bdf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

