### PR TITLE
fix(linux): stop reporting missing PulseAudio as Sentry errors

### DIFF
--- a/crates/audio-actual/src/speaker/linux.rs
+++ b/crates/audio-actual/src/speaker/linux.rs
@@ -257,11 +257,11 @@ fn pipewire_capture_loop(
         init_tx,
     );
 
-    if let Err(error) = &result {
+    if let Err(error) = result {
         let _ = setup_err_tx.send(Err(anyhow::anyhow!(error.to_string())));
     }
 
-    result
+    Ok(())
 }
 
 fn pipewire_capture_setup(
@@ -515,9 +515,10 @@ fn pulseaudio_capture_loop(
     let (mut stream, actual_rate) = match setup_result {
         Ok(values) => values,
         Err(err) => {
+            tracing::warn!(error = %err, "pulseaudio_capture_setup_failed");
             let _ = init_tx.send(Err(anyhow::anyhow!(err.to_string())));
             mainloop.stop();
-            return Err(err);
+            return Ok(());
         }
     };
 

--- a/crates/detect/src/mic/linux.rs
+++ b/crates/detect/src/mic/linux.rs
@@ -139,7 +139,7 @@ fn run_detector(
     let mut mainloop = match Mainloop::new() {
         Some(m) => m,
         None => {
-            tracing::error!("failed_to_create_pulseaudio_mainloop");
+            tracing::warn!("failed_to_create_pulseaudio_mainloop");
             return;
         }
     };
@@ -147,21 +147,18 @@ fn run_detector(
     let mut context = match Context::new(&mainloop, "anarlog-mic-detector") {
         Some(c) => c,
         None => {
-            tracing::error!("failed_to_create_pulseaudio_context");
+            tracing::warn!("failed_to_create_pulseaudio_context");
             return;
         }
     };
 
-    if context
-        .connect(None, ContextFlagSet::NOFLAGS, None)
-        .is_err()
-    {
-        tracing::error!("failed_to_connect_to_pulseaudio");
+    if let Err(error) = context.connect(None, ContextFlagSet::NOFLAGS, None) {
+        tracing::warn!(?error, "failed_to_connect_to_pulseaudio");
         return;
     }
 
-    if mainloop.start().is_err() {
-        tracing::error!("failed_to_start_pulseaudio_mainloop");
+    if let Err(error) = mainloop.start() {
+        tracing::warn!(?error, "failed_to_start_pulseaudio_mainloop");
         context.disconnect();
         return;
     }
@@ -233,7 +230,7 @@ fn wait_for_context(mainloop: &mut Mainloop, context: &Context, shutdown: &Atomi
         match state {
             pulse::context::State::Ready => return true,
             pulse::context::State::Failed | pulse::context::State::Terminated => {
-                tracing::error!("pulseaudio_context_connection_failed");
+                tracing::warn!(?state, "pulseaudio_context_connection_failed");
                 return false;
             }
             _ => std::thread::sleep(Duration::from_millis(10)),

--- a/crates/device-monitor/src/linux.rs
+++ b/crates/device-monitor/src/linux.rs
@@ -21,7 +21,7 @@ fn setup_pulseaudio(stop_rx: &mpsc::Receiver<()>) -> Option<PulseAudioHandles> {
     let mut proplist = match Proplist::new() {
         Some(p) => p,
         None => {
-            tracing::error!("Failed to create PulseAudio proplist");
+            tracing::warn!("Failed to create PulseAudio proplist");
             let _ = stop_rx.recv();
             return None;
         }
@@ -34,7 +34,7 @@ fn setup_pulseaudio(stop_rx: &mpsc::Receiver<()>) -> Option<PulseAudioHandles> {
         )
         .is_err()
     {
-        tracing::error!("Failed to set PulseAudio application name");
+        tracing::warn!("Failed to set PulseAudio application name");
         let _ = stop_rx.recv();
         return None;
     }
@@ -42,7 +42,7 @@ fn setup_pulseaudio(stop_rx: &mpsc::Receiver<()>) -> Option<PulseAudioHandles> {
     let mainloop = match Mainloop::new() {
         Some(m) => Rc::new(RefCell::new(m)),
         None => {
-            tracing::error!("Failed to create PulseAudio mainloop");
+            tracing::warn!("Failed to create PulseAudio mainloop");
             let _ = stop_rx.recv();
             return None;
         }
@@ -52,7 +52,7 @@ fn setup_pulseaudio(stop_rx: &mpsc::Receiver<()>) -> Option<PulseAudioHandles> {
     {
         Some(c) => Rc::new(RefCell::new(c)),
         None => {
-            tracing::error!("Failed to create PulseAudio context");
+            tracing::warn!("Failed to create PulseAudio context");
             let _ = stop_rx.recv();
             return None;
         }
@@ -62,7 +62,7 @@ fn setup_pulseaudio(stop_rx: &mpsc::Receiver<()>) -> Option<PulseAudioHandles> {
         .borrow_mut()
         .connect(None, ContextFlagSet::NOFLAGS, None)
     {
-        tracing::error!("Failed to connect to PulseAudio: {:?}", e);
+        tracing::warn!("Failed to connect to PulseAudio: {:?}", e);
         let _ = stop_rx.recv();
         return None;
     }
@@ -70,7 +70,7 @@ fn setup_pulseaudio(stop_rx: &mpsc::Receiver<()>) -> Option<PulseAudioHandles> {
     mainloop.borrow_mut().lock();
 
     if let Err(e) = mainloop.borrow_mut().start() {
-        tracing::error!("Failed to start PulseAudio mainloop: {:?}", e);
+        tracing::warn!("Failed to start PulseAudio mainloop: {:?}", e);
         mainloop.borrow_mut().unlock();
         let _ = stop_rx.recv();
         return None;
@@ -84,7 +84,7 @@ fn setup_pulseaudio(stop_rx: &mpsc::Receiver<()>) -> Option<PulseAudioHandles> {
             }
             libpulse_binding::context::State::Failed
             | libpulse_binding::context::State::Terminated => {
-                tracing::error!("PulseAudio context failed");
+                tracing::warn!("PulseAudio context failed");
                 mainloop.borrow_mut().unlock();
                 return None;
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Linux boots without PulseAudio/pipewire-pulse (CI VMs, some desktops) were filing production Sentry errors from best-effort mic detection. Speaker capture setup failures were also logged at `error` even though the caller already handles them and falls back.

**Sentry**
- [`HYPRNOTE2-2MRH`](https://fastrepl.sentry.io/issues/HYPRNOTE2-2MRH) / [`HYPRNOTE2-2M18`](https://fastrepl.sentry.io/issues/HYPRNOTE2-2M18) — `failed_to_connect_to_pulseaudio` from `detect::mic::linux` (Azure/AWS kernels, no audio server)
- [`HYPRNOTE2-2MXB`](https://fastrepl.sentry.io/issues/HYPRNOTE2-2MXB) — `pulseaudio_capture_thread_failed` on speaker-capture *setup* failure
- [`HYPRNOTE2-2MTN`](https://fastrepl.sentry.io/issues/HYPRNOTE2-2MTN) — same pattern for PipeWire setup (`pipewire_capture_thread_failed`, then PulseAudio fallback)

**Changes**
- Mic detector and device monitor log missing/unusable PulseAudio as **warn** (breadcrumb), not **error** (Sentry event). Connect/start failures now include the libpulse error.
- Linux speaker capture forwards setup errors to the parent and returns success from the capture thread, so fallback/init failure is not a Sentry error. Unexpected post-init thread failures still log at error.

Real subscribe/panic/spawn failures stay at error. Runtime PipeWire stream errors (`pipewire_stream_error`) are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-362613dd-bae1-416c-bf57-6c10301d9e48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-362613dd-bae1-416c-bf57-6c10301d9e48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

