### PR TITLE
Refresh generated fs-sync permissions

### DIFF
--- a/plugins/fs-sync/permissions/autogenerated/reference.md
+++ b/plugins/fs-sync/permissions/autogenerated/reference.md
@@ -149,6 +149,32 @@ Denies the attachment_save command without any pre-configured scope.
 <tr>
 <td>
 
+`fs-sync:allow-audio-copy`
+
+</td>
+<td>
+
+Enables the audio_copy command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`fs-sync:deny-audio-copy`
+
+</td>
+<td>
+
+Denies the audio_copy command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `fs-sync:allow-audio-delete`
 
 </td>
@@ -324,32 +350,6 @@ Enables the audio_path command without any pre-configured scope.
 <td>
 
 Denies the audio_path command without any pre-configured scope.
-
-</td>
-</tr>
-
-<tr>
-<td>
-
-`fs-sync:allow-audio-copy`
-
-</td>
-<td>
-
-Enables the audio_copy command without any pre-configured scope.
-
-</td>
-</tr>
-
-<tr>
-<td>
-
-`fs-sync:deny-audio-copy`
-
-</td>
-<td>
-
-Denies the audio_copy command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/fs-sync/permissions/schemas/schema.json
+++ b/plugins/fs-sync/permissions/schemas/schema.json
@@ -343,6 +343,18 @@
           "markdownDescription": "Denies the attachment_save command without any pre-configured scope."
         },
         {
+          "description": "Enables the audio_copy command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-audio-copy",
+          "markdownDescription": "Enables the audio_copy command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the audio_copy command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-audio-copy",
+          "markdownDescription": "Denies the audio_copy command without any pre-configured scope."
+        },
+        {
           "description": "Enables the audio_delete command without any pre-configured scope.",
           "type": "string",
           "const": "allow-audio-delete",
@@ -413,18 +425,6 @@
           "type": "string",
           "const": "deny-audio-metadata",
           "markdownDescription": "Denies the audio_metadata command without any pre-configured scope."
-        },
-        {
-          "description": "Enables the audio_copy command without any pre-configured scope.",
-          "type": "string",
-          "const": "allow-audio-copy",
-          "markdownDescription": "Enables the audio_copy command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the audio_copy command without any pre-configured scope.",
-          "type": "string",
-          "const": "deny-audio-copy",
-          "markdownDescription": "Denies the audio_copy command without any pre-configured scope."
         },
         {
           "description": "Enables the audio_path command without any pre-configured scope.",


### PR DESCRIPTION
## Summary
- align generated permission ordering with current Tauri output
- keep native release-candidate builds source-clean

## Test plan
- pnpm exec dprint fmt
- pnpm fmt:check
- cargo check -p tauri-plugin-fs-sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSON schema ordering only; no ACL identifiers or default grants changed.
> 
> **Overview**
> Regenerates **fs-sync** Tauri permission artifacts so their ordering matches current generator output, without changing which commands are allowed or denied.
> 
> The only substantive diff is **repositioning** `allow-audio-copy` / `deny-audio-copy` in `permissions/autogenerated/reference.md` and `permissions/schemas/schema.json`—from after the audio-path block to immediately after attachment-save (ahead of `audio_delete`). Identifiers, descriptions, and default permission membership are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80501dec0d1102c77c9f335a0150c9a1890f492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->