### PR TITLE
fix(editor): hide CJK placeholders and keep the format toolbar off traffic lights

### DIFF
--- a/packages/editor/src/plugins/placeholder.test.ts
+++ b/packages/editor/src/plugins/placeholder.test.ts
@@ -1,9 +1,20 @@
 import { GapCursor } from "prosemirror-gapcursor";
 import { EditorState, TextSelection } from "prosemirror-state";
-import { describe, expect, it } from "vitest";
+import { EditorView } from "prosemirror-view";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { schema } from "../note/schema";
-import { placeholderPlugin } from "./placeholder";
+import { PLACEHOLDER_COMPOSING_CLASS, placeholderPlugin } from "./placeholder";
+
+const views: EditorView[] = [];
+
+afterEach(() => {
+  for (const view of views) {
+    view.destroy();
+  }
+  views.length = 0;
+  document.body.innerHTML = "";
+});
 
 describe("placeholderPlugin", () => {
   it("decorates only the selected empty top-level block", () => {
@@ -138,5 +149,30 @@ describe("placeholderPlugin", () => {
     const decorations = plugin.props.decorations?.(nestedState)?.find() ?? [];
     expect(decorations).toHaveLength(1);
     expect(decorations[0].from).toBe(emptyParagraphPos);
+  });
+
+  it("hides placeholders while IME composition is active", () => {
+    const plugin = placeholderPlugin(() => "Start writing...");
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("paragraph")]),
+      plugins: [plugin],
+    });
+    const host = document.createElement("div");
+    document.body.append(host);
+    const view = new EditorView(host, { state });
+    views.push(view);
+
+    view.dom.dispatchEvent(
+      new CompositionEvent("compositionstart", { bubbles: true }),
+    );
+    expect(view.dom.classList.contains(PLACEHOLDER_COMPOSING_CLASS)).toBe(true);
+
+    view.dom.dispatchEvent(
+      new CompositionEvent("compositionend", { bubbles: true }),
+    );
+    expect(view.dom.classList.contains(PLACEHOLDER_COMPOSING_CLASS)).toBe(
+      false,
+    );
   });
 });

