### PR TITLE
fix(desktop): show the OS hostname instead of Unnamed device

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -68,6 +68,7 @@
     "fs2:default",
     "git:default",
     "os:default",
+    "os:allow-hostname",
     "opener2:default",
     "mcp:default",
     "messenger:default",

--- a/apps/desktop/src/auth/cloudsync-credentials.test.ts
+++ b/apps/desktop/src/auth/cloudsync-credentials.test.ts
@@ -1,0 +1,64 @@
+import { hostname } from "@tauri-apps/plugin-os";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { commands as miscCommands } from "@anlg/plugin-misc";
+
+import { getDeviceIdentity, sanitizeDeviceName } from "./cloudsync-credentials";
+
+vi.mock("@anlg/plugin-misc", () => ({
+  commands: {
+    getFingerprint: vi.fn(() =>
+      Promise.resolve({ status: "error", error: "unavailable" }),
+    ),
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  hostname: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("~/settings/queries", () => ({
+  getStoredSettingValues: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.mocked(hostname).mockReset();
+  vi.mocked(hostname).mockResolvedValue(null);
+  vi.mocked(miscCommands.getFingerprint).mockReset();
+  vi.mocked(miscCommands.getFingerprint).mockResolvedValue({
+    status: "error",
+    error: "unavailable",
+  });
+});
+
+test("keeps printable hostnames and drops empty or non-ascii names", () => {
+  expect(sanitizeDeviceName("Johns-M4-Max.local")).toBe("Johns-M4-Max.local");
+  expect(sanitizeDeviceName(" John's MacBook ")).toBe("John's MacBook");
+  expect(sanitizeDeviceName("  ")).toBeNull();
+  expect(sanitizeDeviceName(null)).toBeNull();
+  expect(sanitizeDeviceName("존의 MacBook")).toBe("MacBook");
+  expect(sanitizeDeviceName("존의맥북")).toBeNull();
+  expect(sanitizeDeviceName("a".repeat(200))).toBe("a".repeat(128));
+});
+
+test("treats hostname lookup failures as an unnamed device", async () => {
+  vi.mocked(hostname).mockRejectedValue(new Error("not allowed"));
+
+  await expect(getDeviceIdentity()).resolves.toEqual({
+    fingerprint: null,
+    name: null,
+  });
+});
+
+test("reads the machine hostname as the sync device name", async () => {
+  vi.mocked(hostname).mockResolvedValue("Johns-M4-Max.local");
+  vi.mocked(miscCommands.getFingerprint).mockResolvedValue({
+    status: "ok",
+    data: "fingerprint-1234",
+  });
+
+  await expect(getDeviceIdentity()).resolves.toEqual({
+    fingerprint: "fingerprint-1234",
+    name: "Johns-M4-Max.local",
+  });
+});

--- a/apps/desktop/src/auth/cloudsync-credentials.ts
+++ b/apps/desktop/src/auth/cloudsync-credentials.ts
@@ -145,6 +145,28 @@ export function readE2eeIdentity(userId: string) {
   return read;
 }
 
+const MAX_DEVICE_NAME_BYTES = 128;
+
+export function sanitizeDeviceName(name: string | null | undefined) {
+  if (typeof name !== "string") {
+    return null;
+  }
+
+  const ascii = Array.from(name.trim())
+    .filter((char) => {
+      const code = char.charCodeAt(0);
+      return code >= 0x20 && code <= 0x7e;
+    })
+    .join("")
+    .trim();
+  if (!ascii) {
+    return null;
+  }
+  return ascii.length <= MAX_DEVICE_NAME_BYTES
+    ? ascii
+    : ascii.slice(0, MAX_DEVICE_NAME_BYTES);
+}
+
 export async function getDeviceIdentity() {
   if (cachedDeviceIdentity) {
     return cachedDeviceIdentity;
@@ -162,7 +184,8 @@ export async function getDeviceIdentity() {
 
   let name: string | null = null;
   try {
-    name = await hostname();
+    // hostname() is excluded from os:default and needs os:allow-hostname.
+    name = sanitizeDeviceName(await hostname());
   } catch {
     // Device name is optional.
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Sync settings listed every machine as **Unnamed device** because we never actually received a hostname.

The desktop already calls `hostname()` from `@tauri-apps/plugin-os` and sends it as `x-anarlog-device-name`. Tauri's `os:default` permission set explicitly excludes hostname, so that call failed, the catch swallowed it, and `device_name` stayed null in `sync_devices`.

This grants `os:allow-hostname` and sanitizes the value to printable ASCII (max 128 bytes) so it is a valid HTTP header. Existing unnamed devices pick up their hostname on the next credential exchange.

After this ships, reopen Sync settings: the current device should show something like `Johns-MacBook-Pro.local` instead of Unnamed device. Other already-registered devices update the next time they sync.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44987d3c-2e88-4fe4-956f-24f7c7607d80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44987d3c-2e88-4fe4-956f-24f7c7607d80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

