### PR TITLE
Move share Email and Slack into overflow menu

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -577,6 +577,7 @@ msgstr "Automations"
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr "Model is thinking..."
 msgid "Monday"
 msgstr "Monday"
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr "More options"
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr "Paused"
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr "People"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -577,6 +577,7 @@ msgstr ""
 
 #: src/calendar/components/apple/permission.tsx
 #: src/instruction/index.tsx
+#: src/session-sharing/delivery-panel.tsx
 #: src/settings/general/e2ee-setup.tsx
 #: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
@@ -2505,6 +2506,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
+#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
@@ -2958,7 +2960,6 @@ msgid "Paused"
 msgstr ""
 
 #: src/contacts/organization-details.tsx
-#: src/session-sharing/delivery-panel.tsx
 #: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""

--- a/apps/desktop/src/session-sharing/delivery-panel.test.tsx
+++ b/apps/desktop/src/session-sharing/delivery-panel.test.tsx
@@ -1,20 +1,53 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  createElement,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { ShareRecapModeSelector } from "./delivery-panel";
+import { ShareRecapOverflowMenu } from "./delivery-panel";
 
-describe("ShareRecapModeSelector", () => {
-  it("offers invitation, email, and Slack delivery", () => {
+vi.mock("@iconify-icon/react", () => ({
+  Icon: (props: Record<string, unknown>) =>
+    createElement("iconify-icon", props),
+}));
+
+vi.mock("@anlg/ui/components/ui/dropdown-menu", () => ({
+  AppFloatingPanel: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenu: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & { onSelect?: () => void }) => (
+    <button type="button" {...props} onClick={onSelect}>
+      {children}
+    </button>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+describe("ShareRecapOverflowMenu", () => {
+  it("offers email and Slack delivery from the overflow menu", () => {
     const onValueChange = vi.fn();
-    render(
-      <ShareRecapModeSelector value="invite" onValueChange={onValueChange} />,
-    );
+    render(<ShareRecapOverflowMenu onValueChange={onValueChange} />);
 
+    expect(screen.queryByRole("button", { name: "People" })).toBeNull();
+    expect(screen.getByRole("button", { name: "More options" })).toBeTruthy();
     expect(
-      screen
-        .getByRole("button", { name: "People" })
-        .getAttribute("aria-pressed"),
-    ).toBe("true");
+      document.querySelector('iconify-icon[icon="logos:slack-icon"]'),
+    ).not.toBeNull();
+
     fireEvent.click(screen.getByRole("button", { name: "Email" }));
     fireEvent.click(screen.getByRole("button", { name: "Slack" }));
 

--- a/apps/desktop/src/session-sharing/delivery-panel.tsx
+++ b/apps/desktop/src/session-sharing/delivery-panel.tsx
@@ -1,15 +1,23 @@
+import { Icon } from "@iconify-icon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
+  CaretLeft,
   CircleNotch,
+  DotsThree,
   EnvelopeSimple,
   LockSimple,
-  SlackLogo,
-  UserPlus,
 } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 
 import { Button } from "@anlg/ui/components/ui/button";
+import {
+  AppFloatingPanel,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@anlg/ui/components/ui/dropdown-menu";
 import {
   Select,
   SelectContent,
@@ -17,7 +25,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@anlg/ui/components/ui/select";
-import { cn } from "@anlg/utils";
 
 import { listSlackChannels } from "./delivery-client";
 import {
@@ -33,44 +40,87 @@ import { useOpenIntegrationUrl } from "~/shared/integration";
 
 export type ShareRecapMode = "invite" | "email" | "slack";
 
-export function ShareRecapModeSelector({
-  value,
+function SlackBrandIcon({ size }: { size: number }) {
+  return (
+    <Icon
+      icon="logos:slack-icon"
+      width={size}
+      height={size}
+      aria-hidden="true"
+    />
+  );
+}
+
+export function ShareRecapOverflowMenu({
   onValueChange,
 }: {
-  value: ShareRecapMode;
-  onValueChange: (value: ShareRecapMode) => void;
+  onValueChange: (value: Exclude<ShareRecapMode, "invite">) => void;
 }) {
+  const { t } = useLingui();
+
   return (
-    <div className="bg-muted/60 grid grid-cols-3 gap-0.5 rounded-lg p-0.5">
-      {(
-        [
-          ["invite", UserPlus],
-          ["email", EnvelopeSimple],
-          ["slack", SlackLogo],
-        ] as const
-      ).map(([mode, Icon]) => (
-        <button
-          key={mode}
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
           type="button"
-          aria-pressed={value === mode}
-          onClick={() => onValueChange(mode)}
-          className={cn([
-            "flex h-7 items-center justify-center gap-1.5 rounded-md text-xs transition-colors",
-            value === mode
-              ? "bg-background text-foreground shadow-xs"
-              : "text-muted-foreground hover:text-foreground",
-          ])}
+          size="icon"
+          variant="ghost"
+          aria-label={t`More options`}
+          className="text-muted-foreground hover:text-foreground"
         >
-          <Icon className="size-3.5" aria-hidden="true" />
-          {mode === "invite" ? (
-            <Trans>People</Trans>
-          ) : mode === "email" ? (
+          <DotsThree className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent variant="app" align="end" className="w-44">
+        <AppFloatingPanel className="overflow-hidden p-1">
+          <DropdownMenuItem
+            onSelect={() => onValueChange("email")}
+            className="cursor-pointer"
+          >
+            <EnvelopeSimple aria-hidden="true" />
             <Trans>Email</Trans>
-          ) : (
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => onValueChange("slack")}
+            className="cursor-pointer"
+          >
+            <span className="flex size-4 items-center justify-center">
+              <SlackBrandIcon size={16} />
+            </span>
             <Trans>Slack</Trans>
-          )}
+          </DropdownMenuItem>
+        </AppFloatingPanel>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function ShareRecapFormHeading({
+  id,
+  onBack,
+  children,
+}: {
+  id: string;
+  onBack?: () => void;
+  children: ReactNode;
+}) {
+  const { t } = useLingui();
+
+  return (
+    <div className="flex items-center gap-1">
+      {onBack ? (
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label={t`Back`}
+          className="text-muted-foreground hover:text-foreground flex size-6 shrink-0 items-center justify-center rounded-md"
+        >
+          <CaretLeft className="size-3.5" aria-hidden="true" />
         </button>
-      ))}
+      ) : null}
+      <h3 id={id} className="text-xs font-medium">
+        {children}
+      </h3>
     </div>
   );
 }
@@ -80,12 +130,14 @@ export function EmailRecapForm({
   ownerEmail,
   disabled,
   pending,
+  onBack,
   onSubmit,
 }: {
   sessionId: string;
   ownerEmail: string;
   disabled: boolean;
   pending: boolean;
+  onBack?: () => void;
   onSubmit: (emails: string[]) => void;
 }) {
   const { t } = useLingui();
@@ -98,9 +150,9 @@ export function EmailRecapForm({
   return (
     <section aria-labelledby="email-recap-heading" className="space-y-2">
       <div>
-        <h3 id="email-recap-heading" className="text-xs font-medium">
+        <ShareRecapFormHeading id="email-recap-heading" onBack={onBack}>
           <Trans>Email meeting notes</Trans>
-        </h3>
+        </ShareRecapFormHeading>
         <p className="text-muted-foreground mt-0.5 text-[11px] leading-4">
           <Trans>
             Send the summary in the email. Replies go directly to you.
@@ -127,10 +179,12 @@ export function EmailRecapForm({
 export function SlackRecapForm({
   disabled,
   pending,
+  onBack,
   onSubmit,
 }: {
   disabled: boolean;
   pending: boolean;
+  onBack?: () => void;
   onSubmit: (channel: { id: string; name: string }) => void;
 }) {
   const { t } = useLingui();
@@ -163,9 +217,9 @@ export function SlackRecapForm({
     return (
       <section aria-labelledby="slack-recap-heading" className="space-y-2">
         <div>
-          <h3 id="slack-recap-heading" className="text-xs font-medium">
+          <ShareRecapFormHeading id="slack-recap-heading" onBack={onBack}>
             <Trans>Send to Slack</Trans>
-          </h3>
+          </ShareRecapFormHeading>
           <p className="text-muted-foreground mt-0.5 text-[11px] leading-4">
             <Trans>Connect Slack to choose a channel for this recap.</Trans>
           </p>
@@ -187,7 +241,7 @@ export function SlackRecapForm({
           {openingAction ? (
             <CircleNotch className="size-3.5 animate-spin" aria-hidden="true" />
           ) : (
-            <SlackLogo className="size-3.5" aria-hidden="true" />
+            <SlackBrandIcon size={14} />
           )}
           {reconnect ? (
             <Trans>Reconnect Slack</Trans>
@@ -202,9 +256,9 @@ export function SlackRecapForm({
   return (
     <section aria-labelledby="slack-recap-heading" className="space-y-2">
       <div>
-        <h3 id="slack-recap-heading" className="text-xs font-medium">
+        <ShareRecapFormHeading id="slack-recap-heading" onBack={onBack}>
           <Trans>Send to Slack</Trans>
-        </h3>
+        </ShareRecapFormHeading>
         <p className="text-muted-foreground mt-0.5 text-[11px] leading-4">
           <Trans>Post the meeting summary to a channel you can access.</Trans>
         </p>

--- a/apps/desktop/src/session-sharing/draft-panel.tsx
+++ b/apps/desktop/src/session-sharing/draft-panel.tsx
@@ -10,7 +10,7 @@ import {
 
 import {
   EmailRecapForm,
-  ShareRecapModeSelector,
+  ShareRecapOverflowMenu,
   SlackRecapForm,
   type ShareRecapMode,
 } from "./delivery-panel";
@@ -82,10 +82,6 @@ export function SessionShareDraftContent({
 
         <div className="scrollbar-soft min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-2">
           <div className="space-y-2">
-            <ShareRecapModeSelector
-              value={recapMode}
-              onValueChange={setRecapMode}
-            />
             {recapMode === "invite" ? (
               <section aria-labelledby="invite-people-heading">
                 <h3 id="invite-people-heading" className="sr-only">
@@ -129,12 +125,14 @@ export function SessionShareDraftContent({
                 ownerEmail={ownerEmail}
                 disabled={disabled || actionPending}
                 pending={pendingAction?.type === "email"}
+                onBack={() => setRecapMode("invite")}
                 onSubmit={(emails) => onAction({ type: "email", emails })}
               />
             ) : (
               <SlackRecapForm
                 disabled={disabled || actionPending}
                 pending={pendingAction?.type === "slack"}
+                onBack={() => setRecapMode("invite")}
                 onSubmit={(channel) => onAction({ type: "slack", channel })}
               />
             )}
@@ -165,7 +163,8 @@ export function SessionShareDraftContent({
           </div>
         </div>
 
-        <footer className="border-border/60 flex justify-end border-t px-3 py-2">
+        <footer className="border-border/60 flex items-center justify-end gap-1 border-t px-3 py-2">
+          <ShareRecapOverflowMenu onValueChange={setRecapMode} />
           <Button
             type="button"
             size="sm"

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -32,7 +32,7 @@ import { setSessionShareScope, ShareManagementError } from "./client";
 import { useSessionRecapDelivery } from "./delivery-management";
 import {
   EmailRecapForm,
-  ShareRecapModeSelector,
+  ShareRecapOverflowMenu,
   SlackRecapForm,
   type ShareRecapMode,
 } from "./delivery-panel";
@@ -438,11 +438,6 @@ export function SessionSharePopoverContent({
                 </section>
               ) : null}
 
-              <ShareRecapModeSelector
-                value={recapMode}
-                onValueChange={setRecapMode}
-              />
-
               {recapMode === "invite" ? (
                 <section aria-labelledby="invite-people-heading">
                   <h3 id="invite-people-heading" className="sr-only">
@@ -534,12 +529,14 @@ export function SessionSharePopoverContent({
                   ownerEmail={ownerEmail}
                   disabled={!canPublish || anyPending || deliveryPending}
                   pending={emailMutation.isPending}
+                  onBack={() => setRecapMode("invite")}
                   onSubmit={(emails) => emailMutation.mutate(emails)}
                 />
               ) : (
                 <SlackRecapForm
                   disabled={!canPublish || anyPending || deliveryPending}
                   pending={slackMutation.isPending}
+                  onBack={() => setRecapMode("invite")}
                   onSubmit={(channel) => slackMutation.mutate(channel)}
                 />
               )}
@@ -592,7 +589,8 @@ export function SessionSharePopoverContent({
             </div>
           </div>
 
-          <footer className="border-border/60 flex items-center justify-end border-t px-3 py-2">
+          <footer className="border-border/60 flex items-center justify-end gap-1 border-t px-3 py-2">
+            <ShareRecapOverflowMenu onValueChange={setRecapMode} />
             <Button
               type="button"
               size="sm"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The share modal no longer uses People / Email / Slack tabs. People stays as the default view; Email and Slack are overflow-menu options next to Copy link, with a back control to return. Slack uses the brand icon instead of Phosphor’s hashtag-style logo.

## Testing
- `pnpm exec dprint fmt` + scoped `dprint check` on the changed files
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop test`
- `pnpm -F desktop exec lingui extract --clean --workers 1` and compile (no catalog diff)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cf3d35c-2822-45cd-ad05-25f33ccd9ef5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cf3d35c-2822-45cd-ad05-25f33ccd9ef5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

