### PR TITLE
Add conceptual figures to image-less blog posts

### DIFF
--- a/apps/web/content/articles/anthropic-data-retention-policy.mdx
+++ b/apps/web/content/articles/anthropic-data-retention-policy.mdx
@@ -44,6 +44,8 @@ Turning it off does not retroactively remove data already used for training. Lik
 
 ## How Is the Anthropic API Different for Privacy-Conscious Users?
 
+![How Anthropic's consumer Claude apps and the Anthropic API handle conversation data differently](/api/assets/blog/articles/anthropic-data-retention-policy/claude-data-paths.png)
+
 The consumer product and the API have meaningfully different data policies, and the API is notably stronger.
 
 As of September 14, 2025, Anthropic reduced API log retention from 30 days to 7 days. API inputs and outputs are automatically deleted after 7 days. They are never used for model training.

--- a/apps/web/content/articles/avoma-alternatives.mdx
+++ b/apps/web/content/articles/avoma-alternatives.mdx
@@ -27,6 +27,8 @@ That structure is why the useful question is not "what is better than Avoma." It
 
 ## Work out which layer you are replacing
 
+![The three product layers bundled into Avoma: meeting assistant, conversation intelligence, and revenue intelligence](/api/assets/blog/articles/avoma-alternatives/avoma-three-layers.png)
+
 Avoma's own packaging is the clearest map of what you might be paying for.
 
 | Layer | What it does | Who needs it | What it costs in Avoma |

--- a/apps/web/content/articles/azure-open-ai-data-retention-policy.mdx
+++ b/apps/web/content/articles/azure-open-ai-data-retention-policy.mdx
@@ -28,6 +28,8 @@ This is a materially different setup from [Google Gemini's human review policy](
 
 ## Modified Abuse Monitoring and Zero Data Retention
 
+![Where prompts go in Azure OpenAI: the default abuse-monitoring path and the approved zero-retention path](/api/assets/blog/articles/azure-open-ai-data-retention-policy/azure-openai-data-flow.png)
+
 Standard abuse monitoring retains your data for 30 days. If that does not meet your requirements, there are two paths forward.
 
 Modified abuse monitoring removes human review from your subscription while keeping automated checks in place. If your application is approved, Microsoft will not store prompts and completions from your subscription for human review purposes.

--- a/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
+++ b/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
@@ -16,6 +16,8 @@ But the answer isn't to give up on AI-powered meeting notes. It's to take contro
 
 ## What happens to your data with cloud-based transcription tools?
 
+![Cloud transcription relies on vendor servers, while on-device transcription keeps processing on your Mac](/api/assets/blog/articles/can-you-transcribe-meetings-without-sending-data-to-cloud/cloud-vs-local-transcription.png)
+
 With cloud-based tools, your sensitive discussions, client information, and strategic planning sessions are processed by third-party vendors with varying privacy standards.
 
 Your audio and transcripts may be stored on servers across different countries, used for AI training, and subject to the provider's changing privacy policies.

--- a/apps/web/content/articles/char-is-now-anarlog.mdx
+++ b/apps/web/content/articles/char-is-now-anarlog.mdx
@@ -16,6 +16,8 @@ If you're here for meeting notes — you're in the right place. anarlog.so is th
 
 ### why two names
 
+![The product's naming history from Hyprnote to Char to Anarlog](/api/assets/blog/articles/char-is-now-anarlog/name-timeline.png)
+
 Char (the meeting notetaker) and Char (the agentic todo notepad we've been building) were trying to live under one brand. They couldn't.
 
 The meeting notetaker is finished software in the best sense — system audio capture, local-first meeting data, your AI of choice, no bots in your calls. People love it because it's *focused*. They want a tool they can audit, fork, and run on their own terms.

--- a/apps/web/content/articles/char-vs-meetily.mdx
+++ b/apps/web/content/articles/char-vs-meetily.mdx
@@ -38,6 +38,8 @@ Meetily is a private transcription recorder. It records, transcribes locally, an
 
 ## **Similarities Between Anarlog and Meetily**
 
+![Anarlog and Meetily compared: both local-first, differing in polish and focus](/api/assets/blog/articles/char-vs-meetily/anarlog-vs-meetily-axes.png)
+
 Both tools were built as a direct reaction to cloud meeting tools like Otter and Fireflies. They share the same foundational decisions:
 
 - System audio capture. No bot joins your call. No calendar permissions required.

--- a/apps/web/content/articles/chatgpt-data-retention-policy.mdx
+++ b/apps/web/content/articles/chatgpt-data-retention-policy.mdx
@@ -45,6 +45,8 @@ Temporary Chat mode works somewhat differently. Conversations in Temporary Chat 
 
 ## How ChatGPT's Data Retention Policy Differs by Plan
 
+![ChatGPT data handling across consumer plans, business plans, and the API](/api/assets/blog/articles/chatgpt-data-retention-policy/chatgpt-retention-by-plan.png)
+
 Not all ChatGPT users are equal when it comes to data retention:
 
 ### 1. Free, Plus, Pro, Team

--- a/apps/web/content/articles/figures.json
+++ b/apps/web/content/articles/figures.json
@@ -1,7 +1,16 @@
 {
   "ai-meeting-notes-without-bot": [],
   "ai-meeting-summary-tools": [],
-  "anthropic-data-retention-policy": [],
+  "anthropic-data-retention-policy": [
+    {
+      "filename": "claude-data-paths.png",
+      "content": "Claude.ai apps\nTraining toggle on: multi-year retention\nTraining toggle off: standard retention\nAnthropic API\nNo training on inputs by default\nLimited abuse-monitoring retention",
+      "context": "Two-branch diagram for an Anarlog blog post contrasting how conversation data is handled in Anthropic's consumer Claude apps versus the Anthropic API. Neutral, factual tone; no alarmist styling.",
+      "visualQuery": "flowchart",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "avoma-alternatives": [
     {
       "filename": "avoma-three-layers.png",
@@ -11,7 +20,16 @@
       "width": 1000
     }
   ],
-  "azure-open-ai-data-retention-policy": [],
+  "azure-open-ai-data-retention-policy": [
+    {
+      "filename": "azure-openai-data-flow.png",
+      "content": "Your prompt\nAzure OpenAI service in your region\nDefault: abuse-monitoring storage up to 30 days\nApproved: modified monitoring, no prompt storage\nResponses returned to you",
+      "context": "Horizontal data-flow diagram for an Anarlog blog post showing where prompts go in Azure OpenAI, with the default abuse-monitoring path and the approved zero-retention path as branches.",
+      "visualQuery": "flowchart",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "best-ai-meeting-assistant-for-taking-notes": [],
   "best-ai-notetaker": [],
   "best-ai-notetaker-for-in-person-meetings": [],
@@ -19,10 +37,46 @@
   "best-ai-notetaker-for-zoom": [],
   "best-ai-notetakers-google-meet": [],
   "bot-free-ai-meeting-assistants": [],
-  "can-you-transcribe-meetings-without-sending-data-to-cloud": [],
-  "char-is-now-anarlog": [],
-  "char-vs-meetily": [],
-  "chatgpt-data-retention-policy": [],
+  "can-you-transcribe-meetings-without-sending-data-to-cloud": [
+    {
+      "filename": "cloud-vs-local-transcription.png",
+      "content": "Cloud transcription\nMicrophone\nVendor servers\nTranscript returned\nOn-device transcription\nMicrophone\nLocal model on your Mac\nTranscript stays local",
+      "context": "Side-by-side comparison diagram for an Anarlog blog post contrasting the data path of cloud transcription against fully on-device transcription. The on-device path should read as shorter and self-contained.",
+      "visualQuery": "comparison",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
+  "char-is-now-anarlog": [
+    {
+      "filename": "name-timeline.png",
+      "content": "Hyprnote\nChar\nAnarlog\nSame local-first meeting notepad",
+      "context": "Simple horizontal timeline for an Anarlog announcement post showing the product's naming history from Hyprnote to Char to Anarlog, with the constant being the same local-first meeting notepad.",
+      "visualQuery": "timeline",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
+  "char-vs-meetily": [
+    {
+      "filename": "anarlog-vs-meetily-axes.png",
+      "content": "Both: local-first and open source\nAnarlog: native app polish, live notepad, AI stack choice\nMeetily: self-hosted focus, community project",
+      "context": "Comparison diagram for an Anarlog blog post positioning Anarlog and Meetily. They share local-first open-source foundations but differ in product polish and focus. Honest, not dismissive of Meetily.",
+      "visualQuery": "comparison",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
+  "chatgpt-data-retention-policy": [
+    {
+      "filename": "chatgpt-retention-by-plan.png",
+      "content": "Title: ChatGPT Data Handling by Plan\nFree and Plus: chats stored until deleted, training controlled by a settings toggle\nTeam and Enterprise: no training on business data, admin retention controls\nAPI: limited retention, no training by default",
+      "context": "Three-column reference figure comparing how OpenAI handles data across the three ChatGPT usage tiers. Each column is one tier with its data-handling facts. Do not frame as pros versus cons.",
+      "visualQuery": "three column comparison",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "enterprise-ai-notetaking-tools": [],
   "fathom-ai-alternatives": [],
   "fireflies-ai-alternatives": [],
@@ -41,9 +95,36 @@
       "width": 1200
     }
   ],
-  "how-to-have-productive-one-on-one-meetings": [],
-  "how-to-participate-in-meetings-effectively": [],
-  "how-to-reduce-meeting-fatigue": [],
+  "how-to-have-productive-one-on-one-meetings": [
+    {
+      "filename": "one-on-one-loop.png",
+      "content": "Shared agenda\nListen more than you talk\nCapture decisions\nFollow through\nConsistent cadence",
+      "context": "Circular loop diagram showing the repeating weekly system that keeps manager one-on-ones productive. Use the five step labels exactly as given, no added descriptions, plain ASCII text only.",
+      "visualQuery": "cycle",
+      "orientation": "horizontal",
+      "width": 1100
+    }
+  ],
+  "how-to-participate-in-meetings-effectively": [
+    {
+      "filename": "participation-framework.png",
+      "content": "Prepare before the meeting\nSpeak early\nCapture notes as you go\nAsk sharp questions\nFollow up after",
+      "context": "Five-step horizontal framework for participating effectively in meetings, ordered before, during, and after. Keep all five steps separate. Plain ASCII text only, no ampersands.",
+      "visualQuery": "flowchart",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
+  "how-to-reduce-meeting-fatigue": [
+    {
+      "filename": "fatigue-causes-fixes.png",
+      "content": "Constant self-view\nHide your own camera tile\nBack-to-back calls\nAdd buffers between meetings\nHolding notes in your head\nOffload capture to a notetaker",
+      "context": "Cause-to-fix mapping diagram for an Anarlog blog post pairing each driver of meeting fatigue with a practical intervention.",
+      "visualQuery": "comparison",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "how-to-transcribe-zoom-calls": [],
   "is-ai-notetaking-legal": [],
   "is-fireflies-ai-safe": [],
@@ -53,7 +134,16 @@
   "mac-productivity-apps": [],
   "markdown-note-taking-apps": [],
   "meetgeek-alternatives": [],
-  "meetily-review": [],
+  "meetily-review": [
+    {
+      "filename": "meetily-pipeline.png",
+      "content": "System audio\nLocal Whisper transcription\nLocal or self-hosted LLM\nMeeting summary on your machine",
+      "context": "Horizontal pipeline diagram for an Anarlog review post showing how Meetily processes meetings entirely on local or self-hosted infrastructure.",
+      "visualQuery": "flowchart",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "meeting-action-items": [],
   "meeting-decision-log": [],
   "meeting-minutes-software": [],
@@ -69,22 +159,59 @@
   "meeting-preparation-checklist": [],
   "meeting-productivity-tools": [],
   "mistral-api-key": [],
-  "mistral-data-retention-policy": [],
-  "notetakers-for-developers": [],
-  "notion-meeting-notes": [
+  "mistral-data-retention-policy": [
     {
-      "filename": "notion-relations.png",
-      "content": "Meetings\nPeople\nProjects\nAction items",
-      "context": "Relationship diagram for an Anarlog blog post showing a Notion Meetings database linked by relation to People, Projects, and Action Items.",
+      "filename": "mistral-data-flow.png",
+      "content": "Your prompt\nMistral EU-hosted service\nDefault: limited retention for abuse monitoring\nEligible customers: zero-retention option\nTraining: only if you explicitly opt in",
+      "context": "Data-flow diagram summarizing how Mistral handles prompts. The three outcomes are default limited retention, an optional zero-retention path, and training that happens only with explicit opt-in. Training must not look like a default outcome.",
+      "visualQuery": "flowchart",
       "orientation": "horizontal",
       "width": 1200
     }
   ],
-  "notta-ai-alternative": [],
+  "notetakers-for-developers": [],
+  "notion-meeting-notes": [
+    {
+      "filename": "notion-relations.png",
+      "content": "Title: Notion Meeting Notes Schema\nMeetings database in the center\nRelated to People: who attended\nRelated to Projects: what it concerns\nRelated to Action Items: what was assigned",
+      "context": "Relationship diagram of a Notion setup with the Meetings database as the central hub, linked by relations to People, Projects, and Action Items. Meetings must be the central node.",
+      "visualQuery": "hub and spoke",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
+  "notta-ai-alternative": [
+    {
+      "filename": "notta-decision-flow.png",
+      "content": "Need translation and multilingual cloud workflow\nChoose Notta\nNeed local storage and control over AI processing\nChoose a local-first notetaker",
+      "context": "Two-branch decision diagram for an Anarlog blog post helping readers decide between Notta's cloud model and a local-first alternative based on what they actually need.",
+      "visualQuery": "decision tree",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "obsidian-meeting-notes": [],
   "open-source-meeting-transcription-software": [],
-  "openrouter-data-retention-policy": [],
-  "organize-meeting-notes": [],
+  "openrouter-data-retention-policy": [
+    {
+      "filename": "openrouter-request-path.png",
+      "content": "Your request\nOpenRouter gateway\nPrompt logging off by default\nUnderlying model provider\nProvider retention policy applies\nZero-retention endpoints available",
+      "context": "Request-path diagram for an Anarlog blog post showing that OpenRouter sits in front of many model providers, and that each provider applies its own retention policy after the gateway.",
+      "visualQuery": "flowchart",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
+  "organize-meeting-notes": [
+    {
+      "filename": "capture-to-retrieval.png",
+      "content": "Title: From Capture to Retrieval\nCapture during the meeting\nStructure decisions and actions\nTag and link related notes\nRetrieve instantly with search",
+      "context": "Four-stage pipeline showing a personal meeting-notes system. Use the title exactly as given.",
+      "visualQuery": "flowchart",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "otter-ai-alternatives": [],
   "otter-ai-review": [],
   "plaud-ai-alternatives": [],
@@ -92,9 +219,36 @@
   "see-zoom-meeting-history": [],
   "selfhosted-ai-notetakers": [],
   "tactiq-alternatives": [],
-  "tldv-alternatives": [],
+  "tldv-alternatives": [
+    {
+      "filename": "tldv-alternatives-map.png",
+      "content": "Title: tldv Alternatives by Use Case\nCentral node: tldv alternatives\nSales coaching: revenue intelligence tools\nFree unlimited recording: generous free-tier notetakers\nPrivacy and control: local-first notetakers\nLightweight capture: browser extension tools",
+      "context": "Mind map grouping tldv alternatives by the job the reader is hiring them for. The central node must be labeled tldv alternatives, four branches around it.",
+      "visualQuery": "mind map",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "tldv-review": [],
-  "transcription-software-mac": [],
-  "what-makes-reliable-ai-note-taker": [],
+  "transcription-software-mac": [
+    {
+      "filename": "mac-transcription-decision.png",
+      "content": "Live meeting transcription with privacy\nAnarlog\nDrag-and-drop file transcription\nMacWhisper\nEdit podcasts by editing text\nDescript\nAutomated meeting bot\nOtter\nHuman-verified accuracy\nRev",
+      "context": "Decision-tree diagram for an Anarlog blog post matching common Mac transcription needs to the right tool. Anarlog is one branch among several; keep it honest.",
+      "visualQuery": "decision tree",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
+  "what-makes-reliable-ai-note-taker": [
+    {
+      "filename": "reliability-stack.png",
+      "content": "Capture never fails\nTranscription is accurate\nSummaries stay faithful\nNotes remain yours for years",
+      "context": "Vertical stack diagram for an Anarlog blog post showing the layers of reliability an AI notetaker must deliver, from raw capture at the bottom to long-term ownership at the top.",
+      "visualQuery": "pyramid",
+      "orientation": "vertical",
+      "width": 1000
+    }
+  ],
   "zoom-ai-companion-review": []
 }

--- a/apps/web/content/articles/hipaa-compliant-ai-notetaker.mdx
+++ b/apps/web/content/articles/hipaa-compliant-ai-notetaker.mdx
@@ -41,6 +41,8 @@ The exception is genuinely local processing. If audio is captured, transcribed, 
 
 ## The subprocessor chain is where most notetakers break
 
+![Every party that receives protected health information becomes a business associate needing its own BAA](/api/assets/blog/articles/hipaa-compliant-ai-notetaker/baa-chain.png)
+
 A modern notetaker is rarely one vendor. It is a capture app, a transcription engine, and a language model that writes the summary — often three companies.
 
 Signing a BAA with the notetaker does not automatically cover the model provider behind it. That provider is receiving the transcript, which contains the PHI. The chain has to hold end to end.

--- a/apps/web/content/articles/how-to-have-productive-one-on-one-meetings.mdx
+++ b/apps/web/content/articles/how-to-have-productive-one-on-one-meetings.mdx
@@ -119,6 +119,8 @@ This longitudinal view is impossible to maintain in your head across multiple re
 
 ## The manager's system: putting it all together
 
+![The repeating cycle that keeps manager one-on-ones productive](/api/assets/blog/articles/how-to-have-productive-one-on-one-meetings/one-on-one-loop.png)
+
 Here's what the actual workflow looks like when you're using Anarlog:
 
 **Before each 1:1 (5 minutes):**

--- a/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
+++ b/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
@@ -37,6 +37,8 @@ The solution isn't to "focus harder." It's to build systems that reduce the cogn
 
 ## Meeting participation strategies that work
 
+![Five-step framework for participating effectively in meetings](/api/assets/blog/articles/how-to-participate-in-meetings-effectively/participation-framework.png)
+
 ### 1. Pre-load context instead of reconstructing it live
 
 You walk into a meeting and spend the first ten minutes trying to remember what was discussed last time. Who said what. What was decided. What's still unresolved.

--- a/apps/web/content/articles/how-to-reduce-meeting-fatigue.mdx
+++ b/apps/web/content/articles/how-to-reduce-meeting-fatigue.mdx
@@ -30,6 +30,8 @@ The fatigue isn't from talking. It's from the constant effort of trying to be pr
 
 ## 5 ways to reduce meeting fatigue without cutting meetings
 
+![Common drivers of meeting fatigue paired with practical interventions](/api/assets/blog/articles/how-to-reduce-meeting-fatigue/fatigue-causes-fixes.png)
+
 If you can't reduce your meeting load, focus on reducing the cognitive overhead around meetings.
 
 (Note: Anarlog appears a few times below because I built it to solve these exact problems.)

--- a/apps/web/content/articles/meetily-review.mdx
+++ b/apps/web/content/articles/meetily-review.mdx
@@ -43,6 +43,8 @@ The codebase is MIT licensed and public on GitHub. The community edition is free
 
 ## **How Does Meetily Work?**
 
+![Meetily's local processing pipeline from system audio to meeting summary](/api/assets/blog/articles/meetily-review/meetily-pipeline.png)
+
 Meetily captures audio from your microphone and system output as separate channels. Transcription runs on your device using either Parakeet (the default) or Whisper Large V3. Both are open-source models that run entirely on local hardware.
 
 Parakeet is the faster option. It runs at roughly 4x the speed of Whisper with lower resource usage. GPU acceleration works on Apple Silicon via Metal, NVIDIA via CUDA, and AMD/Intel via Vulkan. On a modern Mac, transcription happens in real time without visible CPU strain.

--- a/apps/web/content/articles/meeting-notes-template.mdx
+++ b/apps/web/content/articles/meeting-notes-template.mdx
@@ -45,6 +45,8 @@ The ordering is the whole point. Decisions and action items sit above the notes 
 
 ## Four rules that decide whether a template works
 
+![The anatomy of a useful meeting note, with outcomes above raw discussion](/api/assets/blog/articles/meeting-notes-template/meeting-note-anatomy.png)
+
 Format matters less than these.
 
 **One owner per action item.** An item assigned to two people is assigned to nobody. If two people genuinely need to act, that is two items. This is the single most common failure in meeting notes, and no template fixes it for you.

--- a/apps/web/content/articles/mistral-data-retention-policy.mdx
+++ b/apps/web/content/articles/mistral-data-retention-policy.mdx
@@ -16,6 +16,8 @@ Here is how the policy works in practice.
 
 ## What Mistral Stores by Default
 
+![How Mistral handles prompts: default limited retention, an optional zero-retention path, and training only with explicit opt-in](/api/assets/blog/articles/mistral-data-retention-policy/mistral-data-flow.png)
+
 For API users, Mistral retains your inputs and outputs for 30 rolling days after the request is processed. This window exists for abuse monitoring. After 30 days, the data is deleted. It is not used to train Mistral's models unless you explicitly opt in.
 
 For free users of Le Chat, Mistral's consumer product, your conversations may be used for model improvement unless you opt out. You can do this by opening the Privacy menu in the Admin Console and disabling the toggle under Anonymous improvement data.

--- a/apps/web/content/articles/notion-meeting-notes.mdx
+++ b/apps/web/content/articles/notion-meeting-notes.mdx
@@ -17,6 +17,8 @@ This guide builds the database side first, because that is the part that keeps w
 
 ## What we're building
 
+![A Notion meeting-notes schema linking Meetings to People, Projects, and Action Items](/api/assets/blog/articles/notion-meeting-notes/notion-relations.png)
+
 A meeting notes system with four pieces:
 
 - A **Meetings** database with typed properties instead of free-text pages

--- a/apps/web/content/articles/notta-ai-alternative.mdx
+++ b/apps/web/content/articles/notta-ai-alternative.mdx
@@ -88,6 +88,8 @@ That matters for engineers, technical founders, consultants, lawyers, operators,
 
 ## The decision criteria that matter
 
+![Deciding between Notta's cloud workflow and a local-first notetaker](/api/assets/blog/articles/notta-ai-alternative/notta-decision-flow.png)
+
 ### 1. File ownership
 
 Ask where the canonical note lives.

--- a/apps/web/content/articles/openrouter-data-retention-policy.mdx
+++ b/apps/web/content/articles/openrouter-data-retention-policy.mdx
@@ -36,6 +36,8 @@ This gives you granular control if you need it. For most use cases, simply not e
 
 ## What OpenRouter's Underlying Provider Stores
 
+![An OpenRouter request passes through the gateway, then the underlying provider's own retention policy applies](/api/assets/blog/articles/openrouter-data-retention-policy/openrouter-request-path.png)
+
 This is where OpenRouter's data policy gets more complicated.
 
 When you send a request through OpenRouter, it routes that request to a provider. That provider processes your prompt under their own data retention policy. OpenRouter does not change what the provider stores. If your request goes to OpenAI's API, [OpenAI's 30-day abuse monitoring window](https://anarlog.so/blog/chatgpt-data-retention-policy/) applies. If it goes to Anthropic's API, [Anthropic's 7-day window](https://anarlog.so/blog/anthropic-data-retention-policy/) applies.

--- a/apps/web/content/articles/organize-meeting-notes.mdx
+++ b/apps/web/content/articles/organize-meeting-notes.mdx
@@ -13,6 +13,8 @@ Most people capture meeting notes fine. Finding them three weeks later is the pr
 
 ## How to Organize Your Meeting Notes
 
+![A meeting-notes system in four stages: capture, structure, tag and link, retrieve](/api/assets/blog/articles/organize-meeting-notes/capture-to-retrieval.png)
+
 ### **Use Your Meeting Assistant's Built-In Features**
 
 Before building any system on top, most people underuse what their note-taking app already gives them. Conversational search. Summaries that pull out decisions and action items. Templates for recurring meetings. Anarlog, Otter, Granola, Fireflies - all of them have this to some degree.

--- a/apps/web/content/articles/tldv-alternatives.mdx
+++ b/apps/web/content/articles/tldv-alternatives.mdx
@@ -12,6 +12,8 @@ So, if you're in the market for a tl;dv alternative, I have compiled the best op
 
 ## Top tl;dv Competitors for Specific Use Cases
 
+![tl;dv alternatives grouped by use case](/api/assets/blog/articles/tldv-alternatives/tldv-alternatives-map.png)
+
 | Tool         | Best for                                      | Pricing                                   | Bot-free? |
 | ------------ | --------------------------------------------- | ----------------------------------------- | --------- |
 | Anarlog         | Data ownership, privacy, offline use          | Free (local + BYOK). Cloud: $15/mo        | Yes       |

--- a/apps/web/content/articles/what-makes-reliable-ai-note-taker.mdx
+++ b/apps/web/content/articles/what-makes-reliable-ai-note-taker.mdx
@@ -21,6 +21,8 @@ If you're evaluating note-taking tools, here's what matters.
 
 ## Measuring reliability in AI notetakers
 
+![The reliability layers of an AI notetaker, from capture to long-term ownership](/api/assets/blog/articles/what-makes-reliable-ai-note-taker/reliability-stack.png)
+
 In system design, reliability scales with the number of dependencies your tool needs to function. The fewer external services required, the more reliable it is.
 
 Most AI notetakers today depend on multiple layers. Understanding those dependencies helps you decide which vulnerabilities you can live with and which ones break your workflow.


### PR DESCRIPTION
## What
22 articles had zero body images and were marked deliberately figure-less in figures.json. This declares and embeds one reviewed Napkin conceptual figure for 20 of them (data-retention explainers, comparison/alternatives pages, meeting how-tos), generated via the media:figures batch pipeline and uploaded to the Supabase blog bucket.

- Every figure was visually reviewed; 8 were regenerated for factual framing or text glitches before embedding
- Figures are conceptual only (flows, comparisons, frameworks); no product UI is fabricated
- google-gemini-data-retention-policy intentionally stays figure-less: the generated figure was off-spec and Napkin free-tier credits are exhausted until Aug 24; will regenerate then
- transcription-software-mac figure ships in #6965

## Validation
- media:figures:check: 21/21 declared figures present
- typecheck, dprint clean
- Spot-checked figure URLs return 200 through the production asset proxy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9e58dd0124b6ce73c294c1887f384622906c9de9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->