### PR TITLE
fix(oauth): PKCE cookies, Microsoft login scopes, read-only calendar connect

### DIFF
--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -12,6 +12,7 @@ import {
   type NewAccountAuthMethod,
   shouldOfferNewAccountTrialCheckoutFallback,
 } from "@/functions/new-account-trial-policy";
+import { oauthProviderScopes } from "@/functions/oauth-provider";
 import { claimPendingReferral } from "@/functions/referrals";
 import {
   getSupabaseAdminClient,
@@ -252,20 +253,13 @@ export const doAuth = createServerFn({ method: "POST" })
     const supabase = getSupabaseServerClient();
     const params = buildAuthCallbackParams(data);
 
-    const scopes =
-      data.provider === "github" && data.rra
-        ? "repo"
-        : data.provider === "azure"
-          ? "email"
-          : undefined;
-
     const { data: authData, error } = await supabase.auth.signInWithOAuth({
       provider: data.provider,
       options: {
         redirectTo: buildAuthCallbackUrl(params),
         queryParams:
           data.provider === "azure" ? { prompt: "select_account" } : undefined,
-        scopes,
+        scopes: oauthProviderScopes(data.provider, data.rra),
       },
     });
 

--- a/apps/web/src/functions/oauth-provider.test.ts
+++ b/apps/web/src/functions/oauth-provider.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { oauthProviderScopes } from "./oauth-provider.ts";
+
+test("Microsoft login requests OIDC identity scopes", () => {
+  assert.equal(oauthProviderScopes("azure"), "openid email profile");
+});
+
+test("Google login uses provider defaults", () => {
+  assert.equal(oauthProviderScopes("google"), undefined);
+});
+
+test("GitHub only requests repo when reconnecting for admin access", () => {
+  assert.equal(oauthProviderScopes("github"), undefined);
+  assert.equal(oauthProviderScopes("github", true), "repo");
+});

--- a/apps/web/src/functions/oauth-provider.ts
+++ b/apps/web/src/functions/oauth-provider.ts
@@ -1,0 +1,11 @@
+export type OAuthProvider = "azure" | "google" | "github";
+
+export function oauthProviderScopes(provider: OAuthProvider, rra?: boolean) {
+  if (provider === "github" && rra) {
+    return "repo";
+  }
+  if (provider === "azure") {
+    return "openid email profile";
+  }
+  return undefined;
+}

--- a/apps/web/src/functions/supabase.ts
+++ b/apps/web/src/functions/supabase.ts
@@ -4,6 +4,7 @@ import { createClientOnlyFn, createServerOnlyFn } from "@tanstack/react-start";
 import { getCookies, setCookie } from "@tanstack/react-start/server";
 
 import { env, requireEnv } from "@/env";
+import { toSetCookieOptions } from "@/lib/supabase-cookies";
 
 export const getSupabaseBrowserClient = createClientOnlyFn(() => {
   return createBrowserClient(
@@ -33,9 +34,9 @@ export const getSupabaseServerClient = createServerOnlyFn(() => {
             value,
           }));
         },
-        setAll(cookies: Array<{ name: string; value: string }>) {
+        setAll(cookies) {
           cookies.forEach((cookie) => {
-            setCookie(cookie.name, cookie.value);
+            setCookie(cookie.name, cookie.value, toSetCookieOptions(cookie));
           });
         },
       },

--- a/apps/web/src/lib/integration-connection-error.test.ts
+++ b/apps/web/src/lib/integration-connection-error.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getConnectionErrorMessage } from "./integration-connection-error.ts";
+
+test("explains Google’s blocked-app page when Calendar connect is closed", () => {
+  assert.match(
+    getConnectionErrorMessage(
+      "window_closed",
+      "Google Calendar",
+      "google-calendar",
+    ),
+    /This app is blocked/,
+  );
+});
+
+test("keeps Outlook window-closed copy generic", () => {
+  assert.equal(
+    getConnectionErrorMessage("window_closed", "Outlook Calendar", "outlook"),
+    "The Outlook Calendar sign-in window closed before the connection finished. Please try again.",
+  );
+});
+
+test("asks users to allow pop-ups when the browser blocks the window", () => {
+  assert.match(
+    getConnectionErrorMessage(
+      "blocked_by_browser",
+      "Google Calendar",
+      "google-calendar",
+    ),
+    /Allow pop-ups/,
+  );
+});

--- a/apps/web/src/lib/integration-connection-error.ts
+++ b/apps/web/src/lib/integration-connection-error.ts
@@ -1,0 +1,22 @@
+export function getConnectionErrorMessage(
+  errorType: string,
+  providerName: string,
+  integrationId?: string,
+) {
+  if (errorType === "blocked_by_browser") {
+    return `Your browser blocked the ${providerName} sign-in window. Allow pop-ups for Anarlog and try again.`;
+  }
+  if (errorType === "window_closed") {
+    if (integrationId === "google-calendar") {
+      return 'The Google sign-in window closed before Calendar connected. If Google showed "This app is blocked", that is Google\'s verification gate, not Anarlog. Email founders@anarlog.so if you need access.';
+    }
+    return `The ${providerName} sign-in window closed before the connection finished. Please try again.`;
+  }
+  if (errorType === "resource_capped") {
+    return "This integration has reached its connection limit. Contact support to connect another account.";
+  }
+  if (integrationId === "google-calendar") {
+    return 'Google rejected the Calendar connection. If you saw "This app is blocked", Google is still verifying Anarlog. Email founders@anarlog.so if you need access.';
+  }
+  return `${providerName} rejected the connection. Please try again or contact support if it keeps happening.`;
+}

--- a/apps/web/src/lib/supabase-cookies.test.ts
+++ b/apps/web/src/lib/supabase-cookies.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { toSetCookieOptions } from "./supabase-cookies.ts";
+
+test("forwards PKCE cookie options onto the document", () => {
+  const options = toSetCookieOptions({
+    name: "sb-auth-code-verifier",
+    value: "verifier",
+    options: {
+      httpOnly: true,
+      maxAge: 3600,
+      path: "/",
+      sameSite: "lax",
+      secure: true,
+    },
+  });
+
+  assert.deepEqual(options, {
+    domain: undefined,
+    expires: undefined,
+    httpOnly: true,
+    maxAge: 3600,
+    path: "/",
+    sameSite: "lax",
+    secure: true,
+  });
+});
+
+test("defaults the cookie path so OAuth redirects still send the verifier", () => {
+  const options = toSetCookieOptions({
+    name: "sb-auth-code-verifier",
+    value: "verifier",
+  });
+
+  assert.equal(options.path, "/");
+  assert.equal(options.sameSite, undefined);
+});

--- a/apps/web/src/lib/supabase-cookies.ts
+++ b/apps/web/src/lib/supabase-cookies.ts
@@ -1,0 +1,33 @@
+type SameSite = "lax" | "strict" | "none";
+
+export type SupabaseCookie = {
+  name: string;
+  value: string;
+  options?: {
+    domain?: string;
+    expires?: Date;
+    httpOnly?: boolean;
+    maxAge?: number;
+    path?: string;
+    sameSite?: SameSite | boolean;
+    secure?: boolean;
+  };
+};
+
+export function toSetCookieOptions(cookie: SupabaseCookie) {
+  const sameSite = cookie.options?.sameSite;
+  return {
+    domain: cookie.options?.domain,
+    expires: cookie.options?.expires,
+    httpOnly: cookie.options?.httpOnly,
+    maxAge: cookie.options?.maxAge,
+    path: cookie.options?.path ?? "/",
+    sameSite:
+      sameSite === true
+        ? ("strict" as const)
+        : sameSite === false
+          ? undefined
+          : sameSite,
+    secure: cookie.options?.secure,
+  };
+}

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -1,4 +1,4 @@
-import Nango, { type AuthErrorType, type ConnectUI } from "@nangohq/frontend";
+import Nango, { type ConnectUI } from "@nangohq/frontend";
 import { useNavigate } from "@tanstack/react-router";
 import { useRef, useState } from "react";
 
@@ -10,25 +10,10 @@ import { getAccessToken } from "@/functions/access-token";
 import { useAnalytics } from "@/hooks/use-posthog";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import { captureOperationalError } from "@/lib/error-reporting";
+import { getConnectionErrorMessage } from "@/lib/integration-connection-error";
 
 import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
 import { getIntegrationDisplay, Route } from "./integration";
-
-function getConnectionErrorMessage(
-  errorType: AuthErrorType,
-  providerName: string,
-) {
-  if (errorType === "blocked_by_browser") {
-    return `Your browser blocked the ${providerName} sign-in window. Allow pop-ups for Anarlog and try again.`;
-  }
-  if (errorType === "window_closed") {
-    return `The ${providerName} sign-in window closed before the connection finished. Please try again.`;
-  }
-  if (errorType === "resource_capped") {
-    return "This integration has reached its connection limit. Contact support to connect another account.";
-  }
-  return `${providerName} rejected the connection. Please try again or contact support if it keeps happening.`;
-}
 
 export function ConnectFlow({ sessionToken }: { sessionToken?: string } = {}) {
   const search = Route.useSearch();
@@ -165,7 +150,11 @@ export function ConnectFlow({ sessionToken }: { sessionToken?: string } = {}) {
           );
           inFlightRef.current = false;
           setConnectionError(
-            getConnectionErrorMessage(errorType, display.name),
+            getConnectionErrorMessage(
+              errorType,
+              display.name,
+              search.integration_id,
+            ),
           );
           updateStatus("error");
           connectUIRef.current?.close();

--- a/crates/api-nango/src/integrations.rs
+++ b/crates/api-nango/src/integrations.rs
@@ -1,5 +1,36 @@
+use std::collections::HashMap;
+
+use anlg_nango::{ConnectionConfigOverride, IntegrationConfigDefault};
+
 pub trait NangoIntegrationId: Send + Sync + 'static {
     const ID: &'static str;
+}
+
+pub const GOOGLE_CALENDAR_OAUTH_SCOPES: &str = "https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.events.readonly";
+
+pub const OUTLOOK_OAUTH_SCOPES: &str = "offline_access User.Read Calendars.Read";
+
+pub fn oauth_scopes_override(integration_id: &str) -> Option<&'static str> {
+    match integration_id {
+        GoogleCalendar::ID => Some(GOOGLE_CALENDAR_OAUTH_SCOPES),
+        Outlook::ID => Some(OUTLOOK_OAUTH_SCOPES),
+        _ => None,
+    }
+}
+
+pub fn integrations_config_defaults(
+    integration_id: &str,
+) -> Option<HashMap<String, IntegrationConfigDefault>> {
+    let scopes = oauth_scopes_override(integration_id)?;
+    Some(HashMap::from([(
+        integration_id.to_string(),
+        IntegrationConfigDefault {
+            user_scopes: None,
+            connection_config: Some(ConnectionConfigOverride {
+                oauth_scopes_override: Some(scopes.to_string()),
+            }),
+        },
+    )]))
 }
 
 pub struct GoogleCalendar;
