### PR TITLE
fix(desktop): auto-dismiss error toasts after 5s

### DIFF
--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -990,7 +990,7 @@ async function activateCloudsync(
       if (credentialErrorCode === DEVICE_LIMIT_ERROR_CODE) {
         sonnerToast.error(
           t`Cloud sync is limited to 5 devices. Remove another device to sync here.`,
-          { id: DEVICE_LIMIT_TOAST_ID, duration: Infinity },
+          { id: DEVICE_LIMIT_TOAST_ID },
         );
         console.warn(
           "[cloudsync] device limit reached; sync remains disabled on this device",

--- a/apps/desktop/src/auth/context.test.tsx
+++ b/apps/desktop/src/auth/context.test.tsx
@@ -1486,7 +1486,7 @@ describe("AuthProvider", () => {
     );
     expect(mocks.toastError).toHaveBeenCalledWith(
       "The notes on this device are linked to another Anarlog account. Sign in with the account previously used here.",
-      { id: "auth-account-mismatch", duration: Infinity },
+      { id: "auth-account-mismatch" },
     );
   });
 

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -218,7 +218,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       sonnerToast.error(
         t`The notes on this device are linked to another Anarlog account. Sign in with the account previously used here.`,
-        { id: ACCOUNT_MISMATCH_TOAST_ID, duration: Infinity },
+        { id: ACCOUNT_MISMATCH_TOAST_ID },
       );
       await rejectAuthChange(transition, true);
     },

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -1150,7 +1150,7 @@ describe("SessionShareButton", () => {
     await waitFor(() =>
       expect(mocks.toastError).toHaveBeenCalledWith(
         "Could not publish the desktop edits. Check the latest web copy and try again.",
-        { id: "desktop-edits-publish-failed", duration: Infinity },
+        { id: "desktop-edits-publish-failed" },
       ),
     );
     expect(mocks.recordPublishedSessionShareState).not.toHaveBeenCalled();

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -178,7 +178,7 @@ export function SessionSharePopoverContent({
       if (error instanceof ShareOperationAbortedError) return;
       sonnerToast.error(
         t`Could not publish the desktop edits. Check the latest web copy and try again.`,
-        { id: "desktop-edits-publish-failed", duration: Infinity },
+        { id: "desktop-edits-publish-failed" },
       );
     },
     onSettled: onChanged,

--- a/apps/desktop/src/shared/ui/settings-alert.test.tsx
+++ b/apps/desktop/src/shared/ui/settings-alert.test.tsx
@@ -8,14 +8,21 @@ const mocks = vi.hoisted(() => ({
   dismiss: vi.fn(),
 }));
 
-vi.mock("@anlg/ui/components/ui/toast", () => ({
-  sonnerToast: {
-    message: mocks.message,
-    error: mocks.error,
-    warning: mocks.warning,
-    dismiss: mocks.dismiss,
-  },
-}));
+vi.mock("@anlg/ui/components/ui/toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@anlg/ui/components/ui/toast")>();
+  return {
+    ...actual,
+    sonnerToast: {
+      message: mocks.message,
+      error: mocks.error,
+      warning: mocks.warning,
+      dismiss: mocks.dismiss,
+    },
+  };
+});
+
+import { TOAST_DURATIONS } from "@anlg/ui/components/ui/toast";
 
 import { SettingsAlertToast } from "./settings-alert";
 
@@ -43,7 +50,7 @@ describe("SettingsAlertToast", () => {
 
     expect(mocks.error).toHaveBeenCalledWith("Provider not configured.", {
       id: "settings-alert",
-      duration: Infinity,
+      duration: TOAST_DURATIONS.error,
       dismissible: true,
       closeButton: true,
     });
@@ -63,7 +70,7 @@ describe("SettingsAlertToast", () => {
     expect(mocks.dismiss).toHaveBeenCalledWith("settings-alert");
   });
 
-  it("keeps required settings actions persistent", () => {
+  it("auto-dismisses error settings alerts while keeping actions available", () => {
     const onClick = vi.fn();
 
     render(
@@ -80,7 +87,7 @@ describe("SettingsAlertToast", () => {
       "Repair Keychain access.",
       expect.objectContaining({
         id: "keychain-alert",
-        duration: Infinity,
+        duration: TOAST_DURATIONS.error,
         dismissible: false,
         closeButton: false,
         action: expect.objectContaining({ label: "Repair" }),

--- a/apps/desktop/src/shared/ui/settings-alert.tsx
+++ b/apps/desktop/src/shared/ui/settings-alert.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent } from "react";
 
-import { sonnerToast } from "@anlg/ui/components/ui/toast";
+import { sonnerToast, TOAST_DURATIONS } from "@anlg/ui/components/ui/toast";
 
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
@@ -56,7 +56,7 @@ function SettingsAlertToastLifecycle({
     const dismissible = lifecycle === "persistent";
     const options = {
       id,
-      duration: Infinity,
+      duration: variant === "error" ? TOAST_DURATIONS.error : Infinity,
       dismissible,
       closeButton: dismissible,
       ...(action

--- a/apps/desktop/src/shared/ui/toast-duration.test.ts
+++ b/apps/desktop/src/shared/ui/toast-duration.test.ts
@@ -40,6 +40,8 @@ describe("toast durations", () => {
   });
 
   it("applies the default duration for each timed toast category", () => {
+    expect(TOAST_DURATIONS.error).toBe(5_000);
+
     sonnerToast.success("Saved");
     sonnerToast.info("Heads up");
     sonnerToast.warning("Check this");
@@ -74,17 +76,22 @@ describe("toast durations", () => {
     expect(mocks.loading).toHaveBeenCalledWith("Working", { id: "loading" });
   });
 
-  it("auto-dismisses error toasts even when callers request Infinity", () => {
+  it("caps error toasts at five seconds even when callers request longer", () => {
     sonnerToast.error("Try again", { duration: Infinity, id: "error" });
     sonnerToast.error("Custom window", { duration: 12_000, id: "custom" });
+    sonnerToast.error("Shorter window", { duration: 2_000, id: "short" });
 
     expect(mocks.error).toHaveBeenCalledWith("Try again", {
       duration: TOAST_DURATIONS.error,
       id: "error",
     });
     expect(mocks.error).toHaveBeenCalledWith("Custom window", {
-      duration: 12_000,
+      duration: TOAST_DURATIONS.error,
       id: "custom",
+    });
+    expect(mocks.error).toHaveBeenCalledWith("Shorter window", {
+      duration: 2_000,
+      id: "short",
     });
   });
 });

--- a/apps/desktop/src/shared/ui/toast-duration.test.ts
+++ b/apps/desktop/src/shared/ui/toast-duration.test.ts
@@ -73,4 +73,18 @@ describe("toast durations", () => {
     });
     expect(mocks.loading).toHaveBeenCalledWith("Working", { id: "loading" });
   });
+
+  it("auto-dismisses error toasts even when callers request Infinity", () => {
+    sonnerToast.error("Try again", { duration: Infinity, id: "error" });
+    sonnerToast.error("Custom window", { duration: 12_000, id: "custom" });
+
+    expect(mocks.error).toHaveBeenCalledWith("Try again", {
+      duration: TOAST_DURATIONS.error,
+      id: "error",
+    });
+    expect(mocks.error).toHaveBeenCalledWith("Custom window", {
+      duration: 12_000,
+      id: "custom",
+    });
+  });
 });

--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -55,15 +55,20 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("@anlg/ui/components/ui/toast", () => ({
-  sonnerToast: {
-    message: mocks.message,
-    error: mocks.error,
-    warning: mocks.warning,
-    loading: mocks.loading,
-    dismiss: mocks.dismiss,
-  },
-}));
+vi.mock("@anlg/ui/components/ui/toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@anlg/ui/components/ui/toast")>();
+  return {
+    ...actual,
+    sonnerToast: {
+      message: mocks.message,
+      error: mocks.error,
+      warning: mocks.warning,
+      loading: mocks.loading,
+      dismiss: mocks.dismiss,
+    },
+  };
+});
 
 vi.mock("~/auth", () => ({
   useAuth: () => ({ session: null, signIn: mocks.signIn }),
@@ -136,6 +141,8 @@ vi.mock("./useDismissedToasts", () => ({
     isDismissed: (id: string) => mocks.dismissedToastIds.has(id),
   }),
 }));
+
+import { TOAST_DURATIONS } from "@anlg/ui/components/ui/toast";
 
 import { ToastNotifications } from "./index";
 
@@ -370,7 +377,10 @@ describe("ToastNotifications", () => {
 
     expect(mocks.error).toHaveBeenCalledWith(
       "The update download failed",
-      expect.objectContaining({ id: "desktop-update:1.0.34:failed" }),
+      expect.objectContaining({
+        id: "desktop-update:1.0.34:failed",
+        duration: TOAST_DURATIONS.error,
+      }),
     );
   });
 

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 
-import { sonnerToast } from "@anlg/ui/components/ui/toast";
+import { sonnerToast, TOAST_DURATIONS } from "@anlg/ui/components/ui/toast";
 
 import {
   createDevtoolsToastPreview,
@@ -292,7 +292,7 @@ function SonnerNotification({
     const dismissible = toast.lifecycle.type === "persistent";
     const options = {
       id: toast.id,
-      duration: Infinity,
+      duration: toast.variant === "error" ? TOAST_DURATIONS.error : Infinity,
       closeButton: dismissible,
       dismissible,
       icon: toast.icon,

--- a/apps/desktop/src/stt/capture-lifecycle.ts
+++ b/apps/desktop/src/stt/capture-lifecycle.ts
@@ -359,7 +359,7 @@ export function useCaptureLifecycle(sessionId: string) {
         sonnerToast.dismiss("meeting-disclosure-send-failed");
         const notifyFailure = (message: string, id: string) => {
           if (requestRecoveryOnFailure) {
-            sonnerToast.error(message, { id, duration: Infinity });
+            sonnerToast.error(message, { id });
           }
         };
         const requestRecovery = async () => {

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -2595,7 +2595,7 @@ describe("useStartListening", () => {
 
     expect(sonnerToastErrorMock).toHaveBeenCalledWith(
       "Anarlog could not save part of the live transcript.",
-      { id: "live-transcript-persist-failed", duration: Infinity },
+      { id: "live-transcript-persist-failed" },
     );
     expect(queueAutoEnhanceIfSummaryEmptyMock).not.toHaveBeenCalled();
     expect(queueAutoEnhanceMock).not.toHaveBeenCalled();
@@ -2645,7 +2645,7 @@ describe("useStartListening", () => {
 
     expect(sonnerToastErrorMock).toHaveBeenCalledWith(
       "Anarlog could not finish saving the transcript. The recording was kept so you can try again.",
-      { id: "post-capture-transcript-incomplete", duration: Infinity },
+      { id: "post-capture-transcript-incomplete" },
     );
     expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
     expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
@@ -2684,7 +2684,7 @@ describe("useStartListening", () => {
 
     expect(sonnerToastErrorMock).toHaveBeenCalledWith(
       "Post-meeting transcription failed. The recording was kept so you can try again.",
-      { id: "post-capture-batch-failed", duration: Infinity },
+      { id: "post-capture-batch-failed" },
     );
     expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
     expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
@@ -2764,7 +2764,7 @@ describe("useStartListening", () => {
 
     expect(sonnerToastErrorMock).toHaveBeenCalledWith(
       "Anarlog could not finish saving the transcript. The recording was kept so you can try again.",
-      { id: "post-capture-transcript-incomplete", duration: Infinity },
+      { id: "post-capture-transcript-incomplete" },
     );
     expect(queueAutoEnhanceIfSummaryEmptyMock).not.toHaveBeenCalled();
     expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
@@ -3008,7 +3008,7 @@ describe("useStartListening", () => {
     expect(queueAutoEnhanceIfSummaryEmptyMock).toHaveBeenCalledOnce();
     expect(sonnerToastErrorMock).toHaveBeenCalledWith(
       "The transcript was saved, but Anarlog could not start the summary. Try generating it again.",
-      { id: "post-capture-summary-failed", duration: Infinity },
+      { id: "post-capture-summary-failed" },
     );
     expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
     expect(saveCaptureLifecycleMarkerMock).toHaveBeenCalledWith(

--- a/packages/ui/src/components/ui/toast.tsx
+++ b/packages/ui/src/components/ui/toast.tsx
@@ -19,6 +19,20 @@ function withDefaultDuration(
   return { duration, ...options };
 }
 
+function withAutoDismissDuration(
+  duration: number,
+  options?: ExternalToast,
+): ExternalToast {
+  const requested = options?.duration;
+  return {
+    ...options,
+    duration:
+      requested === undefined || !Number.isFinite(requested)
+        ? duration
+        : requested,
+  };
+}
+
 export const sonnerToast: typeof rawSonnerToast = Object.assign(
   (message: Parameters<typeof rawSonnerToast>[0], options?: ExternalToast) =>
     rawSonnerToast(message, withDefaultDuration(TOAST_DURATIONS.info, options)),
@@ -54,7 +68,7 @@ export const sonnerToast: typeof rawSonnerToast = Object.assign(
     ) =>
       rawSonnerToast.error(
         message,
-        withDefaultDuration(TOAST_DURATIONS.error, options),
+        withAutoDismissDuration(TOAST_DURATIONS.error, options),
       ),
     message: (
       message: Parameters<typeof rawSonnerToast.message>[0],

--- a/packages/ui/src/components/ui/toast.tsx
+++ b/packages/ui/src/components/ui/toast.tsx
@@ -9,7 +9,7 @@ export const TOAST_DURATIONS = {
   success: 3_000,
   info: 4_000,
   warning: 6_000,
-  error: 8_000,
+  error: 5_000,
 } as const;
 
 function withDefaultDuration(
@@ -29,7 +29,7 @@ function withAutoDismissDuration(
     duration:
       requested === undefined || !Number.isFinite(requested)
         ? duration
-        : requested,
+        : Math.min(requested, duration),
   };
 }
 
@@ -101,7 +101,7 @@ const Toaster = ({
     toastOptions={{
       classNames: {
         toast:
-          "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border group-[.toaster]:border-border group-[.toaster]:shadow-md group-[.toaster]:rounded-xl group-[.toaster]:overflow-visible group-[.toaster]:w-[300px] group-[.toaster]:p-3.5 group-[.toaster]:gap-3",
+          "group toast pointer-events-auto group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border group-[.toaster]:border-border group-[.toaster]:shadow-md group-[.toaster]:rounded-xl group-[.toaster]:overflow-visible group-[.toaster]:w-[300px] group-[.toaster]:p-3.5 group-[.toaster]:gap-3",
         description: "group-[.toast]:text-muted-foreground",
         actionButton:
           "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Error toasts no longer stay on screen until dismissed.

They auto-dismiss after **5 seconds** at most. Hovering the toast pauses that timer so you can keep reading it; the countdown resumes when the pointer leaves.

- Error toasts always auto-dismiss, even if a caller requests `Infinity` or a longer duration
- Finite durations shorter than 5s are still honored
- Warnings, loading toasts, and action prompts can still stay until their condition clears

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e1909fc-3ae3-46bc-82fe-0ac2f14b226e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e1909fc-3ae3-46bc-82fe-0ac2f14b226e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

