### PR TITLE
fix: prevent i18n from blocking desktop startup

### DIFF
--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -13,24 +13,6 @@ import type { ContextRef } from "~/chat/context/entities";
 import { useChatAppearance } from "~/chat/hooks/use-chat-appearance";
 import { useTabs } from "~/store/zustand/tabs";
 
-const SUGGESTIONS = [
-  {
-    label: t`List action items.`,
-    icon: ListChecks,
-    prompt: t`What are my action items from this meeting?`,
-  },
-  {
-    label: t`Draft follow-up email.`,
-    icon: Envelope,
-    prompt: t`Draft a follow-up email to the participants`,
-  },
-  {
-    label: t`Find key decisions.`,
-    icon: MagnifyingGlass,
-    prompt: t`What were the key decisions that have been made?`,
-  },
-];
-
 export function ChatBodyEmpty({
   isModelConfigured = true,
   hasContext = false,
@@ -46,6 +28,23 @@ export function ChatBodyEmpty({
 }) {
   const { isDarkAppearance } = useChatAppearance();
   const openNew = useTabs((state) => state.openNew);
+  const suggestions = [
+    {
+      label: t`List action items.`,
+      icon: ListChecks,
+      prompt: t`What are my action items from this meeting?`,
+    },
+    {
+      label: t`Draft follow-up email.`,
+      icon: Envelope,
+      prompt: t`Draft a follow-up email to the participants`,
+    },
+    {
+      label: t`Find key decisions.`,
+      icon: MagnifyingGlass,
+      prompt: t`What were the key decisions that have been made?`,
+    },
+  ];
 
   const handleGoToSettings = useCallback(() => {
     openNew({ type: "settings", state: { tab: "intelligence" } });
@@ -105,7 +104,7 @@ export function ChatBodyEmpty({
       <div className="flex w-full flex-col">
         {hasContext && (
           <div className="flex flex-col gap-0.5">
-            {SUGGESTIONS.map(({ label, icon: Icon, prompt }) => (
+            {suggestions.map(({ label, icon: Icon, prompt }) => (
               <button
                 key={label}
                 onClick={() => handleSuggestionClick(prompt)}

--- a/apps/desktop/src/i18n/catalogs.test.ts
+++ b/apps/desktop/src/i18n/catalogs.test.ts
@@ -21,4 +21,15 @@ describe("i18n catalogs", () => {
     expect(second.locale).toBe("ko");
     expect(first._("dEgA5A")).not.toBe("dEgA5A");
   });
+
+  it("does not let a slower catalog overwrite a newer locale", async () => {
+    const stale = createI18n("ko");
+    const latest = createI18n("ja");
+
+    await latest;
+    expect(i18n.locale).toBe("ja");
+
+    await stale;
+    expect(i18n.locale).toBe("ja");
+  });
 });

--- a/apps/desktop/src/i18n/catalogs.test.ts
+++ b/apps/desktop/src/i18n/catalogs.test.ts
@@ -1,3 +1,4 @@
+import { i18n } from "@lingui/core";
 import { describe, expect, it } from "vitest";
 
 import { createI18n, getCatalogLocalesForDisplayLocale } from "./catalogs";
@@ -15,6 +16,7 @@ describe("i18n catalogs", () => {
     const first = await createI18n("ko");
     const second = await createI18n("ko");
 
+    expect(first).toBe(i18n);
     expect(first.locale).toBe("ko");
     expect(second.locale).toBe("ko");
     expect(first._("dEgA5A")).not.toBe("dEgA5A");

--- a/apps/desktop/src/i18n/catalogs.ts
+++ b/apps/desktop/src/i18n/catalogs.ts
@@ -6,6 +6,7 @@ const catalogModules = import.meta.glob<{ messages: Messages }>(
   "./locales/*/messages.ts",
 );
 const catalogCache = new Map<DisplayLocale, Promise<Messages>>();
+let createI18nGeneration = 0;
 
 export function getCatalogLocalesForDisplayLocale(
   locale: DisplayLocale,
@@ -14,8 +15,13 @@ export function getCatalogLocalesForDisplayLocale(
 }
 
 export async function createI18n(locale: DisplayLocale): Promise<I18n> {
+  const generation = ++createI18nGeneration;
   const locales = getCatalogLocalesForDisplayLocale(locale);
   const messages = await Promise.all(locales.map(loadCatalog));
+  if (generation !== createI18nGeneration) {
+    return i18n;
+  }
+
   const sourceMessages = messages[0]!;
   const activeMessages = messages[messages.length - 1]!;
 

--- a/apps/desktop/src/i18n/catalogs.ts
+++ b/apps/desktop/src/i18n/catalogs.ts
@@ -1,4 +1,4 @@
-import { setupI18n, type I18n, type Messages } from "@lingui/core";
+import { i18n, type I18n, type Messages } from "@lingui/core";
 
 import { SOURCE_LOCALE, type DisplayLocale } from "./locales";
 
@@ -14,7 +14,6 @@ export function getCatalogLocalesForDisplayLocale(
 }
 
 export async function createI18n(locale: DisplayLocale): Promise<I18n> {
-  const i18n = setupI18n();
   const locales = getCatalogLocalesForDisplayLocale(locale);
   const messages = await Promise.all(locales.map(loadCatalog));
   const sourceMessages = messages[0]!;

--- a/apps/desktop/src/session-sharing/access-management.tsx
+++ b/apps/desktop/src/session-sharing/access-management.tsx
@@ -77,12 +77,6 @@ type AccessMutation =
       entry: Extract<SessionShareAccessEntry, { entryType: "request" }>;
     };
 
-const capabilityLabels: Record<SessionAccessCapability, string> = {
-  viewer: t`Can view`,
-  commenter: t`Can comment`,
-  editor: t`Can edit`,
-};
-
 const capabilityRanks: Record<SessionAccessCapability, number> = {
   viewer: 1,
   commenter: 2,
@@ -313,6 +307,12 @@ export function AccessEntryRow({
   onMutate: (mutation: AccessMutation) => void;
 }) {
   const label = contactName || entry.userEmail || t`Anarlog user`;
+  const capabilityLabels: Record<SessionAccessCapability, string> = {
+    viewer: t`Can view`,
+    commenter: t`Can comment`,
+    editor: t`Can edit`,
+  };
+
   return (
     <div className="hover:bg-accent/50 flex min-h-9 items-center gap-2 rounded-lg px-1.5 py-1">
       <ContactFacehash name={label} size={24} />


### PR DESCRIPTION
- Activate loaded catalogs on Lingui's shared runtime instance
- Defer translated constants until rendering so imports cannot abort boot
- Cover the shared instance behavior in catalog tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 59fe02f0a3fe26d8cd8de89a996b42de6a218a5d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->