@@ -54,4 +85,51 @@ pub struct Notion;
 
 impl NangoIntegrationId for Notion {
     const ID: &'static str = "notion";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calendar_connect_requests_readonly_google_scopes() {
+        let defaults = integrations_config_defaults(GoogleCalendar::ID).unwrap();
+        let config = defaults.get(GoogleCalendar::ID).unwrap();
+        let scopes = config
+            .connection_config
+            .as_ref()
+            .and_then(|c| c.oauth_scopes_override.as_deref())
+            .unwrap();
+
+        assert_eq!(scopes, GOOGLE_CALENDAR_OAUTH_SCOPES);
+        assert!(
+            !scopes.split_whitespace().any(|scope| {
+                scope.ends_with("/calendar") || scope.ends_with("/calendar.events")
+            }),
+            "calendar connect must not request write scopes: {scopes}"
+        );
+    }
+
+    #[test]
+    fn calendar_connect_requests_readonly_outlook_scopes() {
+        let defaults = integrations_config_defaults(Outlook::ID).unwrap();
+        let scopes = defaults
+            .get(Outlook::ID)
+            .unwrap()
+            .connection_config
+            .as_ref()
+            .and_then(|c| c.oauth_scopes_override.as_deref())
+            .unwrap();
+
+        assert_eq!(scopes, OUTLOOK_OAUTH_SCOPES);
+        assert!(scopes.contains("Calendars.Read"));
+        assert!(!scopes.contains("Calendars.ReadWrite"));
+    }
+
+    #[test]
+    fn other_integrations_keep_dashboard_scopes() {
+        assert!(integrations_config_defaults(GitHub::ID).is_none());
+        assert!(integrations_config_defaults(Slack::ID).is_none());
+        assert!(integrations_config_defaults("unknown").is_none());
+    }
 }

