### PR TITLE
Wait out SQLITE_BUSY when loading CloudSync on new pool connections.

### DIFF
--- a/crates/cloudsync/src/api.rs
+++ b/crates/cloudsync/src/api.rs
@@ -8,7 +8,10 @@ use sqlx::{Executor, Sqlite, SqliteConnection};
 
 use crate::error::Error;
 
-const EXTENSION_LOAD_BUSY_RETRIES: usize = 4;
+// PRAGMA busy_timeout = 50 keeps SQLite's C busy-handler short so after_connect
+// does not park a Tokio worker. Retry SQLITE_BUSY asynchronously for the same
+// 5s budget used by the rest of the app instead of failing the pool connect.
+const EXTENSION_LOAD_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 type ExtensionLoadLock = tokio::sync::Mutex<()>;
 
 static EXTENSION_LOAD_LOCKS: OnceLock<std::sync::Mutex<HashMap<PathBuf, Weak<ExtensionLoadLock>>>> =
@@ -107,56 +110,40 @@ async fn load_and_validate_extension(
     connection: &mut SqliteConnection,
     extension_path: &Path,
 ) -> Result<(), Error> {
+    // Loading the extension is per-connection and does not need a reserved
+    // lock. BEGIN IMMEDIATE here fights in-flight writers and makes sqlx log
+    // after_connect SQLITE_BUSY while the pool grows.
     sqlx::query("PRAGMA busy_timeout = 50")
         .execute(&mut *connection)
         .await?;
 
-    let begin_result = begin_extension_load(connection).await;
-    if let Err(error) = begin_result {
-        restore_busy_timeout(connection).await?;
-        return Err(error);
-    }
-
-    let load_result = async {
-        load_extension(connection, extension_path).await?;
-        validate_extension(connection).await
-    }
-    .await;
-    let finish_result = if load_result.is_ok() {
-        sqlx::query("COMMIT").execute(&mut *connection).await
-    } else {
-        sqlx::query("ROLLBACK").execute(&mut *connection).await
+    let deadline = tokio::time::Instant::now() + EXTENSION_LOAD_BUSY_TIMEOUT;
+    let mut attempt = 0u32;
+    let result = loop {
+        match load_extension_and_validate(connection, extension_path).await {
+            Ok(()) => break Ok(()),
+            Err(error) if is_busy_error(&error) => {
+                let now = tokio::time::Instant::now();
+                if now >= deadline {
+                    break Err(error);
+                }
+                let delay = Duration::from_millis(10_u64 << attempt.min(5));
+                tokio::time::sleep(delay.min(deadline - now)).await;
+                attempt = attempt.saturating_add(1);
+            }
+            Err(error) => break Err(error),
+        }
     };
-    let restore_result = restore_busy_timeout(connection).await;
-
-    load_result?;
-    finish_result?;
-    restore_result?;
-    Ok(())
+    restore_busy_timeout(connection).await?;
+    result
 }
 
-async fn begin_extension_load(connection: &mut SqliteConnection) -> Result<(), Error> {
-    let mut last_error = None;
-    for attempt in 0..EXTENSION_LOAD_BUSY_RETRIES {
-        match sqlx::query("BEGIN IMMEDIATE")
-            .execute(&mut *connection)
-            .await
-        {
-            Ok(_) => return Ok(()),
-            Err(error) if is_sqlite_busy(&error) => {
-                last_error = Some(error);
-                if attempt + 1 < EXTENSION_LOAD_BUSY_RETRIES {
-                    let delay_ms = 10_u64 << attempt;
-                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-                }
-            }
-            Err(error) => return Err(error.into()),
-        }
-    }
-
-    Err(last_error
-        .expect("extension load retry loop must capture the final SQLITE_BUSY error")
-        .into())
+async fn load_extension_and_validate(
+    connection: &mut SqliteConnection,
+    extension_path: &Path,
+) -> Result<(), Error> {
+    load_extension(connection, extension_path).await?;
+    validate_extension(connection).await
 }
 
 fn is_sqlite_busy(error: &sqlx::Error) -> bool {
@@ -166,6 +153,19 @@ fn is_sqlite_busy(error: &sqlx::Error) -> bool {
             message.contains("database is locked") || message.contains("database table is locked")
         }
     })
+}
+
+fn is_busy_error(error: &Error) -> bool {
+    match error {
+        Error::Sqlx(error) => is_sqlite_busy(error),
+        error => {
+            let message = error.to_string().to_ascii_lowercase();
+            message.contains("database is locked")
+                || message.contains("database table is locked")
+                || message.contains("sqlite error 5")
+                || message.contains("sqlite error 6")
+        }
+    }
 }
 
 async fn restore_busy_timeout(connection: &mut SqliteConnection) -> Result<(), Error> {
@@ -496,4 +496,19 @@ where
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_busy_messages_are_retried() {
+        assert!(is_busy_error(&Error::ExtensionInitialization(
+            "failed to load sqlite-sync (sqlite error 5): database is locked".to_string(),
+        )));
+        assert!(!is_busy_error(&Error::ExtensionInitialization(
+            "expected sqlite-sync 1.1.2, loaded 1.0.0".to_string(),
+        )));
+    }
 }

--- a/crates/db-core/src/tests.rs
+++ b/crates/db-core/src/tests.rs
@@ -242,17 +242,13 @@ async fn cloudsync_pool_serializes_and_validates_every_extension_load() {
         .await
         .unwrap();
 
-        let started_at = std::time::Instant::now();
         let first_pool = db.pool().clone();
         let second_pool = db.pool().clone();
         let first = tokio::spawn(async move { first_pool.acquire().await });
         let second = tokio::spawn(async move { second_pool.acquire().await });
-        tokio::time::sleep(Duration::from_millis(90)).await;
-        sqlx::query("COMMIT").execute(&mut *writer).await.unwrap();
-
         let mut first = first.await.unwrap().unwrap();
         let mut second = second.await.unwrap().unwrap();
-        assert!(started_at.elapsed() >= Duration::from_millis(90));
+        sqlx::query("COMMIT").execute(&mut *writer).await.unwrap();
 
         assert_cloudsync_connection_ready(
             &mut writer,


### PR DESCRIPTION
after_connect gave up on BEGIN IMMEDIATE after ~270ms, so sqlx retried the whole connect and logged "database is locked" during normal desktop writes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection initialization and SQLite locking behavior on every new pool connection with CloudSync enabled; wrong retry/classification could delay connects or mask real load failures.
> 
> **Overview**
> **CloudSync sqlite-sync extension loading** no longer wraps `BEGIN IMMEDIATE` around each load. That transaction fought active writers and caused sqlx `after_connect` to fail quickly (~270ms) with "database is locked" when the pool grew during normal writes.
> 
> Loads now use a short `PRAGMA busy_timeout = 50` so SQLite’s C busy handler does not block Tokio workers, then **retry** `load_extension` + validation asynchronously with exponential backoff for up to **5 seconds** (aligned with app-wide busy handling). Busy detection was extended via `is_busy_error` so extension-load failures that surface as locked-database messages are retried, not only raw sqlx busy codes.
> 
> The **db-core** integration test for concurrent pool acquires under a held writer was adjusted: it no longer depends on a fixed 90ms delay before commit, matching the new willingness to wait on busy during connect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08460eb88181f71b41f828f23173b75013d8b6e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->