### PR TITLE
Stop requiring Linux-only audio QA to publish

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -174,40 +174,24 @@ The dry-run workflow must:
 - upload `desktop-release-provenance-<version>-<sha>`, including the exact
   artifact hashes and pinned CrabNebula CLI version, asset ID, and SHA-256
 
-Run the Linux virtual-audio gate against that exact dry-run candidate:
-
-```bash
-gh workflow run desktop_linux_audio_qa.yaml \
-  --ref main \
-  -f version=<version> \
-  -f candidate_sha=<40-character-main-sha> \
-  -f dry_run_id=<dry-run-id>
-```
-
-Watch the run and verify its head SHA is still the candidate SHA. It must
-produce passing `linux-audio-qa-<version>-x64` and
-`linux-audio-qa-<version>-arm64` evidence artifacts. This gate proves virtual
-microphone/system routing, capture, separation, and persistence with
-`NO_AEC=1`. Physical-device AEC validation remains non-blocking while
-`ANLG-98` is open and returns to the release gate when that issue is completed.
-
-After the exact dry-run artifacts and Linux audio QA run pass the required
-platform gates and `main` still points to the candidate SHA, publish only
-through the provenance workflow:
+After the exact dry-run artifacts pass the required platform gates and `main`
+still points to the candidate SHA, publish only through the provenance
+workflow. Do not run `desktop_linux_audio_qa` as a publish gate; Linux is
+covered by the same dry-run provenance as macOS and Windows. That workflow
+remains available for optional debugging.
 
 ```bash
 gh workflow run desktop_publish.yaml \
   --ref main \
   -f version=<version> \
   -f candidate_sha=<40-character-main-sha> \
-  -f dry_run_id=<dry-run-id> \
-  -f audio_qa_run_id=<linux-audio-qa-run-id>
+  -f dry_run_id=<dry-run-id>
 ```
 
 Watch that workflow to completion. It must verify the dry-run run identity,
-artifact hashes, both Linux audio evidence artifacts, CrabNebula tool
-identity and hash, current `main`, and the immutable tag before publishing. It
-must also verify every file mirrored to GitHub against the provenance manifest.
+artifact hashes, CrabNebula tool identity and hash, current `main`, and the
+immutable tag before publishing. It must also verify every file mirrored to
+GitHub against the provenance manifest.
 
 ## Final Checks
 
@@ -215,7 +199,6 @@ Before reporting success, capture:
 
 - computed stable version
 - dry-run workflow URL and head SHA
-- Linux audio QA workflow URL, head SHA, and x64/ARM64 evidence artifacts
 - publish workflow URL and head SHA
 - `desktop_v<version>` tag
 - GitHub release URL

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -21,11 +21,6 @@ on:
         description: "Publish Windows artifacts from the candidate"
         type: boolean
         default: true
-      audio_qa_run_id:
-        description: "Successful desktop Linux virtual-audio QA run for the candidate"
-        required: false
-        type: string
-        default: ""
 
 concurrency:
   group: desktop-stable-release
@@ -44,13 +39,11 @@ jobs:
       dry_run_id: ${{ steps.parse.outputs.dry_run_id }}
       include_linux: ${{ steps.parse.outputs.include_linux }}
       include_windows: ${{ steps.parse.outputs.include_windows }}
-      audio_qa_run_id: ${{ steps.parse.outputs.audio_qa_run_id }}
     steps:
       - id: parse
         env:
           EXECUTION_REF: ${{ github.ref }}
           EXECUTION_SHA: ${{ github.sha }}
-          INPUT_AUDIO_QA_RUN_ID: ${{ inputs.audio_qa_run_id }}
           INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha }}
           INPUT_DRY_RUN_ID: ${{ inputs.dry_run_id }}
           INPUT_INCLUDE_LINUX: ${{ inputs.include_linux }}
