### PR TITLE
feat(imports): connect Pocket history through MCP

### DIFF
--- a/apps/desktop/src/imports/parser.test.ts
+++ b/apps/desktop/src/imports/parser.test.ts
@@ -106,38 +106,24 @@ describe("meeting export parser", () => {
     });
   });
 
-  it("keeps Pocket title and date when enrichment wraps the recording in data", () => {
-    const [meeting] = parseMeetingExport({
-      path: "mcp://pocket/rec_123.json",
-      name: "rec_123.json",
+  it("imports each meeting from a titled collection export", () => {
+    const meetings = parseMeetingExport({
+      path: "/tmp/export.json",
+      name: "export.json",
       content: JSON.stringify({
-        recordingId: "rec_123",
-        recordingTitle: "Weekly Sync",
-        recordingDate: "2026-03-25T15:04:05Z",
-        transcript: [{ speaker: "Ada", text: "Ship it" }],
-        summary: { text: "Ship the launch." },
-        success: true,
-        data: [
-          {
-            recordingId: "rec_123",
-            transcriptSegments: [
-              { text: "Ship it", start: 1.0, end: 2.0, speaker: "Ada" },
-            ],
-            summary: { text: "Ship the launch." },
-          },
+        title: "March export",
+        topic: "search",
+        meetings: [
+          { id: "meeting-1", title: "Weekly planning" },
+          { id: "meeting-2", title: "Customer call" },
         ],
       }),
     });
 
-    expect(meeting).toMatchObject({
-      externalId: "rec_123",
-      title: "Weekly Sync",
-      startedAt: "2026-03-25T15:04:05.000Z",
-    });
-    expect(meeting?.transcript[0]).toMatchObject({
-      speaker: "Ada",
-      text: "Ship it",
-    });
+    expect(meetings.map((meeting) => meeting.title)).toEqual([
+      "Weekly planning",
+      "Customer call",
+    ]);
   });
 
   it("normalizes call-oriented MCP meeting fields", () => {

--- a/apps/desktop/src/imports/parser.test.ts
+++ b/apps/desktop/src/imports/parser.test.ts
@@ -72,6 +72,40 @@ describe("meeting export parser", () => {
     expect(meeting?.noteMarkdown).toContain("Move forward with the migration");
   });
 
+  it("parses Pocket MCP recording fields", () => {
+    const [meeting] = parseMeetingExport({
+      path: "mcp://pocket/rec_123.json",
+      name: "rec_123.json",
+      content: JSON.stringify({
+        recordingId: "rec_123",
+        recordingTitle: "Weekly Sync",
+        recordingDate: "2026-03-25T15:04:05Z",
+        transcriptSegments: [
+          {
+            text: "Let's review the launch plan.",
+            start: 0.62,
+            end: 4.88,
+            speaker: "Alex",
+          },
+        ],
+        summary: { text: "Finalize QA by Friday." },
+      }),
+    });
+
+    expect(meeting).toMatchObject({
+      externalId: "rec_123",
+      title: "Weekly Sync",
+      startedAt: "2026-03-25T15:04:05.000Z",
+    });
+    expect(meeting?.noteMarkdown).toContain("Finalize QA by Friday.");
+    expect(meeting?.transcript[0]).toMatchObject({
+      speaker: "Alex",
+      text: "Let's review the launch plan.",
+      startMs: 620,
+      endMs: 4_880,
+    });
+  });
+
   it("normalizes call-oriented MCP meeting fields", () => {
     const [meeting] = parseMeetingExport({
       path: "mcp://jiminny/call-1.json",

--- a/apps/desktop/src/imports/parser.test.ts
+++ b/apps/desktop/src/imports/parser.test.ts
@@ -106,6 +106,40 @@ describe("meeting export parser", () => {
     });
   });
 
+  it("keeps Pocket title and date when enrichment wraps the recording in data", () => {
+    const [meeting] = parseMeetingExport({
+      path: "mcp://pocket/rec_123.json",
+      name: "rec_123.json",
+      content: JSON.stringify({
+        recordingId: "rec_123",
+        recordingTitle: "Weekly Sync",
+        recordingDate: "2026-03-25T15:04:05Z",
+        transcript: [{ speaker: "Ada", text: "Ship it" }],
+        summary: { text: "Ship the launch." },
+        success: true,
+        data: [
+          {
+            recordingId: "rec_123",
+            transcriptSegments: [
+              { text: "Ship it", start: 1.0, end: 2.0, speaker: "Ada" },
+            ],
+            summary: { text: "Ship the launch." },
+          },
+        ],
+      }),
+    });
+
+    expect(meeting).toMatchObject({
+      externalId: "rec_123",
+      title: "Weekly Sync",
+      startedAt: "2026-03-25T15:04:05.000Z",
+    });
+    expect(meeting?.transcript[0]).toMatchObject({
+      speaker: "Ada",
+      text: "Ship it",
+    });
+  });
+
   it("normalizes call-oriented MCP meeting fields", () => {
     const [meeting] = parseMeetingExport({
       path: "mcp://jiminny/call-1.json",

--- a/apps/desktop/src/imports/parser.ts
+++ b/apps/desktop/src/imports/parser.ts
@@ -117,6 +117,7 @@ function normalizeMeeting(value: unknown, fallbackTitle: string) {
   const transcriptValue = firstValue(record, [
     "transcript",
     "transcription",
+    "transcriptSegments",
     "utterances",
     "segments",
     "sentences",
@@ -165,6 +166,8 @@ function normalizeMeeting(value: unknown, fallbackTitle: string) {
           "startTime",
           "meeting_date",
           "meetingDate",
+          "recording_date",
+          "recordingDate",
           "date",
           "created_at",
           "createdAt",
@@ -339,6 +342,7 @@ function parseTranscriptValue(value: unknown): ImportedMeeting["transcript"] {
   if (record) {
     return parseTranscriptValue(
       firstValue(record, [
+        "transcriptSegments",
         "segments",
         "utterances",
         "sentences",

--- a/apps/desktop/src/imports/parser.ts
+++ b/apps/desktop/src/imports/parser.ts
@@ -75,12 +75,31 @@ function findMeetingCandidates(value: unknown): unknown[] {
   const record = asRecord(value);
   if (!record) return [];
 
-  for (const key of MEETING_ARRAY_KEYS) {
-    const candidate = record[key];
-    if (Array.isArray(candidate)) return candidate;
+  if (!looksLikeSingleMeeting(record)) {
+    for (const key of MEETING_ARRAY_KEYS) {
+      const candidate = record[key];
+      if (Array.isArray(candidate)) return candidate;
+    }
   }
 
   return [value];
+}
+
+function looksLikeSingleMeeting(record: JsonRecord) {
+  return Boolean(
+    firstText(record, [
+      "title",
+      "meeting_title",
+      "meetingTitle",
+      "call_title",
+      "callTitle",
+      "recording_title",
+      "recordingTitle",
+      "meeting_name",
+      "meetingName",
+      "topic",
+    ]),
+  );
 }
 
 function normalizeMeeting(value: unknown, fallbackTitle: string) {

--- a/apps/desktop/src/imports/parser.ts
+++ b/apps/desktop/src/imports/parser.ts
@@ -75,31 +75,12 @@ function findMeetingCandidates(value: unknown): unknown[] {
   const record = asRecord(value);
   if (!record) return [];
 
-  if (!looksLikeSingleMeeting(record)) {
-    for (const key of MEETING_ARRAY_KEYS) {
-      const candidate = record[key];
-      if (Array.isArray(candidate)) return candidate;
-    }
+  for (const key of MEETING_ARRAY_KEYS) {
+    const candidate = record[key];
+    if (Array.isArray(candidate)) return candidate;
   }
 
   return [value];
-}
-
-function looksLikeSingleMeeting(record: JsonRecord) {
-  return Boolean(
-    firstText(record, [
-      "title",
-      "meeting_title",
-      "meetingTitle",
-      "call_title",
-      "callTitle",
-      "recording_title",
-      "recordingTitle",
-      "meeting_name",
-      "meetingName",
-      "topic",
-    ]),
-  );
 }
 
 function normalizeMeeting(value: unknown, fallbackTitle: string) {

--- a/apps/desktop/src/imports/providers.test.ts
+++ b/apps/desktop/src/imports/providers.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("meeting import providers", () => {
   it("keeps every researched provider in the catalog", () => {
-    expect(MEETING_IMPORT_PROVIDERS).toHaveLength(30);
+    expect(MEETING_IMPORT_PROVIDERS).toHaveLength(31);
     expect(
       new Set(MEETING_IMPORT_PROVIDERS.map((provider) => provider.id)).size,
     ).toBe(MEETING_IMPORT_PROVIDERS.length);
@@ -30,6 +30,7 @@ describe("meeting import providers", () => {
       "tactiq",
       "jiminny",
       "plaud",
+      "pocket",
       "zoom",
       "microsoft-teams",
       "google-meet",
@@ -39,6 +40,12 @@ describe("meeting import providers", () => {
       MEETING_IMPORT_PROVIDERS.find((provider) => provider.id === "plaud"),
     ).toMatchObject({
       directImport: "cli",
+    });
+    expect(
+      MEETING_IMPORT_PROVIDERS.find((provider) => provider.id === "pocket"),
+    ).toMatchObject({
+      directImport: "mcp-oauth",
+      helpUrl: "https://docs.heypocketai.com/docs",
     });
     expect(
       MEETING_IMPORT_PROVIDERS.find((provider) => provider.id === "zoom"),
@@ -64,15 +71,18 @@ describe("meeting import providers", () => {
     const providers = detectMeetingImportProviders([
       { id: "com.granola.app", name: "Granola" },
       { id: "com.microsoft.teams2", name: "Microsoft Teams" },
+      { id: "com.heypocket.desktop", name: "Pocket" },
     ]);
 
     expect(providers.map((provider) => provider.id)).toEqual([
       "granola",
+      "pocket",
       "microsoft-teams",
       "google-meet",
     ]);
     expect(providers.map((provider) => provider.installedAppId)).toEqual([
       "com.granola.app",
+      "com.heypocket.desktop",
       "com.microsoft.teams2",
       "google-meet",
     ]);

--- a/apps/desktop/src/imports/providers.test.ts
+++ b/apps/desktop/src/imports/providers.test.ts
@@ -70,22 +70,46 @@ describe("meeting import providers", () => {
   it("detects exact native names and bundle identifiers", () => {
     const providers = detectMeetingImportProviders([
       { id: "com.granola.app", name: "Granola" },
+      { id: "ai.plaud.desktop.plaud", name: "Plaud Desktop" },
       { id: "com.microsoft.teams2", name: "Microsoft Teams" },
-      { id: "com.heypocket.desktop", name: "Pocket" },
+      { id: "com.openvisionengineering.pocket-desktop-app", name: "Pocket" },
     ]);
 
     expect(providers.map((provider) => provider.id)).toEqual([
       "granola",
+      "plaud",
       "pocket",
       "microsoft-teams",
       "google-meet",
     ]);
     expect(providers.map((provider) => provider.installedAppId)).toEqual([
       "com.granola.app",
-      "com.heypocket.desktop",
+      "ai.plaud.desktop.plaud",
+      "com.openvisionengineering.pocket-desktop-app",
       "com.microsoft.teams2",
       "google-meet",
     ]);
+  });
+
+  it("detects Plaud and Pocket desktop apps from Windows display names", () => {
+    const providers = detectMeetingImportProviders([
+      { id: "windows:hklm:Plaud Desktop", name: "Plaud Desktop" },
+      { id: "windows:hkcu:Pocket", name: "Pocket Desktop" },
+    ]);
+
+    expect(providers.map((provider) => provider.id)).toEqual([
+      "plaud",
+      "pocket",
+      "google-meet",
+    ]);
+  });
+
+  it("does not treat Pocket Casts as Pocket", () => {
+    expect(
+      detectMeetingImportProviders([
+        { id: "com.electron.pocket-casts", name: "Pocket Casts" },
+      ]).map((provider) => provider.id),
+    ).toEqual(["google-meet"]);
   });
 
   it("does not accept bundle identifier prefixes", () => {

--- a/apps/desktop/src/imports/providers.ts
+++ b/apps/desktop/src/imports/providers.ts
@@ -172,6 +172,15 @@ export const MEETING_IMPORT_PROVIDERS: MeetingImportProvider[] = [
     bundleIds: ["ai.plaud.desktop.plaud"],
   },
   {
+    id: "pocket",
+    name: "Pocket",
+    access: "MCP",
+    helpUrl: "https://docs.heypocketai.com/docs",
+    directImport: "mcp-oauth",
+    nativeNames: ["Pocket", "Pocket Desktop", "Pocket AI"],
+    bundleIds: ["com.heypocket.app", "com.heypocket.desktop"],
+  },
+  {
     id: "zoom",
     name: "Zoom",
     access: "OAuth",

--- a/apps/desktop/src/imports/providers.ts
+++ b/apps/desktop/src/imports/providers.ts
@@ -168,7 +168,7 @@ export const MEETING_IMPORT_PROVIDERS: MeetingImportProvider[] = [
     helpUrl:
       "https://support.plaud.ai/hc/en-us/articles/57751026815257-Plaud-CLI",
     directImport: "cli",
-    nativeNames: ["Plaud"],
+    nativeNames: ["Plaud", "Plaud Desktop"],
     bundleIds: ["ai.plaud.desktop.plaud"],
   },
   {
@@ -178,7 +178,7 @@ export const MEETING_IMPORT_PROVIDERS: MeetingImportProvider[] = [
     helpUrl: "https://docs.heypocketai.com/docs",
     directImport: "mcp-oauth",
     nativeNames: ["Pocket", "Pocket Desktop", "Pocket AI"],
-    bundleIds: ["com.heypocket.app", "com.heypocket.desktop"],
+    bundleIds: ["com.openvisionengineering.pocket-desktop-app"],
   },
   {
     id: "zoom",

--- a/apps/desktop/src/imports/screen.test.tsx
+++ b/apps/desktop/src/imports/screen.test.tsx
@@ -413,6 +413,31 @@ describe("MeetingImportScreen", () => {
     ).toBeNull();
   });
 
+  it("connects Pocket through MCP OAuth instead of file-only import", async () => {
+    mockDetected(["pocket"]);
+    mocks.connectConnectedImport.mockResolvedValue({
+      providerId: "pocket",
+      clientId: "pocket-client",
+      tokenJson: "{}",
+    });
+
+    renderImports();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Connect & import" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.connectConnectedImport).toHaveBeenCalledOnce();
+    });
+    expect(mocks.connectNangoImport).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(
+        /Connected · New meetings are imported automatically while Anarlog is running/i,
+      ),
+    ).toBeTruthy();
+  });
+
   it("shows the empty state when nothing is detected", async () => {
     mockDetected([]);
 

--- a/crates/detect/src/list/competitors.rs
+++ b/crates/detect/src/list/competitors.rs
@@ -7,6 +7,8 @@ const MACOS_COMPETITOR_BUNDLE_IDS: &[(&str, &str)] = &[
     ("Fathom", "Fathom"),
     ("com.jamie.app", "Jamie"),
     ("ai.plaud.desktop.plaud", "Plaud"),
+    ("com.heypocket.app", "Pocket"),
+    ("com.heypocket.desktop", "Pocket"),
     ("ai.limitless.desktop", "Limitless"),
     ("com.memoryvault.MemoryVault", "Rewind"),
 ];
@@ -19,6 +21,7 @@ const WINDOWS_COMPETITOR_PROCESS_NAMES: &[(&str, &str)] = &[
     ("Otter.exe", "Otter"),
     ("Jamie.exe", "Jamie"),
     ("Plaud.exe", "Plaud"),
+    ("Pocket.exe", "Pocket"),
     ("Limitless.exe", "Limitless"),
     ("Rewind.exe", "Rewind"),
 ];
@@ -96,6 +99,10 @@ mod tests {
         assert_eq!(
             competitor_name_for_macos_bundle_id("com.granola.app"),
             Some("Granola")
+        );
+        assert_eq!(
+            competitor_name_for_macos_bundle_id("com.heypocket.desktop"),
+            Some("Pocket")
         );
         assert_eq!(
             competitor_name_for_macos_bundle_id("com.granola.app.helper"),

--- a/crates/detect/src/list/competitors.rs
+++ b/crates/detect/src/list/competitors.rs
@@ -7,8 +7,7 @@ const MACOS_COMPETITOR_BUNDLE_IDS: &[(&str, &str)] = &[
     ("Fathom", "Fathom"),
     ("com.jamie.app", "Jamie"),
     ("ai.plaud.desktop.plaud", "Plaud"),
-    ("com.heypocket.app", "Pocket"),
-    ("com.heypocket.desktop", "Pocket"),
+    ("com.openvisionengineering.pocket-desktop-app", "Pocket"),
     ("ai.limitless.desktop", "Limitless"),
     ("com.memoryvault.MemoryVault", "Rewind"),
 ];
@@ -101,8 +100,12 @@ mod tests {
             Some("Granola")
         );
         assert_eq!(
-            competitor_name_for_macos_bundle_id("com.heypocket.desktop"),
+            competitor_name_for_macos_bundle_id("com.openvisionengineering.pocket-desktop-app"),
             Some("Pocket")
+        );
+        assert_eq!(
+            competitor_name_for_macos_bundle_id("ai.plaud.desktop.plaud"),
+            Some("Plaud")
         );
         assert_eq!(
             competitor_name_for_macos_bundle_id("com.granola.app.helper"),

--- a/docs/imports.mdx
+++ b/docs/imports.mdx
@@ -17,9 +17,9 @@ Meeting-history import turns official exports from another meeting assistant int
 4. Select one or more JSON, CSV, Markdown, text, VTT, or SRT export files.
 5. Review the result shown when the import finishes.
 
-Anarlog detects supported meeting-assistant apps installed on your computer. Supported sources include Granola, Circleback, Fireflies.ai, Fathom, Krisp, Otter.ai, Notion AI Meeting Notes, Zoom, Microsoft Teams, Google Meet, Webex, Plaud, ChatGPT Record, Slack Huddles, and others.
+Anarlog detects supported meeting-assistant apps installed on your computer. Supported sources include Granola, Circleback, Fireflies.ai, Fathom, Krisp, Otter.ai, Notion AI Meeting Notes, Zoom, Microsoft Teams, Google Meet, Webex, Plaud, Pocket, ChatGPT Record, Slack Huddles, and others.
 
-For assistants that support a direct connection (OAuth, MCP, or a local CLI such as Plaud), choose **Connect & import**. Anarlog signs in through the official integration — for Plaud it runs `plaud` on your machine — and keeps importing new meetings while it is running.
+For assistants that support a direct connection (OAuth, MCP, or a local CLI such as Plaud), choose **Connect & import**. Anarlog signs in through the official integration — for Plaud it runs `plaud` on your machine, and for Pocket it uses the official MCP server — and keeps importing new meetings while it is running.
 
 The exact content depends on the source export. Anarlog keeps supported titles, dates, notes, summaries, transcripts, speakers, and participants when those fields are available.
 

--- a/packages/changelog/content/1.4.11.md
+++ b/packages/changelog/content/1.4.11.md
@@ -23,6 +23,8 @@ summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcrip
 - Import Plaud recordings the same way after signing in with the official Plaud
   CLI on your computer
 - Import Pocket recordings the same way after signing in through Pocket MCP
+- Detect Plaud Desktop and Pocket Desktop when they are installed so they
+  appear in Import settings
 - Recognize Google Meet and Zoom from their official camera marks in Import
   settings and the meeting header
 

--- a/packages/changelog/content/1.4.11.md
+++ b/packages/changelog/content/1.4.11.md
@@ -22,6 +22,7 @@ summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcrip
   the background while Anarlog is running
 - Import Plaud recordings the same way after signing in with the official Plaud
   CLI on your computer
+- Import Pocket recordings the same way after signing in through Pocket MCP
 - Recognize Google Meet and Zoom from their official camera marks in Import
   settings and the meeting header
 

--- a/plugins/importer/src/connected_mcp.rs
+++ b/plugins/importer/src/connected_mcp.rs
@@ -107,6 +107,13 @@ const MCP_PROVIDERS: &[McpProvider] = &[
         list_tools: &["search_calls"],
         enrichment_tools: &["get_call"],
     },
+    McpProvider {
+        id: "pocket",
+        name: "Pocket",
+        endpoint: "https://public.heypocketai.com/mcp",
+        list_tools: &["search_pocket_conversations"],
+        enrichment_tools: &["get_pocket_conversation"],
+    },
 ];
 
 fn provider(provider_id: &str) -> Result<McpProvider, String> {
@@ -616,7 +623,15 @@ async fn list_all_meetings(
 ) -> Result<Vec<Value>, String> {
     let mut payloads = Vec::new();
     let mut cursor: Option<String> = None;
-    let cursor_property = schema_property(tool, &["cursor", "next_cursor", "nextCursor"]);
+    let cursor_property = schema_property(
+        tool,
+        &[
+            "cursor",
+            "next_cursor",
+            "nextCursor",
+            "recordingDateBeforeExclusive",
+        ],
+    );
     let offset_property = schema_property(tool, &["skip", "offset"]);
     let mut offset = 0_u64;
 
@@ -929,6 +944,7 @@ fn meeting_has_content(meeting: &Value) -> bool {
             "summary",
             "transcript",
             "transcription",
+            "transcriptSegments",
             "sentences",
             "segments",
             "utterances",
@@ -980,11 +996,25 @@ fn meeting_id(record: &Map<String, Value>) -> Option<String> {
 
 fn next_cursor(payloads: &[Value]) -> Option<String> {
     for payload in payloads {
-        if let Some(cursor) = find_string(payload, &["next_cursor", "nextCursor"]) {
+        if is_false_flag(payload, &["has_more", "hasMore"]) {
+            return None;
+        }
+        if let Some(cursor) = find_string(
+            payload,
+            &[
+                "next_cursor",
+                "nextCursor",
+                "nextRecordingDateBeforeExclusive",
+            ],
+        ) {
             return Some(cursor);
         }
     }
     None
+}
+
+fn is_false_flag(value: &Value, keys: &[&str]) -> bool {
+    matches!(find_value(value, keys), Some(Value::Bool(false)))
 }
 
 fn transcript_value(payloads: &[Value]) -> Option<Value> {
@@ -995,6 +1025,7 @@ fn transcript_value(payloads: &[Value]) -> Option<Value> {
                 "transcript",
                 "raw_transcript",
                 "rawTranscript",
+                "transcriptSegments",
                 "segments",
                 "utterances",
                 "sentences",
@@ -1017,7 +1048,7 @@ fn merge_enrichment(meeting: &mut Value, tool_name: &str, payloads: Vec<Value>) 
     };
     let normalized_tool = normalized_tool_name(tool_name);
 
-    if normalized_tool.contains("transcript")
+    if (normalized_tool.contains("transcript") || normalized_tool.contains("conversation"))
         && let Some(transcript) = transcript_value(&payloads)
     {
         record.insert("transcript".to_string(), transcript);
@@ -1235,6 +1266,96 @@ mod tests {
 
         assert!(meeting_has_content(&meeting));
         assert_eq!(meeting["transcript"][0]["text"], "Ship it");
+    }
+
+    #[test]
+    fn extracts_pocket_recordings_and_transcript_segments() {
+        let payloads = vec![serde_json::json!({
+            "success": true,
+            "data": [{
+                "recordingId": "rec_123",
+                "recordingTitle": "Weekly Sync",
+                "recordingDate": "2026-03-25T15:04:05Z",
+                "transcriptSegments": [
+                    { "text": "Let's review the launch plan.", "start": 0.62, "end": 4.88, "speaker": "Alex" }
+                ]
+            }]
+        })];
+        let meetings = meeting_records(&payloads);
+        let files = meeting_files(provider("pocket").unwrap(), meetings);
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "mcp://pocket/rec_123.json");
+        assert!(files[0].content.contains("Weekly Sync"));
+        let meeting: Value = serde_json::from_str(&files[0].content).unwrap();
+        assert!(meeting_has_content(&meeting));
+    }
+
+    #[test]
+    fn pages_pocket_recordings_with_exclusive_date_cursors() {
+        let next = next_cursor(&[serde_json::json!({
+            "data": {
+                "meta": {
+                    "hasMore": true,
+                    "nextRecordingDateBeforeExclusive": "2026-03-20T12:00:00.000Z"
+                }
+            }
+        })]);
+        assert_eq!(next.as_deref(), Some("2026-03-20T12:00:00.000Z"));
+
+        assert_eq!(
+            next_cursor(&[serde_json::json!({
+                "data": {
+                    "meta": {
+                        "hasMore": false,
+                        "nextRecordingDateBeforeExclusive": "2026-03-01T00:00:00.000Z"
+                    }
+                }
+            })]),
+            None
+        );
+
+        let tool = Tool::new(
+            "search_pocket_conversations",
+            "Search conversations",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "recordingDateBeforeExclusive": { "type": "string" }
+                }
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+        );
+        assert_eq!(
+            schema_property(&tool, &["recordingDateBeforeExclusive"]).as_deref(),
+            Some("recordingDateBeforeExclusive")
+        );
+    }
+
+    #[test]
+    fn merges_pocket_conversation_transcripts() {
+        let mut meeting = serde_json::json!({
+            "recordingId": "rec_123",
+            "recordingTitle": "Weekly Sync"
+        });
+        merge_enrichment(
+            &mut meeting,
+            "get_pocket_conversation",
+            vec![serde_json::json!({
+                "success": true,
+                "data": [{
+                    "recordingId": "rec_123",
+                    "transcriptSegments": [{ "text": "Ship it", "start": 1.0, "end": 2.0, "speaker": "Ada" }],
+                    "summary": { "text": "Ship the launch." }
+                }]
+            })],
+        );
+
+        assert!(meeting_has_content(&meeting));
+        assert_eq!(meeting["transcript"][0]["text"], "Ship it");
+        assert_eq!(meeting["summary"]["text"], "Ship the launch.");
     }
 
     #[test]

--- a/plugins/importer/src/connected_mcp.rs
+++ b/plugins/importer/src/connected_mcp.rs
@@ -1105,12 +1105,37 @@ fn merge_enrichment(meeting: &mut Value, tool_name: &str, payloads: Vec<Value>) 
     }
 
     for payload in payloads {
-        if let Value::Object(payload_record) = payload {
+        for payload_record in enrichment_records(payload) {
             for (key, value) in payload_record {
+                if is_envelope_key(&key) {
+                    continue;
+                }
                 record.entry(key).or_insert(value);
             }
         }
     }
+}
+
+fn enrichment_records(payload: Value) -> Vec<Map<String, Value>> {
+    match payload {
+        Value::Array(items) => items.into_iter().flat_map(enrichment_records).collect(),
+        Value::Object(mut record) => match record.remove("data") {
+            Some(data) => {
+                let inner = enrichment_records(data);
+                if inner.is_empty() {
+                    vec![record]
+                } else {
+                    inner
+                }
+            }
+            None => vec![record],
+        },
+        _ => Vec::new(),
+    }
+}
+
+fn is_envelope_key(key: &str) -> bool {
+    matches!(key, "success" | "error" | "errors" | "status" | "meta")
 }
 
 fn find_string(value: &Value, keys: &[&str]) -> Option<String> {
@@ -1338,7 +1363,8 @@ mod tests {
     fn merges_pocket_conversation_transcripts() {
         let mut meeting = serde_json::json!({
             "recordingId": "rec_123",
-            "recordingTitle": "Weekly Sync"
+            "recordingTitle": "Weekly Sync",
+            "recordingDate": "2026-03-25T15:04:05Z"
         });
         merge_enrichment(
             &mut meeting,
@@ -1354,8 +1380,12 @@ mod tests {
         );
 
         assert!(meeting_has_content(&meeting));
+        assert_eq!(meeting["recordingTitle"], "Weekly Sync");
+        assert_eq!(meeting["recordingDate"], "2026-03-25T15:04:05Z");
         assert_eq!(meeting["transcript"][0]["text"], "Ship it");
         assert_eq!(meeting["summary"]["text"], "Ship the launch.");
+        assert!(meeting.get("data").is_none());
+        assert!(meeting.get("success").is_none());
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Pocket as a meeting-history source, the same way Plaud was added, using Pocket’s official docs and MCP server.

**Connect & import**
- Detect the Pocket and Plaud desktop apps and offer **Connect & import**
- Sign in through Pocket MCP OAuth (`https://public.heypocketai.com/mcp`)
- List recordings with `search_pocket_conversations` and enrich with `get_pocket_conversation`
- Keep paging through older recordings via `recordingDateBeforeExclusive`

**Desktop detection**
- Pocket Desktop on macOS is `com.openvisionengineering.pocket-desktop-app` (confirmed from the current DMG), with display names `Pocket` / `Pocket Desktop` / `Pocket AI`
- Plaud Desktop matches `ai.plaud.desktop.plaud` and the Windows display name `Plaud Desktop`
- Pocket Casts is not treated as Pocket

**Parsing**
- Read Pocket `recordingId` / `recordingTitle` / `recordingDate` / `transcriptSegments`
- Merge `get_pocket_conversation` inner recordings instead of the `{ success, data }` envelope so title and start time survive Connect & import
- Keep titled JSON collection exports (`{ title, meetings: [...] }`) as one meeting per array item

Docs: https://docs.heypocketai.com/docs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbae00eb-deca-4f81-8e09-5a2c3c30f1b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbae00eb-deca-4f81-8e09-5a2c3c30f1b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

