### PR TITLE
fix(onboarding): auto-start the welcome demo after Join & record

### DIFF
--- a/apps/desktop/src/onboarding/welcome-note.constants.ts
+++ b/apps/desktop/src/onboarding/welcome-note.constants.ts
@@ -1,12 +1,16 @@
 export const WELCOME_NOTE_DEMO_URL = "https://anarlog.so/onboarding-demo/";
 export const WELCOME_NOTE_TRACKING_ID = "anarlog-onboarding-demo-v1";
 export const WELCOME_NOTE_COMPLETE_PATH = "/onboarding-demo/complete";
+export const WELCOME_NOTE_DEMO_AUTOJOIN_PARAM = "autojoin";
 
-export function buildWelcomeNoteDemoUrl(meetingLink: string, port: number) {
+export function buildWelcomeNoteDemoUrl(meetingLink: string, port?: number) {
   const url = new URL(meetingLink);
-  url.searchParams.set(
-    "completion_url",
-    `http://127.0.0.1:${port}${WELCOME_NOTE_COMPLETE_PATH}`,
-  );
+  url.searchParams.set(WELCOME_NOTE_DEMO_AUTOJOIN_PARAM, "1");
+  if (port != null) {
+    url.searchParams.set(
+      "completion_url",
+      `http://127.0.0.1:${port}${WELCOME_NOTE_COMPLETE_PATH}`,
+    );
+  }
   return url.toString();
 }

--- a/apps/desktop/src/onboarding/welcome-note.test.ts
+++ b/apps/desktop/src/onboarding/welcome-note.test.ts
@@ -33,6 +33,7 @@ import {
   stopActiveWelcomeDemo,
   takePendingWelcomeSession,
 } from "./welcome-note";
+import { buildWelcomeNoteDemoUrl } from "./welcome-note.constants";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -170,4 +171,15 @@ it("ignores a demo callback when listening already stopped", async () => {
 
   expect(mocks.execute).not.toHaveBeenCalled();
   expect(mocks.listenerState.stop).not.toHaveBeenCalled();
+});
+
+it("auto-joins the hosted demo and optionally attaches a completion callback", () => {
+  expect(buildWelcomeNoteDemoUrl("https://anarlog.so/onboarding-demo/")).toBe(
+    "https://anarlog.so/onboarding-demo/?autojoin=1",
+  );
+  expect(
+    buildWelcomeNoteDemoUrl("https://anarlog.so/onboarding-demo/", 43210),
+  ).toBe(
+    "https://anarlog.so/onboarding-demo/?autojoin=1&completion_url=http%3A%2F%2F127.0.0.1%3A43210%2Fonboarding-demo%2Fcomplete",
+  );
 });

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -542,9 +542,48 @@ describe("OuterHeader", () => {
     expect(openedUrl.origin + openedUrl.pathname).toBe(
       "https://anarlog.so/onboarding-demo/",
     );
+    expect(openedUrl.searchParams.get("autojoin")).toBe("1");
     expect(openedUrl.searchParams.get("completion_url")).toBe(
       "http://127.0.0.1:43210/onboarding-demo/complete",
     );
+  });
+
+  it("still auto-joins the welcome demo if the completion callback cannot start", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.startCallbackServer.mockRejectedValue(new Error("unavailable"));
+    mocks.sessionEvents = {
+      "session-1": {
+        tracking_id: "anarlog-onboarding-demo-v1",
+        meeting_link: "https://anarlog.so/onboarding-demo/",
+      },
+    };
+
+    try {
+      render(
+        <OuterHeader
+          sessionId="session-1"
+          currentView={{ type: "raw" } as EditorView}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Join & record" }));
+
+      await vi.waitFor(() => {
+        expect(mocks.openUrl).toHaveBeenCalledOnce();
+      });
+
+      const openedUrl = new URL(mocks.openUrl.mock.calls[0][0]);
+      expect(openedUrl.origin + openedUrl.pathname).toBe(
+        "https://anarlog.so/onboarding-demo/",
+      );
+      expect(openedUrl.searchParams.get("autojoin")).toBe("1");
+      expect(openedUrl.searchParams.get("completion_url")).toBeNull();
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("prompts new users to try the prerecorded welcome demo", () => {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -255,6 +255,7 @@ function HeaderMeetingActionPill({
 
     let url = meetingLink;
     if (isWelcomeDemo) {
+      url = buildWelcomeNoteDemoUrl(meetingLink);
       try {
         const scheme = await getScheme();
         const result = await deeplinkCommands.startCallbackServer(scheme);

--- a/apps/web/public/onboarding-demo/index.html
+++ b/apps/web/public/onboarding-demo/index.html
@@ -978,6 +978,7 @@
       const avatarPhoto = document.querySelector(".avatar-photo");
       const params = new URLSearchParams(window.location.search);
       const completionUrl = getCompletionUrl(params.get("completion_url"));
+      const shouldAutojoin = params.get("autojoin") === "1";
       const joiningUrl = getJoiningUrl();
 
       document.querySelector(".joining-url").textContent = joiningUrl;
@@ -989,6 +990,7 @@
 
         const url = new URL(window.location.href);
         url.searchParams.delete("completion_url");
+        url.searchParams.delete("autojoin");
         return url.toString();
       }
 
@@ -1054,6 +1056,13 @@
         joinButton.disabled = false;
       }
 
+      async function readyToJoin() {
+        showJoin();
+        if (shouldAutojoin) {
+          await playFromStart({ fallbackToJoin: true });
+        }
+      }
+
       function setOpenPanel(panelName) {
         const wasChatOpen = !chatPanel.hidden;
         const wasDetailsOpen = !detailsPanel.hidden;
@@ -1087,7 +1096,7 @@
           const videoOverride = params.get("video");
           if (videoOverride) {
             video.src = getVideoUrl(videoOverride).toString();
-            showJoin();
+            await readyToJoin();
             return;
           }
 
@@ -1111,20 +1120,27 @@
             .map((part) => part[0])
             .join("")
             .slice(0, 2);
-          showJoin();
+          await readyToJoin();
         } catch (error) {
           showError(error.message);
         }
       }
 
-      async function playFromStart() {
+      async function playFromStart({ fallbackToJoin = false } = {}) {
         endedLayer.hidden = true;
         errorLayer.hidden = true;
-        joinLayer.hidden = true;
+        if (!fallbackToJoin) {
+          joinLayer.hidden = true;
+        }
         video.currentTime = 0;
         try {
           await video.play();
+          joinLayer.hidden = true;
         } catch (error) {
+          if (fallbackToJoin && error?.name === "NotAllowedError") {
+            showJoin();
+            return;
+          }
           showError(
             error?.name === "NotAllowedError"
               ? "Your browser blocked playback. Allow media playback and join again."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Join & record already starts listening and opens the hosted demo. The demo still stopped on **Ready to join?**, so playback didn’t start until a second **Join now** click.

This passes `autojoin=1` from the desktop Join & record action. The demo page then starts the prerecorded meeting automatically. If the browser blocks unmuted autoplay, the lobby stays up so the user can click Join now.

Direct visits to `/onboarding-demo/` without the param are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-066f05ac-dc11-43cb-94ae-9d9bf7b7ced8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-066f05ac-dc11-43cb-94ae-9d9bf7b7ced8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