--- a/crates/api-nango/src/routes/connect.rs
+++ b/crates/api-nango/src/routes/connect.rs
@@ -84,6 +84,9 @@ pub async fn create_session(
             let reconnect_req = anlg_nango::ReconnectSessionRequest {
                 connection_id: connection_id.to_string(),
                 integration_id: body.integration_id.clone(),
+                integrations_config_defaults: crate::integrations::integrations_config_defaults(
+                    &body.integration_id,
+                ),
             };
 
             let session = state.nango.reconnect_session(reconnect_req).await?;
@@ -104,6 +107,9 @@ pub async fn create_session(
                 let reconnect_req = anlg_nango::ReconnectSessionRequest {
                     connection_id: existing.connection_id.clone(),
                     integration_id: body.integration_id.clone(),
+                    integrations_config_defaults: crate::integrations::integrations_config_defaults(
+                        &body.integration_id,
+                    ),
                 };
 
                 match state.nango.reconnect_session(reconnect_req).await {
@@ -153,8 +159,10 @@ pub async fn create_session(
             tags: Some(tags),
         },
         organization: None,
-        allowed_integrations: Some(vec![body.integration_id]),
-        integrations_config_defaults: None,
+        allowed_integrations: Some(vec![body.integration_id.clone()]),
+        integrations_config_defaults: crate::integrations::integrations_config_defaults(
+            &body.integration_id,
+        ),
     };
 
     let session = state.nango.create_connect_session(req).await?;

--- a/crates/nango/src/connect_session.rs
+++ b/crates/nango/src/connect_session.rs
@@ -64,6 +64,8 @@ common_derives! {
     pub struct ReconnectSessionRequest {
         pub connection_id: String,
         pub integration_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub integrations_config_defaults: Option<HashMap<String, IntegrationConfigDefault>>,
     }
 }
 

--- a/crates/nango/src/lib.rs
+++ b/crates/nango/src/lib.rs
@@ -104,4 +104,66 @@ mod tests {
             .unwrap();
         assert_eq!(nango_client.api_base.as_str(), "https://api.nango.dev/");
     }
+
+    #[test]
+    fn connect_session_serializes_oauth_scope_overrides() {
+        let mut defaults = std::collections::HashMap::new();
+        defaults.insert(
+            "google-calendar".to_string(),
+            IntegrationConfigDefault {
+                user_scopes: None,
+                connection_config: Some(ConnectionConfigOverride {
+                    oauth_scopes_override: Some(
+                        "https://www.googleapis.com/auth/calendar.readonly".to_string(),
+                    ),
+                }),
+            },
+        );
+
+        let json = serde_json::to_value(&CreateConnectSessionRequest {
+            end_user: EndUser {
+                id: "user-1".to_string(),
+                display_name: None,
+                email: None,
+                tags: None,
+            },
+            organization: None,
+            allowed_integrations: Some(vec!["google-calendar".to_string()]),
+            integrations_config_defaults: Some(defaults),
+        })
+        .unwrap();
+
+        assert_eq!(
+            json["integrations_config_defaults"]["google-calendar"]["connection_config"]["oauth_scopes_override"],
+            "https://www.googleapis.com/auth/calendar.readonly"
+        );
+    }
+
+    #[test]
+    fn reconnect_session_serializes_oauth_scope_overrides() {
+        let mut defaults = std::collections::HashMap::new();
+        defaults.insert(
+            "outlook".to_string(),
+            IntegrationConfigDefault {
+                user_scopes: None,
+                connection_config: Some(ConnectionConfigOverride {
+                    oauth_scopes_override: Some(
+                        "offline_access User.Read Calendars.Read".to_string(),
+                    ),
+                }),
+            },
+        );
+
+        let json = serde_json::to_value(&ReconnectSessionRequest {
+            connection_id: "conn-1".to_string(),
+            integration_id: "outlook".to_string(),
+            integrations_config_defaults: Some(defaults),
+        })
+        .unwrap();
+
+        assert_eq!(
+            json["integrations_config_defaults"]["outlook"]["connection_config"]["oauth_scopes_override"],
+            "offline_access User.Read Calendars.Read"
+        );
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Google and Microsoft login plus calendar connect had several code-level failures. This PR fixes those. It does **not** unblock new Google Calendar users: production is still over Google’s unverified-app 100-user cap on `hyprnote-calendar-prod`. That needs Cloud Console verification (ANLG-290). Do not retarget Nango prod at another OAuth client; that would force existing connections to reconnect.

## What was broken

- **Microsoft login** requested `email` only, which overrides Supabase OIDC defaults and can drop `openid`.
- **PKCE cookies**: `setAll` dropped cookie options (`path`, `sameSite`, `secure`), so the code verifier could be missing after the OAuth redirect.
- **Calendar connect** used Nango dashboard default scopes (often full `calendar` / `Calendars.ReadWrite`) instead of the read-only access the product actually uses.
- **Google Calendar** “This app is blocked” looked like an Anarlog bug. Callbacks and Nango are fine; Google is refusing new consents for the unverified client.

## Code changes

- Azure login scopes: `openid email profile`. GitHub+rra still requests `repo`.
- Forward Supabase cookie options in `setAll`, defaulting `path` to `/`.
- Nango connect **and** reconnect sessions override Google Calendar to `calendar.readonly` + `calendar.events.readonly`, Outlook to `Calendars.Read`.
- Google Calendar connect errors mention the blocked-app verification gate and `founders@anarlog.so`.

## Ops still required

Google Calendar connect for **new** accounts stays blocked until `hyprnote-calendar-prod` in GCP `useful-shell-447307-d4` is verified (or the user cap is otherwise lifted). Existing connections can keep working. Read-only scopes do not lift that cap (`calendar.readonly` is still sensitive).

## Checks

- `pnpm -F web typecheck`
- `node --experimental-strip-types --test` on the new web OAuth tests
- `cargo test -p api-nango -p nango`
- `cargo check -p api-nango -p nango`
- `dprint` on changed files (Swift fmt skipped on Linux)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fabc92d-daa6-4cfc-8513-a591925ffac0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fabc92d-daa6-4cfc-8513-a591925ffac0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

