### PR TITLE
fix(desktop): restyle current-device chip and disconnect action

### DIFF
--- a/apps/desktop/src/settings/sync/index.test.tsx
+++ b/apps/desktop/src/settings/sync/index.test.tsx
@@ -282,6 +282,45 @@ describe("SettingsSync", () => {
     });
   });
 
+  it("shows this-device as a chip and disconnects other devices", async () => {
+    mocks.requestSyncDevices.mockResolvedValue({
+      devices: [
+        {
+          deviceFingerprint: "current-device",
+          deviceName: "Johns-M4-Max.local",
+          createdAt: "2026-08-20T00:00:00Z",
+          lastSeenAt: "2026-08-20T00:00:00Z",
+        },
+        {
+          deviceFingerprint: "other-device",
+          deviceName: null,
+          createdAt: "2026-08-18T00:00:00Z",
+          lastSeenAt: "2026-08-18T00:00:00Z",
+        },
+      ],
+      pendingDevices: [],
+      maxDevices: 5,
+    });
+    renderSettings();
+
+    expect(await screen.findByText("Johns-M4-Max.local")).toBeTruthy();
+    const thisDevice = screen.getByText("This device");
+    expect(thisDevice.className).toContain("rounded-full");
+    expect(screen.queryByText(/· This device/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Remove device" })).toBeNull();
+
+    const disconnect = screen.getByRole("button", { name: "Disconnect" });
+    expect(disconnect.className).toContain("text-destructive");
+    fireEvent.click(disconnect);
+
+    await vi.waitFor(() =>
+      expect(mocks.removeSyncDevice).toHaveBeenCalledWith(
+        "token",
+        "other-device",
+      ),
+    );
+  });
+
   it("replaces an active device when the device limit is reached", async () => {
     mocks.credentialBlock = "device_limit";
     mocks.getE2eeIdentityStatus.mockResolvedValue({ configured: false });

--- a/apps/desktop/src/settings/sync/index.tsx
+++ b/apps/desktop/src/settings/sync/index.tsx
@@ -6,10 +6,10 @@ import {
   CircleNotch,
   CloudSlash,
   Devices,
+  Plugs,
   Plus,
   Shield,
   ShieldCheck,
-  Trash,
   Warning,
 } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -26,6 +26,7 @@ import {
 import type { CloudsyncActivityEntry } from "@anlg/plugin-db";
 import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { commands as settingsCommands } from "@anlg/plugin-settings";
+import { Badge } from "@anlg/ui/components/ui/badge";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   Dialog,
@@ -76,6 +77,57 @@ async function readE2eeIdentityStatus(accountUserId: string) {
   } catch (error) {
     throw error instanceof Error ? error : new Error(String(error));
   }
+}
+
+function DeviceTitle({
+  name,
+  current,
+}: {
+  name: string | null;
+  current: boolean;
+}) {
+  const { t } = useLingui();
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <p className="truncate text-sm font-medium">
+        {name || t`Unnamed device`}
+      </p>
+      {current ? (
+        <Badge variant="secondary" size="sm" className="shrink-0">
+          <Trans>This device</Trans>
+        </Badge>
+      ) : null}
+    </div>
+  );
+}
+
+function DisconnectDeviceButton({
+  fingerprint,
+  isPending,
+  pendingFingerprint,
+  onDisconnect,
+}: {
+  fingerprint: string;
+  isPending: boolean;
+  pendingFingerprint?: string;
+  onDisconnect: (fingerprint: string) => void;
+}) {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+      disabled={isPending}
+      onClick={() => onDisconnect(fingerprint)}
+    >
+      {isPending && pendingFingerprint === fingerprint ? (
+        <CircleNotch className="size-3.5 animate-spin" />
+      ) : (
+        <Plugs className="size-3.5" />
+      )}
+      <Trans>Disconnect</Trans>
+    </Button>
+  );
 }
 
 function formatSyncBytes(bytes: number) {
@@ -810,10 +862,7 @@ export function SettingsSync() {
               >
                 <Devices className="text-muted-foreground size-4 shrink-0" />
                 <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium">
-                    {device.deviceName || t`Unnamed device`}
-                    {current ? ` · ${t`This device`}` : ""}
-                  </p>
+                  <DeviceTitle name={device.deviceName} current={current} />
                   <p className="text-muted-foreground text-[11px]">{t`Last seen ${formatDistanceToNow(new Date(device.lastSeenAt))}`}</p>
                 </div>
                 {!current && (
@@ -836,17 +885,12 @@ export function SettingsSync() {
                       </Button>
                     )}
                     {credentialBlock !== "device_limit" && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        aria-label={t`Remove device`}
-                        disabled={removeDeviceMutation.isPending}
-                        onClick={() =>
-                          removeDeviceMutation.mutate(device.deviceFingerprint)
-                        }
-                      >
-                        <Trash className="size-3.5" />
-                      </Button>
+                      <DisconnectDeviceButton
+                        fingerprint={device.deviceFingerprint}
+                        isPending={removeDeviceMutation.isPending}
+                        pendingFingerprint={removeDeviceMutation.variables}
+                        onDisconnect={removeDeviceMutation.mutate}
+                      />
                     )}
                   </>
                 )}
@@ -864,10 +908,7 @@ export function SettingsSync() {
               >
                 <Devices className="text-muted-foreground size-4 shrink-0" />
                 <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium">
-                    {device.deviceName || t`Unnamed device`}
-                    {current ? ` · ${t`This device`}` : ""}
-                  </p>
+                  <DeviceTitle name={device.deviceName} current={current} />
                   <p className="text-muted-foreground text-[11px]">
                     {device.status === "sealed"
                       ? t`Approved — waiting for this device to finish`
@@ -905,17 +946,12 @@ export function SettingsSync() {
                   </span>
                 )}
                 {!current && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={t`Remove pending device`}
-                    disabled={removeDeviceMutation.isPending}
-                    onClick={() =>
-                      removeDeviceMutation.mutate(device.deviceFingerprint)
-                    }
-                  >
-                    <Trash className="size-3.5" />
-                  </Button>
+                  <DisconnectDeviceButton
+                    fingerprint={device.deviceFingerprint}
+                    isPending={removeDeviceMutation.isPending}
+                    pendingFingerprint={removeDeviceMutation.variables}
+                    onDisconnect={removeDeviceMutation.mutate}
+                  />
                 )}
               </div>
             );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Show **This device** as a secondary badge chip next to the device name, instead of `· This device` inline text.
- Replace the trash icon on other devices with an outline **Disconnect** button (plugs icon + label) using destructive styling.

## Test plan
- Open Settings → Sync with at least two registered devices.
- Confirm the current device shows a “This device” chip and no disconnect control.
- Confirm other devices show a red Disconnect button instead of a trash icon, and that disconnect still removes the device.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfa75875-a5e7-4b9d-9262-82816bbc8a7e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfa75875-a5e7-4b9d-9262-82816bbc8a7e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

