### PR TITLE
chore(release): add desktop 1.4.11 changelog

### DIFF
--- a/packages/changelog/content/1.4.11.md
+++ b/packages/changelog/content/1.4.11.md
@@ -1,0 +1,64 @@
+---
+date: "2026-08-20"
+summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcript editing, folders and meeting moves, clearer startup progress, and more reliable updates and settings."
+---
+
+## Cloud sync
+
+- Approve a new device from another device that already has sync access instead
+  of entering the recovery key again
+- See pending devices in Settings → Sync, remove them, or replace an old device
+  when you reach the five-device limit; recovery-key entry remains available as
+  a fallback
+- Recover from the personal-encryption validation issue and temporary database
+  locks that could leave cloud sync stuck while connecting
+
+## Transcripts and meetings
+
+- Use the new transcript **Select** mode to pick individual or continuous
+  segments, reassign their speaker together, or merge consecutive segments
+- Keep speaker labels aligned with their words during live transcription, and
+  get separate speaker labels when using Azure Speech
+- Put a note into a new or existing top-level folder directly from the session
+  toolbar
+- Ask chat to move a finished recording, transcript, summary, notes, and action
+  items onto the correct meeting
+- Keep an active recording from being interrupted by an overlapping scheduled
+  meeting, and see calendar details instead of **Join & record** after a meeting
+  has ended
+
+## Startup and updates
+
+- See a branded loading screen with useful progress while Anarlog checks or
+  migrates the database, imports old notes, and prepares cloud sync
+- Open the app without getting stuck on a white screen when a startup task is
+  slow or unavailable
+- Install a downloaded update reliably on the next launch, retry after a
+  temporary check or install failure, and clean up stale update downloads
+- Repair an interrupted 1.4.10 database migration automatically and wait out a
+  brief post-update database lock instead of failing to start
+- Keep the main window where you left it after an update, while still recovering
+  a window that is no longer visible
+- Prevent localization loading from stopping the desktop app during startup
+
+## Settings and developers
+
+- Keep App and Meetings switches saved, including automatic updates, launch at
+  login, tray and Dock visibility, scheduled recording, the floating bar,
+  recording disclosure, and meeting-chat capture
+- Reset an Intelligence or Transcription provider from the **Advanced** section
+  with a clearly marked destructive action
+- Add the Anarlog skill to Claude Code, Codex, Cursor, OpenCode, or every
+  detected coding agent from Settings → Developers
+- Get the bundled `anarlog` CLI installed automatically when it is missing
+
+## Other improvements
+
+- Use a Windows-style application title bar on Linux
+- Find Email and Slack sharing in the overflow menu while invitations stay
+  immediately available
+- Keep stale @-mention searches from replacing newer results or reopening a
+  dismissed suggestion list
+- Let error toasts clear themselves after five seconds; hover to pause the timer
+- Connect calendars with read-only permissions and more reliable Microsoft
+  sign-in handoff


### PR DESCRIPTION
## Summary
- add the dated 1.4.11 changelog with a concise index preview
- cover desktop user-facing changes since `desktop_v1.4.10`, including trusted-device sync approval, transcript tools, startup progress, and updater reliability
- exclude internal refactors, CI, and packaging-only changes

## Test plan
- [x] `pnpm exec dprint fmt`
- [x] `pnpm -F @anlg/changelog typecheck`
- [x] `pnpm fmt:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c2aba6c8446ab573d2cd2e11fd144826060e0ce3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->