### PR TITLE
docs: restructure README with centered header, badges, and reference tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,96 @@
 > **Note:** The team is now building **[char](https://char.com)**. The **anarlog** community application remains open-source, MIT-licensed, and maintained as the local-first meeting notetaker in this repo. Source-visible enterprise components are commercially licensed.
 
-![anarlog](apps/web/public/og.jpg)
+<div align="center">
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/fastrepl/anarlog)
+  <img width="110" src="apps/desktop/src-tauri/icons/stable/128x128@2x.png" alt="anarlog icon" />
 
-# anarlog
+  <h1>anarlog</h1>
 
-An open-source AI meeting notetaker that is local-first, privacy-first, and yours to fork.
+  <p>
+    <b>The privacy-first AI meeting notepad.</b>
+    <br />
+    Open source, local-first, and yours to fork. Granola, rearranged.
+  </p>
 
-Granola, rearranged.
+  <p>
+    <a href="https://anarlog.so">Website</a>
+    &nbsp;•&nbsp;
+    <a href="https://docs.anarlog.so">Docs</a>
+    &nbsp;•&nbsp;
+    <a href="https://github.com/fastrepl/anarlog/releases/latest">Download</a>
+    &nbsp;•&nbsp;
+    <a href="https://discord.gg/Vk882WS3gF">Discord</a>
+    &nbsp;•&nbsp;
+    <a href="https://www.reddit.com/r/anarlog/">r/anarlog</a>
+    &nbsp;•&nbsp;
+    <a href="https://x.com/anarlogapp">@anarlogapp</a>
+    &nbsp;•&nbsp;
+    <a href="https://status.anarlog.so">Status</a>
+  </p>
 
