### PR TITLE
fix(desktop): nudge welcome demo popover 2px down

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -412,7 +412,7 @@ function HeaderMeetingActionPill({
           <PopoverContent
             data-welcome-demo-prompt
             side="bottom"
-            sideOffset={8}
+            sideOffset={10}
             onOpenAutoFocus={(event) => event.preventDefault()}
             className="border-border bg-popover text-popover-foreground pointer-events-none w-72 max-w-[calc(100vw-1rem)] rounded-md border px-3 py-2.5 text-sm shadow-sm"
           >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The “Try the demo” popover under **Join & record** sat flush against the pill — the arrow tip touched the button.

This bumps `sideOffset` from `8` to `10` so there’s a small 2px gap between the button and the pointer.

```412:417:apps/desktop/src/session/components/outer-header/index.tsx
          <PopoverContent
            data-welcome-demo-prompt
            side="bottom"
            sideOffset={10}
            onOpenAutoFocus={(event) => event.preventDefault()}
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-066f05ac-dc11-43cb-94ae-9d9bf7b7ced8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-066f05ac-dc11-43cb-94ae-9d9bf7b7ced8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

