### PR TITLE
perf(web): landing page quick wins from Lighthouse audit

### DIFF
--- a/apps/web/src/components/anarlog-logo.tsx
+++ b/apps/web/src/components/anarlog-logo.tsx
@@ -9,6 +9,8 @@ export function AnarlogLogo({
     <img
       src="/logo.svg"
       alt="Anarlog"
+      width={1205}
+      height={334}
       className={className}
       data-compact={compact ? "true" : undefined}
     />

--- a/apps/web/src/components/home-page/hero-section.tsx
+++ b/apps/web/src/components/home-page/hero-section.tsx
@@ -15,6 +15,7 @@ import {
   detectDesktopPlatform,
   getOrderedDesktopDownloadSections,
 } from "@/lib/download";
+import { getResizedImageUrl } from "@/lib/image-cdn";
 import { createTrackedTimers } from "@/lib/tracked-timers";
 
 import { CredibilityLogoMarquee } from "./social-proof-sections";
@@ -305,7 +306,16 @@ function HeroWorkflowDemo() {
         ])}
       >
         <img
-          src="/images/hero-meeting-participants.webp"
+          src={getResizedImageUrl("/images/hero-meeting-participants.webp", {
+            width: 600,
+          })}
+          srcSet={[300, 600, 900]
+            .map(
+              (width) =>
+                `${getResizedImageUrl("/images/hero-meeting-participants.webp", { width })} ${width}w`,
+            )
+            .join(", ")}
+          sizes="(min-width: 640px) 286px, 66vw"
           alt="Four participants in a video meeting"
           width={1200}
           height={215}

