### PR TITLE
Move provider Reset into Advanced as a destructive action

### DIFF
--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -14,6 +14,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@anlg/ui/components/ui/accordion";
+import { Button } from "@anlg/ui/components/ui/button";
 import {
   InputGroup,
   InputGroupInput,
@@ -364,6 +365,24 @@ export function NonAnarlogProviderCard({
     }
   };
 
+  const hasAdvancedFields = (!showBaseUrl && !!config.baseUrl) || !showApiKey;
+  const showAdvanced = !config.hideAdvanced && hasAdvancedFields;
+  const resetAction = hasStoredConfig ? (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={() => void handleReset()}
+      disabled={clearProvider.isPending}
+      className="text-destructive hover:text-destructive/80 h-7 self-start px-0 hover:bg-transparent"
+    >
+      {clearProvider.isPending ? (
+        <CircleNotch className="size-3 animate-spin" aria-hidden="true" />
+      ) : null}
+      <Trans>Reset</Trans>
+    </Button>
+  ) : null;
+
   return (
     <AccordionItem
       disabled={config.disabled || locked}
@@ -471,55 +490,35 @@ export function NonAnarlogProviderCard({
               )}
             </div>
           )}
-          {!config.hideAdvanced &&
-            ((!showBaseUrl && config.baseUrl) || !showApiKey) && (
-              <details className="flex flex-col gap-4 pt-2">
-                <summary className="text-muted-foreground hover:text-foreground cursor-pointer text-xs hover:underline">
-                  <Trans>Advanced</Trans>
-                </summary>
-                <div className="mt-4 flex flex-col gap-4">
-                  {!showBaseUrl && config.baseUrl && (
-                    <form.Field name="base_url">
-                      {(field) => (
-                        <FormField field={field} label={t`Base URL`} />
-                      )}
-                    </form.Field>
-                  )}
-                  {!showApiKey && (
-                    <form.Field name="api_key">
-                      {(field) => (
-                        <FormField
-                          field={field}
-                          label={t`API Key`}
-                          placeholder={t`Enter your API key (optional)`}
-                          type="password"
-                        />
-                      )}
-                    </form.Field>
-                  )}
-                </div>
-              </details>
-            )}
-          {hasStoredConfig ? (
-            <button
-              type="button"
-              onClick={() => void handleReset()}
-              disabled={clearProvider.isPending}
-              className={cn([
-                "inline-flex cursor-pointer items-center gap-1 self-start text-xs",
-                "text-muted-foreground hover:text-foreground transition-colors",
-                "disabled:cursor-not-allowed disabled:opacity-50",
-              ])}
-            >
-              {clearProvider.isPending ? (
-                <CircleNotch
-                  className="size-3 animate-spin"
-                  aria-hidden="true"
-                />
-              ) : null}
-              <Trans>Reset</Trans>
-            </button>
-          ) : null}
+          {showAdvanced ? (
+            <details>
+              <summary className="text-muted-foreground hover:text-foreground cursor-pointer text-xs hover:underline">
+                <Trans>Advanced</Trans>
+              </summary>
+              <div className="mt-2 flex flex-col gap-4">
+                {!showBaseUrl && config.baseUrl && (
+                  <form.Field name="base_url">
+                    {(field) => <FormField field={field} label={t`Base URL`} />}
+                  </form.Field>
+                )}
+                {!showApiKey && (
+                  <form.Field name="api_key">
+                    {(field) => (
+                      <FormField
+                        field={field}
+                        label={t`API Key`}
+                        placeholder={t`Enter your API key (optional)`}
+                        type="password"
+                      />
+                    )}
+                  </form.Field>
+                )}
+                {resetAction}
+              </div>
+            </details>
+          ) : (
+            resetAction
+          )}
           {clearProvider.error && (
             <p className="text-destructive text-xs">
               {clearProvider.error.message}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reset on AI provider cards was a muted text link at the bottom of the card, sitting outside Advanced with extra space above Base URL.

- Style Reset as a destructive ghost button
- Place it inside the Advanced section (still available at the form level when Advanced is hidden)
- Drop the extra `details` flex/`mt-4` spacing above Base URL

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-375c04e6-3618-4faf-a230-e5d59ceb20d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-375c04e6-3618-4faf-a230-e5d59ceb20d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

