### PR TITLE
fix(stt): load cached Soniqo live models without HuggingFace

### DIFF
--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -208,7 +208,9 @@ async fn spawn_soniqo_rx_task(
             Err(error) => {
                 tracing::error!(
                     anarlog.session.id = %args.session_id,
-                    error.message = ?error,
+                    anarlog.stt.provider.name = "soniqo",
+                    anarlog.stt.model = %model,
+                    error.message = %error,
                     "soniqo_live_start_failed(dual)"
                 );
                 args.runtime.emit_error(SessionErrorEvent::ConnectionError {
@@ -249,7 +251,9 @@ async fn spawn_soniqo_rx_task(
                 Err(error) => {
                     tracing::error!(
                         anarlog.session.id = %args.session_id,
-                        error.message = ?error,
+                        anarlog.stt.provider.name = "soniqo",
+                        anarlog.stt.model = %model,
+                        error.message = %error,
                         "soniqo_live_start_failed(single)"
                     );
                     args.runtime.emit_error(SessionErrorEvent::ConnectionError {

--- a/crates/transcribe-soniqo/build.rs
+++ b/crates/transcribe-soniqo/build.rs
@@ -203,6 +203,7 @@ fn prepare_swift_package(swift_build_dir: &Path) {
     run_command(command, "resolving Soniqo Swift dependencies");
 
     patch_speech_swift_manifest(swift_build_dir);
+    patch_parakeet_streaming_offline_mode(swift_build_dir);
 }
 
 #[cfg(target_os = "macos")]
@@ -253,6 +254,60 @@ fn patch_speech_swift_manifest(swift_build_dir: &Path) {
         panic!(
             "failed to patch Soniqo speech-swift manifest {}: {error}",
             manifest.display()
+        )
+    });
+}
+
+#[cfg(target_os = "macos")]
+include!("src/streaming_offline.rs");
+
+#[cfg(target_os = "macos")]
+fn patch_parakeet_streaming_offline_mode(swift_build_dir: &Path) {
+    let path = swift_build_dir
+        .join("checkouts")
+        .join("speech-swift")
+        .join("Sources")
+        .join("ParakeetStreamingASR")
+        .join("ParakeetStreamingASR.swift");
+    let contents = fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read Soniqo Parakeet streaming source {}: {error}",
+            path.display()
+        )
+    });
+    let patched = patch_parakeet_streaming_source(&contents).unwrap_or_else(|error| {
+        panic!(
+            "failed to patch Soniqo Parakeet streaming offline mode in {}: {error}",
+            path.display()
+        )
+    });
+
+    if patched == contents {
+        return;
+    }
+
+    let mut permissions = fs::metadata(&path)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to read permissions for Soniqo Parakeet streaming source {}: {error}",
+                path.display()
+            )
+        })
+        .permissions();
+    if permissions.readonly() {
+        permissions.set_readonly(false);
+        fs::set_permissions(&path, permissions).unwrap_or_else(|error| {
+            panic!(
+                "failed to make Soniqo Parakeet streaming source writable {}: {error}",
+                path.display()
+            )
+        });
+    }
+
+    fs::write(&path, patched).unwrap_or_else(|error| {
+        panic!(
+            "failed to patch Soniqo Parakeet streaming source {}: {error}",
+            path.display()
         )
     });
 }

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -5,6 +5,8 @@ mod error;
 mod model;
 mod platform;
 mod responses;
+#[cfg(test)]
+mod streaming_offline;
 mod types;
 
 pub use error::{Error, Result};
@@ -171,7 +173,15 @@ impl LiveTranscriptionSession {
             )));
         }
 
