### PR TITLE
fix(desktop): stop sending temperature 0 to cloud LLMs

### DIFF
--- a/apps/desktop/src/ai/hooks/useLLMConnection.ts
+++ b/apps/desktop/src/ai/hooks/useLLMConnection.ts
@@ -13,6 +13,7 @@ import type { AIProviderStorage } from "@anlg/store";
 
 import { createAppleFoundationModel } from "../apple-foundation-model";
 import { createAuthFetch } from "../auth-fetch";
+import { omitTemperatureMiddleware } from "../omit-temperature-middleware";
 import { createTracedFetch, tracedFetch } from "../traced-fetch";
 
 import { useAuth } from "~/auth";
@@ -229,6 +230,7 @@ const wrapWithThinkingMiddleware = (
   return wrapLanguageModel({
     model,
     middleware: [
+      omitTemperatureMiddleware,
       extractReasoningMiddleware({ tagName: "think" }),
       extractReasoningMiddleware({ tagName: "thinking" }),
     ],

--- a/apps/desktop/src/ai/omit-temperature-middleware.test.ts
+++ b/apps/desktop/src/ai/omit-temperature-middleware.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { omitTemperatureMiddleware } from "./omit-temperature-middleware";
+
+describe("omitTemperatureMiddleware", () => {
+  it("removes temperature from generation params", async () => {
+    const transformParams = omitTemperatureMiddleware.transformParams;
+    expect(transformParams).toEqual(expect.any(Function));
+
+    const params = {
+      prompt: [
+        {
+          role: "user" as const,
+          content: [{ type: "text" as const, text: "Hi" }],
+        },
+      ],
+      temperature: 0,
+      maxOutputTokens: 8192,
+    };
+
+    const next = await transformParams!({
+      type: "generate",
+      params,
+      model: {
+        specificationVersion: "v3",
+        provider: "openai",
+        modelId: "gpt-5.4",
+        supportedUrls: {},
+        doGenerate: vi.fn(),
+        doStream: vi.fn(),
+      },
+    });
+
+    expect(next).not.toHaveProperty("temperature");
+    expect(next.maxOutputTokens).toBe(8192);
+  });
+});

--- a/apps/desktop/src/ai/omit-temperature-middleware.ts
+++ b/apps/desktop/src/ai/omit-temperature-middleware.ts
@@ -1,0 +1,12 @@
+import type { LanguageModelMiddleware } from "ai";
+
+// Frontier chat/reasoning models reject an explicit temperature (including 0).
+// Cloud providers already pick a supported default when the field is omitted.
+export const omitTemperatureMiddleware: LanguageModelMiddleware = {
+  specificationVersion: "v3",
+  transformParams: async ({ params }) => {
+    const next = { ...params };
+    delete next.temperature;
+    return next;
+  },
+};

--- a/apps/desktop/src/error-reporting.test.ts
+++ b/apps/desktop/src/error-reporting.test.ts
@@ -246,6 +246,18 @@ describe("user-caused failures", () => {
         extra: { "error.code": "insufficient_quota" },
       }),
     ).toBeNull();
+    expect(
+      sanitizeErrorEvent({
+        type: undefined,
+        message: "`temperature` is deprecated for this model.",
+      }),
+    ).toBeNull();
+    expect(
+      sanitizeErrorEvent({
+        type: undefined,
+        message: "The model does not exist.",
+      }),
+    ).toBeNull();
   });
 
   it("keeps errors whose only match is an earlier breadcrumb", () => {

--- a/apps/desktop/src/error-reporting.ts
+++ b/apps/desktop/src/error-reporting.ts
@@ -16,6 +16,7 @@ let errorReportingConsentRevision = 0;
 // Sentry. Keep in sync with `crates/user-error`.
 const USER_ERROR_MARKERS = [
   "billing_hard_limit_reached",
+  "cors requests are not allowed",
   "credit balance is too low",
   "exceeded your current quota",
   "incorrect api key",
@@ -31,6 +32,11 @@ const USER_ERROR_MARKERS = [
   "plans & billing",
   "plans and billing",
   "quota exceeded",
+  "signature expired",
+  "temperature is deprecated",
+  "temperature` is deprecated",
+  "the model does not exist",
+  "unsupported value: 'temperature'",
   "upgrade or purchase credits",
 ];
 

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -381,6 +381,9 @@ describe("inferAutomaticSpeakerAssignments", () => {
     });
 
     expect(mocks.generateText).toHaveBeenCalledTimes(2);
+    expect(mocks.generateText.mock.calls[0]![0]).not.toHaveProperty(
+      "temperature",
+    );
     expect(automaticHumanIds(updates[0]!)).toEqual([
       "human-lex",
       "human-george",

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -160,7 +160,7 @@ Return only JSON with this shape: {"mapping":{"cluster_id":"...","confidence":0.
               output: Output.object({
                 schema: candidateSpeakerAttributionOutputSchema,
               }),
-              temperature: 0,
+              ...(isAppleFoundationModel(model) ? { temperature: 0 } : {}),
               maxRetries: 2,
               maxOutputTokens: 200,
               abortSignal: signal,

--- a/crates/user-error/src/lib.rs
+++ b/crates/user-error/src/lib.rs
@@ -7,6 +7,7 @@ use sentry::protocol::{Context, Event, Value};
 
 const USER_ERROR_MARKERS: &[&str] = &[
     "billing_hard_limit_reached",
+    "cors requests are not allowed",
     "credit balance is too low",
     "exceeded your current quota",
     "incorrect api key",
@@ -22,6 +23,11 @@ const USER_ERROR_MARKERS: &[&str] = &[
     "plans & billing",
     "plans and billing",
     "quota exceeded",
+    "signature expired",
+    "temperature is deprecated",
+    "temperature` is deprecated",
+    "the model does not exist",
+    "unsupported value: 'temperature'",
     "upgrade or purchase credits",
 ];
 
@@ -76,6 +82,19 @@ mod tests {
         assert!(is_user_error_text(ANTHROPIC_CREDIT_ERROR));
         assert!(is_user_error_text(
             "{\"code\":\"insufficient_quota\",\"type\":\"invalid_request_error\"}"
+        ));
+        assert!(is_user_error_text(
+            "`temperature` is deprecated for this model."
+        ));
+        assert!(is_user_error_text(
+            "Unsupported value: 'temperature' does not support 0 with this model."
+        ));
+        assert!(is_user_error_text("The model does not exist."));
+        assert!(is_user_error_text(
+            "CORS requests are not allowed for this Organization because of its settings."
+        ));
+        assert!(is_user_error_text(
+            "Signature expired: 20260505T035233Z is now earlier than 20260819T144923Z"
         ));
         assert!(!is_user_error_text("failed to open database"));
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

High-priority Sentry alerts from today still show cloud LLM 400s for explicit `temperature: 0` (`HYPRNOTE2-2N35`, `HYPRNOTE2-2N38`). #6667 stopped sending that default, then #6754 put `temperature: 0` back on speaker attribution for Apple on-device models without gating it to Apple.

- Keep `temperature: 0` only for Apple Foundation Models
- Strip `temperature` from all other cloud language-model requests so enhance/chat cannot regress the same way
- Drop remaining user-config LLM failures from Sentry (deprecated temperature, missing model, Anthropic org CORS, expired AWS signatures)

## Test plan

- `pnpm -F desktop exec tsc --noEmit`
- `pnpm -F desktop test`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `cargo test -p user-error`
- `pnpm exec dprint fmt` / check on the changed non-Swift files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01d83-2d7d-7d6c-a211-5df5148a1489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01d83-2d7d-7d6c-a211-5df5148a1489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