@@ -68,15 +61,6 @@ jobs:
           fi
           if [[ ! "$INPUT_DRY_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error::Dry-run workflow ID must be a positive integer"
-            exit 1
-          fi
-          if [[ "$INPUT_INCLUDE_LINUX" == "true" ]]; then
-            if [[ ! "$INPUT_AUDIO_QA_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
-              echo "::error::Linux audio QA workflow ID must be a positive integer when Linux is included"
-              exit 1
-            fi
-          elif [[ -n "$INPUT_AUDIO_QA_RUN_ID" ]]; then
-            echo "::error::Linux audio QA workflow ID must be empty when Linux is excluded"
             exit 1
           fi
 
@@ -97,7 +81,6 @@ jobs:
           echo "dry_run_id=$INPUT_DRY_RUN_ID" >> $GITHUB_OUTPUT
           echo "include_linux=$INPUT_INCLUDE_LINUX" >> $GITHUB_OUTPUT
           echo "include_windows=$INPUT_INCLUDE_WINDOWS" >> $GITHUB_OUTPUT
-          echo "audio_qa_run_id=$INPUT_AUDIO_QA_RUN_ID" >> $GITHUB_OUTPUT
 
   verify-candidate:
     needs: parse
@@ -216,58 +199,6 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --name "desktop-release-provenance-$VERSION-$EXPECTED_SHA" \
             --dir release-provenance
-      - name: Verify Linux virtual-audio QA evidence
-        if: ${{ needs.parse.outputs.include_linux == 'true' }}
-        env:
-          AUDIO_QA_RUN_ID: ${{ needs.parse.outputs.audio_qa_run_id }}
-          DRY_RUN_ID: ${{ needs.parse.outputs.dry_run_id }}
-          EXPECTED_SHA: ${{ needs.parse.outputs.candidate_sha }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.parse.outputs.version }}
-        run: |
-          RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$AUDIO_QA_RUN_ID")
-          ARTIFACTS=$(gh api \
-            "repos/$GITHUB_REPOSITORY/actions/runs/$AUDIO_QA_RUN_ID/artifacts?per_page=100")
-          printf '%s' "$RUN" > "$RUNNER_TEMP/linux-audio-qa-run.json"
-          printf '%s' "$ARTIFACTS" > "$RUNNER_TEMP/linux-audio-qa-artifacts.json"
-          node scripts/verify-linux-audio-qa-run.mjs \
-            --run "$RUNNER_TEMP/linux-audio-qa-run.json" \
-            --artifacts "$RUNNER_TEMP/linux-audio-qa-artifacts.json" \
-            --repository "$GITHUB_REPOSITORY" \
-            --version "$VERSION" \
-            --candidate-sha "$EXPECTED_SHA" \
-            --run-id "$AUDIO_QA_RUN_ID" \
-            --output "$RUNNER_TEMP/linux-audio-qa-downloads.json"
-
-          for arch in x64 arm64; do
-            NAME="linux-audio-qa-$VERSION-$arch"
-            ARTIFACT_ID=$(jq -er \
-              --arg arch "$arch" \
-              '.[] | select(.architecture == $arch) | .id' \
-              "$RUNNER_TEMP/linux-audio-qa-downloads.json")
-            ARTIFACT_DIGEST=$(jq -er \
-              --arg arch "$arch" \
-              '.[] | select(.architecture == $arch) | .digest' \
-              "$RUNNER_TEMP/linux-audio-qa-downloads.json")
-            mkdir -p "linux-audio-qa/$arch"
-            gh api \
-              "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
-              > "$RUNNER_TEMP/$NAME.zip"
-            ACTUAL_DIGEST="sha256:$(sha256sum "$RUNNER_TEMP/$NAME.zip" | cut -d ' ' -f 1)"
-            if [[ "$ACTUAL_DIGEST" != "$ARTIFACT_DIGEST" ]]; then
-              echo "::error::$NAME digest mismatch: expected $ARTIFACT_DIGEST, got $ACTUAL_DIGEST"
-              exit 1
-            fi
-            unzip -q "$RUNNER_TEMP/$NAME.zip" -d "linux-audio-qa/$arch"
-          done
-
-          node scripts/verify-linux-audio-qa-evidence.mjs \
-            --evidence-dir linux-audio-qa \
-            --manifest release-provenance/manifest.json \
-            --version "$VERSION" \
-            --candidate-sha "$EXPECTED_SHA" \
-            --dry-run-id "$DRY_RUN_ID" \
-            --audio-qa-run-id "$AUDIO_QA_RUN_ID"
       - id: release
         uses: ./.github/actions/cn_release
         with:

--- a/RELEASE_AUDIT.md
+++ b/RELEASE_AUDIT.md
@@ -36,7 +36,8 @@ Run these before publishing a stable desktop release.
 
 4. **Real-hardware QA** (cannot run in CI/Cloud Agent):
    - Critical Pro user journey on a Mac — follow `.agents/skills/qa-critical-ux`.
-   - Linux system-audio capture — `desktop_linux_audio_qa` against the candidate.
+     Linux and Windows ship from the same dry-run provenance; do not run a
+     separate Linux-only audio QA gate before publish.
 
 5. **Changelog** — add the entry via `.agents/skills/new-changelog`.
 


### PR DESCRIPTION
## Summary
- Drop `audio_qa_run_id` from `desktop_publish` so Linux publishes from the same dry-run provenance as macOS and Windows
- Keep `desktop_linux_audio_qa` available for optional debugging
- PulseAudio Sentry logging already landed in #6963; no changelog because it is not user-facing

## Test plan
- [ ] Confirm `desktop_publish.yaml` has no `audio_qa_run_id` input or evidence step
- [ ] After merge, dry-run 1.4.11 from the new main SHA with Linux included
- [ ] Publish without a Linux audio QA run ID

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the stable release gate: Linux audio QA is no longer verified before publish, so regressions in Linux capture/routing would not block a release. Workflow identity and artifact-hash checks for the dry-run candidate remain.
> 
> **Overview**
> Stable desktop publish no longer requires a successful `desktop_linux_audio_qa` run. Linux artifacts ship from the same dry-run provenance as macOS and Windows.
> 
> `desktop_publish` drops the `audio_qa_run_id` input, related validation, and the evidence download/verify step. Release docs (`release-new-version` skill and `RELEASE_AUDIT.md`) now treat that workflow as optional debugging, not a blocking gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032cfe3c4077c96cf0063d47c593a3ec0534642d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->