### PR TITLE
Ignore repository-local pnpm store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target/
 **/.build/
 node_modules/
+.pnpm-store/
 .DS_Store
 .shuttle/
 Secrets*.toml


### PR DESCRIPTION
Keep pnpm's regenerable package cache out of working-tree changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gitignore-only change with no runtime, build, or security impact.
> 
> **Overview**
> Adds **`.pnpm-store/`** to `.gitignore`, alongside `node_modules/`, so a repo-local pnpm package cache does not show up as untracked or modified files. The store is regenerable and does not need to be versioned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d112e42d428c8680203733bf28ac812b5baeaf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->