-        let session_token = platform::live_start(model)?;
+        let session_token = platform::live_start(model).map_err(|error| {
+            tracing::error!(
+                anarlog.stt.provider.name = "soniqo",
+                anarlog.stt.model = %model,
+                error = %error,
+                "soniqo_native_live_start_failed"
+            );
+            error
+        })?;
         Ok(Self {
             model,
             session_token,

--- a/crates/transcribe-soniqo/src/streaming_offline.rs
+++ b/crates/transcribe-soniqo/src/streaming_offline.rs
@@ -1,0 +1,77 @@
+pub(crate) fn patch_parakeet_streaming_source(source: &str) -> Result<String, &'static str> {
+    const SIGNATURE: &str = "    public static func fromPretrained(\n        modelId: String? = nil,\n        progressHandler: ((Double, String) -> Void)? = nil\n    ) async throws -> ParakeetStreamingASRModel {";
+    const PATCHED_SIGNATURE: &str = "    public static func fromPretrained(\n        modelId: String? = nil,\n        offlineMode: Bool = false,\n        progressHandler: ((Double, String) -> Void)? = nil\n    ) async throws -> ParakeetStreamingASRModel {";
+    const DOWNLOAD: &str = "            try await HuggingFaceDownloader.downloadWeights(\n                modelId: effectiveModelId,\n                to: cacheDir,\n                additionalFiles: [";
+    const PATCHED_DOWNLOAD: &str = "            try await HuggingFaceDownloader.downloadWeights(\n                modelId: effectiveModelId,\n                to: cacheDir,\n                offlineMode: offlineMode,\n                additionalFiles: [";
+
+    let mut patched = source.to_string();
+
+    if !patched.contains(PATCHED_SIGNATURE) {
+        if !patched.contains(SIGNATURE) {
+            return Err("ParakeetStreamingASR fromPretrained signature not found");
+        }
+        patched = patched.replacen(SIGNATURE, PATCHED_SIGNATURE, 1);
+    }
+
+    if patched.contains(PATCHED_DOWNLOAD) {
+        return Ok(patched);
+    }
+
+    if patched.contains(DOWNLOAD) {
+        return Ok(patched.replacen(DOWNLOAD, PATCHED_DOWNLOAD, 1));
+    }
+
+    Err("ParakeetStreamingASR downloadWeights call not found")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::patch_parakeet_streaming_source;
+
+    const SOURCE: &str = r#"    public static func fromPretrained(
+        modelId: String? = nil,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> ParakeetStreamingASRModel {
+        progressHandler?(0.0, "Downloading model...")
+        do {
+            try await HuggingFaceDownloader.downloadWeights(
+                modelId: effectiveModelId,
+                to: cacheDir,
+                additionalFiles: [
+                    "encoder.mlmodelc/**",
+                ]
+            ) { fraction in
+                progressHandler?(fraction * 0.7, "Downloading model...")
+            }
+        }
+    }
+"#;
+
+    #[test]
+    fn adds_offline_mode_to_streaming_from_pretrained() {
+        let patched = patch_parakeet_streaming_source(SOURCE).unwrap();
+
+        assert!(patched.contains("offlineMode: Bool = false"));
+        assert!(patched.contains("offlineMode: offlineMode"));
+        assert!(!patched.contains(
+            "        modelId: String? = nil,\n        progressHandler: ((Double, String) -> Void)? = nil"
+        ));
+    }
+
+    #[test]
+    fn streaming_offline_patch_is_idempotent() {
+        let patched = patch_parakeet_streaming_source(SOURCE).unwrap();
+
+        assert_eq!(patch_parakeet_streaming_source(&patched).unwrap(), patched);
+    }
+
+    #[test]
+    fn streaming_offline_patch_rejects_unknown_source() {
+        let error = patch_parakeet_streaming_source("public class Unrelated {}").unwrap_err();
+
+        assert_eq!(
+            error,
+            "ParakeetStreamingASR fromPretrained signature not found"
+        );
+    }
+}

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -140,9 +140,12 @@ private enum SpeechModelKind: String, CaseIterable {
 
     switch self {
     case .parakeetStreaming:
+      // speech-swift's streaming loader always contacts HuggingFace unless
+      // offlineMode is set; live start must keep working from the local cache.
       return .streaming(
         try await ParakeetStreamingASRModel.fromPretrained(
           modelId: repo,
+          offlineMode: offlineMode,
           progressHandler: progressHandler
         )
       )
@@ -687,8 +690,13 @@ private actor SoniqoBridge {
       if let kind {
         markModelIdle(kind)
       }
+      let cached = kind.map { $0.filesReady() } ?? false
       return encodeJSON(
-        StatusPayload(running: false, sessionToken: nil, error: error.localizedDescription)
+        StatusPayload(
+          running: false,
+          sessionToken: nil,
+          error: "\(error.localizedDescription) (model_cached=\(cached))"
+        )
       )
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Soniqo live transcription can fail at session start in mic+speaker mode even after the Parakeet streaming model is already downloaded.

## Cause

`ParakeetStreamingASRModel.fromPretrained` always contacts HuggingFace. Batch/omnilingual already pass `offlineMode` when files are cached; streaming did not, and speech-swift 0.0.22 has no streaming `offlineMode` argument.

That matches the sibling production error:

`Failed to load model 'aufklarer/Parakeet-EOU-120M-CoreML-INT8': Download failed (... HTTP 503)`

Dual vs single is the same `LiveTranscriptionSession::start` path. This event happened to be dual-channel.

## Fix

- Patch the speech-swift streaming loader at build time so `fromPretrained` accepts `offlineMode`
- Pass `offlineMode` when the streaming files are already on disk
- Include model id, Display error text, and `model_cached=` on native start failures for Sentry

Fixes HYPRNOTE2-2N42

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-362613dd-bae1-416c-bf57-6c10301d9e48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-362613dd-bae1-416c-bf57-6c10301d9e48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