--- a/packages/editor/src/plugins/placeholder.ts
+++ b/packages/editor/src/plugins/placeholder.ts
@@ -16,6 +16,8 @@ export type PersistentPlaceholderFunction = (props: {
 
 export const placeholderPluginKey = new PluginKey("placeholder");
 
+export const PLACEHOLDER_COMPOSING_CLASS = "is-composing";
+
 function getPlaceholderTarget(doc: PMNode, $anchor: ResolvedPos) {
   for (let depth = $anchor.depth; depth > 0; depth--) {
     const node = $anchor.node(depth);
@@ -51,6 +53,16 @@ export function placeholderPlugin(
   return new Plugin({
     key: placeholderPluginKey,
     props: {
+      handleDOMEvents: {
+        compositionstart(view) {
+          view.dom.classList.add(PLACEHOLDER_COMPOSING_CLASS);
+          return false;
+        },
+        compositionend(view) {
+          view.dom.classList.remove(PLACEHOLDER_COMPOSING_CLASS);
+          return false;
+        },
+      },
       decorations(state) {
         const { doc, selection } = state;
         const { $anchor } = selection;

--- a/packages/editor/src/styles/prosemirror.css
+++ b/packages/editor/src/styles/prosemirror.css
@@ -56,6 +56,14 @@
   height: 0;
 }
 
+/* IME composition paints glyphs in the DOM before ProseMirror state updates,
+   so empty-node placeholder decorations would otherwise overlap them. */
+.ProseMirror.is-composing .is-editor-empty:first-child::before,
+.ProseMirror.is-composing .is-empty::before,
+.ProseMirror.is-composing .react-placeholder-widget {
+  display: none;
+}
+
 .ProseMirror .react-placeholder-widget {
   float: left;
   pointer-events: auto;

--- a/packages/editor/src/widgets/format-toolbar.test.ts
+++ b/packages/editor/src/widgets/format-toolbar.test.ts
@@ -1,8 +1,15 @@
 import { EditorState, TextSelection } from "prosemirror-state";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { schema } from "../note/schema";
-import { selectionTouchesTitleHeading } from "./format-toolbar";
+import {
+  getClipBoundary,
+  selectionTouchesTitleHeading,
+} from "./format-toolbar";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
 
 function createState(from: number, to: number) {
   const doc = schema.node("doc", null, [
@@ -39,5 +46,26 @@ describe("selectionTouchesTitleHeading", () => {
     });
 
     expect(selectionTouchesTitleHeading(state)).toBe(false);
+  });
+});
+
+describe("getClipBoundary", () => {
+  it("returns the nearest overflow ancestor", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    const inner = document.createElement("div");
+    const target = document.createElement("div");
+    inner.append(target);
+    scroller.append(inner);
+    document.body.append(scroller);
+
+    expect(getClipBoundary(target)).toBe(scroller);
+  });
+
+  it("falls back to the element when there is no overflow ancestor", () => {
+    const target = document.createElement("div");
+    document.body.append(target);
+
+    expect(getClipBoundary(target)).toBe(target);
   });
 });

--- a/packages/editor/src/widgets/format-toolbar.tsx
+++ b/packages/editor/src/widgets/format-toolbar.tsx
@@ -23,12 +23,50 @@ import {
 import { toggleMark } from "prosemirror-commands";
 import type { MarkType } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
 import { useRef } from "react";
 import { createPortal } from "react-dom";
 
 import { cn } from "@anlg/utils";
 
 import { schema } from "../note/schema";
+
+const OVERFLOW_CLIP = /(auto|scroll|overlay|hidden|clip)/;
+
+export function getClipBoundary(element: Element): Element {
+  let current = element.parentElement;
+  while (current && current !== document.documentElement) {
+    const { overflow, overflowX, overflowY } = getComputedStyle(current);
+    if (
+      OVERFLOW_CLIP.test(overflowY) ||
+      OVERFLOW_CLIP.test(overflowX) ||
+      OVERFLOW_CLIP.test(overflow)
+    ) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return element;
+}
+
+export function createSelectionVirtualElement(
+  view: EditorView,
+  from: number,
+  to: number,
+): VirtualElement {
+  const start = view.coordsAtPos(from);
+  const end = view.coordsAtPos(to);
+  return {
+    contextElement: view.dom,
+    getBoundingClientRect: () =>
+      new DOMRect(
+        Math.min(start.left, end.left),
+        start.top,
+        Math.abs(end.right - start.left),
+        end.bottom - start.top,
+      ),
+  };
+}
 
 export function selectionTouchesTitleHeading(state: EditorState): boolean {
   const firstNode = state.doc.firstChild;
@@ -105,24 +143,25 @@ export function FormatToolbar({
     if (!toolbar) return;
 
     const { from, to } = view.state.selection;
-    const start = view.coordsAtPos(from);
-    const end = view.coordsAtPos(to);
-
-    const referenceEl: VirtualElement = {
-      getBoundingClientRect: () =>
-        new DOMRect(
-          Math.min(start.left, end.left),
-          start.top,
-          Math.abs(end.right - start.left),
-          end.bottom - start.top,
-        ),
-    };
+    const referenceEl = createSelectionVirtualElement(view, from, to);
+    // Portaled toolbars clip to the viewport by default, which includes window
+    // chrome. Stay inside the editor scrollport so the menu flips below the
+    // first line instead of covering traffic lights.
+    const boundary = getClipBoundary(view.dom);
 
     const update = () => {
       void computePosition(referenceEl, toolbar, {
         placement: "top",
         strategy: "fixed",
-        middleware: [offset(8), flip(), shift({ padding: 8 })],
+        middleware: [
+          offset(8),
+          flip({
+            boundary,
+            fallbackPlacements: ["bottom"],
+            padding: 8,
+          }),
+          shift({ boundary, padding: 8 }),
+        ],
       }).then(({ x, y }) => {
         Object.assign(toolbar.style, {
           left: `${x}px`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
IME composition draws glyphs in the DOM before ProseMirror state updates, so empty-note placeholders stayed visible over composing CJK text. The selection toolbar was also clipped to the viewport, which includes macOS window chrome, so it could sit on top of the traffic lights.

## Changes
- Mark the editor as composing during IME and hide placeholder decorations until composition ends
- Clip the format toolbar to the editor scrollport and flip it below the first line when there isn’t room above

## Tests
- `pnpm -F @anlg/editor test`
- `pnpm -F @anlg/editor typecheck`
- `dprint check` on the changed files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-967b59c3-a3a4-42bd-abd2-4dc53ad8d9dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-967b59c3-a3a4-42bd-abd2-4dc53ad8d9dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

