### PR TITLE
fix(desktop): show clipped transcript selection borders

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment.test.tsx
@@ -6,6 +6,7 @@ import {
   SegmentRenderer,
   type TranscriptSearchRenderState,
 } from "./segment";
+import { TranscriptSelectionProvider } from "./selection-context";
 
 import type { Segment, SegmentWord } from "~/stt/live-segment";
 
@@ -232,6 +233,34 @@ describe("SegmentRenderer", () => {
     );
 
     expect(mocks.wordSpan).toHaveBeenCalledTimes(8);
+  });
+
+  it("draws selected borders inside the segment so list overflow cannot clip them", () => {
+    const view = render(
+      <TranscriptSelectionProvider
+        selectMode
+        selectedKeys={new Set(["transcript-1:segment-1"])}
+        registerSource={() => () => {}}
+      >
+        <SegmentRenderer
+          segment={createSegment()}
+          offsetMs={0}
+          transcriptId="transcript-1"
+          speakerLabel="Speaker 1"
+          currentMs={0}
+          seekAndPlay={vi.fn()}
+          audioExists
+          search={EMPTY_TRANSCRIPT_SEARCH}
+        />
+      </TranscriptSelectionProvider>,
+    );
+
+    const section = view.container.querySelector(
+      "[data-transcript-selected='true']",
+    );
+    expect(section?.className).toContain("ring-inset");
+    expect(section?.className).toContain("ring-1");
+    expect(section?.className).toContain("ring-primary/30");
   });
 
   it("persists text corrections when leaving write mode content", async () => {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
@@ -112,7 +112,7 @@ export const SegmentRenderer = memo(
         className={cn([
           "rounded-lg px-2 transition-colors",
           selectMode ? "cursor-pointer" : null,
-          "data-[transcript-selected=true]:bg-primary/10 data-[transcript-selected=true]:ring-primary/30 data-[transcript-selected=true]:ring-1",
+          "data-[transcript-selected=true]:bg-primary/10 data-[transcript-selected=true]:ring-primary/30 data-[transcript-selected=true]:ring-1 data-[transcript-selected=true]:ring-inset",
         ])}
       >
         <SegmentHeader


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Selected transcript entries used an outset `ring-1`, and the virtualized list clips horizontal overflow with `overflow-x-clip`. That also clips overflow on the other axis, so the top and bottom selection borders disappeared—especially on the first entry under the toolbar and on consecutive selected blocks.

Draw the selection ring inside the segment (`ring-inset`) so those horizontal borders stay visible without changing the speaker-label overflow clip.

## Test plan
- [x] `pnpm exec dprint fmt` + scoped `dprint check` on changed files
- [x] `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- [x] `pnpm -F desktop typecheck`
- [x] `pnpm -F desktop exec vitest run src/session/components/note-input/transcript/renderer/segment.test.tsx`
- [ ] In Select mode, selected entries show a full top and bottom border, including the first visible row and adjacent selected blocks

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e08d34b6-cdfa-40f8-adf4-9cf48befdaf0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e08d34b6-cdfa-40f8-adf4-9cf48befdaf0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

