### PR TITLE
fix(desktop): don't treat the Sentry crash reporter as a second app launch

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -75,6 +75,22 @@ fn start_minidump_reporting(
     }
 }
 
+fn run_crash_reporter_process() -> ! {
+    let client = sentry::init(sentry::ClientOptions {
+        dsn: option_env!("SENTRY_DSN")
+            .filter(|_| std::env::var_os("ANARLOG_DISABLE_SENTRY").is_none())
+            .and_then(|dsn| dsn.parse().ok()),
+        release: option_env!("APP_VERSION").map(|v| format!("anarlog-desktop@{}", v).into()),
+        auto_session_tracking: false,
+        before_send: Some(Arc::new(|event| {
+            tauri_plugin_tracing::redaction::sanitize_sentry_event(event)
+        })),
+        ..Default::default()
+    });
+    let _ = tauri_plugin_sentry::minidump::init(&client);
+    std::process::exit(0);
+}
+
 async fn load_crash_reporting_consent(db: &anlg_db_core::Db) -> bool {
     let rows = sqlx::query_as::<_, (String, String)>(
         "SELECT id, value_json FROM app_settings \
@@ -140,6 +156,13 @@ fn create_audio_provider(_bundle_id: &str) -> std::sync::Arc<dyn anlg_audio_actu
 
 #[tokio::main]
 pub async fn main() {
+    // Sentry minidump reporting re-execs this binary with --crash-reporter-server.
+    // That helper must reach minidump::init instead of the launch lock, or it
+    // shows "Anarlog is already starting" on every launch and never serves dumps.
+    if startup::is_crash_reporter_process() {
+        run_crash_reporter_process();
+    }
+
     tauri::async_runtime::set(tokio::runtime::Handle::current());
     let context = tauri::generate_context!();
     let identifier = context.config().identifier.clone();

--- a/apps/desktop/src-tauri/src/startup.rs
+++ b/apps/desktop/src-tauri/src/startup.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 
 const LAUNCH_LOCK_FILENAME: &str = "launch.lock";
 const SLOW_STARTUP_INDICATOR_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
+const CRASH_REPORTER_SERVER_ARG: &str = "--crash-reporter-server";
 
 // Startup migrations can hold the database for minutes before any window or
 // plugin exists, so single-instance semantics are enforced with an OS file
@@ -17,6 +18,14 @@ pub enum LaunchLockState {
     Acquired(LaunchLock),
     HeldByAnotherProcess,
     Unavailable(String),
+}
+
+pub fn is_crash_reporter_process() -> bool {
+    std::env::args().any(|arg| is_crash_reporter_arg(&arg))
+}
+
+fn is_crash_reporter_arg(arg: &str) -> bool {
+    arg.starts_with(CRASH_REPORTER_SERVER_ARG)
 }
 
 pub fn acquire_launch_lock(identifier: &str) -> LaunchLockState {
@@ -135,6 +144,16 @@ fn spawn_indicator_alert() -> Option<std::process::Child> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn crash_reporter_args_are_detected() {
+        assert!(is_crash_reporter_arg(
+            "--crash-reporter-server=/tmp/temp-socket-abc"
+        ));
+        assert!(is_crash_reporter_arg("--crash-reporter-server"));
+        assert!(!is_crash_reporter_arg("--background"));
+        assert!(!is_crash_reporter_arg("--crash-reporter"));
+    }
 
     #[test]
     fn launch_lock_excludes_a_second_holder_until_released() {


### PR DESCRIPTION
The minidump helper re-execs the same binary with --crash-reporter-server, so the new launch lock showed "Anarlog is already starting" on every open and the helper never started.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 233f10f85cdbb66978c14642e775107d4367b12c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->