### PR TITLE
docs(changelog): cover late 1.4.11 desktop changes

### DIFF
--- a/packages/changelog/content/1.4.11.md
+++ b/packages/changelog/content/1.4.11.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-08-20"
-summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcript editing, folders and meeting moves, clearer startup progress, and more reliable updates and settings."
+summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcript editing, one-click imports from Zoom, Meet, Teams, and more, plus folders, clearer startup progress, and more reliable updates."
 ---
 
 ## Cloud sync
@@ -10,8 +10,20 @@ summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcrip
 - See pending devices in Settings → Sync, remove them, or replace an old device
   when you reach the five-device limit; recovery-key entry remains available as
   a fallback
+- Tell this computer apart with a **This device** chip and device-type icons,
+  and disconnect another device with a labeled **Disconnect** action
 - Recover from the personal-encryption validation issue and temporary database
   locks that could leave cloud sync stuck while connecting
+
+## Imports
+
+- Connect Zoom, Fathom, Notion AI Meeting Notes, Webex, Microsoft Teams, or
+  Google Meet with **Connect & import**, then keep new meetings importing in
+  the background while Anarlog is running
+- Import Plaud recordings the same way after signing in with the official Plaud
+  CLI on your computer
+- Recognize Google Meet and Zoom from their official camera marks in Import
+  settings and the meeting header
 
 ## Transcripts and meetings
 
@@ -21,11 +33,18 @@ summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcrip
   get separate speaker labels when using Azure Speech
 - Put a note into a new or existing top-level folder directly from the session
   toolbar
+- Title the note in the editor only: the duplicate header title is gone, tabs
+  sit on the left, and **Stop** takes the Transcript tab's place during a live
+  meeting while the live transcript stays in the floating bar
 - Ask chat to move a finished recording, transcript, summary, notes, and action
   items onto the correct meeting
 - Keep an active recording from being interrupted by an overlapping scheduled
-  meeting, and see calendar details instead of **Join & record** after a meeting
-  has ended
+  meeting
+- After a meeting ends, open calendar details from a dedicated toolbar action
+  instead of seeing **Join & record**, and keep recording from restarting until
+  the session finishes
+- Start the welcome demo automatically after **Join & record** instead of
+  waiting on a second **Join now**
 
 ## Startup and updates
 
@@ -33,6 +52,11 @@ summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcrip
   migrates the database, imports old notes, and prepares cloud sync
 - Open the app without getting stuck on a white screen when a startup task is
   slow or unavailable
+- Open the app even when crash reporting starts in the background, instead of
+  seeing **Anarlog is already starting**
+- See the macOS microphone permission prompt after a fresh permission reset
+  instead of the request disappearing before the dialog appears
+- Click the macOS menu bar icon without crashing when the tray menu is rebuilt
 - Install a downloaded update reliably on the next launch, retry after a
   temporary check or install failure, and clean up stale update downloads
 - Repair an interrupted 1.4.10 database migration automatically and wait out a
@@ -57,6 +81,8 @@ summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcrip
 - Use a Windows-style application title bar on Linux
 - Find Email and Slack sharing in the overflow menu while invitations stay
   immediately available
+- Keep the empty-note placeholder hidden while composing Chinese, Japanese, or
+  Korean text, and keep the format toolbar off the macOS window controls
 - Keep stale @-mention searches from replacing newer results or reopening a
   dismissed suggestion list
 - Let error toasts clear themselves after five seconds; hover to pause the timer


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- refresh the 1.4.11 changelog for desktop changes that landed after `#6944`
- add one-click **Connect & import** for Zoom, Fathom, Notion AI Meeting Notes, Webex, Microsoft Teams, Google Meet, and Plaud
- cover session chrome (title, tabs, Stop), welcome-demo auto-start, macOS microphone/tray/crash-reporter reliability, and editor CJK/toolbar fixes
- keep internal CI, packaging, and tiny layout tweaks out of the user-facing notes

## Test plan
- [x] `pnpm -F @anlg/changelog typecheck`
- [x] `pnpm exec dprint check --allow-no-files packages/changelog/content/1.4.11.md`
- [ ] confirm the notes match `desktop_v1.4.10..HEAD` user-facing desktop changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01ee6-1eb4-7ad7-a22c-d9956f3a6609?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01ee6-1eb4-7ad7-a22c-d9956f3a6609&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

