### PR TITLE
Fix macOS microphone permission prompt

### DIFF
--- a/plugins/permissions/src/ext.rs
+++ b/plugins/permissions/src/ext.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 use crate::models::PermissionStatus;
 
 #[cfg(target_os = "macos")]
-use block2::StackBlock;
-#[cfg(target_os = "macos")]
 use objc2_av_foundation::{AVCaptureDevice, AVMediaTypeAudio};
 #[cfg(target_os = "macos")]
 use objc2_contacts::{CNContactStore, CNEntityType};
@@ -511,11 +509,20 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Permissions<'a, R, M> {
     async fn request_microphone(&self) -> Result<(), crate::Error> {
         #[cfg(target_os = "macos")]
         {
+            let (tx, rx) = std::sync::mpsc::channel::<bool>();
+            let completion = block2::RcBlock::new(move |granted: objc2::runtime::Bool| {
+                let _ = tx.send(granted.as_bool());
+            });
+
             unsafe {
                 let media_type = AVMediaTypeAudio.unwrap();
-                let block = StackBlock::new(|_granted| {});
-                AVCaptureDevice::requestAccessForMediaType_completionHandler(media_type, &block);
+                AVCaptureDevice::requestAccessForMediaType_completionHandler(
+                    media_type,
+                    &completion,
+                );
             }
+
+            let _ = rx.recv_timeout(std::time::Duration::from_secs(60));
         }
 
         #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
## Summary
- keep the AVFoundation completion handler alive until the user responds
- restore the onboarding permission dialog after a fresh macOS TCC reset

## Test plan
- cargo check --locked -p tauri-plugin-permissions
- cargo test --locked -p tauri-plugin-permissions --lib --no-run
- pnpm fmt:check
- launch a clean Dev bundle through LaunchServices and verify macOS displays and records the microphone consent prompt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, macOS-only change to microphone request timing; no auth or data-path changes beyond fixing TCC prompt behavior.
> 
> **Overview**
> **Fixes macOS microphone permission prompting** by changing how `request_microphone` registers AVFoundation’s completion handler.
> 
> On macOS, `request_microphone` no longer uses a no-op `StackBlock` that could be dropped before the system shows or finishes the TCC dialog. It now uses an `RcBlock` wired to an `mpsc` channel and **waits up to 60 seconds** for the user’s grant/deny—matching the pattern already used for calendar, reminders, and contacts in the same file.
> 
> The unused `StackBlock` import is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46863a2a5c68c84e017c8efb4742fb660e8a4894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->