-**[Website](https://anarlog.so)** · **[Docs](https://docs.anarlog.so)** · **[Download](https://github.com/fastrepl/anarlog/releases/latest)** · **[r/anarlog](https://www.reddit.com/r/anarlog/)** · **[@anarlogapp](https://x.com/anarlogapp)** · **[Status](https://status.anarlog.so)**
+  <p>
+    <a href="https://github.com/fastrepl/anarlog/stargazers"><img src="https://img.shields.io/github/stars/fastrepl/anarlog?style=flat&color=ffe09d" alt="GitHub stars" /></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-black" alt="MIT license" /></a>
+    <a href="https://discord.gg/Vk882WS3gF"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
+    <a href="https://deepwiki.com/fastrepl/anarlog"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
+  </p>
 
-## How to use it
+  <img width="100%" src="apps/web/public/og.jpg" alt="anarlog" />
 
-Download the latest release for your platform:
+</div>
 
-→ [github.com/fastrepl/anarlog/releases/latest](https://github.com/fastrepl/anarlog/releases/latest)
+<br />
 
-Open it and join a meeting. anarlog records, transcribes locally, and stores its canonical meeting data in a local SQLite database. Export Markdown when it fits your workflow. Bring your own LLM: OpenAI, Anthropic, Gemini, OpenRouter, Ollama, LM Studio, Unsloth, or anything OpenAI-compatible.
+anarlog is an open-source alternative to Granola. It takes notes in your meetings without sending a bot to join the call: it listens to your device audio, transcribes on your machine, and keeps everything in a local SQLite database you can open yourself.
 
-To self-host, clone the repo, build it, and run it.
+It is built for people who want AI meeting notes without handing their conversations to someone else's cloud, and for anyone who needs to get a notetaker past a security review with a straight face.
 
-## Why use it
+## Why anarlog
 
-- **Your data, your device.** Sessions, notes, and transcripts are stored locally in SQLite. Attachments and recordings remain local files, and you can export Markdown when you need it.
-- **Local transcription.** Transcription runs on-device, so audio never leaves your machine.
-- **Bring your own AI.** Use any LLM provider, including OpenAI-compatible services and local models.
-- **Open-source community layer, MIT.** Fork it, sell it, or self-host it.
-- **Optional cloud features.** You can use local or bring-your-own-key workflows, or opt into hosted AI, encrypted CloudSync, and sharing when those fit your workflow.
+- **No bot joins your call.** anarlog captures audio directly on your device. Nothing appears in the participant list, and nothing records from inside the meeting.
+- **Local by default.** Transcription runs on-device, so meeting audio never has to leave your machine.
+- **Your data, in a format you can read.** Sessions, notes, and transcripts live in local SQLite. Recordings and attachments are plain local files. Export Markdown whenever it fits your workflow.
+- **Bring your own AI.** Use OpenAI, Anthropic, Gemini, OpenRouter, Ollama, LM Studio, Unsloth, or anything OpenAI-compatible, including fully local models.
+- **Readable source, MIT.** The community application is MIT-licensed. Fork it, audit it, sell it, or self-host it.
+- **Cloud is opt-in, not required.** Hosted AI, encrypted CloudSync, and sharing exist when you want them. Nothing depends on them.
+- **A front door for your org.** Self-hosting and source-visible enterprise components give security and IT teams a real path to yes.
+
+## What runs where
+
+| Part of the workflow | Where it happens |
+| --- | --- |
+| Audio capture and recording | Your device |
+| Transcription | Your device, on-device models |
+| Notes and transcript storage | Local SQLite plus local files |
+| AI summaries and chat | Your choice: local model, your own API key, or optional hosted AI |
+| Sync and sharing | Off by default, opt-in encrypted CloudSync |
+
+## Get started
+
+1. Download the latest release for macOS (Apple Silicon or Intel), Windows, or Linux from [releases](https://github.com/fastrepl/anarlog/releases/latest).
+2. Open it and join a meeting. anarlog records and transcribes locally as you go.
+3. Generate a note, edit it like a document, and export Markdown when you need it.
+4. Optional: connect an LLM provider or a local model in settings for summaries and chat.
+
+Product docs live at [docs.anarlog.so](https://docs.anarlog.so). To self-host, clone the repo, build it, and run it.
+
+## Repository map
+
+| Path | What lives there |
+| --- | --- |
+| `apps/desktop` | Tauri v2 desktop app: React and TypeScript UI, Rust backend |
+| `apps/web` | anarlog.so web app |
+| `apps/api` | API server |
+| `apps/cli` | CLI |
+| `apps/mobile` | Mobile app |
+| `plugins/*` | ~50 Tauri plugins: local STT, local LLM, calendar, export, notifications, and more |
+| `crates/*` | ~180 Rust crates: audio capture, transcription, diarization, storage, and more |
+| `packages/*` | Shared TypeScript packages: editor, database, UI, plugin SDK |
+| `enterprise/` | Source-visible enterprise components, commercially licensed |
+
+## Local development
+
+Ask [DeepWiki](https://deepwiki.com/fastrepl/anarlog) — it stays current with the codebase and can answer setup, architecture, and where-does-X-live questions directly.
 
 ## Name history
 
@@ -42,6 +104,25 @@ If you came here from Granola, welcome. If you came here from Hyprnote, welcome 
 
 Either way, it's yours.
 
----
+## Contributing
 
-**License:** Community [MIT](LICENSE) · Enterprise [commercial](LICENSE.enterprise) · [Full boundary](LICENSING.md) · **Maintainers:** [fastrepl](https://github.com/fastrepl)
+Issues, pull requests, bug reports, and docs fixes are all welcome.
+
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+- Join the community on [Discord](https://discord.gg/Vk882WS3gF) or [r/anarlog](https://www.reddit.com/r/anarlog/).
+
+Contributions outside `enterprise/` are distributed under the MIT license.
+
+## License
+
+- Community application: [MIT](LICENSE)
+- Enterprise components: [commercial](LICENSE.enterprise)
+- Full boundary: [LICENSING.md](LICENSING.md)
+
+Maintained by [fastrepl](https://github.com/fastrepl).
+
+## Contributors
+
+<a href="https://github.com/fastrepl/anarlog/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=fastrepl/anarlog" alt="Contributors" />
+</a>


### PR DESCRIPTION
Modeled on the Cap and GitButler READMEs.

- Centered header: app icon, tagline, link row (adds Discord), and stars/MIT/Discord/DeepWiki badges above the banner
- New intro framing: no bot joins the call, transcribes on your machine, local SQLite you can open yourself
- "Why anarlog" bullets aligned with the privacy-first positioning (local by default, BYO AI, readable source, opt-in cloud, self-host path for orgs)
- "What runs where" table making the local-vs-optional-cloud boundary explicit
- Repository map table (apps, plugins, crates, packages, enterprise)
- Local development section points to DeepWiki instead of listing setup commands
- Contributors wall via contrib.rocks
- Keeps the char note, name history, and MIT/enterprise licensing boundary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a60786673e3dd303b7215173780dce7eae3b1c8e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->