--- a/apps/web/src/components/home-page/privacy-section.tsx
+++ b/apps/web/src/components/home-page/privacy-section.tsx
@@ -117,18 +117,24 @@ export function LocalFilesVisual() {
       <img
         src="/icons/file.webp"
         alt=""
+        width={160}
+        height={221}
         className="w-10 rotate-[-5deg] object-contain transition-transform duration-300 ease-out hover:rotate-[-9deg]"
         draggable={false}
       />
       <img
         src="/icons/folderchar.svg"
         alt=""
+        width={1004}
+        height={841}
         className="w-14 object-contain transition-transform duration-300 ease-out hover:rotate-[3deg]"
         draggable={false}
       />
       <img
         src="/icons/file.webp"
         alt=""
+        width={160}
+        height={221}
         className="w-10 rotate-[6deg] object-contain transition-transform duration-300 ease-out hover:rotate-[10deg]"
         draggable={false}
       />

--- a/apps/web/src/components/home-page/social-proof-sections.tsx
+++ b/apps/web/src/components/home-page/social-proof-sections.tsx
@@ -7,27 +7,103 @@ import { cn } from "@anlg/utils";
 
 import { getResizedImageSrcSet, getResizedImageUrl } from "@/lib/image-cdn";
 
-const credibilityLogos = [
-  { name: "Databricks", src: "/icons/databricks.svg", className: "max-h-5" },
-  { name: "Cloudflare", src: "/icons/cloudflare.png" },
-  { name: "Amazon", src: "/icons/amazon.svg", className: "max-h-5" },
-  { name: "Meta", src: "/icons/meta.svg", className: "max-h-5" },
-  { name: "Y Combinator", src: "/icons/yc.svg" },
-  { name: "Palantir", src: "/icons/palantir.svg", className: "max-h-5" },
-  { name: "Apple", src: "/icons/apple.svg", className: "max-h-5" },
-  { name: "Disney", src: "/icons/disney.svg", className: "max-h-5" },
+// `width`/`height` are the intrinsic dimensions of each asset so the browser
+// can reserve the correct aspect ratio before the image loads (CLS). CSS still
+// controls the rendered size. `resizeWidth` routes oversized bitmap logos
+// through the Netlify Image CDN at ~2x their rendered width.
+const credibilityLogos: {
+  name: string;
+  src: string;
+  width: number;
+  height: number;
+  className?: string;
+  resizeWidth?: number;
+}[] = [
+  {
+    name: "Databricks",
+    src: "/icons/databricks.svg",
+    width: 276,
+    height: 42,
+    className: "max-h-5",
+  },
+  {
+    name: "Cloudflare",
+    src: "/icons/cloudflare.png",
+    width: 1556,
+    height: 704,
+    resizeWidth: 106,
+  },
+  {
+    name: "Amazon",
+    src: "/icons/amazon.svg",
+    width: 399,
+    height: 133,
+    className: "max-h-5",
+  },
+  {
+    name: "Meta",
+    src: "/icons/meta.svg",
+    width: 256,
+    height: 171,
+    className: "max-h-5",
+  },
+  { name: "Y Combinator", src: "/icons/yc.svg", width: 64, height: 64 },
+  {
+    name: "Palantir",
+    src: "/icons/palantir.svg",
+    width: 210,
+    height: 51,
+    className: "max-h-5",
+  },
+  {
+    name: "Apple",
+    src: "/icons/apple.svg",
+    width: 42,
+    height: 51,
+    className: "max-h-5",
+  },
+  {
+    name: "Disney",
+    src: "/icons/disney.svg",
+    width: 155,
+    height: 66,
+    className: "max-h-5",
+  },
   {
     name: "Richmond American",
     src: "/icons/richmond_american.svg",
+    width: 165,
+    height: 51,
     className: "max-h-5",
   },
-  { name: "Adobe", src: "/icons/adobe.svg", className: "max-h-5" },
-  { name: "Wayfair", src: "/icons/wayfair.svg", className: "max-h-5" },
-  { name: "Bain & Company", src: "/icons/bain.svg", className: "max-h-5" },
+  {
+    name: "Adobe",
+    src: "/icons/adobe.svg",
+    width: 66,
+    height: 17,
+    className: "max-h-5",
+  },
+  {
+    name: "Wayfair",
+    src: "/icons/wayfair.svg",
+    width: 630,
+    height: 150,
+    className: "max-h-5",
+  },
+  {
+    name: "Bain & Company",
+    src: "/icons/bain.svg",
+    width: 547,
+    height: 60,
+    className: "max-h-5",
+  },
   {
     name: "McKinsey & Company",
     src: "/icons/mckinsey.png",
+    width: 960,
+    height: 297,
     className: "max-h-5",
+    resizeWidth: 130,
   },
 ];
 
@@ -277,7 +353,15 @@ export function CredibilityLogoMarquee() {
               {credibilityLogos.map((logo) => (
                 <img
                   key={`${trackIndex}-${logo.name}`}
-                  src={logo.src}
+                  src={
+                    logo.resizeWidth
+                      ? getResizedImageUrl(logo.src, {
+                          width: logo.resizeWidth,
+                        })
+                      : logo.src
+                  }
+                  width={logo.width}
+                  height={logo.height}
                   alt=""
                   className={cn([
                     "h-6 w-auto max-w-none object-contain opacity-65 grayscale transition-[filter,opacity] duration-200 hover:opacity-100 hover:grayscale-0",

--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -51,6 +51,8 @@ export function SiteFooter() {
           <img
             src="/icons/fastrepl.svg"
             alt="Fastrepl"
+            width={4261}
+            height={1242}
             className="h-4 w-auto"
           />
           <span>© 2026</span>

--- a/apps/web/src/components/web-providers.tsx
+++ b/apps/web/src/components/web-providers.tsx
@@ -27,6 +27,21 @@ type AnalyticsWindow = Window &
     gtag?: (...args: unknown[]) => void;
   };
 
+/**
+ * Defers third-party analytics script injection until the main thread is
+ * idle so it stays off the critical rendering path (LCP/TBT). Falls back to
+ * a timeout where `requestIdleCallback` is unavailable (e.g. Safari).
+ */
+function runWhenIdle(callback: () => void): () => void {
+  if (typeof window.requestIdleCallback === "function") {
+    const idleId = window.requestIdleCallback(callback, { timeout: 5000 });
+    return () => window.cancelIdleCallback(idleId);
+  }
+
+  const timeoutId = window.setTimeout(callback, 2000);
+  return () => window.clearTimeout(timeoutId);
+}
+
 function GoogleAnalyticsScript() {
   useMountEffect(() => {
     if (
@@ -42,29 +57,34 @@ function GoogleAnalyticsScript() {
       return;
     }
 
-    setGoogleAnalyticsDisabled(false);
+    const cancelIdle = runWhenIdle(() => {
+      setGoogleAnalyticsDisabled(false);
 
-    if (document.getElementById(GOOGLE_TAG_ID)) {
-      return () => setGoogleAnalyticsDisabled(true);
-    }
+      if (document.getElementById(GOOGLE_TAG_ID)) {
+        return;
+      }
 
-    const analyticsWindow = window as AnalyticsWindow;
-    analyticsWindow.dataLayer = analyticsWindow.dataLayer ?? [];
-    analyticsWindow.gtag =
-      analyticsWindow.gtag ??
-      function gtag() {
-        analyticsWindow.dataLayer?.push(arguments);
-      };
-    analyticsWindow.gtag("js", new Date());
-    analyticsWindow.gtag("config", GOOGLE_ANALYTICS_ID);
+      const analyticsWindow = window as AnalyticsWindow;
+      analyticsWindow.dataLayer = analyticsWindow.dataLayer ?? [];
+      analyticsWindow.gtag =
+        analyticsWindow.gtag ??
+        function gtag() {
+          analyticsWindow.dataLayer?.push(arguments);
+        };
+      analyticsWindow.gtag("js", new Date());
+      analyticsWindow.gtag("config", GOOGLE_ANALYTICS_ID);
 
-    const script = document.createElement("script");
-    script.id = GOOGLE_TAG_ID;
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`;
-    script.async = true;
-    document.head.appendChild(script);
+      const script = document.createElement("script");
+      script.id = GOOGLE_TAG_ID;
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`;
+      script.async = true;
+      document.head.appendChild(script);
+    });
 
-    return () => setGoogleAnalyticsDisabled(true);
+    return () => {
+      cancelIdle();
+      setGoogleAnalyticsDisabled(true);
+    };
   });
 
   return null;
@@ -85,26 +105,31 @@ function MicrosoftClarityScript() {
       return;
     }
 
-    const clarityWindow = window as ClarityWindow;
-    clarityWindow.clarity = clarityWindow.clarity ?? createClarityFallback();
+    const cancelIdle = runWhenIdle(() => {
+      const clarityWindow = window as ClarityWindow;
+      clarityWindow.clarity = clarityWindow.clarity ?? createClarityFallback();
 
-    clarityWindow.clarity("consentv2", {
-      ad_Storage: "denied",
-      analytics_Storage: "granted",
+      clarityWindow.clarity("consentv2", {
+        ad_Storage: "denied",
+        analytics_Storage: "granted",
+      });
+      clarityWindow.clarity("start");
+
+      if (document.getElementById(MICROSOFT_CLARITY_SCRIPT_ID)) {
+        return;
+      }
+
+      const script = document.createElement("script");
+      script.id = MICROSOFT_CLARITY_SCRIPT_ID;
+      script.async = true;
+      script.src = `https://www.clarity.ms/tag/${MICROSOFT_CLARITY_TAG_ID}`;
+      document.head.appendChild(script);
     });
-    clarityWindow.clarity("start");
 
-    if (document.getElementById(MICROSOFT_CLARITY_SCRIPT_ID)) {
-      return disableMicrosoftClarity;
-    }
-
-    const script = document.createElement("script");
-    script.id = MICROSOFT_CLARITY_SCRIPT_ID;
-    script.async = true;
-    script.src = `https://www.clarity.ms/tag/${MICROSOFT_CLARITY_TAG_ID}`;
-    document.head.appendChild(script);
-
-    return disableMicrosoftClarity;
+    return () => {
+      cancelIdle();
+      disableMicrosoftClarity();
+    };
   });
 
   return null;


### PR DESCRIPTION
## Context

Mobile Lighthouse for anarlog.so scores 65 (lab, throttled Moto G). Field Core Web Vitals pass, so these are the safe, zero-visual-change wins from the audit:

- Improve image delivery: est. 94 KiB
- Image elements missing explicit width/height (lab CLS 0.08)
- 3rd parties on critical path: GTM 162 KiB, Clarity 25 KiB

## Changes

**Images**
- Credibility marquee: route the two oversized PNG logos through the existing Netlify Image CDN helper (`getResizedImageUrl`) at ~2x rendered width. Cloudflare 25.8 KiB -> 1.2 KiB, McKinsey 39.6 KiB -> 2.2 KiB (verified against the production CDN endpoint).
- Hero meeting image: CDN-resized `src` + responsive `srcSet`/`sizes`. 34.2 KiB -> 11.1 KiB desktop, 4.5 KiB mobile.
- Add intrinsic `width`/`height` to every image Lighthouse flagged (marquee logos, `AnarlogLogo`, footer Fastrepl logo, privacy-section illustrations) so the browser reserves aspect ratio before load. CSS still controls rendered size, so nothing moves visually.

**Third-party analytics**
- GA4 and Microsoft Clarity script injection now waits for `requestIdleCallback` (5s timeout, `setTimeout` fallback for Safari) instead of running on mount. Same guards (GPC, private routes, dev) and cleanup semantics; scripts just load a moment later, off the critical rendering path.

## Not included (follow-ups discussed)

- Self-hosting/subsetting Google Fonts (render-blocking, 93 KiB)
- Bundle splitting for the 301 KiB unused JS
- Disabling PostHog recorder/surveys on marketing routes (needs product decision)

No visual or UX changes. Typecheck, oxlint, and dprint pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-page image and script-timing tweaks only. Analytics still uses the same privacy guards; scripts just load later.
> 
> **Overview**
> Landing-page performance pass with no visual changes: smaller images, reserved aspect ratios, and analytics off the critical path.
> 
> Oversized bitmaps now go through `getResizedImageUrl` (Cloudflare/McKinsey logos; hero meeting photo with `srcSet`/`sizes`). Intrinsic `width`/`height` are set on flagged images so the browser can reserve space before load.
> 
> GA4 and Clarity inject via `requestIdleCallback` (Safari `setTimeout` fallback) instead of on mount. Existing GPC, private-route, and cleanup behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aa308aadae18a83ec0a3dfc8ddde1c9478f9a51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->